### PR TITLE
pythonPackages.nbconflux: init at 0.7.0

### DIFF
--- a/pkgs/development/python-modules/nbconflux/default.nix
+++ b/pkgs/development/python-modules/nbconflux/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, nbconvert, requests }:
+
+buildPythonPackage rec {
+  pname = "nbconflux";
+  version = "0.7.0";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "558e1ec23be44b4ea8fd383094dd89b0b023051cedb6e12889cc590f00bd1fa8";
+  };
+    
+  propagatedBuildInputs = [ nbconvert requests ];
+  
+  meta = with lib; {
+    description = "Converts Jupyter Notebooks to Atlassian Confluence (R) pages using nbconvert";
+    homepage = "https://github.com/Valassis-Digital-Media/nbconflux";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4303,6 +4303,8 @@ in {
 
   names = callPackage ../development/python-modules/names { };
 
+  nbconflux = callPackage ../development/python-modules/nbconflux { };
+
   nbconvert = callPackage ../development/python-modules/nbconvert { };
 
   nbformat = callPackage ../development/python-modules/nbformat { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Make 'nbconflux' Python package available in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
