### PR TITLE
lilypond: allow building on Darwin

### DIFF
--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation {
     license = licenses.gpl3;
     maintainers = with maintainers; [ marcweber yurrriq ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin;
   };
 
   patches = [ ./findlib.patch ];

--- a/pkgs/misc/lilypond/unstable.nix
+++ b/pkgs/misc/lilypond/unstable.nix
@@ -1,4 +1,4 @@
-{ fetchgit, lilypond, ghostscript, gyre-fonts }:
+{ stdenv, fetchgit, lilypond, ghostscript, gyre-fonts }:
 
 let
 
@@ -13,6 +13,10 @@ lilypond.overrideAttrs (oldAttrs: {
     url = "https://git.savannah.gnu.org/r/lilypond.git";
     rev = "release/${version}-1";
     sha256 = "1ycyx9x76d79jh7wlwyyhdjkyrwnhzqpw006xn2fk35s0jrm2iz0";
+  };
+
+  meta = oldAttrs.meta // {
+    broken = stdenv.isDarwin;
   };
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

LilyPond was marked broken on Darwin in commit 287ab732d941115a86e1fd08db7faf1dda21d0fe. I’m not sure what’s changed, but I tried building it on my macOS 10.14 (Mojave) machine just now and it built and ran without a problem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
