### PR TITLE
kdeFrameworks: 5.65.0 -> 5.66.0

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.65/ )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.66/ )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,659 +3,659 @@
 
 {
   attica = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/attica-5.65.0.tar.xz";
-      sha256 = "a62908517f9cf44fd13c2cb37868f6484710284bc85bd85b532c3b8b7fc2b9ea";
-      name = "attica-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/attica-5.66.0.tar.xz";
+      sha256 = "e87ea061d393104804aa65db69ec3489512b472d8fb821c9fc49ffdcb85177fb";
+      name = "attica-5.66.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/baloo-5.65.0.tar.xz";
-      sha256 = "c24c53838d57b40a1f099cb40240cad86fb9ebbf09fd0f811d9ce14a9cf5f3bf";
-      name = "baloo-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/baloo-5.66.0.tar.xz";
+      sha256 = "9495869eee72f587efadc8a848c3f76b93a1dcb1914c8e818d7084451107a1f8";
+      name = "baloo-5.66.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/bluez-qt-5.65.0.tar.xz";
-      sha256 = "ad60bd7ee5d46bcee838d3c36031ccd4d427cd6ac93286831695f89198a5f143";
-      name = "bluez-qt-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/bluez-qt-5.66.0.tar.xz";
+      sha256 = "cc3f3fcc1df87b61480549d658c1a27690661aaa4f22a65552efe3f6bf41c887";
+      name = "bluez-qt-5.66.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/breeze-icons-5.65.0.tar.xz";
-      sha256 = "166c0a7d49524313c5355e763f6561075ef33cae968ddf6da3174d2788dd7da3";
-      name = "breeze-icons-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/breeze-icons-5.66.0.tar.xz";
+      sha256 = "445a77204c7d9ac398e7f1d1594cd93e719665c85c7fb9ef71fde1ce68cb64d7";
+      name = "breeze-icons-5.66.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/extra-cmake-modules-5.65.0.tar.xz";
-      sha256 = "41634536ca1165a758acd85aa11112177616019e2d3974693a92d1d9bc91c105";
-      name = "extra-cmake-modules-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/extra-cmake-modules-5.66.0.tar.xz";
+      sha256 = "2ff1a4ede28488ea787e742ab37edaacc5f59bf9188476e48f681ce23300b9c4";
+      name = "extra-cmake-modules-5.66.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/frameworkintegration-5.65.0.tar.xz";
-      sha256 = "3170f99d4418b25225813822e22a1bdf8d73af87cd00b696089b696b151d43be";
-      name = "frameworkintegration-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/frameworkintegration-5.66.0.tar.xz";
+      sha256 = "55c01613436781d74652bef19fc594448cdee4c002d5e1713b583473455f54d8";
+      name = "frameworkintegration-5.66.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kactivities-5.65.0.tar.xz";
-      sha256 = "00a64654861cdff809be5f78931bfd671fe81841380b9c3926f75957c18f139b";
-      name = "kactivities-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kactivities-5.66.0.tar.xz";
+      sha256 = "7c37c8f189cb3c9f0cacbcef606562d8bc596e685d2a47bc9994deae6e69f41f";
+      name = "kactivities-5.66.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kactivities-stats-5.65.0.tar.xz";
-      sha256 = "5a7ae4c43610ac6d6ce084d639a9a3b6db58ac14a61b56be53a9282573b296c0";
-      name = "kactivities-stats-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kactivities-stats-5.66.0.tar.xz";
+      sha256 = "567de599a8fd8b6a5304fc1696e24b069b4eaa7bbc643b1e760293d8c1162b73";
+      name = "kactivities-stats-5.66.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kapidox-5.65.0.tar.xz";
-      sha256 = "3748814024088e72a510bde782f47235fded41835ee4dcc130a441a814af7a68";
-      name = "kapidox-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kapidox-5.66.0.tar.xz";
+      sha256 = "19af4d93adfa22ff4de832185c1e9191d35039394bb032ee60e33efc5cc456db";
+      name = "kapidox-5.66.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/karchive-5.65.0.tar.xz";
-      sha256 = "9e6cdb2cf10407fd435b97eb284ac56ad1bca95f0b1789a8bc26c9cee7edcc52";
-      name = "karchive-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/karchive-5.66.0.tar.xz";
+      sha256 = "434f315af624d315b06a35ba5e71e570f36ca454af891833d6e896e42edf23d8";
+      name = "karchive-5.66.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kauth-5.65.0.tar.xz";
-      sha256 = "277821947090e806f5850983e110134480915bf8e9609e0f24eaf34f7ca00c5f";
-      name = "kauth-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kauth-5.66.0.tar.xz";
+      sha256 = "f167ec8f926caf348a161a39e0c0588f517fe3a49ab4f39c1dfa94f47e104414";
+      name = "kauth-5.66.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kbookmarks-5.65.0.tar.xz";
-      sha256 = "c00a04d77ce2b4744feb5ae43f50f8ae5c18b752eae52a8f4d9db47046daf18a";
-      name = "kbookmarks-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kbookmarks-5.66.0.tar.xz";
+      sha256 = "b225463ec0fe2424a1f5e70c83b02e3ece6a3ca80832cd2621732d18d7160a43";
+      name = "kbookmarks-5.66.0.tar.xz";
     };
   };
   kcalendarcore = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kcalendarcore-5.65.0.tar.xz";
