### PR TITLE
signal-desktop: 1.29.6 -> 1.30.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,9 +1,8 @@
-{ stdenv, lib, fetchurl, dpkg, wrapGAppsHook
+{ stdenv, lib, fetchurl, autoPatchelfHook, dpkg, wrapGAppsHook
 , gnome2, gtk3, atk, at-spi2-atk, cairo, pango, gdk-pixbuf, glib, freetype, fontconfig
 , dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr, libXcomposite
 , libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss, nspr, alsaLib
 , cups, expat, systemd, libnotify, libuuid, at-spi2-core, libappindicator-gtk3
-, autoPatchelfHook
 # Unfortunately this also overwrites the UI language (not just the spell
 # checking language!):
 , hunspellDicts, spellcheckerLanguage ? null # E.g. "de_DE"
@@ -24,7 +23,7 @@ let
       else "");
 in stdenv.mkDerivation rec {
   pname = "signal-desktop";
-  version = "1.29.6"; # Please backport all updates to the stable channel.
+  version = "1.30.0"; # Please backport all updates to the stable channel.
   # All releases have a limited lifetime and "expire" 90 days after the release.
   # When releases "expire" the application becomes unusable until an update is
   # applied. The expiration date for the current release can be extracted with:
@@ -34,7 +33,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1s1rc4kyv0nxz5fy5ia7fflphf3izk80ks71q4wd67k1g9lvcw24";
+    sha256 = "1gbvna40sc83s7mwip5281yn4bs0k19fj061y0xzwkvh0yk06x3i";
   };
 
   nativeBuildInputs = [
@@ -88,12 +87,20 @@ in stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
   dontPatchELF = true;
+  # We need to run autoPatchelf manually with the "no-recurse" option, see
+  # https://github.com/NixOS/nixpkgs/pull/78413 for the reasons.
+  dontAutoPatchelf = true;
 
   installPhase = ''
     mkdir -p $out/lib
 
     mv usr/share $out/share
-    mv opt/Signal $out/lib
+    mv opt/Signal $out/lib/Signal
+
+    # Note: The following path contains bundled libraries:
+    # $out/lib/Signal/resources/app.asar.unpacked/node_modules/sharp/vendor/lib/
+    # We run autoPatchelf with the "no-recurse" option to avoid picking those
+    # up, but resources/app.asar still requires them.
 
     # Symlink to bin
     mkdir -p $out/bin
@@ -109,6 +116,8 @@ in stdenv.mkDerivation rec {
     # Fix the desktop link
     substituteInPlace $out/share/applications/signal-desktop.desktop \
       --replace /opt/Signal/signal-desktop $out/bin/signal-desktop
+
+    autoPatchelf --no-recurse -- $out/lib/Signal/
   '';
 
   meta = {


### PR DESCRIPTION
Changelog: https://github.com/signalapp/Signal-Desktop/releases/tag/v1.30.0

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
#### Current problem

This currently fails with the following error message:
```bash
/run/current-system/sw/bin/signal-desktop: symbol lookup error: /nix/store/8n103q18ip21zjl0xh36618291h6bkag-pango-1.44.7/lib/libpangoft2-1.0.so.0: undefined symbol: pango_font_get_hb_font
```

The problem seems to be that signal-desktop is looking in the wrong place as this symbol is defined in `libpango-1.0.so`:
```bash
$ nm -D /nix/store/8n103q18ip21zjl0xh36618291h6bkag-pango-1.44.7/lib/libpangoft2-1.0.so.0 | grep pango_font_get_hb_font
                 U pango_font_get_hb_font
$ nm -D /nix/store/8n103q18ip21zjl0xh36618291h6bkag-pango-1.44.7/lib/libpango-1.0.so | grep pango_font_get_hb_font
0000000000018220 T pango_font_get_hb_font
```

But the new `autoPatchelfHook` abstraction (https://github.com/NixOS/nixpkgs/pull/77850) seems to select the wrong shared library (a bundled one instead of the system library):
```bash
$ ldd /nix/store/jjlnp1yid3bcj8yyj0jlr2ykpy30ivnq-signal-desktop-1.30.0/bin/.signal-desktop-wrapped | grep pango
	libpangocairo-1.0.so.0 => /nix/store/jjlnp1yid3bcj8yyj0jlr2ykpy30ivnq-signal-desktop-1.30.0/lib/Signal/resources/app.asar.unpacked/node_modules/sharp/vendor/lib/libpangocairo-1.0.so.0 (0x00007f8e88264000)
	libpango-1.0.so.0 => /nix/store/jjlnp1yid3bcj8yyj0jlr2ykpy30ivnq-signal-desktop-1.30.0/lib/Signal/resources/app.asar.unpacked/node_modules/sharp/vendor/lib/libpango-1.0.so.0 (0x00007f8e88014000)
	libpangoft2-1.0.so.0 => /nix/store/8n103q18ip21zjl0xh36618291h6bkag-pango-1.44.7/lib/libpangoft2-1.0.so.0 (0x00007f8e864bc000)
```

Which doesn't contain the required symbol ([added in version 1.44](https://developer.gnome.org/pango/stable/api-index-1-44.html)):
```bash
$ nm -D /nix/store/jjlnp1yid3bcj8yyj0jlr2ykpy30ivnq-signal-desktop-1.30.0/lib/Signal/resources/app.asar.unpacked/node_modules/sharp/vendor/lib/libpango-1.0.so.0 | grep pango_font_get_hb_font || echo "No match"
No match
```

@worldofpeace: Any ideas what to do here? I guess we could e.g. manually change the search path, but maybe there's a better solution for such cases.

**Update (also relevant):** `Signal/resources/app.asar.unpacked/node_modules/sharp` is new in version 1.30.0: https://github.com/signalapp/Signal-Desktop/issues/3919
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
