### PR TITLE
ripasso-cursive: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/tools/security/ripasso/cursive.nix
+++ b/pkgs/tools/security/ripasso/cursive.nix
@@ -2,17 +2,17 @@
 
 with rustPlatform;
 buildRustPackage rec {
-  version = "0.3.0";
+  version = "0.4.0";
   pname = "ripasso-cursive";
 
   src = fetchFromGitHub {
     owner = "cortex";
     repo = "ripasso";
     rev  = "release-${version}";
-    sha256 = "1rkb23i9gcfmifcl31s8w86k7aza6nxrh3w33fvhv1ins1gxxk7w";
+    sha256 = "164da20j727p8l7hh37j2r8pai9sj402nhswvg0nrlgj53nr6083";
   };
 
-  cargoSha256 = "1p0bsl4h2w257vfjbpqiga693gaslfq34g30dghpqb5n4kl416zp";
+  cargoSha256 = "1vyhdbia7khh0ixim00knai5d270jl5a5crqik1qaz7bkwc02bsp";
 
   cargoBuildFlags = [ "-p ripasso-cursive -p ripasso-man" ];
 


### PR DESCRIPTION
###### Motivation for this change

0.3.0 -> 0.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
