### PR TITLE
Revert "aws-checksums: 0.1.3 -> 0.1.5"

### DIFF
--- a/pkgs/development/libraries/aws-checksums/default.nix
+++ b/pkgs/development/libraries/aws-checksums/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-checksums";
-  version = "0.1.5";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "018fnpn0jc686jxp5wf8qxmjphk3z43l8n1mgcgaa9zw94i24jgk";
+    sha256 = "1s6zwf97rkkvnf3p7vlaykwa4pxpvj78pmxvvjf5jk29f93b49xp";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#74112

I prematurely merged it, sorry about that. It breaks `aws-sdk-cpp`