### PR TITLE
firecracker: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -1,27 +1,27 @@
 { fetchurl, stdenv }:
 
 let
-  version = "0.19.0";
+  version = "0.20.0";
 
   suffix = {
-    x86_64-linux  = "";
-    aarch64-linux = "-aarch64";
+    x86_64-linux  = "x86_64";
+    aarch64-linux = "aarch64";
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   baseurl = "https://github.com/firecracker-microvm/firecracker/releases/download";
   fetchbin = name: sha256: fetchurl {
-    url    = "${baseurl}/v${version}/${name}-v${version}${suffix}";
+    url    = "${baseurl}/v${version}/${name}-v${version}-${suffix}";
     sha256 = sha256."${stdenv.hostPlatform.system}";
   };
 
   firecracker-bin = fetchbin "firecracker" {
-    x86_64-linux  = "0yjhw77xc2nc96p36jhf0va95gf6hwi9n270g4iiwakycdy048mx";
-    aarch64-linux = "165yca7pcwpqw3x6dihcjz1xcwjh37sdi9qrrjk9zasxx7xcniym";
+    x86_64-linux  = "073pp4q5dnyr126k8k7qdkqclqx18hj12app4gj2is0413gia8z9";
+    aarch64-linux = "1w5f522imq5dnjrdidnrq7jlwcdrsiz32shv9bh66dhy336sd8qw";
   };
 
   jailer-bin = fetchbin "jailer" {
-    x86_64-linux  = "1q792b4bl1q3ach8nc8l0fbcil44knv3wa542xrskndzdz28lhsp";
-    aarch64-linux = "1cnwlpy5bswjprk7fcjgf6lxidhp7z00qx691nkwhzjkby80j490";
+    x86_64-linux  = "0falk6y9y0pimgav1yg6ydn6wsslz0my01qd9by8ipk3f3776531";
+    aarch64-linux = "1j4x4p4zz1ydvpzbbmxszyqv28qbl4v3hiwdj2f67f1jn1cv9l7z";
   };
 
 in


### PR DESCRIPTION
https://github.com/firecracker-microvm/firecracker/blob/v0.20.0/CHANGELOG.md#0200

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
