### PR TITLE
pythonPackages.subunit: enable tests

### DIFF
--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , pkgs
+, python
 , testtools
 , testscenarios
 }:
@@ -9,12 +10,17 @@ buildPythonPackage {
   src = pkgs.subunit.src;
 
   propagatedBuildInputs = [ testtools ];
-  checkInputs = [ testscenarios ];
   nativeBuildInputs = [ pkgs.pkgconfig ];
   buildInputs = [ pkgs.check pkgs.cppunit ];
 
   patchPhase = ''
     sed -i 's/version=VERSION/version="${pkgs.subunit.version}"/' setup.py
+  '';
+
+  checkInputs = [ python testscenarios ];
+  pythonImportsCheck = [ "subunit" ];
+  checkPhase = ''
+    ${python.interpreter} all_tests.py
   '';
 
   meta = pkgs.subunit.meta;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Enable & run tests built into the subunit package.
Subunit is dependency for stestr, test package used in qiskit (#78772 ) @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
