### PR TITLE
pythonPackages.osqp: init at 0.6.1

### DIFF
--- a/pkgs/development/python-modules/osqp/default.nix
+++ b/pkgs/development/python-modules/osqp/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cmake
+, future
+, numpy
+  # check inputs
+, scipy
+, pytestCheckHook
+, mkl
+}:
+
+buildPythonPackage rec {
+  pname = "osqp";
+  version = "0.6.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "130frig5bznfacqp9jwbshmbqd2xw3ixdspsbkrwsvkdaab7kca7";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  dontUseCmakeConfigure = true;
+
+  propagatedBuildInputs = [
+    numpy
+    future
+  ];
+
+  checkInputs = [ scipy pytestCheckHook mkl ];
+  pythonImportsCheck = [ "osqp" ];
+  dontUseSetuptoolsCheck = true;  # running setup.py fails if false
+  preCheck = ''
+    export LD_LIBRARY_PATH=${lib.strings.makeLibraryPath [ mkl ]}:$LD_LIBRARY_PATH;
+  '';
+
+  meta = with lib; {
+    description = "The Operator Splitting QP Solver";
+    longDescription = ''
+      Numerical optimization package for solving problems in the form
+        minimize        0.5 x' P x + q' x
+        subject to      l <= A x <= u
+
+      where x in R^n is the optimization variable
+    '';
+    homepage = "https://osqp.org/";
+    downloadPage = "https://github.com/oxfordcontrol/osqp";
+    license = licenses.asl20;
+    maintainers = with lib.maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2985,6 +2985,8 @@ in {
 
   oscrypto = callPackage ../development/python-modules/oscrypto { };
 
+  osqp = callPackage ../development/python-modules/osqp { };
+
   oyaml = callPackage ../development/python-modules/oyaml { };
 
   pamela = callPackage ../development/python-modules/pamela { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add dependency for upcoming qiskit package #78772 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
