### PR TITLE
python: auto patch wheels with manylinux RPATH

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -22,6 +22,7 @@
 , sha256
 , passthruFun
 , bash
+, bundledPipForEnsurePip ? null
 , stripConfig ? false
 , stripIdlelib ? false
 , stripTests ? false
@@ -128,6 +129,10 @@ in with passthru; stdenv.mkDerivation {
   postPatch = ''
   '' + optionalString (x11Support && (tix != null)) ''
     substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
+  '' + optionalString (bundledPipForEnsurePip != null) ''
+    for p in Lib/ensurepip/_bundled/pip-*.whl; do
+      cp "${bundledPipForEnsurePip}/$(basename "$p")" "$p"
+    done
   '';
 
   CPPFLAGS = concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs);

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -149,6 +149,26 @@ in {
     };
   });
 
+  python38Nix = python38Packages.python.override {
+    self = python38Nix;
+    bundledPipForEnsurePip = let
+        pipVersion = "19.2.3";
+        patchelf-pip = callPackage ../../python-modules/patchelf-pip {
+          python = python38Packages.python;
+          bootstrapped-pip = python38Packages.bootstrapped-pip;
+          manylinuxPackage = pythonManylinuxPackages.manylinux1Package;
+          src = fetchFromGitHub {
+            owner = "pypa";
+            repo = "pip";
+            rev = "${pipVersion}";
+            sha256 = "1jz29836dmvq6si1z5djf43cmq04my82z29xni937b6rwrvlc47a";
+          };
+          version = pipVersion;
+          patch = ../../python-modules/patchelf-pip/patches/19_2_3.patch;
+        };
+      in patchelf-pip;
+  };
+
   pypy27 = callPackage ./pypy {
     self = pypy27;
     sourceVersion = {

--- a/pkgs/development/python-modules/patchelf-pip/default.nix
+++ b/pkgs/development/python-modules/patchelf-pip/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, python
+, bootstrapped-pip
+, patchelf
+, manylinuxPackage
+, patch
+, src
+, version
+}:
+
+stdenv.mkDerivation rec {
+  inherit version src;
+  pname = "pip";
+  name = "${python.libPrefix}-${pname}-${version}";
+  nativeBuildInputs = [ python bootstrapped-pip ];
+  buildInputs = [ patchelf manylinuxPackage ];
+  patches = [ patch ];
+  postPatch = ''
+      substituteInPlace src/pip/_internal/wheel.py \
+        --subst-var-by PATCHELF_BIN '${patchelf}/bin/patchelf' \
+        --subst-var-by NIX_MANYLILIB_PATH '${manylinuxPackage}/lib' \
+        --subst-var-by DYNAMIC_LOADER "$(cat ${stdenv.cc.bintools}/nix-support/dynamic-linker)"
+  '';
+  buildPhase = ''
+    export SOURCE_DATE_EPOCH=315532800
+    python setup.py bdist_wheel
+  '';
+  installPhase = ''
+    mkdir -p "$out"
+    mv dist/pip-*.whl "$out"
+  '';
+  meta = {
+    description = "The PyPA recommended tool for installing Python packages";
+    license = stdenv.lib.licenses.mit;
+    homepage = https://pip.pypa.io/;
+  };
+}

--- a/pkgs/development/python-modules/patchelf-pip/patches/19_2_3.patch
+++ b/pkgs/development/python-modules/patchelf-pip/patches/19_2_3.patch
@@ -1,0 +1,67 @@
+diff --git a/src/pip/_internal/wheel.py b/src/pip/_internal/wheel.py
+index 67bcc7f7..2e87b84b 100644
+--- a/src/pip/_internal/wheel.py
++++ b/src/pip/_internal/wheel.py
+@@ -12,6 +12,7 @@ import os.path
+ import re
+ import shutil
+ import stat
++import struct
+ import sys
+ import warnings
+ from base64 import urlsafe_b64encode
+@@ -124,6 +125,42 @@ def fix_script(path):
+     return None
+ 
+ 
++PATCHELF_BIN = '@PATCHELF_BIN@'
++NIX_MANYLILIB_PATH = '@NIX_MANYLILIB_PATH@'
++DYNAMIC_LOADER = '@DYNAMIC_LOADER@'
++
++
++def fix_nix_elf(path):
++    # type: (str) -> Optional[bool]
++    """Fix ELF files for use with nix
++    Return True if file was changed."""
++    if os.path.isfile(path):
++        with open(path, 'rb') as f:
++            head = f.read(0x12)
++        if len(head) < 0x12:
++            return False
++        if head[0:4] == b'\x7fELF':
++            output = call_subprocess([PATCHELF_BIN, '--print-rpath', path],
++                                     show_stdout=False, on_returncode='warn')
++            old_rpath = output.strip()
++            new_rpath = NIX_MANYLILIB_PATH
++            if old_rpath:
++                new_rpath = f'{old_rpath}:{new_rpath}'
++            # The --force-rpath does what we want here
++            # No RPATH/RUNPATH -> RPATH
++            # RPATH exists -> RPATH
++            # RUNPATH exists -> RUNPATH
++            # We can't convert RPATH to RUNPATH or some dynamic library setups break
++            # TODO: Find out why it doesn't work if we convert all rpath to runpath
++            call_subprocess([PATCHELF_BIN, '--force-rpath', '--set-rpath', new_rpath, path],
++                            show_stdout=False, on_returncode='warn')
++        if struct.unpack('<h', head[0x10:0x12]) == (2,):
++            call_subprocess([PATCHELF_BIN, '--set-interpreter', DYNAMIC_LOADER, path],
++                            show_stdout=False, on_returncode='warn')
++        return True
++    return None
++
++
+ dist_info_re = re.compile(r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>.+?))?)
+                                 \.dist-info$""", re.VERBOSE)
+ 
+@@ -423,7 +460,7 @@ def move_wheel_files(
+                     changed = fixer(destfile)
+                 record_installed(srcfile, destfile, changed)
+ 
+-    clobber(source, lib_dir, True)
++    clobber(source, lib_dir, True, fixer=fix_nix_elf)
+ 
+     assert info_dir, "%s .dist-info directory not found" % req
+ 
+-- 
+2.21.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9375,7 +9375,7 @@ in
   python3Packages = python3.pkgs;
 
   pythonInterpreters = callPackage ./../development/interpreters/python {};
-  inherit (pythonInterpreters) python27 python35 python36 python37 python38 python39 python3Minimal pypy27 pypy36;
+  inherit (pythonInterpreters) python27 python35 python36 python37 python38 python39 python3Minimal python38Nix pypy27 pypy36;
 
   # Python package sets.
   python27Packages = lib.hiPrioSet (recurseIntoAttrs python27.pkgs);


### PR DESCRIPTION
I'm using this for some while now and it works well for me. For now please consider it as RFC because I'm not sure if there is interst in merging it at all and there might be better ways to integrate it into the existing python infrastructure.

What this does is to:
* Patch _pip_ to
  * Scan for ELF files after installing a wheel package
  * Patch a path with the _manylinux1_ libraries into the `RPATH`
  * Patch the interpreter to a valid path if it is an executable
* Bundle the patched _pip_ with python
* Expose the python as `python38Nix`

That means _manylinux1_ compatible wheels can be used on NixOS.
E.g. the following does work with new python package:
```
$ python -m venv venv
$ source venv/bin/activate
$ pip install --only-binary :all: pandas
$ python -c 'import pandas'
```