### PR TITLE
waf: 2.0.18 -> 2.0.19

### DIFF
--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, fetchpatch, python, ensureNewerSourcesForZipFilesHook
+{ stdenv, fetchFromGitLab, python, ensureNewerSourcesForZipFilesHook
 # optional list of extra waf tools, e.g. `[ "doxygen" "pytest" ]`
 , withTools ? null
 }:
@@ -8,21 +8,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "waf";
-  version = "2.0.18";
+  version = "2.0.19";
 
   src = fetchFromGitLab {
     owner = "ita1024";
     repo = "waf";
     rev = "${pname}-${version}";
-    sha256 = "1ifcanm2x2i8qwgfkwgdxwaqcdwsx5jg8bd1d6sqjps3pz7s5qxx";
+    sha256 = "1ydmx20blr776qnmnqp0whyiy81a3glln49m9fva2cmampmandpb";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://gitlab.com/grahamc/waf/commit/fc1c98f1fb575fb26b867a61cbca79aa894db2ea.patch";
-      sha256 = "0kzfrr6nh1ay8nyk0i69nhkkrq7hskn7yw1qyjxrda1y3wxj6jp8";
-    })
-  ];
 
   buildInputs = [ python ensureNewerSourcesForZipFilesHook ];
 


### PR DESCRIPTION
The patch for sorting files in `tar` is no longer needed, as it has been fixed
upstream: https://gitlab.com/ita1024/waf/-/merge_requests/2227

Changelog:
https://gitlab.com/ita1024/waf/blob/waf-2.0.19/ChangeLog


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).