### PR TITLE
fusee-interface-tk: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3878,6 +3878,12 @@
     githubId = 17659803;
     name = "Matthias Axel Kröll";
   };
+  kristian-brucaj = {
+    email = "kbrucaj@gmail.com";
+    github = "kristian-brucaj";
+    githubId = 8893110;
+    name = "Kristian Brucaj";
+  };
   kristoff3r = {
     email = "k.soeholm@gmail.com";
     github = "kristoff3r";

--- a/pkgs/applications/misc/fusee-interface-tk/default.nix
+++ b/pkgs/applications/misc/fusee-interface-tk/default.nix
@@ -1,0 +1,42 @@
+{ stdenv , fetchFromGitHub , python3 , makeWrapper }: 
+
+let pythonEnv = python3.withPackages(ps: [ ps.tkinter ps.pyusb ]); 
+in stdenv.mkDerivation { 
+
+  pname = "fusee-interface-tk";
+  version = "1.0.0";
+  
+  src = fetchFromGitHub { 
+    owner = "nh-server";
+    repo = "fusee-interfacee-tk";
+    rev = "3053a5ffef8efb5ae3da9666f8f53285c5a904b2";
+    sha256 = "0ycsxv71b5yvkcawxmcnmywxfvn8fdg1lyq71xdw7qrskxv5fgq7";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ pythonEnv ];
+   
+  installPhase = '' 
+    mkdir -p $out/bin
+    
+    # The program isn't just called app, so I'm renaming it based on the repo name 
+    # It also isn't a standard program, so we need to append the shebang to the top
+    echo "#!${pythonEnv.interpreter}" > $out/bin/fusee-launcher-tk.py 
+    cat app.py >> $out/bin/fusee-launcher-tk.py 
+    chmod +x $out/bin/fusee-launcher-tk.py 
+    
+
+    # app.py depends on these to run 
+    cp *.py $out/bin/ 
+    cp intermezzo.bin $out/bin/intermezzo.bin
+  '';
+
+  meta = with stdenv.lib; { 
+    homepage = "https://github.com/nh-server/fusee-interfacee-tk";
+    description = "A tool to send .bin files to a Nintendo Switch in RCM mode";
+    longDescription = "A mod of falquinhos Fusée Launcher for use with Nintendo Homebrew Switch Guide. It also adds the ability to mount SD while in RCM. 
+    Must be run as sudo.";
+    maintainers = [ applications.misc.kristian-brucaj ];
+    license = licenses.gpl2;
+  };
+} 

--- a/pkgs/applications/misc/fusee-interface-tk/default.nix
+++ b/pkgs/applications/misc/fusee-interface-tk/default.nix
@@ -21,9 +21,9 @@ in stdenv.mkDerivation {
     
     # The program isn't just called app, so I'm renaming it based on the repo name 
     # It also isn't a standard program, so we need to append the shebang to the top
-    echo "#!${pythonEnv.interpreter}" > $out/bin/fusee-launcher-tk.py 
-    cat app.py >> $out/bin/fusee-launcher-tk.py 
-    chmod +x $out/bin/fusee-launcher-tk.py 
+    echo "#!${pythonEnv.interpreter}" > $out/bin/fusee-launcher-tk 
+    cat app.py >> $out/bin/fusee-launcher-tk
+    chmod +x $out/bin/fusee-launcher-tk 
     
 
     # app.py depends on these to run 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3451,6 +3451,8 @@ in
   fuse-7z-ng = callPackage ../tools/filesystems/fuse-7z-ng { };
 
   fuse-overlayfs = callPackage ../tools/filesystems/fuse-overlayfs {};
+  
+  fusee-interface-tk = callPackage ../applications/misc/fusee-interface-tk { };
 
   fusee-launcher = callPackage ../development/tools/fusee-launcher { };
 


### PR DESCRIPTION
Add fusee-interfacee-tk package to applications/misc
Added self as maintainer to fusee-interface-tk

###### Motivation for this change
Wanted to use fusee-interface-tk from https://github.com/nh-server/fusee-interfacee-tk in NixOS

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
