### PR TITLE
ytop: init at 0.4.0

### DIFF
--- a/pkgs/tools/system/ytop/default.nix
+++ b/pkgs/tools/system/ytop/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, rustPlatform, fetchFromGitHub, IOKit }:
+
+assert stdenv.isDarwin -> IOKit != null;
+
+rustPlatform.buildRustPackage rec {
+  pname = "ytop";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "cjbassi";
+    repo = pname;
+    rev = version;
+    sha256 = "1158nlg5b93jyljwvf9f2m8m3ph8sksk5dh9sfnvbiifbk4gizv7";
+  };
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
+
+  cargoSha256 = "11pcchwahcwdvmfwfs6j2zg23grlw538wfs90mvqy2mpccj7d3ys";
+  verifyCargoDeps = true;
+
+  meta = with stdenv.lib; {
+    description = "A TUI system monitor written in Rust";
+    homepage = https://github.com/cjbassi/ytop;
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7551,6 +7551,10 @@ in
 
   yeshup = callPackage ../tools/system/yeshup { };
 
+  ytop = callPackage ../tools/system/ytop {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
+
   yggdrasil = callPackage ../tools/networking/yggdrasil { };
 
   # To expose more packages for Yi, override the extraPackages arg.


### PR DESCRIPTION
###### Motivation for this change
From [cjbassi/gotop](https://github.com/cjbassi/gotop) README:
> NO LONGER MAINTAINED. Future development has moved to ytop, a Rust port of gotop.

[cjbassi/ytop](https://github.com/cjbassi/ytop) - a TUI system monitor written in Rust.

cc @magnetophon, @marsam 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh ./result
/nix/store/cf0495whapdjgdafdj6mw9spsycygal1-ytop-0.4.0	 29.4M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