-      sha256 = "fb79dc1bd1153c7fc38242c577a324462b8913e151bc33b74f7997e48d494cb8";
-      name = "kcalendarcore-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kcalendarcore-5.66.0.tar.xz";
+      sha256 = "bbdb48c775ccc1e1bdba962b5ccdc0611a2d14523076d33c4507c05db3ab33d3";
+      name = "kcalendarcore-5.66.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kcmutils-5.65.0.tar.xz";
-      sha256 = "fbb525cb21afbf9752d171ceb333a805c40d4722b98da6fce0243e37b8398ec3";
-      name = "kcmutils-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kcmutils-5.66.0.tar.xz";
+      sha256 = "e02dbf996ed93bdc2813a2a64dcb0ddeb54987dd84bbe787bd890b17d57e4a85";
+      name = "kcmutils-5.66.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kcodecs-5.65.0.tar.xz";
-      sha256 = "eca1642a559aad9aed57ea3ad5c7a62a2b20ad13969b6fcba671f5bc7c9782fd";
-      name = "kcodecs-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kcodecs-5.66.0.tar.xz";
+      sha256 = "0dcb684ad75374bbab82b90bda20e914cf656bd51a6dff69bbb1bfc650481a05";
+      name = "kcodecs-5.66.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kcompletion-5.65.0.tar.xz";
-      sha256 = "bdd7201940fa47ac1b62f6fcf7a12883abed44876ff729cb430c11d3868eb8ae";
-      name = "kcompletion-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kcompletion-5.66.0.tar.xz";
+      sha256 = "be5e272e257b9fe5b951d7c596fef7c75b16886e6b1cd5ebff60d87bd6dd495d";
+      name = "kcompletion-5.66.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kconfig-5.65.0.tar.xz";
-      sha256 = "8dfa064effdf559e1179e9d7e5ec12ff9d79fcfef1859bd1793557261e94a6ed";
-      name = "kconfig-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kconfig-5.66.0.tar.xz";
+      sha256 = "c0df73bde40162a5ffc20604c2ad343e71a6df852c3f7b05e70e1464f5f63256";
+      name = "kconfig-5.66.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kconfigwidgets-5.65.0.tar.xz";
-      sha256 = "210a694aacd0d6bd26a5a6b78986d180960ddb7e26933b127a0107ae4995a120";
-      name = "kconfigwidgets-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kconfigwidgets-5.66.0.tar.xz";
+      sha256 = "730834528307c65691d67c901f1c186b49d74ee986ef75e171e867e8751bf10a";
+      name = "kconfigwidgets-5.66.0.tar.xz";
     };
   };
   kcontacts = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kcontacts-5.65.0.tar.xz";
