### PR TITLE
mopidy-mpris: init at 3.0.1  mopidy-somafm: init at 2.0.0  mopidy-youtube: 2.0.2 -> 3.0  mopidy-gmusic: 3.0.0 -> 4.0.0

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -28,6 +28,8 @@ let
 
     mopidy-mpris = callPackage ./mpris.nix { };
 
+    mopidy-somafm = callPackage ./somafm.nix { };
+
     mopidy-spotify-tunigo = callPackage ./spotify-tunigo.nix { };
 
     mopidy-youtube = callPackage ./youtube.nix { };

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -26,6 +26,8 @@ let
 
     mopidy-mpd = callPackage ./mpd.nix { };
 
+    mopidy-mpris = callPackage ./mpris.nix { };
+
     mopidy-spotify-tunigo = callPackage ./spotify-tunigo.nix { };
 
     mopidy-youtube = callPackage ./youtube.nix { };

--- a/pkgs/applications/audio/mopidy/gmusic.nix
+++ b/pkgs/applications/audio/mopidy/gmusic.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, pythonPackages, mopidy }:
+{ stdenv, python3Packages, mopidy }:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "mopidy-gmusic";
-  version = "3.0.0";
+  version = "4.0.0";
 
-  src = fetchurl {
-    url = "https://github.com/mopidy/mopidy-gmusic/archive/v${version}.tar.gz";
-    sha256 = "0a2s4xrrhnkv85rx4w5bj6ih9xm34jy0q71fdvbzmi827g9dw5sz";
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "Mopidy-GMusic";
+    sha256 = "14yswmlfs659rs3k595606m77lw9c6pjykb5pikqw21sb97haxl3";
   };
 
   propagatedBuildInputs = [
     mopidy
-    pythonPackages.requests
-    pythonPackages.gmusicapi
-    pythonPackages.cachetools
+    python3Packages.requests
+    python3Packages.gmusicapi
+    python3Packages.cachetools
   ];
 
   doCheck = false;

--- a/pkgs/applications/audio/mopidy/mpris.nix
+++ b/pkgs/applications/audio/mopidy/mpris.nix
@@ -1,0 +1,27 @@
+{ stdenv, python3Packages, mopidy }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mopidy-mpris";
+  version = "3.0.1";
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "Mopidy-MPRIS";
+    sha256 = "0qk46aq5r92qgkldzl41x09naww1gv92l4c4hknyl7yymyvm9lr2";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+    python3Packages.pydbus
+  ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://www.mopidy.com/;
+    description = "Mopidy extension for controlling Mopidy through D-Bus using the MPRIS specification";
+    license = licenses.asl20;
+    maintainers = [ maintainers.nickhu ];
+  };
+}
+

--- a/pkgs/applications/audio/mopidy/somafm.nix
+++ b/pkgs/applications/audio/mopidy/somafm.nix
@@ -1,0 +1,26 @@
+{ stdenv, python3Packages, mopidy }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mopidy-somafm";
+  version = "2.0.0";
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "Mopidy-SomaFM";
+    sha256 = "1j88rrliys8hqvnb35k1xqw88bvrllcb4rb53lgh82byhscsxlf3";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+  ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://www.mopidy.com/;
+    description = "Mopidy extension for playing music from SomaFM";
+    license = licenses.mit;
+    maintainers = [ maintainers.nickhu ];
+  };
+}
+

--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -1,17 +1,23 @@
-{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+{ stdenv, python3Packages, mopidy }:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "mopidy-youtube";
-  version = "2.0.2";
+  version = "3.0";
 
-  src = fetchFromGitHub {
-    owner = "mopidy";
-    repo = "mopidy-youtube";
-    rev = "v${version}";
-    sha256 = "06r3ikyg2ch5n7fbn3sgj04hk6icpfpk1r856qch41995k3bbfg7";
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "Mopidy-YouTube";
+    sha256 = "0x1q9rfnjx65n6hi8s5rw5ff4xv55h63zy52fwm8aksdnzppr7gd";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ mopidy pafy ];
+  patchPhase = "sed s/bs4/beautifulsoup4/ -i setup.cfg";
+
+  propagatedBuildInputs = [
+    mopidy
+    python3Packages.beautifulsoup4
+    python3Packages.cachetools
+    python3Packages.youtube-dl
+  ];
 
   doCheck = false;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20798,6 +20798,7 @@ in
     mopidy-mpd
     mopidy-mpris
     mopidy-musicbox-webclient
+    mopidy-somafm
     mopidy-soundcloud
     mopidy-spotify
     mopidy-spotify-tunigo

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20787,7 +20787,21 @@ in
     python = python3;
   };
 
-  inherit (mopidyPackages) mopidy mopidy-gmusic mopidy-local-images mopidy-local-sqlite mopidy-spotify mopidy-moped mopidy-mopify mopidy-spotify-tunigo mopidy-youtube mopidy-soundcloud mopidy-musicbox-webclient mopidy-iris mopidy-mpd;
+  inherit (mopidyPackages)
+    mopidy
+    mopidy-gmusic
+    mopidy-iris
+    mopidy-local-images
+    mopidy-local-sqlite
+    mopidy-moped
+    mopidy-mopify
+    mopidy-mpd
+    mopidy-mpris
+    mopidy-musicbox-webclient
+    mopidy-soundcloud
+    mopidy-spotify
+    mopidy-spotify-tunigo
+    mopidy-youtube;
 
   motif = callPackage ../development/libraries/motif { };
 


### PR DESCRIPTION
`mopidy-gmusic: 3.0.0 -> 4.0.0`
`mopidy-mpris: init at 3.0.1`
`mopidy-somafm: init at 2.0.0`
`mopidy-youtube: 2.0.2 -> 3.0.0`

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

~~This changeset moves mopidy onto the python3 branch (the python2 version is EOL), and updates some plugins. Note that `mopidy-mpd` was bundled with mopidy previously, but has been extracted into its own plugin in this release.~~ This was merged in a different PR.

~~This PR is slightly WIP as in I cannot figure out how to get `mopidy-youtube` to build; any help debugging this build error would be appreciated.~~ Fixed by @balsoft's comment below.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
