### PR TITLE
pythonPackages.ecos: init at 2.0.7.post1

### DIFF
--- a/pkgs/development/python-modules/ecos/default.nix
+++ b/pkgs/development/python-modules/ecos/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+, pkgs
+, numpy
+, scipy
+  # check inputs
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "ecos";
+  version = "2.0.7.post1";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "embotech";
+    repo = "ecos-python";
+    rev = version;
+    sha256 = "1wzmamz2r4xr2zxgfwnm5q283185d1q6a7zn30vip18lxpys70z0";
+    fetchSubmodules = true;
+  };
+
+  prePatch = ''
+    echo '__version__ = "${version}"' >> ./src/ecos/version.py
+  '';
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+  ];
+
+  checkInputs = [ nose ];
+  checkPhase = ''
+    # Run tests
+    cd ./src
+    nosetests test_interface.py test_interface_bb.py
+  '';
+  pythonImportsCheck = [ "ecos" ];
+
+  meta = with lib; {
+    description = "Python package for ECOS: Embedded Cone Solver";
+    downloadPage = "https://github.com/embotech/ecos-python/releases";
+    homepage = pkgs.ecos.meta.homepage;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3431,6 +3431,8 @@ in {
 
   ecdsa = callPackage ../development/python-modules/ecdsa { };
 
+  ecos = callPackage ../development/python-modules/ecos { };
+
   effect = callPackage ../development/python-modules/effect {};
 
   enum = callPackage ../development/python-modules/enum { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add dependency for upcoming qiskit package #78772
Split from #78772 per request

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
