### PR TITLE
speechd: 0.8.8 → 0.9.1

### DIFF
--- a/pkgs/development/libraries/speechd/default.nix
+++ b/pkgs/development/libraries/speechd/default.nix
@@ -1,6 +1,15 @@
-{ stdenv, pkgconfig, fetchurl, python3Packages
-, intltool, itstool, libtool, texinfo, autoreconfHook
-, glib, dotconf, libsndfile
+{ stdenv
+, pkgconfig
+, fetchurl
+, python3Packages
+, intltool
+, itstool
+, libtool
+, texinfo
+, autoreconfHook
+, glib
+, dotconf
+, libsndfile
 , withLibao ? true, libao
 , withPulse ? false, libpulseaudio
 , withAlsa ? false, alsaLib
@@ -35,11 +44,29 @@ in stdenv.mkDerivation rec {
     sha256 = "1wvck00w9ixildaq6hlhnf6wa576y02ac96lp6932h3k1n08jaiw";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook intltool libtool itstool texinfo wrapPython ];
+  nativeBuildInputs = [
+    pkgconfig
+    autoreconfHook
+    intltool
+    libtool
+    itstool
+    texinfo
+    wrapPython
+  ];
 
-  buildInputs = [ glib dotconf libsndfile libao libpulseaudio alsaLib python ]
-    ++ optionals withEspeak [ espeak sonic pcaudiolib ]
-    ++ optional withFlite flite
+  buildInputs = [
+    glib
+    dotconf
+    libsndfile
+    libao
+    libpulseaudio
+    alsaLib
+    python
+  ] ++ optionals withEspeak [
+    espeak
+    sonic
+    pcaudiolib
+  ] ++ optional withFlite flite
     ++ optional withPico svox
     # TODO: add flint/festival support with festival-freebsoft-utils package
     # ++ optional withFestival festival-freebsoft-utils
@@ -73,7 +100,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Common interface to speech synthesis";
-    homepage = https://devel.freebsoft.org/speechd;
+    homepage = "https://devel.freebsoft.org/speechd";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ berce ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/speechd/fix-paths.patch
+++ b/pkgs/development/libraries/speechd/fix-paths.patch
@@ -1,0 +1,11 @@
+--- a/speech-dispatcherd.service.in
++++ b/speech-dispatcherd.service.in
+@@ -19,7 +19,7 @@
+ [Service]
+ Type=forking
+ ExecStart=@bindir@/speech-dispatcher -d
+-ExecReload=/bin/kill -HUP $MAINPID
++ExecReload=@utillinux@/bin/kill -HUP $MAINPID
+ 
+ [Install]
+ WantedBy=multi-user.target


### PR DESCRIPTION
###### Motivation for this change
0.9.0: https://lists.nongnu.org/archive/html/speechd-discuss/2019-01/msg00058.html
0.9.1: https://lists.nongnu.org/archive/html/speechd-discuss/2019-05/msg00000.html

Drops intltool and adds systemd service :tada: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @berce