### PR TITLE
tdesktop: 1.9.3 -> 1.9.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -18,30 +18,27 @@ with lib;
 
 mkDerivation rec {
   pname = "telegram-desktop";
-  version = "1.9.3";
+  version = "1.9.4";
   # Note: Due to our strong dependency on the Arch patches it's probably best
   # to also wait for the Arch update (especially if the patches don't apply).
 
   # Telegram-Desktop with submodules
   src = fetchurl {
     url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "1fx7v7j7iw4iywdbl89c5f1y74via61a0k20zrgjv5a0j4v6g76a";
+    sha256 = "1ldsgbix0ca4pl2z55wiz90ll3542zsm9slayrzyr7b2jw7arxwy";
   };
 
   # Arch patches (svn export telegram-desktop/trunk)
   archPatches = fetchsvn {
     url = "svn://svn.archlinux.org/community/telegram-desktop/trunk";
     # svn log svn://svn.archlinux.org/community/telegram-desktop/trunk
-    rev = "549803";
-    sha256 = "1py2a25wgpvx0n4kz383fj0jav1qdm8wqx5bdaygg6296r294czj";
+    rev = "553350";
+    sha256 = "05fyij490flrbn4jfwhm8gx9imh0wfby4j9fj69f45qgkpsd7ajb";
   };
 
   # Note: It would be best if someone could get as many patches upstream as
   # possible (we currently depend a lot on custom patches...).
   patches = [
-    "${archPatches}/0001-Dynamic-linking-system-libs.patch"
-    "${archPatches}/0002-Dynamic-linking-system-qt.patch"
-    "${archPatches}/0004-gtk3.patch"
     "${archPatches}/0005-Use-system-wide-fonts.patch"
     "${archPatches}/0006-Revert-Disable-DemiBold-fallback-for-Semibold.patch"
   ];
@@ -49,8 +46,6 @@ mkDerivation rec {
   postPatch = ''
     substituteInPlace Telegram/SourceFiles/platform/linux/linux_libs.cpp \
       --replace '"appindicator3"' '"${libappindicator-gtk3}/lib/libappindicator3.so"'
-    substituteInPlace cmake/external/ranges/CMakeLists.txt \
-      --replace "/usr/include" "${range-v3}/include"
   '';
 
   # We want to run wrapProgram manually (with additional parameters)
@@ -83,17 +78,34 @@ mkDerivation rec {
   CPPFLAGS = NIX_CFLAGS_COMPILE;
 
   cmakeFlags = [
+    "-Ddisable_autoupdate=ON"
     #"-DTDESKTOP_API_TEST=ON" # TODO: Officiall API credentials for Nixpkgs
     "-DTDESKTOP_API_ID=17349" # See: https://github.com/NixOS/nixpkgs/issues/55271
     "-DTDESKTOP_API_HASH=344583e45741c457fe1862106095a5eb"
     "-DDESKTOP_APP_USE_GLIBC_WRAPS=OFF"
-    "-DDESKTOP_APP_USE_SYSTEM_LIBS=ON"
+    "-DDESKTOP_APP_USE_PACKAGED=ON"
+    "-DDESKTOP_APP_USE_PACKAGED_RLOTTIE=OFF"
     "-DDESKTOP_APP_DISABLE_CRASH_REPORTS=ON"
-    "-Ddisable_autoupdate=ON"
     "-DTDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME=ON"
     "-DTDESKTOP_DISABLE_DESKTOP_FILE_GENERATION=ON"
+    "-DTDESKTOP_USE_PACKAGED_TGVOIP=OFF"
     #"-DDESKTOP_APP_SPECIAL_TARGET=\"\"" # TODO: Error when set to "": Bad special target '""'
   ];
+
+  # Note: The following packages could be packaged system-wide, but it's
+  # probably best to use the bundled ones from tdesktop (Arch does this too):
+  # rlottie:
+  # - CMake flag: "-DTDESKTOP_USE_PACKAGED_TGVOIP=ON"
+  # - Sources (problem: there are no stable releases!):
+  #   - desktop-app (tdesktop): https://github.com/desktop-app/rlottie
+  #   - upstream: https://github.com/Samsung/rlottie
+  # libtgvoip:
+  # - CMake flag: "-DDESKTOP_APP_USE_PACKAGED_RLOTTIE=ON"
+  # - Sources  (problem: the stable releases might be too old!):
+  #   - tdesktop: https://github.com/telegramdesktop/libtgvoip
+  #   - upstream: https://github.com/grishka/libtgvoip
+  # Both of these packages are included in this PR (kotatogram-desktop):
+  # https://github.com/NixOS/nixpkgs/pull/75210
 
   installPhase = ''
     install -Dm755 bin/Telegram $out/bin/telegram-desktop
@@ -115,7 +127,8 @@ mkDerivation rec {
       "''${gappsWrapperArgs[@]}" \
       "''${qtWrapperArgs[@]}" \
       --prefix PATH : ${xdg_utils}/bin \
-      --set XDG_RUNTIME_DIR "XDG-RUNTIME-DIR"
+      --set XDG_RUNTIME_DIR "XDG-RUNTIME-DIR" \
+      --unset QT_QPA_PLATFORMTHEME # From the Arch wrapper
     sed -i $out/bin/telegram-desktop \
       -e "s,'XDG-RUNTIME-DIR',\"\''${XDG_RUNTIME_DIR:-/run/user/\$(id --user)}\","
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Notes

Luckily this further simplifies things by getting rid of 3 custom patches :)
State: LGTM :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