-      sha256 = "84dd287010c8daa6865337df39ce14b44f8f7c14c810fe095d264d5bafa7b306";
-      name = "kcontacts-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kcontacts-5.66.0.tar.xz";
+      sha256 = "08086f554eb4718e91a9e96d143ba05fc741289928db9bcc21b21ca7125b0017";
+      name = "kcontacts-5.66.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kcoreaddons-5.65.0.tar.xz";
-      sha256 = "0f334b123b307829d11a39f639845f2f74d290490b264d9b188f1a785e16bf41";
-      name = "kcoreaddons-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kcoreaddons-5.66.0.tar.xz";
+      sha256 = "8a8edf566cb08ad83cb17f942eeb8746993249cd0f7679f7eb810201b85e464b";
+      name = "kcoreaddons-5.66.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kcrash-5.65.0.tar.xz";
-      sha256 = "6b05608507dd2f8821399c4596021bcf9da79a284726a093c8b81b6d3cc4e034";
-      name = "kcrash-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kcrash-5.66.0.tar.xz";
+      sha256 = "5a518059de3f3e85ee7b38a0edf348d097993518ce9b17504470f0d8aad3f2e4";
+      name = "kcrash-5.66.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kdbusaddons-5.65.0.tar.xz";
-      sha256 = "e2777538c6d1f0dd5956b3bc2c9cfe34fe360655c188e658f52f926ff8cb3fcc";
-      name = "kdbusaddons-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kdbusaddons-5.66.0.tar.xz";
+      sha256 = "ee600f15af2fb9a28ad15f7e0689d519211fa63b86f2e6c356bd32530ebdfa46";
+      name = "kdbusaddons-5.66.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kdeclarative-5.65.0.tar.xz";
-      sha256 = "a0274de8c84d73dd17b1bc0faf64a9e0d0655035c0574148ba64986e367cd881";
-      name = "kdeclarative-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kdeclarative-5.66.0.tar.xz";
+      sha256 = "ed3a334d8bce6d70e68e013d4210bd6e11cb2ebce9ede4c1813f44dada7eca73";
+      name = "kdeclarative-5.66.0.tar.xz";
     };
   };
   kded = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kded-5.65.0.tar.xz";
