### PR TITLE
PBIS AD login integration

### DIFF
--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -14,6 +14,7 @@ let
   nsswins = canLoadExternalModules && config.services.samba.nsswins;
   ldap = canLoadExternalModules && (config.users.ldap.enable && config.users.ldap.nsswitch);
   sssd = canLoadExternalModules && config.services.sssd.enable;
+  lsass = canLoadExternalModules && config.services.pbis.enable;
   resolved = canLoadExternalModules && config.services.resolved.enable;
   googleOsLogin = canLoadExternalModules && config.security.googleOsLogin.enable;
 
@@ -29,6 +30,7 @@ let
   passwdArray = [ "files" ]
     ++ optional sssd "sss"
     ++ optional ldap "ldap"
+    ++ optional lsass "lsass"
     ++ optional mymachines "mymachines"
     ++ optional googleOsLogin "cache_oslogin oslogin"
     ++ [ "systemd" ];

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -772,6 +772,7 @@
   ./services/security/nginx-sso.nix
   ./services/security/oauth2_proxy.nix
   ./services/security/oauth2_proxy_nginx.nix
+  ./services/security/pbis.nix
   ./services/security/physlock.nix
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -324,6 +324,10 @@ let
               "account sufficient ${pkgs.sssd}/lib/security/pam_sss.so"}
           ${optionalString (config.services.sssd.enable && cfg.sssdStrictAccess)
               "account [default=bad success=ok user_unknown=ignore] ${pkgs.sssd}/lib/security/pam_sss.so"}
+          ${optionalString config.services.pbis.enable ''
+            account optional ${config.services.pbis.package.sys}/lib/security/pam_lsass.so unknown_ok
+            account sufficient ${config.services.pbis.package.sys}/lib/security/pam_lsass.so
+          ''}
           ${optionalString config.krb5.enable
               "account sufficient ${pam_krb5}/lib/security/pam_krb5.so"}
           ${optionalString cfg.googleOsLoginAccountVerification ''
@@ -389,6 +393,8 @@ let
               "auth sufficient ${pam_ldap}/lib/security/pam_ldap.so use_first_pass"}
           ${optionalString config.services.sssd.enable
               "auth sufficient ${pkgs.sssd}/lib/security/pam_sss.so use_first_pass"}
+          ${optionalString config.services.pbis.enable
+              "auth sufficient ${config.services.pbis.package.sys}/lib/security/pam_lsass.so use_first_pass smartcard"}
           ${optionalString config.krb5.enable ''
             auth [default=ignore success=1 service_err=reset] ${pam_krb5}/lib/security/pam_krb5.so use_first_pass
             auth [default=die success=done] ${pam_ccreds}/lib/security/pam_ccreds.so action=validate use_first_pass
@@ -406,6 +412,8 @@ let
               "password sufficient ${pam_ldap}/lib/security/pam_ldap.so"}
           ${optionalString config.services.sssd.enable
               "password sufficient ${pkgs.sssd}/lib/security/pam_sss.so use_authtok"}
+          ${optionalString config.services.pbis.enable
+              "password sufficient ${config.services.pbis.package.sys}/lib/security/pam_lsass.so try_first_pass"}
           ${optionalString config.krb5.enable
               "password sufficient ${pam_krb5}/lib/security/pam_krb5.so use_first_pass"}
           ${optionalString config.services.samba.syncPasswordsByPam
@@ -432,6 +440,8 @@ let
               "session optional ${pam_ldap}/lib/security/pam_ldap.so"}
           ${optionalString config.services.sssd.enable
               "session optional ${pkgs.sssd}/lib/security/pam_sss.so"}
