### PR TITLE
libcint: init at 3.0.19

### DIFF
--- a/pkgs/development/libraries/libcint/default.nix
+++ b/pkgs/development/libraries/libcint/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, openblas
+  # Check Inputs
+, python2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libcint";
+  version = "3.0.19";
+
+  src = fetchFromGitHub {
+    owner = "sunqm";
+    repo = "libcint";
+    rev = "v${version}";
+    sha256 = "0x613f2hiqi2vbhp20fcl7rhxb07f2714lplzd0vkvv07phagip9";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openblas ];
+  cmakeFlags = [
+    "-DENABLE_TEST=1"
+    "-DQUICK_TEST=1"
+    "-DCMAKE_INSTALL_PREFIX=" # ends up double-adding /nix/store/... prefix, this avoids issue
+  ];
+
+  doCheck = true;
+  # Test syntax (like print statements) is written in python2. Fixed when #33 merged: https://github.com/sunqm/libcint/pull/33
+  checkInputs = [ python2.pkgs.numpy ];
+
+  meta = with lib; {
+    description = "General GTO integrals for quantum chemistry";
+    longDescription = ''
+      libcint is an open source library for analytical Gaussian integrals.
+      It provides C/Fortran API to evaluate one-electron / two-electron
+      integrals for Cartesian / real-spheric / spinor Gaussian type functions.
+    '';
+    homepage = "http://wiki.sunqm.net/libcint";
+    downloadPage = "https://github.com/sunqm/libcint";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12289,6 +12289,8 @@ in
 
   libchop = callPackage ../development/libraries/libchop { };
 
+  libcint = callPackage ../development/libraries/libcint { };
+
   libclc = callPackage ../development/libraries/libclc { };
 
   libcli = callPackage ../development/libraries/libcli { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add dependency for upcoming qiskit-terra package #78772 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
