### PR TITLE
qjournalctl: init at 0.6.2

### DIFF
--- a/pkgs/applications/system/qjournalctl/default.nix
+++ b/pkgs/applications/system/qjournalctl/default.nix
@@ -1,0 +1,36 @@
+{ 
+  stdenv,
+  fetchFromGitHub,
+  qtbase,
+  qmake,
+  pkgconfig,
+  libssh,
+	wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qjournalctl";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "pentix";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "08qfcf5yrfzsis9gkawkhshwmmi0jqw8xv23925hqass4a2xz704";
+  };
+
+  postPatch = ''
+    substituteInPlace qjournalctl.pro --replace /usr/ $out/
+  '';
+
+  nativeBuildInputs = [ qmake pkgconfig libssh ];
+  buildInputs = [ qtbase wrapQtAppsHook];
+
+  meta = with stdenv.lib; {
+    description = "Qt-based Graphical User Interface for systemd's journalctl command";
+    homepage = https://github.com/pentix/qjournalctl;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill srgom ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5990,6 +5990,8 @@ in
 
   qjoypad = callPackage ../tools/misc/qjoypad { };
 
+	qjournalctl = libsForQt5.callPackage ../applications/system/qjournalctl {};
+
   qownnotes = libsForQt5.callPackage ../applications/office/qownnotes { };
 
   qpdf = callPackage ../development/libraries/qpdf { };


### PR DESCRIPTION

###### Motivation for this change
bring back https://github.com/NixOS/nixpkgs/pull/55762/commits from dead

###### Things done

Copy pasted aanderse's code plus some qt specific changes plus a version bump 

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
