### PR TITLE
pythonPackages.marshmallow-polyfield: init at 5.7

### DIFF
--- a/pkgs/development/python-modules/marshmallow-polyfield/default.nix
+++ b/pkgs/development/python-modules/marshmallow-polyfield/default.nix
@@ -1,0 +1,34 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, marshmallow
+  # Check Inputs
+, pytestCheckHook
+, pytestcov
+}:
+
+buildPythonPackage rec {
+  pname = "marshmallow-polyfield";
+  version = "5.7";
+
+  src = fetchFromGitHub {
+    owner = "Bachmann1234";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15yx8ib5yx1xx6kq8wnfdmv9zm43k7y33c6zpq5rba6a30v4lcnd";
+  };
+
+  propagatedBuildInputs = [
+    marshmallow
+  ];
+  
+  # setuptools check can run, but won't find tests
+  checkInputs = [ pytestCheckHook pytestcov ];
+
+  meta = with lib; {
+    description = "An unofficial extension to Marshmallow to allow for polymorphic fields";
+    homepage = "https://github.com/Bachmann1234/marshmallow-polyfield";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4105,6 +4105,8 @@ in {
 
   marshmallow-enum = callPackage ../development/python-modules/marshmallow-enum { };
 
+  marshmallow-polyfield = callPackage ../development/python-modules/marshmallow-polyfield { };
+
   marshmallow-sqlalchemy = callPackage ../development/python-modules/marshmallow-sqlalchemy { };
 
   manuel = callPackage ../development/python-modules/manuel { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add dependency for upcoming qiskit-terra package #78772 @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
