### PR TITLE
pythonPackages.fastdtw: init at 0.3.4

### DIFF
--- a/pkgs/development/python-modules/fastdtw/default.nix
+++ b/pkgs/development/python-modules/fastdtw/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, cython
+, numpy
+  # Check Inputs
+, pytestCheckHook
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "fastdtw";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "slaypni";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0irc5x4ahfp7f7q4ic97qa898s2awi0vdjznahxrfjirn8b157dw";
+  };
+
+  patches = [
+    # Removes outdated cythonized C++ file, which doesn't match CPython. Will be auto-used if left.
+    # Remove when PR 40 merged
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/slaypni/fastdtw/pull/40.patch";
+      sha256 = "0xjma0h84bk1n32wgk99rwfc85scp187a7fykhnylmcc73ppal9q";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  pythonImportsCheck = [ "fastdtw.fastdtw" ];
+  checkInputs = [ pytestCheckHook ];
+  dontUseSetuptoolsCheck = true;  # looks for pytest-runner
+  preCheck = ''
+    echo "Temporarily moving tests to $OUT to find cython modules"
+    export PACKAGEDIR=$out/${python.sitePackages}
+    cp -r $TMP/source/tests $PACKAGEDIR
+    pushd $PACKAGEDIR
+  '';
+  postCheck = ''
+    rm -rf tests
+    popd
+  '';
+
+
+  meta = with lib; {
+    description = "Python implementation of FastDTW (Dynamic Time Warping)";
+    longDescription = ''
+      FastDTW is an approximate Dynamic Time Warping (DTW) algorithm that provides
+      optimal or near-optimal alignments with an O(N) time and memory complexity.
+    '';
+    homepage = "https://github.com/slaypni/fastdtw";
+    license = licenses.mit;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2647,6 +2647,8 @@ in {
 
   Fabric = callPackage ../development/python-modules/Fabric { };
 
+  fastdtw = callPackage ../development/python-modules/fastdtw { };
+
   faulthandler = if ! isPy3k
     then callPackage ../development/python-modules/faulthandler {}
     else throw "faulthandler is built into ${python.executable}";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add dependency for upcoming qiskit-terra package #78772 @jonringer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
