### PR TITLE
mkgmap: 4289 -> 4432

### DIFF
--- a/pkgs/applications/misc/mkgmap/default.nix
+++ b/pkgs/applications/misc/mkgmap/default.nix
@@ -17,12 +17,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "mkgmap";
-  version = "4289";
+  version = "4432";
 
   src = fetchsvn {
     url = "https://svn.mkgmap.org.uk/mkgmap/mkgmap/trunk";
     rev = version;
-    sha256 = "1sm1pw71q7z0jrxm8bcgm6xjl2mcidyibcf0a3m8fv2andidxrb4";
+    sha256 = "1z1ppf9v1b9clnx20v15xkmdrfw6q4h7i15drzxsdh2wl6bafzvx";
   };
 
   # This patch removes from the build process


### PR DESCRIPTION
###### Motivation for this change
http://www.mkgmap.org.uk/download/mkgmap.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/6gvv7vmasvvj3jlrnls0v0adjj4i05zm-mkgmap-4289
/nix/store/6gvv7vmasvvj3jlrnls0v0adjj4i05zm-mkgmap-4289	391.8M
$ nix path-info -Sh /nix/store/zwigci4m3kpf8n32lgvyv2vadmphipgl-mkgmap-4432
/nix/store/zwigci4m3kpf8n32lgvyv2vadmphipgl-mkgmap-4432	391.8M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
