### PR TITLE
hercules: init at 3.13 (attempt 2)

### DIFF
--- a/pkgs/applications/virtualization/hercules/default.nix
+++ b/pkgs/applications/virtualization/hercules/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "hercules";
+  version = "3.13";
+
+  src = fetchurl {
+    url = "http://downloads.hercules-390.eu/${pname}-${version}.tar.gz";
+    sha256 = "0zg6rwz8ib4alibf8lygi8qn69xx8n92kbi8b3jhi1ymb32mf349";
+  };
+
+  meta = with stdenv.lib; {
+    description = "IBM mainframe emulator";
+    homepage = "http://www.hercules-390.eu";
+    license = licenses.qpl;
+    maintainers = [ maintainers.dkudriavtsev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19466,6 +19466,8 @@ in
 
   herbstluftwm = callPackage ../applications/window-managers/herbstluftwm { };
 
+  hercules = callPackage ../applications/virtualization/hercules { };
+
   hexchat = callPackage ../applications/networking/irc/hexchat { };
 
   hexcurse = callPackage ../applications/editors/hexcurse { };


### PR DESCRIPTION
###### Motivation for this change

Add the Hercules IBM mainframe emulator to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
