### PR TITLE
pxview: init at 0.2.5

### DIFF
--- a/pkgs/development/libraries/pxlib/default.nix
+++ b/pkgs/development/libraries/pxlib/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, intltool }:
+
+stdenv.mkDerivation rec {
+  pname = "pxlib";
+  version = "0.6.8";
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1yafwz4z5h30hqvk51wpgbjlmq9f2z2znvfim87ydrfrqfjmi6sz";
+  };
+
+  nativeBuildInputs = [ intltool ];
+
+  meta = with stdenv.lib; {
+    description = "Library to read and write Paradox files";
+    homepage = "http://pxlib.sourceforge.net/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.winpat ];
+  };
+}

--- a/pkgs/development/tools/pxview/default.nix
+++ b/pkgs/development/tools/pxview/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pkgconfig, perl, perlPackages, pxlib }:
+
+stdenv.mkDerivation rec {
+  pname = "pxview";
+  version = "0.2.5";
+  src = fetchurl {
+    url = "mirror://sourceforge/pxlib/${pname}_${version}.orig.tar.gz";
+    sha256 = "1kpdqs6lvnyj02v9fbz1s427yqhgrxp7zw63rzfgiwd4iqp75139";
+  };
+
+  buildInputs = [ pxlib perl ] ++ (with perlPackages; [ libxml_perl ]);
+  nativeBuildInputs = [ pkgconfig ];
+
+  configureFlags = [ "--with-pxlib=${pxlib.out}" ];
+
+  # https://sourceforge.net/p/pxlib/bugs/12/
+  LDFLAGS = "-lm";
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    description = "Program to convert Paradox databases";
+    homepage = "http://pxlib.sourceforge.net/pxview/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.winpat ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25880,6 +25880,8 @@ in
 
   pxlib = callPackage ../development/libraries/pxlib {};
 
+  pxview = callPackage ../development/tools/pxview {};
+
   unstick = callPackage ../os-specific/linux/unstick {};
 
   quartus-prime-lite = callPackage ../applications/editors/quartus-prime {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25878,6 +25878,8 @@ in
 
   kcli = callPackage ../development/tools/kcli {};
 
+  pxlib = callPackage ../development/libraries/pxlib {};
+
   unstick = callPackage ../os-specific/linux/unstick {};
 
   quartus-prime-lite = callPackage ../applications/editors/quartus-prime {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
