### PR TITLE
python2.pkgs.ipython, python2.pkgs.sphinx: use proper python2 lexer

### DIFF
--- a/pkgs/development/python-modules/ipython/5.nix
+++ b/pkgs/development/python-modules/ipython/5.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 # Build dependencies
 , glibcLocales
 # Test dependencies
@@ -35,6 +36,15 @@ buildPythonPackage rec {
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace setup.py --replace "'gnureadline'" " "
   '';
+
+  patches = [
+    # Use the proper pygments lexer for python2 (https://github.com/ipython/ipython/pull/12095)
+    (fetchpatch {
+      name = "python2-lexer.patch";
+      url = "https://github.com/ipython/ipython/pull/12095/commits/8805293b5e4bce9150cc2ad9c5d6d984849ae447.patch";
+      sha256 = "16p4gl7a49v76w33j39ih7yspy6x2d14p9bh4wdpg9cafhw9nbc0";
+    })
+  ];
 
   buildInputs = [ glibcLocales ];
 

--- a/pkgs/development/python-modules/sphinx/2.nix
+++ b/pkgs/development/python-modules/sphinx/2.nix
@@ -60,6 +60,13 @@ buildPythonPackage rec {
   # Lots of tests. Needs network as well at some point.
   doCheck = false;
 
+  patches = [
+    # Since pygments 2.5, PythonLexer refers to python3. If we want to use
+    # python2, we need to explicitly specify Python2Lexer.
+    # Not upstreamed since there doesn't seem to be any upstream maintenance
+    # branch for 1.8 (and this patch doesn't make any sense for 2.x).
+    ./python2-lexer.patch
+  ];
   # https://github.com/NixOS/nixpkgs/issues/22501
   # Do not run `python sphinx-build arguments` but `sphinx-build arguments`.
   postPatch = ''

--- a/pkgs/development/python-modules/sphinx/python2-lexer.patch
+++ b/pkgs/development/python-modules/sphinx/python2-lexer.patch
@@ -1,0 +1,22 @@
+diff --git a/sphinx/highlighting.py b/sphinx/highlighting.py
+index ac2bd1b06..63ca52de2 100644
+--- a/sphinx/highlighting.py
++++ b/sphinx/highlighting.py
+@@ -16,7 +16,7 @@ from pygments.filters import ErrorToken
+ from pygments.formatters import HtmlFormatter, LatexFormatter
+ from pygments.lexer import Lexer  # NOQA
+ from pygments.lexers import get_lexer_by_name, guess_lexer
+-from pygments.lexers import PythonLexer, Python3Lexer, PythonConsoleLexer, \
++from pygments.lexers import Python2Lexer, Python3Lexer, PythonConsoleLexer, \
+     CLexer, TextLexer, RstLexer
+ from pygments.styles import get_style_by_name
+ from pygments.util import ClassNotFound
+@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
+ 
+ lexers = dict(
+     none = TextLexer(stripnl=False),
+-    python = PythonLexer(stripnl=False),
++    python = Python2Lexer(stripnl=False),
+     python3 = Python3Lexer(stripnl=False),
+     pycon = PythonConsoleLexer(stripnl=False),
+     pycon3 = PythonConsoleLexer(python3=True, stripnl=False),


### PR DESCRIPTION
###### Motivation for this change

Pygments 2.5 [made](https://pygments.org/docs/changelog/) the `PythonLexer` an alias to `Python3Lexer`. To use python2, one now has to explicitly use `Python2Lexer`.

Sphinx and ipython both use this lexer. The sphinx patch fixes the currently broken sage docbuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
