### PR TITLE
treewide: fix dead urls

### DIFF
--- a/pkgs/applications/misc/wmname/default.nix
+++ b/pkgs/applications/misc/wmname/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Prints or set the window manager name property of the root window";
-    homepage = https://tools.suckless.org/wmname;
+    homepage = https://tools.suckless.org/x/wmname;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/applications/networking/cluster/chronos/default.nix
+++ b/pkgs/applications/networking/cluster/chronos/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage    = http://airbnb.github.io/chronos;
+    homepage    = https://mesos.github.io/chronos;
     license     = licenses.asl20;
     description = "Fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules";
     maintainers = with maintainers; [ offline ];

--- a/pkgs/development/ocaml-modules/biocaml/default.nix
+++ b/pkgs/development/ocaml-modules/biocaml/default.nix
@@ -23,7 +23,7 @@ buildDunePackage rec {
 
   meta = with stdenv.lib; {
     description = "Bioinformatics library for Ocaml";
-    homepage = "http://${owner}.github.io/${pname}";
+    homepage = http://biocaml.org/;
     maintainers = [ maintainers.bcdarwin ];
     license = licenses.gpl2;
   };

--- a/pkgs/development/python-modules/mailchimp/default.nix
+++ b/pkgs/development/python-modules/mailchimp/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A CLI client and Python API library for the MailChimp email platform";
-    homepage = "http://apidocs.mailchimp.com/api/2.0/";
+    homepage = https://mailchimp.com/developer;
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/setuptoolsdarcs/default.nix
+++ b/pkgs/development/python-modules/setuptoolsdarcs/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Setuptools plugin for the Darcs version control system";
-    homepage = http://allmydata.org/trac/setuptools_darcs;
+    homepage = https://pypi.org/project/setuptools_darcs;
     license = licenses.bsd0;
   };
 }

--- a/pkgs/os-specific/linux/sinit/default.nix
+++ b/pkgs/os-specific/linux/sinit/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.mit ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
-    homepage = https://tools.suckless.org/sinit;
+    homepage = https://core.suckless.org/sinit;
     downloadPage = "https://git.suckless.org/sinit";
   };
 }

--- a/pkgs/servers/identd/nullidentdmod/default.nix
+++ b/pkgs/servers/identd/nullidentdmod/default.nix
@@ -18,7 +18,7 @@
   meta = with stdenv.lib; {
     description = "Simple identd that just replies with a random string or customized userid";
     license = licenses.gpl2;
-    homepage = http://acidhub.click/NullidentdMod;
+    homepage = https://github.com/Acidhub/nullidentdmod;
     maintainers = with maintainers; [ das_j ];
     platforms = platforms.linux; # Must be run by systemd
   };

--- a/pkgs/tools/X11/sselp/default.nix
+++ b/pkgs/tools/X11/sselp/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   version = "0.2";
   pname = "sselp";
- 
+
   src = fetchurl {
     url = "https://dl.suckless.org/tools/${pname}-${version}.tar.gz";
     sha256 = "08mqp00lrh1chdrbs18qr0xv63h866lkmfj87kfscwdm1vn9a3yd";
   };
- 
+
   buildInputs = [ libX11 ];
 
   patchPhase = ''
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = https://tools.suckless.org/sselp;
+    homepage = https://tools.suckless.org/x/sselp;
     description = "Prints the X selection to stdout, useful in scripts";
     license = stdenv.lib.licenses.mit;
     maintainers = [stdenv.lib.maintainers.magnetophon ];

--- a/pkgs/tools/networking/horst/default.nix
+++ b/pkgs/tools/networking/horst/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Small and lightweight IEEE802.11 wireless LAN analyzer with a text interface";
-    homepage = http://br1.einfach.org/tech/horst/;
+    homepage = https://github.com/br101/horst;
     maintainers = [ maintainers.fpletz ];
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/tools/security/mkp224o/default.nix
+++ b/pkgs/tools/security/mkp224o/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Vanity address generator for tor onion v3 (ed25519) hidden services";
-    homepage = http://cathug2kyi4ilneggumrenayhuhsvrgn6qv2y47bgeet42iivkpynqad.onion/;
+    homepage = https://github.com/cathugger/mkp224o;
     license = licenses.cc0;
     platforms = platforms.linux;
     maintainers = with maintainers; [ volth ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Following #78265 I thought I would try and tackle all the dead links listed in Repology, by both updating the ones that were moved and listing explicitly projects that are nowhere to be found. This is still WIP as there are 279 remaining pkgs for me to go through.

List of really dead projects with unfindable homepages and/or source directories (so far):
```
cernlib (http://cernlib.web.cern.ch)
libesmtp (http://www.stafford.uklinux.net/libesmtp/)
x86info (http://codemonkey.org.uk/projects/x86info/)
zdelta (http://cis.poly.edu/zdelta)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
