### PR TITLE
zsh: fix bracketed-paste-magic

### DIFF
--- a/pkgs/shells/zsh/bracketed-paste-magic.patch
+++ b/pkgs/shells/zsh/bracketed-paste-magic.patch
@@ -1,0 +1,22 @@
+diff --git a/Functions/Zle/bracketed-paste-magic b/Functions/Zle/bracketed-paste-magic
+index 4baae82..840091b 100644
+--- a/Functions/Zle/bracketed-paste-magic
++++ b/Functions/Zle/bracketed-paste-magic
+@@ -162,7 +162,7 @@ bracketed-paste-magic() {
+ 
+ 	# There are active widgets.  Reprocess $PASTED as keystrokes.
+ 	NUMERIC=1
+-	zle -U - $PASTED
++	zle -U - "$PASTED"
+ 
+ 	# Just in case there are active undo widgets
+ 
+@@ -212,7 +212,7 @@ bracketed-paste-magic() {
+     # Arrange to display highlighting if necessary
+     if [[ -z $zle_highlight || -n ${(M)zle_highlight:#paste:*} ]]; then
+ 	zle -R
+-	zle .read-command && zle -U - $KEYS
++	zle .read-command && zle -U - "$KEYS"
+     fi
+ }
+ 

--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -18,6 +18,13 @@ stdenv.mkDerivation {
     sha256 = "1s3yww0mzgvpc48kp0x868mm3gbna42sbgzya0nknj0x5hn2jq3j";
   };
 
+  patches = [
+    # Bracketed-paste-magic error in Putty due to empty $PASTED variable
+    # http://www.zsh.org/mla/workers/2019/msg00808.html
+    # This patch included in the next version
+    ./bracketed-paste-magic.patch
+  ];
+
   buildInputs = [ ncurses pcre ];
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
Fix this error (Used putty/kitty):
`bracketed-paste-magic:zle:47: not enough arguments for -U`

http://www.zsh.org/mla/workers/2019/msg00808.html
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
