### PR TITLE
qemu: add patches for CVE-2020-7039 and CVE-2020-7211

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -84,6 +84,37 @@ stdenv.mkDerivation rec {
       stripLen = 1;
       extraPrefix = "slirp/";
     })
+    # patches listed at: https://nvd.nist.gov/vuln/detail/CVE-2020-7039
+    (fetchpatch {
+      name = "CVE-2020-7039-1.patch";
+      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=2655fffed7a9e765bcb4701dd876e9dab975f289";
+      sha256 = "1jh0k3lg3553c2x1kq1kl3967jabhba5gm584wjpmr5mjqk3lnz1";
+      stripLen = 1;
+      extraPrefix = "slirp/";
+      excludes = ["slirp/CHANGELOG.md"];
+    })
+    (fetchpatch {
+      name = "CVE-2020-7039-2.patch";
+      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=82ebe9c370a0e2970fb5695aa19aa5214a6a1c80";
+      sha256 = "08ccxcmrhzknnzd1a1q2brszv3a7h02n26r73kpli10b0hn12r2l";
+      stripLen = 1;
+      extraPrefix = "slirp/";
+    })
+    (fetchpatch {
+      name = "CVE-2020-7039-3.patch";
+      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=ce131029d6d4a405cb7d3ac6716d03e58fb4a5d9";
+      sha256 = "18ypj9an2jmsmdn58853rbz42r10587h7cz5fdws2x4635778ibd";
+      stripLen = 1;
+      extraPrefix = "slirp/";
+    })
+    # patches listed at: https://nvd.nist.gov/vuln/detail/CVE-2020-7211
+    (fetchpatch {
+      name = "CVE-2020-7211.patch";
+      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=14ec36e107a8c9af7d0a80c3571fe39b291ff1d4";
+      sha256 = "1lc8zabqs580iqrsr5k7zwgkx6qjmja7apwfbc36lkvnrxwfzmrc";
+      stripLen = 1;
+      extraPrefix = "slirp/";
+    })
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {


### PR DESCRIPTION
###### Motivation for this change
Patch two known CVEs in QEMU.

Fixes #78762

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @ckauhaus