### PR TITLE
flow: 0.116.1 -> 0.117.0

### DIFF
--- a/pkgs/development/tools/analysis/flow/default.nix
+++ b/pkgs/development/tools/analysis/flow/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, CoreServices, fetchpatch }:
+{ stdenv, fetchFromGitHub, ocamlPackages, CoreServices }:
 
 stdenv.mkDerivation rec {
   pname = "flow";
-  version = "0.116.1";
+  version = "0.117.0";
 
   src = fetchFromGitHub {
     owner  = "facebook";
     repo   = "flow";
     rev    = "refs/tags/v${version}";
-    sha256 = "19j2zw8ajky04d2ayfzj99yz805igip1ql3i4v7bblamc8sk38cn";
+    sha256 = "1s3qlq0jfx94fr7vzzc7jw8l5mvsrrxhq9mcf50aq0ipz0fz0il9";
   };
 
   installPhase = ''
@@ -18,14 +18,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = (with ocamlPackages; [ ocaml findlib ocamlbuild dtoa core_kernel sedlex_2 ocaml_lwt lwt_log lwt_ppx ppx_deriving ppx_gen_rec ppx_tools_versioned visitors wtf8 ocaml-migrate-parsetree ])
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
-
-  patches = [
-    # Fix List.compare labeled argument. Remove with the next release
-    (fetchpatch {
-      url = "https://github.com/facebook/flow/commit/d061b38042327d8241fb6dec7c8307c86b2f23d6.patch";
-      sha256 = "1rmkb1zldgm2y2n32nm2xd8c7wk3hccsbljjz6bm6a0yixa6w77l";
-    })
-  ];
 
   meta = with stdenv.lib; {
     description = "A static type checker for JavaScript";


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/facebook/flow/releases/tag/v0.117.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
