### PR TITLE
protontricks: 1.3.1 -> 1.4

### DIFF
--- a/pkgs/tools/package-management/protontricks/default.nix
+++ b/pkgs/tools/package-management/protontricks/default.nix
@@ -1,18 +1,31 @@
 { stdenv, lib, buildPythonApplication, fetchFromGitHub
-, vdf, wine, winetricks, zenity
+, setuptools_scm, vdf
+, wine, winetricks, zenity
+, pytest
 }:
 
 buildPythonApplication rec {
   pname = "protontricks";
-  version = "1.3.1";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "Matoking";
     repo = pname;
     rev = version;
-    sha256 = "0snhm9r5igik030iqxm3zd9zvhlnsxi20zac71bbc29qflsi2dhk";
+    sha256 = "1aarx6g8ykw1jvygfngmz8apdvfj26rcq10bwl228612kwigh7s2";
   };
 
+  # Fix interpreter in mock run.sh for tests
+  postPatch = ''
+    substituteInPlace tests/conftest.py \
+      --replace '#!/bin/bash' '#!${stdenv.shell}' \
+  '';
+
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
+  '';
+
+  nativeBuildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ vdf ];
 
   # The wine install shipped with Proton must run under steam's
@@ -24,11 +37,11 @@ buildPythonApplication rec {
     "--set STEAM_RUNTIME 0"
     "--set-default WINE ${wine}/bin/wine"
     "--set-default WINESERVER ${wine}/bin/wineserver"
-    "--prefix PATH : ${lib.makeBinPath [
-      (winetricks.override { inherit wine; })
-      zenity
-    ]}"
+    "--prefix PATH : ${lib.makeBinPath [ winetricks zenity ]}"
   ];
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
 
   meta = with stdenv.lib; {
     description = "A simple wrapper for running Winetricks commands for Proton-enabled games";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23433,9 +23433,12 @@ in
   };
 
   protontricks = callPackage ../tools/package-management/protontricks {
-    inherit (python3Packages) buildPythonApplication vdf;
+    inherit (python3Packages) buildPythonApplication pytest setuptools_scm vdf;
     inherit (gnome3) zenity;
     wine = wineWowPackages.minimal;
+    winetricks = winetricks.override {
+      wine = wineWowPackages.minimal;
+    };
   };
 
   stepmania = callPackage ../games/stepmania {


### PR DESCRIPTION
Changes included in the upgrade:
- Protontricks now uses setuptools_scm. Specify `SETUPTOOLS_SCM_PRETEND_VERSION` to workaround missing .git.
- Start running tests that were introduced in 1.3.
- Override wine used in winetricks from all-packages.nix instead of protontricks/default.nix.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update to [latest version](https://github.com/Matoking/protontricks/releases/tag/1.4) and start running tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
