### PR TITLE
ocamlPackages.biocaml: 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/development/ocaml-modules/biocaml/default.nix
+++ b/pkgs/development/ocaml-modules/biocaml/default.nix
@@ -4,7 +4,7 @@
 
 buildDunePackage rec {
   pname = "biocaml";
-  version = "0.10.0";
+  version = "0.10.1";
 
   owner = "biocaml";
 
@@ -14,7 +14,7 @@ buildDunePackage rec {
     inherit owner;
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "0dghqx6jbzihmga8jjwwavs0wqksgcns4z1nmwj0ds9ik3mcra30";
+    sha256 = "1f19nc8ld0iv45jjnsvaah3ddj88s2n9wj8mrz726kzg85cfr8xj";
   };
 
   buildInputs = [ ppx_jane ppx_sexp_conv ];
@@ -23,7 +23,7 @@ buildDunePackage rec {
 
   meta = with stdenv.lib; {
     description = "Bioinformatics library for Ocaml";
-    homepage = "http://${owner}.github.io/${pname}";
+    homepage = "http://${pname}.org";
     maintainers = [ maintainers.bcdarwin ];
     license = licenses.gpl2;
   };

--- a/pkgs/development/ocaml-modules/cfstream/default.nix
+++ b/pkgs/development/ocaml-modules/cfstream/default.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "cfstream";
-  version = "1.3.0";
+  version = "1.3.1";
 
   minimumOCamlVersion = "4.04.1";
 
@@ -10,7 +10,7 @@ buildDunePackage rec {
     owner = "biocaml";
     repo   = pname;
     rev    = version;
-    sha256 = "1bpzpci0cx6r3sdk183mm603wgzvvj46nlx0lpx44108anxcxbak";
+    sha256 = "0qnxfp6y294gjsccx7ksvwn9x5q20hi8sg24rjypzsdkmlphgdnd";
   };
 
   patches = [ ./git_commit.patch ];

--- a/pkgs/development/ocaml-modules/cfstream/git_commit.patch
+++ b/pkgs/development/ocaml-modules/cfstream/git_commit.patch
@@ -1,13 +1,13 @@
-diff --git a/lib/jbuild b/lib/jbuild
-index fcc5a39..d72d50c 100644
---- a/lib/jbuild
-+++ b/lib/jbuild
-@@ -10,7 +10,7 @@
- (rule (
-   (targets (GIT_COMMIT))
-   (deps (../bin/git_commit.sh))
--  (action (with-stdout-to ${@} (run ${<})))
-+  (action (with-stdout-to ${@} (run echo "None")))
- ))
+diff --git a/lib/dune b/lib/dune
+index 2266b87..344c704 100644
+--- a/lib/dune
++++ b/lib/dune
+@@ -8,7 +8,7 @@
+ (rule
+  (targets GIT_COMMIT)
+  (deps (:x ../bin/git_commit.sh))
+- (action (with-stdout-to %{targets} (run %{x})))
++ (action (with-stdout-to %{targets} (run echo None)))
+ )
  
- (rule (
+ (rule


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update package.  Fixed website in the Nix expression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
