### PR TITLE
burpsuite: fix coredump on jre8

### DIFF
--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -1,19 +1,17 @@
-{ stdenv, fetchurl, jre, runtimeShell }:
+{ stdenv, fetchurl, jdk12, runtimeShell }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "burpsuite";
   version = "2.1.07";
   jar = fetchurl {
     name = "burpsuite.jar";
     url = "https://portswigger.net/Burp/Releases/Download?productId=100&version=${version}&type=Jar";
-    sha256 = "0811pkxmwl9d58lgqbvyfi2q79ni5w8hs61jycxkvkqxrinpgki3";
+    sha256 = "23ce776dcc1dcf3d3bf332180d112fd1a68345747e2ffc282a2d515efbbc2120";
   };
   launcher = ''
     #!${runtimeShell}
-    exec ${jre}/bin/java -jar ${jar} "$@"
+    exec ${jdk12}/bin/java -jar ${jar} "$@"
   '';
-in stdenv.mkDerivation {
-  pname = "burpsuite";
-  inherit version;
   buildCommand = ''
     mkdir -p $out/bin
     echo "${launcher}" > $out/bin/burpsuite
@@ -22,7 +20,7 @@ in stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "An integrated platform for performing security testing of web applications";
     longDescription = ''
       Burp Suite is an integrated platform for performing security testing of web applications.
@@ -30,11 +28,11 @@ in stdenv.mkDerivation {
       initial mapping and analysis of an application's attack surface, through to finding and
       exploiting security vulnerabilities.
     '';
-    homepage = https://portswigger.net/burp/;
-    downloadPage = "https://portswigger.net/burp/freedownload";
-    license = [ stdenv.lib.licenses.unfree ];
-    platforms = jre.meta.platforms;
+    homepage = "https://portswigger.net/burp/";
+    downloadPage = "https://portswigger.net/burp/communitydownload";
+    license = [ licenses.unfree ];
+    platforms = jdk12.meta.platforms;
     hydraPlatforms = [];
-    maintainers = with stdenv.lib.maintainers; [ bennofs ];
+    maintainers = [ maintainers.bennofs ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Getting SIGSEGV when starting burp with `JRE 8.0_222`. 
When using `jdk12` the jar starts without any problems.

Coredump of the SIGSEGV with `JRE 8.0_222`:
```
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007fd404020adf, pid=29473, tid=0x00007fd400b1d700
#
# JRE version: OpenJDK Runtime Environment (8.0_222) (build 1.8.0_222-ga)
# Java VM: OpenJDK 64-Bit Server VM (25.222-bga mixed mode linux-amd64 compressed oops)
# Problematic frame:
# C  [libc.so.6+0x152adf]  __memmove_avx_unaligned_erms+0x12f
```

###### Things done
Use `jdk12` instead of `jre`. I know that `jre` is the officially recommended way, however it doesn't work for me. Further, I adjusted the sha256 sum (taken from official website (https://portswigger.net/burp/communitydownload) and verified locally)

Tested locally on `Ubuntu18.04`. Installed via:
```
nix-env -f $NIXPKGS -iA burpsuite
```
