### PR TITLE
subunit: 1.1.0 -> 1.3.0

### DIFF
--- a/pkgs/development/libraries/subunit/default.nix
+++ b/pkgs/development/libraries/subunit/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchurl, pkgconfig, check, cppunit, perl, pythonPackages }:
+{ stdenv, fetchFromGitHub, pkg-config, autoreconfHook, check, cppunit, perl, pythonPackages }:
 
 # NOTE: for subunit python library see pkgs/top-level/python-packages.nix
 
 stdenv.mkDerivation rec {
   pname = "subunit";
-  version = "1.1.0";
+  version = "1.3.0";
 
-  src = fetchurl {
-    url = "https://launchpad.net/subunit/trunk/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "0lcah7p66c05p7xpw6ns1is0i02lh0nq8gq51mv4wyvbr6zaasa8";
+  src = fetchFromGitHub {
+    owner = "testing-cabal";
+    repo = pname;
+    rev = version;
+    sha256 = "1hk5v8gg5azwrc079xqigj0sp6qm47vzg1qwjbvb8dbjwlg75rvz";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ check cppunit perl pythonPackages.wrapPython ];
 
   propagatedBuildInputs = with pythonPackages; [ testtools testscenarios ];
@@ -20,8 +22,10 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A streaming protocol for test results";
-    homepage = https://launchpad.net/subunit;
+    homepage = "https://launchpad.net/subunit";
+    downloadPage = "https://github.com/testing-cabal/subunit";
     license = licenses.asl20;
     platforms = platforms.all;
+    maintainers = with maintainers; [ drewrisinger ];
   };
 }

--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , pkgs
+, python
 , testtools
 , testscenarios
 }:
@@ -9,12 +10,17 @@ buildPythonPackage {
   src = pkgs.subunit.src;
 
   propagatedBuildInputs = [ testtools ];
-  checkInputs = [ testscenarios ];
   nativeBuildInputs = [ pkgs.pkgconfig ];
   buildInputs = [ pkgs.check pkgs.cppunit ];
 
   patchPhase = ''
     sed -i 's/version=VERSION/version="${pkgs.subunit.version}"/' setup.py
+  '';
+
+  checkInputs = [ python testscenarios ];
+  pythonImportsCheck = [ "subunit" ];
+  checkPhase = ''
+    ${python.interpreter} all_tests.py
   '';
 
   meta = pkgs.subunit.meta;

--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -1,7 +1,11 @@
 { buildPythonPackage
 , pkgs
-, python
 , testtools
+  # Check Inputs
+, fixtures
+, hypothesis
+, pytest
+, python
 , testscenarios
 }:
 
@@ -17,10 +21,14 @@ buildPythonPackage {
     sed -i 's/version=VERSION/version="${pkgs.subunit.version}"/' setup.py
   '';
 
-  checkInputs = [ python testscenarios ];
+  checkInputs = [ fixtures hypothesis pytest python testscenarios ];
   pythonImportsCheck = [ "subunit" ];
   checkPhase = ''
-    ${python.interpreter} all_tests.py
+    # Not very necessary. This test isn't actually currently run
+    substituteInPlace python/iso8601/test_iso8601.py --replace "import iso8601" "import subunit.iso8601 as iso8601"
+
+    ${python.interpreter} -m unittest all_tests.py # theoretically this should run all tests, but doesn't work. /bin/sh can't source paths
+    pytest --pyargs subunit.tests # This has ~30 fails, most down to some classes missing "option" attribute.
   '';
 
   meta = pkgs.subunit.meta;

--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -26,9 +26,14 @@ buildPythonPackage {
   checkPhase = ''
     # Not very necessary. This test isn't actually currently run
     substituteInPlace python/iso8601/test_iso8601.py --replace "import iso8601" "import subunit.iso8601 as iso8601"
+    export SHELL_SHARE=./shell/share/
+    patchShebangs ./shell/tests/*.sh
+    # this SHOULD run all tests in python/subunit/tests, but only runs ./shell/tests/*
+    ${python.interpreter} -m unittest all_tests.py
 
-    ${python.interpreter} -m unittest all_tests.py # theoretically this should run all tests, but doesn't work. /bin/sh can't source paths
-    pytest --pyargs subunit.tests # This has ~30 fails, most down to some classes missing "option" attribute.
+    # Use pyargs b/c tests are in site-packages/subunit/tests/...
+    # This has ~30 fails, most down to some classes missing "option" attribute. Don't know cause of others
+    pytest --pyargs subunit.tests
   '';
 
   meta = pkgs.subunit.meta;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bump subunit as requirement for tester (``stestr``) for upcoming qiskit package #78772

launchpad fetch doesn't work for >1.1.0, so switched to equivalent git repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
