### PR TITLE
date: init at v2.4.1

### DIFF
--- a/pkgs/development/libraries/date/default.nix
+++ b/pkgs/development/libraries/date/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, fetchpatch
+, cmake, ninja, curl }:
+
+stdenv.mkDerivation rec {
+  pname = "date";
+  version = "unstable-2019-01-16";
+
+  src = fetchFromGitHub {
+    owner = "HowardHinnant";
+    repo = "date";
+    rev = "9a0ee2542848ab8625984fc8cdbfb9b5414c0082";
+    sha256 = "0yxsn0hj22n61bjywysxqgfv7hj5xvsl6isma95fl8xrimpny083";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/HowardHinnant/date/pull/538.patch";
+      sha256 = "0k06a73jsdhpl293q2s51hr0ziyczfz3j7b13w36x2wppm6n71z5";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  buildInputs = [ curl ];
+
+  cmakeFlags = [
+    "-DBUILD_TZ_LIB=true"
+    "-DBUILD_SHARED_LIBS=true"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/HowardHinnant/date";
+    description = "A date and time library based on the C++11/14/17 <chrono> header";
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11190,6 +11190,8 @@ in
     kerberos = if stdenv.isFreeBSD then libheimdal else kerberos;
   };
 
+  date = callPackage ../development/libraries/date {  };
+
   # Make bdb5 the default as it is the last release under the custom
   # bsd-like license
   db = db5;


### PR DESCRIPTION
#### Motivation for this change

Used my newest versions of Waybar. Packaging it now for nixpkgs-wayland users.

Blocked on: https://github.com/HowardHinnant/date/issues/537

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
