### PR TITLE
dart: 2.0.0 -> 2.7.1 (stable) + 2.0.0 -> 2.8.0-dev.10.0 (dev)

### DIFF
--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -1,49 +1,58 @@
-{ stdenv, fetchurl, unzip, version ? "2.0.0" }:
+{ stdenv, fetchurl, unzip, version ? "2.7.1" }:
 
 let
 
   sources = let
 
     base = "https://storage.googleapis.com/dart-archive/channels";
-    stable = "${base}/stable/release";
-    dev = "${base}/dev/release";
+    stable_version = "stable";
+    dev_version = "dev";
+    x86_64 = "x64";
+    i686 = "ia32";
+    aarch64 = "arm64";
 
   in {
-    "1.16.1-x86_64-linux" = fetchurl {
-      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
-      sha256 = "01cbnc8hd2wwprmivppmzvld9ps644k16wpgqv31h1596l5p82n2";
-    };
-    "1.16.1-i686-linux" = fetchurl {
-      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
-      sha256 = "0jfwzc3jbk4n5j9ka59s9bkb25l5g85fl1nf676mvj36swcfykx3";
-    };
     "1.24.3-x86_64-linux" = fetchurl {
-      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
-      sha256 = "e323c97c35e6bc5d955babfe2e235a5484a82bb1e4870fa24562c8b9b800559b";
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
+      sha256 = "16sm02wbkj328ni0z1z4n4msi12lb8ijxzmbbfamvg766mycj8z3";
     };
     "1.24.3-i686-linux" = fetchurl {
-      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
-      sha256 = "d67b8f8f9186e7d460320e6bce25ab343c014b6af4b2f61369ee83755d4da528";
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
+      sha256 = "0a559mfpb0zfd49zdcpld95h2g1lmcjwwsqf69hd9rw6j67qyyyn";
     };
-    "2.0.0-x86_64-linux" = fetchurl {
-      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
-      sha256 = "4014a1e8755d2d32cc1573b731a4a53acdf6dfca3e26ee437f63fe768501d336";
+    "1.24.3-aarch64-linux" = fetchurl {
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
+      sha256 = "1p5bn04gr91chcszgmw5ng8mlzgwsrdr2v7k7ppwr1slkx97fsrh";
     };
-    "2.0.0-i686-linux" = fetchurl {
-      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
-      sha256 = "3164a9de70bf11ab5b20af0d51c8b3303f2dce584604dce33bea0040bdc0bbba";
+    "2.7.1-x86_64-linux" = fetchurl {
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
+      sha256 = "1zjd9hxxg1dsyzkzgqjvl933kprf8h143z5qi4mj1iczxv7zp27a";
     };
-    "2.0.0-dev.26.0-x86_64-linux" = fetchurl {
-      url = "${dev}/${version}/sdk/dartsdk-linux-x64-release.zip";
-      sha256 = "18360489a7914d5df09b34934393e16c7627ba673c1e9ab5cfd11cd1d58fd7df";
+    "2.7.1-i686-linux" = fetchurl {
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
+      sha256 = "0cggr1jbhzahmazlhba0vw2chz9zxd98jgk6zxvxdnw5hvkx8si1";
     };
-    "2.0.0-dev.26.0-i686-linux" = fetchurl {
-      url = "${dev}/${version}/sdk/dartsdk-linux-ia32-release.zip";
-      sha256 = "83ba8b64c76f48d8de4e0eb887e49b7960053f570d27e7ea438cc0bac789955e";
+    "2.7.1-aarch64-linux" = fetchurl {
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
+      sha256 = "0m4qlc3zy87habr61npykvpclggn5k4hadl59v2b0ymvxa4h5zfh";
+    };
+    "2.8.0-dev.10.0-x86_64-linux" = fetchurl {
+      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
+      sha256 = "17x0q94zampm99dd2sn6q1644lfwcl0ig2rdlmfzd9i4llj2ddbl";
+    };
+    "2.8.0-dev.10.0-i686-linux" = fetchurl {
+      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
+      sha256 = "0hmkg4jrffzh8x2mxn8nbf7dl7k0v2vacbmxgpsl382vw9wwj96j";
+    };
+    "2.8.0-dev.10.0-aarch64-linux" = fetchurl {
+      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
+      sha256 = "185ipcmr9h76g44kzlj5pyj99cljlap82rhd1c2larfklyj5ryvv";
     };
   };
 
 in
+
+with stdenv.lib;
 
 stdenv.mkDerivation {
 
@@ -65,19 +74,20 @@ stdenv.mkDerivation {
              $out/bin/dart
   '';
 
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc ];
+  libPath = makeLibraryPath [ stdenv.cc.cc ];
 
   dontStrip = true;
 
   meta = {
-    platforms = [ "i686-linux" "x86_64-linux" ];
     homepage = https://www.dartlang.org/;
+    maintainers = with maintainers; [ grburst ];
     description = "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
     longDescription = ''
       Dart is a class-based, single inheritance, object-oriented language
       with C-style syntax. It offers compilation to JavaScript, interfaces,
       mixins, abstract classes, reified generics, and optional typing.
     '';
-    license = stdenv.lib.licenses.bsd3;
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+    license = licenses.bsd3;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25783,9 +25783,9 @@ in
   spdlog = spdlog_1;
 
   dart = callPackage ../development/interpreters/dart { };
-  dart_stable = dart.override { version = "2.0.0"; };
-  dart_old = dart.override { version = "1.24.3"; };
-  dart_dev = dart.override { version = "2.0.0-dev.26.0"; };
+  dart_old = dart.override    { version = "1.24.3"; };
+  dart_stable = dart.override { version = "2.7.1"; };
+  dart_dev = dart.override    { version = "2.8.0-dev.10.0"; };
 
   httrack = callPackage ../tools/backup/httrack { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I recently built an app using `flutter`. I ran into multiple issues, one being that the current version of `dart` in nixos is not compatible with the newest `flutter` version. Currently, adding support for `flutter` is discussed in this issue #36759 and it looks promising to get added into the nixos ecosystem :-)

In order to be able to build the app, I had to update the dart version. There is another issue complaining about the old version of dart in #78183 and another pull request which is outdated again #60607

Please do not hesitate to reply, since I would be happy having this updated in the nixos packages.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
