### PR TITLE
biblatex-check: init at 2019-11-09

### DIFF
--- a/pkgs/tools/typesetting/biblatex-check/default.nix
+++ b/pkgs/tools/typesetting/biblatex-check/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, python }:
+
+stdenv.mkDerivation {
+  pname = "biblatex-check";
+  version = "2019-11-09";
+
+  src = fetchFromGitHub {
+    owner = "Pezmc";
+    repo = "BibLatex-Check";
+    rev = "2db50bf94d1480f37edf1b3619e73baf4ef85938";
+    sha256 = "1bq0yqckhssazwkivipdjmn1jpsf301i4ppyl88qhc5igx39wg25";
+  };
+
+  buildInputs = [ python ];
+
+  installPhase = ''
+    install -Dm755 biblatex_check.py $out/bin/biblatex-check
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python2/3 script for checking BibLatex .bib files";
+    homepage = "https://github.com/Pezmc/BibLatex-Check";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2263,6 +2263,8 @@ in
 
   biber = callPackage ../tools/typesetting/biber { };
 
+  biblatex-check = callPackage ../tools/typesetting/biblatex-check { };
+
   birdfont = callPackage ../tools/misc/birdfont { };
   xmlbird = callPackage ../tools/misc/birdfont/xmlbird.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Package up this script, hopefully others find useful too! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).