### PR TITLE
Merge pull request #78265 from Synthetica9/https-homepages

### DIFF
--- a/nixos/lib/testing/jquery-ui.nix
+++ b/nixos/lib/testing/jquery-ui.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "jquery-ui-1.11.4";
 
   src = fetchurl {
-    url = "http://jqueryui.com/resources/download/${name}.zip";
+    url = "https://jqueryui.com/resources/download/${name}.zip";
     sha256 = "0ciyaj1acg08g8hpzqx6whayq206fvf4whksz2pjgxlv207lqgjh";
   };
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    homepage = http://jqueryui.com/;
+    homepage = https://jqueryui.com/;
     description = "A library of JavaScript widgets and effects";
     platforms = stdenv.lib.platforms.all;
   };

--- a/nixos/modules/services/amqp/rabbitmq.nix
+++ b/nixos/modules/services/amqp/rabbitmq.nix
@@ -98,8 +98,8 @@ in {
           will be merged into these options by RabbitMQ at runtime to
           form the final configuration.
 
-          See http://www.rabbitmq.com/configure.html#config-items
-          For the distinct formats, see http://www.rabbitmq.com/configure.html#config-file-formats
+          See https://www.rabbitmq.com/configure.html#config-items
+          For the distinct formats, see https://www.rabbitmq.com/configure.html#config-file-formats
         '';
       };
 
@@ -116,8 +116,8 @@ in {
           The contents of this option will be merged into the <literal>configItems</literal>
           by RabbitMQ at runtime to form the final configuration.
 
-          See the second table on http://www.rabbitmq.com/configure.html#config-items
-          For the distinct formats, see http://www.rabbitmq.com/configure.html#config-file-formats
+          See the second table on https://www.rabbitmq.com/configure.html#config-items
+          For the distinct formats, see https://www.rabbitmq.com/configure.html#config-file-formats
         '';
       };
 

--- a/pkgs/applications/audio/sonic-visualiser/default.nix
+++ b/pkgs/applications/audio/sonic-visualiser/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "View and analyse contents of music audio files";
-    homepage = http://www.sonicvisualiser.org/;
+    homepage = https://www.sonicvisualiser.org/;
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.goibhniu maintainers.marcweber ];
     platforms = platforms.linux;

--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -93,7 +93,7 @@ with stdenv.lib; stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Open-source virtual modular synthesizer";
-    homepage = http://vcvrack.com/;
+    homepage = https://vcvrack.com/;
     # The source is BSD-3 licensed, some of the art is CC-BY-NC 4.0 or under a
     # no-derivatives clause
     license = with licenses; [ bsd3 cc-by-nc-40 unfreeRedistributable ];

--- a/pkgs/applications/audio/vkeybd/default.nix
+++ b/pkgs/applications/audio/vkeybd/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation  rec {
 
   meta = with stdenv.lib; {
     description = "Virtual MIDI keyboard";
-    homepage = http://www.alsa-project.org/~tiwai/alsa.html;
+    homepage = https://www.alsa-project.org/~tiwai/alsa.html;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.goibhniu ];

--- a/pkgs/applications/blockchains/wownero.nix
+++ b/pkgs/applications/blockchains/wownero.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       signatures using different participants for the same tx outputs on
       opposing forks.
     '';
-    homepage    = http://wownero.org/;
+    homepage    = https://wownero.org/;
     license     = licenses.bsd3;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ fuwa ];

--- a/pkgs/applications/editors/emacs-modes/org-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/org-generated.nix
@@ -6,7 +6,7 @@
         ename = "org";
         version = "20191203";
         src = fetchurl {
-          url = "http://orgmode.org/elpa/org-20191203.tar";
+          url = "https://orgmode.org/elpa/org-20191203.tar";
           sha256 = "1fcgiswjnqmfzx3xkmlqyyhc4a8ms07vdsv7nkizgxqdh9hwfm2q";
         };
         packageRequires = [];
@@ -21,7 +21,7 @@
         ename = "org-plus-contrib";
         version = "20191203";
         src = fetchurl {
-          url = "http://orgmode.org/elpa/org-plus-contrib-20191203.tar";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20191203.tar";
           sha256 = "1kvw95492acb7gqn8gxbp1vg4fyw80w43yvflxnfxdf6jnnw2wah";
         };
         packageRequires = [];

--- a/pkgs/applications/editors/emacs-modes/org-mac-link/default.nix
+++ b/pkgs/applications/editors/emacs-modes/org-mac-link/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Insert org-mode links to items selected in various Mac apps";
-    homepage = http://orgmode.org/worg/org-contrib/org-mac-link.html;
+    homepage = https://orgmode.org/worg/org-contrib/org-mac-link.html;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -80,7 +80,7 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "Photo and video importer for cameras, phones, and memory cards";
-    homepage = http://www.damonlynch.net/rapid/;
+    homepage = https://www.damonlynch.net/rapid/;
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jfrankenau ];

