### PR TITLE
python38Packages.uvloop: disable

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -6,6 +6,7 @@
 , libuv
 , psutil
 , isPy27
+, pythonAtLeast
 , CoreServices
 , ApplicationServices
 }:
@@ -13,7 +14,8 @@
 buildPythonPackage rec {
   pname = "uvloop";
   version = "0.14.0";
-  disabled = isPy27;
+  # python 3.8 hangs on tests, assuming it's subtly broken with race condition
+  disabled = isPy27 || pythonAtLeast "3.8";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
Tests hang, indicating race condition

it's been broken for a few months, and tired of it blocking PR reviews

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
