### PR TITLE
amdgpu-fan: init at 0.0.6

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -332,6 +332,7 @@
   ./services/games/terraria.nix
   ./services/hardware/acpid.nix
   ./services/hardware/actkbd.nix
+  ./services/hardware/amdgpu-fan.nix
   ./services/hardware/bluetooth.nix
   ./services/hardware/bolt.nix
   ./services/hardware/brltty.nix

--- a/nixos/modules/services/hardware/amdgpu-fan.nix
+++ b/nixos/modules/services/hardware/amdgpu-fan.nix
@@ -1,0 +1,73 @@
+{ config, lib, pkgs, ... }:
+with lib;
+
+let
+  cfg = config.services.amdgpu-fan;
+  pkg = pkgs.amdgpu-fan;
+  amdgpuFanConfigFile = pkgs.writeText "amdgpu-fan.yml" ''
+    # speed matrix
+    # -[temp(*C), speed(0-100%)]
+    ${cfg.speed_matrix}
+
+    # optional list of cards
+    ${cfg.cards}
+  '';
+
+in
+{
+
+  options.services.amdgpu-fan = {
+    enable = mkEnableOption "Python daemon for controlling the fans on amdgpu cards";
+
+    speed_matrix = mkOption {
+      type = types.lines;
+      default = ''
+        - [0, 0]
+        - [40, 30]
+        - [60, 50]
+        - [80, 100]
+      '';
+      example = ''
+        - [0, 0]
+        - [20, 20]
+        - [40, 60]
+        - [60, 100]
+      '';
+      description = ''
+            Define fan speed for different temperatures using a speed matrix
+      '';
+    };
+
+    cards = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        cards:
+        - card0
+      '';
+      description = ''
+            Define cards that can be controlled. This can be any card returned from:
+            `ls /sys/class/drm | grep "^card[[:digit:]]$"`
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkg ];
+    environment.etc."amdgpu-fan.yml".source = amdgpuFanConfigFile;
+
+    systemd.services.amdgpu-fan =  {
+      description = "amdgpu fan controller";
+      wantedBy = [ "default.target" ];
+      serviceConfig = {
+        ExecStart = "${pkg}/bin/amdgpu-fan";
+        Restart = "always";
+      };
+      restartTriggers = [ amdgpuFanConfigFile ];
+    };
+
+  };
+}
+
+

--- a/pkgs/development/python-modules/amdgpu-fan/default.nix
+++ b/pkgs/development/python-modules/amdgpu-fan/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, pyyaml, setuptools }:
+
+buildPythonPackage rec {
+  pname = "amdgpu-fan";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    owner = "chestm007";
+    repo = pname;
+    rev = version;
+    sha512 = "33bqbg6hp4y0pa5nc4jwk4dfsip48p14kdd3jvbww5bf4wn4z3acqzzcrszrx1yc5gmn3744hg49a1fv67mqncn3nl9kp6hmlnwv0lb";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ numpy pyyaml ];
+  buildInputs = [ setuptools ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace 'PROJECTVERSION' '${version}'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python controller for amdgpu fan";
+    homepage = "https://github.com/chestm007/amdgpu-fan";
+    maintainers = with maintainers; [ grburst ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -764,6 +764,8 @@ in
 
   alttab = callPackage ../tools/X11/alttab { };
 
+  amdgpu-fan = with python3Packages; toPythonApplication amdgpu-fan;
+
   amule = callPackage ../tools/networking/p2p/amule { };
 
   amuleDaemon = appendToName "daemon" (amule.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -147,6 +147,8 @@ in {
 
   alerta-server = callPackage ../development/python-modules/alerta-server { };
 
+  amdgpu-fan = callPackage ../development/python-modules/amdgpu-fan { };
+
   androguard = callPackage ../development/python-modules/androguard { };
 
   phonenumbers = callPackage ../development/python-modules/phonenumbers { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is a small tool / service in order to control the amdgpu fan. Currently, I am using it on a local branch. I did not test everything extensively but I am running it without any issues for a while now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
