### PR TITLE
installation-cd-graphical-gnome: updates

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -1,5 +1,4 @@
-# This module defines a NixOS installation CD that contains X11 and
-# GNOME 3.
+# This module defines a NixOS installation CD that contains GNOME.
 
 { lib, ... }:
 
@@ -10,10 +9,22 @@ with lib;
 
   services.xserver.desktopManager.gnome3.enable = true;
 
-  # Auto-login as root.
-  services.xserver.displayManager.gdm.autoLogin = {
+  # Wayland can be problematic for some hardware like Nvidia graphics cards.
+  services.xserver.displayManager.defaultSession = "gnome-xorg";
+
+  services.xserver.displayManager.gdm = {
     enable = true;
-    user = "root";
+    # autoSuspend makes the machine automatically suspend after inactivity.
+    # It's possible someone could/try to ssh'd into the machine and obviously
+    # have issues because it's inactive.
+    # See:
+    # * https://github.com/NixOS/nixpkgs/pull/63790
+    # * https://gitlab.gnome.org/GNOME/gnome-control-center/issues/22
+    autoSuspend = false;
+    autoLogin = {
+      enable = true;
+      user = "nixos";
+    };
   };
 
 }


### PR DESCRIPTION
Note we're not using wayland default in the graphical media because it
could cause headaches for Nvidia users. But the session is still available
if someone logs out.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This doesn't add it to the release. It's just stuff that I'd like committed that's been languishing around.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
