### PR TITLE
python3Packages.pywick: init at 0.5.6

### DIFF
--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -1,0 +1,39 @@
+{ buildPythonPackage
+, fetchPypi
+, h5py
+, numpy
+, dill
+, astropy
+, scipy
+, pandas
+, pytest
+, pytestcov
+, pytestrunner
+, coveralls
+, lib
+}:
+
+buildPythonPackage rec {
+  pname   = "hickle";
+  version = "3.4.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1d1qj3yl7635lgkqacz9r8fyhv71396l748ww4wy05ibpignjm2x";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements_test.txt \
+      --replace 'astropy<3.1;' 'astropy;' --replace 'astropy<3.0;' 'astropy;'
+  '';
+
+  propagatedBuildInputs = [ h5py numpy dill ];
+  checkInputs = [ pytest pytestcov pytestrunner coveralls scipy pandas astropy ];
+
+  meta = {
+    description = "Serialize Python data to HDF5";
+    homepage = "https://github.com/telegraphic/hickle";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/pywick/default.nix
+++ b/pkgs/development/python-modules/pywick/default.nix
@@ -1,0 +1,48 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytest
+, h5py
+, hickle
+, numpy
+, pandas
+, pillow
+, six
+, pytorch
+, torchvision
+, tqdm
+, lib
+}:
+
+buildPythonPackage rec {
+  pname   = "pywick";
+  version = "0.5.6";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "achaiah";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1gmlifnv9kji0d1jwg1pa8d96zg48w17qg0sgxwy1y1jf3hn37bm";
+  };
+
+  propagatedBuildInputs = [
+    h5py hickle numpy pandas pillow six pytorch torchvision tqdm
+  ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    runHook preCheck
+    pytest tests/
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "High-level training framework for Pytorch";
+    homepage = "https://github.com/achaiah/pywick";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2717,6 +2717,8 @@ in {
 
   hbmqtt = callPackage ../development/python-modules/hbmqtt { };
 
+  hickle = callPackage ../development/python-modules/hickle { };
+
   hiro = callPackage ../development/python-modules/hiro {};
 
   hglib = callPackage ../development/python-modules/hglib {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1306,6 +1306,8 @@ in {
 
   pywebpush = callPackage ../development/python-modules/pywebpush { };
 
+  pywick = callPackage ../development/python-modules/pywick { };
+
   pyxml = disabledIf isPy3k (callPackage ../development/python-modules/pyxml{ });
 
   pyvcd = callPackage ../development/python-modules/pyvcd { };


### PR DESCRIPTION
python3Packages.hickle: init at 3.4.5

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

Add a package.

Package `hickle` has a test dependency on `astropy<3.1` which I have lifted since Nixpkgs contains `astropy==4.0`.  The tests pass, but this doesn't mean that I warrant that all `astropy` data can be used with this package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
