### PR TITLE
pythonPackages.scs: init at 2.1.1

### DIFF
--- a/pkgs/development/python-modules/scs/default.nix
+++ b/pkgs/development/python-modules/scs/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, blas
+, liblapack
+, numpy
+, scipy
+, scs
+  # check inputs
+, nose
+}:
+
+buildPythonPackage rec {
+  inherit (scs) pname version;
+
+  src = fetchFromGitHub {
+    owner = "bodono";
+    repo = "scs-python";
+    rev = "f02abdc0e2e0a5851464e30f6766ccdbb19d73f0"; # need to choose commit manually, untagged
+    sha256 = "174b5s7cwgrn1m55jlrszdl403zhpzc4yl9acs6kjv9slmg1mmjr";
+  };
+
+  preConfigure = ''
+    rm -r scs
+    ln -s ${scs.src} scs
+  '';
+
+  buildInputs = [
+    liblapack
+    blas
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+  ];
+
+  checkInputs = [ nose ];
+  checkPhase = ''
+    nosetests
+  '';
+  pythonImportsCheck = [ "scs" ];
+
+  meta = with lib; {
+    description = "Python interface for SCS: Splitting Conic Solver";
+    longDescription = ''
+      Solves convex cone programs via operator splitting.
+      Can solve: linear programs (LPs), second-order cone programs (SOCPs), semidefinite programs (SDPs),
+      exponential cone programs (ECPs), and power cone programs (PCPs), or problems with any combination of those cones.
+    '';
+    homepage = "https://github.com/cvxgrp/scs"; # upstream C package
+    downloadPage = "https://github.com/bodono/scs-python";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4980,6 +4980,8 @@ in {
   python-simple-hipchat = callPackage ../development/python-modules/python-simple-hipchat {};
   python_simple_hipchat = self.python-simple-hipchat;
 
+  scs = callPackage ../development/python-modules/scs { scs = pkgs.scs; };
+
   python_keyczar = callPackage ../development/python-modules/python_keyczar { };
 
   python-language-server = callPackage ../development/python-modules/python-language-server {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add dependency for qiskit (cvxpy's dependency).
Python interface for C Splitting Cone Solver. C Package in tree at ``lib.science.math.scs``.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
