### PR TITLE
lobster: init at unstable-2020-01-22

### DIFF
--- a/pkgs/development/compilers/lobster/default.nix
+++ b/pkgs/development/compilers/lobster/default.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, callPackage
+
+# Linux deps
+, libGL
+, xorg
+
+# Darwin deps
+, cf-private
+, Cocoa
+, AudioToolbox
+, OpenGL
+, Foundation
+, ForceFeedback
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lobster";
+  version = "unstable-2020-07-27";
+
+  src = fetchFromGitHub {
+    owner = "aardappel";
+    repo = pname;
+    rev = "9d68171494a79c83931426b624a0249a9c51882c";
+    sha256 = "0d4gn71jym662i00rdmynv53ng1lgl81s5lw1sdddgn41wzs28dd";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = if stdenv.isDarwin
+    then [
+      cf-private
+      Cocoa
+      AudioToolbox
+      OpenGL
+      Foundation
+      ForceFeedback
+    ]
+    else [
+      libGL
+      xorg.libX11
+      xorg.libXext
+    ];
+
+  preConfigure = "cd dev";
+  enableParallelBuilding = true;
+
+  passthru.tests = {
+    can-run-hello-world = callPackage ./test-can-run-hello-world.nix {};
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "http://strlen.com/lobster";
+    description = "The Lobster programming language";
+    longDescription = ''
+      Lobster is a programming language that tries to combine the advantages of
+      very static typing and memory management with a very lightweight,
+      friendly and terse syntax, by doing most of the heavy lifting for you.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/compilers/lobster/test-can-run-hello-world.nix
+++ b/pkgs/development/compilers/lobster/test-can-run-hello-world.nix
@@ -1,0 +1,13 @@
+{ stdenv, lobster }:
+
+stdenv.mkDerivation {
+  name = "lobster-test-can-run-hello-world";
+  meta.timeout = 10;
+  buildCommand = ''
+    ${lobster}/bin/lobster \
+      ${lobster}/share/Lobster/samples/rosettacode/hello_world_test.lobster \
+      | grep 'Goodbye, World!'
+    touch $out
+  '';
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8992,6 +8992,12 @@ in
 
   lizardfs = callPackage ../tools/filesystems/lizardfs { };
 
+  lobster = callPackage ../development/compilers/lobster {
+    inherit (darwin) cf-private;
+    inherit (darwin.apple_sdk.frameworks)
+      Cocoa AudioToolbox OpenGL Foundation ForceFeedback;
+  };
+
   lld = llvmPackages.lld;
   lld_5 = llvmPackages_5.lld;
   lld_6 = llvmPackages_6.lld;


### PR DESCRIPTION
###### Motivation for this change

I picked the darwin bits from #59128.
Could someone please trigger a darwin build? not sure if this is still relevant:
https://github.com/NixOS/nixpkgs/pull/59128/commits/1e8d9c20e5b2c554e5a33f17ac3cf455da147f48#diff-d82c125fb3539f785cdbfe6eec27d90dR20-R27

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Closes #59128