-      sha256 = "14ba21ffed8b425be7550c8b7e3ba78d3f208b800bba7db6c950e02c06d1f032";
-      name = "kded-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kded-5.66.0.tar.xz";
+      sha256 = "52223e641c4e8e3158220ed7b6c48e4c3f3e67f882603ada0e3757b4136255a4";
+      name = "kded-5.66.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/portingAids/kdelibs4support-5.65.0.tar.xz";
-      sha256 = "c7ebd744c1c8dbc1b8adcf815a7a019b73e5f85653dda3e19dc9f31cab4e7701";
-      name = "kdelibs4support-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/portingAids/kdelibs4support-5.66.0.tar.xz";
+      sha256 = "314d0ddb95c024c3d36dd262fcaa9295b462e6430f84b22c82f145029e3b2708";
+      name = "kdelibs4support-5.66.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/portingAids/kdesignerplugin-5.65.0.tar.xz";
-      sha256 = "e6ba152df5848789cd35f1734dfd3d20f439a21ebba8b96caf747654de42c515";
-      name = "kdesignerplugin-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/portingAids/kdesignerplugin-5.66.0.tar.xz";
+      sha256 = "a7f9c530d8c7d214a176ee381541bd45f3a000a3e86404040b11f1394912d40b";
+      name = "kdesignerplugin-5.66.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kdesu-5.65.0.tar.xz";
-      sha256 = "a39a727db863a45969cca2736b321257a2a6c0f2db7e0c70cbe9cf8b3f180d40";
-      name = "kdesu-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kdesu-5.66.0.tar.xz";
+      sha256 = "764d30acb0ef1d609c9454ecabb939bd64a814442e01aba769eba0673b56f88a";
+      name = "kdesu-5.66.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/portingAids/kdewebkit-5.65.0.tar.xz";
-      sha256 = "82525a8fda1e9e2e7cde348b6e7227b0747f93d75a7648f4863e0e6889640586";
-      name = "kdewebkit-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/portingAids/kdewebkit-5.66.0.tar.xz";
+      sha256 = "f73d2599ce2269eaab45ddc11bdeb49dc887e950ded57454f3fd6499c370a777";
+      name = "kdewebkit-5.66.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kdnssd-5.65.0.tar.xz";
-      sha256 = "e7f684580f3f6060a73da33439b463ed0f47f72e7129c142b09b4b642331969f";
-      name = "kdnssd-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kdnssd-5.66.0.tar.xz";
+      sha256 = "e280246212329f2834437ea3e84971fc85f3a3e6824963322e1f5de6aa04709c";
+      name = "kdnssd-5.66.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kdoctools-5.65.0.tar.xz";
-      sha256 = "0ff2b70bc46ffc7b62dba9476163ed26ba7fddb8be0ba34ecf48055bcabb649b";
-      name = "kdoctools-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kdoctools-5.66.0.tar.xz";
+      sha256 = "41e4ca7aceab17919ef4a82ad99606f520ebfe57f30205597b4184f7a3730a7a";
+      name = "kdoctools-5.66.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kemoticons-5.65.0.tar.xz";
-      sha256 = "923853ef4fd472369f9d5ec3732d6d03dc55b6ba1dd79146f24551d642e09e51";
-      name = "kemoticons-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kemoticons-5.66.0.tar.xz";
+      sha256 = "dc307192d883108134da104d1507709a3b80c5b5e9984377840bd42d39a431dd";
+      name = "kemoticons-5.66.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kfilemetadata-5.65.0.tar.xz";
-      sha256 = "9df372bcc1f910a332b4f5f8b34f5cfeb453c002bec93cdb4004e36157883a75";
-      name = "kfilemetadata-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kfilemetadata-5.66.0.tar.xz";
+      sha256 = "d78c2128887591229e6c61c60e77af8647e407d570b07892f5f06ab682f807b9";
+      name = "kfilemetadata-5.66.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kglobalaccel-5.65.0.tar.xz";
-      sha256 = "48fc4678ad28aaba07056b2e6f4b8cc7b8e9522cad8dbed43980a0b38ad9b8df";
-      name = "kglobalaccel-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kglobalaccel-5.66.0.tar.xz";
+      sha256 = "fae805994f946791525da65ca15f93b65b2001241c7539ad04b3aaef937fb1c3";
+      name = "kglobalaccel-5.66.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kguiaddons-5.65.0.tar.xz";
-      sha256 = "f6b34db7c21ced8179351f2bf38c7c073fa4e0f6de2f9d03986aedba4f87488d";
-      name = "kguiaddons-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kguiaddons-5.66.0.tar.xz";
+      sha256 = "379e5ed87b00d344a13e424e39d97d74d494c503400bcd72df132de74c8cc591";
+      name = "kguiaddons-5.66.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kholidays-5.65.0.tar.xz";
-      sha256 = "613f9050c4970a22680c72680dc76d45b270fb5b76129a994a375ad158ab832c";
-      name = "kholidays-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kholidays-5.66.0.tar.xz";
+      sha256 = "2d9bb70fbcb3a45208409228b5e5a88b0cb00fe8f2621e2e938bc77c2df11f02";
+      name = "kholidays-5.66.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/portingAids/khtml-5.65.0.tar.xz";
-      sha256 = "cfbfda470b4aecd189489e44983aa3c725ef0d234992afd38701273663d7ccba";
-      name = "khtml-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/portingAids/khtml-5.66.0.tar.xz";
+      sha256 = "ee34b082760262fb9b5e287960955075ec72179585e51567350a08bf0b4b7a10";
+      name = "khtml-5.66.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/ki18n-5.65.0.tar.xz";
-      sha256 = "303c3ef4fc7e417233211373a21759332f39a9ae45c9ce7b407eaba412d2caa4";
-      name = "ki18n-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/ki18n-5.66.0.tar.xz";
+      sha256 = "9622337a513fcb8f0b5100c218b9fa85617f92024e5d7feada6d071f58a329e3";
+      name = "ki18n-5.66.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kiconthemes-5.65.0.tar.xz";
-      sha256 = "6549774254705861654e0393ab53b7a06b62415644d6bbe5479f7458b22895c5";
-      name = "kiconthemes-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kiconthemes-5.66.0.tar.xz";
+      sha256 = "93fa9b8d0f951c2c9991f366081f98670086f2b66a740d7be95b64c35dff111d";
+      name = "kiconthemes-5.66.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kidletime-5.65.0.tar.xz";
-      sha256 = "10b12437efb42c66956a728dad3a04d84dab5a081536a3b7029393a0ae3f1722";
-      name = "kidletime-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kidletime-5.66.0.tar.xz";
+      sha256 = "66e891b33ed9026ed6fd211cd1ecf3405255b19d3a58199b87af0b22a40d7185";
+      name = "kidletime-5.66.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kimageformats-5.65.0.tar.xz";
-      sha256 = "51ed246d07e33b5214a5594566955c2b1eff44e009998e74d7f2fe8011f82d13";
-      name = "kimageformats-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kimageformats-5.66.0.tar.xz";
+      sha256 = "c3b02befbb03f25deca0c7ffafea8c8a5eb79e21d8e2e566bf6fddf4f8afe04d";
+      name = "kimageformats-5.66.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kinit-5.65.0.tar.xz";
-      sha256 = "bbff3999f40d67284e7f90118f29dbedc9fdd673ce74f29f82a9115f4b5efbc1";
-      name = "kinit-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kinit-5.66.0.tar.xz";
+      sha256 = "6d9b6ea1542ff5529fd42f49240be37bbd8a3dfdfe8c45ac980b3c9b3fee650e";
+      name = "kinit-5.66.0.tar.xz";
     };
   };
   kio = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kio-5.65.0.tar.xz";
