### PR TITLE
hll2340dw brother: added driver to cups

### DIFF
--- a/pkgs/misc/cups/drivers/hll2340dw/default.nix
+++ b/pkgs/misc/cups/drivers/hll2340dw/default.nix
@@ -1,0 +1,68 @@
+{stdenv, fetchurl, cups, dpkg, gnused, makeWrapper, ghostscript, file, a2ps, coreutils, gawk, perl, gnugrep, which}:
+
+let
+  version = "3.2.0-1";
+  lprdeb = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101912/hll2340dlpr-${version}.i386.deb";
+    sha256 = "c0ae98b49b462cd8fbef445550f2177ce9d8bf627c904e182daa8cbaf8781e50";
+  };
+
+  cupsdeb = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101913/hll2340dcupswrapper-${version}.i386.deb";
+    sha256 = "8aa24a6a825e3a4d5b51778cb46fe63032ec5a731ace22f9ef2b0ffcc2033cc9";
+  };
+
+in
+stdenv.mkDerivation {
+  name = "cups-brother-hll2340dw";
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cups ghostscript dpkg a2ps ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out
+    dpkg-deb -x ${cupsdeb} $out
+    dpkg-deb -x ${lprdeb} $out
+
+    substituteInPlace $out/opt/brother/Printers/HLL2340D/lpd/filter_HLL2340D \
+      --replace /opt "$out/opt" \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$out/opt/brother/Printers/HLL2340D/\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"HLL2340D\"; #"
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/opt/brother/Printers/HLL2340D/lpd/brprintconflsr3
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/opt/brother/Printers/HLL2340D/lpd/rawtobr3
+
+    for f in \
+      $out/opt/brother/Printers/HLL2340D/cupswrapper/brother_lpdwrapper_HLL2340D \
+      $out/opt/brother/Printers/HLL2340D/cupswrapper/paperconfigml1 \
+    ; do
+      wrapProgram $f \
+        --prefix PATH : ${stdenv.lib.makeBinPath [
+          coreutils ghostscript gnugrep gnused
+        ]}
+    done
+
+    mkdir -p $out/lib/cups/filter/
+    ln -s $out/opt/brother/Printers/HLL2340D/lpd/filter_HLL2340D $out/lib/cups/filter/brother_lpdwrapper_HLL2340D
+
+    mkdir -p $out/share/cups/model
+    ln -s $out/opt/brother/Printers/HLL2340D/cupswrapper/brother-HLL2340D-cups-en.ppd $out/share/cups/model/
+
+    wrapProgram $out/opt/brother/Printers/HLL2340D/lpd/filter_HLL2340D \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ ghostscript a2ps file gnused gnugrep coreutils which ] }
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.brother.com/;
+    description = "Brother hl-l2340dw printer driver";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=es&prod=hll2340dw_us_eu_as&os=128&flang=English";
+    maintainers = [ maintainers.qknight ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24726,6 +24726,8 @@ in
 
   cups-brother-hl3140cw = pkgsi686Linux.callPackage ../misc/cups/drivers/hl3140cw { };
 
+  cups-brother-hll2340dw = pkgsi686Linux.callPackage  ../misc/cups/drivers/hll2340dw { };
+
   cups-googlecloudprint = callPackage ../misc/cups/drivers/googlecloudprint { };
 
   # this driver ships with pre-compiled 32-bit binary libraries


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I wanted to print using my Brother hl-l23dw using cups. I've printed a test-page from the localhost:631 page and conclude that this is working!

I think it is safe to just 'merge' ;-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
