### PR TITLE
nixos/doc: add a section mentioning GitHub team for nixos release managers

### DIFF
--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -187,7 +187,7 @@
     </listitem>
     <listitem>
      <para>
-      Update "Chapter 4. Upgrading NixOS" section of the manual to match 
+      Update "Chapter 4. Upgrading NixOS" section of the manual to match
       new stable release version.
      </para>
     </listitem>
@@ -235,6 +235,10 @@
    manager who already has managed one release and one release manager being
    introduced to their role, making it easier to pass on knowledge and
    experience.
+  </para>
+  <para>
+   Release managers for current NixOS release are tracked by GitHub team
+   <link xlink:href="https://github.com/orgs/NixOS/teams/nixos-release-managers/members"><literal>@NixOS/nixos-release-managers</literal></link>.
   </para>
   <para>
    A release manager's role and responsibilities are:

--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -237,7 +237,7 @@
    experience.
   </para>
   <para>
-   Release managers for current NixOS release are tracked by GitHub team
+   Release managers for the current NixOS release are tracked by GitHub team
    <link xlink:href="https://github.com/orgs/NixOS/teams/nixos-release-managers/members"><literal>@NixOS/nixos-release-managers</literal></link>.
   </para>
   <para>


### PR DESCRIPTION
This team should be kept up-to-date with each release.

Previously this info had to be grepped from appropriate Discourse thread.

I expect that this team can make final decisions over merge/don'tmerge PRs, and team can request additional review by-name/by-handle. I also expect that this team should normally be pinged only on approved PRs, so they are not "first-line" reviewers.

cc @NixOS/nixos-release-managers 