### PR TITLE
clang_7,clang_8,clang_9: fix compilation of HIP-code

### DIFF
--- a/pkgs/development/compilers/llvm/7/clang/HIP-use-PATH-7.patch
+++ b/pkgs/development/compilers/llvm/7/clang/HIP-use-PATH-7.patch
@@ -1,0 +1,68 @@
+From 8412cba68835f8f4cc527d02194b181faa5944d4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Holger=20W=C3=BCnsche?= <holger.o.wuensche@t-online.de>
+Date: Tue, 21 Jan 2020 19:46:09 +0100
+Subject: [PATCH] [HIP] use GetProgramPath for executable discovery
+
+This change replaces the manual building of executable paths
+using llvm::sys::path::append with GetProgramPath.
+This enables adding other paths in case executables reside
+in different directories and makes the code easier to read.
+
+Differential Revision: https://reviews.llvm.org/D72903
+---
+ clang/lib/Driver/ToolChains/HIP.cpp | 18 ++++++------------
+ 1 file changed, 6 insertions(+), 12 deletions(-)
+
+diff --git a/lib/Driver/ToolChains/HIP.cpp b/lib/Driver/ToolChains/HIP.cpp
+index 03acf45a9b3..75fd3226c75 100644
+--- a/lib/Driver/ToolChains/HIP.cpp
++++ b/lib/Driver/ToolChains/HIP.cpp
+@@ -98,9 +98,8 @@ const char *AMDGCN::Linker::constructLLVMLinkCommand(
+   const char *OutputFileName =
+       C.addTempFile(C.getArgs().MakeArgString(TmpName));
+   CmdArgs.push_back(OutputFileName);
+-  SmallString<128> ExecPath(C.getDriver().Dir);
+-  llvm::sys::path::append(ExecPath, "llvm-link");
+-  const char *Exec = Args.MakeArgString(ExecPath);
++  const char *Exec =
++      Args.MakeArgString(getToolChain().GetProgramPath("llvm-link"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, Inputs));
+   return OutputFileName;
+ }
+@@ -141,9 +140,8 @@ const char *AMDGCN::Linker::constructOptCommand(
+   const char *OutputFileName =
+       C.addTempFile(C.getArgs().MakeArgString(TmpFileName));
+   OptArgs.push_back(OutputFileName);
+-  SmallString<128> OptPath(C.getDriver().Dir);
+-  llvm::sys::path::append(OptPath, "opt");
+-  const char *OptExec = Args.MakeArgString(OptPath);
++  const char *OptExec =
++      Args.MakeArgString(getToolChain().GetProgramPath("opt"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, OptExec, OptArgs, Inputs));
+   return OutputFileName;
+ }
+@@ -161,9 +159,7 @@ const char *AMDGCN::Linker::constructLlcCommand(
+   const char *LlcOutputFile =
+       C.addTempFile(C.getArgs().MakeArgString(LlcOutputFileName));
+   LlcArgs.push_back(LlcOutputFile);
+-  SmallString<128> LlcPath(C.getDriver().Dir);
+-  llvm::sys::path::append(LlcPath, "llc");
+-  const char *Llc = Args.MakeArgString(LlcPath);
++  const char *Llc = Args.MakeArgString(getToolChain().GetProgramPath("llc"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, Llc, LlcArgs, Inputs));
+   return LlcOutputFile;
+ }
+@@ -178,9 +174,7 @@ void AMDGCN::Linker::constructLldCommand(Compilation &C, const JobAction &JA,
+   ArgStringList LldArgs{"-flavor",    "gnu", "--no-undefined",
+                         "-shared",    "-o",  Output.getFilename(),
+                         InputFileName};
+-  SmallString<128> LldPath(C.getDriver().Dir);
+-  llvm::sys::path::append(LldPath, "lld");
+-  const char *Lld = Args.MakeArgString(LldPath);
++  const char *Lld = Args.MakeArgString(getToolChain().GetProgramPath("lld"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, Lld, LldArgs, Inputs));
+ }
+ 
+-- 
+2.23.1
+

