### PR TITLE
nixos/tests/openarena: run real openarena clients

### DIFF
--- a/nixos/tests/openarena.nix
+++ b/nixos/tests/openarena.nix
@@ -1,41 +1,71 @@
-import ./make-test-python.nix ({ pkgs, ...} : {
-  name = "openarena";
-  meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ tomfitzhenry ];
-  };
+import ./make-test-python.nix ({ pkgs, ...} :
 
-  machine =
+let
+  client =
     { pkgs, ... }:
 
-    { imports = [];
-      environment.systemPackages = with pkgs; [
-        socat
-      ];
-      services.openarena = {
-        enable = true;
-        extraFlags = [
-          "+set dedicated 2"
-          "+set sv_hostname 'My NixOS server'"
-          "+map oa_dm1"
-        ];
-      };
+    { imports = [ ./common/x11.nix ];
+      hardware.opengl.driSupport = true;
+      environment.systemPackages = [ pkgs.openarena ];
+    };
+
+in {
+  name = "openarena";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ fpletz ];
+  };
+
+  nodes =
+    { server =
+        { services.openarena = {
+            enable = true;
+            extraFlags = [ "+set g_gametype 0" "+map oa_dm7" "+addbot Angelyss" "+addbot Arachna" ];
+            openPorts = true;
+          };
+        };
+
+      client1 = client;
+      client2 = client;
     };
 
   testScript =
     ''
-      machine.wait_for_unit("openarena.service")
-      machine.wait_until_succeeds("ss --numeric --udp --listening | grep -q 27960")
+      start_all()
 
-      # The log line containing 'resolve address' is last and only message that occurs after
-      # the server starts accepting clients.
-      machine.wait_until_succeeds(
-          "journalctl -u openarena.service | grep 'resolve address: dpmaster.deathmask.net'"
+      server.wait_for_unit("openarena")
+      server.wait_until_succeeds("ss --numeric --udp --listening | grep -q 27960")
+
+      client1.wait_for_x()
+      client2.wait_for_x()
+
+      client1.execute("openarena +set r_fullscreen 0 +set name Foo +connect server &")
+      client2.execute("openarena +set r_fullscreen 0 +set name Bar +connect server &")
+
+      server.wait_until_succeeds(
+          "journalctl -u openarena -e | grep -q 'Foo.*entered the game'"
+      )
+      server.wait_until_succeeds(
+          "journalctl -u openarena -e | grep -q 'Bar.*entered the game'"
       )
 
-      # Check it's possible to join the server.
-      # Can't use substring match instead of grep because the output is not utf-8
-      machine.succeed(
-          "echo -n -e '\\xff\\xff\\xff\\xffgetchallenge' | socat - UDP4-DATAGRAM:127.0.0.1:27960 | grep -q challengeResponse"
-      )
+      server.sleep(10)  # wait for a while to get a nice screenshot
+
+      client1.screenshot("screen_client1_1")
+      client2.screenshot("screen_client2_1")
+
+      client1.block()
+
+      server.sleep(10)
+
+      client1.screenshot("screen_client1_2")
+      client2.screenshot("screen_client2_2")
+
+      client1.unblock()
+
+      server.sleep(10)
+
+      client1.screenshot("screen_client1_3")
+      client2.screenshot("screen_client2_3")
     '';
+
 })


### PR DESCRIPTION
###### Motivation for this change

The old Quake3 NixOS test was removed in 50ea99cbc18d3f480a773de5250b4ef9c7f6d514 which served as a nice demo to showcase what NixOS tests are capable of. This commit adds the same functionality to run real openarena clients.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
