### PR TITLE
Mpv plugin bookmark 20180320.lua

### DIFF
--- a/pkgs/applications/video/mpv/scripts/bookmark.nix
+++ b/pkgs/applications/video/mpv/scripts/bookmark.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromGitHub, mpv }:
+
+stdenv.mkDerivation rec {
+  name = "mpv-plugin-bookmark-${version}.lua";
+  version = "20180320";
+
+  src = fetchFromGitHub {
+    owner = "yozorayuki";
+    repo = "mpv-plugin-bookmark";
+    rev = "08fa0a415a4a220a91b8436ca681e3da92120b9d";
+    sha256 = "0ann6c2rajy36a6w72l2q6288r6v03ha278i5qh5hk6r9q6gkhy8";
+  };
+
+  installPhase = ''
+    cp bookmark.lua $out
+  '';
+
+  meta = with lib; {
+    description = "mpv plugin to record your playing history for each folder and you can choose resume to play next time";
+    homepage = https://github.com/yozorayuki/mpv-plugin-bookmark;
+    license = licenses.asl20;
+    maintainers = [ maintainers.mschneider ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20374,6 +20374,7 @@ in
   mpv-with-scripts = callPackage ../applications/video/mpv/wrapper.nix { };
 
   mpvScripts = {
+    bookmark = callPackage ../applications/video/mpv/scripts/bookmark.nix {};
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
   };


### PR DESCRIPTION
### mpv-plugin-bookmark
mpv plugin for recording last play in current playing folder and you can resume to play

this plugin will also load the playlist from the playing folder automatically

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
