### PR TITLE
xpra: 2.5.3 -> 3.0.5

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -14,11 +14,11 @@ let
   xf86videodummy = callPackage ./xf86videodummy { };
 in buildPythonApplication rec {
   pname = "xpra";
-  version = "2.5.3";
+  version = "3.0.5";
 
   src = fetchurl {
     url = "https://xpra.org/src/${pname}-${version}.tar.xz";
-    sha256 = "1ys35lj28903alccks9p055psy1fsk1nxi8ncchvw8bfxkkkvbys";
+    sha256 = "1zy4q8sq0j00ybxw3v8ylaj2aj10x2gb0a05aqbcnrwp3hf983vz";
   };
 
   patches = [

--- a/pkgs/tools/X11/xpra/fix-paths.patch
+++ b/pkgs/tools/X11/xpra/fix-paths.patch
@@ -2,18 +2,20 @@ gdiff --git a/setup.py b/setup.py
 index 8d3df15..6156206 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -2359,10 +2359,7 @@ if v4l2_ENABLED:
-     v4l2_pkgconfig = pkgconfig()
-     #fuly warning: cython makes this difficult,
-     #we have to figure out if "device_caps" exists in the headers:
--    ENABLE_DEVICE_CAPS = False
--    if os.path.exists("/usr/include/linux/videodev2.h"):
--        hdata = open("/usr/include/linux/videodev2.h").read()
--        ENABLE_DEVICE_CAPS = hdata.find("device_caps")>=0
-+    ENABLE_DEVICE_CAPS = True
-     kwargs = {"ENABLE_DEVICE_CAPS" : ENABLE_DEVICE_CAPS}
-     make_constants("xpra", "codecs", "v4l2", "constants", **kwargs)
+ -2322,11 +2322,7 @@ if v4l2_ENABLED:                                                                                                                                                       
+     videodev2_h = "/usr/include/linux/videodev2.h"                                                                                                                                           
+     constants_pxi = "xpra/codecs/v4l2/constants.pxi"                                                                                                                                         
+     if not os.path.exists(videodev2_h) or should_rebuild(videodev2_h, constants_pxi):                                                                                                        
+-        ENABLE_DEVICE_CAPS = 0                                                                                                                                                               
+-        if os.path.exists(videodev2_h):                                                                                                                                                      
+-            with open(videodev2_h) as f:
+-                hdata = f.read()
+-            ENABLE_DEVICE_CAPS = int(hdata.find("device_caps")>=0)
++        ENABLE_DEVICE_CAPS = 1
+         with open(constants_pxi, "wb") as f:
+             f.write(b"DEF ENABLE_DEVICE_CAPS=%i" % ENABLE_DEVICE_CAPS)
      cython_add(Extension("xpra.codecs.v4l2.pusher",
+     
 diff --git a/xpra/x11/bindings/keyboard_bindings.pyx b/xpra/x11/bindings/keyboard_bindings.pyx
 index bd7023d..064c6b5 100644
 --- a/xpra/x11/bindings/keyboard_bindings.pyx


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Closes #78707.
Old version (2.5.3) is EOL from upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
