### PR TITLE
pythonPackages.stestr: init at 2.6.0

### DIFF
--- a/pkgs/development/python-modules/stestr/default.nix
+++ b/pkgs/development/python-modules/stestr/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchPypi
+, cliff
+, fixtures
+, future
+, pbr
+, pythonSubunit
+, pyyaml
+, six
+, testtools
+, voluptuous
+  # check inputs
+, doc8
+, ddt
+, coverage
+, sphinx
+, pytest
+, sqlalchemy
+}:
+
+buildPythonPackage rec {
+  pname = "stestr";
+  version = "2.6.0";
+
+  # setup versioning requires either sdist tarball or upstream git access.
+  # So forced to use pre-built sdist from Pypi, but fine b/c tests included.
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "040ryqdml2x2klf8l1alsg0jg79s7s6rsz9w9v7mwa183mq5qjnn";
+  };
+
+  propagatedBuildInputs = [
+    cliff
+    fixtures
+    future
+    pbr
+    pythonSubunit
+    pyyaml
+    six
+    testtools
+    voluptuous
+  ];
+
+  # remove test requirements that aren't in Nix.
+  prePatch = ''
+    substituteInPlace test-requirements.txt --replace "subunit2sql>=1.8.0" "" --replace "hacking<1.2.0,>=1.1.0" ""
+  '';
+
+  checkInputs = [
+    coverage  # "needed" for checking (in test-requirements.txt), though not used
+    doc8
+    ddt
+    pytest
+    sphinx
+  ];
+  pythonCheckImports = [ "stestr" ];
+  checkPhase = ''
+    export PATH=$out/bin:$PATH  # add stestr to path
+    export HOME=$(mktemp -d)    # some tests require home for tempfiles
+    stestr init # for test_load.py
+    pytest \
+      --ignore-glob='**/test_sql.py'  # requires subunit2sql
+  '';
+
+  meta = with lib; {
+    description = "A parallel Python test runner built around subunit";
+    homepage = "https://github.com/mtreinish/stestr" ;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5929,6 +5929,10 @@ in {
 
   python_statsd = callPackage ../development/python-modules/python_statsd { };
 
+  stestr = callPackage ../development/python-modules/stestr {
+    pythonSubunit = self.subunit;
+  };
+
   stompclient = callPackage ../development/python-modules/stompclient { };
 
   subdownloader = callPackage ../development/python-modules/subdownloader { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add test dependency for qiskit #78772 @jonringer 
Depends on #78876 and #78877 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