--- a/pkgs/applications/graphics/shutter/default.nix
+++ b/pkgs/applications/graphics/shutter/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Screenshot and annotation tool";
-    homepage = http://shutter-project.org/;
+    homepage = https://shutter-project.org/;
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/applications/misc/loxodo/default.nix
+++ b/pkgs/applications/misc/loxodo/default.nix
@@ -30,7 +30,7 @@ py.buildPythonApplication {
 
   meta = with stdenv.lib; {
     description = "A Password Safe V3 compatible password vault";
-    homepage = http://www.christoph-sommer.de/loxodo/;
+    homepage = https://www.christoph-sommer.de/loxodo/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
       instructions for your 3D printer. It cuts the model into horizontal
       slices (layers), generates toolpaths to fill them and calculates the
       amount of material to be extruded.'';
-    homepage = http://slic3r.org/;
+    homepage = https://slic3r.org/;
     license = licenses.agpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ bjornfor the-kenny ];

--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "The TeamSpeak voice communication tool";
-    homepage = http://teamspeak.com/;
+    homepage = https://teamspeak.com/;
     license = {
       fullName = "Teamspeak client license";
       url = http://sales.teamspeakusa.com/licensing.php;

--- a/pkgs/applications/networking/irc/wraith/default.nix
+++ b/pkgs/applications/networking/irc/wraith/default.nix
@@ -40,7 +40,7 @@ mkDerivation rec {
       The binary will not run when moved onto non-NixOS systems; use patchelf
       to fix its runtime dependenices.
     '';
-    homepage = http://wraith.botpack.net/;
+    homepage = https://wraith.botpack.net/;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ elitak ];
     platforms = platforms.linux;

--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (rec {
   dontStrip = !ocaml.nativeCompilers;
 
   meta = {
-    homepage = http://www.cis.upenn.edu/~bcpierce/unison/;
+    homepage = https://www.cis.upenn.edu/~bcpierce/unison/;
     description = "Bidirectional file synchronizer";
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/applications/office/zim/default.nix
+++ b/pkgs/applications/office/zim/default.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   version = "0.72.0";
 
   src = fetchurl {
-    url = "http://zim-wiki.org/downloads/${name}.tar.gz";
+    url = "https://zim-wiki.org/downloads/${name}.tar.gz";
     sha256 = "1n3gmg7g86s8iwcx0i7rvvfdfs1fzmc9awr9qzjd2rckw4bkxad1";
   };
 

--- a/pkgs/applications/science/biology/poretools/default.nix
+++ b/pkgs/applications/science/biology/poretools/default.nix
@@ -16,7 +16,7 @@ pythonPackages.buildPythonPackage rec {
   meta = {
     description = "a toolkit for working with nanopore sequencing data from Oxford Nanopore";
     license = stdenv.lib.licenses.mit;
-    homepage = http://poretools.readthedocs.io/en/latest/;
+    homepage = https://poretools.readthedocs.io/en/latest/;
     maintainers = [stdenv.lib.maintainers.rybern];
   };
 }

--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -46,7 +46,7 @@ mkDerivation rec {
       A GUI ground control station for autonomous vehicles using the MAVLink protocol.
       Includes support for the APM and PX4 based controllers.
     '';
-    homepage = http://ardupilot.org/planner2/;
+    homepage = https://ardupilot.org/planner2/;
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ wucke13 ];
   };

--- a/pkgs/applications/version-management/git-and-tools/subgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/subgit/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   src = fetchurl {
-    url = "http://subgit.com/download/${name}.zip";
+    url = "https://subgit.com/download/${name}.zip";
     sha256 = "0dwd2kymmprci3b61ayr6axzlkc8zgbc40jqxvvyzschfxw9y0v5";
   };
 }

--- a/pkgs/applications/version-management/redmine/default.nix
+++ b/pkgs/applications/version-management/redmine/default.nix
@@ -36,7 +36,7 @@ in
     '';
 
     meta = with stdenv.lib; {
-      homepage = http://www.redmine.org/;
+      homepage = https://www.redmine.org/;
       platforms = platforms.linux;
       maintainers = [ maintainers.aanderse ];
       license = licenses.gpl2;

--- a/pkgs/applications/version-management/smartgithg/default.nix
+++ b/pkgs/applications/version-management/smartgithg/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GUI for Git, Mercurial, Subversion";
-    homepage = http://www.syntevo.com/smartgit/;
+    homepage = https://www.syntevo.com/smartgit/;
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ jraygauthier ];

--- a/pkgs/applications/video/simplescreenrecorder/default.nix
+++ b/pkgs/applications/video/simplescreenrecorder/default.nix
@@ -31,7 +31,7 @@ mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A screen recorder for Linux";
-    homepage = http://www.maartenbaert.be/simplescreenrecorder;
+    homepage = https://www.maartenbaert.be/simplescreenrecorder;
     license = licenses.gpl3;
     platforms = [ "x86_64-linux" ];
     maintainers = [ maintainers.goibhniu ];

--- a/pkgs/data/fonts/ttf-envy-code-r/default.nix
+++ b/pkgs/data/fonts/ttf-envy-code-r/default.nix
@@ -17,7 +17,7 @@ in fetchzip {
   sha256 = "0x0r07nax68cmz7490x2crzzgdg4j8fg63wppcmjqm0230bggq2z";
 
   meta = with lib; {
-    homepage = http://damieng.com/blog/tag/envy-code-r;
+    homepage = https://damieng.com/blog/tag/envy-code-r;
     description = "Free scalable coding font by DamienG";
     license = licenses.unfree;
     maintainers = [ maintainers.lyt ];

--- a/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
+++ b/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
@@ -5,7 +5,7 @@ let
 in
 fetchzip {
   name = "ultimate-oldschool-pc-font-pack-${version}";
-  url = "http://int10h.org/oldschool-pc-fonts/download/ultimate_oldschool_pc_font_pack_v${version}.zip";
+  url = "https://int10h.org/oldschool-pc-fonts/download/ultimate_oldschool_pc_font_pack_v${version}.zip";
   sha256 = "0hid4dgqfy2w26734vcw2rxmpacd9vd1r2qpdr9ww1n3kgc92k9y";
 
   postFetch= ''
@@ -15,7 +15,7 @@ fetchzip {
 
   meta = with lib; {
     description = "The Ultimate Oldschool PC Font Pack (TTF Fonts)";
-    homepage = "http://int10h.org/oldschool-pc-fonts/";
+    homepage = "https://int10h.org/oldschool-pc-fonts/";
     license = licenses.cc-by-sa-40;
     maintainers = [ maintainers.endgame ];
   };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-dict-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-dict-plugin.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = "Dictionary plugin for Xfce panel";
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];
-    broken = true; # see http://goodies.xfce.org/projects/panel-plugins/xfce4-dict-plugin
+    broken = true; # see https://goodies.xfce.org/projects/panel-plugins/xfce4-dict-plugin
   };
 }

--- a/pkgs/development/compilers/souffle/default.nix
+++ b/pkgs/development/compilers/souffle/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A translator of declarative Datalog programs into the C++ language";
-    homepage    = "http://souffle-lang.github.io/";
+    homepage    = "https://souffle-lang.github.io/";
     platforms   = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice copumpkin wchresta ];
     license     = licenses.upl;

--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
       libraries support applications from web servers and databases to
       GUIs and charts.
     '';
-    homepage = http://racket-lang.org/;
+    homepage = https://racket-lang.org/;
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ kkallio henrytill vrthra ];
     platforms = [ "x86_64-darwin" "x86_64-linux" ];

--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.16.0";
 
   src = fetchurl {
-    url = "http://lv2plug.in/spec/${pname}-${version}.tar.bz2";
+    url = "https://lv2plug.in/spec/${pname}-${version}.tar.bz2";
     sha256 = "1ppippbpdpv13ibs06b0bixnazwfhiw0d0ja6hx42jnkgdyp5hyy";
   };
 

--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "2D physics engine";
-    homepage = http://box2d.org/;
+    homepage = https://box2d.org/;
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
     license = licenses.zlib;

--- a/pkgs/development/libraries/levmar/default.nix
+++ b/pkgs/development/libraries/levmar/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "levmar-2.6";
 
   src = fetchurl {
-    url = "http://www.ics.forth.gr/~lourakis/levmar/${name}.tgz";
+    url = "https://www.ics.forth.gr/~lourakis/levmar/${name}.tgz";
     sha256 = "1mxsjip9x782z6qa6k5781wjwpvj5aczrn782m9yspa7lhgfzx1v";
   };
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = { 
     description = "ANSI C implementations of Levenberg-Marquardt, usable also from C++";
-    homepage = http://www.ics.forth.gr/~lourakis/levmar/;
+    homepage = https://www.ics.forth.gr/~lourakis/levmar/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/libraries/libxl/default.nix
+++ b/pkgs/development/libraries/libxl/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3.8.8";
 
   src = fetchurl {
-    url = "http://www.libxl.com/download/${pname}-lin-${version}.tar.gz";
+    url = "https://www.libxl.com/download/${pname}-lin-${version}.tar.gz";
     sha256 = "08jarfcl8l5mrmkx6bcifi3ghkaja9isz77zgggl84yl66js5pc3";
   };
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A library for parsing Excel files";
-    homepage    = "http://www.libxl.com/";
+    homepage    = "https://www.libxl.com/";
     license     = licenses.unfree;
     platforms   = platforms.linux;
     maintainers = with maintainers; [  ];

--- a/pkgs/development/libraries/rabbitmq-java-client/default.nix
+++ b/pkgs/development/libraries/rabbitmq-java-client/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "RabbitMQ Java client library which allows Java code to interface to AMQP servers";
-    homepage = http://www.rabbitmq.com/java-client.html;
+    homepage = https://www.rabbitmq.com/java-client.html;
     license = with licenses; [ mpl11 gpl2 ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/rlog/default.nix
+++ b/pkgs/development/libraries/rlog/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   };
 
   meta = {
-    homepage = http://www.arg0.net/rlog;
+    homepage = https://www.arg0.net/rlog;
     description = "A C++ logging library used in encfs";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.lgpl3;

--- a/pkgs/development/libraries/safefile/default.nix
+++ b/pkgs/development/libraries/safefile/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.asl20 ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
-    homepage = http://research.cs.wisc.edu/mist/safefile/;
+    homepage = https://research.cs.wisc.edu/mist/safefile/;
     updateWalker = true;
   };
 }

--- a/pkgs/development/libraries/shhmsg/default.nix
+++ b/pkgs/development/libraries/shhmsg/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "shhmsg-1.4.2";
 
   src = fetchurl {
-    url = "http://shh.thathost.com/pub-unix/files/${name}.tar.gz";
+    url = "https://shh.thathost.com/pub-unix/files/${name}.tar.gz";
     sha256 = "0ax02fzqpaxr7d30l5xbndy1s5vgg1ag643c7zwiw2wj1czrxil8";
   };
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A library for displaying messages";
-    homepage = http://shh.thathost.com/pub-unix/;
+    homepage = https://shh.thathost.com/pub-unix/;
     license = licenses.artistic1;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/shhopt/default.nix
+++ b/pkgs/development/libraries/shhopt/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "shhopt-1.1.7";
 
   src = fetchurl {
-    url = "http://shh.thathost.com/pub-unix/files/${name}.tar.gz";
+    url = "https://shh.thathost.com/pub-unix/files/${name}.tar.gz";
     sha256 = "0yd6bl6qw675sxa81nxw6plhpjf9d2ywlm8a5z66zyjf28sl7sds";
   };
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A library for parsing command line options";
-    homepage = http://shh.thathost.com/pub-unix/;
+    homepage = https://shh.thathost.com/pub-unix/;
     license = licenses.artistic1;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/szip/default.nix
+++ b/pkgs/development/libraries/szip/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Compression library that can be used with the hdf5 library";
-    homepage = http://www.hdfgroup.org/doc_resource/SZIP/;
+    homepage = https://www.hdfgroup.org/doc_resource/SZIP/;
     license = stdenv.lib.licenses.unfree;
   };
 }

--- a/pkgs/development/libraries/tokyo-tyrant/default.nix
+++ b/pkgs/development/libraries/tokyo-tyrant/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "tokyotyrant-1.1.41";
 
   src = fetchurl {
-    url = "http://fallabs.com/tokyotyrant/${name}.tar.gz";
+    url = "https://fallabs.com/tokyotyrant/${name}.tar.gz";
     sha256 = "13xqcinhydqmh7231qlir6pymacjwcf98drybkhd9597kzxp1bs2";
   };
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
          licensed under the GNU Lesser General Public License.
        '';
 
-    homepage = http://fallabs.com/tokyotyrant/;
+    homepage = https://fallabs.com/tokyotyrant/;
 
     license = stdenv.lib.licenses.lgpl21Plus;
 

--- a/pkgs/development/libraries/wcslib/default.nix
+++ b/pkgs/development/libraries/wcslib/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "World Coordinate System Library for Astronomy";
-    homepage = http://www.atnf.csiro.au/people/mcalabre/WCS/;
+    homepage = https://www.atnf.csiro.au/people/mcalabre/WCS/;
 
     longDescription = ''Library for world coordinate systems for
     spherical geometries and their conversion to image coordinate

--- a/pkgs/development/libraries/zimlib/default.nix
+++ b/pkgs/development/libraries/zimlib/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Library for reading and writing ZIM files";
-    homepage =  http://www.openzim.org/wiki/Zimlib;
+    homepage =  https://www.openzim.org/wiki/Zimlib;
     license = licenses.gpl2;
     maintainers = with maintainers; [ robbinch ];
     platforms = platforms.linux;

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1173,7 +1173,7 @@ luautf8 = buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "http://github.com/starwing/luautf8";
+    homepage = "https://github.com/starwing/luautf8";
     description = "A UTF-8 support module for Lua";
     maintainers = with maintainers; [ pstn ];
     license = {
@@ -1212,7 +1212,7 @@ lua-yajl = buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
-    homepage = "http://github.com/brimworks/lua-yajl";
+    homepage = "https://github.com/brimworks/lua-yajl";
     description = "Integrate the yajl JSON library with Lua.";
     maintainers = with maintainers; [ pstn ];
     license = {

--- a/pkgs/development/python-modules/cjson/default.nix
+++ b/pkgs/development/python-modules/cjson/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A very fast JSON encoder/decoder for Python";
-    homepage = http://ag-projects.com/;
+    homepage = https://ag-projects.com/;
     license = licenses.lgpl2;
   };
 }

--- a/pkgs/development/python-modules/eventlib/default.nix
+++ b/pkgs/development/python-modules/eventlib/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Eventlib bindings for python";
-    homepage    = "http://ag-projects.com/";
+    homepage    = "https://ag-projects.com/";
     license     = licenses.lgpl2;
   };
 

