### PR TITLE
pythonPackages.Babel: Fix build with Nix < 2.3

### DIFF
--- a/pkgs/development/python-modules/Babel/default.nix
+++ b/pkgs/development/python-modules/Babel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, pytz, pytest, freezegun, glibcLocales }:
+{ stdenv, lib, buildPythonPackage, fetchPypi, fetchpatch, pytz, pytest, freezegun, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "Babel";
@@ -9,14 +9,31 @@ buildPythonPackage rec {
     sha256 = "e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28";
   };
 
+  patches = [
+    # The following 2 patches fix the test suite failing on nix < 2.3 with
+    # Python < 3 because those nix versions do not run in a pseudoterminal,
+    # which makes Python 2 not set the default encoding to UTF-8, and the
+    # Babel code crashes when printing a warning in that case.
+    # See #75676 and https://github.com/python-babel/babel/pull/691.
+    # It is important to fix this because otherwise Babel is not buildable
+    # with older nix versions (e.g. on machines used as --builders).
+    # TODO: Remove at release > 2.8.0.
+    (fetchpatch {
+      name = "Babel-Introduce-invariant-that-invalid_pofile-takes-unicode-line.patch";
+      url = "https://github.com/python-babel/babel/commit/f4f6653e6aa053724d2c6dc0ee71dcb928013352.patch";
+      sha256 = "1kyknwn9blspcf9yxmgdiaxdii1dnkblyhcflqwhxyl1mss1dxv5";
+    })
+    (fetchpatch {
+      name = "Babel-Fix-unicode-printing-error-on-Python-2-without-TTY.patch";
+      url = "https://github.com/python-babel/babel/commit/da7f31143847659b6b74d802618b03438aceb350.patch";
+      sha256 = "09yny8614knr8ngrrddmqzkxk70am135rccv2ncc6dji4xbqbfln";
+    })
+  ];
+
   propagatedBuildInputs = [ pytz ];
 
   checkInputs = [ pytest freezegun ];
 
-  # Note that a test will fail with an encoding error on Python 2 with Nix < 2.3
-  # due to https://github.com/NixOS/nixpkgs/pull/75676#issuecomment-579008837.
-  # TODO: Remove the above comment when we use a version that includes the fix
-  #       from https://github.com/python-babel/babel/pull/691
   doCheck = !stdenv.isDarwin;
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/75676#issuecomment-579050687

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
