### PR TITLE
python3Packages.cirq: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1905,6 +1905,12 @@
     email = "burkett.andrew@gmail.com";
     name = "Andrew Burkett";
   };
+  drewrisinger = {
+    email = "drisinger+nixpkgs@gmail.com";
+    github = "drewrisinger";
+    gitHubId = 10198051;
+    name = "Drew Risinger";
+  };
   dsferruzza = {
     email = "david.sferruzza@gmail.com";
     github = "dsferruzza";

--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -1,0 +1,86 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, google_api_python_client
+, matplotlib
+, networkx
+, numpy
+, pandas
+, pythonProtobuf  # pythonPackages.protobuf
+, requests
+, scipy
+, sortedcontainers
+, sympy
+, typing-extensions
+  # test inputs
+, pytestCheckHook
+, pytest-benchmark
+, ply
+, pydot
+, pyyaml
+, pygraphviz
+}:
+
+buildPythonPackage rec {
+  pname = "cirq";
+  version = "0.6.1";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "quantumlib";
+    repo = "cirq";
+    rev = "v${version}";
+    sha256 = "0lhr2dka7vpz9xd6akxphrcv2b3ni2cgjywpc1r7qpqa5mrq1q7f";
+  };
+
+  # Cirq 0.6 requires networkx==2.3 only for optional qiskit dependency/test, disable this to avoid networkx version conflicts. https://github.com/quantumlib/Cirq/issues/2368
+  # Cirq locks protobuf==3.8.0, but tested working with default pythonPackages.protobuf (3.7). This avoids overrides/pythonPackages.protobuf conflicts
+  prePatch = ''
+    substituteInPlace requirements.txt --replace "networkx==2.3" "networkx" \
+      --replace "protobuf==3.8.0" "protobuf"
+
+    # Fix sympy 1.5 test failures. Should be fixed in v0.7
+    substituteInPlace cirq/optimizers/eject_phased_paulis_test.py --replace "phase_exponent=0.125 + x / 8" "phase_exponent=0.125 + x * 0.125"
+    substituteInPlace cirq/contrib/quirk/cells/parse_test.py --replace "parse_formula('5t') == 5 * t" "parse_formula('5t') == 5.0 * t"
+  '';
+
+  propagatedBuildInputs = [
+    google_api_python_client
+    numpy
+    matplotlib
+    networkx
+    pandas
+    pythonProtobuf
+    requests
+    scipy
+    sortedcontainers
+    sympy
+    typing-extensions
+  ];
+
+  doCheck = true;
+  # pythonImportsCheck = [ "cirq" "cirq.Ciruit" ];  # cirq's importlib hook doesn't work here
+  dontUseSetuptoolsCheck = true;
+  checkInputs = [
+    pytestCheckHook
+    pytest-benchmark
+    ply
+    pydot
+    pyyaml
+    pygraphviz
+  ];
+  # TODO: enable op_serializer_test. Error is type checking, for some reason wants bool instead of numpy.bool_. Not sure if protobuf or internal issue
+  pytestFlagsArray = [
+    "--ignore=dev_tools"  # Only needed when developing new code, which is out-of-scope
+    "--ignore=cirq/google/op_serializer_test.py"  # investigating in https://github.com/quantumlib/Cirq/issues/2727
+  ];
+
+  meta = with lib; {
+    description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
+    homepage = "http://github.com/quantumlib/cirq";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1824,6 +1824,10 @@ in {
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
 
+  cirq = callPackage ../development/python-modules/cirq {
+    pythonProtobuf = self.protobuf;
+  };
+
   colorcet = callPackage ../development/python-modules/colorcet { };
 
   coloredlogs = callPackage ../development/python-modules/coloredlogs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add Google's Cirq package.
Uses: Quantum information science.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
