### PR TITLE
chrome-token-signing: 1.0.7 -> 1.1.0

### DIFF
--- a/pkgs/tools/security/chrome-token-signing/default.nix
+++ b/pkgs/tools/security/chrome-token-signing/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "chrome-token-signing";
-  version = "1.0.7";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "open-eid";
     repo = "chrome-token-signing";
     rev = "v${version}";
-    sha256 = "1icbr5gyf7qqk1qjgcrf6921ws84j5h8zrpzw5mirq4582l5gsav";
+    sha256 = "1bksh7xrgqfmyrl04l0fri4ldigb1vkzff32n89bnl44nd42bgcr";
   };
 
   buildInputs = [ qmake pcsclite pkgconfig ];

--- a/pkgs/tools/security/chrome-token-signing/default.nix
+++ b/pkgs/tools/security/chrome-token-signing/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchFromGitHub, qmake, pcsclite, pkgconfig, opensc }:
+{ stdenv, mkDerivation, fetchFromGitHub, qmake, pcsclite, pkgconfig, opensc }:
 
 mkDerivation rec {
   pname = "chrome-token-signing";
@@ -27,4 +27,12 @@ mkDerivation rec {
     install -D -t $out/etc/chromium/native-messaging-hosts host-linux/ee.ria.esteid.json
     install -D -t $out/lib/mozilla/native-messaging-hosts host-linux/ff/ee.ria.esteid.json
   '';
+
+  meta = with stdenv.lib; {
+    description = "Chrome and Firefox extension for signing with your eID on the web";
+    homepage = "https://github.com/open-eid/chrome-token-signing/wiki";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.linux;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Updating the package and adding ```meta```.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
