### PR TITLE
xfce4-dockbarx-plugin: fix for xfce 4.14

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, pkgconfig, fetchFromGitHub, python2, bash, vala
-, dockbarx, gtk2, xfce, pythonPackages, wafHook }:
+, dockbarx, gtk2, gnome2, xfce, pythonPackages, wafHook }:
 
 stdenv.mkDerivation rec {
   ver = "0.5";
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
     wrapPythonProgramsIn "$out/share/xfce4/panel/plugins" "$out $pythonPath"
   '';
 
+  propagatedUserEnvPkgs = [ gnome2.GConf.out ];
+  
   meta = with stdenv.lib; {
     homepage = https://github.com/TiZ-EX1/xfce4-dockbarx-plugin;
     description = "A plugins to embed DockbarX into xfce4-panel";


### PR DESCRIPTION
without `pkgs.gnome2.GConf` (either in `environment,systemPackages` or in `services.dbus.packages`) it crashes with

```
xsession[3161]: Traceback (most recent call last):
xsession[3161]:   File "/nix/store/273hi9c452s7s1l3jlpmc0xw3405lsvy-xfce4-dockbarx-plugin-0.5-a2dcb66/share/xfce4/panel/plugins/.xfce4-dockbarx-plug-wrapped", line 241, in <module>
xsession[3161]:     dbx = DockBarXFCEPlug()
xsession[3161]:   File "/nix/store/273hi9c452s7s1l3jlpmc0xw3405lsvy-xfce4-dockbarx-plugin-0.5-a2dcb66/share/xfce4/panel/plugins/.xfce4-dockbarx-plug-wrapped", line 45, in __init__
xsession[3161]:     import dockbarx.dockbar as db
xsession[3161]:   File "/nix/store/2lf9w704xnajng02r3sa3gicrzy4l8pn-dockbarx-0.93/lib/python2.7/site-packages/dockbarx/dockbar.py", line 28, in <module>
xsession[3161]:     import cairowidgets
xsession[3161]:   File "/nix/store/2lf9w704xnajng02r3sa3gicrzy4l8pn-dockbarx-0.93/lib/python2.7/site-packages/dockbarx/cairowidgets.py", line 29, in <module>
xsession[3161]:     from common import Globals, connect, disconnect
xsession[3161]:   File "/nix/store/2lf9w704xnajng02r3sa3gicrzy4l8pn-dockbarx-0.93/lib/python2.7/site-packages/dockbarx/common.py", line 1022, in <module>
xsession[3161]:     __opacify_obj = Opacify()
xsession[3161]:   File "/nix/store/2lf9w704xnajng02r3sa3gicrzy4l8pn-dockbarx-0.93/lib/python2.7/site-packages/dockbarx/common.py", line 333, in __init__
xsession[3161]:     self.globals = Globals()
xsession[3161]:   File "/nix/store/2lf9w704xnajng02r3sa3gicrzy4l8pn-dockbarx-0.93/lib/python2.7/site-packages/dockbarx/common.py", line 718, in __init__
xsession[3161]:     self.DEFAULT_SETTINGS)
xsession[3161]:   File "/nix/store/2lf9w704xnajng02r3sa3gicrzy4l8pn-dockbarx-0.93/lib/python2.7/site-packages/dockbarx/common.py", line 876, in __get_gconf_settings
xsession[3161]:     gconf_set[type(value)](gdir + "/" + name, value)
xsession[3161]: glib.GError: Failed to contact configuration server; the most common cause is a missing or misconfigured D-Bus session bus daemon. See http://projects.gnome.org/gconf/ for information. (Details -  1: GetIOR failed: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.gnome.GConf was not provided by any .service files)
```