### PR TITLE
enum4linux: init at 0.8.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2399,6 +2399,12 @@
     githubId = 415760;
     name = "Jonas Höglund";
   };
+  fishi0x01 = {
+    email = "fishi0x01@gmail.com";
+    github = "fishi0x01";
+    githubId = 10799507;
+    name = "Karl Fischer";
+  };
   Flakebi = {
     email = "flakebi@t-online.de";
     github = "Flakebi";

--- a/pkgs/tools/security/enum4linux/default.nix
+++ b/pkgs/tools/security/enum4linux/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, makeWrapper, samba, perl, openldap }:
+
+stdenv.mkDerivation rec {
+  pname = "enum4linux";
+  version = "0.8.9";
+  src = fetchurl {
+    url = "https://labs.portcullis.co.uk/download/enum4linux-${version}.tar.gz";
+    sha256 = "41334df0cb1ba82db9e3212981340372bb355a8160073331d2a1610908a62d85";
+  };
+
+  dontBuild = true;
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ samba perl openldap ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp enum4linux.pl $out/bin/enum4linux
+
+    wrapProgram $out/bin/enum4linux \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ samba openldap ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tool for enumerating information from Windows and Samba systems";
+    homepage = "https://labs.portcullis.co.uk/tools/enum4linux/";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.fishi0x01 ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -179,6 +179,8 @@ in
 
   deviceTree = callPackage ../os-specific/linux/device-tree {};
 
+  enum4linux = callPackage ../tools/security/enum4linux {};
+
   device-tree_rpi = callPackage ../os-specific/linux/device-tree/raspberrypi.nix {};
 
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
enum4linux is a perl script for smb enumeration. 
Basically it is a wrapper script around rpcclient, net, nmblookup and smbclient (those are provided by the smbclient package as far as I can see). 
It also ships as package for Kali Linux.

###### Things done

This is my first package - so I am pretty sure that there are a lot of enhancements possible.

Successfully build/installed on Ubuntu18.04 via:
```
$ nix-env -f $NIXPKGS -iA enum4linux
```
After installation I could successfully run `enum4linux`. I do have `smbclient` installed through nixpkgs, which provides the underlying tools that are used by `enum4linux`. 
Ideally, `samba` and `perl` are added as a runtime dependency, but I am not sure if I am doing that properly. 
