### PR TITLE
MozPhab: init at 0.1.74

### DIFF
--- a/pkgs/applications/misc/MozPhab/default.nix
+++ b/pkgs/applications/misc/MozPhab/default.nix
@@ -1,0 +1,29 @@
+{ lib, python3Packages, pkgs }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "MozPhab";
+  version = "0.1.74";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1qbl54pvba15b2ic9lxsajakbk4gj1rjazzj4qbrh43ngllrhi7y";
+  };
+
+  propagatedBuildInputs = [
+    python3Packages.setuptools
+    pkgs.mercurial
+  ];
+
+  meta = with lib; {
+    description = "Phabricator CLI from Mozilla to support submission of a series of commits";
+    longDescription = ''
+      MozPhab is a custom command-line tool, moz-phab, which communicates to
+      Phabricator’s API, providing several conveniences, including support for
+      submitting series of commits.
+    '';
+    homepage = "https://moz-conduit.readthedocs.io/en/latest/phabricator-user.html";
+    license = licenses.mpl20;
+    maintainers = [ maintainers.raboof ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4742,6 +4742,8 @@ in
 
   motion = callPackage ../applications/video/motion { };
 
+  MozPhab = callPackage ../applications/misc/MozPhab { };
+
   mtail = callPackage ../servers/monitoring/mtail {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

MozPhab is the recommended tool for submitting patches to Mozilla Firefox.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).