### PR TITLE
Add `types.secretPath`

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -4,7 +4,7 @@
 let
   inherit (builtins) head tail length;
   inherit (lib.trivial) and;
-  inherit (lib.strings) concatStringsSep;
+  inherit (lib.strings) concatStringsSep validDerivationName;
   inherit (lib.lists) fold concatMap concatLists;
 in
 
@@ -310,7 +310,7 @@ rec {
       path' = builtins.storePath path;
       res =
         { type = "derivation";
-          name = builtins.unsafeDiscardStringContext (builtins.substring 33 (-1) (baseNameOf path'));
+          name = validDerivationName (builtins.substring 33 (-1) (baseNameOf path'));
           outPath = path';
           outputs = [ "out" ];
           out = res;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -32,6 +32,7 @@ let
     modules = callLibs ./modules.nix;
     options = callLibs ./options.nix;
     types = callLibs ./types.nix;
+    secrets = callLibs ./secrets.nix;
 
     # constants
     licenses = callLibs ./licenses.nix;
@@ -120,7 +121,8 @@ let
       scrubOptionValue literalExample showOption showFiles
       unknownModule mkOption;
     inherit (types) isType setType defaultTypeMerge defaultFunctor
-      isOptionType mkOptionType secretInNixStore;
+      isOptionType mkOptionType;
+    inherit (secrets) unprotectPath secretInNixStore;
     inherit (asserts)
       assertMsg assertOneOf;
     inherit (debug) addErrorContextToAttrs traceIf traceVal traceValFn

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -120,7 +120,7 @@ let
       scrubOptionValue literalExample showOption showFiles
       unknownModule mkOption;
     inherit (types) isType setType defaultTypeMerge defaultFunctor
-      isOptionType mkOptionType;
+      isOptionType mkOptionType secretInNixStore;
     inherit (asserts)
       assertMsg assertOneOf;
     inherit (debug) addErrorContextToAttrs traceIf traceVal traceValFn

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -412,7 +412,8 @@ rec {
       if isDefined then
         foldl' (res: def:
           if type.check def.value then res
-          else throw "The option value `${showOption loc}' in `${def.file}' is not of type `${type.description}'."
+          else throw ("The option value `${showOption loc}' in `${def.file}' is not of type `${type.description}'. "
+            + (type.checkFailedMessage or (x: "")) def.value)
         ) (type.merge loc defsFinal) defsFinal
       else
         # (nixos-option detects this specific error message and gives it special

--- a/lib/secrets.nix
+++ b/lib/secrets.nix
@@ -1,0 +1,75 @@
+{ lib }:
+with lib.strings;
+with lib.types;
+with lib.options;
+rec {
+
+
+  # A type for paths containing secrets
+  secretPath = mkOptionType {
+    name = "secret path";
+    check = x: path.check x && (
+      # Secrets shouldn't be path literals because those could be copied into the store
+      # Secrets also shouldn't be in /nix/store through other means
+      builtins.typeOf x != "path" && ! hasPrefix builtins.storeDir (toString x)
+      # Unless this is explicitly wanted with secretInNixStore
+      || x._secretInNixStore or false);
+    checkFailedMessage = x: optionalString (path.check x) "If you want to import the secret into the globally readable Nix store, use lib.secretInNixStore on the value.";
+    # mergeEqualOption does strictly evaluate all definitions, which can
+    # import paths into /nix/store, but this isn't a problem, since all
+    # definitions will have been checked already, so only paths that *should*
+    # be imported into the store will be evaluated here, namely the ones
+    # marked with secretInNixStore
+    merge = loc: defs: protectPath loc (mergeEqualOption loc defs);
+  };
+
+  /* Explicitly define a secret path in the world-readable Nix store, allowing
+     it to be used as a value for options of type secretPath.
+  */
+  secretInNixStore = path:
+    let
+      storePath =
+        # Type is a literal path, indicating the path to exist in the evaluation
+        # hosts Nix store
+        if builtins.typeOf path == "path" then
+          # Don't import again if the path refers to something in the store
+          if hasPrefix builtins.storeDir (toString path) then
+            builtins.storePath path
+          # Otherwise import the path into the store
+          else builtins.path {
+            name = validDerivationName (baseNameOf path);
+            path = path;
+          }
+        # It's not a literal path, meaning it's something string-like, either
+        # - Without context: It's a store path the evaluation host doesn't know
+        #   about, but the target host will
+        # - With context: It's a store path the evaluation host will build and
+        #   transfer to the target host
+        else if hasPrefix builtins.storeDir (toString path) then
+          # Both above cases can be handled by just passing along the path
+          # directly
+          path
+        # The path is neither a /nix/store path nor is it a literal path,
+        # meaning there's no way to put this path into the store
+        else throw ("secretInNixStore: The path '${toString path}' can't be in "
+          + "the Nix store. You probably don't need to use secretInNixStore for "
+          + "this path.");
+    # Evaluate the path right away to trigger the error early
+    in builtins.seq storePath {
+      # Set outPath such interpolating this string yields the store path
+      outPath = storePath;
+      _secretInNixStore = true;
+    };
+
+
+  protectPath = loc: path: {
+    __toString = throw "The value of `${lib.concatStringsSep "." loc}' is a protected path to a secret, which needs to be explicitly unprotected with `lib.unprotectPath' in order to be usable.";
+    # Argument such that it doesn't get called by any automatic means
+    wrappedPath = { _nixos_protected_path }: path;
+  };
+
+  unprotectPath = protectedPath: protectedPath.wrappedPath {
+    _nixos_protected_path = null;
+  };
+
+}

--- a/lib/secrets.nix
+++ b/lib/secrets.nix
@@ -33,9 +33,12 @@ rec {
         # hosts Nix store
         if builtins.typeOf path == "path" then
           # Don't import again if the path refers to something in the store
+          # We do this so that secrets aren't stored multiple times in the store
           if hasPrefix builtins.storeDir (toString path) then
             builtins.storePath path
           # Otherwise import the path into the store
+          # We could just use string interpolation to do this, but that wouldn't
+          # work with invalid-as-derivation-name filenames
           else builtins.path {
             name = validDerivationName (baseNameOf path);
             path = path;

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -58,9 +58,8 @@ rec {
      of the next function, and the last function returns the
      final value.
   */
-  pipe = val: functions:
-    let reverseApply = x: f: f x;
-    in builtins.foldl' reverseApply val functions;
+  pipe = let reverseApply = x: f: f x; in
+    builtins.foldl' reverseApply;
   /* note please don’t add a function like `compose = flip pipe`.
      This would confuse users, because the order of the functions
      in the list is not clear. With pipe, it’s obvious that it

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -255,23 +255,7 @@ rec {
       merge = mergeEqualOption;
     };
 
-    # A type for paths containing secrets
-    secretPath = mkOptionType {
-      name = "secret path";
-      check = x: path.check x && (
-        # Secrets shouldn't be path literals because those could be copied into the store
-        # Secrets also shouldn't be in /nix/store through other means
-        builtins.typeOf x != "path" && ! hasPrefix builtins.storeDir (toString x)
-        # Unless this is explicitly wanted with secretInNixStore
-        || x._secretInNixStore or false);
-      checkFailedMessage = x: optionalString (path.check x) "If you want to import the secret into the globally readable Nix store, use lib.secretInNixStore on the value.";
-      # mergeEqualOption does strictly evaluate all definitions, which can
-      # import paths into /nix/store, but this isn't a problem, since all
-      # definitions will have been checked already, so only paths that *should*
-      # be imported into the store will be evaluated here, namely the ones
-      # marked with secretInNixStore
-      merge = mergeEqualOption;
-    };
+    inherit (lib.secrets) secretPath;
 
     # drop this in the future:
     list = builtins.trace "`types.list` is deprecated; use `types.listOf` instead" types.listOf;
@@ -646,44 +630,6 @@ rec {
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 
   };
-
-  /* Explicitly define a secret path in the world-readable Nix store, allowing
-     it to be used as a value for options of type secretPath.
-  */
-  secretInNixStore = path:
-    let
-      storePath =
-        # Type is a literal path, indicating the path to exist in the evaluation
-        # hosts Nix store
-        if builtins.typeOf path == "path" then
-          # Don't import again if the path refers to something in the store
-          if hasPrefix builtins.storeDir (toString path) then
-            builtins.storePath path
-          # Otherwise import the path into the store
-          else builtins.path {
-            name = validDerivationName (baseNameOf path);
-            path = path;
-          }
-        # It's not a literal path, meaning it's something string-like, either
-        # - Without context: It's a store path the evaluation host doesn't know
-        #   about, but the target host will
-        # - With context: It's a store path the evaluation host will build and
-        #   transfer to the target host
-        else if hasPrefix builtins.storeDir (toString path) then
-          # Both above cases can be handled by just passing along the path
-          # directly
-          path
-        # The path is neither a /nix/store path nor is it a literal path,
-        # meaning there's no way to put this path into the store
-        else throw ("secretInNixStore: The path '${toString path}' can't be in "
-          + "the Nix store. You probably don't need to use secretInNixStore for "
-          + "this path.");
-    # Evaluate the path right away to trigger the error early
-    in builtins.seq storePath {
-      # Set outPath such interpolating this string yields the store path
-      outPath = storePath;
-      _secretInNixStore = true;
-    };
 
 };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -255,6 +255,24 @@ rec {
       merge = mergeEqualOption;
     };
 
+    # A type for paths containing secrets
+    secretPath = mkOptionType {
+      name = "secret path";
+      check = x: path.check x && (
+        # Secrets shouldn't be path literals because those could be copied into the store
+        # Secrets also shouldn't be in /nix/store through other means
+        builtins.typeOf x != "path" && ! hasPrefix builtins.storeDir (toString x)
+        # Unless this is explicitly wanted with secretInNixStore
+        || x._secretInNixStore or false);
+      checkFailedMessage = x: optionalString (path.check x) "If you want to import the secret into the globally readable Nix store, use lib.secretInNixStore on the value.";
+      # mergeEqualOption does strictly evaluate all definitions, which can
+      # import paths into /nix/store, but this isn't a problem, since all
+      # definitions will have been checked already, so only paths that *should*
+      # be imported into the store will be evaluated here, namely the ones
+      # marked with secretInNixStore
+      merge = mergeEqualOption;
+    };
+
     # drop this in the future:
     list = builtins.trace "`types.list` is deprecated; use `types.listOf` instead" types.listOf;
 
@@ -628,6 +646,45 @@ rec {
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 
   };
+
+  /* Explicitly define a secret path in the world-readable Nix store, allowing
+     it to be used as a value for options of type secretPath.
+  */
+  secretInNixStore = path:
+    let
+      storePath =
+        # Type is a literal path, indicating the path to exist in the evaluation
+        # hosts Nix store
+        if builtins.typeOf path == "path" then
+          # Don't import again if the path refers to something in the store
+          if hasPrefix builtins.storeDir (toString path) then
+            builtins.storePath path
+          # Otherwise import the path into the store
+          else builtins.path {
+            name = validDerivationName (baseNameOf path);
+            path = path;
+          }
+        # It's not a literal path, meaning it's something string-like, either
+        # - Without context: It's a store path the evaluation host doesn't know
+        #   about, but the target host will
+        # - With context: It's a store path the evaluation host will build and
+        #   transfer to the target host
+        else if hasPrefix builtins.storeDir (toString path) then
+          # Both above cases can be handled by just passing along the path
+          # directly
+          path
+        # The path is neither a /nix/store path nor is it a literal path,
+        # meaning there's no way to put this path into the store
+        else throw ("secretInNixStore: The path '${toString path}' can't be in "
+          + "the Nix store. You probably don't need to use secretInNixStore for "
+          + "this path.");
+    # Evaluate the path right away to trigger the error early
+    in builtins.seq storePath {
+      # Set outPath such interpolating this string yields the store path
+      outPath = storePath;
+      _secretInNixStore = true;
+    };
+
 };
 
 in outer_types // outer_types.types

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -58,6 +58,9 @@ rec {
     , # Function applied to each definition that should return true if
       # its type-correct, false otherwise.
       check ? (x: true)
+    , # Function for additional error message in case the type check fails for
+      # a value. Ideally includes type-related recovery hints
+      checkFailedMessage ? (x: "")
     , # Merge a list of definitions together into a single value.
       # This function is called with two arguments: the location of
       # the option in the configuration as a list of strings
@@ -93,7 +96,7 @@ rec {
       functor ? defaultFunctor name
     }:
     { _type = "option-type";
-      inherit name check merge emptyValue getSubOptions getSubModules substSubModules typeMerge functor;
+      inherit name check checkFailedMessage merge emptyValue getSubOptions getSubModules substSubModules typeMerge functor;
       description = if description == null then name else description;
     };
 


### PR DESCRIPTION
###### Motivation for this change
NixOS modules currently have no way to declare a path option as a secret. Using `types.path` in no way prevents people from putting secrets in the Nix store (you can prevent it only for path literals like `/run/keys/foo` by setting `apply = toString`, which I've been suggesting for some time).

This PR solves this problem by introducing `types.secretPath` which is a type that prevents assignments to values in the Nix store. Along with it comes the function `lib.secretInNixStore`, which explicitly imports a secret into the Nix store, and is the only way to get around the checks in `secretPath`. This is for scenarios where you don't care about a secret being in the Nix store.

On the side this also introduces `lib.strings.validDerivationName` for generating a valid derivation name from a potentially invalid one.

###### Things done

- [ ] Go through the code to do some cleaning up, making sure the comments are all up-to-date
- [ ] Added tests, ideally including ones that verify secrets aren't imported unless `secretInNixStore` is used
- [ ] Added documentation
- [ ] Go through NixOS modules to replace `types.path` with `types.secretPath` where appropriate
- [ ] Ideally make sure that the `_secretInNixStore` attribute doesn't end up in the nix store. This doesn't matter much since the secret is already in the store, but we shouldn't help an attacker by letting them know which files are secrets and which aren't

Ping @Profpatsch @rycee @roberth 