--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A robust materials analysis code that defines core object representations for structures and molecules";
-    homepage = http://pymatgen.org/;
+    homepage = https://pymatgen.org/;
     license = licenses.mit;
     maintainers = with maintainers; [ psyanticy ];
   };

--- a/pkgs/development/python-modules/pysqlite/default.nix
+++ b/pkgs/development/python-modules/pysqlite/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://pysqlite.org/;
+    homepage = https://pysqlite.org/;
     description = "Python bindings for the SQLite embedded relational database engine";
     longDescription = ''
       pysqlite is a DB-API 2.0-compliant database interface for SQLite.

--- a/pkgs/development/python-modules/sipsimple/default.nix
+++ b/pkgs/development/python-modules/sipsimple/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "SIP SIMPLE implementation for Python";
-    homepage = http://sipsimpleclient.org/;
+    homepage = https://sipsimpleclient.org/;
     license = licenses.gpl3;
     maintainers = with maintainers; [ pSub ];
   };

--- a/pkgs/development/python-modules/stringtemplate/default.nix
+++ b/pkgs/development/python-modules/stringtemplate/default.nix
@@ -5,7 +5,7 @@ buildPythonPackage rec {
   version = "3.2b1";
 
   src = fetchurl {
-    url = "http://www.stringtemplate.org/download/${pname}-${version}.tar.gz";
+    url = "https://www.stringtemplate.org/download/${pname}-${version}.tar.gz";
     sha256 = "0lbib0l8c1q7i1j610rwcdagymr1idahrql4dkgnm5rzyg2vk3ml";
   };
 
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    homepage = http://www.stringtemplate.org/;
+    homepage = https://www.stringtemplate.org/;
     description = "Text Templating Library";
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Higher-level text processing, built on spaCy";
-    homepage = "http://textacy.readthedocs.io/";
+    homepage = "https://textacy.readthedocs.io/";
     license = licenses.asl20;
     maintainers = with maintainers; [ rvl ];
   };

