### PR TITLE
pythonPackages.dlx: init at 1.0.4

### DIFF
--- a/pkgs/development/python-modules/dlx/default.nix
+++ b/pkgs/development/python-modules/dlx/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "dlx";
+  version = "1.0.4";
+
+  # untagged releases
+  src = fetchFromGitHub {
+    owner = "sraaphorst";
+    repo = "dlx_python";
+    rev = "02d1ed534df60513095633da07e67a6593b9e9b4";
+    sha256 = "0c6dblbypwmx6yrk9qxp157m3cd7lq3j411ifr3shscv1igxv5hk";
+  };
+
+  # No test suite, so just run an example
+  pythonImportsCheck = [ "dlx" ];
+  # ./examples/design.py requires pyncomb, not in tree
+  checkPhase = ''
+    # example sudoku board from ./examples/sudoku.py
+    ${python.interpreter} ./examples/sudoku.py 3 "070285010008903500000000000500010008010000090900040003000000000002408600090632080"
+  '';
+
+  meta = with lib; {
+    description = "Implementation of Donald Knuth's Dancing Links algorithm";
+    homepage = "https://github.com/sraaphorst/dlx_python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2497,6 +2497,8 @@ in {
 
   discogs_client = callPackage ../development/python-modules/discogs_client { };
 
+  dlx = callPackage ../development/python-modules/dlx { };
+
   dmenu-python = callPackage ../development/python-modules/dmenu { };
 
   dnslib = callPackage ../development/python-modules/dnslib { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add dependency for upcoming qiskit-terra package #78772 @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
