### PR TITLE
add deluge v2

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/2.nix
+++ b/pkgs/applications/networking/p2p/deluge/2.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, fetchpatch, intltool, python, pythonPackages, libtorrentRasterbar
+, gtk3, pango, gettext, wrapGAppsHook, gdk-pixbuf, gobject-introspection, atk, cairo,
+ hicolor-icon-theme, gnome3
+}:
+
+pythonPackages.buildPythonPackage rec {
+  pname = "deluge";
+  version = "2.0.3";
+
+  src = fetchurl {
+    url = "https://ftp.osuosl.org/pub/deluge/source/2.0/deluge-${version}.tar.xz";
+    sha256 = "14d8kn2pvr1qv8mwqrxmj85jycr73vwfqz12hzag0ararbkfhyky";
+  };
+
+  patches = [
+  ];
+
+  doCheck = false;
+
+  propagatedBuildInputs = with pythonPackages; [
+    gtk3 pango pygobject3 twisted Mako chardet pyxdg pyopenssl service-identity
+    libtorrentRasterbar.dev libtorrentRasterbar.python setuptools
+    pillow rencode setproctitle 
+  ];
+
+  buildInputs = [ gtk3 hicolor-icon-theme gnome3.adwaita-icon-theme ];
+
+  nativeBuildInputs = [ 
+    intltool 
+    gettext wrapGAppsHook pango gdk-pixbuf atk cairo
+    libtorrentRasterbar.dev
+
+    # Temporary fix
+    # See https://github.com/NixOS/nixpkgs/issues/61578
+    # and https://github.com/NixOS/nixpkgs/issues/56943
+    gobject-introspection
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://deluge-torrent.org;
+    description = "Torrent client";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ domenkozar ebzzry ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2757,6 +2757,10 @@ in
   deluge = callPackage ../applications/networking/p2p/deluge {
     pythonPackages = python2Packages;
   };
+  deluge2 = callPackage ../applications/networking/p2p/deluge/2.nix {
+    pythonPackages = python3Packages;
+    libtorrentRasterbar = callPackage ../development/libraries/libtorrent-rasterbar { python = python3; };
+  };
 
   desktop-file-utils = callPackage ../tools/misc/desktop-file-utils { };
 


### PR DESCRIPTION

###### Motivation for this change
update deluge to v2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
