### PR TITLE
chatterino2: use mkDerivation from qt

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pkgconfig, fetchFromGitHub, qtbase, qtsvg, qtmultimedia, qmake, boost, openssl }:
+{ mkDerivation, lib, pkgconfig, fetchFromGitHub, qtbase, qtsvg, qtmultimedia, qmake, boost, openssl }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "chatterino2";
   version = "unstable-2019-05-11";
   src = fetchFromGitHub {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
   nativeBuildInputs = [ qmake pkgconfig ];
   buildInputs = [ qtbase qtsvg qtmultimedia boost openssl ];
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A chat client for Twitch chat";
     longDescription = ''
       Chatterino is a chat client for Twitch chat. It aims to be an


### PR DESCRIPTION
###### Motivation for this change

```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
