### PR TITLE
Lua for sile

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -18,6 +18,7 @@ http,,,,,vcunat
 inspect,,,,,
 ldoc,,,,,
 lgi,,,,,
+linenoise,,,,,
 ljsyscall,,,,lua5_1,lblasc
 lpeg,,,,,vyp
 lpeg_patterns,,,,,

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -75,3 +75,4 @@ std__debug,std._debug,,,,
 std_normalize,std.normalize,,,,
 stdlib,,,,,vyp
 pulseaudio,,,,,doronbehar
+vstruct,,,,,

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -52,6 +52,7 @@ luafilesystem,,,1.7.0-2,,flosse vcunat
 lualogging,,,,,
 luaossl,,,,lua5_1,vcunat
 luaposix,,,,,vyp lblasc
+luarepl,,,,,
 luasec,,,,,flosse
 luasocket,,,,,
 luasql-sqlite3,,,,,vyp

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -44,6 +44,7 @@ luadbi-mysql,,,,,
 luadbi-postgresql,,,,,
 luadbi-sqlite3,,,,,
 luadoc,,,,,
+luaepnf,,,,,
 luaevent,,,,,
 luaexpat,,,1.3.0-1,,arobyn flosse
 luaffi,,http://luarocks.org/dev,,,

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -11,7 +11,7 @@ compat53,,,,,vcunat
 coxpcall,,,1.17.0-1,,
 cqueues,,,,,vcunat
 cyrussasl,,,,,vcunat
-digestif,,http://luarocks.org/dev,,lua5_3,
+digestif,,,,lua5_3,
 dkjson,,,,,
 fifo,,,,,
 http,,,,,vcunat

--- a/maintainers/scripts/update-luarocks-packages
+++ b/maintainers/scripts/update-luarocks-packages
@@ -19,7 +19,7 @@ export LUAROCKS_CONFIG="$NIXPKGS_PATH/maintainers/scripts/luarocks-config.lua"
 
 # 10 is a pretty arbitrary number of simultaneous jobs, but it is generally
 # impolite to hit a webserver with *too* many simultaneous connections :)
-PARALLEL_JOBS=10
+PARALLEL_JOBS=1
 
 exit_trap() {
     local lc="$BASH_COMMAND" rc=$?

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1536,9 +1536,23 @@ stdlib = buildLuarocksPackage {
     homepage = "http://lua-stdlib.github.io/lua-stdlib";
     description = "General Lua Libraries";
     maintainers = with maintainers; [ vyp ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
+  };
+};
+vstruct = buildLuarocksPackage {
+  pname = "vstruct";
+  version = "2.0.2-1";
+
+  src = fetchurl {
+    url    = mirror://luarocks/vstruct-2.0.2-1.src.rock;
+    sha256 = "05k1685618wh7vg8av92mh1i1rjqg15x12gifbp9kyqzc2nk3kzq";
+  };
+  disabled = (luaOlder "5.1") || (luaAtLeast "5.3");
+  propagatedBuildInputs = [ lua ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ToxicFrog/vstruct";
+    description = "Lua library to manipulate binary data";
   };
 };
 

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1083,9 +1083,30 @@ luaposix = buildLuarocksPackage {
     homepage = "https://github.com/luaposix/luaposix/";
     description = "Lua bindings for POSIX";
     maintainers = with maintainers; [ vyp lblasc ];
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
+  };
+};
+luarepl = buildLuarocksPackage {
+  pname = "luarepl";
+  version = "0.9-1";
+
+  knownRockspec = (fetchurl {
+    url    = mirror://luarocks/luarepl-0.9-1.rockspec;
+    sha256 = "1409lanxv4s8kq5rrh46dvld77ip33qzfn3vac3i9zpzbmgb5i8z";
+  }).outPath;
+
+  src = fetchurl {
+    url    = https://github.com/hoelzro/lua-repl/archive/0.9.tar.gz;
+    sha256 = "04xka7b84d9mrz3gyf8ywhw08xp65v8jrnzs8ry8k9540aqs721w";
+  };
+
+  disabled = (luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/hoelzro/lua-repl";
+    description = "A reusable REPL component for Lua, written in Lua";
+    license.fullName = "MIT/X11";
   };
 };
 luasec = buildLuarocksPackage {

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -933,9 +933,24 @@ luadoc = buildLuarocksPackage {
   meta = with stdenv.lib; {
     homepage = "http://luadoc.luaforge.net/";
     description = "LuaDoc is a documentation tool for Lua source code";
-    license = {
-      fullName = "MIT/X11";
-    };
+    license.fullName = "MIT/X11";
+  };
+};
+luaepnf = buildLuarocksPackage {
+  pname = "luaepnf";
+  version = "0.3-1";
+
+  src = fetchurl {
+    url    = mirror://luarocks/luaepnf-0.3-1.src.rock;
+    sha256 = "12z7radxk1dkyjqflr85sghywgc82xdg4mzb9mbwbrrqbnjw8mp5";
+  };
+  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  propagatedBuildInputs = [ lua lpeg ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://siffiejoe.github.io/lua-luaepnf/";
+    description = "Extended PEG Notation Format (easy grammars for LPeg)";
+    license.fullName = "MIT";
   };
 };
 luaevent = buildLuarocksPackage {

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -402,6 +402,31 @@ lgi = buildLuarocksPackage {
     };
   };
 };
