### PR TITLE
tt2020: init at 2020-01-05

### DIFF
--- a/pkgs/data/fonts/tt2020/default.nix
+++ b/pkgs/data/fonts/tt2020/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub }:
+
+let
+  pname = "TT2020";
+  version = "2020-01-05";
+in
+fetchFromGitHub {
+  name = "${pname}-${version}";
+  owner = "ctrlcctrlv";
+  repo = pname;
+  rev = "2b418fab5f99f72a18b3b2e7e2745ac4e03aa612";
+  sha256 = "1z0nizvs0gp0xl7pn6xcjvsysxhnfm7aqfamplkyvya3fxvhncds";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -Dm644 -t $out/share/fonts/truetype dist/*.ttf
+    install -Dm644 -t $out/share/fonts/woff2 dist/*.woff2
+  '';
+
+  meta = with lib; {
+    description = "An advanced, open source, hyperrealistic, multilingual typewriter font for a new decade";
+    homepage = "https://ctrlcctrlv.github.io/TT2020";
+    license = licenses.ofl;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25824,6 +25824,8 @@ in
 
   tlwg = callPackage ../data/fonts/tlwg { };
 
+  tt2020 = callPackage ../data/fonts/tt2020 { };
+
   simplehttp2server = callPackage ../servers/simplehttp2server { };
 
   diceware = callPackage ../tools/security/diceware { };


### PR DESCRIPTION
###### Motivation for this change
[TT2020](https://ctrlcctrlv.github.io/TT2020/) is an advanced, open source, hyperrealistic, multilingual typewriter font for a new decade.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
$ nix path-info -Sh ./result
/nix/store/8al47f39vki1sghrxwhgm2mh6rzrw664-TT2020-2020-01-05	283.0M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
