### PR TITLE
Adds the libmonome package, but an older version

### DIFF
--- a/pkgs/development/libraries/libmonome/default.nix
+++ b/pkgs/development/libraries/libmonome/default.nix
@@ -1,0 +1,48 @@
+# PITFALL: If you'd prefer not to run this with `sudo` (which is sensible),
+# you'll need to make sure the user has access to the monome.
+# When the user does not, running `monomeserial`
+# will result in something like:
+#   [jeff@jbb-dell:~]$ monomeserial
+#   libmonome: could not open monome device: Permission denied
+#   failed to open /dev/ttyUSB0
+# In that case, run `ls -l <device path>`
+# (e.g., for the example above, `ls -l /dev/ttyUSB0`)
+# to find the name of the group that owns the device,
+# and add it to the user's `extraGroups` in the appropriate `.nix` file.
+
+# MAYBE A PROBLEM, but I'm guessing not:
+# The [installation instructions at monome.org](https://monome.org/docs/serialosc/raspbian/)
+# indicate that you should use `liblo-dev`, which is a Debian package.
+# This package instead depends on `liblo`.
+# When I view the Debian package:
+#   https://packages.debian.org/jessie/liblo-dev
+# it looks like all it contains is liblo 0.28-3:
+#   dep: liblo7 (= 0.28-3)
+# "liblo" in nixpkgs (currently) installs liblo 0.29:
+#   https://nixos.org/nixos/packages.html?channel=nixos-19.03&query=liblo
+
+# I found no wafHook documentation,
+# so I aped this file from the nixpkgs repo:
+# pkgs/tools/networking/weighttp/default.nix
+
+
+{ stdenv, libudev, liblo, fetchgit, python3, wafHook}:
+
+stdenv.mkDerivation rec {
+  name = "libmonome";
+  version = "v1.4.2";
+
+  src = fetchgit {
+    url = https://github.com/monome/libmonome.git;
+    rev = version;
+    # date = 2018-04-30T17:26:39-04:00;
+    sha256 = "17g4m17ibpcwyxzh4pqpd7h7xk146ay130jlk3zjjn23fypwahhi";
+  };
+
+  nativeBuildInputs = [ wafHook ];
+  buildInputs = [
+    liblo
+    libudev
+    python3
+  ];
+}

--- a/pkgs/development/libraries/serialosc/default.nix
+++ b/pkgs/development/libraries/serialosc/default.nix
@@ -1,0 +1,54 @@
+# PITFALL: Depends on libmonome, which is available from this repo, or from
+# [my fork of nixpkgs](https://github.com/JeffreyBenjaminBrown/nixpkgs),
+# but which is not yet part of the nixpkgs master branch.
+
+{ stdenv, libmonome, liblo, fetchgit, python3, wafHook, libudev, udev, systemd, avahi-compat, avahi }:
+
+stdenv.mkDerivation rec {
+  name = "serialosc";
+  version = "v1.4.1";
+
+  src = fetchgit {
+    # Once, it seemed to finish, and I don't know how! Then it crashed with:
+    # Switched to a new branch 'fetchgit'
+    # removing `.git'...
+    # hash mismatch in fixed-output derivation '/nix/store/5zj802wfjd0ima92lpzzsqdjqvrnrwf9-serialosc':
+    # wanted: sha256:1vqcxi32wc4pklbddllflkaigkfvd4ykwrjqccayvrk10dx1sna3
+    # got:    sha256:1zmzjasv21ix7i7s58a31k0025ji32hv2jm2ww6s0xhjmr5ax34j
+
+    # This way it [[gets pretty far]].
+    # The fetchSubmodules value I set again seems to have no effect.
+    url = https://github.com/monome/serialosc.git;
+    rev = "v1.4.1";
+    sha256 = "1zmzjasv21ix7i7s58a31k0025ji32hv2jm2ww6s0xhjmr5ax34j";
+
+    # For this I duplicated the serialosc repo including all submodules.
+    # It seems to behave just like the [[gets pretty far]] config.
+    # url = https://github.com/JeffreyBenjaminBrown/serialosc-nix-cheat;
+    # sha256 = "1pm49yqimpard9x2qbma1gyxlmv5bk0kwppn5djnfklgp636km1n";
+
+    # This is currently the hash of master.
+    # Gives me "Submodules aren't initialized!"
+    # url = https://github.com/monome/serialosc.git;
+    # sha256 = "0hc8jpn4vbv52g9rnqprfjybbhvj6dzra5rkdyq9g6h4fqpqlrwm";
+
+    # If I use what prefetch gives me, it always fails, with
+    # "Submodules aren't initialized!"
+    # url = https://github.com/monome/serialosc.git;
+    # sha256 = "1vqcxi32wc4pklbddllflkaigkfvd4ykwrjqccayvrk10dx1sna3";
+    # I've tried fetchSubmodules = false, true, or omitted.
+  };
+
+  nativeBuildInputs = [ wafHook ];
+  buildInputs = [
+    avahi
+    avahi-compat
+    liblo
+    libmonome
+    libudev
+    libudev
+    python3
+    systemd
+    udev
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8905,6 +8905,8 @@ in
 
   serialdv = callPackage ../development/libraries/serialdv {  };
 
+  serialosc = callPackage ../development/libraries/serialosc { };
+
   serpent = callPackage ../development/compilers/serpent { };
 
   shmig = callPackage ../development/tools/database/shmig { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12558,6 +12558,8 @@ in
 
   liblo = callPackage ../development/libraries/liblo { };
 
+  libmonome = callPackage ../development/libraries/libmonome { };
+
   liblscp = callPackage ../development/libraries/liblscp { };
 
   libe-book = callPackage ../development/libraries/libe-book {};


### PR DESCRIPTION
  as described here:
    [libmonome on Github](https://github.com/monome/libmonome)
    [installation instructions](https://monome.org/docs/serialosc/linux/)

  It lets you control a [monome](https://monome.org/)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
