### PR TITLE
aws-sam-cli: 0.34.0 -> 0.40.0

### DIFF
--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -24,6 +24,29 @@ let
         doCheck = false;
       });
 
+      cookiecutter = super.cookiecutter.overridePythonAttrs (oldAttrs: rec {
+        version = "1.6.0";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "0glsvaz8igi2wy1hsnhm9fkn6560vdvdixzvkq6dn20z3hpaa5hk";
+        };
+      });
+
+      boto3 = super.boto3.overridePythonAttrs (oldAttrs: rec {
+        version = "1.10.50";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "199nr61ivm4bychn3rxyzzyca5f8wlwags3s43rdv9yn048xa02w";
+        };
+      });
+
+      botocore = super.botocore.overridePythonAttrs (oldAttrs: rec {
+        version = "1.13.50";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "1m3lbi13d9gcp6wfhv0pkwg8akasxlhv49y34ybj74ppgximqnkn";
+        };
+      });
     };
   };
 
@@ -33,11 +56,11 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "0.34.0";
+  version = "0.40.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ndgcbd6zr23lvmqn4wikgvnlwl0gj0wgyawaspwm3b0jlvxadik";
+    sha256 = "1vlg5fdkq5xr4v3a86gyxbbrx4rzdspbv62ki7q8yq8xdja1qz05";
   };
 
   # Tests are not included in the PyPI package


### PR DESCRIPTION
###### Motivation for this change

The build for `aws-sam-cli` currently fails on master and unstable since the merge of #76232.
Besides updating `aws-sam-cli` and some of its dependencies this also fixes the current issue by overriding the version of `cookiecutter`.

[Release notes for v0.40.0](https://github.com/awslabs/aws-sam-cli/releases/tag/v0.40.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
