### PR TITLE
gettext: Add macOS warning patch

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, libiconv, xz }:
+{ stdenv, lib, fetchurl, libiconv, xz, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "gettext";
@@ -11,7 +11,15 @@ stdenv.mkDerivation rec {
   patches = [
     ./absolute-paths.diff
     ./gettext.git-2336451ed68d91ff4b5ae1acbc1eca30e47a86a9.patch
-  ];
+  ]
+  # HACK: Since this is merely a UX fix, to minimise rebuilds only patch
+  #       the final library.
+  #       Remove the entire thing when updating to the next release.
+  ++ lib.optional (stdenv.isDarwin && !(lib.hasPrefix "bootstrap" stdenv.name))
+      (fetchpatch {
+        url = "https://git.savannah.gnu.org/cgit/gettext.git/patch?id=ec0e6b307456ceab352669ae6bccca9702108753";
+        sha256 = "0xqs01c7xl7vmw6bqvsmrzxxjxk2a4spcdpmlwm3b4hi2wc2lxnf";
+      });
 
   outputs = [ "out" "man" "doc" "info" ];
 

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -12,10 +12,7 @@ stdenv.mkDerivation rec {
     ./absolute-paths.diff
     ./gettext.git-2336451ed68d91ff4b5ae1acbc1eca30e47a86a9.patch
   ]
-  # HACK: Since this is merely a UX fix, to minimise rebuilds only patch
-  #       the final library.
-  #       Remove the entire thing when updating to the next release.
-  ++ lib.optional (stdenv.isDarwin && !(lib.hasPrefix "bootstrap" stdenv.name))
+  ++ lib.optional stdenv.isDarwin
       (fetchpatch {
         url = "https://git.savannah.gnu.org/cgit/gettext.git/patch?id=ec0e6b307456ceab352669ae6bccca9702108753";
         sha256 = "0xqs01c7xl7vmw6bqvsmrzxxjxk2a4spcdpmlwm3b4hi2wc2lxnf";


### PR DESCRIPTION
gettext 0.20 fixed a bug with handling locale on macOS, but this caused
it to report an annoying warning on systems where “language”
differs from “region”. See Homebrew issue for details:
<https://github.com/Homebrew/homebrew-core/issues/41139>.

Add upstream patch that has not been released yet.
Details:
<https://www.mail-archive.com/bug-gnulib@gnu.org/msg36768.html>.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

```
Warning: Failed to set locale category
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).