### PR TITLE
pythonPackages.pproxy: init at 2.3.2

### DIFF
--- a/pkgs/development/python-modules/pproxy/default.nix
+++ b/pkgs/development/python-modules/pproxy/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, isPy27
+, buildPythonPackage
+, fetchFromGitHub
+, pycryptodome
+, uvloop
+}:
+
+buildPythonPackage rec {
+  pname = "pproxy";
+  version = "2.3.2";
+
+  disabled = isPy27;
+
+  # doesn't use tagged releases. Tests not in PyPi versioned releases
+  src = fetchFromGitHub {
+    owner = "qwj";
+    repo = "python-proxy";
+    rev = "818ab9cc10565789fe429a7be50ddefb9c583781";
+    sha256 = "0g3cyi5lzakhs5p3fpwywbl8jpapnr8890zw9w45dqg8k0svc1fi";
+  };
+
+  propagatedBuildInputs = [
+    pycryptodome
+    uvloop
+  ];
+
+  pythonImportsCheck = [ "pproxy" ];
+  disabledTests = [ "api_server" "api_client" ];  # try to connect to outside Internet, so disabled
+  # test suite doesn't use test runner. so need to run ``python ./tests/*``
+  checkPhase = ''
+    shopt -s extglob
+    for f in ./tests/!(${builtins.concatStringsSep "|" disabledTests}).py ; do
+      echo "***Testing $f***"
+      eval "python $f"
+    done
+  '';
+
+  meta = with lib; {
+    description = "Proxy server that can tunnel among remote servers by regex rules";
+    homepage = "https://github.com/qwj/python-proxy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4736,6 +4736,8 @@ in {
 
   ppft = callPackage ../development/python-modules/ppft { };
 
+  pproxy = callPackage ../development/python-modules/pproxy { };
+
   praw = if isPy3k then callPackage ../development/python-modules/praw { }
     else callPackage ../development/python-modules/praw/6.3.nix { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add dependency for upcoming qiskit package #78772 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