--- a/pkgs/development/python-modules/umap-learn/default.nix
+++ b/pkgs/development/python-modules/umap-learn/default.nix
@@ -42,7 +42,7 @@ def test_umap_transform_on_iris()"
 
   meta = with lib; {
     description = "Uniform Manifold Approximation and Projection";
-    homepage = http://github.com/lmcinnes/umap;
+    homepage = https://github.com/lmcinnes/umap;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Fast implementation of asyncio event loop on top of libuv";
-    homepage = http://github.com/MagicStack/uvloop;
+    homepage = https://github.com/MagicStack/uvloop;
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/venusian/default.nix
+++ b/pkgs/development/python-modules/venusian/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A library for deferring decorator actions";
-    homepage = http://pylonsproject.org/;
+    homepage = https://pylonsproject.org/;
     license = licenses.bsd0;
     maintainers = with maintainers; [ domenkozar ];
   };

--- a/pkgs/development/python-modules/web/default.nix
+++ b/pkgs/development/python-modules/web/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
       Think about the ideal way to write a web app.
       Write the code to make it happen.
     '';
-    homepage = "http://webpy.org/";
+    homepage = "https://webpy.org/";
     license = licenses.publicDomain;
     maintainers = with maintainers; [ layus ];
   };

--- a/pkgs/development/python-modules/xstatic-jquery-ui/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-ui/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ xstatic-jquery ];
 
   meta = with lib;{
-    homepage = http://jqueryui.com/;
+    homepage = https://jqueryui.com/;
     description = "jquery-ui packaged static files for python";
     license = licenses.mit;
     maintainers = with maintainers; [ makefu ];

--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -22,7 +22,7 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "DB Browser for SQLite";
-    homepage = http://sqlitebrowser.org/;
+    homepage = https://sqlitebrowser.org/;
     license = licenses.gpl3;
     maintainers = with maintainers; [  ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/devtodo/default.nix
+++ b/pkgs/development/tools/devtodo/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://swapoff.org/devtodo1.html;
+    homepage = https://swapoff.org/devtodo1.html;
     description = "A hierarchical command-line task manager";
     license = licenses.gpl2;
     maintainers = [ maintainers.woffs ];

--- a/pkgs/development/tools/misc/saleae-logic/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic/default.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Software for Saleae logic analyzers";
-    homepage = http://www.saleae.com/;
+    homepage = https://www.saleae.com/;
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/tools/misc/watson-ruby/default.nix
+++ b/pkgs/development/tools/misc/watson-ruby/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An inline issue manager";
-    homepage    = http://goosecode.com/watson/;
+    homepage    = https://goosecode.com/watson/;
     license     = with licenses; mit;
     maintainers = with maintainers; [ robertodr nicknovitski ];
     platforms   = platforms.unix;

--- a/pkgs/games/snake4/default.nix
+++ b/pkgs/games/snake4/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "snake4-1.0.14";
 
   src = fetchurl {
-    url = "http://shh.thathost.com/pub-unix/files/${name}.tar.gz";
+    url = "https://shh.thathost.com/pub-unix/files/${name}.tar.gz";
     sha256 = "14cng9l857np42zixp440mbc8y5675frb6lhsds53j1cws9cncw9";
   };
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A game starring a fruit-eating snake";
-    homepage = http://shh.thathost.com/pub-unix/html/snake4.html;
+    homepage = https://shh.thathost.com/pub-unix/html/snake4.html;
     license = licenses.artistic1;
     platforms = platforms.linux;
   };

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://springlobby.info/;
+    homepage = https://springlobby.info/;
     repositories.git = git://github.com/springlobby/springlobby.git;
     description = "Cross-platform lobby client for the Spring RTS project";
     license = licenses.gpl2;

--- a/pkgs/games/stepmania/default.nix
+++ b/pkgs/games/stepmania/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage = http://www.stepmania.com/;
+    homepage = https://www.stepmania.com/;
     description = "Free dance and rhythm game for Windows, Mac, and Linux";
     platforms = platforms.linux;
     license = licenses.mit; # expat version

--- a/pkgs/games/tdm/default.nix
+++ b/pkgs/games/tdm/default.nix
@@ -20,7 +20,7 @@ let
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
   src = fetchurl {
-    url = "http://www.thedarkmod.com/sources/thedarkmod.${version}.src.7z";
+    url = "https://www.thedarkmod.com/sources/thedarkmod.${version}.src.7z";
     sha256 = "17wdpip8zvm2njz0xrf7xcxl73hnsc6i83zj18kn8rnjkpy50dd6";
   };
   nativeBuildInputs = [

--- a/pkgs/games/zandronum/default.nix
+++ b/pkgs/games/zandronum/default.nix
@@ -75,7 +75,7 @@ in stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://zandronum.com/;
+    homepage = https://zandronum.com/;
     description = "Multiplayer oriented port, based off Skulltag, for Doom and Doom II by id Software";
     maintainers = with maintainers; [ lassulus MP2E ];
     license = licenses.unfreeRedistributable;

--- a/pkgs/misc/drivers/sundtek/default.nix
+++ b/pkgs/misc/drivers/sundtek/default.nix
@@ -46,6 +46,6 @@ in
       maintainers = [ maintainers.simonvandel ];
       platforms = platforms.unix;
       license = licenses.unfree;
-      homepage = http://support.sundtek.com/index.php/topic,1573.0.html;
+      homepage = https://support.sundtek.com/index.php/topic,1573.0.html;
     };
   }

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "User-space tools for the Linux kernel ftrace subsystem";
-    homepage    = http://kernelshark.org/;
+    homepage    = https://kernelshark.org/;
     license     = licenses.gpl2;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ thoughtpolice basvandijk ];

