### PR TITLE
cri-o: Fix build tags usage

### DIFF
--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -16,8 +16,7 @@
 }:
 
 let
-  makeFlags = "BUILDTAGS=\"apparmor seccomp selinux
-    containers_image_ostree_stub\"";
+  buildTags = "apparmor seccomp selinux containers_image_ostree_stub";
 in buildGoPackage rec {
   project = "cri-o";
   version = "1.16.1";
@@ -47,7 +46,7 @@ in buildGoPackage rec {
     # Build the crio binaries
     function build() {
       go build \
-        -tags ${makeFlags} \
+        -tags "${buildTags}" \
         -o bin/"$1" \
         -buildmode=pie \
         -ldflags '-s -w ${ldflags}' \


### PR DESCRIPTION
##### Motivation for this change

The build tags have been used wrongly and result in builds containing not the right feature sets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