-      sha256 = "7d3cc0c82e83c082b424a2fe4c796c4c46f233ccd565775babbf6b434fce851b";
-      name = "kio-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kio-5.66.0.tar.xz";
+      sha256 = "c5350e20474b48c4fc02347186b7e4db24cb7580ba8c0f1e120b302e6b8db17d";
+      name = "kio-5.66.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kirigami2-5.65.0.tar.xz";
-      sha256 = "034222e4beec5c5b142cdbdd35304fe5374097367237af1feb5252dabe87e261";
-      name = "kirigami2-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kirigami2-5.66.0.tar.xz";
+      sha256 = "4e4abfeaa5e997de52076786dd0d314f178bc883b1b48a8b2cf37dd5979ac41b";
+      name = "kirigami2-5.66.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kitemmodels-5.65.0.tar.xz";
-      sha256 = "01980a8b518cdb442ace10f7a61dacec1cb61ff708d86edf83ee079cb6451d41";
-      name = "kitemmodels-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kitemmodels-5.66.0.tar.xz";
+      sha256 = "5c8bcc36b9c29868ba7fa1ece9b83385379d7fed04937a92454ac94a356b3854";
+      name = "kitemmodels-5.66.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kitemviews-5.65.0.tar.xz";
-      sha256 = "689f2517432861932a05b5c71e1c8c1378bee6773850e8a13a5907d0af58d5cb";
-      name = "kitemviews-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kitemviews-5.66.0.tar.xz";
+      sha256 = "026461fa2e3e0237a56eb18a2817453c788514578f27a4aa0832b85fe98a09ab";
+      name = "kitemviews-5.66.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kjobwidgets-5.65.0.tar.xz";
-      sha256 = "2b68d848b086f274020334cadd28d212125e05a7fdd97ff97ac801aed80ec852";
-      name = "kjobwidgets-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kjobwidgets-5.66.0.tar.xz";
+      sha256 = "34501be3ec85f0e71dba22669b3c862b297606e9bbff9aae466667c7075b6f8d";
+      name = "kjobwidgets-5.66.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/portingAids/kjs-5.65.0.tar.xz";
-      sha256 = "d7c9f86a500049a3aa940be469e86e5dbe00d41de9c9488916958ef1a1037df0";
-      name = "kjs-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/portingAids/kjs-5.66.0.tar.xz";
+      sha256 = "9bed62ebf9fba7d986ff7baabf6c4431f02826c9be70beda15cc62c692fb5f7f";
+      name = "kjs-5.66.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/portingAids/kjsembed-5.65.0.tar.xz";
-      sha256 = "e6d919e6c87f7a38df623a4f5061cafa50b61fe10f9d4769f61f116f4e920d21";
-      name = "kjsembed-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/portingAids/kjsembed-5.66.0.tar.xz";
+      sha256 = "58fe647901b69167b7c66a284c3181c2eda9c3b751548eb43bfe0795d10eb0ce";
+      name = "kjsembed-5.66.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/portingAids/kmediaplayer-5.65.0.tar.xz";
-      sha256 = "bbab29b71d07ec736b842abc54a67441cb89b25b81e957bd8a95c1550f95c673";
-      name = "kmediaplayer-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/portingAids/kmediaplayer-5.66.0.tar.xz";
+      sha256 = "7ec1fea10a1017a0f32183fdc3b2cca38c11273240423ac0d393626436fd4230";
+      name = "kmediaplayer-5.66.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/knewstuff-5.65.0.tar.xz";
-      sha256 = "0ec8ab4d7f52c94fb479c0c56ed762748832c76e88b495694b7485e79d9797d9";
-      name = "knewstuff-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/knewstuff-5.66.0.tar.xz";
+      sha256 = "acef94661e3a0e42938224c17b90f835d6686d88a25698fe82980d7e1139b1fe";
+      name = "knewstuff-5.66.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/knotifications-5.65.0.tar.xz";
-      sha256 = "9d766c1566ea7cab83e6cd9c57f76583b3404f9864ed1ba1bc65535ea4c98087";
-      name = "knotifications-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/knotifications-5.66.0.tar.xz";
+      sha256 = "aad3697a35109fad49fa286b7837d382599478bac33151cd7991c760866c12c1";
+      name = "knotifications-5.66.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/knotifyconfig-5.65.0.tar.xz";
-      sha256 = "a0eb8a27b545d7cc9c61bef6630b9f6d68da76e49c2c8ac8b4ae03d8f89b1e54";
-      name = "knotifyconfig-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/knotifyconfig-5.66.0.tar.xz";
+      sha256 = "fd9e09b099f49896b5afa6f5663ef82266531ec413d4edeb03ebc768314a37d8";
+      name = "knotifyconfig-5.66.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kpackage-5.65.0.tar.xz";
-      sha256 = "5ac5f6a687c244709487bc47d7aeca276ad7a925d7618fdf04a7af0e1e3fa581";
-      name = "kpackage-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kpackage-5.66.0.tar.xz";
+      sha256 = "ae848a72e789a80d4a9d0346e90cb1038ebc784da6e7ff645411edd878554ab5";
+      name = "kpackage-5.66.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kparts-5.65.0.tar.xz";
-      sha256 = "f0fb059a21c744fd5da8e201e4fe329ed1bccaf586541fecd55ddb48191e725f";
-      name = "kparts-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kparts-5.66.0.tar.xz";
+      sha256 = "6de2395cd6a9993f216f4dc4718f352bc4cbbd8147734c76be0e1e6149f733d0";
+      name = "kparts-5.66.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kpeople-5.65.0.tar.xz";
-      sha256 = "e12ab7b8b02369a505f2f408b9ffba6742369e9f8b9fa7cafed9b23a49526eac";
-      name = "kpeople-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kpeople-5.66.0.tar.xz";
+      sha256 = "2728f08a9417ceb62aa9fc5a3340aed291aeb8a852e5f6f46c5a23fcc34168ab";
+      name = "kpeople-5.66.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kplotting-5.65.0.tar.xz";
-      sha256 = "967d483cba446a2fb734cd1bcc5340349b62f38f41b3759cc58bf8970ac3b719";
-      name = "kplotting-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kplotting-5.66.0.tar.xz";
+      sha256 = "2a4387f748614f005cf67e549b9466c6eed52589ac58297857ba6a0be92c32ee";
+      name = "kplotting-5.66.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kpty-5.65.0.tar.xz";
-      sha256 = "b7607cac36ef58aca675a2d90445f1152670c513d6992112ab01ade5400d4554";
-      name = "kpty-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kpty-5.66.0.tar.xz";
+      sha256 = "a7fac6ced7504cec13a6776f0f4ba22db9878e44e2bbf85a219a2590e061c859";
+      name = "kpty-5.66.0.tar.xz";
     };
   };
   kquickcharts = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kquickcharts-5.65.0.tar.xz";
