### PR TITLE
pythonPackages.django: 1.11 -> 2.2

### DIFF
--- a/pkgs/development/python-modules/diskcache/default.nix
+++ b/pkgs/development/python-modules/diskcache/default.nix
@@ -6,6 +6,7 @@
 , pytest_xdist
 , pytest-django
 , mock
+, django
 }:
 
 buildPythonPackage rec {
@@ -36,5 +37,6 @@ buildPythonPackage rec {
     homepage = "http://www.grantjenks.com/docs/diskcache/";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = lib.versionAtLeast django.version "2.0";
   };
 }

--- a/pkgs/development/python-modules/django-compat/default.nix
+++ b/pkgs/development/python-modules/django-compat/default.nix
@@ -1,6 +1,9 @@
 { stdenv, buildPythonPackage, fetchFromGitHub, python,
   django, six
 }:
+if stdenv.lib.versionAtLeast django.version "2.0"
+then throw "django-compat requires django < 2.0"
+else
 buildPythonPackage rec {
   pname = "django-compat";
   version = "1.0.15";

--- a/pkgs/development/python-modules/django-configurations/default.nix
+++ b/pkgs/development/python-modules/django-configurations/default.nix
@@ -9,6 +9,7 @@
 , django-cache-url
 , six
 , django
+, setuptools_scm
 }:
 
 buildPythonPackage rec {
@@ -20,7 +21,9 @@ buildPythonPackage rec {
     sha256 = "9e3bcea1355ac50a4c9f854f751d214cb17e5f8adf18405a4488d0a1e8945915";
   };
 
-  checkInputs = [ django-discover-runner mock dj-database-url dj-email-url dj-search-url django-cache-url six ];
+  buildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ six ];
+  checkInputs = [ django-discover-runner mock dj-database-url dj-email-url dj-search-url django-cache-url ];
 
   checkPhase = ''
     export PYTHONPATH=.:$PYTHONPATH

--- a/pkgs/development/python-modules/django-pglocks/default.nix
+++ b/pkgs/development/python-modules/django-pglocks/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, django }:
+{ lib, buildPythonPackage, fetchPypi, django, six }:
 
 buildPythonPackage rec {
   pname = "django-pglocks";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ django ];
-  propagatedBuildInputs = [ django ];
+  propagatedBuildInputs = [ django six ];
 
   # tests need a postgres database
   doCheck = false;

--- a/pkgs/development/python-modules/django-raster/default.nix
+++ b/pkgs/development/python-modules/django-raster/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, fetchPypi, isPy3k,
   numpy, django_colorful, pillow, psycopg2,
-  pyparsing, django, celery, boto3
+  pyparsing, django, celery, boto3, importlib-metadata
 }:
 if stdenv.lib.versionOlder django.version "2.0"
 then throw "django-raster requires Django >= 2.0. Consider overiding the python package set to use django_2."
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   propagatedBuildInputs = [ numpy django_colorful pillow psycopg2
-                            pyparsing django celery boto3 ];
+                            pyparsing django celery boto3 importlib-metadata ];
 
   meta = with stdenv.lib; {
     description = "Basic raster data integration for Django";

--- a/pkgs/development/python-modules/django-sesame/default.nix
+++ b/pkgs/development/python-modules/django-sesame/default.nix
@@ -1,21 +1,21 @@
-{ lib, buildPythonPackage, fetchPypi
+{ lib, buildPythonPackage, fetchFromGitHub
 , django }:
 
 buildPythonPackage rec {
   pname = "django-sesame";
   version = "1.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e68bad4a6ef44322380f1f01d009f9d3cb55d1ffef0b669574b511db5ab0c6c0";
+  src = fetchFromGitHub {
+    owner = "aaugustin";
+    repo = pname;
+    rev = version;
+    sha256 = "0k8s44zn2jmasp0w064vrx685fn4pbmdfx8qmhkab1hd5ys6pi44";
   };
 
   checkInputs = [ django ];
 
   checkPhase = ''
-    PYTHONPATH="$(pwd):$PYTHONPATH" \
-    DJANGO_SETTINGS_MODULE=sesame.test_settings \
-      django-admin test sesame
+    make test
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/django_appconf/default.nix
+++ b/pkgs/development/python-modules/django_appconf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, six, django }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, six, django, fetchpatch }:
 buildPythonPackage rec {
   pname = "django-appconf";
   version = "1.0.3";
@@ -11,6 +11,14 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ six django ];
+
+  patches = [
+    (fetchpatch {
+      name = "backport_django_2_2.patch";
+      url = "https://github.com/django-compressor/django-appconf/commit/1526a842ee084b791aa66c931b3822091a442853.patch";
+      sha256 = "1vl2s6vlf15089s8p4c3g4d5iqm8jva66bdw683r8440f80ixgmw";
+    })
+  ];
 
   checkPhase = ''
     # prove we're running tests against installed package, not build dir

--- a/pkgs/development/python-modules/mezzanine/default.nix
+++ b/pkgs/development/python-modules/mezzanine/default.nix
@@ -18,6 +18,9 @@
 , chardet
 }:
 
+if stdenv.lib.versionOlder django.version "1.11" || stdenv.lib.versionAtLeast django.version "2.0"
+then throw "mezzanine requires django-1.11. Consider overriding python package set to use django_1_11"
+else
 buildPythonPackage rec {
   version = "4.3.1";
   pname = "Mezzanine";

--- a/pkgs/servers/mail/mailman/web.nix
+++ b/pkgs/servers/mail/mailman/web.nix
@@ -1,7 +1,11 @@
 { buildPythonPackage, lib, fetchgit, isPy3k
 , git, makeWrapper, sassc, hyperkitty, postorius, whoosh
+, django
 }:
 
+if lib.versionOlder "2.2" django.version
+then throw "mailman-web requires django < 2.2"
+else
 buildPythonPackage rec {
   pname = "mailman-web-unstable";
   version = "2019-09-29";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15307,7 +15307,11 @@ in
 
   mailman-rss = callPackage ../development/python-modules/mailman-rss { };
 
-  mailman-web = with python3.pkgs; toPythonApplication mailman-web;
+  mailman-web = with (python3.override {
+    packageOverrides = self: super: {
+      django = self.django_1_11;
+    };
+  }).pkgs; toPythonApplication mailman-web;
 
   mattermost = callPackage ../servers/mattermost { };
   matterircd = callPackage ../servers/mattermost/matterircd.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3216,6 +3216,8 @@ in {
 
   django = self.django_1_11;
 
+  django_lts = self.django_2_2;
+
   django_1_11 = callPackage ../development/python-modules/django/1_11.nix {
     gdal = self.gdal;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3214,7 +3214,7 @@ in {
 
   crayons = callPackage ../development/python-modules/crayons{ };
 
-  django = self.django_1_11;
+  django = self.django_lts;
 
   django_lts = self.django_2_2;
 


### PR DESCRIPTION
###### Motivation for this change

Django-1.11 will end its support before in march 2020, so I try to get rid of it before the 20.03 release.

This PR tries to fix most breakages.

This is still a WIP, but I’d like to have it integreated before 20.03 feature freeze, even if I still have some fixing to do after.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
