### PR TITLE
bitcoin-gold: init at 0.15.2

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-gold.nix
+++ b/pkgs/applications/blockchains/bitcoin-gold.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, fetchFromGitHub
+, openssl
+, boost
+, libevent
+, autoreconfHook
+, db4
+, pkgconfig
+, protobuf
+, hexdump
+, zeromq
+, libsodium
+, withGui
+, qtbase ? null
+, qttools ? null
+, wrapQtAppsHook ? null
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  
+  pname = "bitcoin" + toString (optional (!withGui) "d") + "-gold";
+  version = "0.15.2";
+
+  src = fetchFromGitHub {
+    owner = "BTCGPU";
+    repo = "BTCGPU";
+    rev = "v${version}";
+    sha256 = "0grd1cd8d2nsrxl27la85kcan09z73fn70ncr9km4iccaj5pg12h";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    hexdump
+  ] ++ optionals withGui [
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    openssl
+    boost
+    libevent
+    db4
+    zeromq
+    libsodium
+  ] ++ optionals withGui [
+    qtbase
+    qttools
+    protobuf
+  ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+      "--with-boost-libdir=${boost.out}/lib"
+  ] ++ optionals withGui [
+      "--with-gui=qt5"
+      "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+  ];
+
+  meta = {
+    description = "BTG is a cryptocurrency with Bitcoin fundamentals, mined on common GPUs instead of specialty ASICs";
+    homepage = "https://bitcoingold.org/";
+    license = licenses.mit;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22645,6 +22645,9 @@ in
   bitcoin-classic  = libsForQt5.callPackage ../applications/blockchains/bitcoin-classic.nix { boost = boost165; withGui = true; };
   bitcoind-classic = callPackage ../applications/blockchains/bitcoin-classic.nix { boost = boost165; withGui = false; };
 
+  bitcoin-gold = libsForQt5.callPackage ../applications/blockchains/bitcoin-gold.nix { boost = boost165; withGui = true; };
+  bitcoind-gold = callPackage ../applications/blockchains/bitcoin-gold.nix { boost = boost165; withGui = false; };
+
   btc1 = callPackage ../applications/blockchains/btc1.nix {
     inherit (darwin.apple_sdk.frameworks) AppKit;
     boost = boost165;


### PR DESCRIPTION
###### Motivation for this change

bitcoin-gold: init at 0.15.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
