### PR TITLE
acsccid: 1.1.6 -> 1.1.8

### DIFF
--- a/pkgs/tools/security/acsccid/default.nix
+++ b/pkgs/tools/security/acsccid/default.nix
@@ -1,20 +1,21 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, gettext, flex, perl, pkgconfig, pcsclite, libusb }:
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, gettext, flex, perl, pkgconfig, pcsclite, libusb, libiconv }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.6";
+  version = "1.1.8";
   pname = "acsccid";
 
   src = fetchFromGitHub {
     owner = "acshk";
-    repo = "acsccid";
-    rev = "26bc84c738d12701e6a7289ed578671d71cbf3cb";
-    sha256 = "09k7hvcay092wkyf0hjsvimg1h4qzss1nk7m5yanlib4ldhw5g5c";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12aahrvsk21qgpjwcrr01s742ixs44nmjkvcvqyzhqb307x1rrn3";
   };
 
   doCheck = true;
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ pcsclite libusb autoconf automake libtool gettext flex perl ];
+  buildInputs = [ pcsclite libusb autoconf automake libtool gettext flex perl ]
+                ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv ];
 
   postPatch = ''
     sed -e s_/bin/echo_echo_g -i src/Makefile.am


### PR DESCRIPTION
###### Motivation for this change

acsccid: 1.1.6 -> 1.1.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
