### PR TITLE
silicon: init at 0.3.0

### DIFF
--- a/pkgs/tools/misc/silicon/default.nix
+++ b/pkgs/tools/misc/silicon/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, pkgconfig
+, cmake
+, llvmPackages
+, expat
+, freetype
+, libxcb
+, python3
+, AppKit
+, CoreText
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "silicon";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Aloxaf";
+    repo = "silicon";
+    rev = "v${version}";
+    sha256 = "0j211qrkwgll7rm15dk4fcazmxkcqk2zah0qg2s3y0k7cx65bcxy";
+  };
+
+  cargoSha256 = "11b9i1aa36wc7mg2lsvmkiisl23mjkg02xcvlb7zdangwzbv13sq";
+
+  buildInputs = [ llvmPackages.libclang expat freetype ]
+    ++ lib.optionals stdenv.isLinux [ libxcb ]
+    ++ lib.optionals stdenv.isDarwin [ AppKit CoreText Security ];
+
+  nativeBuildInputs = [ cmake pkgconfig ]
+    ++ lib.optionals stdenv.isLinux [ python3 ];
+
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+
+  meta = with lib; {
+    description = "Create beautiful image of your source code.";
+    homepage = "https://github.com/Aloxaf/silicon";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = with maintainers; [ evanjs ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10562,6 +10562,10 @@ in
 
   sigrok-cli = callPackage ../development/tools/sigrok-cli { };
 
+  silicon = callPackage ../tools/misc/silicon {
+    inherit (darwin.apple_sdk.frameworks) AppKit CoreText Security;
+  };
+
   simpleTpmPk11 = callPackage ../tools/security/simple-tpm-pk11 { };
 
   slimerjs = callPackage ../development/tools/slimerjs {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[Silicon](https://github.com/Aloxaf/silicon) is similar to [carbon](https://carbon.now.sh), but works offline, and even supports the Nix expression language.
``` bash
cat nixpkgs/pkgs/tools/misc/silicon/default.nix | silicon -l nix --output /tmp/silicon.nix.png
```
![silicon nix](https://user-images.githubusercontent.com/1847524/73409647-e40ce280-42cd-11ea-9a33-beb4c77ed05d.png)

###### Things done
Can anybody confirm whether this works on Darwin?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
