### PR TITLE
knot-resolver: 4.3.0 -> 5.0.0 -> 5.0.1

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -299,7 +299,7 @@ in
       couchpotato = 267;
       gogs = 268;
       pdns-recursor = 269;
-      kresd = 270;
+      #kresd = 270; # switched to "knot-resolver" with dynamic ID
       rpc = 271;
       geoip = 272;
       fcron = 273;
@@ -600,7 +600,7 @@ in
       headphones = 266;
       couchpotato = 267;
       gogs = 268;
-      kresd = 270;
+      #kresd = 270; # switched to "knot-resolver" with dynamic ID
       #rpc = 271; # unused
       #geoip = 272; # unused
       fcron = 273;

--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -3,12 +3,34 @@
 with lib;
 
 let
-
   cfg = config.services.kresd;
-  configFile = pkgs.writeText "kresd.conf" ''
-    ${optionalString (cfg.listenDoH != []) "modules.load('http')"}
-    ${cfg.extraConfig};
-  '';
+
+  # Convert systemd-style address specification to kresd config line(s).
+  # On Nix level we don't attempt to precisely validate the address specifications.
+  mkListen = kind: addr: let
+    al_v4 = builtins.match "([0-9.]\+):([0-9]\+)" addr;
+    al_v6 = builtins.match "\\[(.\+)]:([0-9]\+)" addr;
+    al_portOnly = builtins.match "()([0-9]\+)" addr;
+    al = findFirst (a: a != null)
+      (throw "services.kresd.*: incorrect address specification '${addr}'")
+      [ al_v4 al_v6 al_portOnly ];
+    port = last al;
+    addrSpec = if al_portOnly == null then "'${head al}'" else "{'::', '127.0.0.1'}";
+    in # freebind is set for compatibility with earlier kresd services;
+       # it could be configurable, for example.
+      ''
+        net.listen(${addrSpec}, ${port}, { kind = '${kind}', freebind = true })
+      '';
+
+  configFile = pkgs.writeText "kresd.conf" (
+    optionalString (cfg.listenDoH != []) ''
+      modules.load('http')
+    ''
+    + concatMapStrings (mkListen "dns") cfg.listenPlain
+    + concatMapStrings (mkListen "tls") cfg.listenTLS
+    + concatMapStrings (mkListen "doh") cfg.listenDoH
+    + cfg.extraConfig
+  );
 
   package = pkgs.knot-resolver.override {
     extraFeatures = cfg.listenDoH != [];
@@ -25,6 +47,7 @@ in {
           value
       )
     )
+    (mkRemovedOptionModule [ "services" "kresd" "cacheDir" ] "Please use (bind-)mounting instead.")
   ];
 
   ###### interface
