### PR TITLE
python3Packages.nibabel: 3.0.0 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/nibabel/default.nix
+++ b/pkgs/development/python-modules/nibabel/default.nix
@@ -1,31 +1,28 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy3k
 , isPy27
-, bz2file
-, mock
 , nose
+, pytest
 , numpy
-, six
+, h5py
+, pydicom
+, scipy
 }:
 
 buildPythonPackage rec {
   pname = "nibabel";
-  version = "3.0.0";
+  version = "3.0.1";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f5bc325c9cb203c6f0ab876ba1a5ada811284bb3a4c5d063eeaafaefbad873d";
+    sha256 = "08nlny8vzkpjpyb0q943cq57m2s4wndm86chvd3d5qvar9z6b36k";
   };
 
-  propagatedBuildInputs = [
-    numpy
-    six
-  ] ++ lib.optional (!isPy3k) bz2file;
+  propagatedBuildInputs = [ numpy scipy h5py pydicom ];
 
-  checkInputs = [ nose mock ];
+  checkInputs = [ nose pytest ];
 
   checkPhase = ''
     nosetests
@@ -36,5 +33,6 @@ buildPythonPackage rec {
     description = "Access a multitude of neuroimaging data formats";
     license = licenses.mit;
     maintainers = with maintainers; [ ashgillman ];
+    platforms = platforms.x86_64;  # https://github.com/nipy/nibabel/issues/861
   };
 }

--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, buildPythonPackage, fetchPypi, nose, nibabel, numpy, scikitlearn
-, scipy, matplotlib }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest
+, nibabel, numpy, pandas, scikitlearn, scipy, matplotlib, joblib }:
 
 buildPythonPackage rec {
   pname = "nilearn";
@@ -10,19 +10,24 @@ buildPythonPackage rec {
     sha256 = "07eb764f2b7b39b487f806a067e394d8ebffff21f57cd1ecdb5c4030b7210210";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py --replace "required_packages.append('sklearn')" ""
+  '';
+  # https://github.com/nilearn/nilearn/issues/2288
+
   # disable some failing tests
   checkPhase = ''
-    nosetests nilearn/tests \
-    -e test_cache_mixin_with_expand_user -e test_clean_confounds -e test_detrend \
-    -e test_clean_detrending -e test_high_variance_confounds
+    pytest nilearn/tests -k 'not test_cache_mixin_with_expand_user'  # accesses ~/
   '';
 
-  checkInputs = [ nose ];
+  checkInputs = [ pytest ];
 
   propagatedBuildInputs = [
+    joblib
     matplotlib
     nibabel
     numpy
+    pandas
     scikitlearn
     scipy
   ];

--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -8,12 +8,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.3.0";
+  version = "1.4.1";
   pname = "pydicom";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1j11lsykqbnw9d6gzgj6kfn6lawvm5d9azd9palj3l1xhj0hlnsq";
+    sha256 = "0ki4736h6mp77733rsrwicl8pyig39idywzcmwvw3nzi2r1yc7w8";
   };
 
   propagatedBuildInputs = [ numpy pillow ];


### PR DESCRIPTION
pythonPackages.pydicom: 1.3.0 -> 1.4.1

for pydicom: adds python 3.8 support (previously broken)

for nibabel:
- this unbreaks the package due to erroring tests in 3.0.0
- remove obsolete (mostly Python2-related) deps
- add deps to support MINC, DICOM, and SPM formats
- only build on x64 due to a dtype bug on Arm64

Refresh of  #77472.

Depending package `nilearn` still fails to build for unrelated reasons [edit: fix pushed].  Also seems to be some issue with Nipype tests taking a long time/hanging with Python 3.8, but this was never building before.  Will investigate these separately.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
