### PR TITLE
python3Packages.gunicorn: add setuptools

### DIFF
--- a/pkgs/development/python-modules/gunicorn/default.nix
+++ b/pkgs/development/python-modules/gunicorn/default.nix
@@ -1,5 +1,10 @@
 { stdenv, buildPythonPackage, fetchPypi
-, pytest, mock, pytestcov, coverage }:
+, coverage
+, mock
+, pytest
+, pytestcov
+, setuptools
+}:
 
 buildPythonPackage rec {
   pname = "gunicorn";
@@ -10,6 +15,8 @@ buildPythonPackage rec {
     sha256 = "fa2662097c66f920f53f70621c6c58ca4a3c4d3434205e608e121b5b3b71f4f3";
   };
 
+  propagatedBuildInputs = [ setuptools ];
+
   checkInputs = [ pytest mock pytestcov coverage ];
 
   prePatch = ''
@@ -17,9 +24,12 @@ buildPythonPackage rec {
       --replace "coverage>=4.0,<4.4" "coverage"
   '';
 
-  # Test failures but patch does not apply cleanly
-  # https://github.com/benoitc/gunicorn/commit/f38f717539b1b7296720805b8ae3969c3509b9c1
-  doCheck = false;
+  # better than no tests
+  checkPhase = ''
+    $out/bin/gunicorn --help > /dev/null
+  '';
+
+  pythonImportsCheck = [ "gunicorn" ];
 
   meta = with stdenv.lib; {
     homepage = https://pypi.python.org/pypi/gunicorn;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bugfix is cherry-picked from master.
Execution of `gunicorn` binary was broken because of missing runtime dependency `setuptools`.
The other binary `gunicorn_paster` does still not work, because some other missing dependency. But the `gunicorn_paster` binary is already removed in the next gunicorn version which is used on master. Therefore I decided to not put any effort into fixing `gunicorn_paster`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
