### PR TITLE
unar: mark as broken

### DIFF
--- a/pkgs/tools/archivers/unar/default.nix
+++ b/pkgs/tools/archivers/unar/default.nix
@@ -57,5 +57,6 @@ in stdenv.mkDerivation rec {
     '';
     license = with licenses; [ lgpl21Plus ];
     platforms = with platforms; linux;
+    broken = true;
   };
 }


### PR DESCRIPTION
#### Motivation for this change

Marking ```unar``` as broken. The software is not actively maintained and doesn't compile anymore. Will remove from nixpkgs if not fixed / owned in upcoming weeks. 