### PR TITLE
lfe: 1.2.1 -> 1.3

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -66,8 +66,9 @@ let
         # Remove old versions of elixir, when the supports fades out:
         # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 
-        lfe = lfe_1_2;
+        lfe = lfe_1_3;
         lfe_1_2 = lib.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3 buildHex; };
+        lfe_1_3 = lib.callLFE ../interpreters/lfe/1.3.nix { inherit erlang buildRebar3 buildHex; };
 
         # Non hex packages. Examples how to build Rebar/Mix packages with and
         # without helper functions buildRebar3 and buildMix.

--- a/pkgs/development/interpreters/lfe/1.3.nix
+++ b/pkgs/development/interpreters/lfe/1.3.nix
@@ -1,0 +1,43 @@
+{ fetchpatch, mkDerivation }:
+
+let
+  _fetchpatch =
+    { rev, sha256 }:
+    fetchpatch {
+      url = "https://github.com/rvirding/lfe/commit/${rev}.patch";
+      inherit sha256;
+    };
+  fetchPatches = map _fetchpatch;
+in
+
+mkDerivation {
+  version = "1.3";
+  sha256 = "0pgwi0h0d34353m39jin8dxw4yykgfcg90k6pc4qkjyrg40hh4l6";
+  maximumOTPVersion = "21";
+  patches = fetchPatches [
+    {
+      rev = "b457e5d521bb35008e6049fab31b4073cc10d583";
+      sha256 = "1zrq1b3291xhb0jsirgb5s8hacq5xvz7xidsp29aqcnpazdvivdc";
+    }
+    {
+      rev = "5fe9f37741b7d53bd43109fd3435e1437f124a0d";
+      sha256 = "1anqlcbih52lc0wynf58r67w1jhn264lz49rczwgh19pqg92dvqf";
+    }
+    {
+      rev = "b8f3e06511cb6805cf3a904c1589b27f33f3958d";
+      sha256 = "1zqafc0asm9m6cq7r0brvfawv69fqggy1phif3zknjmpicf25pqf";
+    }
+    {
+      rev = "40c239a608460e55563edb68c1b6faca57518b54";
+      sha256 = "03av5115jwyammw337xzy50l6api5h0wbwwda5vzw0w10zwb2z8y";
+    }
+    {
+      rev = "5faa7106419263689bfc0bc08a7451ccb1fba718";
+      sha256 = "0ml5yh5b3rn4ympks4bpx409hkra0i79zvq80azk0kmbjd869fxp";
+    }
+    {
+      rev = "9ff978693babcfd043d741b5c6940920b8315892";
+      sha256 = "04968dmp527wbkdv7dqpaj3nsyjls93whc1b5hx73b39dvl3n3y1";
+    }
+  ];
+}

