### PR TITLE
gitAndTools.git-interactive-rebase-tool: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8004,4 +8004,10 @@
     githubId = 56247270;
     name = "Foxit";
   };
+  masaeedu = {
+    email = "masaeedu@gmail.com";
+    github = "masaeedu";
+    githubId = 3674056;
+    name = "Asad Saeeduddin";
+  };
 }

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -103,6 +103,8 @@ let
 
   git-imerge = callPackage ./git-imerge { };
 
+  git-interactive-rebase-tool = callPackage ./git-interactive-rebase-tool {};
+
   git-machete = python3Packages.callPackage ./git-machete { };
 
   git-octopus = callPackage ./git-octopus { };

--- a/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/01-terminaltests.patch
+++ b/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/01-terminaltests.patch
@@ -1,0 +1,169 @@
+--- a/src/display/utils.rs
++++ b/src/display/utils.rs
+@@ -53,166 +53,3 @@
+ 		_ => ColorMode::TwoTone,
+ 	}
+ }
+-
+-#[cfg(all(windows, test))]
+-mod tests {
+-	use crate::display::color_mode::ColorMode;
+-	use crate::display::utils::detect_color_mode;
+-
+-	#[test]
+-	fn detect_color_mode_windows() {
+-		assert_eq!(detect_color_mode(2), ColorMode::ThreeBit);
+-	}
+-}
+-
+-#[cfg(all(unix, test))]
+-mod tests {
+-	use crate::display::color_mode::ColorMode;
+-	use crate::display::utils::detect_color_mode;
+-	use std::env::{remove_var, set_var};
+-
+-	fn clear_env() {
+-		remove_var("COLORTERM");
+-		remove_var("VTE_VERSION");
+-		remove_var("TERM_PROGRAM");
+-		remove_var("TERM");
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_no_env_2_colors() {
+-		clear_env();
+-		assert_eq!(detect_color_mode(2), ColorMode::TwoTone);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_no_env_8_colors() {
+-		clear_env();
+-		assert_eq!(detect_color_mode(8), ColorMode::ThreeBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_no_env_less_8_colors() {
+-		clear_env();
+-		assert_eq!(detect_color_mode(7), ColorMode::TwoTone);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_no_env_16_colors() {
+-		clear_env();
+-		assert_eq!(detect_color_mode(16), ColorMode::FourBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_no_env_less_16_colors() {
+-		clear_env();
+-		assert_eq!(detect_color_mode(15), ColorMode::ThreeBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_no_env_256_colors() {
+-		clear_env();
+-		assert_eq!(detect_color_mode(256), ColorMode::EightBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_no_env_less_256_colors() {
+-		clear_env();
+-		assert_eq!(detect_color_mode(255), ColorMode::FourBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_no_env_more_256_colors() {
+-		clear_env();
+-		assert_eq!(detect_color_mode(257), ColorMode::EightBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_term_env_no_256() {
+-		clear_env();
+-		set_var("TERM", "XTERM");
+-		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_term_env_with_256() {
+-		clear_env();
+-		set_var("TERM", "XTERM-256");
+-		assert_eq!(detect_color_mode(0), ColorMode::EightBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_term_program_env_apple_terminal() {
+-		clear_env();
+-		set_var("TERM_PROGRAM", "Apple_Terminal");
+-		assert_eq!(detect_color_mode(0), ColorMode::EightBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_term_program_env_iterm() {
+-		clear_env();
+-		set_var("TERM_PROGRAM", "iTerm.app");
+-		assert_eq!(detect_color_mode(0), ColorMode::EightBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_term_program_env_other() {
+-		clear_env();
+-		set_var("TERM_PROGRAM", "other");
+-		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_vte_version_0_36_00() {
+-		clear_env();
+-		set_var("VTE_VERSION", "3600");
+-		assert_eq!(detect_color_mode(0), ColorMode::TrueColor);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_vte_version_greater_0_36_00() {
+-		clear_env();
+-		set_var("VTE_VERSION", "3601");
+-		assert_eq!(detect_color_mode(0), ColorMode::TrueColor);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_vte_version_less_0_36_00() {
+-		clear_env();
+-		set_var("VTE_VERSION", "1");
+-		assert_eq!(detect_color_mode(0), ColorMode::EightBit);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_vte_version_0() {
+-		clear_env();
+-		set_var("VTE_VERSION", "0");
+-		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+-	}
+-	#[test]
+-	fn detect_color_mode_vte_version_invalid() {
+-		clear_env();
+-		set_var("VTE_VERSION", "invalid");
+-		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_colorterm_env_is_truecolor() {
+-		clear_env();
+-		set_var("COLORTERM", "truecolor");
+-		assert_eq!(detect_color_mode(0), ColorMode::TrueColor);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_colorterm_env_is_24bit() {
+-		clear_env();
+-		set_var("COLORTERM", "24bit");
+-		assert_eq!(detect_color_mode(0), ColorMode::TrueColor);
+-	}
+-
+-	#[test]
+-	fn detect_color_mode_colorterm_env_is_other() {
+-		clear_env();
+-		set_var("COLORTERM", "other");
+-		assert_eq!(detect_color_mode(0), ColorMode::TwoTone);
+-	}
+-}

--- a/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
@@ -1,0 +1,27 @@
+{ lib, ncurses5, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-interactive-rebase-tool";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "MitMaro";
+    repo = pname;
+    rev = version;
+    sha256 = "10z3di2qypgsmg2z7xfs9nlrf9vng5i7l8dvqadv1l4lb9zz7i8q";
+  };
+
+  patches = [ ./01-terminaltests.patch ];
+
+  cargoSha256 = "002kr52vlpv1rhnxki29xflpmgk6bszrw0dsxcc34kyal0593ajk";
+
+  buildInputs = [ ncurses5 ];
+
+  meta = with lib; {
+    homepage = "https://github.com/MitMaro/git-interactive-rebase-tool";
+    description = "Native cross platform full feature terminal based sequence editor for git interactive rebase";
+    changelog = "https://github.com/MitMaro/git-interactive-rebase-tool/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ masaeedu ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds [`git-interactive-rebase-tool`](https://github.com/MitMaro/git-interactive-rebase-tool), a nice interactive alternative to modifying a rebase task sequence file

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).