### PR TITLE
docbookrx & kramdown-asciidoc: init

### DIFF
--- a/pkgs/tools/typesetting/docbookrx/Gemfile
+++ b/pkgs/tools/typesetting/docbookrx/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'nokogiri', '~> 1.8.0'

--- a/pkgs/tools/typesetting/docbookrx/Gemfile.lock
+++ b/pkgs/tools/typesetting/docbookrx/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (~> 1.8.0)
+
+BUNDLED WITH
+   1.17.3

--- a/pkgs/tools/typesetting/docbookrx/default.nix
+++ b/pkgs/tools/typesetting/docbookrx/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, ruby
+, bundlerEnv
+# , libxml2
+}:
+
+let
+  env = bundlerEnv {
+    name = "docbookrx-env";
+    gemdir = ./.;
+
+    inherit ruby;
+
+    # buildInputs = [
+    #   libxml2
+    # ];
+
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+
+in stdenv.mkDerivation {
+
+  pname = "docbookrx";
+  version = "unstable-2018-05-02";
+
+  buildInputs = [ env.wrappedRuby ];
+
+  src = fetchFromGitHub {
+    owner = "asciidoctor";
+    repo = "docbookrx";
+    rev = "682d8c2f7a9e1e6f546c5f7d0067353621c68a7a";
+    sha256 = "07jilh17gj8xx4ps4ln787izmhv8xwwwv6fkqqg3pwjni5qikx7w";
+  };
+
+  # TODO: I don't know ruby packaging but this does the trick for now
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -a bin/docbookrx $out/bin
+    cp -a lib $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "(An early version of) a DocBook to AsciiDoc converter written in Ruby.";
+    homepage = https://asciidoctor.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/tools/typesetting/docbookrx/gemset.nix
+++ b/pkgs/tools/typesetting/docbookrx/gemset.nix
@@ -1,0 +1,23 @@
+{
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13d32jjadpjj6d2wdhkfpsmy68zjx90p49bgf8f7nkpz86r1fr11";
+      type = "gem";
+    };
+    version = "2.3.0";
+  };
+  nokogiri = {
+    dependencies = ["mini_portile2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0byyxrazkfm29ypcx5q4syrv126nvjnf7z6bqi01sqkv4llsi4qz";
+      type = "gem";
+    };
+    version = "1.8.5";
+  };
+}

--- a/pkgs/tools/typesetting/kramdown-asciidoc/Gemfile
+++ b/pkgs/tools/typesetting/kramdown-asciidoc/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'kramdown-asciidoc'

--- a/pkgs/tools/typesetting/kramdown-asciidoc/Gemfile.lock
+++ b/pkgs/tools/typesetting/kramdown-asciidoc/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    kramdown (1.17.0)
+    kramdown-asciidoc (1.0.1)
+      kramdown (~> 1.17.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kramdown-asciidoc
+
+BUNDLED WITH
+   1.17.3

--- a/pkgs/tools/typesetting/kramdown-asciidoc/default.nix
+++ b/pkgs/tools/typesetting/kramdown-asciidoc/default.nix
@@ -1,0 +1,37 @@
+{ lib, bundlerApp, makeWrapper,
+  # Optional dependencies, can be null
+  epubcheck, kindlegen,
+  bundlerUpdateScript
+}:
+
+let
+  app = bundlerApp {
+    pname = "kramdown-asciidoc";
+    gemdir = ./.;
+
+    exes = [
+      "kramdoc"
+    ];
+
+    # buildInputs = [ makeWrapper ];
+
+    # postBuild = ''
+    #     wrapProgram "$out/bin/asciidoctor-epub3" \
+    #       ${lib.optionalString (epubcheck != null) "--set EPUBCHECK ${epubcheck}/bin/epubcheck"} \
+    #       ${lib.optionalString (kindlegen != null) "--set KINDLEGEN ${kindlegen}/bin/kindlegen"}
+    #   '';
+
+    # passthru = {
+    #   updateScript = bundlerUpdateScript "kramdown-asciidoc";
+    # };
+
+    meta = with lib; {
+      description = "A kramdown extension for converting Markdown documents to AsciiDoc.";
+      homepage = https://asciidoctor.org/;
+      license = licenses.mit;
+      maintainers = with maintainers; [ ];
+      platforms = platforms.unix;
+    };
+  };
+in
+  app

--- a/pkgs/tools/typesetting/kramdown-asciidoc/gemset.nix
+++ b/pkgs/tools/typesetting/kramdown-asciidoc/gemset.nix
@@ -1,0 +1,23 @@
+{
+  kramdown = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n1c4jmrh5ig8iv1rw81s4mw4xsp4v97hvf8zkigv4hn5h542qjq";
+      type = "gem";
+    };
+    version = "1.17.0";
+  };
+  kramdown-asciidoc = {
+    dependencies = ["kramdown"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nr4hss1byhchwkqy2w0dgc7s83n0s5xm0pjms2cmckc4sbrryxi";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2964,6 +2964,8 @@ in
     ssh = openssh;
   };
 
+  kramdown-asciidoc = callPackage ../tools/typesetting/kramdown-asciidoc { };
+
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
   rage = callPackage ../tools/security/rage {
@@ -7591,7 +7593,7 @@ in
   zpaqd = callPackage ../tools/archivers/zpaq/zpaqd.nix { };
 
   zsh-autoenv = callPackage ../tools/misc/zsh-autoenv { };
-  
+
   zsh-bd = callPackage ../shells/zsh/zsh-bd { };
 
   zsh-git-prompt = callPackage ../shells/zsh/zsh-git-prompt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2845,6 +2845,8 @@ in
 
   docbook2mdoc = callPackage ../tools/misc/docbook2mdoc { };
 
+  docbookrx = callPackage ../tools/typesetting/docbookrx { };
+
   docear = callPackage ../applications/office/docear { };
 
   dockbarx = callPackage ../applications/misc/dockbarx { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