+linenoise = buildLuarocksPackage {
+  pname = "linenoise";
+  version = "0.9-1";
+
+  knownRockspec = (fetchurl {
+    url    = mirror://luarocks/linenoise-0.9-1.rockspec;
+    sha256 = "0wic8g0d066pj9k51farsvcdbnhry2hphvng68w9k4lh0zh45yg4";
+  }).outPath;
+
+  src = fetchurl {
+    url    = https://github.com/hoelzro/lua-linenoise/archive/0.9.tar.gz;
+    sha256 = "177h6gbq89arwiwxah9943i8hl5gvd9wivnd1nhmdl7d8x0dn76c";
+  };
+
+  disabled = (luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/hoelzro/lua-linenoise";
+    description = "A binding for the linenoise command line library";
+    license = {
+      fullName = "MIT/X11";
+    };
+  };
+};
 ljsyscall = buildLuarocksPackage {
   pname = "ljsyscall";
   version = "0.12-1";

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -266,28 +266,18 @@ cyrussasl = buildLuarocksPackage {
 };
 digestif = buildLuarocksPackage {
   pname = "digestif";
-  version = "scm-1";
+  version = "0.2-1";
 
-  knownRockspec = (fetchurl {
-    url    = http://luarocks.org/dev/digestif-scm-1.rockspec;
-    sha256 = "18rixbni4hmrmh3qj3vpjbsphzdvchswajphc9ysm52ccpyzh687";
-  }).outPath;
-
-  src = fetchgit ( removeAttrs (builtins.fromJSON ''{
-  "url": "git://github.com/astoff/digestif",
-  "rev": "51c321f1b68b77f648fa6adf356de48925f69fe0",
-  "date": "2019-06-08T15:03:33+02:00",
-  "sha256": "1c9cl81vfzirc325wipdy992yn20b8xv8nqzl5mdhyz8zfp84hs7",
-  "fetchSubmodules": true
-}
- '') ["date"]) ;
-
+  src = fetchurl {
+    url    = mirror://luarocks/digestif-0.2-1.src.rock;
+    sha256 = "03blpj5lxlhmxa4hnj21sz7sc84g96igbc7r97yb2smmlbyq8hxd";
+  };
   disabled = (luaOlder "5.3");
   propagatedBuildInputs = [ lua lpeg dkjson ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/astoff/digestif/";
-    description = "Code analyzer for TeX.";
+    description = "A code analyzer for TeX";
     license = {
       fullName = "MIT";
     };

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -4,9 +4,9 @@ luarocks.overrideAttrs(old: {
   version = "2019-09-07";
   src = fetchFromGitHub {
     owner = "nix-community";
-    repo = "luarocks";
-    rev = "fa7c367bcdad36768db5f19fd4fcdd9681a14429";
-    sha256 = "0kziwfw5gqq5xsckl7qf9wasaiy8rp42h5qrcnjx07qp47a9ldx7";
+    repo = "luarocks-nix";
+    rev = "73b8772e56fd39dfffda9e3b13e9eb31e93d5cde";
+    sha256 = "00jgshygw439pbaxg7yph3ijia6nid9r1br416wdbyl5wqhlhm1y";
   };
   patches = [
     ./darwin-3.1.3.patch


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

add missing packages for https://github.com/NixOS/nixpkgs/pull/77738

@doronbehar while regenerating the set, I noticed pulseaudio was generated. Maybe you could move you changes to lua-pulseaudio in pkgs/development/lua-modules/overrides.nix instead.

@shados I've disabled parallel, I have never been able to complete a single update with a value != 1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
