### PR TITLE
doc: python: fixing mistake in venv example

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1061,11 +1061,9 @@ in pkgs.mkShell rec {
     pythonPackages.numpy
     pythonPackages.requests
 
-    # the following packages are related to the dependencies of your python
-    # project.
-    # In this particular example the python modules listed in the
-    # requirements.txt require the following packages to be installed locally
-    # in order to compile any binary extensions they may require.
+    # In this particular example, in order to compile any binary extensions they may
+    # require, the python modules listed in the hypothetical requirements.txt need
+    # the following packages to be installed locally:
     taglib
     openssl
     git
@@ -1075,7 +1073,8 @@ in pkgs.mkShell rec {
     zlib
   ];
 
-  # Now we can execute any commands within the virtual environment
+  # Now we can execute any commands within the virtual environment.
+  # This is optional and can be left out to run pip manually.
   postShellHook = ''
     pip install -r requirements.txt
   '';
@@ -1091,12 +1090,14 @@ with import <nixpkgs> { };
 
 let
   venvDir = "./.venv";
+  pythonPackages = python3Packages;
 in pkgs.mkShell rec {
   name = "impurePythonEnv";
   buildInputs = [
-    python3Packages.python
-    python3Packages.virtualenv
-    ...
+    pythonPackages.python
+    # Needed when using python 2.7
+    # pythonPackages.virtualenv
+    # ...
   ];
 
   # This is very close to how venvShellHook is implemented, but
@@ -1108,14 +1109,18 @@ in pkgs.mkShell rec {
       echo "Skipping venv creation, '${venvDir}' already exists"
     else
       echo "Creating new venv environment in path: '${venvDir}'"
+      # Note that the module venv was only introduced in python 3, so for 2.7
+      # this needs to be replaced with a call to virtualenv
       ${pythonPackages.python.interpreter} -m venv "${venvDir}"
     fi
 
     # Under some circumstances it might be necessary to add your virtual
     # environment to PYTHONPATH, which you can do here too;
-    # PYTHONPATH=$PWD/${venvDir}/${python.sitePackages}/:$PYTHONPATH
+    # PYTHONPATH=$PWD/${venvDir}/${pythonPackages.python.sitePackages}/:$PYTHONPATH
 
     source "${venvDir}/bin/activate"
+
+    # As in the previous example, this is optional.
     pip install -r requirements.txt
   '';
 }


### PR DESCRIPTION
When updating the section to python 3 some places still referred to pythonPackages and were overlooked.
Decided to switch it to be more similar to the first example binding pythonPackages and clarified comments a bit based on confusion I observed on IRC.

Related to https://github.com/NixOS/nixpkgs/pull/77569

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@FRidh @jonringer 