### PR TITLE
kubernetes-helm: 3.0.1 -> 3.0.3 and improve build meta

### DIFF
--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -12,7 +12,6 @@ buildGoModule rec {
   };
   modSha256 = "1kmm6yb03g9lsz380rvf32j4icp3rcq7ixxcgsxfgpwqvq08zkn6";
 
-  goPackagePath = "k8s.io/helm";
   subPackages = [ "cmd/helm" ];
   buildFlagsArray = [ "-ldflags=-w -s -X helm.sh/helm/v3/internal/version.version=v${version}" ];
 

--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -2,19 +2,19 @@
 
 buildGoModule rec {
   pname = "helm";
-  version = "3.0.1";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "helm";
     repo = "helm";
     rev = "v${version}";
-    sha256 = "0l5rmmrb6b57w1szwp6g7ad3xv0pgvc394mzjr4bi3bzcjsn7wny";
+    sha256 = "1gdrm3zz7524c8v3g128drfzdyalxlipbzxmwhalm7px4p5z4n0j";
   };
-  modSha256 = "0xjzzwmq3i77anb7w2qfnz7vc0gxq02lylj0xs6dzwl543winshm";
+  modSha256 = "1kmm6yb03g9lsz380rvf32j4icp3rcq7ixxcgsxfgpwqvq08zkn6";
 
   goPackagePath = "k8s.io/helm";
   subPackages = [ "cmd/helm" ];
-  buildFlagsArray = [ "-ldflags=-w -s -X helm.sh/helm/v3/internal/version.gitCommit=v${version}" ];
+  buildFlagsArray = [ "-ldflags=-w -s -X helm.sh/helm/v3/internal/version.version=v${version}" ];
 
   nativeBuildInputs = [ installShellFiles ];
   postInstall = ''
@@ -27,6 +27,6 @@ buildGoModule rec {
     homepage = https://github.com/kubernetes/helm;
     description = "A package manager for kubernetes";
     license = licenses.asl20;
-    maintainers = with maintainers; [ rlupton20 edude03 saschagrunert ];
+    maintainers = with maintainers; [ rlupton20 edude03 saschagrunert Frostman ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update K8s Helm to the latest version. Both 3.0.2 and 3.0.3 are patch releases with some important fixes. Additionally, I'd like to add myself to maintainers as I'm using it quite extensively and can help to keep its package up to date and supported.

https://github.com/helm/helm/releases/tag/v3.0.2
https://github.com/helm/helm/releases/tag/v3.0.3

Fix to `ldflags` is needed to get correct `helm version` output:
```
$ helm version
version.BuildInfo{Version:"v3.0.3", GitCommit:"", GitTreeState:"", GoVersion:"go1.13.6"}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/78796)
<!-- Reviewable:end -->
