### PR TITLE
dmd: 2.085.1 -> 2.090.0

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -2,10 +2,10 @@
 , makeWrapper, unzip, which, writeTextFile
 , curl, tzdata, gdb, darwin, git
 , targetPackages, ldc
-, version ? "2.090.0"
-, dmdSha256 ? "0c2q8nzdg1fw3k0ifqbs7zljpjaq9byxrkz99hp9jhjpvwyvzrd5"
-, druntimeSha256 ? "0xqvgv43aih24myp0rmzan6qcm398vxsl967vsdgzq8faxn0qpcs"
-, phobosSha256 ? "02wzhiwxg4qalp28x04p4jjmw3gvgxx4g9xiff35sa1s5m2wj0yw"
+, version ? "2.091.0"
+, dmdSha256 ? "064bi5nyznwlbzws82kqlp4b287az3v5n002nxrpxpsrgwgzacv9"
+, druntimeSha256 ? "1x7ya3mrbw5nzn85gsvaxphfk24v2c4799mxqy75a4hixk5f83xk"
+, phobosSha256 ? "1cdl5lg8v49g880sc0iisi0qzbwqpydk1xlxkrrw26f4135jcd7r"
 }:
 
 let

--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -2,10 +2,10 @@
 , makeWrapper, unzip, which, writeTextFile
 , curl, tzdata, gdb, darwin, git
 , targetPackages, ldc
-, version ? "2.085.1"
-, dmdSha256 ? "0ccidfcawrcwdpfjwjiln5xwr4ffp8i2hwx52p8zn3xmc5yxm660"
-, druntimeSha256 ? "109f2glsqrlshk06761xlw4r5v22mivp873cq9g5gcax3g00k617"
-, phobosSha256 ? "0giispqqx8j8xg6c0hm7nx77bcahiwic8rvf12sws3sv5pizv8pr"
+, version ? "2.090.0"
+, dmdSha256 ? "0c2q8nzdg1fw3k0ifqbs7zljpjaq9byxrkz99hp9jhjpvwyvzrd5"
+, druntimeSha256 ? "0xqvgv43aih24myp0rmzan6qcm398vxsl967vsdgzq8faxn0qpcs"
+, phobosSha256 ? "02wzhiwxg4qalp28x04p4jjmw3gvgxx4g9xiff35sa1s5m2wj0yw"
 }:
 
 let


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update to latest DMD https://github.com/dlang/dmd/releases/tag/v2.090.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
