### PR TITLE
pythonPackages.commentjson: init at 0.8.2

### DIFF
--- a/pkgs/development/python-modules/commentjson/default.nix
+++ b/pkgs/development/python-modules/commentjson/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, lark-parser, python, six }:
+
+buildPythonPackage rec {
+  pname = "commentjson";
+  version = "0.8.2";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "db57d6e219140dd7ff2b8bc11a83cca73b317a0ae82d3d447814ed16fd4d2b55";
+  };
+  
+  propagatedBuildInputs = [ lark-parser ];
+
+  checkInputs = [ six ];
+  
+  checkPhase = ''
+    ${python.interpreter} setup.py test
+  '';
+
+  # Test is broken
+  doCheck = false;
+  
+  meta = with lib; {
+    description = "Helps creating JSON files with Python and JavaScript style inline comments";
+    homepage = "https://github.com/vaidik/commentjson";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -550,6 +550,8 @@ in {
 
   cocotb = callPackage ../development/python-modules/cocotb { };
 
+  commentjson = callPackage ../development/python-modules/commentjson { };
+
   compiledb = callPackage ../development/python-modules/compiledb { };
 
   connexion = callPackage ../development/python-modules/connexion { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Making commentjson Python package available in Nix.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
