### PR TITLE
[wip] nixos/lsb.nix: init

### DIFF
--- a/nixos/modules/config/lsb.nix
+++ b/nixos/modules/config/lsb.nix
@@ -70,10 +70,10 @@
       SDL SDL_image SDL_mixer SDL_ttf SDL2 SDL2_image SDL2_mixer SDL2_ttf
 
       # Imaging
-      cups libsane
+      cups sane-backend
 
       # Trial Use
-      libpng15 gtk3
+      libpng gtk3
 
     ];
 
@@ -92,13 +92,13 @@
       pathsToLink = ["/lib"];
       ignoreCollisions = true;
     };
-  in lib.mkIf config.environment.lsb.enable ({
+  in lib.mkIf config.environment.lsb.enable (lib.mkMerge [{
     environment.sessionVariables.LD_LIBRARY_PATH =
       "${base-libs64}/lib${lib.optionalString config.environment.lsb.support32Bit ":${base-libs32}/lib"}";
 
     environment.systemPackages = with pkgs; [
       # Core
-      bc gnum4 man lsb-release file psmisc ed gettext util-linux
+      bc gnum4 man lsb-release file psmisc ed gettext utillinux
 
       # Languages
       python2 perl python3
@@ -117,12 +117,12 @@
     ];
 
     environment.ld-linux = true;
-  } // lib.mkIf config.environment.lsb.enableDesktop {
+  } (lib.mkIf config.environment.lsb.enableDesktop {
     hardware.opengl.enable = lib.mkDefault true;
     hardware.pulseaudio.enable = lib.mkDefault true;
-  } // lib.mkIf (config.environment.lsb.support32Bit && config.environment.lsb.enableDesktop) {
+  }) (lib.mkIf (config.environment.lsb.support32Bit && config.environment.lsb.enableDesktop) {
     hardware.opengl.driSupport32Bit = lib.mkDefault true;
     hardware.pulseaudio.support32Bit = lib.mkDefault true;
-  });
+  })]);
 
 }

--- a/nixos/modules/config/lsb.nix
+++ b/nixos/modules/config/lsb.nix
@@ -41,7 +41,7 @@
       libxml2 libxslt
 
       # Bonus (not in LSB)
