### PR TITLE
users-groups: add skel support via environment.etc.skel

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -213,7 +213,16 @@ foreach my $u (@{$spec->{users}}) {
 
     # Create a home directory.
     if ($u->{createHome}) {
-        make_path($u->{home}, { mode => 0700 }) if ! -e $u->{home};
+        my $new_home = 0;
+        if ( !-e $u->{home} ) {
+            make_path($u->{home}, { mode => 0700 });
+            $new_home = 1;
+        }
+        if (defined $new_home && $spec->{skel} && -e $spec->{skel} && $u->{copySkel}) {
+            system("cp --dereference --recursive --preserve=mode --no-preserve=owner $spec->{skel}/. $u->{home}");
+            system("chmod +w -R $u->{home}");
+            system("chown -R $u->{uid}:$u->{gid} $u->{home}");
+        }
         chown $u->{uid}, $u->{gid}, $u->{home};
     }
 

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -171,6 +171,15 @@ let
         '';
       };
 
+      copySkel = mkOption {
+        type = types.bool;
+        default = config.createHome;
+        description = ''
+          If this is true, createHome is true, and environment.etc.skel is set, the skel directory's contents
+          will be copied into the home directory when it is first created.
+        '';
+      };
+
       useDefaultShell = mkOption {
         type = types.bool;
         default = false;
@@ -383,7 +392,8 @@ let
     inherit (cfg) mutableUsers;
     users = mapAttrsToList (_: u:
       { inherit (u)
-          name uid group description home createHome isSystemUser
+          name uid group description isSystemUser
+          home createHome copySkel
           password passwordFile hashedPassword
           initialPassword initialHashedPassword;
         shell = utils.toShellPath u.shell;
@@ -394,6 +404,7 @@ let
           filterAttrs (n: u: elem g.name u.extraGroups) cfg.users
         ));
       }) cfg.groups;
+    skel = "${config.system.build.etc}/etc/skel";
   });
 
   systemShells =

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -83,6 +83,7 @@ in
   ejabberd = handleTest ./xmpp/ejabberd.nix {};
   elk = handleTestOn ["x86_64-linux"] ./elk.nix {};
   env = handleTest ./env.nix {};
+  environmentSkel = handleTest ./environment-skel.nix {};
   etcd = handleTestOn ["x86_64-linux"] ./etcd.nix {};
   etcd-cluster = handleTestOn ["x86_64-linux"] ./etcd-cluster.nix {};
   fancontrol = handleTest ./fancontrol.nix {};

--- a/nixos/tests/environment-skel.nix
+++ b/nixos/tests/environment-skel.nix
@@ -1,0 +1,29 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "environment-skel";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ mkg20001 ];
+  };
+
+  nodes = {
+    machine = { config, lib, pkgs, ... }: {
+      users.users.testuser = {
+        isNormalUser = true;
+        home = "/home/testuser";
+        createHome = true;
+      };
+
+      environment.etc.skel.source = pkgs.runCommand "homecontent" {} ''
+        mkdir -p $out/new-directory
+        touch $out/new-file
+      '';
+    };
+  };
+
+  testScript = {nodes, ...}: ''
+    machine.start()
+    machine.wait_for_unit("default.target")
+
+    machine.succeed("test -d /home/testuser/new-directory")
+    machine.succeed("test -f /home/testuser/new-file")
+  '';
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

For projects like https://github.com/mercode-org/meros-nix it makes sense to have the ability to customize a few things here and there. Since /etc/skel is available everywhere else, why not on nixOS?

This adds multiple options:
 - environment.etc.skel: Provides the directory to copy from
 - users.users.<name>.copySkel: Boolean, default true if createHome true. Enables copying of /etc/skel for that user.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
