### PR TITLE
pythonPackages.pytest-memprof: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/pytest-memprof/default.nix
+++ b/pkgs/development/python-modules/pytest-memprof/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, psutil, pytest }:
+
+buildPythonPackage rec {
+  pname = "pytest-memprof";
+  version = "0.2.0";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c9bc9f1edf2ab90dcac4208412d397b19f5ed450f14e0dba8a8951be0606af67";
+  };
+   
+  propagatedBuildInputs = [ psutil pytest ];
+
+  meta = with lib; {
+    description = "Estimates memory consumption of test functions";
+    homepage = "https://sissource.ethz.ch/schmittu/pytest-memprof";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1222,6 +1222,8 @@ in {
 
   pytest-flask = callPackage ../development/python-modules/pytest-flask { };
 
+  pytest-memprof = callPackage ../development/python-modules/pytest-memprof { };
+
   pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };
 
   pytest-ordering = callPackage ../development/python-modules/pytest-ordering { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Make 'pytest-memprof' Python package available in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
