### PR TITLE
WIP srcpy: init at XX

### DIFF
--- a/pkgs/applications/misc/srcpy/default.nix
+++ b/pkgs/applications/misc/srcpy/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, pkgconfig
+, ninja
+, ffmpeg
+, SDL2
+, android-studio
+, jdk8
+, gradle
+}:
+
+stdenv.mkDerivation rec {
+  name = "srcpy";
+  version = "1.12.1";
+
+  src = fetchFromGitHub {
+    owner = "Genymobile";
+    repo = name;
+    rev = "v${version}";
+    sha256 = "16zi0d2jjm2nlrwkwvsxzfpgy45ami45wfh67wq7na2h2ywfmgcp";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    android-studio
+    jdk8
+    gradle
+  ];
+
+  buildInputs = [
+    ffmpeg
+    SDL2
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6553,6 +6553,8 @@ in
 
   srcml = callPackage ../applications/version-management/srcml { };
 
+  srcpy = callPackage ../applications/misc/srcpy { };
+
   srt-to-vtt-cl = callPackage ../tools/cd-dvd/srt-to-vtt-cl { };
 
   sourcehut = callPackage ../applications/version-management/sourcehut { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It seems useful, going to use it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
