### PR TITLE
haskellPackages.bustle: fix building on Hydra

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -608,6 +608,14 @@ self: super: {
     (bustle: bustle.override { hgettext = null; })
     (bustle: disableCabalFlag bustle "hgettext")
 
+    # Bustle specifies OtherLicense even though the code is actually LGPL
+    # https://gitlab.freedesktop.org/bustle/bustle/merge_requests/17
+    (bustle: bustle.overrideAttrs (attrs: {
+      meta = builtins.removeAttrs attrs.meta [ "hydraPlatforms" ] // {
+        license = pkgs.lib.licenses.lgpl21Plus;
+      };
+    }))
+
     # Install icons, metadata and cli program.
     (bustle: overrideCabal bustle (drv: {
       buildDepends = [ pkgs.libpcap ];

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -602,28 +602,33 @@ self: super: {
   # https://github.com/athanclark/sets/issues/2
   sets = dontCheck super.sets;
 
-  # Install icons, metadata and cli program.
-  # Do not build hgettext as it is broken
-  # https://gitlab.freedesktop.org/bustle/bustle/issues/13
-  bustle = overrideCabal (disableCabalFlag (super.bustle.override { hgettext = null; }) "hgettext") (drv: {
-    buildDepends = [ pkgs.libpcap ];
-    buildTools = with pkgs.buildPackages; [ gettext perl help2man ];
-    patches = [
-      # fix build
-      # https://gitlab.freedesktop.org/bustle/bustle/merge_requests/14
-      (pkgs.fetchpatch {
-        url = "https://gitlab.freedesktop.org/bustle/bustle/commit/ee4b81cbc232d47ba9940f1987777b17452e71ff.patch";
-        sha256 = "0v9cvbmrma5jcqcg1narpm1549h0cg8mr6i00qxmq0x6hs04dnwa";
-      })
-      (pkgs.fetchpatch {
-        url = "https://gitlab.freedesktop.org/bustle/bustle/commit/aae6843f51f54679d440fb3813e61355dc8406b9.patch";
-        sha256 = "1a8hr38hd1gdkqhsy56hyl7njw8ci79iigr81aalkb7hn4ckvh2a";
-      })
-    ];
-    postInstall = ''
-      make install PREFIX=$out
-    '';
-  });
+  bustle = pkgs.lib.pipe super.bustle [
+    # Do not build hgettext as it is broken
+    # https://gitlab.freedesktop.org/bustle/bustle/issues/13
+    (bustle: bustle.override { hgettext = null; })
+    (bustle: disableCabalFlag bustle "hgettext")
+
+    # Install icons, metadata and cli program.
+    (bustle: overrideCabal bustle (drv: {
+      buildDepends = [ pkgs.libpcap ];
+      buildTools = with pkgs.buildPackages; [ gettext perl help2man ];
+      patches = [
+        # fix build
+        # https://gitlab.freedesktop.org/bustle/bustle/merge_requests/14
+        (pkgs.fetchpatch {
+          url = "https://gitlab.freedesktop.org/bustle/bustle/commit/ee4b81cbc232d47ba9940f1987777b17452e71ff.patch";
+          sha256 = "0v9cvbmrma5jcqcg1narpm1549h0cg8mr6i00qxmq0x6hs04dnwa";
+        })
+        (pkgs.fetchpatch {
+          url = "https://gitlab.freedesktop.org/bustle/bustle/commit/aae6843f51f54679d440fb3813e61355dc8406b9.patch";
+          sha256 = "1a8hr38hd1gdkqhsy56hyl7njw8ci79iigr81aalkb7hn4ckvh2a";
+        })
+      ];
+      postInstall = ''
+        make install PREFIX=$out
+      '';
+    }))
+  ];
 
   # Byte-compile elisp code for Emacs.
   ghc-mod = overrideCabal super.ghc-mod (drv: {


### PR DESCRIPTION
For some reasons, perhaps inherited from hgettext, bustle had
`hydraPlatforms = stdenv.lib.platforms.none` set in `hackage-packages.nix`.

It builds fine with our overrides so let's unset the attribute.