### PR TITLE
Don't set background to black if ~/.background-image not present

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -74,9 +74,6 @@ in
           + optionalString (needBGCond d) ''
             if [ -e $HOME/.background-image ]; then
               ${pkgs.feh}/bin/feh --bg-${cfg.wallpaper.mode} ${optionalString cfg.wallpaper.combineScreens "--no-xinerama"} $HOME/.background-image
-            else
-              # Use a solid black background as fallback
-              ${pkgs.xorg.xsetroot}/bin/xsetroot -solid black
             fi
           '';
         });

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -68,21 +68,18 @@ in
           scripts before forwarding the value to the
           <varname>displayManager</varname>.
         '';
-        apply = list: {
-          list = map (d: d // {
-            manage = "desktop";
-            start = d.start
-            + optionalString (needBGCond d) ''
-              if [ -e $HOME/.background-image ]; then
-                ${pkgs.feh}/bin/feh --bg-${cfg.wallpaper.mode} ${optionalString cfg.wallpaper.combineScreens "--no-xinerama"} $HOME/.background-image
-              else
-                # Use a solid black background as fallback
-                ${pkgs.xorg.xsetroot}/bin/xsetroot -solid black
-              fi
-            '';
-          }) list;
-          needBGPackages = [] != filter needBGCond list;
-        };
+        apply = map (d: d // {
+          manage = "desktop";
+          start = d.start
+          + optionalString (needBGCond d) ''
+            if [ -e $HOME/.background-image ]; then
+              ${pkgs.feh}/bin/feh --bg-${cfg.wallpaper.mode} ${optionalString cfg.wallpaper.combineScreens "--no-xinerama"} $HOME/.background-image
+            else
+              # Use a solid black background as fallback
+              ${pkgs.xorg.xsetroot}/bin/xsetroot -solid black
+            fi
+          '';
+        });
       };
 
       default = mkOption {
@@ -100,5 +97,5 @@ in
 
   };
 
-  config.services.xserver.displayManager.session = cfg.session.list;
+  config.services.xserver.displayManager.session = cfg.session;
 }


### PR DESCRIPTION
###### Motivation for this change
In https://github.com/NixOS/nixpkgs/pull/49492 @mkaito mentions their usecase of running `nitrogen --restore` to set the background image, which could be implemented with e.g. `services.xserver.windowManager.i3.extraSessionCommands`, but only if the code for `~/.background-image` wouldn't run after that, which sets a black background, which was done because of https://github.com/NixOS/nixpkgs/pull/25101.

This PR gets rid of setting the background to black again, which I think was the wrong solution to that problem.

This can be tested with a `configuration.nix` like
```nix
{ config, pkgs, ... }: {
  services.xserver = {
    enable = true;
    displayManager.auto = {
      enable = true;
      user = "demo";
    };
    windowManager.i3 = {
      enable = true;
      extraSessionCommands = ''
        ${pkgs.feh}/bin/feh --bg-max ${config.boot.loader.grub.splashImage}
      '';
    };
  };

  users.users.demo = {
    initialPassword = "";
    isNormalUser = true;
  };
}
```

which when ran with
```bash
$ nix-build nixos --arg configuration ./configuration.nix -A vm
$ result/bin/run-nixos-vm
```

results in the background image being set:

![2020-01-23_03-28](https://user-images.githubusercontent.com/20525370/72951946-7d00a280-3d90-11ea-8572-d413d85d6370.png)

which wasn't possible like this previously

Ping @mkaito @worldofpeace @jtojnar @hedning 

Note: The first commit is just a cleanup