### PR TITLE
wimboot: Init at 2.6.0

### DIFF
--- a/pkgs/tools/misc/wimboot/default.nix
+++ b/pkgs/tools/misc/wimboot/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, fetchpatch, libbfd, zlib, libiberty }:
+
+stdenv.mkDerivation rec {
+  pname = "wimboot";
+  version = "2.6.0";
+
+  src = fetchFromGitHub {
+    owner = "ipxe";
+    repo = "wimboot";
+    rev = "v${version}";
+    sha256 = "134wqqr147az5vbj4szd0xffwa99b4rar7w33zm3119zsn7sd79k";
+  };
+
+  NIX_CFLAGS_COMPILE = "-Wno-address-of-packed-member"; # Fails on gcc9
+
+  patches = [
+    # Fix for newer binutils
+    (fetchpatch {
+      url =
+        "https://github.com/ipxe/wimboot/commit/91be50c17d4d9f463109d5baafd70f9fdadd86db.patch";
+      sha256 = "113448n49hmk8nz1dxbhxiciwl281zwalvb8z5p9xfnjvibj8274";
+    })
+  ];
+
+  # We cannot use sourceRoot because the patch wouldn't apply
+  postPatch = ''
+    cd src
+  '';
+
+  hardeningDisable = [ "pic" ];
+
+  buildInputs = [ libbfd zlib libiberty ];
+  makeFlags = [ "wimboot.x86_64.efi" ];
+
+  installPhase = ''
+    mkdir -p $out/share/wimboot/
+    cp wimboot.x86_64.efi $out/share/wimboot
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://ipxe.org/wimboot";
+    description = "Windows Imaging Format bootloader";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ das_j ajs124 ];
+    platforms = platforms.x86; # Fails on aarch64
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7183,6 +7183,8 @@ in
 
   wifite2 = callPackage ../tools/networking/wifite2 { };
 
+  wimboot = callPackage ../tools/misc/wimboot { };
+
   wireguard-tools = callPackage ../tools/networking/wireguard-tools { };
 
   woff2 = callPackage ../development/web/woff2 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I'd like to boot WIM files (obviously).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
