### PR TITLE
trac: disabling pygments tests

### DIFF
--- a/pkgs/tools/misc/trac/default.nix
+++ b/pkgs/tools/misc/trac/default.nix
@@ -28,6 +28,9 @@ buildPythonApplication rec {
     # Removing the date format tests as they are outdated
     substituteInPlace trac/util/tests/__init__.py \
       --replace "suite.addTest(datefmt.test_suite())" ""
+    # Removing Pygments tests as per https://trac.edgewall.org/ticket/13229
+    substituteInPlace trac/mimeview/tests/__init__.py \
+      --replace "suite.addTest(pygments.test_suite())" ""
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
#### Motivation for this change

Trac tests are failing after pygments upgrade, disabling until the next version is available.