--- a/pkgs/development/interpreters/lfe/dedup-ebins.patch
+++ b/pkgs/development/interpreters/lfe/dedup-ebins.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 59f2c06..5ee8f6e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -60,7 +60,7 @@ ESRCS = $(notdir $(wildcard $(SRCDIR)/*.erl))
+ XSRCS = $(notdir $(wildcard $(SRCDIR)/*.xrl))
+ YSRCS = $(notdir $(wildcard $(SRCDIR)/*.yrl))
+ LSRCS = $(notdir $(wildcard $(LSRCDIR)/*.lfe))
+-EBINS = $(ESRCS:.erl=.beam) $(XSRCS:.xrl=.beam) $(YSRCS:.yrl=.beam)
++EBINS = $(sort $(ESRCS:.erl=.beam) $(XSRCS:.xrl=.beam) $(YSRCS:.yrl=.beam))
+ LBINS = $(LSRCS:.lfe=.beam)
+ 
+ CSRCS = $(notdir $(wildcard $(CSRCDIR)/*.c))

--- a/pkgs/development/interpreters/lfe/generic-builder.nix
+++ b/pkgs/development/interpreters/lfe/generic-builder.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  inherit (stdenv.lib) getVersion versionAtLeast versions;
+  inherit (stdenv.lib) assertMsg getVersion versionAtLeast versions;
 
   mainVersion = versions.major (getVersion erlang);
 
@@ -25,7 +25,9 @@ let
   };
 
 in
-assert versionAtLeast maximumOTPVersion mainVersion;
+assert (assertMsg (versionAtLeast maximumOTPVersion mainVersion)) ''
+  LFE ${version} is supported on OTP <=${maximumOTPVersion}, not ${mainVersion}.
+'';
 
 buildRebar3 {
   name = baseName;

--- a/pkgs/development/interpreters/lfe/generic-builder.nix
+++ b/pkgs/development/interpreters/lfe/generic-builder.nix
@@ -6,10 +6,13 @@
 , sha256 ? null
 , rev ? version
 , src ? fetchFromGitHub { inherit rev sha256; owner = "rvirding"; repo = "lfe"; }
+, patches ? []
 }:
 
 let
-  inherit (stdenv.lib) assertMsg getVersion versionAtLeast versions;
+  inherit (stdenv.lib)
+    assertMsg makeBinPath optionalString
+    getVersion versionAtLeast versionOlder versions;
 
   mainVersion = versions.major (getVersion erlang);
 
@@ -36,13 +39,15 @@ buildRebar3 {
 
   buildInputs = [ erlang makeWrapper ];
   beamDeps    = [ proper ];
-  patches     = [ ./no-test-deps.patch ];
+  patches     = [ ./no-test-deps.patch ./dedup-ebins.patch ] ++ patches;
   doCheck     = true;
   checkTarget = "travis";
 
+  makeFlags = [ "-e" "MANDB=''" "PREFIX=$$out"];
+
   # These installPhase tricks are based on Elixir's Makefile.
   # TODO: Make, upload, and apply a patch.
-  installPhase = ''
+  installPhase = optionalString (versionOlder version "1.3") ''
     local libdir=$out/lib/lfe
     local ebindir=$libdir/ebin
     local bindir=$libdir/bin
@@ -65,7 +70,7 @@ buildRebar3 {
     # Add some stuff to PATH so the scripts can run without problems.
     for f in $out/bin/*; do
       wrapProgram $f \
-        --prefix PATH ":" "${stdenv.lib.makeBinPath [ erlang coreutils bash ]}:$out/bin"
+        --prefix PATH ":" "${makeBinPath [ erlang coreutils bash ]}:$out/bin"
       substituteInPlace $f --replace "/usr/bin/env" "${coreutils}/bin/env"
     done
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9076,7 +9076,9 @@ in
     fetchHex beamPackages
     relxExe;
 
-  inherit (beam.packages.erlangR19) cuter lfe lfe_1_2;
+  inherit (beam.packages.erlangR19) cuter lfe_1_2;
+
+  inherit (beam.packages.erlangR21) lfe lfe_1_3;
 
   groovy = callPackage ../development/interpreters/groovy { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9069,15 +9069,14 @@ in
   inherit (beam.interpreters)
     erlang erlangR18 erlangR19 erlangR20 erlangR21 erlangR22
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
-    elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6
-    lfe lfe_1_2;
+    elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6;
 
   inherit (beam.packages.erlang)
     rebar rebar3
     fetchHex beamPackages
     relxExe;
 
-  inherit (beam.packages.erlangR19) cuter;
+  inherit (beam.packages.erlangR19) cuter lfe lfe_1_2;
 
   groovy = callPackage ../development/interpreters/groovy { };
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -74,7 +74,7 @@ rec {
     # `beam.packages.erlangR22.elixir`.
     inherit (packages.erlang) elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6;
 
-    inherit (packages.erlang) lfe lfe_1_2;
+    inherit (packages.erlang) lfe lfe_1_2 lfe_1_3;
   };
 
   # Helper function to generate package set with a specific Erlang version.


### PR DESCRIPTION
###### Motivation for this change

Upgrade LFE to 1.3, as discussed here: https://github.com/rvirding/lfe/issues/385

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
