### PR TITLE
yosys: use external abc and simplify derivation

### DIFF
--- a/pkgs/applications/science/logic/abc/default.nix
+++ b/pkgs/applications/science/logic/abc/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "abc-verifier";
-  version = "2018-07-08";
+  version = "2020-01-11";
 
   src = fetchFromGitHub {
     owner = "berkeley-abc";
     repo = "abc";
-    rev    = "24407e13db4b8ca16c3996049b2d33ec3722de39";
-    sha256 = "1rckji7nk81n6v1yajz7daqwipxacv7zlafknvmbiwji30j47sq5";
+    rev    = "71f2b40320127561175ad60f6f2428f3438e5243";
+    sha256 = "15sn146ajxql7l1h8rsag5lhn4spwvgjhwzqawfr78snzadw8by3";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/science/logic/abc/default.nix
+++ b/pkgs/applications/science/logic/abc/default.nix
@@ -1,15 +1,19 @@
 { fetchFromGitHub, stdenv, readline, cmake }:
 
-stdenv.mkDerivation {
+let
+  rev = "71f2b40320127561175ad60f6f2428f3438e5243";
+in stdenv.mkDerivation {
   pname = "abc-verifier";
   version = "2020-01-11";
 
   src = fetchFromGitHub {
+    inherit rev;
     owner = "berkeley-abc";
     repo = "abc";
-    rev    = "71f2b40320127561175ad60f6f2428f3438e5243";
     sha256 = "15sn146ajxql7l1h8rsag5lhn4spwvgjhwzqawfr78snzadw8by3";
   };
+
+  passthru.rev = rev;
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ readline ];

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "yosys";
-  version = "2019.10.18";
+  version = "2020.02.01";
 
   src = fetchFromGitHub {
     owner  = "yosyshq";
     repo   = "yosys";
-    rev    = "3c41599ee1f62e4d77ba630fa1a245ef3fe236fa";
-    sha256 = "0jg2g8v08ax1q6qlvn8c1h147m03adzrgf21043xwbh4c7s5k137";
+    rev    = "a1c840ca5d6e8b580e21ae48550570aa9665741a";
+    sha256 = "1vna04dh6l68nifssgs3hxqwn4k529krmm4crj94a8wwhwra52mh";
     name   = "yosys";
   };
 

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -1,8 +1,15 @@
-{ stdenv, fetchFromGitHub
-, pkgconfig, bison, flex
-, tcl, readline, libffi, python3
-, protobuf, zlib
+{ stdenv
+, bison
+, fetchFromGitHub
+, flex
+, libffi
+, pkgconfig
+, protobuf
+, python3
+, readline
+, tcl
 , verilog
+, zlib
 }:
 
 with builtins;
@@ -37,7 +44,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ tcl readline libffi python3 bison flex protobuf zlib ];
 
-  makeFlags = [ "ENABLE_PROTOBUF=1" ];
+  makeFlags = [ "ENABLE_PROTOBUF=1" "PREFIX=${placeholder "out"}"];
 
   patchPhase = ''
     substituteInPlace ../yosys-abc/Makefile \
@@ -58,7 +65,6 @@ stdenv.mkDerivation rec {
     ln -s ../yosys-abc abc
     make config-${if stdenv.cc.isClang or false then "clang" else "gcc"}
     echo 'ABCREV := default' >> Makefile.conf
-    makeFlags="PREFIX=$out $makeFlags"
 
     # we have to do this ourselves for some reason...
     (cd misc && ${protobuf}/bin/protoc --cpp_out ../backends/protobuf/ ./yosys.proto)


### PR DESCRIPTION
#### Motivation for this change
The yosys derivation currently is very hard to override and more complex than it needs to be.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @heijligen @piegames