### PR TITLE
dat: init at 13.13.1

### DIFF
--- a/pkgs/applications/networking/dat/default.nix
+++ b/pkgs/applications/networking/dat/default.nix
@@ -1,0 +1,92 @@
+{ stdenv
+, fetchurl
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dat";
+  version = "13.13.1";
+
+  suffix = {
+    x86_64-darwin = "macos-x64";
+    x86_64-linux  = "linux-x64";
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://github.com/datproject/dat/releases/download/v${version}/${pname}-${version}-${suffix}.zip";
+    sha256 = {
+      x86_64-darwin = "1qj38zn33hhr2v39jw14k2af091bafh5yvhs91h5dnjb2r8yxnaq";
+      x86_64-linux  = "0vgn57kf3j1pbfxlhj4sl1sm2gfd2gcvhk4wz5yf5mzq1vj9ivpv";
+    }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  buildInputs = [ unzip ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv dat $out/bin
+  '';
+
+  # dat is a node program packaged using zeit/pkg.
+  # thus, it contains hardcoded offsets.
+  # patchelf shifts these locations when it expands headers.
+
+  # this could probably be generalised into allowing any program packaged
+  # with zeit/pkg to be run on nixos.
+
+  preFixup = let
+    libPath = stdenv.lib.makeLibraryPath [stdenv.cc.cc];
+  in stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    orig_size=$(stat --printf=%s $out/bin/dat)
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/dat
+    patchelf --set-rpath ${libPath} $out/bin/dat
+    chmod +x $out/bin/dat
+
+    new_size=$(stat --printf=%s $out/bin/dat)
+
+    ###### zeit-pkg fixing starts here.
+    # we're replacing plaintext js code that looks like
+    # PAYLOAD_POSITION = '1234                  ' | 0
+    # [...]
+    # PRELUDE_POSITION = '1234                  ' | 0
+    # ^-----20-chars-----^^------22-chars------^
+    # ^-- grep points here
+    #
+    # var_* are as described above
+    # shift_by seems to be safe so long as all patchelf adjustments occur
+    # before any locations pointed to by hardcoded offsets
+
+    var_skip=20
+    var_select=22
+    shift_by=$(expr $new_size - $orig_size)
+
+    function fix_offset {
+      # $1 = name of variable to adjust
+      location=$(grep -obUam1 "$1" $out/bin/dat | cut -d: -f1)
+      location=$(expr $location + $var_skip)
+
+      value=$(dd if=$out/bin/dat iflag=count_bytes,skip_bytes skip=$location \
+                 bs=1 count=$var_select status=none)
+      value=$(expr $shift_by + $value)
+
+      echo -n $value | dd of=$out/bin/dat bs=1 seek=$location conv=notrunc
+    }
+
+    fix_offset PAYLOAD_POSITION
+    fix_offset PRELUDE_POSITION
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Peer-to-peer sharing and live synchronization of files";
+    homepage = "https://dat.foundation/";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25899,4 +25899,6 @@ in
   unstick = callPackage ../os-specific/linux/unstick {};
 
   quartus-prime-lite = callPackage ../applications/editors/quartus-prime {};
+
+  dat = callPackage ../applications/networking/dat { };
 }


### PR DESCRIPTION
###### Motivation for this change

`dat` is a tool for peer-to-peer sharing & live synchronization of files similar to IPFS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
