### PR TITLE
swiftformat: 0.44.0 -> 0.44.2

### DIFF
--- a/pkgs/development/tools/swiftformat/default.nix
+++ b/pkgs/development/tools/swiftformat/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "swiftformat";
-  version = "0.44.0";
+  version = "0.44.2";
 
   src = fetchFromGitHub {
     owner = "nicklockwood";
     repo = "SwiftFormat";
     rev = "${version}";
-    sha256 = "13s6syzpxklkv07s1dzdccnqz6p316rrhjpxg8y8dy19ynj5jzvg";
+    sha256 = "17g4w8kmkrhcp7lrfi525ck9jhcm96d0nn93yadacdjcdnchmih1";
   };
 
   preConfigure = "LD=$CC";


### PR DESCRIPTION
## Motivation for this change

Update for the following changes in the program:

### [0.44.2](https://github.com/nicklockwood/SwiftFormat/releases/tag/0.44.2) (2020-02-02)

- Fixed crash in line wrapping logic
- Fixed several cases where braces were not correctly moved according to `wrap` rule
- Prevented wrapping of image and color literals
- Fixed bug with `trailingClosures` rule breaking unwrap operators

### [0.44.1](https://github.com/nicklockwood/SwiftFormat/releases/tag/0.44.1) (2020-01-26)

- Fixed `spaceInsideComments` rule mangling preformatted comments with multiple slashes
- Fixed `redundantFileprivate` breaking code relying on type-inference for `init`
- Reverted overly aggressive argument wrapping change in 0.44.0
- Fixed `redundantParens` rule breaking `#if` statements without space before argument
- Fixed `// swiftformat:disable` directives not affecting `wrap` or `wrapArguments` rules
- Fixed bug where `yodaConditions` rule caused formatting to never terminate
- Fixed crash in `fileHeader` rule

## Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
