### PR TITLE
elixir_1_10: init at 1.10.0

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -36,7 +36,12 @@ let
         buildMix = callPackage ./build-mix.nix {};
 
         # BEAM-based languages.
-        elixir = elixir_1_9;
+        elixir = elixir_1_10;
+
+        elixir_1_10 = lib.callElixir ../interpreters/elixir/1.10.nix {
+          inherit rebar erlang;
+          debugInfo = true;
+        };
 
         elixir_1_9 = lib.callElixir ../interpreters/elixir/1.9.nix {
           inherit rebar erlang;
@@ -58,13 +63,8 @@ let
           debugInfo = true;
         };
 
-        elixir_1_5 = lib.callElixir ../interpreters/elixir/1.5.nix {
-          inherit rebar erlang;
-          debugInfo = true;
-        };
-
         # Remove old versions of elixir, when the supports fades out:
-        #   https://hexdocs.pm/elixir/compatibility-and-deprecations.html
+        # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 
         lfe = lfe_1_2;
         lfe_1_2 = lib.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3 buildHex; };

--- a/pkgs/development/interpreters/elixir/1.10.nix
+++ b/pkgs/development/interpreters/elixir/1.10.nix
@@ -1,0 +1,9 @@
+{ mkDerivation }:
+
+# How to obtain `sha256`:
+# nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
+mkDerivation {
+  version = "1.10.0";
+  sha256 = "1fz22c2jqqm2jvzxar11bh1djg3kqdn5rbxdddlz0cv6mfz7hvgv";
+  minimumOTPVersion = "21";
+}

--- a/pkgs/development/interpreters/elixir/1.5.nix
+++ b/pkgs/development/interpreters/elixir/1.5.nix
@@ -1,7 +1,0 @@
-{ mkDerivation }:
-
-mkDerivation {
-  version = "1.5.3";
-  sha256 = "00kgqcn9g6vflc551wniz9pwv7pszyf8v6smpkqs50j3kbliihy5";
-  minimumOTPVersion = "18";
-}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9100,7 +9100,7 @@ in
   inherit (beam.interpreters)
     erlang erlangR18 erlangR19 erlangR20 erlangR21 erlangR22
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
-    elixir elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5
+    elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6
     lfe lfe_1_2;
 
   inherit (beam.packages.erlang)

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -71,8 +71,8 @@ rec {
 
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
-    # `beam.packages.erlangR19.elixir`.
-    inherit (packages.erlang) elixir elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5;
+    # `beam.packages.erlangR22.elixir`.
+    inherit (packages.erlang) elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6;
 
     inherit (packages.erlang) lfe lfe_1_2;
   };
@@ -83,7 +83,6 @@ rec {
   # Each field in this tuple represents all Beam packages in nixpkgs built with
   # appropriate Erlang/OTP version.
   packages = {
-
     # Packages built with default Erlang version.
     erlang = packagesWith interpreters.erlang;
     erlangR18 = packagesWith interpreters.erlangR18;
@@ -91,6 +90,5 @@ rec {
     erlangR20 = packagesWith interpreters.erlangR20;
     erlangR21 = packagesWith interpreters.erlangR21;
     erlangR22 = packagesWith interpreters.erlangR22;
-
   };
 }


### PR DESCRIPTION
Set elixir_1_10 as default elixir version.
Removed elixir_1_5 as support has faded out now.

###### Motivation for this change
Be fast on new versions!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
Let us be fast!
cc @the-kenny @Havvy @couchemar @ankhers