### PR TITLE
real_time_config_quick_scan: init at unstable-2020-01-16

### DIFF
--- a/pkgs/applications/audio/real_time_config_quick_scan/default.nix
+++ b/pkgs/applications/audio/real_time_config_quick_scan/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, perlPackages, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "realTimeConfigQuickScan";
+  version = "unstable-2020-08-03";
+
+  src = fetchFromGitHub {
+    owner  = "raboof";
+    repo   = pname;
+    rev    = "4b482db17f8d8567ba0abf33459ceb5f756f088c";
+    sha256 = "00l69gzwla9gjv5kpklgxlwnl48wnh8h6w0k8i69qr2cxigg4rhj";
+  };
+
+  buildInputs = [ perlPackages.perl makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/doc
+    # Install Script Files:
+    # *.pm files
+    for i in *.pm; do
+    install -Dm 755 "$i" "$out/share/$i"
+    done
+    # Install doc files:
+    install -D COPYING  "$out/share/doc/COPYING"
+    install -D README.md  "$out/share/doc/README.md"
+    # Install Executable scripts:
+    install -Dm 755 realTimeConfigQuickScan.pl "$out/bin/realTimeConfigQuickScan"
+    install -Dm 755 QuickScan.pl "$out/bin/QuickScan"
+    wrapProgram $out/bin/realTimeConfigQuickScan \
+      --set PERL5LIB "$out/share"
+    wrapProgram $out/bin/QuickScan \
+      --set PERL5LIB "$out/share:${with perlPackages; makePerlPath [ Tk ]}"
+  '';
+  meta = with stdenv.lib; {
+    description = "Linux configuration checker for systems to be used for real-time audio";
+    homepage = "https://github.com/raboof/realtimeconfigquickscan";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.linux ;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6055,6 +6055,9 @@ in
 
   rdma-core = callPackage ../os-specific/linux/rdma-core { };
 
+
+  real_time_config_quick_scan = callPackage ../applications/audio/real_time_config_quick_scan { };
+
   react-native-debugger = callPackage ../development/tools/react-native-debugger { };
 
   read-edid = callPackage ../os-specific/linux/read-edid { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
