### PR TITLE
mc: /bin/rm does not exist

### DIFF
--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -1,5 +1,21 @@
-{ stdenv, fetchurl, pkgconfig, glib, gpm, file, e2fsprogs
-, libX11, libICE, perl, zip, unzip, gettext, slang, libssh2, openssl}:
+{ stdenv
+, fetchurl
+, pkgconfig
+, glib
+, gpm
+, file
+, e2fsprogs
+, libX11
+, libICE
+, perl
+, zip
+, unzip
+, gettext
+, slang
+, libssh2
+, openssl
+, coreutils
+}:
 
 stdenv.mkDerivation rec {
   pname = "mc";
@@ -13,26 +29,41 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [
-    perl glib slang zip unzip file gettext libX11 libICE libssh2 openssl
+    file
+    gettext
+    glib
+    libICE
+    libX11
+    libssh2
+    openssl
+    perl
+    slang
+    unzip
+    zip
   ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [ e2fsprogs gpm ];
 
   enableParallelBuilding = true;
 
   configureFlags = [ "--enable-vfs-smb" ];
 
+  postPatch = ''
+    substituteInPlace src/filemanager/ext.c \
+      --replace /bin/rm ${coreutils}/bin/rm
+  '';
+
   postFixup = ''
     # remove unwanted build-dependency references
     sed -i -e "s!PKG_CONFIG_PATH=''${PKG_CONFIG_PATH}!PKG_CONFIG_PATH=$(echo "$PKG_CONFIG_PATH" | sed -e 's/./0/g')!" $out/bin/mc
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "File Manager and User Shell for the GNU Project";
-    homepage = http://www.midnight-commander.org;
     downloadPage = "http://www.midnight-commander.org/downloads/";
+    homepage = "http://www.midnight-commander.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ sander ];
+    platforms = with platforms; linux ++ darwin;
     repositories.git = git://github.com/MidnightCommander/mc.git;
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [ stdenv.lib.maintainers.sander ];
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
     updateWalker = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`mcview` tries to clean up after itself by running `/bin/rm` on a temporary script. That obviously doesn't work for us.

The noise is due to `nixpkgs-fmt`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
