### PR TITLE
lsd2dsl: 0.4.1 -> 0.5.1

### DIFF
--- a/pkgs/applications/misc/lsd2dsl/default.nix
+++ b/pkgs/applications/misc/lsd2dsl/default.nix
@@ -1,26 +1,29 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake
-, boost, libvorbis, libsndfile, minizip, gtest }:
+{ stdenv, mkDerivation, lib, fetchFromGitHub, cmake
+, boost, libvorbis, libsndfile, minizip, gtest, qtwebkit }:
 
 mkDerivation rec {
   pname = "lsd2dsl";
-  version = "0.4.1";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "nongeneric";
     repo = pname;
     rev = "v${version}";
-    sha256 = "15xjp5xxvl0qc4zp553n7djrbvdp63sfjw406idgxqinfmkqkqdr";
+    sha256 = "100qd9i0x6r0nkw1ic2p0xjr16jlhinxkn1x7i98s4xmw4wyb8n8";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ boost libvorbis libsndfile minizip gtest ];
+  buildInputs = [ boost libvorbis libsndfile minizip gtest qtwebkit ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=unused-result";
+  NIX_CFLAGS_COMPILE = "-Wno-error=unused-result -Wno-error=missing-braces";
 
   installPhase = ''
-    install -Dm755 lsd2dsl $out/bin/lsd2dsl
-    install -m755 qtgui/lsd2dsl-qtgui $out/bin/lsd2dsl-qtgui
+    install -Dm755 console/lsd2dsl $out/bin/lsd2dsl
+    install -m755 gui/lsd2dsl-qtgui $out/bin/lsd2dsl-qtgui
+  '' + lib.optionalString stdenv.isDarwin ''
+    wrapQtApp $out/bin/lsd2dsl
+    wrapQtApp $out/bin/lsd2dsl-qtgui
   '';
 
   meta = with lib; {
@@ -31,6 +34,6 @@ mkDerivation rec {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
-    platforms = with platforms; linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://github.com/nongeneric/lsd2dsl/releases/tag/v0.5.1)
* Enable on darwin

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
$ nix path-info -Sh /nix/store/9yzb8mbjb49716q37cfdsfgcz7wiqcyl-lsd2dsl-0.4.1
/nix/store/9yzb8mbjb49716q37cfdsfgcz7wiqcyl-lsd2dsl-0.4.1	297.5M
$ nix path-info -Sh /nix/store/08f3si0fnjlkgm9ll0jm281hjn258y1l-lsd2dsl-0.5.1
/nix/store/08f3si0fnjlkgm9ll0jm281hjn258y1l-lsd2dsl-0.5.1	450.9M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