-      sha256 = "f9ab7697845c872d25e998f2b213d4c32c0b2ccdef99de018dc486d1c4a98388";
-      name = "kquickcharts-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kquickcharts-5.66.0.tar.xz";
+      sha256 = "70fae10b2af1c504e3b166beb0a342cdef0e0f8eb42e53ba88f0e3b174331624";
+      name = "kquickcharts-5.66.0.tar.xz";
     };
   };
   kross = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/portingAids/kross-5.65.0.tar.xz";
-      sha256 = "c7414c2d6bb959920c2dca01c2b50131a5715629e0229283f8e6dfcfae1a64a5";
-      name = "kross-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/portingAids/kross-5.66.0.tar.xz";
+      sha256 = "109159996da54ec52ec8114ff05f88bdee6428e49ca84515ab73c457e0005ebc";
+      name = "kross-5.66.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/krunner-5.65.0.tar.xz";
-      sha256 = "0806c1d9ade246348e952e538cc75dc303c27728a887b67dbf27edac6cffffe6";
-      name = "krunner-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/krunner-5.66.0.tar.xz";
+      sha256 = "b7d67d61c0b0f96128c143e3d2694dc5ced88a7de73db0f4493f084de9dc9701";
+      name = "krunner-5.66.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kservice-5.65.0.tar.xz";
-      sha256 = "663ca1539929e9d1188de3732fc8d1353bc5714b434fdf2fa37c4769e4b26fa3";
-      name = "kservice-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kservice-5.66.0.tar.xz";
+      sha256 = "f1174576f6e3e562d7de65494efc2c1c3ac569c656b8301ffbe34576ea623a6a";
+      name = "kservice-5.66.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/ktexteditor-5.65.0.tar.xz";
-      sha256 = "830aed1f7d181bf79e57a11373046baf762507a30fe1adc19cb2fc13d9be60c0";
-      name = "ktexteditor-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/ktexteditor-5.66.0.tar.xz";
+      sha256 = "9156e5e554b17d73078e4df09ae524a684f6adff8c2bbd40705b67fd30a6cc0b";
+      name = "ktexteditor-5.66.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/ktextwidgets-5.65.0.tar.xz";
-      sha256 = "dedad270e03688f937b72e683a249bad464a22df3f97a1cd1bc3be400ec31a11";
-      name = "ktextwidgets-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/ktextwidgets-5.66.0.tar.xz";
+      sha256 = "dcc4595ceeecd3f59236ed303f2a0d61915c88eb36ad040a0562b60fb10cb9a1";
+      name = "ktextwidgets-5.66.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kunitconversion-5.65.0.tar.xz";
-      sha256 = "aa751f4b5d9648656120e9e99b0e28560e468daa01156c85865fbfca42de683d";
-      name = "kunitconversion-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kunitconversion-5.66.0.tar.xz";
+      sha256 = "82db51b59ffdb5b2e69bc5c6ea54521acbc49ee5601baaf4e43cba50d12b418c";
+      name = "kunitconversion-5.66.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kwallet-5.65.0.tar.xz";
-      sha256 = "93822bded2273e21be16d8c34c5f33939afeba0dd9d4f2f3ff3ae93029f71eb0";
-      name = "kwallet-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kwallet-5.66.0.tar.xz";
+      sha256 = "6e48070e22a822a4003e1f7a739fe1e335bcf46982cbf4909d23a6e40689a827";
+      name = "kwallet-5.66.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kwayland-5.65.0.tar.xz";
-      sha256 = "75b22e59dd6d3d70ce7a46b8d431050e2f00f6094ae25e969af90ae535037b12";
-      name = "kwayland-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kwayland-5.66.0.tar.xz";
+      sha256 = "f43231f10a5294f7ac3d43d2b903f1cf9649364782ca55831e0c069a54cc170d";
+      name = "kwayland-5.66.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kwidgetsaddons-5.65.0.tar.xz";
-      sha256 = "f5124ae8beb1da1ec5cca979b862c398635ee84e87283a7f528978df928a971d";
-      name = "kwidgetsaddons-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kwidgetsaddons-5.66.0.tar.xz";
+      sha256 = "311d8274469f03b1938da5a4f7ad17c82e3f96bc79ec28624cb748b13403f451";
+      name = "kwidgetsaddons-5.66.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kwindowsystem-5.65.0.tar.xz";
-      sha256 = "9745aebe1d0fdcdede623b9a7cd55b86520e3122278a6c4f82ebb83e0cf514c2";
-      name = "kwindowsystem-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kwindowsystem-5.66.0.tar.xz";
+      sha256 = "416e2ba52a8c95a6b161ca306724525c1971723cb12e7d8ad7fa108e0b820f0c";
+      name = "kwindowsystem-5.66.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kxmlgui-5.65.0.tar.xz";
-      sha256 = "1de343bd51ba57053fd30eefb2237fb022b7cc274be6132fb9064bec64c39e95";
-      name = "kxmlgui-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kxmlgui-5.66.0.tar.xz";
+      sha256 = "a8f9ed354e30ff1f40306e876d96fcd1fa3a26a8e6acfccdeab8f3437d7231bc";
+      name = "kxmlgui-5.66.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/kxmlrpcclient-5.65.0.tar.xz";
-      sha256 = "2b29df46f16c606488238c7936b8cfc198f06549e01ad4b52cae0cb66fa85282";
-      name = "kxmlrpcclient-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/kxmlrpcclient-5.66.0.tar.xz";
+      sha256 = "6b637c138414d93104477034737c9e866d99e43f883a3dfc45d3220df6c21e6c";
+      name = "kxmlrpcclient-5.66.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/modemmanager-qt-5.65.0.tar.xz";
-      sha256 = "21cd64acbe50d402ea5c3636e628acbc8c73ee32021a6e184c449380216380c2";
-      name = "modemmanager-qt-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/modemmanager-qt-5.66.0.tar.xz";
+      sha256 = "50e24894d0243dbd2fc1a44a1e6368e3bb95a20c1ca56106d26752d5854d8be9";
+      name = "modemmanager-qt-5.66.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/networkmanager-qt-5.65.0.tar.xz";
-      sha256 = "171bac57c2f965b893a70e8bbeab5e1ed80d7d6df97cc52b0a830acdf0c1b82a";
-      name = "networkmanager-qt-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/networkmanager-qt-5.66.0.tar.xz";
+      sha256 = "3089951c69845c4f6d1848bbbaf05116a72d4207a9f2d63b063a76c78549bf45";
+      name = "networkmanager-qt-5.66.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/oxygen-icons5-5.65.0.tar.xz";
-      sha256 = "a0e6868aa905f2ca784164fc80b2cb85b1dcebf12588bc4a023c46550923d665";
-      name = "oxygen-icons5-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/oxygen-icons5-5.66.0.tar.xz";
+      sha256 = "c6275fdcd4883c143adf4f16450a63dcb8651073a205bd14c599ec6ab638e8ef";
+      name = "oxygen-icons5-5.66.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/plasma-framework-5.65.0.tar.xz";
-      sha256 = "794616029509897bdf1685fc1fd0b6cfb66f4edd3627aa69138f100a4615c826";
-      name = "plasma-framework-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/plasma-framework-5.66.0.tar.xz";
+      sha256 = "3263ccf95a6fcf8fde087d402d89d64c64c0130d4df62b95b860fada13aad419";
+      name = "plasma-framework-5.66.0.tar.xz";
     };
   };
   prison = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/prison-5.65.0.tar.xz";
