### PR TITLE
 fondo: 1.3.2 -> 1.3.8,  aesop: 1.1.3 -> 1.2.3

### DIFF
--- a/pkgs/applications/graphics/fondo/default.nix
+++ b/pkgs/applications/graphics/fondo/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , fetchFromGitHub
-, fetchpatch
 , pantheon
 , vala
 , pkgconfig
@@ -15,26 +14,28 @@
 , glib-networking
 , libsoup
 , libunity
+, desktop-file-utils
 , wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "fondo";
-  version = "1.3.2";
+  version = "1.3.8";
 
   src = fetchFromGitHub {
     owner = "calo001";
     repo = pname;
     rev = version;
-    sha256 = "0w7qai261l9m7ckzxc2gj3ywa55wm6p5br1xdk7607ql44lfpgba";
+    sha256 = "126diirhmm2igxdpgfv1l20wnz5q8hadgq53d0j83ka72mfd3qg6";
   };
 
   nativeBuildInputs = [
+    desktop-file-utils
     meson
     ninja
-    vala
     pkgconfig
     python3
+    vala
     wrapGAppsHook
   ];
 
@@ -48,14 +49,6 @@ stdenv.mkDerivation rec {
     libsoup
     libunity
     pantheon.granite
-  ];
-
-  patches = [
-    # Fix hardcoded FHS gsettings path
-    (fetchpatch {
-      url = "https://github.com/calo001/fondo/commit/98afdd834201321a3242f0b53bfba4b2ffa04a4c.patch";
-      sha256 = "0vvgbgjja6vyrk6in3sgv8jbl4bwxkm6fhllgjzq7r65gkj4jg79";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/applications/office/aesop/default.nix
+++ b/pkgs/applications/office/aesop/default.nix
@@ -3,23 +3,14 @@
 
 stdenv.mkDerivation rec {
   pname = "aesop";
-  version = "1.1.3";
+  version = "1.2.3";
 
   src = fetchFromGitHub {
     owner = "lainsce";
     repo = pname;
     rev = version;
-    sha256 = "1hnwhxaz0zx4fswrxjzyv5s77v5fimn87yid9sd1qgfv2g1ck0jc";
+    sha256 = "1aa1kp1rndi2dj1d9sf8zhssn5dw183yx1fm2xccdy9zjf9wi4jk";
   };
-
-  patches = [
-    # Fix build
-    # https://github.com/lainsce/aesop/pull/33
-    (fetchpatch {
-      url = "https://github.com/lainsce/aesop/commit/850ec86bbfef5168e537a5af7e0d73d96db56330.patch";
-      sha256 = "14b251wp11rypqw4fafwjbsqy92mxzr8mmaxlv7n4whvwxrzqirh";
-    })
-  ];
 
   nativeBuildInputs = [
     desktop-file-utils


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
