### PR TITLE
pythonPackages.spavro: init at 1.1.22

### DIFF
--- a/pkgs/development/python-modules/spavro/default.nix
+++ b/pkgs/development/python-modules/spavro/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  pname = "spavro";
+  version = "1.1.22";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14f3643cb17dfa5550dc20e114c56c92c31408c050726f5429ccbcedda60fc79";
+  };
+  
+  propagatedBuildInputs = [ six ];
+  
+  meta = with lib; {
+    description = "(SP)eedier AVRO implementation using Cython";
+    homepage = "http://github.com/pluralsight/spavro";
+    license = licenses.asl20;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1394,6 +1394,8 @@ in {
 
   sparse = callPackage ../development/python-modules/sparse { };
 
+  spavro =  callPackage ../development/python-modules/spavro { };
+
   spglib = callPackage ../development/python-modules/spglib { };
 
   sshpubkeys = callPackage ../development/python-modules/sshpubkeys { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Make 'spavro' Python package available in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
