### PR TITLE
fish: fix systemctl completion

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, coreutils, utillinux,
+{ stdenv, fetchurl, fetchpatch, coreutils, utillinux,
   which, gnused, gnugrep,
   groff, man-db, getent, libiconv, pcre2,
   gettext, ncurses, python3,
@@ -100,6 +100,14 @@ let
       url = "https://github.com/fish-shell/fish-shell/releases/download/${version}/${pname}-${version}.tar.gz";
       sha256 = "03j3jl9jzlnhq4p86zj8wqsh5sx45j1d1fvfa80ks1cfdg68qwhl";
     };
+
+    patches = [
+      # completions/systemctl: Harden version comparison
+      (fetchpatch {
+        url = "https://github.com/fish-shell/fish-shell/commit/c6ec4235136e82c709e8d7b455f7c463f9714b48.patch";
+        sha256 = "02m6pkhhx6y21csydznsxkbpnwhcpzyz99xgd9ryh7s03v7wbigw";
+      })
+    ];
 
     nativeBuildInputs = [ cmake ];
     buildInputs = [ ncurses libiconv pcre2 ];


### PR DESCRIPTION
###### Motivation for this change

Previously, typing a command starting with systemctl would result in an
error:

    Integer 243 in '243 (243)' followed by non-digit

Link: https://github.com/fish-shell/fish-shell/issues/5689

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).