### PR TITLE
i3ipc: 1.6.0 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/i3ipc/default.nix
+++ b/pkgs/development/python-modules/i3ipc/default.nix
@@ -1,24 +1,37 @@
 { stdenv, buildPythonPackage, fetchFromGitHub
 , enum-compat
-, xorgserver, pytest, i3, python
+, xorgserver, pytest, pytest-xvfb, pytest-asyncio, i3, python, xlib, xdpyinfo
+, makeFontsConf, coreutils
 }:
 
 buildPythonPackage rec {
   pname = "i3ipc";
-  version = "1.6.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner  = "acrisci";
     repo   = "i3ipc-python";
     rev    = "v${version}";
-    sha256 = "0sb525wvwcnikjaqzha94xr97r1gjys30csmaj17swlxgyczxvq5";
+    sha256 = "10zpbiw1gcndn439g1vxcdkxllwp02qcmaal4w7hi2rzgaw1xkdk";
   };
+  propagatedBuildInputs = [ enum-compat xlib ];
 
-  propagatedBuildInputs = [ enum-compat ];
+  fontsConf = makeFontsConf {
+    fontDirectories = [ ];
+  };
+  FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
+  checkInputs = [ pytest xdpyinfo pytest-asyncio pytest-xvfb xorgserver i3 ];
 
-  checkInputs = [ xorgserver pytest i3 ];
+  postPatch = ''
+    substituteInPlace test/i3.config \
+      --replace /bin/true ${coreutils}/bin/true
+  '';
 
-  checkPhase = ''${python.interpreter} run-tests.py'';
+  checkPhase = ''
+    py.test --ignore=test/aio/test_shutdown_event.py \
+            --ignore=test/test_shutdown_event.py
+  '';
+
 
   meta = with stdenv.lib; {
     description = "An improved Python library to control i3wm and sway";


### PR DESCRIPTION
###### Motivation for this change
i3ipc python module is way to old

###### Things done
Only update the sha1 and the version

- Built on platform(s)
   - [x] other Linux distributions