### PR TITLE
nix-gitignore: update to v3.0.2 (mostly compatible changes)

### DIFF
--- a/pkgs/build-support/nix-gitignore/default.nix
+++ b/pkgs/build-support/nix-gitignore/default.nix
@@ -147,22 +147,27 @@ in rec {
         ' sh {} \; > $out
       '');
 
-  withGitignoreFile = patterns: root:
-    lib.toList patterns ++ [(root + "/.gitignore")];
+  withGitIgnoredFilesAndDirs = patterns: root:
+    lib.toList patterns ++ [(root + "/.gitignore") (".git")];
 
-  withRecursiveGitignoreFile = patterns: root:
+  withRecursiveGitIgnoredFilesAndDirs = patterns: root:
     lib.toList patterns ++ [(compileRecursiveGitignore root)];
 
   # filterSource derivatives
+  gitignoreFilterSourcePureNamed = name: filter: patterns: root:
+    builtins.path {
+      inherit name;
+      path = root;
+      filter = gitignoreFilterPure filter patterns root;
+    };
 
-  gitignoreFilterSourcePure = filter: patterns: root:
-    filterSource (gitignoreFilterPure filter patterns root) root;
+  gitignoreFilterSourcePure = gitignoreFilterSourcePureNamed "gitignore-src";
 
   gitignoreFilterSource = filter: patterns: root:
-    gitignoreFilterSourcePure filter (withGitignoreFile patterns root) root;
+    gitignoreFilterSourcePure filter (withGitIgnoredFilesAndDirs patterns root) root;
 
   gitignoreFilterRecursiveSource = filter: patterns: root:
-    gitignoreFilterSourcePure filter (withRecursiveGitignoreFile patterns root) root;
+    gitignoreFilterSourcePure filter (withRecursiveGitIgnoredFilesAndDirs patterns root) root;
 
   # "Filter"-less alternatives
 
@@ -174,5 +179,5 @@ in rec {
       "use [] or \"\" if there are no additional patterns"
     else gitignoreFilterSource (_: _: true) patterns;
 
-  gitignoreRecursiveSource = gitignoreFilterSourcePure (_: _: true);
+  gitignoreRecursiveSource = gitignoreFilterRecursiveSource (_: _: true);
 }


### PR DESCRIPTION
Taken from the main repo, changes have been published for a while now, with nothing major having been done. Everything seems to be working.