### PR TITLE
cinnamon.updateScript: add updateScript

### DIFF
--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -1,6 +1,8 @@
 { pkgs, lib }:
 
 lib.makeScope pkgs.newScope (self: with self; {
+  updateScript = callPackage ./update.nix { };
+
   cinnamon-desktop = callPackage ./cinnamon-desktop { };
   cinnamon-menus = callPackage ./cinnamon-menus { };
   cinnamon-translations = callPackage ./cinnamon-translations { };

--- a/pkgs/desktops/cinnamon/gh_update/default.nix
+++ b/pkgs/desktops/cinnamon/gh_update/default.nix
@@ -1,0 +1,13 @@
+{}:
+
+let
+  pkgs = import ../../../../. { };
+  nixNodePackage = builtins.fetchGit {
+    url = "git@github.com:mkg20001/nix-node-package";
+    rev = "2b7a5d1dff02ca7f95e651c60476f17c720a3e72";
+  };
+  makeNode = import "${nixNodePackage}/nix/default.nix" pkgs {
+    root = ./.;
+    nodejs = pkgs.nodejs-10_x;
+  };
+in makeNode { }

--- a/pkgs/desktops/cinnamon/gh_update/gh_update.js
+++ b/pkgs/desktops/cinnamon/gh_update/gh_update.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+'use strict'
+
+// Get the latest tag matching the semver policy for the specified github slug
+
+const fetch = require('node-fetch')
+const Semver = require('semver')
+
+const log = console.error // eslint-disable-line no-console
+
+const wait = (i) => new Promise((resolve, reject) => setTimeout(resolve, i))
+
+async function fetchReleases (slug, page, id) {
+  const params = {}
+
+  if (page) {
+    params.page = page
+  }
+
+  const url = `https://api.github.com/repos/${slug}/releases${id ? `/${id}` : '?' + String(new URLSearchParams(params))}`
+
+  log('GET %s', url)
+  const res = await fetch(url)
+
+  if (res.status === 403) { // we're out of requests, wait
+    log('Out of requests, waiting 5 mins...')
+    await wait(5 * 60 * 1000)
+    return fetchReleases(slug, page, id)
+  }
+
+  if (res.status - (res.status % 100) !== 200) {
+    throw new Error(`Failed to fetch data: ${res.status}`)
+  }
+
+  return {
+    res: await res.json(),
+    next: res.headers.get('link') && res.headers.get('link').indexOf('next') !== -1
+  }
+}
+
+async function fetchTags (slug, page, id) {
+  const params = {}
+
+  if (page) {
+    params.page = page
+  }
+
+  const url = `https://api.github.com/repos/${slug}/tags${id ? `/${id}` : '?' + String(new URLSearchParams(params))}`
+
+  log('GET %s', url)
+  const res = await fetch(url)
+
+  if (res.status === 403) { // we're out of requests, wait
+    log('Out of requests, waiting 5 mins...')
+    await wait(5 * 60 * 1000)
+    return fetchReleases(slug, page, id)
+  }
+
+  if (res.status - (res.status % 100) !== 200) {
+    throw new Error(`Failed to fetch data: ${res.status}`)
+  }
+
+  return {
+    res: await res.json(),
+    next: res.headers.get('link') && res.headers.get('link').indexOf('next') !== -1
+  }
+}
+
+function releasesProcessVersions (semver, versionList) {
+  return versionList.res.filter(v => {
+    if (v.prerelease || v.draft) return false
+    if (!semver) return true
+    return Semver.satisfies(v.tag_name.replace(/^v/, ''), semver)
+  })
+}
+
+function tagsProcessVersions (semver, versionList) {
+  return versionList.res.filter(v => {
+    if (!semver) return true
+    return Semver.satisfies(v.name.replace(/^v/, ''), semver)
+  })
+}
+
+async function fetchLatestMatching (slug, semver) {
+  let page = 1
+
+  let versionFound
+
+  while (!versionFound) {
+    const res = await fetchReleases(slug, page)
+
+    const versions = await releasesProcessVersions(semver, res)
+
+    if (versions.length) {
+      versionFound = versions[0]
+    }
+
+    if (!res.next) { break }
+
+    page++
+  }
+
+  page = 1
+
+  while (!versionFound) {
+    const res = await fetchTags(slug, page)
+
+    const versions = await tagsProcessVersions(semver, res)
+
+    if (versions.length) {
+      versionFound = versions[0]
+    }
+
+    if (!res.next) { break }
+  }
+
+  if (!versionFound) {
+    throw new Error('Semver policy isn\'t matching anything at all - Is it even correct?')
+  }
+
+  console.log(versionFound.tag_name || versionFound.name) // eslint-disable-line no-console
+}
+
+fetchLatestMatching(...process.argv.slice(2))

--- a/pkgs/desktops/cinnamon/gh_update/package-lock.json
+++ b/pkgs/desktops/cinnamon/gh_update/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "gh_update",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "semver": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
+      "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A=="
+    }
+  }
+}

--- a/pkgs/desktops/cinnamon/gh_update/package.json
+++ b/pkgs/desktops/cinnamon/gh_update/package.json
@@ -1,0 +1,23 @@
+{
+  "dependencies": {
+    "node-fetch": "^2.6.0",
+    "semver": "^7.1.1"
+  },
+  "bin": {
+    "gh_update": "./gh_update.js"
+  },
+  "name": "gh_update",
+  "version": "0.0.1",
+  "description": "Script to get latest version from github by semver matching",
+  "main": "gh_update.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "github",
+    "nixpkgs",
+    "update"
+  ],
+  "author": "Maciej Krüger <mkg20001@gmail.com>",
+  "license": "MPL-2.0"
+}

--- a/pkgs/desktops/cinnamon/update.nix
+++ b/pkgs/desktops/cinnamon/update.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, writeScript, callPackage, common-updater-scripts }:
+{
+  pname
+, attrPath ? "cinnamon.${pname}"
+
+, gh_repo ? pname
+, gh_owner ? "linuxmint"
+, gh_url ? "${gh_owner}/${gh_repo}"
+
+, semver ? ""
+}:
+
+let
+  bin = callPackage ./gh_update { };
+  updateScript = writeScript "cinnamon-update-script" ''
+    #!${stdenv.shell}
+    set -o errexit
+    attr_path="$1"
+    slug="$2"
+    semver_policy="$3"
+    PATH=${lib.makeBinPath [ common-updater-scripts bin ]}
+    latest_tag=$(gh_update "$slug" "$semver_policy")
+    update-source-version "$attr_path" "$latest_tag"
+  '';
+in [ updateScript attrPath gh_url semver ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

An update script for cinnamon, to make stuff auto-update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
