### PR TITLE
operator-sdk: init at 0.18.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -633,6 +633,12 @@
     githubId = 1296771;
     name = "Anders Riutta";
   };
+  arnarg = {
+    email = "arnarg@fastmail.com";
+    github = "arnarg";
+    githubId = 1291396;
+    name = "Arnar Ingason";
+  };
   arnoldfarkas = {
     email = "arnold.farkas@gmail.com";
     github = "arnoldfarkas";

--- a/pkgs/development/tools/operator-sdk/default.nix
+++ b/pkgs/development/tools/operator-sdk/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule, go, lib, fetchFromGitHub, makeWrapper }:
+
+buildGoModule rec {
+  pname = "operator-sdk";
+  version = "0.18.2";
+
+  src = fetchFromGitHub {
+    owner = "operator-framework";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "02vzxqbh4yw9yvr9cr43hyi0v4hzii4mdb8am41n5y71bcld73v8";
+  };
+
+  vendorSha256 = "0kdbpm6phdcw1rcjggrdvc8hgs3hjc81545qh8jv6zwipmn89i1p";
+
+  subPackages = [ "cmd/operator-sdk" ];
+
+  buildInputs = [ go makeWrapper ];
+
+  # operator-sdk uses the go compiler at runtime
+  allowGoReference = true;
+  postFixup = ''
+    wrapProgram $out/bin/operator-sdk --prefix PATH : ${lib.makeBinPath [ go ]}
+  '';
+
+  meta = with lib; {
+    description = "SDK for building Kubernetes applications. Provides high level APIs, useful abstractions, and project scaffolding.";
+    homepage = "https://github.com/operator-framework/operator-sdk";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ arnarg ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5726,6 +5726,8 @@ in
 
   oppai-ng = callPackage ../tools/misc/oppai-ng { };
 
+  operator-sdk = callPackage ../development/tools/operator-sdk { };
+
   update-dotdee = with python3Packages; toPythonApplication update-dotdee;
 
   update-resolv-conf = callPackage ../tools/networking/openvpn/update-resolv-conf.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Operator-sdk is a cli tool for scaffolding and building Kubernetes operators. This tool is missing in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
