### PR TITLE
wine: Look for root certs at $NIX_SSL_CERT_FILE

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -68,6 +68,11 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   ])
   ++ [ pkgs.xorg.libX11 pkgs.perl ]));
 
+  patches = [
+    # Also look for root certificates at $NIX_SSL_CERT_FILE
+    ./cert-path.patch
+  ];
+
   # Wine locates a lot of libraries dynamically through dlopen().  Add
   # them to the RPATH so that the user doesn't have to set them in
   # LD_LIBRARY_PATH.

--- a/pkgs/misc/emulators/wine/cert-path.patch
+++ b/pkgs/misc/emulators/wine/cert-path.patch
@@ -1,0 +1,24 @@
+diff --git a/dlls/crypt32/rootstore.c b/dlls/crypt32/rootstore.c
+index f795181..fb4926a 100644
+--- a/dlls/crypt32/rootstore.c
++++ b/dlls/crypt32/rootstore.c
+@@ -18,6 +18,7 @@
+ #include "config.h"
+ #include <stdarg.h>
+ #include <stdio.h>
++#include <stdlib.h> /* getenv */
+ #include <sys/types.h>
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+@@ -916,6 +917,11 @@ static void read_trusted_roots_from_known_locations(HCERTSTORE store)
+ 
+         for (i = 0; !ret && i < ARRAY_SIZE(CRYPT_knownLocations); i++)
+             ret = import_certs_from_path(CRYPT_knownLocations[i], from, TRUE);
++
++        char *nix_cert_file = getenv("NIX_SSL_CERT_FILE");
++        if (nix_cert_file != NULL)
++            ret = import_certs_from_path(nix_cert_file, from, TRUE);
++
+         check_and_store_certs(from, store);
+     }
+     CertCloseStore(from, 0);


### PR DESCRIPTION
Closes #78365

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
