### PR TITLE
pythonPackages.mimesis: init at 3.3.0

### DIFF
--- a/pkgs/development/python-modules/mimesis/default.nix
+++ b/pkgs/development/python-modules/mimesis/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi}:
+
+buildPythonPackage rec {
+  pname = "mimesis";
+  version = "3.3.0";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4b8fc414bd101109615fa8b6ad49f1811199e2745a4e9ef527193a4ab69637fc";
+  };
+    
+  meta = with lib; {
+    description = "Fake data generator";
+    homepage = "https://github.com/lk-geimfari/mimesis";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -835,6 +835,8 @@ in {
 
   maxminddb = callPackage ../development/python-modules/maxminddb { };
 
+  mimesis = callPackage ../development/python-modules/mimesis { };
+  
   mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;
 
   mkl-service = callPackage ../development/python-modules/mkl-service { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding Python package for mimesis.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
