### PR TITLE
plasma-applet-volumewin7mixer fix missing dependency

### DIFF
--- a/pkgs/applications/misc/plasma-applet-volumewin7mixer/default.nix
+++ b/pkgs/applications/misc/plasma-applet-volumewin7mixer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, extra-cmake-modules, plasma-framework, kwindowsystem, plasma-pa, fetchFromGitHub }:
+{ stdenv, cmake, extra-cmake-modules, plasma-framework, kwindowsystem, plasma-pa, qt5, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "plasma-applet-volumewin7mixer";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   patches = [ ./cmake.patch ];
   postPatch = '' rm build '';
   nativeBuildInputs = [ cmake extra-cmake-modules ];
-  buildInputs = [ plasma-framework kwindowsystem plasma-pa ];
+  buildInputs = [ plasma-framework kwindowsystem plasma-pa qt5.qtmultimedia ];
 
   meta = with stdenv.lib; {
     description = "A fork of the default volume plasmoid with a Windows 7 theme (vertical sliders).";


### PR DESCRIPTION
Fixes missing dependency on specific qml elements.



<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
One day the applet stopped working complaining that it could not find the module QtMultimedia. I'm not sure what changed but this seems to fix it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
