### PR TITLE
pythonPackages.django_classytags: 0.9.0 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/django_classytags/default.nix
+++ b/pkgs/development/python-modules/django_classytags/default.nix
@@ -2,25 +2,26 @@
 , buildPythonPackage
 , fetchPypi
 , django
+, six
 }:
 
 buildPythonPackage rec {
   pname = "django-classy-tags";
-  version = "0.9.0";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0axzsigvmb17ha5mnr3xf6c851kwinjpkxksxwprwjakh1m59d1q";
+    sha256 = "1cayqddvxd5prhybqi77lif2z4j7mmfmxgc61pq9i82q5gy2asmd";
   };
 
-  propagatedBuildInputs = [ django ];
+  propagatedBuildInputs = [ django six ];
 
   # pypi version doesn't include runtest.py, needed to run tests
   doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Class based template tags for Django";
-    homepage = https://github.com/ojii/django-classy-tags;
+    homepage = "https://github.com/divio/django-classy-tags";
     license = licenses.bsd3;
   };
 


### PR DESCRIPTION
###### Motivation for this change
[CHANGELOG](https://github.com/divio/django-classy-tags/blob/master/CHANGELOG.rst#100-2020-01-22)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