-      sha256 = "8dd4400817b4863597eb87fafce27f6cb11ad8a1f4da7491e4c9e4dcaa2fdff1";
-      name = "prison-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/prison-5.66.0.tar.xz";
+      sha256 = "ff5b4ae32ae44f2aea4b9254afe54af0fc9ea742517116cd2322e1a71a7315ce";
+      name = "prison-5.66.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/purpose-5.65.0.tar.xz";
-      sha256 = "680700a330cee3a82e9cba02a511cd2963aa20875c99e863b4b93998efc81e24";
-      name = "purpose-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/purpose-5.66.0.tar.xz";
+      sha256 = "33b8ec6ede6a1deee6c85e45ebe42aca9a3add7884ee68aa8f1a16ed0637b4db";
+      name = "purpose-5.66.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/qqc2-desktop-style-5.65.0.tar.xz";
-      sha256 = "a583e4ed8a4513fdd287d432d9a68fa30941803c7a77ce58f2a08b9d77d9628c";
-      name = "qqc2-desktop-style-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/qqc2-desktop-style-5.66.0.tar.xz";
+      sha256 = "49bb518fc9f3c08cb330b1d82cb5c68d9ea358a562c6e460ea06aaaa13812b87";
+      name = "qqc2-desktop-style-5.66.0.tar.xz";
     };
   };
   solid = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/solid-5.65.0.tar.xz";
