### PR TITLE
fceux: 2.2.3 -> 2020-01-29

### DIFF
--- a/pkgs/misc/emulators/fceux/default.nix
+++ b/pkgs/misc/emulators/fceux/default.nix
@@ -1,11 +1,14 @@
-{stdenv, fetchurl, scons, zlib, SDL, lua5_1, pkgconfig}:
+{stdenv, fetchFromGitHub, scons, zlib, SDL, lua5_1, pkgconfig}:
 
 stdenv.mkDerivation {
-  name = "fceux-2.2.3";
+  pname = "fceux-unstable";
+  version = "2020-01-29";
 
-  src = fetchurl {
-    url = mirror://sourceforge/fceultra/Source%20Code/2.2.3%20src/fceux-2.2.3.src.tar.gz;
-    sha256 = "0gl2i3qdmcm7v9m5kpfz98w05d8m33990jiwka043ya7lflxvrjb";
+  src = fetchFromGitHub {
+    owner = "TASVideos";
+    repo = "fceux";
+    rev = "fb8d46d9697cb24b0ebe79d84eedf282f69ab337";
+    sha256 = "0gpz411dzfwx9mr34yi4zb1hphd5hha1nvwgzxki0sviwafca992";
   };
 
   nativeBuildInputs = [ pkgconfig scons ];
@@ -30,6 +33,7 @@ stdenv.mkDerivation {
   meta = {
     description = "A Nintendo Entertainment System (NES) Emulator";
     license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.scubed2 ];
     homepage = http://www.fceux.com/;
     platforms = stdenv.lib.platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
Version bump for Python 3 compatibility within scons build rule for
https://github.com/NixOS/nixpkgs/pull/75877

I've manually, locally built with both Python 2 and Python 3 (using above pull request patched in).

I'm using a github snapshot instead of a release because there haven't been any formal releases since 2.2.3 in 2016, but there have been github updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).