### PR TITLE
pythonPackages.regex 2019.12.20 -> 2020.8.1

### DIFF
--- a/pkgs/development/python-modules/regex/default.nix
+++ b/pkgs/development/python-modules/regex/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "regex";
-  version = "2019.12.20";
+  version = "2020.1.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "106e25a841921d8259dcef2a42786caae35bc750fb996f830065b3dfaa67b77e";
+    sha256 = "0lc3fzh72w7hqxihf8ixfhj0p5lhki5jwvrv7crb08lqiwr29x6h";
   };
 
   postCheck = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The `black` code formatter was broken under the previous regex version and works with this version. 

I updated regex because I got this error message from black:
<details><summary>ModuleNotFoundError: No module named 'regex._regex'</summary><p>
Traceback (most recent call last):
  File "/usr/local/bin/black", line 5, in <module>
    from black import patched_main
  File "/nix/store/2mq7rd88rnj3knsg16j3q8x2lg3c0lc2-python3.7-black-19.10b0/lib/python3.7/site-packages/black.py", line 15, in <module>
    import regex as re
  File "/nix/store/gf7y6r2fphfp7mp48khs73b3gw7g38lm-python3.7-regex-2019.12.20/lib/python3.7/site-packages/regex/__init__.py", line 1, in <module>
    from .regex import *
  File "/nix/store/gf7y6r2fphfp7mp48khs73b3gw7g38lm-python3.7-regex-2019.12.20/lib/python3.7/site-packages/regex/regex.py", line 402, in <module>
    import regex._regex_core as _regex_core
  File "/nix/store/gf7y6r2fphfp7mp48khs73b3gw7g38lm-python3.7-regex-2019.12.20/lib/python3.7/site-packages/regex/_regex_core.py", line 21, in <module>
    import regex._regex as _regex
ModuleNotFoundError: No module named 'regex._regex'
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
