### PR TITLE
geant4: 10.5.1 -> 10.6.0

### DIFF
--- a/pkgs/development/libraries/physics/geant4/datasets.nix
+++ b/pkgs/development/libraries/physics/geant4/datasets.nix
@@ -35,78 +35,78 @@ in
   builtins.listToAttrs (map (a: { inherit (a) name; value = mkDataset a; }) [
     {
       name = "G4NDL";
-      version = "4.5";
-      sha256 = "cba928a520a788f2bc8229c7ef57f83d0934bb0c6a18c31ef05ef4865edcdf8e";
+      version = "4.6";
+      sha256 = "022l2jjhi57frfdv9nk6s6q23gmr9zkix06fmni8gf0gmvr7qa4x";
       envvar = "NEUTRONHP";
     }
 
     {
       name = "G4EMLOW";
-      version = "7.7";
-      sha256 = "16dec6adda6477a97424d749688d73e9bd7d0b84d0137a67cf341f1960984663";
+      version = "7.9";
+      sha256 = "1zrsvk2ahlwss6mgjrma6d2ii49vlzcd5r3ccw94c7m9rnk9mgsa";
       envvar = "LE";
     }
 
     {
       name = "G4PhotonEvaporation";
-      version = "5.3";
-      sha256 = "d47ababc8cbe548065ef644e9bd88266869e75e2f9e577ebc36bc55bf7a92ec8";
+      version = "5.5";
+      sha256 = "1mvnbs7yvkii41blks6bkqr8qhxgnj3xxvv1i3vdg2y14shxv5ar";
       envvar = "LEVELGAMMA";
     }
 
     {
       name = "G4RadioactiveDecay";
-      version = "5.3";
-      sha256 = "5c8992ac57ae56e66b064d3f5cdfe7c2fee76567520ad34a625bfb187119f8c1";
+      version = "5.4";
+      sha256 = "0qaark6mqzxr3lqawv6ai8z5211qihlp5x2hn86vzx8kgpd7j1r4";
       envvar = "RADIOACTIVE";
     }
 
     {
       name = "G4SAIDDATA";
       version = "2.0";
-      sha256 = "1d26a8e79baa71e44d5759b9f55a67e8b7ede31751316a9e9037d80090c72e91";
+      sha256 = "149fqy801n1pj2g6lcai2ziyvdz8cxdgbfarax6y8wdakgksh9hx";
       envvar = "SAIDXS";
     }
 
     {
       name = "G4PARTICLEXS";
-      version = "1.1";
-      sha256 = "100a11c9ed961152acfadcc9b583a9f649dda4e48ab314fcd4f333412ade9d62";
+      version = "2.1";
+      sha256 = "0h8ba8jk197npbd9lzq2qlfiklbjgqwk45m1cc6piy5vf8ri0k89";
       envvar = "PARTICLEXS";
     }
 
     {
       name = "G4ABLA";
       version = "3.1";
-      sha256 = "7698b052b58bf1b9886beacdbd6af607adc1e099fc730ab6b21cf7f090c027ed";
+      sha256 = "1v97q28g1xqwnav0lwzwk7hc3b87yrmbvkgadf4bkwcbnm9b163n";
       envvar = "ABLA";
     }
 
     {
       name = "G4INCL";
       version = "1.0";
-      sha256 = "716161821ae9f3d0565fbf3c2cf34f4e02e3e519eb419a82236eef22c2c4367d";
+      sha256 = "0z9nqk125vvf4f19lhgb37jy60jf9zrjqg5zbxbd1wz93a162qbi";
       envvar = "INCL";
     }
 
     {
       name = "G4PII";
       version = "1.3";
-      sha256 = "6225ad902675f4381c98c6ba25fc5a06ce87549aa979634d3d03491d6616e926";
+      sha256 = "09p92rk1sj837m6n6yd9k9a8gkh6bby2bfn6k0f3ix3m4s8as9b2";
       envvar = "PII";
     }
 
     {
       name = "G4ENSDFSTATE";
       version = "2.2";
-      sha256 = "dd7e27ef62070734a4a709601f5b3bada6641b111eb7069344e4f99a01d6e0a6";
+      sha256 = "19p0sq0rmyg48j9hddqy24dn99md7ddiyq09lyj381q7cbpjfznx";
       envvar = "ENSDFSTATE";
     }
 
     {
       name = "G4RealSurface";
-      version = "2.1";
-      sha256 = "2a287adbda1c0292571edeae2082a65b7f7bd6cf2bf088432d1d6f889426dcf3";
+      version = "2.1.1";
+      sha256 = "0l3gs0nlp10cjlwiln3f72zfch0av2g1r8m2ny9afgvwgbwiyj4h";
       envvar = "REALSURFACE";
     }
   ])

--- a/pkgs/development/libraries/physics/geant4/g4py/default.nix
+++ b/pkgs/development/libraries/physics/geant4/g4py/default.nix
@@ -18,12 +18,14 @@ stdenv.mkDerivation {
   inherit (geant4_nomt) version src;
   pname = "g4py";
 
-  sourceRoot = "geant4.10.05.p01/environments/g4py";
-
   nativeBuildInputs = [ cmake ];
   buildInputs = [ geant4_nomt xercesc boost_python python ];
 
   GEANT4_INSTALL = geant4_nomt;
+
+  postPatch = ''
+    cd environments/g4py
+  '';
 
   preConfigure = ''
     # Fix for boost 1.67+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updating version to 10.6.0 and updating associated datasets to their newest version.

Also updated hashes to base32, and fixed issue with bash scripting due to the (new?) default of `set -u`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
