### PR TITLE
gnugp22: try to fix dates (r13y)

### DIFF
--- a/pkgs/tools/security/gnupg/0001-mkdefsinc-use-a-substitutable-SOURCE_DATE_EPOCH.patch
+++ b/pkgs/tools/security/gnupg/0001-mkdefsinc-use-a-substitutable-SOURCE_DATE_EPOCH.patch
@@ -1,0 +1,50 @@
+From: Graham Christensen <graham@grahamc.com>
+Date: Wed, 29 Jan 2020 12:42:43 -0500
+Subject: [PATCH] mkdefsinc: use a substitutable SOURCE_DATE_EPOCH for
+ timestamps
+
+For reproducibility, of course.
+---
+ doc/mkdefsinc.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/doc/mkdefsinc.c b/doc/mkdefsinc.c
+index b8fbed6..1d7ee09 100644
+--- a/doc/mkdefsinc.c
++++ b/doc/mkdefsinc.c
+@@ -105,6 +105,7 @@ get_date_from_files (char **files)
+   struct tm *tp;
+   int errors = 0;
+   time_t stamp = 0;
++  time_t source_date_stamp = @SOURCE_DATE_EPOCH@;
+   char *result;
+
+   for (; (file = *files); files++)
+@@ -130,7 +131,7 @@ get_date_from_files (char **files)
+   if (usedfile)
+     fprintf (stderr, PGM ": taking date from '%s'\n", usedfile);
+
+-  tp = gmtime (&stamp);
++  tp = gmtime (&source_date_stamp);
+   if (!tp)
+     return NULL;
+   result = xmalloc (4+1+2+1+2+1);
+@@ -232,6 +233,7 @@ main (int argc, char **argv)
+
+   if (opt_date && *opt_date)
+     {
++      time_t source_date_stamp = @SOURCE_DATE_EPOCH@;
+       time_t stamp;
+       struct tm *tp;
+
+@@ -241,7 +243,7 @@ main (int argc, char **argv)
+           opt_date[10] = 0;
+         }
+       else if ((stamp = strtoul (opt_date, NULL, 10)) > 0
+-               && (tp = gmtime (&stamp)))
++               && (tp = gmtime (&source_date_stamp)))
+         {
+           p = xmalloc (4+1+2+1+2+1);
+           snprintf (p, 4+1+2+1+2+1, "%04d-%02d-%02d",
+--
+2.23.1


### PR DESCRIPTION
It doesn't work, though, and man pages in $out/share/man/ still use
today's date.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
