### PR TITLE
execline: wrap unconditionally; strip

### DIFF
--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -1,85 +1,49 @@
 { lib, skawarePackages
 # for execlineb-with-builtins
 , coreutils, gnugrep, writeScriptBin, runCommand, runCommandCC
-# Whether to wrap bin/execlineb to have the execline tools on its PATH.
-, execlineb-with-builtins ? true
 }:
 
 with skawarePackages;
 
-let
+buildPackage {
+  pname = "execline";
+  version = "2.5.3.0";
+  sha256 = "0czdrv9m8mnx94nf28dafij6z03k4mbhbs6hccfaardfd5l5q805";
+
+  description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
+
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
 
-  execline =
-    buildPackage {
-      pname = "execline";
-      version = "2.5.3.0";
-      sha256 = "0czdrv9m8mnx94nf28dafij6z03k4mbhbs6hccfaardfd5l5q805";
+  # TODO: nsss support
+  configureFlags = [
+    "--libdir=\${lib}/lib"
+    "--dynlibdir=\${lib}/lib"
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
+  ];
 
-      description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
+  postInstall = ''
+    # remove all execline executables from build directory
+    rm $(find -type f -mindepth 1 -maxdepth 1 -executable)
+    rm libexecline.*
 
-      inherit outputs;
+    mv doc $doc/share/doc/execline/html
+    mv examples $doc/share/doc/execline/examples
 
-      # TODO: nsss support
-      configureFlags = [
-        "--libdir=\${lib}/lib"
-        "--dynlibdir=\${lib}/lib"
-        "--bindir=\${bin}/bin"
-        "--includedir=\${dev}/include"
-        "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-        "--with-include=${skalibs.dev}/include"
-        "--with-lib=${skalibs.lib}/lib"
-        "--with-dynlib=${skalibs.lib}/lib"
-      ];
-
-      postInstall = ''
-        # remove all execline executables from build directory
-        rm $(find -type f -mindepth 1 -maxdepth 1 -executable)
-        rm libexecline.*
-
-        mv doc $doc/share/doc/execline/html
-        mv examples $doc/share/doc/execline/examples
-      '';
-
-    };
-
-  # A wrapper around execlineb, which provides all execline
-  # tools on `execlineb`’s PATH.
-  # It is implemented as a C script, because on non-Linux,
-  # nested shebang lines are not supported.
-  execlineb-with-builtins-drv = runCommandCC "execlineb" {} ''
-    mkdir -p $out/bin
+    mv $bin/bin/execlineb $bin/bin/.execlineb-wrapped
     cc \
       -O \
       -Wall -Wpedantic \
-      -D 'EXECLINEB_PATH()="${execline}/bin/execlineb"' \
-      -D 'EXECLINE_BIN_PATH()="${execline}/bin"' \
+      -D "EXECLINEB_PATH()=\"$bin/bin/.execlineb-wrapped\"" \
+      -D "EXECLINE_BIN_PATH()=\"$bin/bin\"" \
       -I "${skalibs.dev}/include" \
       -L "${skalibs.lib}/lib" \
-      -l"skarnet" \
-      -o "$out/bin/execlineb" \
+      -lskarnet \
+      -o "$bin/bin/execlineb" \
       ${./execlineb-wrapper.c}
   '';
-
-
-  # the original execline package, with bin/execlineb overwritten
-  execline-with-builtins = runCommand "my-execline"
-    (execline.drvAttrs // {
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-    })
-    # copy every output and just overwrite the execlineb binary in $bin
-    ''
-      ${lib.concatMapStringsSep "\n"
-        (output: ''
-          cp -r ${execline.${output}} "''$${output}"
-          chmod --recursive +w "''$${output}"
-        '')
-        outputs}
-      install ${execlineb-with-builtins-drv}/bin/execlineb $bin/bin/execlineb
-    '';
-
-in
-  if execlineb-with-builtins
-  then execline-with-builtins
-  else execline
+}

--- a/pkgs/tools/misc/execline/execlineb-wrapper.c
+++ b/pkgs/tools/misc/execline/execlineb-wrapper.c
@@ -1,3 +1,10 @@
+/*
+ * A wrapper around execlineb, which provides all execline
+ * tools on execlineb’s PATH.
+ * It is implemented as a C program, because on non-Linux,
+ * nested shebang lines are not supported.
+ */
+
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I don't think there's any situation in which an unwrapped execlineb is
useful -- if you want to use different versions of the execlineb tool
it'll still prefer ones in PATH.  At the same time, implementing the
wrapper in this way, as a series of two derivations, meant that we
didn't get stdenv goodness for the wrapper.  This meant that, for
example, the wrapper was not stripped, and so execline ended up with
runtime dependencies on gcc and the Linux headers.  I don't want to
have to reimplement this sort of stuff when it's already in stdenv,
and so it makes much more sense to create the wrapper in the
mkDerivation call, where all of stdenv's normal magic will find it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
