### PR TITLE
vimUtils.vimrcFile: fixes packpath order

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -330,9 +330,8 @@ let
         );
       in
       ''
-        set packpath-=~/.vim/after
-        set packpath+=${packDir packages}
-        set packpath+=~/.vim/after
+        set packpath^=${packDir packages}
+        set runtimepath^=${packDir packages}
 
         filetype indent plugin on | syn on
       '');


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix `vimUtils.vimrcFile`'s packDir import order:
1. Currently the packDir's plugins are added in `rtp` after `$VIMRUNTIME`. This breaks a lot of plugins as most of them expect the pack that the plugin is in  to be loaded before `$VIMRUNTIME`.
2. Just adding `set packpath^=...` is not enough and rtp must also be prepended with the packDir's path. This's makes vim/neovim load plugins from packs in packDir in order specified by its placement in rtp (weird behavior but that's how it works).
3. With the changes in this PR `vim` and `neovim` will load the `packDir` in a similar manner as when placed in `.vim/` or `.config/neovim` and load order will be correct.

Fixes #39364

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
