### PR TITLE
light: 1.2 -> 1.2.1

### DIFF
--- a/pkgs/os-specific/linux/light/default.nix
+++ b/pkgs/os-specific/linux/light/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, autoreconfHook, coreutils }:
 
 stdenv.mkDerivation rec {
-  version = "1.2";
+  version = "1.2.1";
   pname = "light";
   src = fetchFromGitHub {
     owner = "haikarainen";
     repo = "light";
     rev = "v${version}";
-    sha256 = "1h286va0r1xgxlnxfaaarrj3qhxmjjsivfn3khwm0wq1mhkfihra";
+    sha256 = "0zrjipd392bzjvxx0rjrb0cgi0ix1d83fwgw1mcy8kc4d16cgyjg";
   };
 
   configureFlags = [ "--with-udev" ];


### PR DESCRIPTION
###### Motivation for this change

Minor, been using since November so AFAIK works great (as did 1.2).

https://github.com/haikarainen/light/releases/tag/v1.2.1

(the commits tell a better story, it's not as trivial an update as the
blurb on the tag page might suggest :))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).