### PR TITLE
nixos/xfce: use sessionPackages

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -127,14 +127,9 @@ in
       "/share/gtksourceview-4.0"
     ];
 
-    services.xserver.desktopManager.session = [{
-      name = "xfce";
-      bgSupport = true;
-      start = ''
-        ${pkgs.runtimeShell} ${pkgs.xfce.xfce4-session.xinitrc} &
-        waitPID=$!
-      '';
-    }];
+    services.xserver.displayManager.sessionPackages = [
+      pkgs.xfce.xfce4-session
+    ];
 
     services.xserver.updateDbusEnvironment = true;
     services.xserver.gdk-pixbuf.modulePackages = [ pkgs.librsvg ];

--- a/pkgs/desktops/xfce/core/xfce4-session/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-session/default.nix
@@ -1,4 +1,4 @@
-{ mkXfceDerivation, polkit, exo, libxfce4util, libxfce4ui, xfconf, iceauth, gtk3, glib, libwnck3, xorg, xfce4-session }:
+{ mkXfceDerivation, polkit, exo, libxfce4util, libxfce4ui, xfconf, iceauth, gtk3, glib, libwnck3, xorg, xfce4-session, runtimeShell }:
 
 mkXfceDerivation {
   category = "xfce";
@@ -14,9 +14,25 @@ mkXfceDerivation {
   # See https://github.com/NixOS/nixpkgs/issues/36468
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
-  passthru.xinitrc = "${xfce4-session}/etc/xdg/xfce4/xinitrc";
+  # Don't use startxfce4 in xfce.desktop
+  # It's has FHS isms
+  postFixup = ''
+    chmod +x $out/etc/xdg/xfce4/xinitrc
+    patchShebangs $out/etc/xdg/xfce4/xinitrc
 
-  meta =  {
+    substituteInPlace "$out/share/xsessions/xfce.desktop" \
+      --replace "Exec=startxfce4" "Exec=$out/etc/xdg/xfce4/xinitrc"
+  '';
+
+  passthru = {
+    xinitrc = "${xfce4-session}/etc/xdg/xfce4/xinitrc";
+
+    providedSessions = [
+      "xfce"
+    ];
+  };
+
+  meta = {
     description = "Session manager for Xfce";
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Use upstream session in nixpkgs.
Required a little fixup in the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
