### PR TITLE
dino: 2019-10-28 -> 0.1.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -2,7 +2,8 @@
 , vala, cmake, ninja, wrapGAppsHook, pkgconfig, gettext
 , gobject-introspection, gnome3, glib, gdk-pixbuf, gtk3, glib-networking
 , xorg, libXdmcp, libxkbcommon
-, libnotify, libsoup, libgee
+, libnotify, libsoup, libgee, utillinux, libselinux, libsepol, libpsl, brotli
+, libsignal-protocol-c
 , libgcrypt
 , epoxy
 , at-spi2-core
@@ -14,15 +15,15 @@
 , icu
  }:
 
-stdenv.mkDerivation {
-  name = "dino-unstable-2019-10-28";
+stdenv.mkDerivation rec {
+  pname = "dino";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "dino";
     repo = "dino";
-    rev = "388cc56674487e7b9e339637369fc55f0e271daf";
-    sha256 = "1v8rnjbzi8qhwb1fv787byxk8ygfs16z2j64h0s6sd3asr4n0kz1";
-    fetchSubmodules = true;
+    rev = "v${version}";
+    sha256 = "1k5cgj5n8s40i71wqdh6m1q0njl45ichfdbbywx9rga5hljz1c54";
   };
 
   nativeBuildInputs = [
@@ -51,12 +52,19 @@ stdenv.mkDerivation {
     pcre
     xorg.libxcb
     xorg.libpthreadstubs
+    xorg.libXtst
     libXdmcp
     libxkbcommon
     epoxy
     at-spi2-core
     dbus
     icu
+    utillinux
+    libselinux
+    libsepol
+    libpsl
+    brotli
+    libsignal-protocol-c
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -3,7 +3,7 @@
 , gobject-introspection, gnome3, glib, gdk-pixbuf, gtk3, glib-networking
 , xorg, libXdmcp, libxkbcommon
 , libnotify, libsoup, libgee, utillinux, libselinux, libsepol, libpsl, brotli
-, libsignal-protocol-c
+, librsvg, libsignal-protocol-c
 , libgcrypt
 , epoxy
 , at-spi2-core
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
     libpsl
     brotli
     libsignal-protocol-c
+    librsvg
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -67,8 +67,6 @@ stdenv.mkDerivation rec {
     libsignal-protocol-c
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Modern Jabber/XMPP Client using GTK/Vala";
     homepage = https://github.com/dino/dino;

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -72,6 +72,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/dino/dino;
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = [ maintainers.mic92 ];
+    maintainers = with maintainers; [ mic92 qyliss ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
