### PR TITLE
lua5: Fix src URLs

### DIFF
--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -17,7 +17,7 @@ self = stdenv.mkDerivation rec {
   version = "${luaversion}.${sourceVersion.patch}";
 
   src = fetchurl {
-    url = "https://www.lua.org/ftp/${pname}-${luaversion}.tar.gz";
+    url = "https://www.lua.org/ftp/${pname}-${version}.tar.gz";
     sha256 = hash;
   };
 


### PR DESCRIPTION
The 672c3c1d2a8ed40c1ef6bd29823af6a8c915584c #59919 refactor in accidentally
dropped the last version component from the source URLs.  This change
puts its back.

$ for lua in lua5_{1,2,3};do nix-instantiate --json --eval . -A $lua.src.urls | jq -r '.[]' | xargs nix-prefetch-url; done

Between 672c3c1d2a8ed40c1ef6bd29823af6a8c915584c and this change:

lua-5.1.tar.gz 1hbjhh211p82vhwqhx4mmhmvhv56060acnka80gbmfdk3q3bjnvz (wrong hash because this is lua 5.1.0.  We want 5.1.5 )
lua-5.2.tar.gz HTTP error 404
lua-5.3.tar.gz HTTP error 404

Before 672c3c1d2a8ed40c1ef6bd29823af6a8c915584c and after this change:

lua-5.1.5.tar.gz 0cskd4w0g6rdm2q8q3i4n1h3j8kylhs3rq8mxwl9vwlmlxbgqh16
lua-5.2.4.tar.gz 0jwznq0l8qg9wh5grwg07b5cy3lzngvl5m2nl1ikp6vqssmf9qmr <-- Desired hash
lua-5.3.5.tar.gz 1b2qn2rv96nmbm6zab4l877bd4zq7wpwm8drwjiy2ih4jqzysbhc

Converted to base16 with `nix-hash --type sha256 --to-base16`:

lua-5.1.5.tar.gz 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333 <-- Desired hash
lua-5.2.4.tar.gz b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b
lua-5.3.5.tar.gz 0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac <-- Desired hash

###### Motivation for this change

Fix "hash mismatch" errors.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@teto 