### PR TITLE
linuxPackages: 4.19 -> 5.4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -25,6 +25,13 @@
    </listitem>
    <listitem>
     <para>
+     Linux kernel is updated to branch 5.4 by default (from 4.19).
+     Users of Intel GPUs may prefer to explicitly set branch to 4.19 to avoid some regressions.
+     <programlisting>boot.kernelPackages = pkgs.linuxPackages_4_19;</programlisting>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Postgresql for NixOS service now defaults to v11.
     </para>
    </listitem>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16659,7 +16659,7 @@ in
   });
 
   # The current default kernel / kernel modules.
-  linuxPackages = linuxPackages_4_19;
+  linuxPackages = linuxPackages_5_4;
   linux = linuxPackages.kernel;
 
   # Update this when adding the newest kernel major version!


### PR DESCRIPTION
###### Motivation for this change

It's a longterm version that has been out for quite some time:
5.4.15 and 5.5 are current.  I've been using it, so far I'm not aware
of any issues with it.

Feature freeze for the next NixOS release is in two weeks,
so now seems to be high time to decide the default kernel version.
https://discourse.nixos.org/t/nixos-20-03-feature-freeze/5655


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] N/A macOS
   - [ ] N/A other Linux distributions
- [x] (a few) Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested running NixOS with it.
   ~Tested execution of all binary files (usually in `./result/bin/`)~
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date  **FIXME**: if we agree with this, fixup release notes and possibly other docs.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
