### PR TITLE
renderizer: init at 2.0.5

### DIFF
--- a/pkgs/development/tools/renderizer/default.nix
+++ b/pkgs/development/tools/renderizer/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "renderizer";
+  version = "2.0.5";
+
+  src = fetchFromGitHub {
+    owner = "gomatic";
+    repo = pname;
+    rev = version;
+    sha256 = "186wcfzw60z6i59yl37rkppw8w88z5kikvsi65k4r9kwpll2z6z4";
+  };
+
+  modSha256 = "1sxg9skd5hjpg2f4wyxh5hwjrplw3b3v32gn61a9yixfk3wvi05x";
+
+  meta = with stdenv.lib; {
+    description = "CLI to render Go template text files";
+    inherit (src.meta) homepage;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ yurrriq ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/renderizer/default.nix
+++ b/pkgs/development/tools/renderizer/default.nix
@@ -18,6 +18,5 @@ buildGoModule rec {
     inherit (src.meta) homepage;
     license = licenses.gpl3;
     maintainers = with maintainers; [ yurrriq ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25231,6 +25231,8 @@ in
 
   redprl = callPackage ../applications/science/logic/redprl { };
 
+  renderizer = pkgs.callPackage ../development/tools/renderizer {};
+
   retroarchBare = callPackage ../misc/emulators/retroarch {
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.frameworks) AppKit Foundation;


### PR DESCRIPTION
##### Motivation for this change
Add [renderizer](https://github.com/gomatic/renderizer).


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
