### PR TITLE
ktimetracker: init at 5.0.1

### DIFF
--- a/pkgs/applications/office/ktimetracker/default.nix
+++ b/pkgs/applications/office/ktimetracker/default.nix
@@ -1,0 +1,32 @@
+{ mkDerivation, lib, fetchurl, cmake, pkgconfig, extra-cmake-modules,
+kconfig, kconfigwidgets, kdbusaddons, kdoctools, ki18n, kidletime,
+kjobwidgets, kio, knotifications, kwindowsystem, kxmlgui, ktextwidgets,
+kcalendarcore
+}:
+
+mkDerivation rec {
+  pname = "ktimetracker";
+  version = "5.0.1";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.xz";
+    sha256 = "0jp63fby052rapjjaz413b1wjz4qsgpxh82y2d75jzimch0n5s02";
+  };
+
+  nativeBuildInputs = [
+    cmake pkgconfig extra-cmake-modules
+  ];
+
+  buildInputs = [
+		kconfig kconfigwidgets kdbusaddons kdoctools ki18n kidletime kjobwidgets
+kio knotifications kwindowsystem kxmlgui ktextwidgets
+    kcalendarcore
+  ];
+
+  meta = with lib; {
+    description = "Todo management and time tracking application";
+    license = licenses.gpl2;
+    homepage = "https://userbase.kde.org/KTimeTracker";
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19917,6 +19917,8 @@ in
 
   ksuperkey = callPackage ../tools/X11/ksuperkey { };
 
+  ktimetracker = libsForQt5.callPackage ../applications/office/ktimetracker { };
+
   ktorrent = libsForQt5.callPackage ../applications/networking/p2p/ktorrent { };
 
   kubecfg = callPackage ../applications/networking/cluster/kubecfg { };


### PR DESCRIPTION
###### Motivation for this change

https://aspotashev.blogspot.com/2019/12/ktimetracker-501-released.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).