### PR TITLE
Iodine: ipv6 support, updates, hardening, nixos test....

### DIFF
--- a/nixos/modules/services/networking/iodine.nix
+++ b/nixos/modules/services/networking/iodine.nix
@@ -73,7 +73,7 @@ in
                 passwordFile = mkOption {
                   type = types.str;
                   default = "";
-                  description = "File that contains password";
+                  description = "Path to a file containing the password.";
                 };
               };
             }

--- a/nixos/modules/services/networking/iodine.nix
+++ b/nixos/modules/services/networking/iodine.nix
@@ -59,7 +59,7 @@ in
                 relay = mkOption {
                   type = types.str;
                   default = "";
-                  description = "DNS server to use as a intermediate relay to the iodined server";
+                  description = "DNS server to use as an intermediate relay to the iodined server";
                   example = "8.8.8.8";
                 };
 

--- a/nixos/modules/services/networking/iodine.nix
+++ b/nixos/modules/services/networking/iodine.nix
@@ -9,6 +9,8 @@ let
 
   iodinedUser = "iodined";
 
+  /* is this path made unreadable by ProtectHome = true ? */
+  isProtected = x: hasPrefix "/root" x || hasPrefix "/home" x;
 in
 {
   imports = [
@@ -134,6 +136,24 @@ in
             serviceConfig = {
               RestartSec = "30s";
               Restart = "always";
+
+              # hardening :
+              # Filesystem access
+              ProtectSystem = "strict";
+              ProtectHome = if isProtected cfg.passwordFile then "read-only" else "true" ;
+              PrivateTmp = true;
+              ReadWritePaths = "/dev/net/tun";
+              PrivateDevices = false;
+              ProtectKernelTunables = true;
+              ProtectKernelModules = true;
+              ProtectControlGroups = true;
+              # Caps
+              NoNewPrivileges = true;
+              # Misc.
+              LockPersonality = true;
+              RestrictRealtime = true;
+              PrivateMounts = true;
+              MemoryDenyWriteExecute = true;
             };
           };
       in
@@ -147,6 +167,24 @@ in
             after = [ "network.target" ];
             wantedBy = [ "multi-user.target" ];
             script = "exec ${pkgs.iodine}/bin/iodined -f -u ${iodinedUser} ${cfg.server.extraConfig} ${optionalString (cfg.server.passwordFile != "") "< \"${cfg.server.passwordFile}\""} ${cfg.server.ip} ${cfg.server.domain}";
+            serviceConfig = {
+              # Filesystem access
+              ProtectSystem = "strict";
+              ProtectHome = if isProtected cfg.server.passwordFile then "read-only" else "true" ;
+              PrivateTmp = true;
+              ReadWritePaths = "/dev/net/tun";
+              PrivateDevices = false;
+              ProtectKernelTunables = true;
+              ProtectKernelModules = true;
+              ProtectControlGroups = true;
+              # Caps
+              NoNewPrivileges = true;
+              # Misc.
+              LockPersonality = true;
+              RestrictRealtime = true;
+              PrivateMounts = true;
+              MemoryDenyWriteExecute = true;
+            };
           };
         };
 

--- a/nixos/modules/services/networking/iodine.nix
+++ b/nixos/modules/services/networking/iodine.nix
@@ -52,7 +52,7 @@ in
                 server = mkOption {
                   type = types.str;
                   default = "";
-                  description = "Domain or Subdomain of server running iodined";
+                  description = "Hostname of server running iodined";
                   example = "tunnel.mydomain.com";
                 };
 

--- a/nixos/modules/services/networking/iodine.nix
+++ b/nixos/modules/services/networking/iodine.nix
@@ -132,7 +132,7 @@ in
             description = "iodine client - ${name}";
             after = [ "network.target" ];
             wantedBy = [ "multi-user.target" ];
