### PR TITLE
gnomeExtensions.gsconnect: 30 -> 31

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchFromGitHub, substituteAll, python3, openssl, folks, gsound
+{ stdenv, fetchFromGitHub, substituteAll, python3, openssl, gsound
 , meson, ninja, libxml2, pkgconfig, gobject-introspection, wrapGAppsHook
 , glib, gtk3, at-spi2-core, upower, openssh, gnome3, gjs }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-gsconnect";
-  version = "30";
+  version = "31";
 
   src = fetchFromGitHub {
     owner = "andyholmes";
     repo = "gnome-shell-extension-gsconnect";
     rev = "v${version}";
-    sha256 = "17j96y72mj7vg2csn5c9rji7jy04x5qzl8knf5gky6wppxj9zjb4";
+    sha256 = "0nricm31jh4akncs0rkkilmq9afg7kgbj5cy7w26pfqb3l4nhifg";
   };
 
   patches = [
@@ -29,11 +29,9 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    (python3.withPackages (pkgs: [ python3.pkgs.pygobject3 ])) # for folks.py
     glib # libgobject
     gtk3
     at-spi2-core # atspi
-    folks # libfolks
     gnome3.nautilus # TODO: this contaminates the package with nautilus and gnome-autoar typelibs but it is only needed for the extension
     gnome3.nautilus-python
     gsound
@@ -66,15 +64,9 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  preFixup = ''
-    # TODO: figure out why folks GIR does not contain shared-library attribute
-    # https://github.com/NixOS/nixpkgs/issues/47226
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ folks ]}")
-  '';
-
   postFixup = ''
     # Let’s wrap the daemons
-    for file in $out/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/{{daemon,nativeMessagingHost}.js,components/folks.py}; do
+    for file in $out/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/{daemon,nativeMessagingHost}.js; do
       echo "Wrapping program $file"
       wrapGApp "$file"
     done


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

No longer depends on libfolks :tada: 

https://github.com/andyholmes/gnome-shell-extension-gsconnect/releases/tag/v31:

> Notable Fixes
> 
>     Fix notification not shown when payloadTransferInfo is empty (#745, by @R1tschY) trophy
>     Fix undefined/missing addresses (#738, by @ofuangka)
>     Fix themed icon fallbacks in GNOME Shell (#726, with help from @jnsh) trophy
>     Aggressive unpairing on authentication failure (see f736783)
>     Replace libfolks with evolution-data-server for Desktop Contacts (#728)
> 

I'm getting some gi errors from nautilus not being able to load the python nautilus extensions, but that looks like a problem with nautilus as I'm getting the same errors when launching from eg. terminal.

###### Things done

Running it successfully in my session now. Checked that contacts works correctly.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
