### PR TITLE
onesixtyone: init at unstable-2019-12-26

### DIFF
--- a/pkgs/tools/security/onesixtyone/default.nix
+++ b/pkgs/tools/security/onesixtyone/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "onesixtyone";
+  version = "unstable-2019-12-26";
+
+  src = fetchFromGitHub {
+    owner = "trailofbits";
+    repo = "onesixtyone";
+    rev = "9ce1dcdad73d45c8694086a4f90d7713be1cbdd7";
+    sha256 = "111nxn4pcbx6p9j8cjjxv1j1s7dgf7f4dix8acsmahwbpzinzkg3";
+  };
+
+  buildPhase = ''
+    $CC -o onesixtyone onesixtyone.c
+  '';
+
+  installPhase = ''
+    install -D onesixtyone $out/bin/onesixtyone
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fast SNMP Scanner";
+    homepage = "https://github.com/trailofbits/onesixtyone";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.fishi0x01 ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -181,6 +181,8 @@ in
 
   enum4linux = callPackage ../tools/security/enum4linux {};
 
+  onesixtyone = callPackage ../tools/security/onesixtyone {};
+
   device-tree_rpi = callPackage ../os-specific/linux/device-tree/raspberrypi.nix {};
 
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add `onesixtyone` tool for fast SNMP enumeration

###### Things done
Build and run successful locally on `Ubuntu18.04`. Installed via:
```
nix-env -f $NIXPKGS -iA onesixtyone
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).