### PR TITLE
pythonPackages.thriftpy2: init at 0.4.10

### DIFF
--- a/pkgs/development/python-modules/thriftpy2/default.nix
+++ b/pkgs/development/python-modules/thriftpy2/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, ply, tornado }:
+
+buildPythonPackage rec {
+  pname = "thriftpy2";
+  version = "0.4.10";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0bd98580bdb1d1184338e5f105b685f55f3fd60e6335c72d9bb7634ed284cc57";
+  };
+  
+  propagatedBuildInputs = [ ply ];
+  
+  checkInputs = [ tornado ];
+    
+  meta = with lib; {
+    description = "Pure python implementation of Apache Thrift";
+    homepage = "https://thriftpy2.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1432,6 +1432,8 @@ in {
 
   tesserocr = callPackage ../development/python-modules/tesserocr { };
 
+  thriftpy2 = callPackage ../development/python-modules/thriftpy2 { };
+
   trueskill = callPackage ../development/python-modules/trueskill { };
 
   trustme = callPackage ../development/python-modules/trustme {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Make 'thriftpy2' Python package available in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
