### PR TITLE
nixos/buildkite-agents: support multiple buildkite agents

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -440,15 +440,19 @@ users.users.me =
    </listitem>
    <listitem>
     <para>
-      The <link linkend="opt-services.buildkite-agent.enable">Buildkite Agent</link>
-      module and corresponding packages have been updated to 3.x.
-      While doing so, the following options have been changed:
+      The <link linkend="opt-services.buildkite-agents">Buildkite
+      Agent</link> module and corresponding packages have been updated to
+      3.x, and to support multiple instances of the agent running at the
+      same time. This means you will have to rename
+      <literal>services.buildkite-agent</literal> to
+      <literal>services.buildkite-agents.&lt;name&gt;</literal>. Furthermore,
+      the following options have been changed:
     </para>
     <itemizedlist>
       <listitem>
        <para>
          <literal>services.buildkite-agent.meta-data</literal> has been renamed to
-         <link linkend="opt-services.buildkite-agent.tags">services.buildkite-agent.tags</link>,
+         <link linkend="opt-services.buildkite-agents">services.buildkite-agents.&lt;name&gt;.tags</link>,
          to match upstreams naming for 3.x.
          Its type has also changed - it now accepts an attrset of strings.
        </para>
@@ -464,13 +468,13 @@ users.users.me =
        <para>
          <literal>services.buildkite-agent.openssh.privateKeyPath</literal>
          has been renamed to
-         <link linkend="opt-services.buildkite-agent.privateSshKeyPath">buildkite-agent.privateSshKeyPath</link>,
+         <link linkend="opt-services.buildkite-agents">buildkite-agents.&lt;name&gt;.privateSshKeyPath</link>,
          as the whole <literal>openssh</literal> now only contained that single option.
        </para>
       </listitem>
       <listitem>
        <para>
-         <link linkend="opt-services.buildkite-agent.shell">services.buildkite-agent.shell</link>
+         <link linkend="opt-services.buildkite-agents">services.buildkite-agents.&lt;name&gt;.shell</link>
          has been introduced, allowing to specify a custom shell to be used.
        </para>
       </listitem>

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -253,7 +253,7 @@
   ./services/computing/slurm/slurm.nix
   ./services/continuous-integration/buildbot/master.nix
   ./services/continuous-integration/buildbot/worker.nix
-  ./services/continuous-integration/buildkite-agent.nix
+  ./services/continuous-integration/buildkite-agents.nix
   ./services/continuous-integration/hail.nix
   ./services/continuous-integration/hydra/default.nix
   ./services/continuous-integration/gitlab-runner.nix

--- a/nixos/modules/services/continuous-integration/buildkite-agents.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agents.nix
@@ -267,6 +267,6 @@ in
   ]);
 
   imports = [
-    (mkRemovedOptionModule [ "services" "buildkite-agent"] "services.buildkite-agent has been moved to an attribute set at services.buildkite-agents")
+    (mkRemovedOptionModule [ "services" "buildkite-agent"] "services.buildkite-agent has been upgraded from version 2 to version 3 and moved to an attribute set at services.buildkite-agents. Please consult the 20.03 release notes for more information.")
   ];
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -32,7 +32,7 @@ in
   bees = handleTest ./bees.nix {};
   bind = handleTest ./bind.nix {};
   bittorrent = handleTest ./bittorrent.nix {};
-  buildkite-agent = handleTest ./buildkite-agent.nix {};
+  buildkite-agents = handleTest ./buildkite-agents.nix {};
   boot = handleTestOn ["x86_64-linux"] ./boot.nix {}; # syslinux is unsupported on aarch64
   boot-stage1 = handleTest ./boot-stage1.nix {};
   borgbackup = handleTest ./borgbackup.nix {};

--- a/nixos/tests/buildkite-agents.nix
+++ b/nixos/tests/buildkite-agents.nix
@@ -6,18 +6,13 @@ import ./make-test-python.nix ({ pkgs, ... }:
     maintainers = [ flokli ];
   };
 
-  nodes = {
-    node1 = { pkgs, ... }: {
-      services.buildkite-agent = {
-        enable = true;
+  machine = { pkgs, ... }: {
+    services.buildkite-agents = {
+      one = {
         privateSshKeyPath = (import ./ssh-keys.nix pkgs).snakeOilPrivateKey;
         tokenPath = (pkgs.writeText "my-token" "5678");
       };
-    };
-    # don't configure ssh key, run as a separate user
-    node2 = { pkgs, ...}: {
-      services.buildkite-agent = {
-        enable = true;
+      two = {
         tokenPath = (pkgs.writeText "my-token" "1234");
       };
     };
@@ -28,9 +23,9 @@ import ./make-test-python.nix ({ pkgs, ... }:
     # we can't wait on the unit to start up, as we obviously can't connect to buildkite,
     # but we can look whether files are set up correctly
 
-    node1.wait_for_file("/var/lib/buildkite-agent/buildkite-agent.cfg")
-    node1.wait_for_file("/var/lib/buildkite-agent/.ssh/id_rsa")
+    machine.wait_for_file("/var/lib/buildkite-agent-one/buildkite-agent.cfg")
+    machine.wait_for_file("/var/lib/buildkite-agent-one/.ssh/id_rsa")
 
-    node2.wait_for_file("/var/lib/buildkite-agent/buildkite-agent.cfg")
+    machine.wait_for_file("/var/lib/buildkite-agent-two/buildkite-agent.cfg")
   '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Continued from  #68378, which was continued from #59358.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).



###### cc
@flokli @mkaito @balsoft @Infinisil