-      bzip2 curl expat libusb1 libcap dbus
+      bzip2 curl expat libusb1 libcap dbus libuuid
 
     ] ++ lib.optionals config.environment.lsb.enableDesktop [
       # Desktop
@@ -49,6 +49,8 @@
       ## Graphics Libraries (X11)
       xorg.libX11 xorg.libxcb xorg.libSM xorg.libICE xorg.libXt
       xorg.libXft xorg.libXrender xorg.libXext xorg.libXi xorg.libXtst
+      xorg.libXcursor xorg.libXcomposite xorg.libXfixes
+      xorg.libXdamage xorg.libXrandr xorg.libXScrnSaver xorg.libXfixes
       libxkbcommon
 
       ## OpenGL Libraries
@@ -58,7 +60,7 @@
       libpng12 libjpeg fontconfig freetype libtiff cairo pango atk
 
       ## GTK+ Stack Libraries
-      gtk2 gdk-pixbuf glib dbus-glib
+      gtk2 gdk-pixbuf glib dbus-glib at-spi2-core at-spi2-atk
 
       ## Qt Libraries
       qt4

--- a/nixos/modules/config/lsb.nix
+++ b/nixos/modules/config/lsb.nix
@@ -1,0 +1,128 @@
+{ config, pkgs, lib, ... }:
+
+{
+
+  options = {
+    environment.lsb.enable = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+        Enable approximate LSB binary compatibility. This allows
+        binaries that run on other distros to run on NixOS.
+      '';
+      default = false;
+    };
+
+    environment.lsb.enableDesktop = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+        Enable LSB Desktop extensions.
+      '';
+      default = true;
+    };
+
+    environment.lsb.support32Bit = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+         Enable LSB binary compatibility.
+       '';
+      default = false;
+    };
+  };
+
+  config = let
+    # based on LSB 5.0
+    # reference: http://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Common/LSB-Common/requirements.html#RLIBRARIES
+
+    libsFromPkgs = pkgs: with pkgs; [
+      # Core
+      glibc gcc.cc zlib ncurses5 linux-pam nspr nspr nss openssl
+
+      # Runtime Languages
+      libxml2 libxslt
+
+      # Bonus (not in LSB)
+      bzip2 curl expat libusb1 libcap dbus
+
+    ] ++ lib.optionals config.environment.lsb.enableDesktop [
+      # Desktop
+
+      ## Graphics Libraries (X11)
+      xorg.libX11 xorg.libxcb xorg.libSM xorg.libICE xorg.libXt
+      xorg.libXft xorg.libXrender xorg.libXext xorg.libXi xorg.libXtst
+      libxkbcommon
+
+      ## OpenGL Libraries
+      libGL libGLU
+
+      ## Misc. desktop
+      libpng12 libjpeg fontconfig freetype libtiff cairo pango atk
+
+      ## GTK+ Stack Libraries
+      gtk2 gdk-pixbuf glib dbus-glib
+
+      ## Qt Libraries
+      qt4
+
+      ## Sound libraries
+      alsaLib openal
+
+      ## SDL
+      SDL SDL_image SDL_mixer SDL_ttf SDL2 SDL2_image SDL2_mixer SDL2_ttf
+
+      # Imaging
+      cups libsane
+
+      # Trial Use
+      libpng15 gtk3
+
+    ];
+
+    base-libs32 = pkgs.buildEnv {
+      name = "fhs-base-libs32";
+      paths = map lib.getLib (libsFromPkgs pkgs.pkgsi686Linux);
+      extraOutputsToInstall = ["lib"];
+      pathsToLink = ["/lib"];
+      ignoreCollisions = true;
+    };
+
+    base-libs64 = pkgs.buildEnv {
+      name = "fhs-base-libs64";
+      paths = map lib.getLib (libsFromPkgs pkgs);
+      extraOutputsToInstall = ["lib"];
+      pathsToLink = ["/lib"];
+      ignoreCollisions = true;
+    };
+  in lib.mkIf config.environment.lsb.enable ({
+    environment.sessionVariables.LD_LIBRARY_PATH =
+      "${base-libs64}/lib${lib.optionalString config.environment.lsb.support32Bit ":${base-libs32}/lib"}";
+
+    environment.systemPackages = with pkgs; [
+      # Core
+      bc gnum4 man lsb-release file psmisc ed gettext util-linux
+
+      # Languages
+      python2 perl python3
+
+      # Misc.
+      pciutils which usbutils
+
+      # Bonus
+      bzip2
+    ] ++ lib.optionals config.environment.lsb.enableDesktop [
+      # Desktop
+      xdg_utils xorg.xrandr fontconfig cups
+
+      # Imaging
+      foomatic_filters ghostscript
+    ];
+
+    environment.ld-linux = true;
+  } // lib.mkIf config.environment.lsb.enableDesktop {
+    hardware.opengl.enable = lib.mkDefault true;
+    hardware.pulseaudio.enable = lib.mkDefault true;
+  } // lib.mkIf (config.environment.lsb.support32Bit && config.environment.lsb.enableDesktop) {
+    hardware.opengl.driSupport32Bit = lib.mkDefault true;
+    hardware.pulseaudio.support32Bit = lib.mkDefault true;
+  });
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -20,6 +20,7 @@
   ./config/krb5/default.nix
   ./config/ldap.nix
   ./config/locale.nix
+  ./config/lsb.nix
   ./config/malloc.nix
   ./config/networking.nix
   ./config/no-x-libs.nix


### PR DESCRIPTION
Add an LSB module to run binaries built for other distros. Two
sub-options are available:

  - enableDesktop: add extra desktop libraries like gtk & qt
  - support32Bit: support 32-bit binaries

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
