### PR TITLE
zasm: Init at 4.2.6

### DIFF
--- a/pkgs/development/compilers/zasm/default.nix
+++ b/pkgs/development/compilers/zasm/default.nix
@@ -1,0 +1,44 @@
+{ fetchFromGitHub, zlib, stdenv }:
+let
+  libs-src = fetchFromGitHub {
+    owner = "megatokio";
+    repo = "Libraries";
+    rev = "97ea480051b106e83a086dd42583dfd3e9d458a1";
+    sha256 = "1kqmjb9660mnb0r18s1grrrisx6b73ijsinlyr97vz6992jd5dzh";
+  };
+in
+stdenv.mkDerivation {
+  pname = "zasm";
+  version = "4.2.6";
+  src = fetchFromGitHub {
+    owner = "megatokio";
+    repo = "zasm";
+    rev = "f1424add17a5514895a598d6b5e3982579961519";
+    sha256 = "1kqnqdqp2bfsazs6vfx2aiqanxxagn8plx8g6rc11vmr8yqnnpks";
+  };
+
+  buildInputs = [ zlib ];
+
+  configurePhase = ''
+    ln -sf ${libs-src} Libraries
+  '';
+
+  buildPhase = ''
+    cd Linux
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv zasm $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Z80 / 8080 assembler (for unix-style OS)";
+    homepage = "https://k1.spdns.de/Develop/Projects/zasm/Distributions/";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.turbomack ];
+    platforms = platforms.linux;
+    badPlatforms = platforms.aarch64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7780,6 +7780,8 @@ in
 
   you-get = python3Packages.callPackage ../tools/misc/you-get { };
 
+  zasm = callPackage ../development/compilers/zasm {};
+
   zbackup = callPackage ../tools/backup/zbackup {};
 
   zbar = libsForQt5.callPackage ../tools/graphics/zbar { };


### PR DESCRIPTION
Z80 / 8080 assembler.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
