### PR TITLE
Update Haskell package set to LTS 14.21 (plus other fixes)

### DIFF
--- a/pkgs/data/misc/hackage/default.nix
+++ b/pkgs/data/misc/hackage/default.nix
@@ -1,6 +1,6 @@
 { fetchurl }:
 
 fetchurl {
-  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/b2812edaaed9f9033e48dfbcd45e7e5fb56daccd.tar.gz";
-  sha256 = "1a2073gknks4r2ibm3ji1wrib6pr3aicg6wjgzsj2r5xgad7jm6g";
+  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/10e6ea0c54a4aa41de51d1d7e2314115bb2e172a.tar.gz";
+  sha256 = "0kjy1dxa2kra4j02ni8lpg74jy7fl361yiha330c52spvd2v8i8h";
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1337,7 +1337,15 @@ self: super: {
 
   # 2019-12-19 - glirc wants regex-tdfa >=1.3 which results in errors with regex-base which errors more
   # hoping to make a proper derivation with plugins enabled and more reliable building -- kiwi
-  glirc = doJailbreak super.glirc;
+  # 2020-01-17 - as of recently the basic doJailbreak is not enough and have to override regex-tdfa which needs an override for regex-base
+
+  glirc = doJailbreak (super.glirc.override {
+    regex-tdfa = self.regex-tdfa_1_3_1_0;
+  });
+
+  regex-tdfa_1_3_1_0 = doJailbreak (super.regex-tdfa_1_3_1_0.override {
+    regex-base = self.regex-base_0_94_0_0;
+  });
 
   # apply patches from https://github.com/snapframework/snap-server/pull/126
   # manually until they are accepted upstream

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1347,6 +1347,18 @@ self: super: {
     regex-base = self.regex-base_0_94_0_0;
   });
 
+  # 2020-01-19 - there were conflicting versions of brick, vty, and brick-skylighting;
+  # multiple versions of them were being pulled in by the others which is not allowed.
+  # There are more complicated ways of doing this but I was able to make it fairly simple -- kiwi
+  matterhorn = doJailbreak (super.matterhorn.override {
+    brick-skylighting = self.brick-skylighting.override {
+      brick = self.brick_0_50_1;
+    };
+  });
+
+  # 2020-01-19 - because of QuickCheck bounds | was broken anyway and is needed for matterhorn -- kiwi
+  Unique = doJailbreak super.Unique;
+
   # apply patches from https://github.com/snapframework/snap-server/pull/126
   # manually until they are accepted upstream
   snap-server = overrideCabal super.snap-server (drv: {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1237,8 +1237,8 @@ self: super: {
   # Test suite won't link for no apparent reason.
   constraints-deriving = dontCheck super.constraints-deriving;
 
-  # need newer version of ghc-libparser
-  hlint = super.hlint.override { ghc-lib-parser = self.ghc-lib-parser_8_8_2; };
+  # Use a matching version of ghc-lib-parser.
+  ghc-lib-parser-ex = super.ghc-lib-parser-ex.override { ghc-lib-parser = self.ghc-lib-parser_8_8_2; };
 
   # https://github.com/sol/hpack/issues/366
   hpack = self.hpack_0_33_0;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1054,10 +1054,10 @@ self: super: {
   # This will probably be able to be removed when we update to LTS-15.
   dhall_1_29_0 =
     dontCheck (super.dhall_1_29_0.override {
-      prettyprinter = self.prettyprinter_1_5_1;
+      prettyprinter = self.prettyprinter_1_6_0;
       prettyprinter-ansi-terminal =
         self.prettyprinter-ansi-terminal.override {
-          prettyprinter = self.prettyprinter_1_5_1;
+          prettyprinter = self.prettyprinter_1_6_0;
         };
     });
   dhall-bash_1_0_27 = super.dhall-bash_1_0_27.override { dhall = self.dhall_1_29_0; };
@@ -1387,5 +1387,8 @@ self: super: {
 
   # krank-0.1.0 does not accept PyF-0.9.0.0.
   krank = doJailbreak super.krank;
+
+  # prettyprinter-1.6.0 fails its doctest suite.
+  prettyprinter_1_6_0 = dontCheck super.prettyprinter_1_6_0;
 
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -93,7 +93,7 @@ self: super: {
   optparse-applicative = self.optparse-applicative_0_15_1_0;
   pandoc = self.pandoc_2_9_1_1;
   pandoc-types = self.pandoc-types_1_20;
-  prettyprinter = self.prettyprinter_1_5_1;
+  prettyprinter = self.prettyprinter_1_6_0;
   primitive = dontCheck super.primitive_0_7_0_0;  # evaluating the test suite gives an infinite recursion
   regex-base = self.regex-base_0_94_0_0;
   regex-compat = self.regex-compat_0_95_2_0;
@@ -102,10 +102,9 @@ self: super: {
   regex-tdfa = self.regex-tdfa_1_3_1_0;
   shelly = self.shelly_1_9_0;
   singletons = self.singletons_2_6;
-  skylighting = self.skylighting_0_8_3;
-  skylighting-core = self.skylighting-core_0_8_3;
+  skylighting = self.skylighting_0_8_3_2;
+  skylighting-core = self.skylighting-core_0_8_3_2;
   sop-core = self.sop-core_0_5_0_0;
-  tls-session-manager = self.tls-session-manager_0_0_4;
   texmath = self.texmath_0_12;
   th-desugar = self.th-desugar_1_10;
   tls = self.tls_1_5_3;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -69,7 +69,7 @@ core-packages:
 default-package-overrides:
   # pandoc-2.9 does not accept the 0.3 version yet
   - doclayout < 0.3
-  # LTS Haskell 14.20
+  # LTS Haskell 14.21
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
   - abstract-par ==0.3.3
@@ -165,10 +165,10 @@ default-package-overrides:
   - avers ==0.0.17.1
   - avers-api ==0.1.0
   - avers-server ==0.1.0.1
-  - avro ==0.4.5.4
+  - avro ==0.4.6.0
   - avwx ==0.3.0.2
   - aws-cloudfront-signed-cookies ==0.2.0.1
-  - aws-lambda-haskell-runtime ==2.0.2
+  - aws-lambda-haskell-runtime ==2.0.3
   - backprop ==0.2.6.3
   - bank-holidays-england ==0.2.0.2
   - barbies ==1.1.3.0
@@ -176,7 +176,7 @@ default-package-overrides:
   - base16-bytestring ==0.1.1.6
   - base32string ==0.9.1
   - base58string ==0.10.0
-  - base64-bytestring ==1.0.0.2
+  - base64-bytestring ==1.0.0.3
   - base64-bytestring-type ==1.0.1
   - base64-string ==0.2
   - base-compat ==0.10.5
@@ -197,7 +197,7 @@ default-package-overrides:
   - beam-sqlite ==0.4.0.0
   - bench ==1.0.12
   - benchpress ==0.2.2.12
-  - bench-show ==0.3.0
+  - bench-show ==0.3.1
   - bencode ==0.6.0.0
   - bencoding ==0.4.5.2
   - between ==0.11.0.0
@@ -323,8 +323,8 @@ default-package-overrides:
   - ChannelT ==0.0.0.7
   - charset ==0.3.7.1
   - charsetdetect-ae ==1.1.0.4
-  - Chart ==1.9.1
-  - Chart-diagrams ==1.9.2
+  - Chart ==1.9.3
+  - Chart-diagrams ==1.9.3
   - chaselev-deque ==0.5.0.5
   - cheapskate ==0.1.1.1
   - cheapskate-highlight ==0.1.0.0
@@ -340,7 +340,7 @@ default-package-overrides:
   - chronos-bench ==0.2.0.2
   - chunked-data ==0.3.1
   - cipher-aes ==0.2.11
-  - cipher-aes128 ==0.7.0.4
+  - cipher-aes128 ==0.7.0.5
   - cipher-blowfish ==0.0.3
   - cipher-camellia ==0.0.2
   - cipher-des ==0.0.6
@@ -370,7 +370,7 @@ default-package-overrides:
   - codo-notation ==0.5.2
   - coercible-utils ==0.0.0
   - co-log ==0.3.0.0
-  - co-log-core ==0.2.0.0
+  - co-log-core ==0.2.1.0
   - colonnade ==1.2.0.2
   - colorful-monoids ==0.2.1.2
   - colorize-haskell ==1.0.1
@@ -440,7 +440,7 @@ default-package-overrides:
   - credential-store ==0.1.2
   - criterion ==1.5.6.1
   - criterion-measurement ==0.1.2.0
-  - cron ==0.6.1
+  - cron ==0.6.2
   - crypto-api ==0.13.3
   - crypto-api-tests ==0.3
   - cryptocipher ==0.6.2
@@ -481,7 +481,7 @@ default-package-overrides:
   - currency ==0.2.0.0
   - cusparse ==0.2.0.0
   - cutter ==0.0
-  - cyclotomic ==1.0
+  - cyclotomic ==1.0.1
   - czipwith ==1.0.1.2
   - data-accessor ==0.2.2.8
   - data-accessor-mtl ==0.2.0.4
@@ -517,7 +517,7 @@ default-package-overrides:
   - data-textual ==0.3.0.3
   - data-tree-print ==0.1.0.2
   - dataurl ==0.1.0.0
-  - DAV ==1.3.3
+  - DAV ==1.3.4
   - dbcleaner ==0.1.3
   - DBFunctor ==0.1.1.1
   - dbus ==1.2.7
@@ -724,7 +724,7 @@ default-package-overrides:
   - foldable1 ==0.1.0.0
   - fold-debounce ==0.2.0.9
   - fold-debounce-conduit ==0.2.0.4
-  - foldl ==1.4.5
+  - foldl ==1.4.6
   - folds ==0.7.5
   - follow-file ==0.0.3
   - FontyFruity ==0.5.3.5
@@ -781,7 +781,7 @@ default-package-overrides:
   - genvalidity-hspec-cereal ==0.2.0.3
   - genvalidity-hspec-hashable ==0.2.0.4
   - genvalidity-hspec-optics ==0.1.1.1
-  - genvalidity-path ==0.3.0.2
+  - genvalidity-path ==0.3.0.3
   - genvalidity-property ==0.4.0.0
   - genvalidity-scientific ==0.2.1.0
   - genvalidity-text ==0.6.0.0
@@ -803,8 +803,8 @@ default-package-overrides:
   - ghc-paths ==0.1.0.12
   - ghc-prof ==1.4.1.6
   - ghc-syntax-highlighter ==0.0.4.1
-  - ghc-tcplugins-extra ==0.3
-  - ghc-typelits-extra ==0.3.1
+  - ghc-tcplugins-extra ==0.3.2
+  - ghc-typelits-extra ==0.3.2
   - ghc-typelits-knownnat ==0.6
   - ghc-typelits-natnormalise ==0.6.2
   - ghost-buster ==0.1.1.0
@@ -841,7 +841,7 @@ default-package-overrides:
   - gloss-rendering ==1.13.1.1
   - GLURaw ==2.0.0.4
   - GLUT ==2.7.0.15
-  - gnuplot ==0.5.6
+  - gnuplot ==0.5.6.1
   - google-isbn ==1.0.3
   - google-oauth2-jwt ==0.3.2
   - gpolyline ==0.1.0.1
@@ -916,7 +916,7 @@ default-package-overrides:
   - heap ==1.0.4
   - heaps ==0.3.6.1
   - hebrew-time ==0.1.2
-  - hedgehog ==1.0.1
+  - hedgehog ==1.0.2
   - hedgehog-corpus ==0.1.0
   - hedgehog-fn ==1.0
   - hedis ==0.12.11
@@ -983,7 +983,7 @@ default-package-overrides:
   - HSet ==0.0.1
   - hset ==2.2.0
   - hsexif ==0.6.1.6
-  - hs-functors ==0.1.4.0
+  - hs-functors ==0.1.5.0
   - hs-GeoIP ==0.3
   - hsini ==0.5.1.2
   - hsinstall ==2.2
@@ -1211,7 +1211,7 @@ default-package-overrides:
   - language-haskell-extract ==0.2.4
   - language-java ==0.2.9
   - language-javascript ==0.6.0.14
-  - language-puppet ==1.4.6
+  - language-puppet ==1.4.6.1
   - lapack ==0.3.1
   - lapack-carray ==0.0.3
   - lapack-comfort-array ==0.0.0.1
@@ -1227,7 +1227,7 @@ default-package-overrides:
   - leancheck ==0.9.1
   - leancheck-instances ==0.0.3
   - leapseconds-announced ==2017.1.0.1
-  - learn-physics ==0.6.4
+  - learn-physics ==0.6.5
   - lens ==4.17.1
   - lens-action ==0.2.4
   - lens-aeson ==1.0.2
@@ -1312,7 +1312,7 @@ default-package-overrides:
   - matplotlib ==0.7.5
   - matrices ==0.5.0
   - matrix ==0.3.6.1
-  - matrix-market-attoparsec ==0.1.0.8
+  - matrix-market-attoparsec ==0.1.1.3
   - matrix-static ==0.2.1
   - maximal-cliques ==0.1.1
   - mbox ==0.3.4
@@ -1387,7 +1387,7 @@ default-package-overrides:
   - monad-peel ==0.2.1.2
   - monad-products ==4.0.1
   - MonadPrompt ==1.0.0.5
-  - MonadRandom ==0.5.1.1
+  - MonadRandom ==0.5.1.2
   - monad-skeleton ==0.1.5
   - monad-st ==0.2.4.1
   - monads-tf ==0.1.0.3
@@ -1523,7 +1523,7 @@ default-package-overrides:
   - options ==1.2.1.1
   - optparse-applicative ==0.14.3.0
   - optparse-enum ==1.0.0.0
-  - optparse-generic ==1.3.0
+  - optparse-generic ==1.3.1
   - optparse-simple ==0.1.1.2
   - optparse-text ==0.1.1.0
   - ordered-containers ==0.2.2
@@ -1556,8 +1556,8 @@ default-package-overrides:
   - partial-handler ==1.0.3
   - partial-isomorphisms ==0.2.2.1
   - partial-semigroup ==0.5.1.1
-  - password ==0.1.0.0
-  - password-instances ==0.3.0.0
+  - password ==0.1.0.1
+  - password-instances ==0.3.0.1
   - path ==0.6.1
   - path-extra ==0.2.0
   - path-io ==1.4.2
@@ -1644,7 +1644,7 @@ default-package-overrides:
   - postgresql-orm ==0.5.1
   - postgresql-schema ==0.1.14
   - postgresql-simple ==0.6.2
-  - postgresql-simple-migration ==0.1.14.0
+  - postgresql-simple-migration ==0.1.15.0
   - postgresql-simple-queue ==1.0.1
   - postgresql-simple-url ==0.2.1.0
   - postgresql-transactional ==1.1.1
@@ -1704,7 +1704,7 @@ default-package-overrides:
   - psqueues ==0.2.7.2
   - pureMD5 ==2.1.3
   - purescript-bridge ==0.13.0.0
-  - pure-zlib ==0.6.6
+  - pure-zlib ==0.6.7
   - pushbullet-types ==0.4.1.0
   - pusher-http-haskell ==1.5.1.11
   - qchas ==1.1.0.1
@@ -1815,7 +1815,7 @@ default-package-overrides:
   - rhine ==0.5.1.0
   - rhine-gloss ==0.5.1.0
   - rigel-viz ==0.2.0.0
-  - rio ==0.1.12.0
+  - rio ==0.1.13.0
   - rio-orphans ==0.1.1.0
   - rio-prettyprint ==0.1.0.0
   - roc-id ==0.1.0.0
@@ -1851,8 +1851,8 @@ default-package-overrides:
   - say ==0.1.0.1
   - sbp ==2.6.3
   - sbv ==8.3
-  - scalpel ==0.6.0
-  - scalpel-core ==0.6.0
+  - scalpel ==0.6.1
+  - scalpel-core ==0.6.1
   - scanf ==0.1.0.0
   - scanner ==0.3.1
   - scheduler ==1.4.2.1
@@ -1864,7 +1864,7 @@ default-package-overrides:
   - sdl2-image ==2.0.0
   - sdl2-mixer ==1.1.0
   - sdl2-ttf ==2.1.0
-  - secp256k1-haskell ==0.1.6
+  - secp256k1-haskell ==0.1.8
   - securemem ==0.1.10
   - selda ==0.4.0.0
   - selda-json ==0.1.1.0
@@ -2010,7 +2010,7 @@ default-package-overrides:
   - statestack ==0.2.0.5
   - StateVar ==1.2
   - static-text ==0.2.0.4
-  - statistics ==0.15.1.1
+  - statistics ==0.15.2.0
   - stb-image-redux ==0.2.1.3
   - step-function ==0.2
   - stm-chans ==3.0.0.4
@@ -2031,7 +2031,7 @@ default-package-overrides:
   - streaming-attoparsec ==1.0.0.1
   - streaming-bytestring ==0.1.6
   - streaming-cassava ==0.1.0.1
-  - streaming-commons ==0.2.1.1
+  - streaming-commons ==0.2.1.2
   - streaming-wai ==0.1.1
   - streamly ==0.6.1
   - streamproc ==1.6.2
@@ -2097,7 +2097,7 @@ default-package-overrides:
   - tasty-discover ==4.2.1
   - tasty-expected-failure ==0.11.1.2
   - tasty-golden ==2.3.2
-  - tasty-hedgehog ==1.0.0.1
+  - tasty-hedgehog ==1.0.0.2
   - tasty-hspec ==1.1.5.1
   - tasty-hunit ==0.10.0.2
   - tasty-kat ==0.0.3
@@ -2193,7 +2193,7 @@ default-package-overrides:
   - tldr ==0.4.0.2
   - tls ==1.4.1
   - tls-debug ==0.4.5
-  - tls-session-manager ==0.0.3
+  - tls-session-manager ==0.0.4
   - tmapchan ==0.0.3
   - tmapmvar ==0.0.4
   - tmp-postgres ==0.2.0.0
@@ -2248,7 +2248,7 @@ default-package-overrides:
   - typerep-map ==0.3.2
   - type-spec ==0.4.0.0
   - tz ==0.1.3.3
-  - tzdata ==0.1.20190325.0
+  - tzdata ==0.1.20190911.0
   - ua-parser ==0.7.5.1
   - ucam-webauth ==0.1.0.0
   - ucam-webauth-types ==0.1.0.0
@@ -2335,7 +2335,7 @@ default-package-overrides:
   - vector-split ==1.0.0.2
   - vector-th-unbox ==0.2.1.7
   - verbosity ==0.3.0.0
-  - versions ==3.5.1.1
+  - versions ==3.5.2
   - ViennaRNAParser ==1.3.3
   - viewprof ==0.0.0.32
   - vinyl ==0.11.0
@@ -2345,14 +2345,14 @@ default-package-overrides:
   - void ==0.7.3
   - vty ==5.25.1
   - wai ==3.2.2.1
-  - wai-app-static ==3.1.6.3
+  - wai-app-static ==3.1.7.1
   - wai-cli ==0.2.1
   - wai-conduit ==3.0.0.4
   - wai-cors ==0.2.7
   - wai-enforce-https ==0.0.1
   - wai-eventsource ==3.0.0
-  - wai-extra ==3.0.28
-  - wai-handler-launch ==3.0.2.4
+  - wai-extra ==3.0.29
+  - wai-handler-launch ==3.0.3.1
   - wai-logger ==2.3.5
   - wai-middleware-auth ==0.1.2.1
   - wai-middleware-caching ==0.1.0.2
@@ -2455,7 +2455,7 @@ default-package-overrides:
   - yesod ==1.6.0
   - yesod-alerts ==0.1.3.0
   - yesod-auth ==1.6.8
-  - yesod-auth-hashdb ==1.7.1.1
+  - yesod-auth-hashdb ==1.7.1.2
   - yesod-auth-oauth2 ==0.6.1.2
   - yesod-bin ==1.6.0.4
   - yesod-core ==1.6.17

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2603,6 +2603,8 @@ package-maintainers:
     - streaming-wai
   kiwi:
     - glirc
+    - matterhorn
+    - Unique
   psibi:
     - path-pieces
     - persistent
@@ -7173,7 +7175,6 @@ broken-packages:
   - mathlink
   - matrix-as-xyz
   - matsuri
-  - matterhorn
   - maude
   - maxent
   - maxent-learner-hw
@@ -9929,7 +9930,6 @@ broken-packages:
   - uniform-io
   - union
   - union-map
-  - Unique
   - uniqueid
   - uniquely-represented-sets
   - units-attoparsec

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6611,6 +6611,7 @@ broken-packages:
   - json-pointer-hasql
   - json-python
   - json-schema
+  - json-syntax
   - json-togo
   - json-tokens
   - json-tools
@@ -6862,6 +6863,7 @@ broken-packages:
   - legion-extra
   - leksah-server
   - lendingclub
+  - lens-core
   - lens-filesystem
   - lens-prelude
   - lens-text-encoding
@@ -7487,6 +7489,7 @@ broken-packages:
   - musicxml
   - musicxml2
   - mustache-haskell
+  - mutable
   - mutable-iter
   - MutationOrder
   - mute-unmute
@@ -9505,6 +9508,7 @@ broken-packages:
   - tamarin-prover-utils
   - tamper
   - Tape
+  - tar-bytestring
   - target
   - tart
   - task
@@ -9693,6 +9697,8 @@ broken-packages:
   - tip-haskell-frontend
   - tip-lib
   - titan
+  - titan-debug-yampa
+  - titan-record-yampa
   - Titim
   - tkhs
   - tkyprof

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13303,6 +13303,8 @@ in
 
   matio = callPackage ../development/libraries/matio { };
 
+  matterhorn = haskell.lib.justStaticExecutables haskellPackages.matterhorn;
+
   mbedtls = callPackage ../development/libraries/mbedtls { };
 
   mdds = callPackage ../development/libraries/mdds { };


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-01-24 [20:00 CET](http://www.thetimezoneconverter.com/?t=20:00&tz=Berlin). You can watch this live on Twitch: https://www.twitch.tv/peti343. If you'd like to chat with me (and others) during the stream, you're welcome to use the Twitch chat or join the [`#haskell4nix` voice conference](https://discord.gg/YTEa3XR).