### PR TITLE
unoconv: fixing sha256

### DIFF
--- a/pkgs/tools/text/unoconv/default.nix
+++ b/pkgs/tools/text/unoconv/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "unoconv";
     repo = "unoconv";
     rev = version;
-    sha256 = "0ix605lk0k3hv241jb2kf4jq5744q2wh9x0pzkmay5m126vv8kq4";
+    sha256 = "0mxrzzg9bl42lsiw8hcq624qbq8jrhcgmnal7ys68dj0l901snk3";
   };
 
   buildInputs = [ asciidoc makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Upon rebuilding, nixos-rebuild said the sha256 sum is wrong.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
