### PR TITLE
pymol: 2.1.0 -> 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6181,6 +6181,16 @@
     githubId = 6022042;
     name = "Sam Parkinson";
   };
+  samlich = {
+    email = "nixos@samli.ch";
+    github = "samlich";
+    githubId = 1349989;
+    name = "samlich";
+    keys = [{
+      longkeyid = "rsa4096/B1568953B1939F1C";
+      fingerprint = "AE8C 0836 FDF6 3FFC 9580  C588 B156 8953 B193 9F1C";
+    }];
+  };
   samrose = {
    email = "samuel.rose@gmail.com";
    github = "samrose";

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -13,6 +13,7 @@ let
     desktopName = "PyMol Molecular Graphics System";
     genericName = "Molecular Modeler";
     comment = description;
+    icon = pname;
     mimeType = "chemical/x-pdb;chemical/x-mdl-molfile;chemical/x-mol2;chemical/seq-aa-fasta;chemical/seq-na-fasta;chemical/x-xyz;chemical/x-mdl-sdf;";
     categories = "Graphics;Education;Science;Chemistry;";
   };
@@ -33,14 +34,17 @@ python3Packages.buildPythonApplication rec {
   setupPyBuildFlags = [ "--glut" ];
 
   installPhase = ''
-    python setup.py install --home=$out
-    cp -r ${desktopItem}/share/ $out/
+    python setup.py install --home="$out"
     runHook postInstall
   '';
 
   postInstall = with python3Packages; ''
     wrapProgram $out/bin/pymol \
       --prefix PYTHONPATH : ${lib.makeSearchPathOutput "lib" python3.sitePackages [ Pmw tkinter ]}
+
+    mkdir -p "$out/share/icons/"
+    ln -s ../../lib/python/pymol/pymol_path/data/pymol/icons/icon2.svg "$out/share/icons/pymol.svg"
+    cp -r "${desktopItem}/share/applications/" "$out/share/"
   '';
 
   meta = {

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -47,5 +47,6 @@ python3Packages.buildPythonApplication rec {
     description = description;
     homepage = https://www.pymol.org/;
     license = lib.licenses.psfl;
+    maintainers = with lib.maintainers; [ samlich ];
   };
 }

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -29,7 +29,8 @@ python3Packages.buildPythonApplication rec {
   };
 
   buildInputs = [ python3Packages.numpy glew glm freeglut libpng libxml2 tk freetype msgpack ];
-  NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2 -Wno-error=format-security";
+  NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2";
+  hardeningDisable = [ "format" ];
 
   setupPyBuildFlags = [ "--glut" ];
 
@@ -47,10 +48,10 @@ python3Packages.buildPythonApplication rec {
     cp -r "${desktopItem}/share/applications/" "$out/share/"
   '';
 
-  meta = {
+  meta = with lib; {
     description = description;
     homepage = https://www.pymol.org/;
-    license = lib.licenses.psfl;
-    maintainers = with lib.maintainers; [ samlich ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ samlich ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Pymol was broken.

###### Things done
- Fixed build and updated to 2.3.0 which is now hosted on GitHub.
- Added myself as a maintainer as it had none.
- Linked the desktop icon.

I have not fixed Qt support but plan to do so and add at least VMD sometime soon.


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
(failed with pkgs/development/libraries/blitz: No such file or directory, which doesn't seem related)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
(didn't build before)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
