### PR TITLE
glibc: Fix build error due to warning with musl

### DIFF
--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -54,9 +54,10 @@ callPackage ./common.nix { inherit stdenv; } {
         # Fix -Werror build failure when building glibc with musl with GCC >= 8, see:
         # https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
         (stdenv.lib.optional stdenv.hostPlatform.isMusl "-Wno-error=attribute-alias")
-        (stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+        (stdenv.lib.optionals ((stdenv.hostPlatform != stdenv.buildPlatform) || stdenv.hostPlatform.isMusl) [
           # Ignore "error: '__EI___errno_location' specifies less restrictive attributes than its target '__errno_location'"
           # New warning as of GCC 9
+          # Same for musl: https://github.com/NixOS/nixpkgs/issues/78805
           "-Wno-error=missing-attributes"
         ])
       ]);


### PR DESCRIPTION
###### Motivation for this change

Fixes #78805

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
