### PR TITLE
Mons

### DIFF
--- a/pkgs/tools/misc/mons/default.nix
+++ b/pkgs/tools/misc/mons/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchFromGitHub, help2man, xrandr }:
+
+stdenv.mkDerivation rec {
+  pname = "mons";
+  version = "20200107";
+
+  src = fetchFromGitHub {
+    owner = "Ventto";
+    repo = pname;
+    rev = "0c9e1a1dddff23a0525ed8e4ec9af8f9dd8cad4c";
+    sha256 = "02c41mw3g1mgl91hhpz1n45iaqk9s7mdk1ixm8yv6sv17hy8rr4w";
+    fetchSubmodules = true;
+  };
+
+  # PR: https://github.com/Ventto/mons/pull/36
+  preConfigure = ''sed -i 's/usr\///' Makefile'';
+  
+  nativeBuildInputs = [ help2man ];
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with lib; {
+    description = "POSIX Shell script to quickly manage 2-monitors display";
+    homepage = "https://github.com/Ventto/mons.git";
+    license = licenses.mit;
+    maintainers = [ maintainers.mschneider ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1961,6 +1961,8 @@ in
 
   monetdb = callPackage ../servers/sql/monetdb { };
 
+  mons = callPackage ../tools/misc/mons {};
+
   mousetweaks = callPackage ../applications/accessibility/mousetweaks {
     inherit (pkgs.xorg) libX11 libXtst libXfixes;
   };


### PR DESCRIPTION
Mons is a Shell script to quickly manage 2-monitors display using xrandr.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
