### PR TITLE
hexchat: 2.14.2 -> 2.14.3

### DIFF
--- a/pkgs/applications/networking/irc/hexchat/default.nix
+++ b/pkgs/applications/networking/irc/hexchat/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hexchat";
-  version = "2.14.2";
+  version = "2.14.3";
 
   src = fetchFromGitHub {
     owner = "hexchat";
     repo = "hexchat";
     rev = "v${version}";
-    sha256 = "1kz81xfis0bw2cfd6ndw32jdzdl5azk9ixqj4a3lginmlj6fs45a";
+    sha256 = "08kvp0dcn3bvmlqcfp9312075bwkqkpa8m7zybr88pfp210gfl85";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];
@@ -22,14 +22,6 @@ stdenv.mkDerivation rec {
     gtk2 lua perl python3 pciutils dbus-glib libcanberra-gtk2 libproxy
     libnotify openssl desktop-file-utils
     isocodes
-  ];
-
-  patches = [
-    #https://github.com/hexchat/hexchat/issues/2237
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/hexchat/raw/8a08a0c8a8da503b18f2fbb15194c5f3728a689a/f/0001-Python-plugin-Call-EndInterpreter-when-deinit-ing-th.patch";
-      sha256 = "1199dj3wvjqj6h5vlm7lzhaax84j9ki6an8y8fs4rww27iq0lk8g";
-    })
   ];
 
   #hexchat and hexchat-text loads enchant spell checking library at run time and so it needs to have route to the path


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
