### PR TITLE
mpv: use waf from distribution and wafHook helper

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,5 +1,5 @@
 { config, stdenv, fetchurl, fetchFromGitHub, makeWrapper
-, addOpenGLRunpath, docutils, perl, pkgconfig, python3, which
+, addOpenGLRunpath, docutils, perl, pkgconfig, python3, wafHook, which
 , ffmpeg_4, freefont_ttf, freetype, libass, libpthreadstubs, mujs
 , nv-codec-headers, lua, libuchardet, libiconv ? null, darwin
 
@@ -93,14 +93,6 @@ assert youtubeSupport     -> available youtube-dl;
 assert zimgSupport        -> available zimg;
 
 let
-  # Purity: Waf is normally downloaded by bootstrap.py, but
-  # for purity reasons this behavior should be avoided.
-  wafVersion = "2.0.9";
-  waf = fetchurl {
-    urls = [ "https://waf.io/waf-${wafVersion}"
-             "http://www.freehackers.org/~tnagy/release/waf-${wafVersion}" ];
-    sha256 = "0j7sbn3w6bgslvwwh5v9527w3gi2sd08kskrgxamx693y0b0i3ia";
-  };
   luaEnv = lua.withPackages (ps: with ps; [ luasocket ]);
 
 in stdenv.mkDerivation rec {
@@ -121,7 +113,7 @@ in stdenv.mkDerivation rec {
   NIX_LDFLAGS = optionalString x11Support "-lX11 -lXext "
               + optionalString stdenv.isDarwin "-framework CoreFoundation";
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--enable-libmpv-shared"
     "--enable-manpage-build"
     "--disable-libmpv-static"
@@ -140,12 +132,8 @@ in stdenv.mkDerivation rec {
     (enableFeature stdenv.isLinux  "dvbin")
   ];
 
-  configurePhase = ''
-    python3 ${waf} configure --prefix=$out $configureFlags
-  '';
-
   nativeBuildInputs = [
-    addOpenGLRunpath docutils makeWrapper perl pkgconfig python3 which
+    addOpenGLRunpath docutils makeWrapper perl pkgconfig python3 wafHook which
   ];
 
   buildInputs = [
@@ -189,9 +177,7 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildPhase = ''
-    python3 ${waf} build
-  '' + optionalString stdenv.isDarwin ''
+  postBuild = optionalString stdenv.isDarwin ''
     python3 TOOLS/osxbundle.py -s build/mpv
   '';
 
@@ -204,9 +190,7 @@ in stdenv.mkDerivation rec {
       --prefix PYTHONPATH : "${vapoursynth}/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
   '';
 
-  installPhase = ''
-    python3 ${waf} install
-
+  postInstall = ''
     # Use a standard font
     mkdir -p $out/share/mpv
     ln -s ${freefont_ttf}/share/fonts/truetype/FreeSans.ttf $out/share/mpv/subfont.ttf


### PR DESCRIPTION
This cleans up our dependency footprint by ensuring a consistent version, and
also avoids duplicating the logic for how to build a waf package by deferring to
the `wafHook` helper for the `configurePhase`, `buildPhase`, and `installPhase`.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).