### PR TITLE
[19.09] file: fix download url for CVE-2019-18218

### DIFF
--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -15,7 +15,11 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "CVE-2019-18218.patch";
-      url = "https://sources.debian.org/data/main/f/file/1:5.37-6/debian/patches/cherry-pick.FILE5_37-67-g46a8443f.limit-the-number-of-elements-in-a-vector-found-by-oss-fuzz.patch";
+      urls = [
+        "https://src.fedoraproject.org/rpms/file/raw/f6dd8461/f/file-5.37-CVE-2019-18218.patch"
+        "https://git.in-ulm.de/cbiedl/file/raw/054940e842528dca434a92820f9abb89adce0574/debian/patches/cherry-pick.FILE5_37-67-g46a8443f.limit-the-number-of-elements-in-a-vector-found-by-oss-fuzz.patch"
+        "https://sources.debian.org/data/main/f/file/1:5.35-4+deb10u1/debian/patches/cherry-pick.FILE5_37-67-g46a8443f.limit-the-number-of-elements-in-a-vector-found-by-oss-fuzz.patch"
+      ];
       sha256 = "1i22y91yndc3n2p2ngczp1lwil8l05sp8ciicil74xrc5f91y6mj";
     })
   ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This unbreaks the build of `file` for users who don't rely on cache.nixos.org.

###### Things done

```
# cat test.nix
with import <nixpkgs> {};

{
  a = (fetchpatch {
    name = "CVE-2019-18218.patch";
    urls = [
      "https://release.debian.org/proposed-updates/stretch_diffs/file_5.30-1+deb9u3.debdiff"
    ];
    sha256 = "1i22y91yndc3n2p2ngczp1lwil8l05sp8ciicil74xrc5f91y6mj";
  });

  b = (fetchpatch {
    name = "CVE-2019-18218.patch";
    urls = [
      "https://git.in-ulm.de/cbiedl/file/raw/054940e842528dca434a92820f9abb89adce0574/debian/patches/cherry-pick.FILE5_37-67-g46a8443f.limit-the-number-of-elements-in-a-vector-found-by-oss-fuzz.patch"
    ];
    sha256 = "1i22y91yndc3n2p2ngczp1lwil8l05sp8ciicil74xrc5f91y6mj";
  });

  c = (fetchpatch {
    name = "CVE-2019-18218.patch";
    urls = [
      "https://sources.debian.org/data/main/f/file/1:5.35-4+deb10u1/debian/patches/cherry-pick.FILE5_37-67-g46a8443f.limit-the-number-of-elements-in-a-vector-found-by-oss-fuzz.patch"
    ];
    sha256 = "1i22y91yndc3n2p2ngczp1lwil8l05sp8ciicil74xrc5f91y6mj";
  });
}
# nix-build test.nix -A a --check
checking outputs of '/nix/store/f4y4akrw8dggkg092ryhddyhq2a0vd3k-CVE-2019-18218.patch.drv'...

trying https://release.debian.org/proposed-updates/stretch_diffs/file_5.30-1+deb9u3.debdiff
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3598  100  3598    0     0  21289      0 --:--:-- --:--:-- --:--:-- 21289
warning: rewriting hashes in '/nix/store/j681fm0gcmpvnfc5syjv23jsqhj3lfcn-CVE-2019-18218.patch'; cross fingers
/nix/store/j681fm0gcmpvnfc5syjv23jsqhj3lfcn-CVE-2019-18218.patch
# nix-build test.nix -A b --check
checking outputs of '/nix/store/6j23k0qzziz3pwrh1fhlba9vh1vs4lk5-CVE-2019-18218.patch.drv'...

trying https://git.in-ulm.de/cbiedl/file/raw/054940e842528dca434a92820f9abb89adce0574/debian/patches/cherry-pick.FILE5_37-67-g46a8443f.limit-the-number-of-elements-in-a-vector-found-by-oss-fuzz.patch
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1056  100  1056    0     0   1889      0 --:--:-- --:--:-- --:--:--  1889
warning: rewriting hashes in '/nix/store/j681fm0gcmpvnfc5syjv23jsqhj3lfcn-CVE-2019-18218.patch'; cross fingers
/nix/store/j681fm0gcmpvnfc5syjv23jsqhj3lfcn-CVE-2019-18218.patch
# nix-build test.nix -A c --check
checking outputs of '/nix/store/aawwb6x40bpfhff529s9lnf2x621k79b-CVE-2019-18218.patch.drv'...

trying https://sources.debian.org/data/main/f/file/1:5.35-4+deb10u1/debian/patches/cherry-pick.FILE5_37-67-g46a8443f.limit-the-number-of-elements-in-a-vector-found-by-oss-fuzz.patch
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1056  100  1056    0     0   2687      0 --:--:-- --:--:-- --:--:--  2693
warning: rewriting hashes in '/nix/store/j681fm0gcmpvnfc5syjv23jsqhj3lfcn-CVE-2019-18218.patch'; cross fingers
/nix/store/j681fm0gcmpvnfc5syjv23jsqhj3lfcn-CVE-2019-18218.patch
```
