### PR TITLE
opensmtpd: 6.6.1p1 -> 6.6.2p1

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   pname = "opensmtpd";
-  version = "6.6.1p1";
+  version = "6.6.2p1";
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ libasr libevent zlib libressl db pam ];
 
   src = fetchurl {
     url = "https://www.opensmtpd.org/archives/${pname}-${version}.tar.gz";
-    sha256 = "1ngil8j13m2rq07g94j4yjr6zmaimzy8wbfr17shi7rxnazys6zb";
+    sha256 = "16nz2n4s3djlasd6m6dqfwggf6igyfxzq5igny5i0qb8lnn13f33";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Fixes critical vulnerability: https://www.mail-archive.com/misc@opensmtpd.org/msg04850.html

@flokli Since you bumped opensmtpd from 6.4 to 6.6, can be also backport that bump to 19.09?

Here are the changes if we want to pick the changes (not tested if they apply cleanly): https://github.com/OpenSMTPD/OpenSMTPD/compare/6.6.1p1...6.6.2p1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
