### PR TITLE
ruby-gnome: 3.3.7 -> 3.4.1

### DIFF
--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -1117,10 +1117,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0hgb555j5pimy8pjpf20pzbmhpr1wx59phlwbwsq37zjv89wirva";
+      sha256 = "17az8g0n1yzz90kdbjg2hpabi04qccda7v6lin76bs637ivfg2md";
       type = "gem";
     };
-    version = "3.3.7";
+    version = "3.4.1";
   };
   hashie = {
     groups = ["default"];

--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -1706,10 +1706,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "03jdjphc5vk9a9rgvkfhz78dfyxi67a20c12h6pcd22r5xq8hzj0";
+      sha256 = "1d0cn50qgpifrcv8qx72wi6l9xalw3ryngbfmm9xpg9vx5rl1qbp";
       type = "gem";
     };
-    version = "3.3.7";
+    version = "3.4.1";
   };
   parallel = {
     groups = ["default"];

--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -185,10 +185,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1380dvd5dbnhlvagb9z9cr62kh1knza7bcgr9msqshj55iqk4p0k";
+      sha256 = "0gkxdfslcvrwrs48giilji3bgxd5bwijwq33p9h00r10jzfg2028";
       type = "gem";
     };
-    version = "3.3.7";
+    version = "3.4.1";
   };
   camping = {
     dependencies = ["mab" "rack"];

--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -1031,10 +1031,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0bvw0xlq0nrvzv559d3kbihc8m3iv3q70cs6xan0n6dywxayizbf";
+      sha256 = "0194gzn0kialfh0j7crllvp808r64sg6dh297x69b0av21ar5pam";
       type = "gem";
     };
-    version = "3.3.7";
+    version = "3.4.1";
   };
   gh_inspector = {
     groups = ["default"];

--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -1052,10 +1052,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1cv617ad4bhd3qhi5m0638v0mf9kw32g7r89c754xsmmas921igc";
+      sha256 = "1l3jpgbdvb55xhcmpkcqgwx5068dfyi8kijfvzhbqh96ng0p1m7g";
       type = "gem";
     };
-    version = "3.3.7";
+    version = "3.4.1";
   };
   gitlab-markup = {
     groups = ["default"];

--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -113,10 +113,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0saginz71qy4k1hz3sffrjd6zcw54jsm61f7jks02fxys31ir865";
+      sha256 = "0a8q9a1f6x4gy55p8cf52a22bnpjgn18ad9n959x0f4gybbhs948";
       type = "gem";
     };
-    version = "3.3.7";
+    version = "3.4.1";
   };
   atomos = {
     groups = ["default"];

--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -1073,10 +1073,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "08cqwk8valxv4bls891f3ciqa258vbsfgqd3mymf62qdld8m9y3z";
+      sha256 = "18clyn0fp0h5alnkf9i2bqd6wvl78h468pdbzs1csqnba8vw4q1c";
       type = "gem";
     };
-    version = "3.3.7";
+    version = "3.4.1";
   };
   globalid = {
     dependencies = ["activesupport"];

--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -1095,10 +1095,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "14kcf8079wmimzy78yysizsl44d6iaw2pp5xj70vdxg342r4a6k5";
+      sha256 = "1a3x8qiisbax3x0izj8l5w66r53ba5ma53ax2jhdbhbvaxx3d02n";
       type = "gem";
     };
-    version = "3.3.7";
+    version = "3.4.1";
   };
   gpgme = {
     dependencies = ["mini_portile2"];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The most recent glib bump broke rubyPackages.glib2. https://hydra.nixos.org/build/111030999

###### Things done
I have upgraded all the package from the ruby-gnome project from version 3.3.7 to the latest version 3.4.1. Although it went from 3.3 to 3.4 there were no breaking changes and 3.4 so far has just been bug fixes.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
