### PR TITLE
canta-theme: init at 2020-01-31

### DIFF
--- a/pkgs/data/themes/canta/default.nix
+++ b/pkgs/data/themes/canta/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, gdk-pixbuf, librsvg, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "canta-theme";
+  version = "2020-01-31";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "070lhbhh3n7nd6rkwm52v1x4v8spyb932w6qmgs2r19g0whyn55w";
+  };
+
+  buildInputs = [ gdk-pixbuf librsvg ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    patchShebangs .
+    mkdir -p $out/share/themes
+    name= ./install.sh -d $out/share/themes
+    install -D -t $out/share/backgrounds wallpaper/canta-wallpaper.svg
+    rm $out/share/themes/*/{AUTHORS,COPYING}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Flat Design theme for GTK based desktop environments";
+    homepage = "https://github.com/vinceliuice/Canta-theme";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17318,6 +17318,8 @@ in
 
   caladea = callPackage ../data/fonts/caladea {};
 
+  canta-theme = callPackage ../data/themes/canta { };
+
   cantarell-fonts = callPackage ../data/fonts/cantarell-fonts { };
 
   capitaine-cursors = callPackage ../data/icons/capitaine-cursors { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [canta-theme](https://github.com/vinceliuice/Canta-theme), a flat Material Design theme for GTK 3, GTK 2 and Gnome-Shell which supports GTK 3 and GTK 2 based desktop environments like Gnome, Unity, Budgie, Pantheon, XFCE, Mate, etc.

![screenshot1](https://user-images.githubusercontent.com/1217934/73562436-e8eea500-4439-11ea-93fa-666623265fc2.png)
![screenshot2](https://user-images.githubusercontent.com/1217934/73562440-e9873b80-4439-11ea-97db-f4779fec95aa.jpeg)
![screenshot3](https://user-images.githubusercontent.com/1217934/73562441-e9873b80-4439-11ea-9f8d-39487bff6222.jpeg)
![screenshot4](https://user-images.githubusercontent.com/1217934/73562442-ea1fd200-4439-11ea-8ece-5ad86072f040.jpeg)
![screenshot5](https://user-images.githubusercontent.com/1217934/73562445-ea1fd200-4439-11ea-8abf-217c2585f83e.jpeg)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).