### PR TITLE
faust: 2.5.23 -> 2.20.2

### DIFF
--- a/pkgs/applications/audio/faust/faust2jack.nix
+++ b/pkgs/applications/audio/faust/faust2jack.nix
@@ -1,6 +1,7 @@
 { faust
 , gtk2
 , jack2Full
+, alsaLib
 , opencv
 , libsndfile
 }:
@@ -18,6 +19,7 @@ faust.wrapWithBuildEnv {
   propagatedBuildInputs = [
     gtk2
     jack2Full
+    alsaLib
     opencv
     libsndfile
   ];

--- a/pkgs/applications/audio/faust/faust2jackrust.nix
+++ b/pkgs/applications/audio/faust/faust2jackrust.nix
@@ -1,0 +1,18 @@
+{ stdenv
+, faust
+, libjack2
+, cargo
+, binutils
+, gcc
+, gnumake
+, openssl
+, pkgconfig
+
+}:
+
+faust.wrapWithBuildEnv {
+
+  baseName = "faust2jackrust";
+
+  propagatedBuildInputs = [ libjack2 cargo binutils gcc gnumake openssl pkgconfig ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24788,7 +24788,7 @@ in
   faust1 = callPackage ../applications/audio/faust/faust1.nix { };
 
   faust2 = callPackage ../applications/audio/faust/faust2.nix {
-    llvm = llvm_5;
+    llvm = llvm_9;
   };
 
   faust2alqt = callPackage ../applications/audio/faust/faust2alqt.nix { };
@@ -24800,6 +24800,8 @@ in
   faust2firefox = callPackage ../applications/audio/faust/faust2firefox.nix { };
 
   faust2jack = callPackage ../applications/audio/faust/faust2jack.nix { };
+
+  faust2jackrust = callPackage ../applications/audio/faust/faust2jackrust.nix { };
 
   faust2jaqt = callPackage ../applications/audio/faust/faust2jaqt.nix { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Some faust scripts only work in nix-shell, see https://github.com/NixOS/nixpkgs/issues/78610.
In the current faust, one script is broken altogether, this PR fixes that.
Some scripts still don't work in normal shell though...

I'm using llvm_9 cause the default, llvm_7, didn't work.
All the others work, so I figured I'd use the newest.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
