### PR TITLE
cinnamon.cinnamon-control-center: init at 4.4.0

### DIFF
--- a/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
@@ -1,0 +1,124 @@
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, autoreconfHook
+, glib
+, gettext
+, cinnamon-desktop
+, intltool
+, libxslt
+, gtk3
+, libnotify
+, gnome-menus
+, libxml2
+, systemd
+, upower
+, cinnamon-settings-daemon
+, colord
+, polkit
+, ibus
+, libpulseaudio
+, isocodes
+, kerberos
+, libxkbfile
+, cinnamon-menus
+, dbus-glib
+, libgnomekbd
+, libxklavier
+, networkmanager
+, libwacom
+, gnome3
+, libtool
+, wrapGAppsHook
+, tzdata
+, glibc
+, networkmanagerapplet
+, modemmanager
+, xorg
+, gdk-pixbuf
+, cups
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cinnamon-control-center";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "1rxm5n2prh182rxvjs7psxgjddikrjr8492j22060gmyvq55n7kc";
+  };
+
+  configureFlags = [ "--enable-systemd" ];
+
+  buildInputs = [
+    gtk3
+    glib
+    cinnamon-desktop
+    libnotify
+    cinnamon-menus
+    libxml2
+    dbus-glib
+    systemd
+    polkit
+    libgnomekbd
+    libxklavier
+    colord
+    cinnamon-settings-daemon
+    libwacom
+    gnome3.gnome-online-accounts
+    tzdata
+    networkmanager
+    networkmanagerapplet
+    modemmanager
+    xorg.libXxf86misc
+    xorg.libxkbfile
+    gdk-pixbuf
+    cups
+  ];
+
+  /* ./panels/datetime/test-timezone.c:4:#define TZ_DIR "/usr/share/zoneinfo/"
+  ./panels/datetime/tz.h:32:#  define TZ_DATA_FILE "/usr/share/zoneinfo/zone.tab"
+  ./panels/datetime/tz.h:34:#  define TZ_DATA_FILE "/usr/share/lib/zoneinfo/tab/zone_sun.tab" */
+
+  postPatch = ''
+    patchShebangs ./autogen.sh
+    sed 's|TZ_DIR "/usr/share/zoneinfo/"|TZ_DIR "${tzdata}/share/zoneinfo/"|g' -i ./panels/datetime/test-timezone.c
+    sed 's|TZ_DATA_FILE "/usr/share/zoneinfo/zone.tab"|TZ_DATA_FILE "${tzdata}/share/zoneinfo/zone.tab"|g' -i ./panels/datetime/tz.h
+    sed 's|"/usr/share/i18n/locales/"|"${glibc}/share/i18n/locales/"|g' -i panels/datetime/test-endianess.c
+  '';
+
+  autoreconfPhase = ''
+    NOCONFIGURE=1 bash ./autogen.sh
+  '';
+
+  # it needs to have access to that file, otherwise we can't run tests after build
+
+  preBuild = ''
+    mkdir -p $out/share/cinnamon-control-center/
+    ln -s $PWD/panels/datetime $out/share/cinnamon-control-center/
+  '';
+
+  preInstall = ''
+    rm -rfv $out
+  '';
+
+  nativeBuildInputs = [
+    pkgconfig
+    autoreconfHook
+    wrapGAppsHook
+    gettext
+    intltool
+    libxslt
+    libtool
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/cinnamon-control-center";
+    description = "A collection of configuration plugins used in cinnamon-settings";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -1,6 +1,7 @@
 { pkgs, lib }:
 
 lib.makeScope pkgs.newScope (self: with self; {
+  cinnamon-control-center = callPackage ./cinnamon-control-center { };
   cinnamon-desktop = callPackage ./cinnamon-desktop { };
   cinnamon-menus = callPackage ./cinnamon-menus { };
   cinnamon-translations = callPackage ./cinnamon-translations { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Cinnamon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
