### PR TITLE
pythonPackages.docplex: init at 2.12.182

### DIFF
--- a/pkgs/development/python-modules/docplex/default.nix
+++ b/pkgs/development/python-modules/docplex/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, futures
+, docloud
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "docplex";
+  version = "2.12.182";
+
+  # No source available from official repo
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "aaf150b06d44f07639aca48be1fca69c7732d57507e6adc4e8451c7a93489116";
+  };
+
+  propagatedBuildInputs = [
+    docloud
+    requests
+  ] ++ lib.optional isPy27 futures;
+
+  doCheck = false;
+  pythonImportsCheck = [ "docplex" ];
+
+  meta = with lib; {
+    description = "IBM Decision Optimization CPLEX Modeling for Python";
+    homepage = "https://onboarding-oaas.docloud.ibmcloud.com/software/analytics/docloud/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2548,6 +2548,8 @@ in {
 
   docloud = callPackage ../development/python-modules/docloud { };
 
+  docplex = callPackage ../development/python-modules/docplex { };
+
   docopt = callPackage ../development/python-modules/docopt { };
 
   doctest-ignore-unicode = callPackage ../development/python-modules/doctest-ignore-unicode { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add dependency for upcoming package qiskit-aqua #78772 @jonringer 
Depends on #78874 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
