### PR TITLE
chatterino2: unstable-2019-05-11 -> 2.1.7

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatterino2/darwin-frameworks.patch
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/darwin-frameworks.patch
@@ -1,0 +1,27 @@
+Fix build on macOS.
+Patch source: https://github.com/frankosterfeld/qtkeychain/commit/95c6021e280ebe4692e7729cf626c7298db9b226
+
+commit 95c6021e280ebe4692e7729cf626c7298db9b226
+Author: Vadim Peretokin <vperetokin@gmail.com>
+Date:   Tue Sep 10 10:21:40 2019 +0200
+
+    Don't quote LIBS arguments
+
+diff --git a/lib/qtkeychain/qt5keychain.pri b/lib/qtkeychain/qt5keychain.pri
+index ee6d4e8..b3bb626 100644
+--- a/lib/qtkeychain/qt5keychain.pri
++++ b/lib/qtkeychain/qt5keychain.pri
+@@ -73,11 +73,11 @@ win32 {
+ }
+
+ macx:!ios {
+-    LIBS += "-framework Security" "-framework Foundation"
++    LIBS += -framework Security -framework Foundation
+     SOURCES += $$QT5KEYCHAIN_PWD/keychain_mac.cpp
+ }
+
+ ios {
+-    LIBS += "-framework Security" "-framework Foundation"
++    LIBS += -framework Security -framework Foundation
+     OBJECTIVE_SOURCES += $$QT5KEYCHAIN_PWD/keychain_ios.mm
+ }

--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -26,7 +26,7 @@ mkDerivation rec {
       improved/extended version of the Twitch web chat. Chatterino 2 is
       the second installment of the Twitch chat client series
       "Chatterino".
-  '';
+    '';
     homepage = "https://github.com/fourtf/chatterino2";
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -4,7 +4,7 @@ mkDerivation rec {
   pname = "chatterino2";
   version = "2.1.7";
   src = fetchFromGitHub {
-    owner = "fourtf";
+    owner = "Chatterino";
     repo = pname;
     rev = "v${version}";
     sha256 = "0bbdzainfa7hlz5p0jfq4y04i3wix7z3i6w193906bi4gr9wilpg";
@@ -28,7 +28,7 @@ mkDerivation rec {
       the second installment of the Twitch chat client series
       "Chatterino".
     '';
-    homepage = "https://github.com/fourtf/chatterino2";
+    homepage = "https://github.com/Chatterino/chatterino2";
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ rexim ];

--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -2,15 +2,16 @@
 
 mkDerivation rec {
   pname = "chatterino2";
-  version = "unstable-2019-05-11";
+  version = "2.1.7";
   src = fetchFromGitHub {
     owner = "fourtf";
     repo = pname;
-    rev = "8c46cbf571dc8fd77287bf3186445ff52b1d1aaf";
-    sha256 = "0i2385hamhd9i7jdy906cfrd81cybw524j92l87c8pzrkxphignk";
+    rev = "v${version}";
+    sha256 = "0bbdzainfa7hlz5p0jfq4y04i3wix7z3i6w193906bi4gr9wilpg";
     fetchSubmodules = true;
   };
   nativeBuildInputs = [ qmake pkgconfig wrapQtAppsHook ];
+  patches = lib.optionals stdenv.isDarwin [ ./darwin-frameworks.patch ];
   buildInputs = [ qtbase qtsvg qtmultimedia boost openssl ];
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir -p "$out/Applications"


### PR DESCRIPTION
Upgrade chatterino2 to the latest release version.

This commit changes the name of the chatterino2 package. Before this commit, the package is named chatterino2-unstable. After this commit, the package is named chatterino2. If a user wants to upgrade, they must first uninstall chatterino2-unstable before installing chatterino2, else there will be a conflict:

    $ nix-env -iA nixpkgs.chatterino2
    installing 'chatterino2-2.1.7'
    building '/nix/store/hxx0vriblvvlkskcnm4rk32d2ghlvkj5-user-environment.drv'...
    error: packages '/nix/store/icgg81lkh1z17zbzw7ncrfqnkhlb39x9-chatterino2-2.1.7/Applications/chatterino.app/Contents/Info.plist' and '/nix/store/65wapk4pd5gj8dgvd245fzv4z799cnw8-chatterino2-unstable-2019-05-11/Applications/chatterino.app/Contents/Info.plist' have the same priority 5; use 'nix-env --set-flag priority NUMBER INSTALLED_PKGNAME' to change the priority of one of the conflicting packages (0 being the highest priority)
    builder for '/nix/store/hxx0vriblvvlkskcnm4rk32d2ghlvkj5-user-environment.drv' failed with exit code 1
    error: build of '/nix/store/hxx0vriblvvlkskcnm4rk32d2ghlvkj5-user-environment.drv' failed
    $ nix-env -q | grep chatterino2
    chatterino2-unstable-2019-05-11

    $ # chatterino2-unstable conflicts with chatterino2; both can't be
    $ # installed at the same time. Uninstall chatterino2-unstable, then
    $ # try installing chatterino2 again:

    $ nix-env -e chatterino2-unstable
    uninstalling 'chatterino2-unstable-2019-05-11'
    $ nix-env -iA nixpkgs.chatterino2
    installing 'chatterino2-2.1.7'
    $ nix-env -q | grep chatterino2
    chatterino2-2.1.7

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
