### PR TITLE
tdesktop: 1.9.4 -> 1.9.7

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -18,34 +18,35 @@ with lib;
 
 mkDerivation rec {
   pname = "telegram-desktop";
-  version = "1.9.4";
+  version = "1.9.7";
   # Note: Due to our strong dependency on the Arch patches it's probably best
   # to also wait for the Arch update (especially if the patches don't apply).
 
   # Telegram-Desktop with submodules
   src = fetchurl {
     url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "1ldsgbix0ca4pl2z55wiz90ll3542zsm9slayrzyr7b2jw7arxwy";
+    sha256 = "1hj7bv11alc8cfffy0k3za4missdr44cdmia93xn77w012qjn8a4";
   };
 
   # Arch patches (svn export telegram-desktop/trunk)
   archPatches = fetchsvn {
     url = "svn://svn.archlinux.org/community/telegram-desktop/trunk";
     # svn log svn://svn.archlinux.org/community/telegram-desktop/trunk
-    rev = "553350";
-    sha256 = "05fyij490flrbn4jfwhm8gx9imh0wfby4j9fj69f45qgkpsd7ajb";
+    rev = "554983";
+    sha256 = "02gk5dlrmxvyl7w1yxmwclknk1k9drpx6rxqc6vmmw85l763m95j";
   };
 
   # Note: It would be best if someone could get as many patches upstream as
   # possible (we currently depend a lot on custom patches...).
   patches = [
     "${archPatches}/0005-Use-system-wide-fonts.patch"
-    "${archPatches}/0006-Revert-Disable-DemiBold-fallback-for-Semibold.patch"
   ];
 
   postPatch = ''
     substituteInPlace Telegram/SourceFiles/platform/linux/linux_libs.cpp \
       --replace '"appindicator3"' '"${libappindicator-gtk3}/lib/libappindicator3.so"'
+    substituteInPlace Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp \
+      --replace '"libenchant-2.so.2"' '"${enchant2}/lib/libenchant-2.so.2"'
   '';
 
   # We want to run wrapProgram manually (with additional parameters)
@@ -90,6 +91,7 @@ mkDerivation rec {
     "-DTDESKTOP_DISABLE_DESKTOP_FILE_GENERATION=ON"
     "-DTDESKTOP_USE_PACKAGED_TGVOIP=OFF"
     #"-DDESKTOP_APP_SPECIAL_TARGET=\"\"" # TODO: Error when set to "": Bad special target '""'
+    "-DTDESKTOP_LAUNCHER_BASENAME=telegramdesktop" # Note: This is the default
   ];
 
   # Note: The following packages could be packaged system-wide, but it's
@@ -108,7 +110,7 @@ mkDerivation rec {
   # https://github.com/NixOS/nixpkgs/pull/75210
 
   installPhase = ''
-    install -Dm755 bin/Telegram $out/bin/telegram-desktop
+    install -Dm755 bin/telegram-desktop $out/bin/telegram-desktop
 
     mkdir -p $out/share/{kservices5,applications,metainfo}
     sed "s,/usr/bin,$out/bin,g" "../lib/xdg/tg.protocol" > "$out/share/kservices5/tg.protocol"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
