### PR TITLE
Update Haskell package set to LTS 14.22 (plus other fixes)

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.1.nix
+++ b/pkgs/development/compilers/ghc/8.10.1.nix
@@ -86,12 +86,12 @@ let
 
 in
 stdenv.mkDerivation (rec {
-  version = "8.10.0.20200108";
+  version = "8.10.0.20200123";
   name = "${targetPrefix}ghc-${version}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/8.10.1-rc1/ghc-${version}-src.tar.xz";
-    sha256 = "1xm6cb3s2x3rycnyvkh12mp65xi3zbwrk5ima8sg7c245f3dl0ay";
+    sha256 = "162s5g33s918i12qfcqdj5wanc10xg07g5lq3gpm5j7c1v0y1zrf";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1272,7 +1272,7 @@ self: super: {
   });
 
   # The LTS-14.x version of their dependencies are too old.
-  cabal-plan = super.cabal-plan.overrideScope (self: super: { optparse-applicative = self.optparse-applicative_0_15_1_0; ansi-terminal = self.ansi-terminal_0_10_2; base-compat = self.base-compat_0_11_0; semialign = self.semialign_1_1; time-compat = doJailbreak super.time-compat; });
+  cabal-plan = super.cabal-plan.overrideScope (self: super: { optparse-applicative = self.optparse-applicative_0_15_1_0; ansi-terminal = self.ansi-terminal_0_10_2; base-compat = self.base-compat_0_11_1; semialign = self.semialign_1_1; time-compat = doJailbreak super.time-compat; });
   hoogle = super.hoogle.override { haskell-src-exts = self.haskell-src-exts_1_23_0; };
 
   # Version bounds for http-client are too strict:

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -608,6 +608,14 @@ self: super: {
     (bustle: bustle.override { hgettext = null; })
     (bustle: disableCabalFlag bustle "hgettext")
 
+    # Bustle specifies OtherLicense even though the code is actually LGPL
+    # https://gitlab.freedesktop.org/bustle/bustle/merge_requests/17
+    (bustle: bustle.overrideAttrs (attrs: {
+      meta = builtins.removeAttrs attrs.meta [ "hydraPlatforms" ] // {
+        license = pkgs.lib.licenses.lgpl21Plus;
+      };
+    }))
+
     # Install icons, metadata and cli program.
     (bustle: overrideCabal bustle (drv: {
       buildDepends = [ pkgs.libpcap ];

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -602,41 +602,26 @@ self: super: {
   # https://github.com/athanclark/sets/issues/2
   sets = dontCheck super.sets;
 
-  bustle = pkgs.lib.pipe super.bustle [
-    # Do not build hgettext as it is broken
-    # https://gitlab.freedesktop.org/bustle/bustle/issues/13
-    (bustle: bustle.override { hgettext = null; })
-    (bustle: disableCabalFlag bustle "hgettext")
-
-    # Bustle specifies OtherLicense even though the code is actually LGPL
-    # https://gitlab.freedesktop.org/bustle/bustle/merge_requests/17
-    (bustle: bustle.overrideAttrs (attrs: {
-      meta = builtins.removeAttrs attrs.meta [ "hydraPlatforms" ] // {
-        license = pkgs.lib.licenses.lgpl21Plus;
-      };
-    }))
-
-    # Install icons, metadata and cli program.
-    (bustle: overrideCabal bustle (drv: {
-      buildDepends = [ pkgs.libpcap ];
-      buildTools = with pkgs.buildPackages; [ gettext perl help2man ];
-      patches = [
-        # fix build
-        # https://gitlab.freedesktop.org/bustle/bustle/merge_requests/14
-        (pkgs.fetchpatch {
-          url = "https://gitlab.freedesktop.org/bustle/bustle/commit/ee4b81cbc232d47ba9940f1987777b17452e71ff.patch";
-          sha256 = "0v9cvbmrma5jcqcg1narpm1549h0cg8mr6i00qxmq0x6hs04dnwa";
-        })
-        (pkgs.fetchpatch {
-          url = "https://gitlab.freedesktop.org/bustle/bustle/commit/aae6843f51f54679d440fb3813e61355dc8406b9.patch";
-          sha256 = "1a8hr38hd1gdkqhsy56hyl7njw8ci79iigr81aalkb7hn4ckvh2a";
-        })
-      ];
-      postInstall = ''
-        make install PREFIX=$out
-      '';
-    }))
-  ];
+  # Install icons, metadata and cli program.
+  bustle = overrideCabal super.bustle (drv: {
+    buildDepends = [ pkgs.libpcap ];
+    buildTools = with pkgs.buildPackages; [ gettext perl help2man ];
+    patches = [
+      # fix build
+      # https://gitlab.freedesktop.org/bustle/bustle/merge_requests/14
+      (pkgs.fetchpatch {
+        url = "https://gitlab.freedesktop.org/bustle/bustle/commit/ee4b81cbc232d47ba9940f1987777b17452e71ff.patch";
+        sha256 = "0v9cvbmrma5jcqcg1narpm1549h0cg8mr6i00qxmq0x6hs04dnwa";
+      })
+      (pkgs.fetchpatch {
+        url = "https://gitlab.freedesktop.org/bustle/bustle/commit/aae6843f51f54679d440fb3813e61355dc8406b9.patch";
+        sha256 = "1a8hr38hd1gdkqhsy56hyl7njw8ci79iigr81aalkb7hn4ckvh2a";
+      })
+    ];
+    postInstall = ''
+      make install PREFIX=$out
+    '';
+  });
 
   # Byte-compile elisp code for Emacs.
   ghc-mod = overrideCabal super.ghc-mod (drv: {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -602,28 +602,33 @@ self: super: {
   # https://github.com/athanclark/sets/issues/2
   sets = dontCheck super.sets;
 
-  # Install icons, metadata and cli program.
-  # Do not build hgettext as it is broken
-  # https://gitlab.freedesktop.org/bustle/bustle/issues/13
-  bustle = overrideCabal (disableCabalFlag (super.bustle.override { hgettext = null; }) "hgettext") (drv: {
-    buildDepends = [ pkgs.libpcap ];
-    buildTools = with pkgs.buildPackages; [ gettext perl help2man ];
-    patches = [
-      # fix build
-      # https://gitlab.freedesktop.org/bustle/bustle/merge_requests/14
-      (pkgs.fetchpatch {
-        url = "https://gitlab.freedesktop.org/bustle/bustle/commit/ee4b81cbc232d47ba9940f1987777b17452e71ff.patch";
-        sha256 = "0v9cvbmrma5jcqcg1narpm1549h0cg8mr6i00qxmq0x6hs04dnwa";
-      })
-      (pkgs.fetchpatch {
-        url = "https://gitlab.freedesktop.org/bustle/bustle/commit/aae6843f51f54679d440fb3813e61355dc8406b9.patch";
-        sha256 = "1a8hr38hd1gdkqhsy56hyl7njw8ci79iigr81aalkb7hn4ckvh2a";
-      })
-    ];
-    postInstall = ''
-      make install PREFIX=$out
-    '';
-  });
+  bustle = pkgs.lib.pipe super.bustle [
+    # Do not build hgettext as it is broken
+    # https://gitlab.freedesktop.org/bustle/bustle/issues/13
+    (bustle: bustle.override { hgettext = null; })
+    (bustle: disableCabalFlag bustle "hgettext")
+
+    # Install icons, metadata and cli program.
+    (bustle: overrideCabal bustle (drv: {
+      buildDepends = [ pkgs.libpcap ];
+      buildTools = with pkgs.buildPackages; [ gettext perl help2man ];
+      patches = [
+        # fix build
+        # https://gitlab.freedesktop.org/bustle/bustle/merge_requests/14
+        (pkgs.fetchpatch {
+          url = "https://gitlab.freedesktop.org/bustle/bustle/commit/ee4b81cbc232d47ba9940f1987777b17452e71ff.patch";
+          sha256 = "0v9cvbmrma5jcqcg1narpm1549h0cg8mr6i00qxmq0x6hs04dnwa";
+        })
+        (pkgs.fetchpatch {
+          url = "https://gitlab.freedesktop.org/bustle/bustle/commit/aae6843f51f54679d440fb3813e61355dc8406b9.patch";
+          sha256 = "1a8hr38hd1gdkqhsy56hyl7njw8ci79iigr81aalkb7hn4ckvh2a";
+        })
+      ];
+      postInstall = ''
+        make install PREFIX=$out
+      '';
+    }))
+  ];
 
   # Byte-compile elisp code for Emacs.
   ghc-mod = overrideCabal super.ghc-mod (drv: {

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -85,10 +85,10 @@ self: super: {
   lens = self.lens_4_18_1;
   memory = self.memory_0_15_0;
   microlens = self.microlens_0_4_11_2;
-  microlens-ghc = self.microlens-ghc_0_4_11_1;
+  microlens-ghc = self.microlens-ghc_0_4_12;
   microlens-mtl = self.microlens-mtl_0_2_0_1;
-  microlens-platform = self.microlens-platform_0_4_0;
-  microlens-th = self.microlens-th_0_4_3_2;
+  microlens-platform = self.microlens-platform_0_4_1;
+  microlens-th = self.microlens-th_0_4_3_4;
   network = self.network_3_1_1_1;
   optparse-applicative = self.optparse-applicative_0_15_1_0;
   pandoc = dontCheck super.pandoc_2_9_1_1;        # https://github.com/jgm/pandoc/issues/6086

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -147,4 +147,7 @@ self: super: {
   # The LTS-14.x version of the dependencies are too old.
   policeman = super.policeman.overrideScope (self: super: { ansi-terminal = self.ansi-terminal_0_10_2; relude = self.relude_0_6_0_0; });
 
+  # https://github.com/kowainik/relude/issues/241
+  relude_0_6_0_0 = dontCheck super.relude_0_6_0_0;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -144,4 +144,7 @@ self: super: {
   easytest_0_3 = markBroken super.easytest_0_3;
   haskell-src = markBrokenVersion "1.0.3.0" super.haskell-src;
 
+  # The LTS-14.x version of the dependencies are too old.
+  policeman = super.policeman.overrideScope (self: super: { ansi-terminal = self.ansi-terminal_0_10_2; relude = self.relude_0_6_0_0; });
+
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3012,6 +3012,7 @@ broken-packages:
   - archlinux
   - archlinux-web
   - archnews
+  - arduino-copilot
   - arena
   - arff
   - arghwxhaskell
@@ -4929,6 +4930,7 @@ broken-packages:
   - fused-effects-lens
   - fused-effects-random
   - fused-effects-resumable
+  - fused-effects-squeal
   - fusion
   - futhark
   - futun
@@ -5099,6 +5101,7 @@ broken-packages:
   - git-remote-ipfs
   - git-repair
   - git-sanity
+  - git-vogue
   - gitdo
   - github-backup
   - github-data
@@ -7761,6 +7764,7 @@ broken-packages:
   - opensoundcontrol-ht
   - openssh-github-keys
   - openssh-protocol
+  - opentelemetry-lightstep
   - opentheory-char
   - opentok
   - opentype
@@ -9383,6 +9387,7 @@ broken-packages:
   - structures
   - stt
   - stunts
+  - stylish-haskell
   - stylist
   - stylized
   - suavemente

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -69,7 +69,7 @@ core-packages:
 default-package-overrides:
   # pandoc-2.9 does not accept the 0.3 version yet
   - doclayout < 0.3
-  # LTS Haskell 14.21
+  # LTS Haskell 14.22
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
   - abstract-par ==0.3.3
@@ -132,7 +132,7 @@ default-package-overrides:
   - arrow-extras ==0.1.0.1
   - asciidiagram ==1.3.3.3
   - ascii-progress ==0.3.3.0
-  - asif ==6.0.3
+  - asif ==6.0.4
   - asn1-encoding ==0.9.6
   - asn1-parse ==0.9.5
   - asn1-types ==0.3.3
@@ -326,7 +326,7 @@ default-package-overrides:
   - Chart ==1.9.3
   - Chart-diagrams ==1.9.3
   - chaselev-deque ==0.5.0.5
-  - cheapskate ==0.1.1.1
+  - cheapskate ==0.1.1.2
   - cheapskate-highlight ==0.1.0.0
   - cheapskate-lucid ==0.1.0.0
   - check-email ==1.0.2
@@ -423,8 +423,8 @@ default-package-overrides:
   - control-monad-omega ==0.3.2
   - convertible ==1.1.1.0
   - cookie ==0.4.5
-  - core-data ==0.2.1.4
-  - core-text ==0.2.2.6
+  - core-data ==0.2.1.5
+  - core-text ==0.2.3.3
   - countable ==1.0
   - country ==0.1.6
   - courier ==0.1.1.5
@@ -587,7 +587,7 @@ default-package-overrides:
   - download ==0.3.2.7
   - drinkery ==0.4
   - dsp ==0.2.5
-  - dual ==0.1.0.3
+  - dual ==0.1.1.1
   - dual-tree ==0.2.2.1
   - dublincore-xml-conduit ==0.1.0.2
   - dunai ==0.5.1
@@ -669,7 +669,7 @@ default-package-overrides:
   - extractable-singleton ==0.0.1
   - extrapolate ==0.3.3
   - fail ==4.9.0.0
-  - failable ==1.2.2.0
+  - failable ==1.2.4.0
   - fakedata ==0.2.2
   - farmhash ==0.1.0.5
   - fast-builder ==0.1.2.0
@@ -900,7 +900,7 @@ default-package-overrides:
   - haskey-btree ==0.3.0.1
   - haskintex ==0.8.0.0
   - haskoin-core ==0.9.8
-  - hasql ==1.4.0.1
+  - hasql ==1.4.1
   - hasql-optparse-applicative ==0.3.0.5
   - hasql-pool ==0.5.1
   - hasql-transaction ==0.7.2
@@ -983,7 +983,7 @@ default-package-overrides:
   - HSet ==0.0.1
   - hset ==2.2.0
   - hsexif ==0.6.1.6
-  - hs-functors ==0.1.5.0
+  - hs-functors ==0.1.6.0
   - hs-GeoIP ==0.3
   - hsini ==0.5.1.2
   - hsinstall ==2.2
@@ -1037,13 +1037,13 @@ default-package-overrides:
   - http-common ==0.8.2.0
   - http-conduit ==2.3.7.3
   - http-date ==0.0.8
-  - http-directory ==0.1.5
+  - http-directory ==0.1.7
   - http-download ==0.1.0.1
   - httpd-shed ==0.4.1.1
   - http-link-header ==1.0.3.1
   - http-media ==0.8.0.0
   - http-reverse-proxy ==0.6.0
-  - http-streams ==0.8.6.1
+  - http-streams ==0.8.7.1
   - http-types ==0.12.3
   - human-readable-duration ==0.2.1.4
   - HUnit ==1.6.0.0
@@ -1059,7 +1059,7 @@ default-package-overrides:
   - hw-dsv ==0.3.5
   - hweblib ==0.6.3
   - hw-eliasfano ==0.1.1.0
-  - hw-excess ==0.2.2.1
+  - hw-excess ==0.2.2.2
   - hw-fingertree ==0.1.1.1
   - hw-fingertree-strict ==0.1.1.3
   - hw-hedgehog ==0.1.0.5
@@ -1300,13 +1300,13 @@ default-package-overrides:
   - mainland-pretty ==0.7.0.1
   - main-tester ==0.2.0.1
   - makefile ==1.1.0.0
-  - managed ==1.0.6
+  - managed ==1.0.7
   - markdown ==0.1.17.4
   - markdown-unlit ==0.5.0
   - markov-chain ==0.0.3.4
-  - massiv ==0.4.4.0
+  - massiv ==0.4.5.0
   - massiv-io ==0.1.9.0
-  - massiv-test ==0.1.1
+  - massiv-test ==0.1.2
   - mathexpr ==0.3.0.0
   - math-functions ==0.3.3.0
   - matplotlib ==0.7.5
@@ -1452,7 +1452,7 @@ default-package-overrides:
   - network-anonymous-i2p ==0.10.0
   - network-attoparsec ==0.12.2
   - network-bsd ==2.8.0.0
-  - network-byte-order ==0.1.2.0
+  - network-byte-order ==0.1.3.0
   - network-conduit-tls ==1.3.2
   - network-house ==0.1.0.2
   - network-info ==0.2.0.10
@@ -1496,7 +1496,7 @@ default-package-overrides:
   - ObjectName ==1.1.0.1
   - oblivious-transfer ==0.1.0
   - odbc ==0.2.2
-  - oeis ==0.3.9
+  - oeis ==0.3.10
   - oeis2 ==1.0.3
   - ofx ==0.4.4.0
   - old-locale ==1.0.0.7
@@ -1742,7 +1742,7 @@ default-package-overrides:
   - Ranged-sets ==0.4.0
   - range-set-list ==0.1.3.1
   - rank1dynamic ==0.4.0
-  - rank2classes ==1.3.1.2
+  - rank2classes ==1.3.2.1
   - Rasterific ==0.7.5
   - rasterific-svg ==0.3.3.2
   - ratel ==1.0.9
@@ -1900,13 +1900,13 @@ default-package-overrides:
   - servant-elm ==0.6.1
   - servant-foreign ==0.15
   - servant-http-streams ==0.16.0.1
-  - servant-js ==0.9.4
+  - servant-js ==0.9.4.1
   - servant-JuicyPixels ==0.3.0.5
   - servant-kotlin ==0.1.1.9
   - servant-lucid ==0.9
   - servant-machines ==0.15
   - servant-mock ==0.8.5
-  - servant-multipart ==0.11.4
+  - servant-multipart ==0.11.5
   - servant-pipes ==0.15.1
   - servant-rawm ==0.3.2.0
   - servant-ruby ==0.9.0.0
@@ -2187,7 +2187,7 @@ default-package-overrides:
   - timer-wheel ==0.2.0.1
   - timezone-olson ==0.1.9
   - timezone-series ==0.1.9
-  - tintin ==1.10.0
+  - tintin ==1.10.1
   - tinylog ==0.15.0
   - titlecase ==1.0.1
   - tldr ==0.4.0.2
@@ -2229,7 +2229,7 @@ default-package-overrides:
   - tuples-homogenous-h98 ==0.1.1.0
   - tuple-sop ==0.3.1.0
   - tuple-th ==0.2.5
-  - turtle ==1.5.15
+  - turtle ==1.5.16
   - TypeCompose ==0.9.14
   - typed-process ==0.2.6.0
   - type-errors ==0.2.0.0
@@ -2242,7 +2242,7 @@ default-package-overrides:
   - typelits-witnesses ==0.4.0.0
   - type-map ==0.1.6.0
   - typenums ==0.1.2.1
-  - type-of-html ==1.5.0.0
+  - type-of-html ==1.5.1.0
   - type-of-html-static ==0.1.0.2
   - type-operators ==0.2.0.0
   - typerep-map ==0.3.2
@@ -2383,7 +2383,7 @@ default-package-overrides:
   - websockets ==0.12.7.0
   - websockets-snap ==0.10.3.1
   - weigh ==0.0.16
-  - wide-word ==0.1.0.9
+  - wide-word ==0.1.1.0
   - wikicfp-scraper ==0.1.0.11
   - wild-bind ==0.1.2.5
   - wild-bind-x11 ==0.2.0.9

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -132,6 +132,37 @@ let
                      main = defaultMain
                    '';
 
+  # This awk expression transforms a package conf file like
+  #
+  #   author:               John Doe <john-doe@example.com>
+  #   description:
+  #       The purpose of this library is to do
+  #       foo and bar among other things
+  #
+  # into a more easily processeable form:
+  #
+  #   author: John Doe <john-doe@example.com>
+  #   description: The purpose of this library is to do foo and bar among other things
+  unprettyConf = builtins.toFile "unpretty-cabal-conf.awk" ''
+    /^[^ ]+:/ {
+      # When the line starts with a new field, terminate the previous one with a newline
+      if (started == 1) print ""
+      # to strip leading spaces
+      $1=$1
+      printf "%s", $0
+      started=1
+    }
+
+    /^ +/ {
+      # to strip leading spaces
+      $1=$1
+      printf " %s", $0
+    }
+
+    # Terminate the final field with a newline
+    END { print "" }
+  '';
+
   crossCabalFlags = [
     "--with-ghc=${ghcCommand}"
     "--with-ghc-pkg=${ghc.targetPrefix}ghc-pkg"
@@ -344,12 +375,22 @@ stdenv.mkDerivation ({
     # libraries) from all the dependencies.
     local dynamicLinksDir="$out/lib/links"
     mkdir -p $dynamicLinksDir
-    for d in $(grep dynamic-library-dirs "$packageConfDir/"*|awk '{print $2}'|sort -u); do
-      ln -s "$d/"*.dylib $dynamicLinksDir
+
+    # Unprettify all package conf files before reading/writing them
+    for d in "$packageConfDir/"*; do
+      # gawk -i inplace seems to strip the last newline
+      gawk -f ${unprettyConf} "$d" > tmp
+      mv tmp "$d"
+    done
+
+    for d in $(grep '^dynamic-library-dirs:' "$packageConfDir"/* | cut -d' ' -f2- | tr ' ' '\n' | sort -u); do
+      for lib in "$d/"*.dylib; do
+        ln -s "$lib" "$dynamicLinksDir"
+      done
     done
     # Edit the local package DB to reference the links directory.
     for f in "$packageConfDir/"*.conf; do
-      sed -i "s,dynamic-library-dirs: .*,dynamic-library-dirs: $dynamicLinksDir," $f
+      sed -i "s,dynamic-library-dirs: .*,dynamic-library-dirs: $dynamicLinksDir," "$f"
     done
   '') + ''
     ${ghcCommand}-pkg --${packageDbFlag}="$packageConfDir" recache
@@ -418,10 +459,6 @@ stdenv.mkDerivation ({
     runHook postHaddock
   '';
 
-  # The scary sed expression handles two cases in v2.5 Cabal's package configs:
-  # 1. 'id:    short-name-0.0.1-9yvw8HF06tiAXuxm5U8KjO'
-  # 2. 'id:\n
-  #         very-long-descriptive-useful-name-0.0.1-9yvw8HF06tiAXuxm5U8KjO'
   installPhase = ''
     runHook preInstall
 
@@ -436,8 +473,9 @@ stdenv.mkDerivation ({
         rmdir "$packageConfFile"
       fi
       for packageConfFile in "$packageConfDir/"*; do
-        local pkgId=$( ${gnused}/bin/sed -n -e ':a' -e '/^id:$/N; s/id:\n[ ]*\([^\n]*\).*$/\1/p; s/id:[ ]*\([^\n]*\)$/\1/p; ta' $packageConfFile )
-        mv $packageConfFile $packageConfDir/$pkgId.conf
+        local pkgId=$(gawk -f ${unprettyConf} "$packageConfFile" \
+          | grep '^id:' | cut -d' ' -f2)
+        mv "$packageConfFile" "$packageConfDir/$pkgId.conf"
       done
 
       # delete confdir if there are no libraries


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-01-31 [21:00 CET](http://www.thetimezoneconverter.com/?t=21:00&tz=Berlin). You can watch this live on Twitch: https://www.twitch.tv/peti343. If you'd like to chat with me (and others) during the stream, you're welcome to use the Twitch chat or join the [`#haskell4nix` voice conference](https://discord.gg/YTEa3XR).

## TODO

- [x] https://github.com/NixOS/nixpkgs/pull/78738
- [x] Check changes to `bustle`.
- [ ] Try to revive `haskell-ci` build.
- [x] Try `policeman`.