### PR TITLE
 blackmagic: v1.6.1-317-gc9c8b08 -> v1.6.1-409-g7a595ea (add new targets)

### DIFF
--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, gcc-arm-embedded, libftdi1
+, gcc-arm-embedded, libftdi1, libusb, pkgconfig
 , python, pythonPackages
 }:
 
@@ -20,11 +20,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    gcc-arm-embedded
+    gcc-arm-embedded pkgconfig
   ];
 
   buildInputs = [
     libftdi1
+    libusb
     python
     pythonPackages.intelhex
   ];
@@ -60,7 +61,9 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/blacksphere/blackmagic;
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ pjones emily ];
-    platforms = platforms.unix;
+    maintainers = with maintainers; [ pjones emily sorki ];
+    # fails on darwin with
+    # arm-none-eabi-gcc: error: unrecognized command line option '-iframework'
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -7,15 +7,15 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "blackmagic";
-  version = "unstable-2019-08-13";
+  version = "unstable-2020-02-20";
   # `git describe --always`
-  firmwareVersion = "v1.6.1-317-gc9c8b08";
+  firmwareVersion = "v1.6.1-409-g7a595ea";
 
   src = fetchFromGitHub {
     owner = "blacksphere";
     repo = "blackmagic";
-    rev = "c9c8b089f716c31433432f5ee54c5c206e4945cf";
-    sha256 = "0175plba7h3r1p584ygkjlvg2clvxa2m0xfdcb2v8jza2vzc8ywd";
+    rev = "7a595ead255f2a052fe4561c24a0577112c9de84";
+    sha256 = "01kdm1rkj7ll0px882crf9w27d2ka8f3hcdmvhb9jwd60bf5dlap";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/tools/misc/blackmagic/helper.sh
+++ b/pkgs/development/tools/misc/blackmagic/helper.sh
@@ -23,9 +23,16 @@ make_platform() {
   make clean
   make PROBE_HOST="$1"
 
-  if [ "$1" = libftdi ]; then
-    mkdir -p "$out/bin"
+  if [ "$1" = "libftdi" ]; then
     install -m 0555 blackmagic "$out/bin"
+  fi
+
+  if [ "$1" = "pc-hosted" ]; then
+    install -m 0555 blackmagic_hosted "$out/bin"
+  fi
+
+  if [ "$1" = "pc-stlinkv2" ]; then
+    install -m 0555 blackmagic_stlinkv2 "$out/bin"
   fi
 
   for f in $PRODUCTS; do
@@ -44,6 +51,8 @@ make -C libopencm3
 ################################################################################
 # And now all of the platforms:
 cd src
+
+mkdir -p "$out/bin"
 
 for platform in platforms/*/Makefile.inc; do
   probe=$(basename "$(dirname "$platform")")


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to more recent version. Also exposes hosted targets which can be run on host system instead of microcontroller (requires libusb and pkg-config).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
