### PR TITLE
litecoin: move to qt5 and add zeromq supoort

### DIFF
--- a/pkgs/applications/blockchains/litecoin.nix
+++ b/pkgs/applications/blockchains/litecoin.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, mkDerivation, fetchFromGitHub
 , pkgconfig, autoreconfHook
 , openssl, db48, boost, zlib, miniupnpc
-, glib, protobuf, utillinux, qt4, qrencode
+, glib, protobuf, utillinux, qrencode
 , AppKit
 , withGui ? true, libevent
+, qtbase, qttools
 }:
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
 
   name = "litecoin" + (toString (optional (!withGui) "d")) + "-" + version;
   version = "0.17.1";
@@ -24,10 +25,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl db48 boost zlib
                   miniupnpc glib protobuf utillinux libevent ]
                   ++ optionals stdenv.isDarwin [ AppKit ]
-                  ++ optionals withGui [ qt4 qrencode ];
+                  ++ optionals withGui [ qtbase qttools qrencode ];
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
-                     ++ optionals withGui [ "--with-gui=qt4" ];
+                   ++ optionals withGui [
+                      "--with-gui=qt5"
+                      "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/blockchains/litecoin.nix
+++ b/pkgs/applications/blockchains/litecoin.nix
@@ -5,6 +5,7 @@
 , AppKit
 , withGui ? true, libevent
 , qtbase, qttools
+, zeromq
 }:
 
 with stdenv.lib;
@@ -22,7 +23,7 @@ mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  buildInputs = [ openssl db48 boost zlib
+  buildInputs = [ openssl db48 boost zlib zeromq
                   miniupnpc glib protobuf utillinux libevent ]
                   ++ optionals stdenv.isDarwin [ AppKit ]
                   ++ optionals withGui [ qtbase qttools qrencode ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22719,7 +22719,7 @@ in
 
   ledger-live-desktop = callPackage ../applications/blockchains/ledger-live-desktop { };
 
-  litecoin  = callPackage ../applications/blockchains/litecoin.nix {
+  litecoin  = libsForQt5.callPackage ../applications/blockchains/litecoin.nix {
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };
   litecoind = litecoin.override { withGui = false; };


### PR DESCRIPTION
###### Motivation for this change

Fixes https://hydra.nixos.org/build/110857741

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
