### PR TITLE
Dovecot plugin for Full Text Search (FTS) with Xapian

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3813,6 +3813,12 @@
     githubId = 11947756;
     name = "Julien Dehos";
   };
+  julm = {
+    email = "julm+nix@sourcephile.fr";
+    github = "ju1m";
+    githubId = 21160136;
+    name = "Julien Moutinho";
+  };
   jumper149 = {
     email = "felixspringer149@gmail.com";
     github = "jumper149";

--- a/pkgs/servers/mail/dovecot/plugins/fts_xapian/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/fts_xapian/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, pkg-config, dovecot, libtool, xapian, icu64, sqlite }:
+stdenv.mkDerivation {
+  pname = "fts-xapian";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "grosjo";
+    repo = "fts-xapian";
+    rev = "1.3.1";
+    sha256 = "10yl5fyfbx2ijqckx13vbmzj9mpm5pkh8qzichbdgplrzm738q43";
+  };
+
+  buildInputs = [ dovecot xapian icu64 sqlite ];
+
+  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+
+  preConfigure = ''
+    export PANDOC=false
+    autoreconf -vi
+  '';
+
+  configureFlags = [
+    "--with-dovecot=${dovecot}/lib/dovecot"
+    "--without-dovecot-install-dirs"
+    "--with-moduledir=$(out)/lib/dovecot"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/grosjo/fts-xapian";
+    description = "Dovecot FTS plugin based on Xapian";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/mail/dovecot/plugins/fts_xapian/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/fts_xapian/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/grosjo/fts-xapian";
     description = "Dovecot FTS plugin based on Xapian";
     license = licenses.lgpl21;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ julm ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15425,6 +15425,7 @@ in
 
   dovecot = callPackage ../servers/mail/dovecot { };
   dovecot_pigeonhole = callPackage ../servers/mail/dovecot/plugins/pigeonhole { };
+  dovecot_fts_xapian = callPackage ../servers/mail/dovecot/plugins/fts_xapian { };
 
   dspam = callPackage ../servers/mail/dspam { };
 


### PR DESCRIPTION
###### Motivation for this change
Run server-side Xapian-powered Full Text Search (FTS) through IMAP into mails managed by Dovecot2.

###### Things done
Add fts-xapian plugin, loadable with `services.dovecot2.modules = [ pkgs.dovecot_fts_xapian ];`
Pandoc support is disabled.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