--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python
+{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python, lld
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false # TODO: get this info from llvm (passthru?)
@@ -22,7 +22,7 @@ let
     nativeBuildInputs = [ cmake python ]
       ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
 
-    buildInputs = [ libxml2 llvm ]
+    buildInputs = [ libxml2 llvm lld ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
     cmakeFlags = [
@@ -38,7 +38,11 @@ let
       "-DLINK_POLLY_INTO_TOOLS=ON"
     ];
 
-    patches = [ ./purity.patch ];
+    patches = [
+      ./purity.patch
+      # make clang -xhip use $PATH to find executables
+      ./HIP-use-PATH-7.patch
+    ];
 
     postPatch = ''
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' \

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -32,6 +32,7 @@ let
     llvm-polly = callPackage ./llvm.nix { enablePolly = true; };
 
     clang-unwrapped = callPackage ./clang {
+      inherit (tools) lld;
       inherit clang-tools-extra_src;
     };
     clang-polly-unwrapped = callPackage ./clang {

--- a/pkgs/development/compilers/llvm/8/clang/HIP-use-PATH-8.patch
+++ b/pkgs/development/compilers/llvm/8/clang/HIP-use-PATH-8.patch
@@ -1,0 +1,80 @@
+From d9f1b7d7571b252e0ba2359ae6cfa93a9903c0e7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Holger=20W=C3=BCnsche?= <holger.o.wuensche@t-online.de>
+Date: Tue, 21 Jan 2020 19:49:44 +0100
+Subject: [PATCH] [HIP] use GetProgramPath for executable discovery
+
+This change replaces the manual building of executable paths
+using llvm::sys::path::append with GetProgramPath.
+This enables adding other paths in case executables reside
+in different directories and makes the code easier to read.
+
+Differential Revision: https://reviews.llvm.org/D72903
+---
+ clang/lib/Driver/ToolChains/HIP.cpp | 23 ++++++++---------------
+ 1 file changed, 8 insertions(+), 15 deletions(-)
+
+diff --git a/lib/Driver/ToolChains/HIP.cpp b/lang/lib/Driver/ToolChains/HIP.cpp
+index 868765cf88e..31f2d68ec6c 100644
+--- a/lib/Driver/ToolChains/HIP.cpp
++++ b/lib/Driver/ToolChains/HIP.cpp
+@@ -104,9 +104,8 @@ const char *AMDGCN::Linker::constructLLVMLinkCommand(
+   const char *OutputFileName =
+       C.addTempFile(C.getArgs().MakeArgString(TmpName));
+   CmdArgs.push_back(OutputFileName);
+-  SmallString<128> ExecPath(C.getDriver().Dir);
+-  llvm::sys::path::append(ExecPath, "llvm-link");
+-  const char *Exec = Args.MakeArgString(ExecPath);
++  const char *Exec =
++      Args.MakeArgString(getToolChain().GetProgramPath("llvm-link"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, Inputs));
+   return OutputFileName;
+ }
+@@ -147,9 +146,8 @@ const char *AMDGCN::Linker::constructOptCommand(
+   const char *OutputFileName =
+       C.addTempFile(C.getArgs().MakeArgString(TmpFileName));
+   OptArgs.push_back(OutputFileName);
+-  SmallString<128> OptPath(C.getDriver().Dir);
+-  llvm::sys::path::append(OptPath, "opt");
+-  const char *OptExec = Args.MakeArgString(OptPath);
++  const char *OptExec =
++      Args.MakeArgString(getToolChain().GetProgramPath("opt"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, OptExec, OptArgs, Inputs));
+   return OutputFileName;
+ }
+@@ -167,9 +165,7 @@ const char *AMDGCN::Linker::constructLlcCommand(
+   const char *LlcOutputFile =
+       C.addTempFile(C.getArgs().MakeArgString(LlcOutputFileName));
+   LlcArgs.push_back(LlcOutputFile);
+-  SmallString<128> LlcPath(C.getDriver().Dir);
+-  llvm::sys::path::append(LlcPath, "llc");
+-  const char *Llc = Args.MakeArgString(LlcPath);
++  const char *Llc = Args.MakeArgString(getToolChain().GetProgramPath("llc"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, Llc, LlcArgs, Inputs));
+   return LlcOutputFile;
+ }
+@@ -184,9 +180,7 @@ void AMDGCN::Linker::constructLldCommand(Compilation &C, const JobAction &JA,
+   ArgStringList LldArgs{"-flavor",    "gnu", "--no-undefined",
+                         "-shared",    "-o",  Output.getFilename(),
+                         InputFileName};
+-  SmallString<128> LldPath(C.getDriver().Dir);
+-  llvm::sys::path::append(LldPath, "lld");
+-  const char *Lld = Args.MakeArgString(LldPath);
++  const char *Lld = Args.MakeArgString(getToolChain().GetProgramPath("lld"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, Lld, LldArgs, Inputs));
+ }
+ 
+@@ -218,9 +212,8 @@ void AMDGCN::constructHIPFatbinCommand(Compilation &C, const JobAction &JA,
+       Args.MakeArgString(std::string("-outputs=").append(OutputFileName));
+   BundlerArgs.push_back(BundlerOutputArg);
+ 
+-  SmallString<128> BundlerPath(C.getDriver().Dir);
+-  llvm::sys::path::append(BundlerPath, "clang-offload-bundler");
+-  const char *Bundler = Args.MakeArgString(BundlerPath);
++  const char *Bundler = Args.MakeArgString(
++          T.getToolChain().GetProgramPath("clang-offload-bundler"));
+   C.addCommand(llvm::make_unique<Command>(JA, T, Bundler, BundlerArgs, Inputs));
+ }
+ 
+-- 
+2.23.1
+

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python
+{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python, lld
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false # TODO: get this info from llvm (passthru?)
@@ -22,7 +22,7 @@ let
     nativeBuildInputs = [ cmake python ]
       ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
 
-    buildInputs = [ libxml2 llvm ]
+    buildInputs = [ libxml2 llvm lld ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
     cmakeFlags = [
@@ -50,6 +50,8 @@ let
       ./unwindlib.patch
       # https://reviews.llvm.org/D51899
       ./compiler-rt-baremetal.patch
+      # make clang -xhip use $PATH to find executables
+      ./HIP-use-PATH-8.patch
     ];
 
     postPatch = ''

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -32,6 +32,7 @@ let
     llvm-polly = callPackage ./llvm.nix { enablePolly = true; };
 
     clang-unwrapped = callPackage ./clang {
+      inherit (tools) lld;
       inherit clang-tools-extra_src;
     };
     clang-polly-unwrapped = callPackage ./clang {

--- a/pkgs/development/compilers/llvm/9/clang/HIP-use-PATH-9.patch
+++ b/pkgs/development/compilers/llvm/9/clang/HIP-use-PATH-9.patch
@@ -1,0 +1,80 @@
+From 7147e9774c74abcd1d6db24e24d0fd989c2b97dd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Holger=20W=C3=BCnsche?= <holger.o.wuensche@t-online.de>
+Date: Tue, 21 Jan 2020 19:52:04 +0100
+Subject: [PATCH] [HIP] use GetProgramPath for executable discovery
+
+This change replaces the manual building of executable paths
+using llvm::sys::path::append with GetProgramPath.
+This enables adding other paths in case executables reside
+in different directories and makes the code easier to read.
+
+Differential Revision: https://reviews.llvm.org/D72903
+---
+ clang/lib/Driver/ToolChains/HIP.cpp | 23 ++++++++---------------
+ 1 file changed, 8 insertions(+), 15 deletions(-)
+
+diff --git a/lib/Driver/ToolChains/HIP.cpp b/lib/Driver/ToolChains/HIP.cpp
+index 2ec97e798fd..735c302debb 100644
+--- a/lib/Driver/ToolChains/HIP.cpp
++++ b/lib/Driver/ToolChains/HIP.cpp
+@@ -66,9 +66,8 @@ const char *AMDGCN::Linker::constructLLVMLinkCommand(
+   const char *OutputFileName =
+       C.addTempFile(C.getArgs().MakeArgString(TmpName));
+   CmdArgs.push_back(OutputFileName);
+-  SmallString<128> ExecPath(C.getDriver().Dir);
+-  llvm::sys::path::append(ExecPath, "llvm-link");
+-  const char *Exec = Args.MakeArgString(ExecPath);
++  const char *Exec =
++      Args.MakeArgString(getToolChain().GetProgramPath("llvm-link"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, Inputs));
+   return OutputFileName;
+ }
+@@ -114,9 +113,8 @@ const char *AMDGCN::Linker::constructOptCommand(
+   const char *OutputFileName =
+       C.addTempFile(C.getArgs().MakeArgString(TmpFileName));
+   OptArgs.push_back(OutputFileName);
+-  SmallString<128> OptPath(C.getDriver().Dir);
+-  llvm::sys::path::append(OptPath, "opt");
+-  const char *OptExec = Args.MakeArgString(OptPath);
++  const char *OptExec =
++      Args.MakeArgString(getToolChain().GetProgramPath("opt"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, OptExec, OptArgs, Inputs));
+   return OutputFileName;
+ }
+@@ -156,9 +154,7 @@ const char *AMDGCN::Linker::constructLlcCommand(
+   const char *LlcOutputFile =
+       C.addTempFile(C.getArgs().MakeArgString(LlcOutputFileName));
+   LlcArgs.push_back(LlcOutputFile);
+-  SmallString<128> LlcPath(C.getDriver().Dir);
+-  llvm::sys::path::append(LlcPath, "llc");
+-  const char *Llc = Args.MakeArgString(LlcPath);
++  const char *Llc = Args.MakeArgString(getToolChain().GetProgramPath("llc"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, Llc, LlcArgs, Inputs));
+   return LlcOutputFile;
+ }
+@@ -172,9 +168,7 @@ void AMDGCN::Linker::constructLldCommand(Compilation &C, const JobAction &JA,
+   // The output from ld.lld is an HSA code object file.
+   ArgStringList LldArgs{
+       "-flavor", "gnu", "-shared", "-o", Output.getFilename(), InputFileName};
+-  SmallString<128> LldPath(C.getDriver().Dir);
+-  llvm::sys::path::append(LldPath, "lld");
+-  const char *Lld = Args.MakeArgString(LldPath);
++  const char *Lld = Args.MakeArgString(getToolChain().GetProgramPath("lld"));
+   C.addCommand(llvm::make_unique<Command>(JA, *this, Lld, LldArgs, Inputs));
+ }
+ 
+@@ -206,9 +200,8 @@ void AMDGCN::constructHIPFatbinCommand(Compilation &C, const JobAction &JA,
+       Args.MakeArgString(std::string("-outputs=").append(OutputFileName));
+   BundlerArgs.push_back(BundlerOutputArg);
+ 
+-  SmallString<128> BundlerPath(C.getDriver().Dir);
+-  llvm::sys::path::append(BundlerPath, "clang-offload-bundler");
+-  const char *Bundler = Args.MakeArgString(BundlerPath);
++  const char *Bundler = Args.MakeArgString(
++      T.getToolChain().GetProgramPath("clang-offload-bundler"));
+   C.addCommand(llvm::make_unique<Command>(JA, T, Bundler, BundlerArgs, Inputs));
+ }
+ 
+-- 
+2.23.1
+

--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python
+{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python, lld
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false # TODO: get this info from llvm (passthru?)
@@ -22,7 +22,7 @@ let
     nativeBuildInputs = [ cmake python ]
       ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
 
-    buildInputs = [ libxml2 llvm ]
+    buildInputs = [ libxml2 llvm lld ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
     cmakeFlags = [
@@ -43,6 +43,8 @@ let
       ./purity.patch
       # https://reviews.llvm.org/D51899
       ./compiler-rt-baremetal.patch
+      # make clang -xhip use $PATH to find executables
+      ./HIP-use-PATH-9.patch
     ];
 
     postPatch = ''

--- a/pkgs/development/compilers/llvm/9/default.nix
+++ b/pkgs/development/compilers/llvm/9/default.nix
@@ -32,6 +32,7 @@ let
     llvm-polly = callPackage ./llvm.nix { enablePolly = true; };
 
     clang-unwrapped = callPackage ./clang {
+      inherit (tools) lld;
       inherit clang-tools-extra_src;
     };
     clang-polly-unwrapped = callPackage ./clang {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This PR aims to fix the same problem as NixOS/nixpkgs PR #77476; enabling to compile HIP-code using the packaged clang compiler, by also searching in $PATH for required binaries.
The change is committed upstream (https://reviews.llvm.org/D72903), but will not land in the clang versions in nixpkgs (only clang 10+). As such I have created patches for the affected versions. To compile HIP-code lld is needed, so I added it to the clang-package.

Since this is the same change for all 3 versions I packed everything into one commit+PR. If wanted I could also separate it into 3 individual commits/PRs.

###### Things done

I did compile all 3 versions and tested clang_9 using a HIP-program. I did not explicitly test clang_7 or clang_8, because I don't have the required rocm-device-libs. I would need to package these separately and compile them using a compatible compiler. Because only the HIP compilation behavior is changed this should not break anything currently in nixpkgs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
