### PR TITLE
agenda: init at 1.0.12

### DIFF
--- a/pkgs/applications/office/agenda/default.nix
+++ b/pkgs/applications/office/agenda/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, fetchFromGitHub
+, pantheon
+, cmake
+, pkg-config
+, vala
+, gettext
+, glib
+, gtk3
+, libgee
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "agenda";
+  version = "1.0.12";
+
+  src = fetchFromGitHub {
+    owner = "dahenson";
+    repo = pname;
+    rev = version;
+    sha256 = "128c9p2jkc90imlq25xg5alqlam8q4i3gd5p1kcggf7s4amv8l8w";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    vala
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libgee
+    pantheon.granite
+  ];
+
+  passthru = {
+    updateScript = pantheon.updateScript {
+      attrPath = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "A simple, fast, no-nonsense to-do (task) list designed for elementary OS";
+    homepage = https://github.com/dahenson/agenda;
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18100,6 +18100,8 @@ in
 
   agedu = callPackage ../tools/misc/agedu { };
 
+  agenda = callPackage ../applications/office/agenda { };
+
   ahoviewer = callPackage ../applications/graphics/ahoviewer { };
 
   airwave = callPackage ../applications/audio/airwave { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add more curated apps from Elementary OS app store for Pantheon Desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
