### PR TITLE
procs: 0.8.16 -> 0.9.0

### DIFF
--- a/pkgs/tools/admin/procs/default.nix
+++ b/pkgs/tools/admin/procs/default.nix
@@ -4,26 +4,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "procs";
-  version = "0.8.16";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "dalance";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0l4n3gr1sc7wfa21p8yh7idaii0mnfpyqp4cg7f9l4345isy94vq";
+    sha256 = "1lprxfy733rs39fg8yif3p8vz9szk7d529ahn1kn70zm8i3mqpch";
   };
 
-  cargoSha256 = "03c63dlzvag341n6la1s61ccri1avlprd91m11z9zzjhi9b46kcr";
+  cargoSha256 = "11l2dggvkk2vx4xap2q02qrr576i4mswf67plhg23azr43fpi0r5";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
-
-  patches = [
-    # Fix tests on darwin. Remove with the next release
-    (fetchpatch {
-      url = "https://github.com/dalance/procs/commit/bb554e247b5b339bc00fa5dd2e771b0d7cb09cd5.patch";
-      sha256 = "1szvvifa4pdbgdsmdj5f0zq6qzf1lh6wwc6ipawblfzwmg7d9wvk";
-    })
-  ];
 
   meta = with stdenv.lib; {
     description = "A modern replacement for ps written in Rust";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