@@ -35,8 +58,8 @@ in {
       description = ''
         Whether to enable knot-resolver domain name server.
         DNSSEC validation is turned on by default.
-        You can run <literal>sudo nc -U /run/kresd/control</literal>
-        and give commands interactively to kresd.
+        You can run <literal>sudo nc -U /run/knot-resolver/control/1</literal>
+        and give commands interactively to kresd@1.service.
       '';
     };
     extraConfig = mkOption {
@@ -46,16 +69,10 @@ in {
         Extra lines to be added verbatim to the generated configuration file.
       '';
     };
-    cacheDir = mkOption {
-      type = types.path;
-      default = "/var/cache/kresd";
-      description = ''
-        Directory for caches.  They are intended to survive reboots.
-      '';
-    };
     listenPlain = mkOption {
       type = with types; listOf str;
       default = [ "[::1]:53" "127.0.0.1:53" ];
+      example = [ "53" ];
       description = ''
         What addresses and ports the server should listen on.
         For detailed syntax see ListenStream in man systemd.socket.
@@ -84,82 +101,35 @@ in {
 
   ###### implementation
   config = mkIf cfg.enable {
-    environment.etc."kresd.conf".source = configFile; # not required
+    environment.etc."knot-resolver/kresd.conf".source = configFile; # not required
 
-    users.users.kresd =
-      { uid = config.ids.uids.kresd;
-        group = "kresd";
+    users.users.knot-resolver =
+      { isSystemUser = true;
+        group = "knot-resolver";
         description = "Knot-resolver daemon user";
       };
-    users.groups.kresd.gid = config.ids.gids.kresd;
+    users.groups.knot-resolver.gid = null;
 
-    systemd.sockets.kresd = rec {
-      wantedBy = [ "sockets.target" ];
-      before = wantedBy;
-      listenStreams = cfg.listenPlain;
-      socketConfig = {
-        ListenDatagram = listenStreams;
-        FreeBind = true;
-        FileDescriptorName = "dns";
-      };
+    systemd.packages = [ package ]; # the units are patched inside the package a bit
+
+    systemd.targets.kresd = {
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "kres-cache-gc.service" "kresd@1.service" ];
+    };
+    systemd.services."kresd@".serviceConfig = {
+      ExecStart = "${package}/bin/kresd --noninteractive "
+        + "-c ${package}/lib/knot-resolver/distro-preconfig.lua -c ${configFile}";
+      # Ensure correct ownership in case UID or GID changes.
+      CacheDirectory = "knot-resolver";
+      CacheDirectoryMode = "0750";
     };
 
-    systemd.sockets.kresd-tls = mkIf (cfg.listenTLS != []) rec {
-      wantedBy = [ "sockets.target" ];
-      before = wantedBy;
-      partOf = [ "kresd.socket" ];
-      listenStreams = cfg.listenTLS;
-      socketConfig = {
-        FileDescriptorName = "tls";
-        FreeBind = true;
-        Service = "kresd.service";
-      };
-    };
+    environment.etc."tmpfiles.d/knot-resolver.conf".source =
+      "${package}/lib/tmpfiles.d/knot-resolver.conf";
 
-    systemd.sockets.kresd-doh = mkIf (cfg.listenDoH != []) rec {
-      wantedBy = [ "sockets.target" ];
-      before = wantedBy;
-      partOf = [ "kresd.socket" ];
-      listenStreams = cfg.listenDoH;
-      socketConfig = {
-        FileDescriptorName = "doh";
-        FreeBind = true;
-        Service = "kresd.service";
-      };
-    };
-
-    systemd.sockets.kresd-control = rec {
-      wantedBy = [ "sockets.target" ];
-      before = wantedBy;
-      partOf = [ "kresd.socket" ];
-      listenStreams = [ "/run/kresd/control" ];
-      socketConfig = {
-        FileDescriptorName = "control";
-        Service = "kresd.service";
-        SocketMode = "0660"; # only root user/group may connect and control kresd
-      };
-    };
-
-    systemd.tmpfiles.rules = [ "d '${cfg.cacheDir}' 0770 kresd kresd - -" ];
-
-    systemd.services.kresd = {
-      description = "Knot-resolver daemon";
-
-      serviceConfig = {
-        User = "kresd";
-        Type = "notify";
-        WorkingDirectory = cfg.cacheDir;
-        Restart = "on-failure";
-        Sockets = [ "kresd.socket" "kresd-control.socket" ]
-          ++ optional (cfg.listenTLS != []) "kresd-tls.socket";
-      };
-
-      # Trust anchor goes from dns-root-data by default.
-      script = ''
-        exec '${package}/bin/kresd' --config '${configFile}' --forks=1
-      '';
-
-      requires = [ "kresd.socket" ];
-    };
+    # Try cleaning up the previously default location of cache file.
+    # Note that /var/cache/* should always be safe to remove.
+    # TODO: remove later, probably between 20.09 and 21.03
+    systemd.tmpfiles.rules = [ "R /var/cache/kresd" ];
   };
 }

--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -75,7 +75,7 @@ in {
       default = [];
       example = [ "198.51.100.1:443" "[2001:db8::1]:443" "443" ];
       description = ''
-        Addresses and ports on which kresd should provide DNS over HTTPS (see RFC 7858).
+        Addresses and ports on which kresd should provide DNS over HTTPS (see RFC 8484).
         For detailed syntax see ListenStream in man systemd.socket.
       '';
     };

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -16,22 +16,14 @@ lua = luajitPackages;
 
 unwrapped = stdenv.mkDerivation rec {
   pname = "knot-resolver";
-  version = "5.0.0";
+  version = "5.0.1";
 
   src = fetchurl {
     url = "https://secure.nic.cz/files/knot-resolver/${pname}-${version}.tar.xz";
-    sha256 = "ca6023cd0c18b11f4a0cff0c8e882c7f3a5ad6653e9aa95acdbedafc5a53a5ed";
+    sha256 = "4a93264ad0cda7ea2252d1ba057e474722f77848165f2893e0c76e21ae406415";
   };
 
   outputs = [ "out" "dev" ];
-
-  patches = [
-    (fetchpatch { # TODO: included in the next release.
-      name = "fix-GC-path.patch";
-      url = "https://gitlab.labs.nic.cz/knot/knot-resolver/commit/b723dbbe0.diff";
-      sha256 = "1hrwbv9vjybnwm083jxcinzw3fmwlsf1dgxrly7mhjs8d3jhqc4z";
-    })
-  ];
 
   # Path fixups for the NixOS service.
   postPatch = ''

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -60,8 +60,7 @@ unwrapped = stdenv.mkDerivation rec {
     rm "$out"/lib/libkres.a
   '';
 
-  # aarch64: see https://github.com/wahern/cqueues/issues/223
-  doInstallCheck = with stdenv; hostPlatform == buildPlatform && !hostPlatform.isAarch64;
+  doInstallCheck = with stdenv; hostPlatform == buildPlatform;
   installCheckInputs = [ cmocka which cacert ];
   installCheckPhase = ''
     meson test --print-errorlogs


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.labs.nic.cz/knot/knot-resolver/tags/v5.0.0

The service needed lots of changes.  A few smaller changes are added into the PR, e.g. replacement for PR #72014.  See the commit messages for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after):
   negligible increase (9576 bytes)
- [ ] N/A Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] _Tested the NixOS service with various combinations of options._
