### PR TITLE
tzupdate: 1.5.0 -> 2.0.0, use python3

### DIFF
--- a/pkgs/applications/misc/tzupdate/default.nix
+++ b/pkgs/applications/misc/tzupdate/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, python }:
+{ stdenv, python3 }:
 
 let
-  inherit (python.pkgs) buildPythonApplication fetchPypi requests;
+  inherit (python3.pkgs) buildPythonApplication fetchPypi requests;
 in
 buildPythonApplication rec {
   pname = "tzupdate";
-  version = "1.5.0";
+  version = "2.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "13np40h64bgkcj10qw6f4nb51p47bb20fd6pzxq8xbr645a4d34m";
+    sha256 = "12jvyza9pfhazkzq94nizacknnp32lf7kalrjmpz1z2bqqxhx0fm";
   };
 
   propagatedBuildInputs = [ requests ];
 
   meta = with stdenv.lib; {
-    description = "Update timezone information based on geoip.";
-    homepage = https://github.com/cdown/tzupdate;
+    description = "Update timezone information based on geoip";
+    homepage = "https://github.com/cdown/tzupdate";
     maintainers = [ maintainers.michaelpj ];
     license = licenses.unlicense;
   };


### PR DESCRIPTION
###### Motivation for this change
uses python3

closes #78889

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/78944
1 package built:
tzupdate
```