### PR TITLE
heaptrack: wrap with wrapQtAppsHook

### DIFF
--- a/pkgs/development/tools/profiling/heaptrack/default.nix
+++ b/pkgs/development/tools/profiling/heaptrack/default.nix
@@ -1,10 +1,10 @@
 {
-  stdenv, fetchFromGitHub, cmake, extra-cmake-modules,
+  lib, mkDerivation, fetchFromGitHub, cmake, extra-cmake-modules,
   zlib, boost, libunwind, elfutils, sparsehash,
   qtbase, kio, kitemmodels, threadweaver, kconfigwidgets, kcoreaddons, kdiagram
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "heaptrack";
   version = "1.1.0";
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     qtbase kio kitemmodels threadweaver kconfigwidgets kcoreaddons kdiagram
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Heap memory profiler for Linux";
     homepage = https://github.com/KDE/heaptrack;
     license = licenses.lgpl21Plus;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes:
```
$  heaptrack_gui 
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

zsh: abort (core dumped)  heaptrack_gui
```

Please backport to 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

