### PR TITLE
uberwriter: add shared-mime-info to environment and update

### DIFF
--- a/pkgs/applications/editors/uberwriter/default.nix
+++ b/pkgs/applications/editors/uberwriter/default.nix
@@ -11,13 +11,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "uberwriter";
-  version = "unstable-2019-11-29";
+  version = "unstable-2020-01-24";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
-    rev    = "7606a55389f8516d9fed7927fa50ff8822ee9e38";
-    sha256 = "0ky001vs9nfvqf05h4q7fl0n8vsgim59z22i66a8sw6bqipv62sg";
+    rev    = "0647b413407eb8789a25c353602c4ac979dc342a";
+    sha256 = "19z52fpbf0p7dzx7q0r5pk3nn0c8z69g1hv6db0cqp61cqv5z95q";
   };
 
   nativeBuildInputs = [ meson ninja cmake pkgconfig desktop-file-utils

--- a/pkgs/applications/editors/uberwriter/default.nix
+++ b/pkgs/applications/editors/uberwriter/default.nix
@@ -2,7 +2,7 @@
 , wrapGAppsHook, pkgconfig, desktop-file-utils
 , appstream-glib, pythonPackages, glib, gobject-introspection
 , gtk3, webkitgtk, glib-networking, gnome3, gspell, texlive
-, haskellPackages}:
+, shared-mime-info, haskellPackages}:
 
 let
   pythonEnv = pythonPackages.python.withPackages(p: with p;
@@ -41,6 +41,7 @@ in stdenv.mkDerivation rec {
       --prefix PYTHONPATH : "$out/lib/python${pythonEnv.pythonVersion}/site-packages/"
       --prefix PATH : "${texliveDist}/bin"
       --prefix PATH : "${haskellPackages.pandoc-citeproc}/bin"
+      --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
     )
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes an issue where you'd be unable to open files, if `xdg.mime.enable = false`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
