### PR TITLE
pythonPackages.sphinx-autodoc-annotation: init at 1.0-1

### DIFF
--- a/pkgs/development/python-modules/sphinx-autodoc-annotation/default.nix
+++ b/pkgs/development/python-modules/sphinx-autodoc-annotation/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, sphinx }:
+
+buildPythonPackage rec {
+  pname = "sphinx-autodoc-annotation";
+  version = "1.0-1";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4a3d03081efe1e5f2bc9b9d00746550f45b9f543b0c79519c523168ca7f7d89a";
+  };
+  
+  propagatedBuildInputs = [ sphinx ];
+  
+  meta = with lib; {
+    description = "Use Python 3 annotations in sphinx-enabled docstrings";
+    homepage = "https://github.com/hsoft/sphinx-autodoc-annotation";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5440,6 +5440,8 @@ in {
 
   sphinx-argparse = callPackage ../development/python-modules/sphinx-argparse { };
 
+  sphinx-autodoc-annotation = callPackage ../development/python-modules/sphinx-autodoc-annotation { };
+
   sphinxcontrib-websupport = callPackage ../development/python-modules/sphinxcontrib-websupport { };
 
   hieroglyph = callPackage ../development/python-modules/hieroglyph { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Make 'sphinx-autodoc-annotation' Python package available in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
