### PR TITLE
lutris: fix gog integration

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -1,5 +1,5 @@
 { buildPythonApplication, lib, fetchFromGitHub, fetchpatch
-, wrapGAppsHook, gobject-introspection, gnome-desktop, libnotify, libgnome-keyring, pango
+, wrapGAppsHook, gobject-introspection, glib-networking, gnome-desktop, libnotify, libgnome-keyring, pango
 , gdk-pixbuf, atk, webkitgtk, gst_all_1
 , dbus-python, evdev, pyyaml, pygobject3, requests, pillow
 , xrandr, pciutils, psmisc, glxinfo, vulkan-tools, xboxdrv, pulseaudio, p7zip, xgamma
@@ -40,8 +40,9 @@ in buildPythonApplication rec {
     sha256 = "1g093g0difnkjmnm91p20issdsxn9ri4c56zzddj5wfrbmhwdfag";
   };
 
+  nativeBuildInputs = [ wrapGAppsHook ];
   buildInputs = [
-    wrapGAppsHook gobject-introspection gnome-desktop libnotify libgnome-keyring pango
+    gobject-introspection glib-networking gnome-desktop libnotify libgnome-keyring pango
     gdk-pixbuf atk webkitgtk
   ] ++ gstDeps;
 


### PR DESCRIPTION
###### Motivation for this change
closes #65416 

###### Things done
- Added `glib-networking`
- Moved `wrapGAppsHook` from `buildInputs` to `nativeBuildInputs` (this is why it wouldn't be properly wrapped before)

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
6_262_376_376 -> 6_262_378_904
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
