### PR TITLE
dotnetCorePackages: Fix closure size

### DIFF
--- a/pkgs/development/compilers/dotnet/buildDotnet.nix
+++ b/pkgs/development/compilers/dotnet/buildDotnet.nix
@@ -36,6 +36,7 @@ in stdenv.mkDerivation rec {
     sourceRoot = ".";
 
     dontPatchELF = true;
+    noDumpEnvVars = true;
 
     installPhase = ''
         runHook preInstall


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix closure size, which results in copying `env-vars` to output directory. See #73262

```
% nix why-depends /nix/store/8w7566287q3zalhn0xixl9610ssqirfx-dotnet-sdk-3.1.100 /nix/store/cc94mviqcb0wpqq5488p7a0ggp8v3hny-dotnet-sdk-3.1.100-linux-x64.tar.gz
/nix/store/8w7566287q3zalhn0xixl9610ssqirfx-dotnet-sdk-3.1.100
╚═══env-vars: …=".".declare -x src="/nix/store/cc94mviqcb0wpqq5488p7a0ggp8v3hny-dotnet-sdk-3.1.100-linux-x64.ta…
    => /nix/store/cc94mviqcb0wpqq5488p7a0ggp8v3hny-dotnet-sdk-3.1.100-linux-x64.tar.gz
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
