### PR TITLE
dwarf-fortress-packages.dwarf-fortress_0_47_01: init

### DIFF
--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -3,17 +3,17 @@
 
 stdenv.mkDerivation rec {
   pname = "dwarf-therapist";
-  version = "41.0.2";
+  version = "41.1.2";
 
   src = fetchFromGitHub {
     owner = "Dwarf-Therapist";
     repo = "Dwarf-Therapist";
     rev = "v${version}";
-    sha256 = "0cvnk1dkszh7q7viv3i1v3ifzv1w0xyz69mifa1cbvbi47z2dh0d";
+    sha256 = "1qyyny2v4wxqs4ar02s8aawaxnkibz5aa5xgjm421k6v04iqxgcl";
   };
 
-  buildInputs = [ qtbase qtdeclarative ];
   nativeBuildInputs = [ texlive cmake ninja ];
+  buildInputs = [ qtbase qtdeclarative ];
 
   installPhase = if stdenv.isDarwin then ''
     mkdir -p $out/Applications
@@ -22,9 +22,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Tool to manage dwarves in a running game of Dwarf Fortress";
-    maintainers = with maintainers; [ the-kenny abbradar bendlas numinit ];
+    maintainers = with maintainers; [ the-kenny abbradar bendlas numinit jonringer ];
     license = licenses.mit;
     platforms = platforms.unix;
-    homepage = https://github.com/Dwarf-Therapist/Dwarf-Therapist;
+    homepage = "https://github.com/Dwarf-Therapist/Dwarf-Therapist";
   };
 }

--- a/pkgs/games/dwarf-fortress/game.json
+++ b/pkgs/games/dwarf-fortress/game.json
@@ -82,5 +82,16 @@
     "legacy_s": "05madj529y18ndxrih96mivbzng1vz2zbzicrcnj58i2084zm23f",
     "legacy32": "0rapcydiic2nq6idjf7fg53xsxk8dxzyi1vflpz554ghdrnsmwjv",
     "legacy32_s": "16fgbd3lx4r270dxqj6gr1g1iqjj8cv389h2hw1l646xx28g8d2m"
+  },
+  "0.47.01": {
+    "linux": "1wbybkfpgvpd2yliy8mfgddnz806ac4rv4j0lhlsqwpk8jj0mx81",
+    "linux32": "1fnz1mydqgybcm8kzranvjzc2x9g6bcalxv3fsjngvpv13x6izzv",
+    "osx": "18wdffidasbrsbhqjwds08ckbrjhcw0759aynz7zggyy5is9q8iw",
+    "osx32": "1b4kf3vg0zd5w5s0rdhzfz0rswkl6sq0j1f8qmimnw7qd09h43wx",
+    "win": "1v3v2z7g67d6926h9lxakznvbddyxyr85i1ym34y2wywnc886z7r",
+    "win_s": "0yahynimhz4nvdi5qp5a612vf7ikg87w2aj2r8s1lhdw6xwdkpyc",
+    "win32": "07mqhm64c1ddjc3vpyhf9qf14lp19xwz3pgg4c2pvcwy4yyrys22",
+    "win32_s": "07acbxai8g04yxg7n68nyx4jwcqqkgjn7n96q2lzxdvc988kiivz",
+    "legacy32_s": "1gxmc3rsl9glai3wb4wzsda3qyhdimd8s5kbr5m753n8lmzasafx"
   }
 }

--- a/pkgs/games/dwarf-fortress/unfuck.nix
+++ b/pkgs/games/dwarf-fortress/unfuck.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, cmake
 , libGL, libSM, SDL, SDL_image, SDL_ttf, glew, openalSoft
 , ncurses, glib, gtk2, libsndfile, zlib
-, dfVersion
+, dfVersion, pkg-config
 }:
 
 with lib;
@@ -32,6 +32,10 @@ let
       unfuckRelease = "0.44.12";
       sha256 = "1kszkb1d1vll8p04ja41nangsaxb5lv4p3xh2jhmsmipfixw7nvz";
     };
+    "0.47.01" = {
+      unfuckRelease = "0.47.01";
+      sha256 = "11xvb3qh4crdf59pwfwpi73rzm3ysd1r1xp2k1jp7527jmqapk4k";
+    };
   };
 
   release = if hasAttr dfVersion unfuck-releases
@@ -54,7 +58,7 @@ stdenv.mkDerivation {
     "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
     libSM SDL SDL_image SDL_ttf glew openalSoft
     ncurses gtk2 libsndfile zlib libGL


### PR DESCRIPTION
###### Motivation for this change
until dfhack has support for the latest release, I'm not going to bump `dwarf-fortress` default.

However, you should be able to do `dwarf-fortress-packages.dwarf-fortress_0_47_01` and play the game.

closes: #78791
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
