### PR TITLE
pythonPackages.fluidasserts: 20.1.28253 -> 20.1.33141

### DIFF
--- a/pkgs/development/python-modules/azure-storage-file-share/default.nix
+++ b/pkgs/development/python-modules/azure-storage-file-share/default.nix
@@ -1,0 +1,45 @@
+{ buildPythonPackage
+, fetchPypi
+, isPy3k
+, lib
+
+# pythonPackages
+, azure-core
+, cryptography
+, msrest
+, futures
+}:
+
+buildPythonPackage rec {
+  pname = "azure-storage-file-share";
+  version = "12.0.0";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "15f5vk3vd2amggqqznx186raak9wgr57j0l1p9qa62kcl10bs9lg";
+  };
+
+  propagatedBuildInputs = [
+    azure-core
+    cryptography
+    msrest
+  ];
+
+  # requires checkout from monorepo
+  doCheck = false;
+  pythonImportsCheck = [
+    "azure.core"
+    "azure.storage"
+  ];
+
+  meta = with lib; {
+    description = "Microsoft Azure File Share Storage Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/fluidasserts/default.nix
+++ b/pkgs/development/python-modules/fluidasserts/default.nix
@@ -12,9 +12,12 @@
 , azure-mgmt-compute
 , azure-mgmt-keyvault
 , azure-mgmt-network
+, azure-mgmt-resource
+, azure-mgmt-security
 , azure-mgmt-storage
 , azure-mgmt-web
 , azure-storage-file
+, azure-storage-file-share
 , bandit
 , bcrypt
 , beautifulsoup4
@@ -39,6 +42,7 @@
 , psycopg2
 , pycrypto
 , pygments
+, pyhcl
 , pyjks
 , pynacl
 , pyopenssl
@@ -57,30 +61,30 @@
 
 buildPythonPackage rec {
   pname = "fluidasserts";
-  version = "20.1.28253";
+  version = "20.1.33141";
   disabled = !isPy37;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "1d2smx9ywd1azsiwgavp69vlixmvwaabshprm192wnmprbghsp6c";
+    sha256 = "01l6yb3r19q8b4kwqkrzn7mpfsr65zsgzax2fbs43hb6pq6vavnx";
   };
 
   patchPhase = ''
     # Version mismatches between current FluidAsserts and Nixpkgs
     substituteInPlace ./setup.py \
-      --replace 'tlslite-ng==0.8.0-alpha29' 'tlslite-ng==0.7.5' \
-      --replace 'boto3==1.10.17' 'boto3==1.10.1' \
+      --replace 'tlslite-ng==0.8.0-alpha36' 'tlslite-ng==0.7.5' \
+      --replace 'boto3==1.11.7' 'boto3==1.10.1' \
       --replace 'cfn-flip==1.2.2' 'cfn-flip==1.1.0.post1' \
-      --replace 'azure-mgmt-storage==7.1.0' 'azure-mgmt-storage==7.0.0' \
+      --replace 'typed-ast==1.4.1' 'typed-ast==1.4.0' \
+      --replace 'pillow==7.0.0' 'pillow==6.2.1' \
 
     # Functionality that will be not present for the momment
     #   but that we'll work to add in the future
     # Just a minimal portion of fluidasserts use this
     substituteInPlace ./setup.py \
-      --replace "'azure-storage-file-share==12.0.0'," "" \
       --replace "'pymssql==2.1.4'," "" \
-      --replace "'pytesseract==0.3.0'," "" \
+      --replace "'pytesseract==0.3.1'," "" \
       --replace "'pywinrm==0.4.1'," "" \
       --replace "'mitmproxy==5.0.1'," "" \
 
@@ -96,9 +100,12 @@ buildPythonPackage rec {
     azure-mgmt-compute
     azure-mgmt-keyvault
     azure-mgmt-network
+    azure-mgmt-resource
+    azure-mgmt-security
     azure-mgmt-storage
     azure-mgmt-web
     azure-storage-file
+    azure-storage-file-share
     bandit
     bcrypt
     beautifulsoup4
@@ -123,6 +130,7 @@ buildPythonPackage rec {
     psycopg2
     pycrypto
     pygments
+    pyhcl
     pyjks
     pynacl
     pyopenssl
@@ -146,9 +154,10 @@ buildPythonPackage rec {
     rm test/conftest.py
 
     pytest \
+      test/test_cloud_aws_terraform_{ebs,ec2}.py \
       test/test_cloud_aws_cloudformation_{cloudfront,dynamodb,ec2,elb,elb2}.py \
       test/test_cloud_aws_cloudformation_{fsx,iam,kms,rds,s3,secretsmanager}.py \
-      test/test_format_{apk,file,jks,jwt,pdf,pkcs12,string}.py \
+      test/test_format_{apk,jks,jwt,pdf,pkcs12,string}.py \
       test/test_helper_{asynchronous,crypto}.py \
       test/test_lang_{javascript,java}.py \
       test/test_lang_{core,csharp,docker,dotnetconfig,html,php,python,rpgle}.py \

--- a/pkgs/development/python-modules/pyhcl/default.nix
+++ b/pkgs/development/python-modules/pyhcl/default.nix
@@ -1,0 +1,46 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, lib
+
+# pythonPackages
+, coverage
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pyhcl";
+  version = "0.4.0";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "virtuald";
+    repo = pname;
+    rev = version;
+    sha256 = "09kwm3digbwn3kmbk76jswxgwfcfchik6cfa2xbhjanh4xs893hs";
+  };
+
+  # https://github.com/virtuald/pyhcl/blob/51a7524b68fe21e175e157b8af931016d7a357ad/setup.py#L64
+  configurePhase = ''
+    echo '__version__ = "${version}"' > ./src/hcl/version.py
+  '';
+
+  checkInputs = [
+    coverage
+    pytest
+  ];
+
+  # https://github.com/virtuald/pyhcl/blob/51a7524b68fe21e175e157b8af931016d7a357ad/tests/run_tests.sh#L4
+  checkPhase = ''
+    coverage run --source hcl -m pytest tests
+  '';
+
+  meta = with lib; {
+    description = "HCL is a configuration language. pyhcl is a python parser for it";
+    homepage = "https://github.com/virtuald/pyhcl";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -312,6 +312,8 @@ in {
 
   azure-storage-file = callPackage ../development/python-modules/azure-storage-file { };
 
+  azure-storage-file-share = callPackage ../development/python-modules/azure-storage-file-share { };
+
   azure-storage-queue = callPackage ../development/python-modules/azure-storage-queue { };
 
   azure-mgmt-nspkg = callPackage ../development/python-modules/azure-mgmt-nspkg { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2256,6 +2256,8 @@ in {
 
   python-ly = callPackage ../development/python-modules/python-ly {};
 
+  pyhcl = callPackage ../development/python-modules/pyhcl { };
+
   pyhepmc = callPackage ../development/python-modules/pyhepmc { };
 
   pytest = if isPy3k then self.pytest_5 else self.pytest_4;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

this version includes some terraform checks and frees the hard dependency on specific versions of azure packages 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[nix-shell:~/Documents/nixpkgs]$ nix-review rev HEAD
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
 * [new branch]              master     -> refs/nixpkgs-review/0
$ git worktree add /home/kamado/.cache/nixpkgs-review/rev-5e4870a0040bfd76f2b0b43120662e7ceb5e0c3d/nixpkgs 385b9aee085b6c5af25f843eb577b14d2b029748
Preparing worktree (detached HEAD 385b9aee085)
HEAD is now at 385b9aee085 Merge pull request #78338 from r-ryantm/auto-update/qtutilities
$ nix-env -f /home/kamado/.cache/nixpkgs-review/rev-5e4870a0040bfd76f2b0b43120662e7ceb5e0c3d/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 5e4870a0040bfd76f2b0b43120662e7ceb5e0c3d
Updating 385b9aee085..5e4870a0040
Fast-forward
 pkgs/development/python-modules/azure-storage-file-share/default.nix | 41 ++++++++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/fluidasserts/default.nix             | 25 +++++++++++++++--------
 pkgs/development/python-modules/pyhcl/default.nix                    | 46 +++++++++++++++++++++++++++++++++++++++++++
 pkgs/top-level/python-packages.nix                                   |  4 ++++
 4 files changed, 108 insertions(+), 8 deletions(-)
 create mode 100644 pkgs/development/python-modules/azure-storage-file-share/default.nix
 create mode 100644 pkgs/development/python-modules/pyhcl/default.nix
$ nix-env -f /home/kamado/.cache/nixpkgs-review/rev-5e4870a0040bfd76f2b0b43120662e7ceb5e0c3d/nixpkgs -qaP --xml --out-path --show-trace --meta
$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/kamado/.cache/nixpkgs-review/rev-5e4870a0040bfd76f2b0b43120662e7ceb5e0c3d/build.nix
[1/1/3 built, 0.0 MiB DL] building python3.7-fluidasserts-20.1.33141 (installCheckPhase): test/test_cloud_aws_cloudform * [new branch]              master     -> refs/nixpkgs-review/0
[3 built, 0.0 MiB DL]
4 package built:
fluidasserts python37Packages.azure-storage-file-share python37Packages.pyhcl python38Packages.pyhcl
```