### PR TITLE
correction on Guake i18n : guake use C locales (not gettext directly)

### DIFF
--- a/pkgs/applications/terminal-emulators/guake/default.nix
+++ b/pkgs/applications/terminal-emulators/guake/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , python3
-, gettext
+, glibcLocales
 , gobject-introspection
 , wrapGAppsHook
 , gtk3
@@ -31,13 +31,13 @@ python3.pkgs.buildPythonApplication rec {
   strictDeps = false;
 
   nativeBuildInputs = [
-    gettext
     gobject-introspection
     wrapGAppsHook
     python3.pkgs.pip
   ];
 
   buildInputs = [
+    glibcLocales
     gtk3
     keybinder3
     libnotify
@@ -45,6 +45,8 @@ python3.pkgs.buildPythonApplication rec {
     python3
     vte
   ];
+
+  makeWrapperArgs = [ "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive" ];
 
   propagatedBuildInputs = with python3.pkgs; [
     dbus-python


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions => Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
