### PR TITLE
bibclean: init at 3.03

### DIFF
--- a/pkgs/tools/typesetting/bibclean/default.nix
+++ b/pkgs/tools/typesetting/bibclean/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "bibclean";
+  version = "3.03";
+
+  src = fetchurl {
+    url = "http://ftp.math.utah.edu/pub/bibclean/bibclean-${version}.tar.xz";
+    sha256 = "06ic9zix8gh1wz7hd1cnlxxyrp7sqs67a7xnv08r71b5ikri35a3";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile.in --replace man/man1 share/man/man1
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin $out/share/man/man1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Prettyprint and syntax check BibTeX and Scribe bibliography data base files";
+    homepage = "http://ftp.math.utah.edu/pub/bibclean";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2261,6 +2261,8 @@ in
 
   bgs = callPackage ../tools/X11/bgs { };
 
+  bibclean = callPackage ../tools/typesetting/bibclean { };
+
   biber = callPackage ../tools/typesetting/biber { };
 
   biblatex-check = callPackage ../tools/typesetting/biblatex-check { };


### PR DESCRIPTION

###### Motivation for this change

Helpful `*.bib` utility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
