### PR TITLE
x3270: init at 4.0ga9

### DIFF
--- a/pkgs/applications/misc/x3270/default.nix
+++ b/pkgs/applications/misc/x3270/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, openssl, m4, expat
+, libX11, libXt, libXaw, libXmu, bdftopcf, mkfontdir
+, fontadobe100dpi, fontadobeutopia100dpi, fontbh100dpi
+, fontbhlucidatypewriter100dpi, fontbitstream100dpi
+, tcl
+, ncurses }:
+
+let
+  majorVersion = "4";
+  minorVersion = "0";
+  versionSuffix = "ga9";
+in stdenv.mkDerivation rec {
+  pname = "x3270";
+  version = "${majorVersion}.${minorVersion}${versionSuffix}";
+
+  src = fetchurl {
+    url = "http://x3270.bgp.nu/download/0${majorVersion}.0${minorVersion}/suite3270-${version}-src.tgz";
+    sha256 = "0km24rgll0s4ji6iz8lvy5ra76ds162s95y33w5px6697cwqkp9j";
+  };
+
+  buildFlags = "unix";
+
+  postConfigure = ''
+    pushd c3270 ; ./configure ; popd
+  '';
+
+  nativeBuildInputs = [ m4 ];
+  buildInputs = [
+    expat
+    libX11 libXt libXaw libXmu bdftopcf mkfontdir
+    fontadobe100dpi fontadobeutopia100dpi fontbh100dpi
+    fontbhlucidatypewriter100dpi fontbitstream100dpi
+    tcl
+    ncurses
+    expat
+  ];
+
+  meta = with stdenv.lib; {
+    description = "IBM 3270 terminal emulator for the X Window System";
+    homepage = "http://x3270.bgp.nu/index.html";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.anna328p ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7834,6 +7834,8 @@ in
 
   clipnotify = callPackage ../tools/misc/clipnotify { };
 
+  x3270 = callPackage ../applications/misc/x3270 { };
+
   xclip = callPackage ../tools/misc/xclip { };
 
   xcur2png = callPackage ../tools/graphics/xcur2png { };


### PR DESCRIPTION
###### Motivation for this change

Adds x3270, an IBM 3270 terminal emulator for the X Window System, to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
