### PR TITLE
elementary-planner: init at 2.1.1

### DIFF
--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -1,21 +1,22 @@
-{ stdenv, fetchFromGitHub
-, meson, ninja, pkgconfig, appstream-glib, desktop-file-utils
+{ stdenv, fetchFromGitHub, fetchpatch
+, meson, ninja, pkgconfig, desktop-file-utils
 , python3, vala, wrapGAppsHook
 , evolution-data-server
 , libical
 , libgee
 , json-glib
+, glib
 , sqlite
 , libsoup
 , gtk3
-, pantheon /* granite, schemas */
+, pantheon /* granite, icons, maintainers */
 , webkitgtk
-, appstream
 }:
 
 stdenv.mkDerivation rec {
   pname = "elementary-planner";
   version = "2.1.1";
+
   src = fetchFromGitHub {
     owner = "alainm23";
     repo = "planner";
@@ -24,7 +25,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    appstream-glib
     desktop-file-utils
     meson
     ninja
@@ -39,31 +39,33 @@ stdenv.mkDerivation rec {
     libical
     libgee
     json-glib
+    glib
     sqlite
     libsoup
     gtk3
     pantheon.granite
     webkitgtk
-    appstream
-    pantheon.elementary-gsettings-schemas
     pantheon.elementary-icon-theme
+  ];
+
+  # Fix version string, remove in next update!
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/alainm23/planner/pull/194/commits/3d0a2197087b13fe90fa6f85f817ba56798d632c.patch";
+      sha256 = "077q5jddi8jaw2ypc6szbd1c50i4x3b21jvmvi3w7g5zhjwpkmf5";
+    })
   ];
 
   postPatch = ''
     chmod +x build-aux/meson/post_install.py
     patchShebangs build-aux/meson/post_install.py
-
-    # Fix version string not updated in this release.
-    # (please check if still needed when updating!)
-    substituteInPlace src/Dialogs/Preferences.vala \
-      --replace v2.0.8 v${version}
   '';
 
   meta = with stdenv.lib; {
     description = "Task and project manager designed to elementary OS";
     homepage = "https://planner-todo.web.app";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ dtzWill ];
+    maintainers = with maintainers; [ dtzWill ] ++ pantheon.maintainers;
   };
 }
 

--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -14,11 +14,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "planner";
+  pname = "elementary-planner";
   version = "2.1.1";
   src = fetchFromGitHub {
     owner = "alainm23";
-    repo = pname;
+    repo = "planner";
     rev = version;
     sha256 = "0swj94pqf00wwzsgjap8z19k33gg1wj2b78ba1aj9h791j8lmaim";
   };

--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkgconfig, appstream-glib, desktop-file-utils
+, python3, vala, wrapGAppsHook
+, evolution-data-server
+, libical
+, libgee
+, json-glib
+, sqlite
+, libsoup
+, gtk3
+, pantheon /* granite, schemas */
+, webkitgtk
+, appstream
+}:
+
+stdenv.mkDerivation rec {
+  pname = "planner";
+  version = "2.1.1";
+  src = fetchFromGitHub {
+    owner = "alainm23";
+    repo = pname;
+    rev = version;
+    sha256 = "0swj94pqf00wwzsgjap8z19k33gg1wj2b78ba1aj9h791j8lmaim";
+  };
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    evolution-data-server
+    libical
+    libgee
+    json-glib
+    sqlite
+    libsoup
+    gtk3
+    pantheon.granite
+    webkitgtk
+    appstream
+    pantheon.elementary-gsettings-schemas
+    pantheon.elementary-icon-theme
+  ];
+
+  postPatch = ''
+    chmod +x build-aux/meson/post_install.py
+    patchShebangs build-aux/meson/post_install.py
+
+    # Fix version string not updated in this release.
+    # (please check if still needed when updating!)
+    substituteInPlace src/Dialogs/Preferences.vala \
+      --replace v2.0.8 v${version}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Task and project manager designed to elementary OS";
+    homepage = "https://planner-todo.web.app";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18732,6 +18732,8 @@ in
 
   electrum-ltc = callPackage ../applications/misc/electrum/ltc.nix { };
 
+  elementary-planner = callPackage ../applications/office/elementary-planner { };
+
   elinks = callPackage ../applications/networking/browsers/elinks {
     openssl = openssl_1_0_2;
   };


### PR DESCRIPTION
###### Motivation for this change

"Never worry about forgetting things again"

cc @worldofpeace

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).