### PR TITLE
androidenv: add emulator v29.3.6

### DIFF
--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -1,13 +1,39 @@
-{deployAndroidPackage, lib, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgs_i686}:
+{ deployAndroidPackage, lib, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgs_i686 }:
 
 deployAndroidPackage {
   inherit package os;
   buildInputs = [ autoPatchelfHook makeWrapper ]
-    ++ lib.optional (os == "linux") [ pkgs.glibc pkgs.xlibs.libX11 pkgs.xlibs.libXext pkgs.xlibs.libXdamage pkgs.xlibs.libXfixes pkgs.xlibs.libxcb pkgs.libGL pkgs.libpulseaudio pkgs.zlib pkgs.ncurses5 pkgs.stdenv.cc.cc pkgs_i686.glibc ];
+  ++ lib.optional (os == "linux") [
+    pkgs.glibc
+    pkgs.xlibs.libX11
+    pkgs.xlibs.libXext
+    pkgs.xlibs.libXdamage
+    pkgs.xlibs.libXfixes
+    pkgs.xlibs.libxcb
+    pkgs.xlibs.libXcomposite
+    pkgs.xlibs.libXcursor
+    pkgs.xlibs.libXi
+    pkgs.xlibs.libXrender
+    pkgs.xlibs.libXtst
+    pkgs.libcxx
+    pkgs.libGL
+    pkgs.libpulseaudio
+    pkgs.zlib
+    pkgs.ncurses5
+    pkgs.stdenv.cc.cc
+    pkgs_i686.glibc
+    pkgs.expat
+    pkgs.freetype
+    pkgs.nss
+    pkgs.nspr
+    pkgs.alsaLib
+  ];
   patchInstructions = lib.optionalString (os == "linux") ''
     addAutoPatchelfSearchPath $packageBaseDir/lib
     addAutoPatchelfSearchPath $packageBaseDir/lib64
     addAutoPatchelfSearchPath $packageBaseDir/lib64/qt/lib
+    # autoPatchelf is not detecting libuuid :(
+    addAutoPatchelfSearchPath ${pkgs.libuuid.out}/lib
     autoPatchelf $out
 
     # Wrap emulator so that it can load libdbus-1.so at runtime and it no longer complains about XKB keymaps

--- a/pkgs/development/mobile/androidenv/generated/packages.nix
+++ b/pkgs/development/mobile/androidenv/generated/packages.nix
@@ -1012,6 +1012,32 @@
       
     };
   };
+
+  "emulator"."29.3.6".macosx = {
+    name = "emulator";
+    path = "emulator";
+    revision = "29.3.6";
+    displayName = "Android Emulator";
+    archives = {
+      macosx = fetchurl {
+        url = https://dl.google.com/android/repository/emulator-darwin-6137948.zip;
+        sha1 = "cc6388d71b1266dc366a972abea7a9d98ee34d33";
+      };
+    };
+  };
+
+  "emulator"."29.3.6".linux = {
+    name = "emulator";
+    path = "emulator";
+    revision = "29.3.6";
+    displayName = "Android Emulator";
+    archives = {
+      linux = fetchurl {
+        url = https://dl.google.com/android/repository/emulator-linux-6137948.zip;
+        sha1 = "f275185f2d8d627141c03d1ffdcac96d9f4ea035";
+      };
+    };
+  };
   
   "lldb"."2.0.2558144" = {
     


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Android SDK packages are getting out of date. The bash script to automatically generate the packages derivation seems to be broken, and I will attempt to fix it in the near future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Adds an updated version of the android emulator (v29.3.6)

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] ~Ensured that relevant documentation is up to date~ N/A
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
