### PR TITLE
zsh-powerlevel10k: 1.0 -> 1.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "gitstatus";
-  version = "unstable-2019-12-18";
+  version = "unstable-2020-01-28";
 
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "gitstatus";
-    rev = "8ae9c17a60158dcf91f56d9167493e3988a5e921";
-    sha256 = "1czjwsgbmxd1d656srs3n6wj6bmqr8p3aw5gw61q4wdxw3mni2a6";
+    rev = "edb99aa7b86d10ad0a1cfe25135b57c8031d82ad";
+    sha256 = "1nys74qswwc7hn9cv0j7syvbpnw0f15chc9pi11him4d6lsflrfd";
   };
 
   buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];
@@ -25,6 +25,6 @@ stdenv.mkDerivation {
     homepage = https://github.com/romkatv/gitstatus;
     license = [ licenses.gpl3 ];
 
-    maintainers = [ maintainers.mmlb ];
+    maintainers = with maintainers; [ mmlb hexa ];
   };
 }

--- a/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
@@ -5,12 +5,12 @@
 
 stdenv.mkDerivation {
   pname = "powerlevel10k";
-  version = "1.0";
+  version = "1.1";
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "powerlevel10k";
-    rev = "c21961b53c137253020aeffca2b132fdd6bcb116";
-    sha256 = "1jp6jhw5kb10d76zkxdv8c04s51ilmjka336bgnllya9nyqaqpxp";
+    rev = "9d9c50611da19044370ee759e593ccadbad32a6a";
+    sha256 = "0jl4jamh7i8w7lp3qbbakh1wsyrrmslsrjwh9jgyvw50a83hp6fj";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

New upstream release. I've also updated gitstatus to match the version used in this zsh-powerlevel10k version. I'll also add myself as a maintainer for gitstatus.

**Changes since the last release**

    Complete documentation overhaul. Powerlevel10k documentation is no longer embarrassing (still no reference though; coming "soon").
    Worker pool and recursive globber have been rewritten for better performance and simpler code. Performance improvements (large speedup means an improvement in big-O and at least 2x in typical configurations):
        +15% prompt speedup across the board.
        Large prompt speedup for several rarely used prompt segments (disk_usage, ram, etc.).
        Large prompt speedup for a few prompt segments on macOS (battery, swap, etc.).
        Large prompt speedup when many prompt segments are active simultaneously.
        Large prompt speedup when filesystem is slow.
    New prompt segments: nix_shell and timewarrior. Both enabled by default.
    Configuration wizard:
        Many new options for Pure style (color scheme, number of lines, etc.)
        Several new options for 8-color version of Pure style.
        Better support for terminals with less than 256 colors.
        Lean, Classic and Rainbow style configs now have disk_usage and swap prompt segments (disabled by default).
        POWERLEVEL9K_DIR_TRUNCATE_BEFORE_MARKER now contains 'oc'.
    New parameters:
        POWERLEVEL9K_LEGACY_ICON_SPACING=true makes spaces around icons appear just like in powerlevel9k.
        When in a vcs repo, POWERLEVEL9K_DIR_TRUNCATE_BEFORE_MARKER=true removes directory prefix that precedes repo root.
        P9K_KUBECONTEXT_USER can now be used in kubecontext format.
        POWERLEVEL9K_GOENV_SOURCES -- the same as POWERLEVEL9K_RBENV_SOURCES but or go.
        POWERLEVEL9K_TERRAFORM_CLASSES -- the same as POWERLEVEL9K_AWS_CLASSES but for terraform.
    Bug fixes:
        Configuration wizard now correctly follows symlinks when modifying ~/.zshrc and ~/.p10k.zsh.
        ram prompt segment now works on WSL.
        Powerlevel10k now correctly works with zsh-you-should-use in hardcore mode.
        POWERLEVEL9K_PUBLIC_IP_HOST now points to a host that actually works.
        Instant prompt no longer prints nonsensical "entry=" in rare circumstances.
    Misc:
        Config templates no longer work with POWERLEVEL9K_VISUAL_IDENTIFIER='' defined after them.
        Powerlevel10k now detects when Antigen corrupts its source and emits an appropriate error message.
        Command line parser now understands 'tabbed'.
        Remove all references to romkatv/dotfiles-public. Fonts are now hosted in romkatv/powerlevel10k-media together with all images and animations.




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @mmlb 