### PR TITLE
vvvvvv: init at 2.3-git-2020-11-22

### DIFF
--- a/pkgs/games/vvvvvv/default.nix
+++ b/pkgs/games/vvvvvv/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, fetchFromGitHub, requireFile
+, SDL2, SDL2_mixer, cmake, ninja
+, fullGame ? false }:
+
+let
+  dataZip = if fullGame then requireFile {
+    name = "data.zip";
+    sha256 = "1q2pzscrglmwfgdl8yj300wymwskh51iq66l4xcd0qk0q3g3rbkg";
+    message = ''
+      In order to install VVVVVV, you must first download the game's
+      data file (data.zip) as it is not released freely.
+      Once you have downloaded the file, place it in your current
+      directory, use the following command and re-run the installation:
+      nix-prefetch-url file://\$PWD/data.zip
+    '';
+  } else fetchurl {
+    url = https://thelettervsixtim.es/makeandplay/data.zip;
+    sha256 = "1q2pzscrglmwfgdl8yj300wymwskh51iq66l4xcd0qk0q3g3rbkg";
+  };
+in stdenv.mkDerivation rec {
+  pname = "vvvvvv";
+  version = "2.3-git-2a514b2";
+
+  src = fetchFromGitHub {
+    owner = "TerryCavanagh";
+    repo = "VVVVVV";
+    rev = "90cab340f123f1a355f638c47b677c6572a514b2";
+    sha256 = "1bq7kj33pw1dwsgh0s0pqayfyhpnbvpgw2c1w9scpl5l0hkhg44p";
+  };
+
+  nativeBuildInputs = [ cmake ninja ];
+  buildInputs = [ SDL2 SDL2_mixer ];
+
+  preConfigure = ''
+    cd desktop_version
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -t $out/bin VVVVVV
+    cp ${dataZip} $out/bin/data.zip
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A platform game based on flipping gravity";
+    longDescription = ''
+      VVVVVV is a platform game all about exploring one simple mechanical
+      idea - what if you reversed gravity instead of jumping? 
+    '';
+    homepage = https://thelettervsixtim.es;
+    license = licenses.unfree;
+    maintainers = [ maintainers.dkudriavtsev ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/games/vvvvvv/default.nix
+++ b/pkgs/games/vvvvvv/default.nix
@@ -24,13 +24,13 @@ let
   flags = if fullGame then [] else [ "-DMAKEANDPLAY" ];
 in stdenv.mkDerivation rec {
   pname = "vvvvvv";
-  version = "2.3-git-2020-01-22";
+  version = "unstable-2020-02-02";
 
   src = fetchFromGitHub {
     owner = "TerryCavanagh";
     repo = "VVVVVV";
-    rev = "90cab340f123f1a355f638c47b677c6572a514b2";
-    sha256 = "1bq7kj33pw1dwsgh0s0pqayfyhpnbvpgw2c1w9scpl5l0hkhg44p";
+    rev = "4bc76416f551253452012d28e2bc049087e2be73";
+    sha256 = "1sc64f7sxf063bdgnkg23vc170chq2ix25gs836hyswx98iyg5ly";
   };
 
   CFLAGS = flags;
@@ -51,7 +51,7 @@ in stdenv.mkDerivation rec {
     description = "A retro-styled platform game";
     longDescription = ''
       VVVVVV is a platform game all about exploring one simple mechanical
-      idea - what if you reversed gravity instead of jumping? 
+      idea - what if you reversed gravity instead of jumping?
     '';
     homepage = "https://thelettervsixtim.es";
     license = if fullGame then licenses.unfree else licenses.unfreeRedistributable;

--- a/pkgs/games/vvvvvv/default.nix
+++ b/pkgs/games/vvvvvv/default.nix
@@ -4,6 +4,7 @@
 
 let
   dataZip = if fullGame then requireFile {
+    # the data file for the full game
     name = "data.zip";
     sha256 = "1q2pzscrglmwfgdl8yj300wymwskh51iq66l4xcd0qk0q3g3rbkg";
     message = ''
@@ -14,12 +15,16 @@ let
       nix-prefetch-url file://\$PWD/data.zip
     '';
   } else fetchurl {
+    # the data file for the free Make and Play edition
     url = https://thelettervsixtim.es/makeandplay/data.zip;
     sha256 = "1q2pzscrglmwfgdl8yj300wymwskh51iq66l4xcd0qk0q3g3rbkg";
   };
+
+  # if the user does not own the full game, build the Make and Play edition
+  flags = if fullGame then [] else [ "-DMAKEANDPLAY" ];
 in stdenv.mkDerivation rec {
   pname = "vvvvvv";
-  version = "2.3-git-2a514b2";
+  version = "2.3-git-2020-01-22";
 
   src = fetchFromGitHub {
     owner = "TerryCavanagh";
@@ -28,26 +33,27 @@ in stdenv.mkDerivation rec {
     sha256 = "1bq7kj33pw1dwsgh0s0pqayfyhpnbvpgw2c1w9scpl5l0hkhg44p";
   };
 
+  CFLAGS = flags;
+  CXXFLAGS = flags;
+
   nativeBuildInputs = [ cmake ninja ];
   buildInputs = [ SDL2 SDL2_mixer ];
 
-  preConfigure = ''
-    cd desktop_version
-  '';
+  sourceRoot = "source/desktop_version";
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp -t $out/bin VVVVVV
-    cp ${dataZip} $out/bin/data.zip
+    install -d $out/bin
+    install -t $out/bin VVVVVV
+    install -T ${dataZip} $out/bin/data.zip
   '';
 
   meta = with stdenv.lib; {
-    description = "A platform game based on flipping gravity";
+    description = "A retro-styled platform game";
     longDescription = ''
       VVVVVV is a platform game all about exploring one simple mechanical
       idea - what if you reversed gravity instead of jumping? 
     '';
-    homepage = https://thelettervsixtim.es;
+    homepage = "https://thelettervsixtim.es";
     license = licenses.unfree;
     maintainers = [ maintainers.dkudriavtsev ];
     platforms = platforms.all;

--- a/pkgs/games/vvvvvv/default.nix
+++ b/pkgs/games/vvvvvv/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub, requireFile
 , SDL2, SDL2_mixer, cmake, ninja
+, Foundation
 , fullGame ? false }:
 
 let
@@ -24,20 +25,22 @@ let
   flags = if fullGame then [] else [ "-DMAKEANDPLAY" ];
 in stdenv.mkDerivation rec {
   pname = "vvvvvv";
-  version = "unstable-2020-02-02";
+  version = "unstable-2020-02-09";
 
   src = fetchFromGitHub {
     owner = "TerryCavanagh";
     repo = "VVVVVV";
-    rev = "4bc76416f551253452012d28e2bc049087e2be73";
-    sha256 = "1sc64f7sxf063bdgnkg23vc170chq2ix25gs836hyswx98iyg5ly";
+    rev = "1b00d1260064b384f8b294d15ad5eb43f2dde22b";
+    sha256 = "0z98d95ywr30cl6jsxc6ijp2h5p6abgh44ydm5dz9x9zp5rw6zc5";
   };
 
   CFLAGS = flags;
   CXXFLAGS = flags;
 
   nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ SDL2 SDL2_mixer ];
+  buildInputs = [
+    SDL2 SDL2_mixer
+  ] + stdenv.lib.optionalPlatform stdenv.lib.platforms.darwin [ Foundation ];
 
   sourceRoot = "source/desktop_version";
 
@@ -56,6 +59,6 @@ in stdenv.mkDerivation rec {
     homepage = "https://thelettervsixtim.es";
     license = if fullGame then licenses.unfree else licenses.unfreeRedistributable;
     maintainers = [ maintainers.dkudriavtsev ];
-    platforms = platforms.all;
+    platforms = [ platforms.linux platforms.darwin ];
   };
 }

--- a/pkgs/games/vvvvvv/default.nix
+++ b/pkgs/games/vvvvvv/default.nix
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
       idea - what if you reversed gravity instead of jumping? 
     '';
     homepage = "https://thelettervsixtim.es";
-    license = licenses.unfree;
+    license = if fullGame then licenses.unfree else licenses.unfreeRedistributable;
     maintainers = [ maintainers.dkudriavtsev ];
     platforms = platforms.all;
   };

--- a/pkgs/games/vvvvvv/default.nix
+++ b/pkgs/games/vvvvvv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, requireFile
+{ stdenv, fetchurl, fetchFromGitHub, requireFile, makeWrapper
 , SDL2, SDL2_mixer, cmake, ninja
 , Foundation
 , fullGame ? false }:
@@ -18,6 +18,7 @@ let
   } else fetchurl {
     # the data file for the free Make and Play edition
     url = https://thelettervsixtim.es/makeandplay/data.zip;
+    name = "mapdata.zip";
     sha256 = "1q2pzscrglmwfgdl8yj300wymwskh51iq66l4xcd0qk0q3g3rbkg";
   };
 
@@ -42,12 +43,12 @@ in stdenv.mkDerivation rec {
     SDL2 SDL2_mixer
   ] + stdenv.lib.optionalPlatform stdenv.lib.platforms.darwin [ Foundation ];
 
-  sourceRoot = "source/desktop_version";
+    sourceRoot = "source/desktop_version";
 
   installPhase = ''
     install -d $out/bin
     install -t $out/bin VVVVVV
-    install -T ${dataZip} $out/bin/data.zip
+    wrapProgram $out/bin/VVVVVV --add-flags "-assets ${dataZip}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24712,6 +24712,8 @@ in
     libpng = libpng12;
   };
 
+  vvvvvv = callPackage ../games/vvvvvv { };
+
   warmux = callPackage ../games/warmux { };
 
   warsow-engine = callPackage ../games/warsow/engine.nix { };


### PR DESCRIPTION
Adds a package for VVVVVV, a platform game based on inverting gravity.

###### Motivation for this change
Adds the game VVVVVV to nixpkgs.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notes

Fixed version of #78319 which was broken after a bad merge into my nixpkgs fork.
