### PR TITLE
pythonPackages.dash-daq: init at 0.3.3

### DIFF
--- a/pkgs/development/python-modules/dash-daq/default.nix
+++ b/pkgs/development/python-modules/dash-daq/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, dash
+}:
+
+buildPythonPackage rec {
+  pname = "dash_daq";
+  version = "0.3.3";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8370e6624c2b2dd8c53ed8af9a5a376d4b4a8bb4eb4899b57ae8e55fdb8bad8f";
+  };
+  
+  propagatedBuildInputs = [ dash ];
+  
+  # No tests in archive
+  doCheck = false;
+  
+  meta = with lib; {
+    description = "DAQ components for Dash";
+    homepage = "http://github.com/plotly/dash-daq";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2460,6 +2460,8 @@ in {
 
   dash-core-components = callPackage ../development/python-modules/dash-core-components { };
 
+  dash-daq = callPackage ../development/python-modules/dash-daq { };
+
   dash-html-components = callPackage ../development/python-modules/dash-html-components { };
 
   dash-renderer = callPackage ../development/python-modules/dash-renderer { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Make 'dash-daq' Python package available in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
