### PR TITLE
kops: 1.15.0 -> 1.15.1

### DIFF
--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -67,7 +67,7 @@ in rec {
   };
 
   kops_1_15 = mkKops {
-    version = "1.15.0";
-    sha256 = "0sjas8pn0njl767b1y15g7cci2q3kxkxwmgr0wvs7vi3n1s1sf9d";
+    version = "1.15.1";
+    sha256 = "0iq2bqq6zv6sk2psar33c3smnz79rk5v623qx4kr5h47wnqvrfvj";
   };
 }


### PR DESCRIPTION
Upgrade the kops_1_15 attribute of kops to bring in the newest patch release (1.15.1) which includes many important bug fixes.
Full release notes here: https://github.com/kubernetes/kops/releases/tag/v1.15.1

###### Motivation for this change

The current version lacks a bugfix that was breaking my workflow: https://github.com/kubernetes/kops/pull/8377
The newest version brings in this bugfix.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
