### PR TITLE
pythonPackages.data_hacks: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/data_hacks/default.nix
+++ b/pkgs/development/python-modules/data_hacks/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi}:
+
+buildPythonPackage rec {
+  pname = "data_hacks";
+  version = "0.3.1";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "aa047cec15f6577ef2e1d1c0de45e4fe160da0ce92c8d956636fd35c8d6efc15";
+  };
+    
+  meta = with lib; {
+    description = "Command line utilities for data analysis";
+    homepage = "https://github.com/bitly/data_hacks";
+    license = licenses.unlicense;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -584,6 +584,8 @@ in {
 
   datashader = callPackage ../development/python-modules/datashader { };
 
+  data_hacks = callPackage ../development/python-modules/data_hacks { };
+
   dbf = callPackage ../development/python-modules/dbf { };
 
   dbfread = callPackage ../development/python-modules/dbfread { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding Python package for data_hacks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
