### PR TITLE
cargo-geiger: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/tools/rust/cargo-geiger/cargo-lock.patch
+++ b/pkgs/development/tools/rust/cargo-geiger/cargo-lock.patch
@@ -1,0 +1,318 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index b354f9b..5a17ec2 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "aho-corasick"
+-version = "0.7.6"
++version = "0.7.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -55,7 +55,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "backtrace"
+-version = "0.3.42"
++version = "0.3.43"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -78,8 +78,8 @@ name = "better-panic"
+ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "backtrace 0.3.42 (registry+https://github.com/rust-lang/crates.io-index)",
+- "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "backtrace 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "console 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -170,17 +170,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "cargo-geiger"
+-version = "0.9.0"
++version = "0.9.1"
+ dependencies = [
+  "assert_cmd 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "better-panic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "cargo 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "cargo-platform 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "colored 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "console 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "geiger 0.4.3",
+- "insta 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "insta 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pico-args 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -262,7 +262,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "console"
+-version = "0.9.1"
++version = "0.9.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl 0.10.27 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -357,7 +357,7 @@ dependencies = [
+  "curl-sys 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+  "schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+  "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -372,7 +372,7 @@ dependencies = [
+  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libnghttp2-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -390,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "dtoa"
+-version = "0.4.4"
++version = "0.4.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -426,7 +426,7 @@ name = "failure"
+ version = "0.1.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "backtrace 0.3.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "backtrace 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -533,7 +533,7 @@ dependencies = [
+  "libgit2-sys 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -558,7 +558,7 @@ name = "globset"
+ version = "0.4.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "aho-corasick 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
+  "bstr 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -646,16 +646,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "insta"
+-version = "0.13.0"
++version = "0.13.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "console 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+- "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -695,7 +694,7 @@ dependencies = [
+  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libssh2-sys 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -716,7 +715,7 @@ dependencies = [
+  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -791,7 +790,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "openssl"
+-version = "0.10.26"
++version = "0.10.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -799,7 +798,7 @@ dependencies = [
+  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+- "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -809,10 +808,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "openssl-sys"
+-version = "0.9.53"
++version = "0.9.54"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -939,7 +938,7 @@ name = "regex"
+ version = "1.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "aho-corasick 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
+  "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "regex-syntax 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1076,7 +1075,7 @@ name = "serde_yaml"
+ version = "0.8.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1097,7 +1096,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "smallvec"
+-version = "1.1.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -1231,7 +1230,7 @@ name = "unicode-normalization"
+ version = "0.1.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -1259,15 +1258,6 @@ name = "utf8parse"
+ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+-[[package]]
+-name = "uuid"
+-version = "0.8.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+ [[package]]
+ name = "vcpkg"
+ version = "0.2.8"
+@@ -1338,13 +1328,13 @@ dependencies = [
+ 
+ [metadata]
+ "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
+-"checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
++"checksum aho-corasick 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5f56c476256dc249def911d6f7580b5fc7e875895b5d7ee88f5d602208035744"
+ "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+ "checksum assert_cmd 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6283bac8dd7226470d491bc4737816fea4ca1fba7a2847f2e9097fd6bfb4624c"
+ "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+ "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+ "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+-"checksum backtrace 0.3.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b4b1549d804b6c73f4817df2ba073709e96e426f12987127c48e6745568c350b"
++"checksum backtrace 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)" = "7f80256bc78f67e7df7e36d77366f636ed976895d91fe2ab9efa3973e8fe8c4f"
+ "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+ "checksum better-panic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d12a680cc74d8c4a44ee08be4a00dedf671b089c2440b2e3fdaa776cd468476"
+ "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+@@ -1360,7 +1350,7 @@ dependencies = [
+ "checksum colored 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8815e2ab78f3a59928fc32e141fbeece88320a240e43f47b2fd64ea3a88a5b3d"
+ "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
+ "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
+-"checksum console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f5d540c2d34ac9dd0deb5f3b5f54c36c79efa78f6b3ad19106a554d07a7b5d9f"
++"checksum console 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45e0f3986890b3acbc782009e2629dfe2baa430ac091519ce3be26164a2ae6c0"
+ "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+ "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+ "checksum crates-io 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "54a5db4b026e2d3bad49a9775b01722035ebc6976b95ec556716852d640f3ad5"
+@@ -1373,7 +1363,7 @@ dependencies = [
+ "checksum curl-sys 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)" = "0c38ca47d60b86d0cc9d42caa90a0885669c2abc9791f871c81f58cdf39e979b"
+ "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+ "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
+-"checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
++"checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+ "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+ "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+ "checksum escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74cf96bec282dcdb07099f7e31d9fed323bca9435a09aba7b6d99b7617bca96d"
+@@ -1401,7 +1391,7 @@ dependencies = [
+ "checksum ignore 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "522daefc3b69036f80c7d2990b28ff9e0471c683bad05ca258e0a01dd22c5a1e"
+ "checksum im-rc 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0197597d095c0d11107975d3175173f810ee572c2501ff4de64f4f3f119806"
+ "checksum indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
+-"checksum insta 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d07d2003a61f1eae49feeb2aea003d0da6c80587c20ac505d695805c744d4847"
++"checksum insta 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8df742abee84dbf27d20869c9adf77b0d8f7ea3eead13c2c9e3998d136a97058"
+ "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+ "checksum jobserver 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "67b06c1b455f1cf4269a8cfc320ab930a810e2375a42af5075eb8a8b36405ce0"
+ "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+@@ -1419,9 +1409,9 @@ dependencies = [
+ "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+ "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+ "checksum opener 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae"
+-"checksum openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585"
++"checksum openssl 0.10.27 (registry+https://github.com/rust-lang/crates.io-index)" = "e176a45fedd4c990e26580847a525e39e16ec32ac78957dbf62ded31b3abfd6f"
+ "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+-"checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
++"checksum openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)" = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
+ "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+ "checksum petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
+ "checksum pico-args 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ad1f1b834a05d42dae330066e9699a173b28185b3bdc3dbf14ca239585de8cc"
+@@ -1458,7 +1448,7 @@ dependencies = [
+ "checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
+ "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
+ "checksum sized-chunks 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f01db57d7ee89c8e053245deb77040a6cc8508311f381c88749c33d4b9b78785"
+-"checksum smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
++"checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+ "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+ "checksum strip-ansi-escapes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
+ "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+@@ -1479,7 +1469,6 @@ dependencies = [
+ "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+ "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+ "checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
+-"checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+ "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+ "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+ "checksum vte 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf"

--- a/pkgs/development/tools/rust/cargo-geiger/default.nix
+++ b/pkgs/development/tools/rust/cargo-geiger/default.nix
@@ -6,16 +6,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-geiger";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
-    owner = "anderejd";
+    owner = "rust-secure-code";
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "0yn4m94bklxyg0cxzhqm1m976z66rbi58ri1phffvqz457mxj3hk";
+    sha256 = "0kvmjahyx5dcjhry2hkvcshi0lbgipfj0as74a3h3bllfvdfkkg0";
   };
 
-  cargoSha256 = "0608wvbdw4i9pp3x6dgny186if6bzlbivkvfd5lfp1x1f53534za";
+  cargoSha256 = "0aykhhxk416p237safmqh5dhwjgrhvgc6zikkmxi9rq567ypp914";
+  cargoPatches = [ ./cargo-lock.patch ];
 
   # Multiple tests require internet connectivity, so they are disabled here.
   # If we ever get cargo-insta (https://crates.io/crates/insta) in tree,
@@ -40,7 +41,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Detects usage of unsafe Rust in a Rust crate and its dependencies.";
-    homepage = https://github.com/anderejd/cargo-geiger;
+    homepage = https://github.com/rust-secure-code/cargo-geiger;
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ evanjs ];
     platforms = platforms.all;

--- a/pkgs/development/tools/rust/cargo-geiger/update-cargo-lock.sh
+++ b/pkgs/development/tools/rust/cargo-geiger/update-cargo-lock.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# This updates cargo-lock.patch for the diesel version listed in default.nix.
+
+set -eu -o verbose
+
+here=$PWD
+version=$(cat default.nix | grep '^  version = "' | cut -d '"' -f 2)
+checkout=$(mktemp -d)
+git clone -b "cargo-geiger-$version" --depth=1 https://github.com/rust-secure-code/cargo-geiger "$checkout"
+cd "$checkout"
+
+rm -f rust-toolchain
+cargo generate-lockfile
+git add -f Cargo.lock
+git diff HEAD -- Cargo.lock > "$here"/cargo-lock.patch
+
+cd "$here"
+rm -rf "$checkout"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/rust-secure-code/cargo-geiger/releases/tag/cargo-geiger-0.9.1

###### Things done
- add cargo-lock.patch
- add update-cargo-lock.sh
- update src owner and homepage to reflect new main repository
___
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
