### PR TITLE
rtptools: init at 1.22

### DIFF
--- a/pkgs/tools/networking/rtptools/default.nix
+++ b/pkgs/tools/networking/rtptools/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, lib, fetchurl }:
+stdenv.mkDerivation rec {
+  pname = "rtptools";
+  version = "1.22";
+  src = fetchurl {
+    url = "http://www.cs.columbia.edu/irt/software/rtptools/download/rtptools-${version}.tar.gz";
+    sha256 = "0a4c0vmhxibfc58rrxpbav2bsk546chkg50ir4h3i57v4fjb4xic";
+  };
+  meta = {
+    description = "A number of small applications that can be used for processing RTP data";
+    homepage = "http://www.cs.columbia.edu/irt/software/rtptools/";
+    maintainers = [ lib.maintainers.lheckemann ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6076,6 +6076,8 @@ in
   rtmpdump = callPackage ../tools/video/rtmpdump { };
   rtmpdump_gnutls = rtmpdump.override { gnutlsSupport = true; opensslSupport = false; };
 
+  rtptools = callPackages ../tools/networking/rtptools {};
+
   reaverwps = callPackage ../tools/networking/reaver-wps {};
 
   reaverwps-t6x = callPackage ../tools/networking/reaver-wps-t6x {};


### PR DESCRIPTION
###### Motivation for this change
More tools!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
