### PR TITLE
highfive: init at 2.2

### DIFF
--- a/pkgs/development/libraries/highfive/default.nix
+++ b/pkgs/development/libraries/highfive/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, boost
+, eigen
+, hdf5
+, mpiSupport ? hdf5.mpiSupport
+, mpi ? hdf5.mpi
+}:
+
+assert mpiSupport -> mpi != null;
+
+stdenv.mkDerivation rec {
+  pname = "highfive";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "BlueBrain";
+    repo = "HighFive";
+    rev = "4c70d818ed18231563fe49ff197d1c41054be592";
+    sha256 = "02xy3c2ix3nw8109aw75ixj651knzc5rjqwqrxximm4hzwx09frk";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost eigen hdf5 ];
+
+  passthru = {
+    inherit mpiSupport mpi;
+  };
+
+  cmakeFlags = [
+    "-DHIGHFIVE_USE_BOOST=ON"
+    "-DHIGHFIVE_USE_EIGEN=ON"
+    "-DHIGHFIVE_EXAMPLES=OFF"
+    "-DHIGHFIVE_UNIT_TESTS=OFF"
+    "-DHIGHFIVE_USE_INSTALL_DEPS=ON"
+  ]
+  ++ (stdenv.lib.optionals mpiSupport [ "-DHIGHFIVE_PARALLEL_HDF5=ON" ]);
+
+  meta = with stdenv.lib; {
+    inherit version;
+    description = "Header-only C++ HDF5 interface";
+    license = licenses.boost;
+    homepage = "https://bluebrain.github.io/HighFive/";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ robertodr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12117,6 +12117,12 @@ in
     libusb = libusb1;
   };
 
+  highfive = callPackage ../development/libraries/highfive { };
+
+  highfive-mpi = appendToName "mpi" (highfive.override {
+    hdf5 = hdf5-mpi;
+  });
+
   hiredis = callPackage ../development/libraries/hiredis { };
 
   hiredis-vip = callPackage ../development/libraries/hiredis-vip { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add the [HighFive](https://github.com/BlueBrain/HighFive) header-only C++ HDF5 interface.

Supersedes #78915 where I FUBAR-ed the squashing @jonringer had requested. Apologies for the noise and confusion!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).