### PR TITLE
sphinxsearch: Add support for MySQL & xmlpipe2

### DIFF
--- a/pkgs/servers/search/sphinxsearch/default.nix
+++ b/pkgs/servers/search/sphinxsearch/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig,
+{ stdenv, fetchurl, pkgconfig, expat, mariadb, zlib, openssl,
   version ? "2.2.11",
   mainSrc ? fetchurl {
     url = "http://sphinxsearch.com/files/sphinx-${version}-release.tar.gz";
@@ -13,12 +13,17 @@ stdenv.mkDerivation {
 
   configureFlags = [
     "--program-prefix=sphinxsearch-"
-    "--without-mysql"
+    "--with-mysql=${mariadb}/"
+    "--with-libexpat"
     "--enable-id64"
   ];
 
   nativeBuildInputs = [
-    pkgconfig
+    pkgconfig expat
+  ];
+
+  buildInputs = [
+    mariadb zlib openssl
   ];
 
   meta = {

--- a/pkgs/servers/search/sphinxsearch/default.nix
+++ b/pkgs/servers/search/sphinxsearch/default.nix
@@ -19,11 +19,11 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [
-    pkgconfig expat
+    pkgconfig
   ];
 
   buildInputs = [
-    mariadb zlib openssl
+    expat mariadb zlib openssl
   ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Sphinxsearch doesn't support MySQL sources and xmlpipe2
Closes #70076

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
