### PR TITLE
libirecovery: 2019-01-28 -> 2020-01-14, idevicerestore: 2019-02-14 -> 2019-12-26

### DIFF
--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libimobiledevice";
-  version = "2019-11-29";
+  version = "2020-01-20";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "9f79242a441ce37c28db2b84d49621d26418dc53";
-    sha256 = "1hs0hppsfyhjx47jk2j8n5riqjyrdqvdkc0z0kry0sw09c80zjnr";
+    rev = "61babf5f54e7734ebf3044af4c6294524d4b29b5";
+    sha256 = "02dnq6xza72li52kk4p2ak0gq2js3ssfp2fpjlgsv0bbn5mkg2hi";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/libirecovery/default.nix
+++ b/pkgs/development/libraries/libirecovery/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libirecovery";
-  version = "2019-01-28";
+  version = "2020-01-14";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "5da2a0d7d60f79d93c283964888c6fbbc17be1a3";
-    sha256 = "0fqmr1h4b3qn608dn606y7aqv3bsm949gx72b5d6433xlw9b23n8";
+    rev = "10a1f8dd11a11a0b8980fbf26f11e3ce74e7a923";
+    sha256 = "1v5c9dbbkrsplj1zkcczzm0i31ar3wcx6fpxb0pi4dsgj8846aic";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/misc/idevicerestore/default.nix
+++ b/pkgs/tools/misc/idevicerestore/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "idevicerestore";
-  version = "2019-02-14";
+  version = "2019-12-26";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "8a882038b2b1e022fbd19eaf8bea51006a373c06";
-    sha256 = "17lisl7ll43ixl1zqwchn7jljrdyl2p9q99w30i6qaci71mas37m";
+    rev = "8207daaa2ac3cb3a5107aae6aefee8ecbe39b6d4";
+    sha256 = "1jz72bzk1fh12bs65pv06l85135hgfz1aqnbb084bvqcpj4gl40h";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I was curious about restoring an iPhone on Linux and noticed this package was out of date by a few months.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
