### PR TITLE
vegeta: init at 12.7.0

### DIFF
--- a/pkgs/tools/networking/vegeta/default.nix
+++ b/pkgs/tools/networking/vegeta/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  pname = "vegeta";
+  version = "12.7.0";
+
+  src = fetchFromGitHub {
+    owner = "tsenart";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wzx9588hjzxq65fxi1zz9xpsw33qq41hpl0j2f077g4m8yxahv5";
+  };
+
+  goPackagePath = "github.com/tsenart/${pname}";
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Versatile HTTP load testing tool";
+    license = licenses.mit;
+    homepage = "https://github.com/tsenart/vegeta/";
+    maintainers = [ maintainers.mmahut ];
+  };
+}
+

--- a/pkgs/tools/networking/vegeta/deps.nix
+++ b/pkgs/tools/networking/vegeta/deps.nix
@@ -1,0 +1,246 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/alecthomas/jsonschema";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/jsonschema";
+      rev = "f2c93856175a";
+      sha256 = "145w6zg453mbspfyixs71xfjwi3djq20lij1rcgrdcn5gmwj2cal";
+    };
+  }
+  {
+    goPackagePath = "github.com/bmizerany/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bmizerany/perks";
+      rev = "d9a9656a3a4b";
+      sha256 = "0f39b3zfm1zd6xcvlm6szgss026qs84n2j9y5bnb3zxzdkxb9w9n";
+    };
+  }
+  {
+    goPackagePath = "github.com/c2h5oh/datasize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/c2h5oh/datasize";
+      rev = "4eba002a5eae";
+      sha256 = "02sxd659q7m7axfywiqfxk5rh6djh2m5240bin1makldj1nj16j3";
+    };
+  }
+  {
+    goPackagePath = "github.com/dgryski/go-gk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgryski/go-gk";
+      rev = "201884a44051";
+      sha256 = "17csmdlqibg5g2pjybh4522dis6nklyhjvly55pawy0vprd17agz";
+    };
+  }
+  {
+    goPackagePath = "github.com/dgryski/go-lttb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgryski/go-lttb";
+      rev = "318fcdf10a77";
+      sha256 = "0cs2rr2j6fbbpgmfxkq39pir4bibfzkfwxvd2cvw30q97cmfpiz3";
+    };
+  }
+  {
+    goPackagePath = "github.com/gonum/blas";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gonum/blas";
+      rev = "f22b278b28ac";
+      sha256 = "0dh73akv4gazyhva9xbm9xbq786vij8iisivp3p65p6ahf502fs6";
+    };
+  }
+  {
+    goPackagePath = "github.com/gonum/diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gonum/diff";
+      rev = "500114f11e71";
+      sha256 = "1bg4k3bxqb44nz1nmyigr5bx55859n55vvi45w2rq4y5djvpral8";
+    };
+  }
+  {
+    goPackagePath = "github.com/gonum/floats";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gonum/floats";
+      rev = "c233463c7e82";
+      sha256 = "12m7pa64mk3am2i10agg6c1aqdfgx9i3f4bgf3w7wra8bnnjncp6";
+    };
+  }
+  {
+    goPackagePath = "github.com/gonum/integrate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gonum/integrate";
+      rev = "a422b5c0fdf2";
+      sha256 = "01wfav882h3bcp137cd2bsr91hkmmi4d6qwhdm0xv1p2z2qzs7iq";
+    };
+  }
+  {
+    goPackagePath = "github.com/gonum/internal";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gonum/internal";
+      rev = "f884aa714029";
+      sha256 = "038w8pc82vxq773qg0mw472f3p8h5vkh3ggcdn09qd3s6myp2zq7";
+    };
+  }
+  {
+    goPackagePath = "github.com/gonum/lapack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gonum/lapack";
+      rev = "e4cdc5a0bff9";
+      sha256 = "046fffskysg0bmha16s5582bimpis0m6qd7c7k1n65a0qhrslli1";
+    };
+  }
+  {
+    goPackagePath = "github.com/gonum/mathext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gonum/mathext";
+      rev = "8a4bf007ea55";
+      sha256 = "044xy32mgcjc5948na6f6fgqqq17canw3z6sppidmj52s17p0k7i";
+    };
+  }
+  {
+    goPackagePath = "github.com/gonum/matrix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gonum/matrix";
+      rev = "c518dec07be9";
+      sha256 = "0i6pyxxhcy2s9as77g90dsj9xya48775dl5fxgvqal665cxc4l4i";
+    };
+  }
+  {
+    goPackagePath = "github.com/gonum/stat";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gonum/stat";
+      rev = "41a0da705a5b";
+      sha256 = "0r9mqiy3ma0c15p57bz4xq2vf105s9g1lqysb7ff0nip4050cpvn";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.2.0";
+      sha256 = "1fbv0x27k9sn8svafc0hjwsnckk864lv4yi7bvzrxvmd3d5hskds";
+    };
+  }
+  {
+    goPackagePath = "github.com/influxdata/tdigest";
+    fetch = {
+      type = "git";
+      url = "https://github.com/influxdata/tdigest";
+      rev = "a7d76c6f093a";
+      sha256 = "02jxrb2d1n6zflwa7jhgid5344l6zj4gxg4kis20v7xa6iqrj1ni";
+    };
+  }
+  {
+    goPackagePath = "github.com/mailru/easyjson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailru/easyjson";
+      rev = "v0.7.0";
+      sha256 = "13zv5fvjp3nr65lhqhiw6i6mlmqvyls882rlmcas0ab35alsxni8";
+    };
+  }
+  {
+    goPackagePath = "github.com/miekg/dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/miekg/dns";
+      rev = "v1.1.17";
+      sha256 = "0x0375n7n1qmgyn7yvpr65z4ll4l39q2xagyfafw09h3kkrkpka8";
+    };
+  }
+  {
+    goPackagePath = "github.com/streadway/quantile";
+    fetch = {
+      type = "git";
+      url = "https://github.com/streadway/quantile";
+      rev = "b0c588724d25";
+      sha256 = "1y27nrg7wkyrvw07a5s7wl4lpwxshwyvhzc6i0rzn20dajah2vkh";
+    };
+  }
+  {
+    goPackagePath = "github.com/tsenart/go-tsz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tsenart/go-tsz";
+      rev = "cdeb9e1e981e";
+      sha256 = "1lgnllx810ly0203jn9vkimcwqv3302mnh9d7mip1yyq4cmvlj3b";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "9756ffdc2472";
+      sha256 = "0q7hxaaq6lp0v8qqzifvysl47z5rfdlrxkh3d29vsl3wyby3dxl8";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "ba9fcec4b297";
+      sha256 = "1hbqvy6r0s5h0dpdqw8fynl3cq0acin3iyqki9xvl5r8h33yb9bx";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "112230192c58";
+      sha256 = "05i2k43j2d0llq768hg5pf3hb2yhfzp9la1w5wp0rsnnzblr0lfn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "749cb33beabd";
+      sha256 = "0dm3257q3rv2kyn5lmqqim2fqg634v6rhrqq4glvbk4wx4l3v337";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.2";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "2ca718005c18";
+      sha256 = "1nl4cw8vrfigab0hij86vl2mmhfmyim69r7vy5qk2v60g8frvgxg";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/xerrors";
+      rev = "a985d3407aa7";
+      sha256 = "00wzr5w8aadipgc3rkk8f11i41znskfj9ix5nhhaxyg7isrslgcj";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17971,6 +17971,8 @@ in
 
   vegur = callPackage ../data/fonts/vegur { };
 
+  vegeta = callPackage ../tools/networking/vegeta { };
+
   victor-mono = callPackage ../data/fonts/victor-mono { };
 
   vistafonts = callPackage ../data/fonts/vista-fonts { };


### PR DESCRIPTION
###### Motivation for this change

vegeta: init at 12.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
