### PR TITLE
highfive: init at 2.1.1

### DIFF
--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -67,7 +67,7 @@ in rec {
   };
 
   kops_1_15 = mkKops {
-    version = "1.15.0";
-    sha256 = "0sjas8pn0njl767b1y15g7cci2q3kxkxwmgr0wvs7vi3n1s1sf9d";
+    version = "1.15.1";
+    sha256 = "0iq2bqq6zv6sk2psar33c3smnz79rk5v623qx4kr5h47wnqvrfvj";
   };
 }

--- a/pkgs/development/libraries/highfive/default.nix
+++ b/pkgs/development/libraries/highfive/default.nix
@@ -1,0 +1,51 @@
+{
+  stdenv
+, fetchFromGitHub
+, cmake
+, boost
+, eigen
+, hdf5
+}:
+
+let
+  version = "2.1.1";
+  mpiSupport = hdf5.mpiSupport;
+  mpi = hdf5.mpi;
+in
+stdenv.mkDerivation {
+  pname = "highfive";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "BlueBrain";
+    repo = "HighFive";
+    rev = "b9b25da543145166b01bcca01c3cbedfcbd06307";
+    sha256 = "0ci9vv9laav5a3awrvvdrfc10z0n5baiav7q4lxxrzclgmla1nnc";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost eigen hdf5 ];
+
+  passthru = {
+    mpiSupport = mpiSupport;
+    inherit mpi;
+  };
+
+  cmakeFlags = [
+    "-DUSE_BOOST=ON"  # In the next release will be HIGHFIVE_USE_BOOST
+    "-DUSE_EIGEN=ON"  # In the next release will be HIGHFIVE_USE_EIGEN
+    "-DHIGHFIVE_EXAMPLES=OFF"
+    "-DHIGHFIVE_UNIT_TESTS=OFF"
+  ]
+  ++ (stdenv.lib.optionals mpiSupport [ "-DHIGHFIVE_PARALLEL_HDF5=ON" ]);
+
+  meta = with stdenv.lib; {
+    inherit version;
+    description = "Header-only C++ HDF5 interface";
+    license = licenses.boost;
+    homepage = https://bluebrain.github.io/HighFive/ ;
+    platforms = platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ robertodr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11914,6 +11914,12 @@ in
     libusb = libusb1;
   };
 
+  highfive = callPackage ../development/libraries/highfive { };
+
+  highfive-mpi = appendToName "mpi" (highfive.override {
+    hdf5 = hdf5-mpi;
+  });
+
   hiredis = callPackage ../development/libraries/hiredis { };
 
   hiredis-vip = callPackage ../development/libraries/hiredis-vip { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add the [HighFive](https://github.com/BlueBrain/HighFive) header-only C++ HDF5 interface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