--- a/pkgs/servers/amqp/rabbitmq-server/default.nix
+++ b/pkgs/servers/amqp/rabbitmq-server/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.rabbitmq.com/;
+    homepage = https://www.rabbitmq.com/;
     description = "An implementation of the AMQP messaging protocol";
     license = stdenv.lib.licenses.mpl11;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/servers/http/spawn-fcgi/default.nix
+++ b/pkgs/servers/http/spawn-fcgi/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage    = "http://redmine.lighttpd.net/projects/spawn-fcgi";
+    homepage    = "https://redmine.lighttpd.net/projects/spawn-fcgi";
     description = "Provides an interface to external programs that support the FastCGI interface";
     license     = licenses.bsd3;
     maintainers = with maintainers; [ cstrahan ];

--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   installCheckPhase = "$out/bin/groonga --version";
 
   meta = with stdenv.lib; {
-    homepage    = http://groonga.org/;
+    homepage    = https://groonga.org/;
     description = "An open-source fulltext search engine and column store";
     license     = licenses.lgpl21;
     maintainers = [ maintainers.ericsagnes ];

--- a/pkgs/shells/tcsh/default.nix
+++ b/pkgs/shells/tcsh/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
       - history mechanism
       - job control
     '';
-    homepage = http://www.tcsh.org/;
+    homepage = https://www.tcsh.org/;
     license = licenses.bsd2;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "A Python-ish, BASHwards-compatible shell";
-    homepage = http://xon.sh/;
+    homepage = https://xon.sh/;
     license = licenses.bsd3;
     maintainers = with maintainers; [ spwhitt vrthra ];
     platforms = platforms.all;

--- a/pkgs/tools/archivers/unrar/default.nix
+++ b/pkgs/tools/archivers/unrar/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Utility for RAR archives";
-    homepage = http://www.rarlab.com/;
+    homepage = https://www.rarlab.com/;
     license = licenses.unfreeRedistributable;
     maintainers = [ maintainers.ehmry ];
     platforms = platforms.all;

--- a/pkgs/tools/backup/rsnapshot/default.nix
+++ b/pkgs/tools/backup/rsnapshot/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "rsnapshot-1.4.3";
 
   src = fetchurl {
-    url = "http://rsnapshot.org/downloads/${name}.tar.gz";
+    url = "https://rsnapshot.org/downloads/${name}.tar.gz";
     sha256 = "1lavqmmsf53pim0nvming7fkng6p0nk2a51k2c2jdq0l7snpl31b";
   };
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A filesystem snapshot utility for making backups of local and remote systems";
-    homepage = http://rsnapshot.org/;
+    homepage = https://rsnapshot.org/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://help.yandex.com/disk/cli-clients.xml;
+    homepage = https://help.yandex.com/disk/cli-clients.xml;
     description = "A free cloud file storage service";
     maintainers = with stdenv.lib.maintainers; [ smironov jagajaga ];
     platforms = ["i686-linux" "x86_64-linux"];

--- a/pkgs/tools/misc/gnuvd/default.nix
+++ b/pkgs/tools/misc/gnuvd/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Command-line dutch dictionary application";
-    homepage = http://www.djcbsoftware.nl/code/gnuvd/;
+    homepage = https://www.djcbsoftware.nl/code/gnuvd/;
     license = licenses.gpl2;
     platforms = platforms.unix;
   };

