### PR TITLE
cinnamon.cinnamon-session: init at 4.4.0

### DIFF
--- a/pkgs/desktops/cinnamon/cinnamon-session/0001-Add-dbus_glib-dependency.patch
+++ b/pkgs/desktops/cinnamon/cinnamon-session/0001-Add-dbus_glib-dependency.patch
@@ -1,0 +1,38 @@
+From ddc2c4faeec36675654a2f8f04c3011b807fdf79 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Maciej=20Kr=C3=BCger?= <mkg20001@gmail.com>
+Date: Sun, 22 Mar 2020 07:36:25 +0100
+Subject: [PATCH] Add dbus_glib dependency
+
+---
+ cinnamon-session/meson.build | 2 +-
+ meson.build                  | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/cinnamon-session/meson.build b/cinnamon-session/meson.build
+index ee8916f..9dd9283 100644
+--- a/cinnamon-session/meson.build
++++ b/cinnamon-session/meson.build
+@@ -74,7 +74,7 @@ executable('cinnamon-session',
+     xext,
+     xrender,
+     xtest,
+-    # elogind,
++    dbus_glib,
+   ],
+   link_with: [
+     libegg,
+diff --git a/meson.build b/meson.build
+index 231a448..db306dc 100644
+--- a/meson.build
++++ b/meson.build
+@@ -48,6 +48,7 @@ else
+   gconf     = dependency('', required: false)
+ endif
+ conf.set('HAVE_GCONF', gconf.found())
++dbus_glib = dependency('dbus-glib-1')
+ 
+ 
+ gio_unix    = dependency('gio-unix-2.0',      required: false)
+-- 
+2.25.1
+

--- a/pkgs/desktops/cinnamon/cinnamon-session/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-session/default.nix
@@ -1,0 +1,105 @@
+{ fetchFromGitHub
+, cinnamon-desktop
+, cinnamon-settings-daemon
+, dbus-glib
+, docbook_xsl
+, docbook_xml_dtd_412
+, glib
+, gsettings-desktop-schemas
+, gtk3
+, libcanberra
+, libxslt
+, makeWrapper
+, meson
+, ninja
+, pkgconfig
+, python3
+, stdenv
+, systemd
+, wrapGAppsHook
+, xapps
+, xmlto
+, xorg
+, cmake
+, libexecinfo
+, pango
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cinnamon-session";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "0hplck17rksfgqm2z58ajvz4p2m4zg6ksdpbc27ki20iv4fv620s";
+  };
+
+  patches = [
+    ./0001-Add-dbus_glib-dependency.patch
+  ];
+
+  buildInputs = [
+    # meson.build
+    gtk3
+    glib
+    libcanberra
+    pango
+    xorg.libX11
+    xorg.libXext
+    xapps
+    xorg.libXau
+    xorg.libXcomposite
+
+    systemd
+
+    xorg.libXtst
+    xorg.libXrender
+    xorg.xtrans
+
+    # other (not meson.build)
+
+    cinnamon-desktop
+    cinnamon-settings-daemon
+    dbus-glib
+    glib
+    gsettings-desktop-schemas
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    wrapGAppsHook
+    libexecinfo
+    docbook_xsl
+    docbook_xml_dtd_412
+    python3
+    pkgconfig
+    libxslt
+    xmlto
+  ];
+
+  # TODO: https://github.com/NixOS/nixpkgs/issues/36468
+  mesonFlags = [ "-Dc_args=-I${glib.dev}/include/gio-unix-2.0" "-Dgconf=false" "-DENABLE_IPV6=true" ];
+
+  postPatch = ''
+    chmod +x data/meson_install_schemas.py # patchShebangs requires executable file
+    patchShebangs data/meson_install_schemas.py
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${cinnamon-desktop}/share"
+      --prefix XDG_CONFIG_DIRS : "${cinnamon-settings-daemon}/etc/xdg"
+    )
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/cinnamon-session";
+    description = "The Cinnamon session manager";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -4,6 +4,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   cinnamon-desktop = callPackage ./cinnamon-desktop { };
   cinnamon-menus = callPackage ./cinnamon-menus { };
   cinnamon-translations = callPackage ./cinnamon-translations { };
+  cinnamon-session = callPackage ./cinnamon-session { };
   cinnamon-settings-daemon = callPackage ./cinnamon-settings-daemon { };
   cjs = callPackage ./cjs { };
   nemo = callPackage ./nemo { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

More cinnamon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
