### PR TITLE
buildah: 1.13.1 -> 1.13.2

### DIFF
--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -4,13 +4,13 @@
 
 buildGoPackage rec {
   pname = "buildah";
-  version = "1.13.1";
+  version = "1.13.2";
 
   src = fetchFromGitHub {
     owner  = "containers";
     repo   = "buildah";
     rev    = "v${version}";
-    sha256 = "0swhpdr970ik6fhvmj45r84lsp1n6rxm0bgv9i1lvrxy1mdv7r9x";
+    sha256 = "0860ynv93gbicpczfapvrd558dzbqicy9rv4ivyjhb6yyfgy4qai";
   };
 
   outputs = [ "bin" "man" "out" ];

--- a/pkgs/development/tools/buildah/disable-go-module-mode.patch
+++ b/pkgs/development/tools/buildah/disable-go-module-mode.patch
@@ -12,22 +12,21 @@ buildGoPackage may lead to inconsistencies.
  1 file changed, 5 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 9d04177d..4cf9b6a2 100644
+index 07724ce4..6383646e 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -15,12 +15,7 @@ BUILDAH := buildah
+@@ -15,14 +15,8 @@ BUILDAH := buildah
  GO := go
  GO110 := 1.10
  GOVERSION := $(findstring $(GO110),$(shell go version))
 -# test for go module support
 -ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
 -export GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
+-export GO_TEST=GO111MODULE=on $(GO) test -mod=vendor
 -else
  export GO_BUILD=$(GO) build
+ export GO_TEST=$(GO) test
 -endif
- 
+
  GIT_COMMIT ?= $(if $(shell git rev-parse --short HEAD),$(shell git rev-parse --short HEAD),$(error "git failed"))
  SOURCE_DATE_EPOCH ?= $(if $(shell date +%s),$(shell date +%s),$(error "date failed"))
--- 
-2.24.0
-


### PR DESCRIPTION
https://github.com/containers/buildah/blob/v1.13.2/CHANGELOG.md#v1132-2020-01-29

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
