### PR TITLE
dino: remove unnecessary private transitive deps

### DIFF
--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -2,7 +2,7 @@
 , vala, cmake, ninja, wrapGAppsHook, pkgconfig, gettext
 , gobject-introspection, gnome3, glib, gdk-pixbuf, gtk3, glib-networking
 , xorg, libXdmcp, libxkbcommon
-, libnotify, libsoup, libgee, utillinux, libselinux, libsepol, libpsl, brotli
+, libnotify, libsoup, libgee
 , librsvg, libsignal-protocol-c
 , libgcrypt
 , epoxy
@@ -52,18 +52,12 @@ stdenv.mkDerivation rec {
     pcre
     xorg.libxcb
     xorg.libpthreadstubs
-    xorg.libXtst
     libXdmcp
     libxkbcommon
     epoxy
     at-spi2-core
     dbus
     icu
-    utillinux
-    libselinux
-    libsepol
-    libpsl
-    brotli
     libsignal-protocol-c
     librsvg
   ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

As explained by @orivej:

> These (except libsignal-protocol-c) are private dependencies of the
> actual dependencies that should neither be propagated nor added
> manually to dino. For example, libpsl and brotli come from
> libsoup-2.4.pc:
>
>     Requires: glib-2.0 >=  2.38, gobject-2.0 >=  2.38, gio-2.0 >=  2.38
>     Requires.private: libxml-2.0, sqlite3, libpsl >=  0.20, libbrotlidec, zlib
>
> (To be precise, glib uses utillinuxMinimal rather than utillinux.)
>
> The warnings we see, such as Package 'mount', required by 'gio-2.0',
> not found, come from CMake running both pkg-config --libs and
> pkg-config --static --libs to populate both <XXX>_LIBRARIES and
> <XXX>_STATIC_LIBRARIES[1], but dino has no use for the latter.
> Currently these warnings can not be disabled:
> https://gitlab.kitware.com/cmake/cmake/issues/18158
>
> (They could be prevented by pruning Requires.private from shared-only
> libraries akin to <https://github.com/NixOS/nixpkgs/pull/51767>,
> although it can not be detected if a library is shared-only from the
> .pc file alone, and this is just a warning.)
>
> [1]: docs: https://cmake.org/cmake/help/v3.16/module/FindPkgConfig.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
