### PR TITLE
python3Packages.tablib: 0.12.1 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/tablib/default.nix
+++ b/pkgs/development/python-modules/tablib/default.nix
@@ -1,29 +1,36 @@
-{ buildPythonPackage, stdenv, fetchPypi, pytest, unicodecsv, pandas
-, xlwt, openpyxl, pyyaml, xlrd, odfpy, fetchpatch
+{ buildPythonPackage, lib, fetchPypi, isPy27
+, odfpy
+, openpyxl
+, pandas
+, pytest
+, pytestcov
+, pyyaml
+, unicodecsv
+, xlrd
+, xlwt
 }:
 
 buildPythonPackage rec {
   pname = "tablib";
-  version = "0.12.1";
+  version = "1.0.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "11wxchj0qz77dn79yiq30k4b4gsm429f4bizk4lm4rb63nk51kxq";
+    sha256 = "0ddvcgycv5m7q4rn5bch9qnhxjgn7192z537b1wzpmwd5s074cgz";
   };
 
-  checkInputs = [ pytest unicodecsv pandas ];
   propagatedBuildInputs = [ xlwt openpyxl pyyaml xlrd odfpy ];
+  checkInputs = [ pytest pytestcov unicodecsv pandas ];
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/kennethreitz/tablib/commit/0e51a2d0944022af186d2dcd34c0ab3c47141ba5.patch";
-      sha256 = "0lbbl871zdn5vpgqyjkil0c2ap3b5hz19rmihhyvrx7m4mlh1aij";
-    })
-  ];
+  # test_tablib needs MarkupPy, which isn't packaged yet
+  checkPhase = ''
+    pytest --ignore tests/test_tablib.py
+  '';
 
-  meta = with stdenv.lib; {
-    description = "Tablib: format-agnostic tabular dataset library";
-    homepage = http://python-tablib.org;
+  meta = with lib; {
+    description = "Format-agnostic tabular dataset library";
+    homepage = "https://python-tablib.org";
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing  #79060

did some cleanup as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[2 built, 1 copied (56.4 MiB), 9.9 MiB DL]
https://github.com/NixOS/nixpkgs/pull/79090
2 package built:
python37Packages.tablib python38Packages.tablib
```