### PR TITLE
runLaTeX: add additional rerun criterion

### DIFF
--- a/pkgs/tools/typesetting/tex/nix/run-latex.sh
+++ b/pkgs/tools/typesetting/tex/nix/run-latex.sh
@@ -47,6 +47,7 @@ runLaTeX() {
     if fgrep -q \
         -e "LaTeX Warning: Label(s) may have changed." \
         -e "Rerun to get citations correct." \
+        -e "Please rerun LaTeX." \
         "$tmpFile"; then
         runNeeded=1
     fi


### PR DESCRIPTION
###### Motivation for this change

Seems like the phrase "Please rerun LaTeX." is outputted by `biblatex`.
When we detect this, we should actual rerun latex.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