--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib;
     { description = "Network boot firmware";
-      homepage = http://ipxe.org/;
+      homepage = https://ipxe.org/;
       license = licenses.gpl2;
       maintainers = with maintainers; [ ehmry ];
       platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/tools/misc/x11idle/default.nix
+++ b/pkgs/tools/misc/x11idle/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     longDescription = ''
       Idle time passes when the user does not act, i.e. when the user doesn't move the mouse or use the keyboard.
     '';
-    homepage = http://orgmode.org/;
+    homepage = https://orgmode.org/;
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = [ maintainers.swflint ];

--- a/pkgs/tools/networking/stunnel/default.nix
+++ b/pkgs/tools/networking/stunnel/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Universal tls/ssl wrapper";
-    homepage    = "http://www.stunnel.org/";
+    homepage    = "https://www.stunnel.org/";
     license     = stdenv.lib.licenses.gpl2Plus;
     platforms   = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];

--- a/pkgs/tools/networking/uwimap/default.nix
+++ b/pkgs/tools/networking/uwimap/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation ({
   '';
 
   meta = {
-    homepage = http://www.washington.edu/imap/;
+    homepage = https://www.washington.edu/imap/;
     description = "UW IMAP toolkit - IMAP-supporting software developed by the UW";
     license = stdenv.lib.licenses.asl20;
     platforms = with stdenv.lib.platforms; linux;


### PR DESCRIPTION
###### Motivation for this change

According to https://repology.org/repository/nix_unstable/problems, we have a
lot of packages that have http links that redirect to https as their homepage.
This commit updates all these packages to use the https links as their
homepage.

The following script was used to make these updates:

```

curl https://repology.org/api/v1/repository/nix_unstable/problems \
    | jq '.[] | .problem' -r \
    | rg 'Homepage link "(.+)" is a permanent redirect to "(.+)" and should be updated' --replace 's@$1@$2@' \
    | sort | uniq > script.sed

find -name '*.nix' | xargs -P4 -- sed -f script.sed -i
```

This should save a few http 301 requests when building and might be safer for our users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
