### PR TITLE
kompose: 1.18.0 -> 1.20.0

### DIFF
--- a/pkgs/applications/networking/cluster/kompose/default.nix
+++ b/pkgs/applications/networking/cluster/kompose/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, installShellFiles }:
 
 buildGoPackage rec {
   pname = "kompose";
-  version = "1.18.0";
+  version = "1.20.0";
 
   goPackagePath = "github.com/kubernetes/kompose";
 
@@ -10,8 +10,15 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "kubernetes";
     repo = "kompose";
-    sha256 = "1hb4bs710n9fghphhfakwg42wjscf136dcr05zwwfg7iyqx2cipc";
+    sha256 = "1zgxm3zcxapav4jxh1r597rmxmlxcgns1l8w632ch7d90x5ihvll";
   };
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    $bin/bin/kompose completion bash > kompose.bash
+    $bin/bin/kompose completion zsh > kompose.zsh
+    installShellCompletion kompose.{bash,zsh}
+  '';
 
   meta = with stdenv.lib; {
     description = "A tool to help users who are familiar with docker-compose move to Kubernetes";


### PR DESCRIPTION
https://github.com/kubernetes/kompose/blob/v1.20.0/CHANGELOG.md#v1200-2019-12-23

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
