### PR TITLE
bs-platform: fix build on aarch64

### DIFF
--- a/pkgs/development/compilers/bs-platform/build-bs-platform.nix
+++ b/pkgs/development/compilers/bs-platform/build-bs-platform.nix
@@ -30,9 +30,8 @@ stdenv.mkDerivation {
     cp ${custom-ninja}/bin/ninja vendor/ninja/snapshot/ninja.linux
   '';
 
-  configurePhase = ''
-    node scripts/ninja.js config
-  '';
+  # avoid building the development version, will break aarch64 build
+  dontConfigure = true;
 
   buildPhase = ''
     # This is an unfortunate name, but it's actually how to build a release

--- a/pkgs/development/compilers/bs-platform/default.nix
+++ b/pkgs/development/compilers/bs-platform/default.nix
@@ -21,8 +21,5 @@ in
     license = licenses.lgpl3;
     maintainers = with maintainers; [ turbomack gamb anmonteiro ];
     platforms = platforms.all;
-    # Currently there is an issue with aarch build in hydra
-    # https://github.com/BuckleScript/bucklescript/issues/4091
-    badPlatforms = platforms.aarch64;
   };
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/BuckleScript/bucklescript/pull/4139

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @turboMaCk 