-            script = "exec ${pkgs.iodine}/bin/iodine -f -u ${iodinedUser} ${cfg.extraConfig} ${optionalString (cfg.passwordFile != "") "< \"${cfg.passwordFile}\""} ${cfg.relay} ${cfg.server}";
+            script = "exec ${pkgs.iodine}/bin/iodine -f -u ${iodinedUser} ${cfg.extraConfig} ${optionalString (cfg.passwordFile != "") "< \"${builtins.toString cfg.passwordFile}\""} ${cfg.relay} ${cfg.server}";
             serviceConfig = {
               RestartSec = "30s";
               Restart = "always";
@@ -166,7 +166,7 @@ in
             description = "iodine, ip over dns server daemon";
             after = [ "network.target" ];
             wantedBy = [ "multi-user.target" ];
-            script = "exec ${pkgs.iodine}/bin/iodined -f -u ${iodinedUser} ${cfg.server.extraConfig} ${optionalString (cfg.server.passwordFile != "") "< \"${cfg.server.passwordFile}\""} ${cfg.server.ip} ${cfg.server.domain}";
+            script = "exec ${pkgs.iodine}/bin/iodined -f -u ${iodinedUser} ${cfg.server.extraConfig} ${optionalString (cfg.server.passwordFile != "") "< \"${builtins.toString cfg.server.passwordFile}\""} ${cfg.server.ip} ${cfg.server.domain}";
             serviceConfig = {
               # Filesystem access
               ProtectSystem = "strict";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -130,6 +130,7 @@ in
   initrd-network-ssh = handleTest ./initrd-network-ssh {};
   initrdNetwork = handleTest ./initrd-network.nix {};
   installer = handleTest ./installer.nix {};
+  iodine = handleTest ./iodine.nix {};
   ipv6 = handleTest ./ipv6.nix {};
   jackett = handleTest ./jackett.nix {};
   jellyfin = handleTest ./jellyfin.nix {};

--- a/nixos/tests/iodine.nix
+++ b/nixos/tests/iodine.nix
@@ -1,0 +1,63 @@
+import ./make-test-python.nix (
+  { pkgs, ... }: let
+    domain = "whatever.example.com";
+  in
+    {
+      name = "iodine";
+      nodes = {
+        server =
+          { ... }:
+
+            {
+              networking.firewall = {
+                allowedUDPPorts = [ 53 ];
+                trustedInterfaces = [ "dns0" ];
+              };
+              boot.kernel.sysctl = {
+                "net.ipv4.ip_forward" = 1;
+                "net.ipv6.ip_forward" = 1;
+              };
+
+              services.iodine.server = {
+                enable = true;
+                ip = "10.53.53.1/24";
+                passwordFile = "${builtins.toFile "password" "foo"}";
+                inherit domain;
+              };
+
+              # test resource: accessible only via tunnel
+              services.openssh = {
+                enable = true;
+                openFirewall = false;
+              };
+            };
+
+        client =
+          { ... }: {
+            services.iodine.clients.testClient = {
+              # test that ProtectHome is "read-only"
+              passwordFile = "/root/pw";
+              relay = "server";
+              server = domain;
+            };
+            systemd.tmpfiles.rules = [
+              "f /root/pw 0666 root root - foo"
+            ];
+            environment.systemPackages = [
+              pkgs.nagiosPluginsOfficial
+            ];
+          };
+
+      };
+
+      testScript = ''
+        start_all()
+
+        server.wait_for_unit("sshd")
+        server.wait_for_unit("iodined")
+        client.wait_for_unit("iodine-testClient")
+
+        client.succeed("check_ssh -H 10.53.53.1")
+      '';
+    }
+)

--- a/pkgs/tools/networking/iodine/default.nix
+++ b/pkgs/tools/networking/iodine/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchurl, zlib, nettools }:
+{ stdenv, fetchFromGitHub, zlib, nettools }:
 
 stdenv.mkDerivation rec {
-  name = "iodine-0.7.0";
+  pname = "iodine";
+  version = "unstable-2019-09-27";
 
-  src = fetchurl {
-    url = "https://code.kryo.se/iodine/${name}.tar.gz";
-    sha256 = "0gh17kcxxi37k65zm4gqsvbk3aw7yphcs3c02pn1c4s2y6n40axd";
+  src = fetchFromGitHub {
+    owner = "yarrick";
+    repo = "iodine";
+    rev = "8e14f18";
+    sha256 = "0k8m99qfjd5n6n56jnq85y7q8h2i2b8yw6ba0kxsz4jyx97lavg3";
   };
 
   buildInputs = [ zlib ];

--- a/pkgs/tools/networking/iodine/default.nix
+++ b/pkgs/tools/networking/iodine/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, zlib, nettools }:
+{ stdenv, fetchFromGitHub, zlib, nettools, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "iodine";
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-DIFCONFIGPATH=\"${nettools}/bin/\"";
 
   installFlags = [ "prefix=\${out}" ];
+
+  passthru.tests = {
+    inherit (nixosTests) iodine;
+  };
 
   meta = {
     homepage = http://code.kryo.se/iodine/;

--- a/pkgs/tools/networking/network-manager/iodine/default.nix
+++ b/pkgs/tools/networking/network-manager/iodine/default.nix
@@ -1,15 +1,18 @@
-{ stdenv, fetchurl, substituteAll, iodine, intltool, pkgconfig, networkmanager, libsecret, gtk3
+{ stdenv, fetchFromGitLab, substituteAll, autoreconfHook, iodine, intltool, pkgconfig, networkmanager, libsecret, gtk3
 , withGnome ? true, gnome3, fetchpatch, networkmanagerapplet }:
 
 let
   pname = "NetworkManager-iodine";
-  version = "1.2.0";
+  version = "unstable-2019-11-05";
 in stdenv.mkDerivation {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0njdigakidji6mfmbsp8lfi8wl88z1dk8cljbva2w0xazyddbwyh";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "network-manager-iodine";
+    rev = "2ef0abf089b00a0546f214dde0d45e63f2990b79";
+    sha256 = "1ps26fr9b1yyafj7lrzf2kmaxb0ipl0mhagch5kzrjdsc5xkajz7";
   };
 
   patches = [
@@ -27,11 +30,12 @@ in stdenv.mkDerivation {
   buildInputs = [ iodine networkmanager ]
     ++ stdenv.lib.optionals withGnome [ gtk3 libsecret networkmanagerapplet ];
 
-  nativeBuildInputs = [ intltool pkgconfig ];
+  nativeBuildInputs = [ intltool autoreconfHook pkgconfig ];
 
   # glib-2.62 deprecations
   NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
 
+  preConfigure = "intltoolize";
   configureFlags = [
     "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"


### PR DESCRIPTION
##### Motivation for this change

* update iodine for ipv6 support
* update nm-iodine because it is buggy (100% cpu usage after the vpn disconnects)
* add some hardening flags to the nixos service
* add a nixos test to check that the hardening didn't break anything

I ran nixpkgs-fmt on the nixos module, so best reviewed commit by commit :)

###### Things done

Tested on a real setup.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
