### PR TITLE
[19.09] opensmtpd: apply patch for CVE-2020-7247.patch

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./proc_path.diff # TODO: upstream to OpenSMTPD, see https://github.com/NixOS/nixpkgs/issues/54045
+    (fetchurl {
+      name = "CVE-2020-7247.patch";
+      url = "https://github.com/OpenSMTPD/OpenSMTPD/commit/d2688c097e0ff53037c7403e09426771876a3907.patch";
+      sha256 = "1mr5zb7mgpapf80xrcjvvzinzyiqcd3i0z4jwj11wl3zrfq5kwwn";
+    })
   ];
 
   # See https://github.com/OpenSMTPD/OpenSMTPD/issues/885 for the `sh bootstrap`


### PR DESCRIPTION
Backport the fix included in the bump from 6.6.1p1 -> 6.6.2p1.

Master PR: https://github.com/NixOS/nixpkgs/pull/78741

###### Motivation for this change
CVE-2020-7247

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
