### PR TITLE
imlib2: 1.5.1 -> 1.6.1

### DIFF
--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -1,6 +1,11 @@
-{ stdenv, fetchurl, libjpeg, libtiff, giflib, libpng, bzip2, pkgconfig
-, freetype, libid3tag
-, x11Support ? true, xlibsWrapper ? null }:
+{ stdenv, fetchurl
+# Image file formats
+, libjpeg, libtiff, giflib, libpng, libwebp
+# imlib2 can load images from ID3 tags.
+, libid3tag
+, freetype , bzip2, pkgconfig
+, x11Support ? true, xlibsWrapper ? null
+}:
 
 let
   inherit (stdenv.lib) optional;
@@ -14,8 +19,10 @@ stdenv.mkDerivation rec {
     sha256 = "0v8n3dswx7rxqfd0q03xwc7j2w1mv8lv18rdxv487a1xw5vklfad";
   };
 
-  buildInputs = [ libjpeg libtiff giflib libpng bzip2 freetype libid3tag ]
-    ++ optional x11Support xlibsWrapper;
+  buildInputs = [
+    libjpeg libtiff giflib libpng libwebp
+    bzip2 freetype libid3tag
+  ] ++ optional x11Support xlibsWrapper;
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -2,8 +2,9 @@
 , freetype, libid3tag
 , x11Support ? true, xlibsWrapper ? null }:
 
-with stdenv.lib;
-
+let
+  inherit (stdenv.lib) optional;
+in
 stdenv.mkDerivation rec {
   pname = "imlib2";
   version = "1.6.1";
@@ -36,7 +37,7 @@ stdenv.mkDerivation rec {
     moveToOutput bin/imlib2-config "$dev"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Image manipulation library";
 
     longDescription = ''
@@ -47,8 +48,8 @@ stdenv.mkDerivation rec {
       easily, without sacrificing speed.
     '';
 
-    homepage = http://docs.enlightenment.org/api/imlib2/html;
-    license = licenses.free;
+    homepage = "https://docs.enlightenment.org/api/imlib2/html";
+    license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ spwhitt ];
   };

--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -5,11 +5,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "imlib2-1.5.1";
+  pname = "imlib2";
+  version = "1.6.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/enlightenment/${name}.tar.bz2";
-    sha256 = "1bms2iwmvnvpz5jqq3r52glarqkafif47zbh1ykz8hw85d2mfkps";
+    url = "mirror://sourceforge/enlightenment/${pname}-${version}.tar.bz2";
+    sha256 = "0v8n3dswx7rxqfd0q03xwc7j2w1mv8lv18rdxv487a1xw5vklfad";
   };
 
   buildInputs = [ libjpeg libtiff giflib libpng bzip2 freetype libid3tag ]


### PR DESCRIPTION
###### Motivation for this change

Updates imlib2 to the latest version.

Add support for libwebp.

In addition, fixes license metadata, and misc things.

###### Things done

Only limited testing was done.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Closes #74394