### PR TITLE
nixos/doc/network-manager: updates

### DIFF
--- a/nixos/doc/manual/configuration/network-manager.xml
+++ b/nixos/doc/manual/configuration/network-manager.xml
@@ -28,17 +28,21 @@
   <command>nmtui</command> (curses-based terminal user interface). See their
   manual pages for details on their usage. Some desktop environments (GNOME,
   KDE) have their own configuration tools for NetworkManager. On XFCE, there is
-  no configuration tool for NetworkManager by default: by adding
-  <code>networkmanagerapplet</code> to the list of system packages, the
-  graphical applet will be installed and will launch automatically when XFCE is
-  starting (and will show in the status tray).
+  no configuration tool for NetworkManager by default: by enabling <xref linkend="opt-programs.nm-applet.enable"/>, the
+  graphical applet will be installed and will launch automatically when the graphical session is started.
  </para>
 
  <note>
   <para>
    <code>networking.networkmanager</code> and <code>networking.wireless</code>
-   (WPA Supplicant) cannot be enabled at the same time: you can still connect
-   to the wireless networks using NetworkManager.
+   (WPA Supplicant) can be used together if desired. To do this you need to instruct
+   NetworkManager to ignore those interfaces like:
+<programlisting>
+<xref linkend="opt-networking.networkmanager.unmanaged"/> = [
+   "*" "except:type:wwan" "except:type:gsm"
+];
+</programlisting>
+   Refer to the option description for the exact syntax and references to external documentation.
   </para>
  </note>
 </section>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes #71161 

cc @jtojnar @JohnAZoidberg

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
