### PR TITLE
sane module: support overriding config files

### DIFF
--- a/pkgs/applications/graphics/sane/config.nix
+++ b/pkgs/applications/graphics/sane/config.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
     function symlink () {
       local target=$1 linkname=$2
       if [ -e "$linkname" ]; then
-        echo "warning: conflict for $linkname. Overriding."
+        echo "warning: conflict for $linkname. Overriding $(readlink $linkname) with $target."
       fi
       ln -sfn "$target" "$linkname"
     }

--- a/pkgs/applications/graphics/sane/config.nix
+++ b/pkgs/applications/graphics/sane/config.nix
@@ -6,7 +6,7 @@ with stdenv.lib;
 let installSanePath = path: ''
       if [ -e "${path}/lib/sane" ]; then
         find "${path}/lib/sane" -maxdepth 1 -not -type d | while read backend; do
-          ln -s "$backend" "$out/lib/sane/$(basename "$backend")"
+          symlink "$backend" "$out/lib/sane/$(basename "$backend")"
         done
       fi
 
@@ -16,14 +16,14 @@ let installSanePath = path: ''
           if [ "$name" = "dll.conf" ] || [ "$name" = "saned.conf" ] || [ "$name" = "net.conf" ]; then
             cat "$conf" >> "$out/etc/sane.d/$name"
           else
-            ln -s "$conf" "$out/etc/sane.d/$name"
+            symlink "$conf" "$out/etc/sane.d/$name"
           fi
         done
       fi
 
       if [ -e "${path}/etc/sane.d/dll.d" ]; then
         find "${path}/etc/sane.d/dll.d" -maxdepth 1 -not -type d | while read conf; do
-          ln -s "$conf" "$out/etc/sane.d/dll.d/$(basename $conf)"
+          symlink "$conf" "$out/etc/sane.d/dll.d/$(basename $conf)"
         done
       fi
     '';
@@ -33,6 +33,14 @@ stdenv.mkDerivation {
   phases = "installPhase";
 
   installPhase = ''
+    function symlink () {
+      local target=$1 linkname=$2
+      if [ -e "$linkname" ]; then
+        echo "warning: conflict for $linkname. Overriding."
+      fi
+      ln -sfn "$target" "$linkname"
+    }
+
     mkdir -p $out/etc/sane.d $out/etc/sane.d/dll.d $out/lib/sane
   '' + concatMapStrings installSanePath paths;
 }


### PR DESCRIPTION

###### Motivation for this change

Currently, sane configuration cannot be overridden, because backends cannot contain colliding files.
This update allows collisions, and takes the latest file in the list of backends.

See https://discourse.nixos.org/t/l355-epson-wifi-scanner/5543/8

This is a bit hacky, but will be very helpful in a first approach, before someone rewrites this module thoroughly.

TODO: This seems like a good canditate for buildEnv. Is it really important that subdirs are not traversed ? The code dates back to 2014-2016, so maybe the reason is just legacy.

/cc @ttuegel, @abbradar for info

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


