### PR TITLE
oraclejdk8: remove dead code

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -16,7 +16,6 @@
 , pluginSupport ? true
 , installjce ? false
 , config
-, licenseAccepted ? config.oraclejdk.accept_license or false
 , glib
 , libxml2
 , libav_0_8
@@ -35,13 +34,6 @@
 }:
 
 assert swingSupport -> xorg != null;
-
-if !licenseAccepted then throw ''
-    You must accept the Oracle Binary Code License Agreement for Java SE at
-    https://www.oracle.com/technetwork/java/javase/terms/license/index.html
-    by setting nixpkgs config option 'oraclejdk.accept_license = true;'
-  ''
-else assert licenseAccepted;
 
 let
 


### PR DESCRIPTION
`config.oraclejdk.accept_license` does nothing after `oraclejdk8: 8u211 -> 8u241` #77783.
Actually, since few month already, since it is not possible to download `oraclejdk` using `curl`