-      sha256 = "e94cf8e434b49b8a70318a41219e18b6d2d3b1912a2c3050b69cd66773cc3d00";
-      name = "solid-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/solid-5.66.0.tar.xz";
+      sha256 = "78deab8c55c30f2c923795730a9655b4d05a75cd6240bc0caa64104b141a3a39";
+      name = "solid-5.66.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/sonnet-5.65.0.tar.xz";
-      sha256 = "1f63ccfa8266e167fd996a253a3d1933a913c12e829056c74fe335fbfb327cbc";
-      name = "sonnet-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/sonnet-5.66.0.tar.xz";
+      sha256 = "5ca700e8e9954b380cc5f4cee0f392888ae240ccd2c4d3a37a2f41f8ac9c8294";
+      name = "sonnet-5.66.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/syndication-5.65.0.tar.xz";
-      sha256 = "1be1bd32b4c75c6bb1b35d67cc7643089e0c525cb30e392220c1ac88240e7694";
-      name = "syndication-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/syndication-5.66.0.tar.xz";
+      sha256 = "5e6c90360461b820a48069af2838cffbcbedfe8bcd042535823e1cf1b43cd6b7";
+      name = "syndication-5.66.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/syntax-highlighting-5.65.0.tar.xz";
-      sha256 = "5ac5cffeed055adb7f1ef734bab41268dcfbf5e0abdefcf82df2be4479dfc97b";
-      name = "syntax-highlighting-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/syntax-highlighting-5.66.0.tar.xz";
+      sha256 = "e572719cb64524c6abc476eeccca56f54cb0d7352fc747af3036dbe817566c25";
+      name = "syntax-highlighting-5.66.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.65.0";
+    version = "5.66.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.65/threadweaver-5.65.0.tar.xz";
-      sha256 = "19d74c5feb15903047d8bdf7fd1c94b4b6d0d22f3c860ff99ed1ef00a1f4b8b0";
-      name = "threadweaver-5.65.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.66/threadweaver-5.66.0.tar.xz";
+      sha256 = "a63db1ef8421e68534f5b9891013286fbad2ef8677f28c15ec733f086ae5cee3";
+      name = "threadweaver-5.66.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://kde.org/announcements/kde-frameworks-5.66.0.php

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).