### PR TITLE
linuxPackages_5_5.nvidia_x11: fix build

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -26,6 +26,12 @@ rec {
       sha256_64bit = "057wq9p2vl87gy61f079b6d7clw2vhw3kq7rj411brhrnvr7shmd";
       settingsSha256 = "1hr1n78c92zksnnryrcz4b8kxvi6kz4yp801ks85hq4a3rryj4vg";
       persistencedSha256 = "050znx2scm7x3r7czsz77ddjh4bs18hdd3k3shwpi3zflkmnhnvj";
+      patches =
+        # https://gitlab.com/snippets/1923197
+        lib.optional (lib.versionAtLeast (kernel.version or "0") "5.5") (fetchurl {
+          url = "https://gitlab.com/snippets/1923197/raw";
+          sha256 = "012qdsk0sbip6417172jx2iqw7ck8pc204xlsw9bh33jhng61kbx";
+        });
     }
     else legacy_390;
 


### PR DESCRIPTION
###### Motivation for this change

It doesn't currently compile, [as described here](https://gitlab.com/snippets/1923197). Some thoughts:

1. Should the patch be inlined in nixpkgs? I'm not sure if gitlab snippets are like gists where you can link to a specific commit or not, though it seems unlikely that it would be edited again.
2. Is there an existing beta release we could be using?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
