### PR TITLE
creddump: init at 0.3

### DIFF
--- a/pkgs/tools/security/creddump/default.nix
+++ b/pkgs/tools/security/creddump/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitLab, python2, python2Packages }:
+
+python2Packages.buildPythonApplication rec {
+  pname = "creddump";
+  version = "0.3";
+
+  src = fetchFromGitLab {
+    owner = "kalilinux";
+    repo = "packages/creddump";
+    # url-encoding workaround: https://github.com/NixOS/nixpkgs/issues/65796#issuecomment-517829019
+    rev = "debian%2F${version}-1kali2"; # %2F = urlquote("/")
+    sha256 = "0r3rs2hggsvv619l3fh3c0jli6d3ryyj30ni3hz0nz670z5smzcf";
+  };
+
+  # No setup.py is available
+  dontBuild = true;
+  doCheck = false;
+  propagatedBuildInputs = [ python2Packages.pycrypto ];
+
+  installPhase = ''
+    mkdir -p ${placeholder "out"}/bin
+    cp -r framework ${placeholder "out"}/bin/framework
+    cp pwdump.py ${placeholder "out"}/bin/pwdump
+    cp cachedump.py ${placeholder "out"}/bin/cachedump
+    cp lsadump.py ${placeholder "out"}/bin/lsadump
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python tool to extract various credentials and secrets from Windows registry hives";
+    homepage = "https://gitlab.com/kalilinux/packages/creddump";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.fishi0x01 ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -201,6 +201,8 @@ in
 
   onesixtyone = callPackage ../tools/security/onesixtyone {};
 
+  creddump = callPackage ../tools/security/creddump {};
+
   device-tree_rpi = callPackage ../os-specific/linux/device-tree/raspberrypi.nix {};
 
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
`creddump` is a collection of python scripts for retrieving hashes from windows hive files. 

###### Things done
I am wrapping the scripts with `python27Packages.buildPythonApplication`. Build and run successful locally on `Ubuntu18.04`. Installed via:
```
nix-env -f $NIXPKGS -iA creddump
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
