### PR TITLE
date: init at 2.4.1

### DIFF
--- a/pkgs/development/libraries/date/default.nix
+++ b/pkgs/development/libraries/date/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, curl
+}: stdenv.mkDerivation rec {
+  pname = "date";
+  version = "2.4.1";
+
+  src = fetchFromGitHub {
+    owner = "HowardHinnant";
+    repo = "date";
+    rev = "v${version}";
+    sha256 = "1761y28zc6a5adnp09pkjjgir2i0b065gdy0jwwqwi0q3g1zp0h5";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ curl ];
+
+  cmakeFlags = [
+    "-DBUILD_TZ_LIB=true"
+    "-DBUILD_SHARED_LIBS=true"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A date and time library based on the C++11/14/17 <chrono> header";
+    homepage = "https://github.com/HowardHinnant/date";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lovesegfault ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1549,6 +1549,8 @@ in
 
   datasette = with python3Packages; toPythonApplication datasette;
 
+  date = callPackage ../development/libraries/date { };
+
   datefudge = callPackage ../tools/system/datefudge { };
 
   dateutils = callPackage ../tools/misc/dateutils { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
It will be needed for a coming release of Waybar, also seems to be quite popular

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
