### PR TITLE
chromium: avoid java dependency

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -16,7 +16,6 @@
 , libXScrnSaver, libXcursor, libXtst, libGLU, libGL
 , protobuf, speechd, libXdamage, cups
 , ffmpeg, libxslt, libxml2, at-spi2-core
-, jre
 
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
@@ -124,7 +123,6 @@ let
       glib gtk3 dbus-glib
       libXScrnSaver libXcursor libXtst libGLU libGL
       pciutils protobuf speechd libXdamage at-spi2-core
-      jre
     ] ++ optional gnomeKeyringSupport libgnome-keyring3
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]
       ++ optionals cupsSupport [ libgcrypt cups ]
@@ -242,7 +240,8 @@ let
       blink_symbol_level = 0;
       enable_swiftshader = false;
       fieldtrial_testing_like_official_build = true;
-
+      closure_compile = false; # Disable type-checking for the Web UI to avoid a Java dependency.
+      
       # Google API keys, see:
       #   http://www.chromium.org/developers/how-tos/api-keys
       # Note: These are for NixOS/nixpkgs use ONLY. For your own distribution,


### PR DESCRIPTION
Java dependency results in `chromium` must be built per each group of machines with different `jre` (oraclejdk vs openjdk, 8 vs 11, ...).

Also, `Guix` does it: https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/chromium.scm#n472

thanks @danielfullmer (https://github.com/volth/nixpkgs-windows/pull/4#issuecomment-575263312)