### PR TITLE
pythonPackages.llfuse: darwin support, use in borgbackup

### DIFF
--- a/pkgs/development/python-modules/llfuse/default.nix
+++ b/pkgs/development/python-modules/llfuse/default.nix
@@ -1,6 +1,10 @@
-{ stdenv, fetchurl, buildPythonPackage, pkgconfig, pytest, fuse, attr, which
-, contextlib2
+{ stdenv, fetchurl, fetchpatch, buildPythonPackage, pkgconfig, pytest, fuse, attr, which
+, contextlib2, osxfuse
 }:
+
+let
+  inherit (stdenv.lib) optionals optionalString;
+in
 
 buildPythonPackage rec {
   pname = "llfuse";
@@ -11,14 +15,29 @@ buildPythonPackage rec {
     sha256 = "1j9fzxpgmb4rxxyl9jcf84zvznhgi3hnh4hg5vb0qaslxkvng8ii";
   };
 
+  patches = [
+    # https://github.com/python-llfuse/python-llfuse/pull/23 (2 commits)
+    (fetchpatch {
+      url = "https://github.com/python-llfuse/python-llfuse/commit/7579b0e626da1a7882b13caedcdbd4a834702e94.diff";
+      sha256 = "0vpybj4k222h20lyn0q7hz86ziqlapqs5701cknw8d11jakbhhb0";
+    })
+    (fetchpatch {
+      url = "https://github.com/python-llfuse/python-llfuse/commit/438c00ab9e10d6c485bb054211c01b7f8524a736.diff";
+      sha256 = "1zhb05b7k3c9mjqshy9in8yzpbihy7f33x1myq5kdjip1k50cwrn";
+    })
+  ];
+
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ fuse ];
-  checkInputs = [ pytest attr which ];
+  buildInputs =
+    optionals stdenv.isLinux [ fuse ]
+    ++ optionals stdenv.isDarwin [ osxfuse ];
+  checkInputs = [ pytest which ] ++
+    optionals stdenv.isLinux [ attr ];
 
   propagatedBuildInputs = [ contextlib2 ];
 
   checkPhase = ''
-    py.test -k "not test_listdir"
+    py.test -k "not test_listdir" ${optionalString stdenv.isDarwin ''-m "not uses_fuse"''}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -17,8 +17,8 @@ python3.pkgs.buildPythonApplication rec {
     libb2 lz4 zstd openssl python3.pkgs.setuptools_scm
   ] ++ stdenv.lib.optionals stdenv.isLinux [ acl ];
   propagatedBuildInputs = with python3.pkgs; [
-    cython
-  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [ llfuse ];
+    cython llfuse
+  ];
 
   preConfigure = ''
     export BORG_OPENSSL_PREFIX="${openssl.dev}"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Enabling `borg mount` on macOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