+          ${optionalString config.services.pbis.enable
+              "session optional ${config.services.pbis.package.sys}/lib/security/pam_lsass.so"}
           ${optionalString config.krb5.enable
               "session optional ${pam_krb5}/lib/security/pam_krb5.so"}
           ${optionalString cfg.otpwAuth

--- a/nixos/modules/services/security/pbis.nix
+++ b/nixos/modules/services/security/pbis.nix
@@ -1,0 +1,158 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.pbis;
+  pbis = cfg.package;
+  inherit (builtins) isBool isList isString;
+  inherit (lib) mkIf mkDefault mkOption mkEnableOption types;
+  inherit (lib.attrsets) mapAttrsToList;
+  inherit (lib.lists) optional;
+  inherit (lib.strings) concatStringsSep concatMapStringsSep escapeShellArg optionalString;
+in
+{
+  options.services.pbis = with types; {
+
+    enable = mkEnableOption "BeyondTrust AD Bridge Open (ActiveDirectory client)";
+
+    package = mkOption {
+      type = package;
+      default = pkgs.pbis-open;
+      example = pkgs.pbis-open;
+      description = "The PBIS package to use. Useful when you want different compile-time options.";
+    };
+
+    domainJoin = {
+      domain = mkOption {
+        type = str;
+        example = "example.com";
+        description = "The domain name to join (base DN).";
+      };
+
+      userName = mkOption {
+        type = str;
+        example = "admin@example.com";
+        description = "The domain user name (bind DN).";
+      };
+
+      passwordFile = mkOption {
+        type = nullOr (either path str);
+        example = "/var/lib/pbis/bind.passwd";
+        default = null;
+        description = ''
+          The filepath which contains domain user plaintext password (bind DN password).
+          If omitted, password is not specified.
+          WARNING: if passwordFile is not configured to be persistent on disk
+          (especially under /run/keys with NixOps), you may be LOCKED OUT after reboot.
+          Place passwordFile in secure and persistent path.
+        '';
+      };
+
+      extraOptions = mkOption {
+        type = listOf str;
+        example = [ "--notimesync" ];
+        default = [];
+        description = "Extra command line options that are passed to `domainjoin-cli join`.";
+      };
+    };
+
+    ignoreUsers = mkOption {
+      type = listOf str;
+      example = [ "root" "nginx" ];
+      default = [ "root" ];
+      description = "Special users who should bypass AD to login.";
+    };
+
+    ignoreGroups = mkOption {
+      type = listOf str;
+      example = [ "root" "tty" "wheel" ];
+      default = [ "root" "tty" ];
+      description = "Special user groups which should bypass AD to login.";
+    };
+
+    config = mkOption {
+      type = attrs;
+      example = {
+        AssumeDefaultDomain = true;
+        UserDomainPrefix = "example.com";
+        LoginShellTemplate = "/run/current-system/sw/bin/bash";
+        RequireMembershipOf = [ ''MyOrg/Admins'' ''MyOrg\MyTeam'' ];
+        SyncSystemTime = false;
+      };
+      description = ''
+        Sequence of setup subcommands to feed to `$${cfg.package}/bin/config`.
+        Find available options in Configuration Tool Reference Guide PDF of AD Bridge Documentation.
+        https://www.beyondtrust.com/docs/ad-bridge/documents/adb-config-tool-reference-guide.pdf
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.lwsmd = {
+      description = "BeyondTrust AD Bridge PBIS Service Manager";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "forking";
+        ExecStart = "${pbis}/bin/lwsmd --start-as-daemon";
+        StateDirectory = [ "pbis" ];
+        Restart = mkDefault "always";
+        TemporaryFileSystem = "/opt:mode=777"; # See below
+      };
+
+      # taken from sssd
+      before = [ "systemd-user-sessions.service" "nss-user-lookup.target" ];
+      after = [ "network-online.target" "nscd.service" ];
+      requires = [ "network-online.target" "nscd.service" ];
+      wants = [ "nss-user-lookup.target" ];
+      restartTriggers = [ config.environment.etc."nscd.conf".source ];
+
+      preStart = ''
+        set -x
+        # This is evil but I could not find any workaround that
+        # lwsmd trying to load /opt/pbis/lib/lw-svcm/eventlog.so
+        # NIX_REDIRECTS tweak also did not work.
+        ln -snf ${pbis} /opt/pbis
+
+        # Setup registry (adapted from deb package's postinst)
+        cp -af ${pbis.sys}/var/lib/pbis/lw{config,report}.xml /var/lib/pbis/
+        ${pbis}/bin/lwsmd --start-as-daemon --disable-autostart
+        REGSHELL=${pbis}/bin/regshell
+        for i in "${pbis}/share/config/"*.reg; do
+          $REGSHELL import "$i"
+          $REGSHELL cleanup "$i"
+        done
+        $REGSHELL set_value '[HKEY_THIS_MACHINE\Services\lwio\Parameters\Drivers]' 'Load' 'rdr'
+        $REGSHELL set_value '[HKEY_THIS_MACHINE\Services\lsass]' 'Dependencies' 'netlogon lwio lwreg rdr'
+        $REGSHELL set_value '[HKEY_THIS_MACHINE\Services\eventlog]' 'Dependencies' ""
+        $REGSHELL set_value '[HKEY_THIS_MACHINE\Services\dcerpc]' 'Arguments' ""
+        $REGSHELL set_value '[HKEY_THIS_MACHINE\Services\lsass\Parameters\Providers\ActiveDirectory]' Path '${cfg.package}/lib/lsa-provider/ad_open.so'
+        ${pbis}/bin/lwsm shutdown
+      '';
+
+      postStart = with cfg.domainJoin; ''
+        ${pbis}/bin/pbis-status | grep "Unknown" >/dev/null && {
+          ${pbis}/bin/domainjoin-cli join ${toString extraOptions} \
+            ${escapeShellArg domain} \
+            ${escapeShellArg userName} \
+            ${optionalString (passwordFile != null) "$(cat ${passwordFile})"} \
+            >/dev/null 2>&1 || true
+            # ^ignore errors: pbis's stateful behavior (change PAM module and conf) cause some errors
+        }
+        ${pbis}/bin/ad-cache --delete-all
+        ${ let convertValue = v:
+                 if isBool v then (if v then "true" else "false")
+                 else if isList v then toString (map escapeShellArg v)
+                 else if isString v then escapeShellArg v
+                 else toString v;
+               escapedArgsList = mapAttrsToList (key: value: "${escapeShellArg key} ${convertValue value}") cfg.config;
+           in concatMapStringsSep "\n" (args: "${pbis}/bin/config " + args) escapedArgsList
+         }
+      '';
+    };
+
+    # Add pbis-sys/lib(/libnss_lsass.so.2) to sshd's LD_LIBRARY_PATH.
+    system.nssModules = optional cfg.enable cfg.package.sys;
+
+    environment.etc."pbis/user-ignore".text = concatStringsSep "\n" cfg.ignoreUsers;
+    environment.etc."pbis/group-ignore".text = concatStringsSep "\n" cfg.ignoreGroups;
+  };
+}

--- a/pkgs/tools/security/pbis/default.nix
+++ b/pkgs/tools/security/pbis/default.nix
@@ -38,10 +38,10 @@ stdenv.mkDerivation rec {
   configureScript = ''../configure'';
   configureFlags = [
     "CFLAGS=-O"
-    "--docdir=${placeholder "prefix"}/share/doc"
-    "--mandir=${placeholder "prefix"}/share/doc/man"
-    "--datadir=${placeholder "prefix"}/share"
-    "--lw-initdir=${placeholder "prefix"}/etc/init.d"
+    "--docdir=${placeholder "out"}/share/doc"
+    "--mandir=${placeholder "out"}/share/doc/man"
+    "--datadir=${placeholder "out"}/share"
+    "--lw-initdir=${placeholder "out"}/etc/init.d"
     "--selinux=no" # NixOS does not support SELinux
     "--build-isas=x86_64" # [lwbase] endianness (host/x86_32): [lwbase] ERROR: could not determine endianness
     "--fail-on-warn=no"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bring Active Directory authentication to NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
