### PR TITLE
fusee-interfacee-tk: init at V1.0.0

### DIFF
--- a/pkgs/applications/misc/fusee-interfacee-tk/default.nix
+++ b/pkgs/applications/misc/fusee-interfacee-tk/default.nix
@@ -1,0 +1,40 @@
+{ stdenv , fetchFromGitHub , python3 , makeWrapper }: 
+
+let pythonEnv = python3.withPackages(ps: [ ps.tkinter ps.pyusb ]); 
+in stdenv.mkDerivation rec { 
+  pname = "fusee-interfacee-tk";
+  version = "1.0.0";
+
+  src = fetchFromGitHub { 
+    owner = "nh-server";
+    repo = pname;
+    rev = "V${version}"; 
+    sha256 = "0ycsxv71b5yvkcawxmcnmywxfvn8fdg1lyq71xdw7qrskxv5fgq7";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ pythonEnv ];
+
+  installPhase = '' 
+    mkdir -p $out/bin
+			      
+    # The program isn't just called app, so I'm renaming it based on the repo name 
+    # It also isn't a standard program, so we need to append the shebang to the top
+    echo "#!${pythonEnv.interpreter}" > $out/bin/fusee-interfacee-tk 
+    cat app.py >> $out/bin/fusee-interfacee-tk
+    chmod +x $out/bin/fusee-interfacee-tk 
+							      
+    # app.py depends on these to run 
+    cp *.py $out/bin/ 
+    cp intermezzo.bin $out/bin/intermezzo.bin
+  '';
+
+  meta = with stdenv.lib; { 
+    homepage = "https://github.com/nh-server/fusee-interfacee-tk";
+    description = "A tool to send .bin files to a Nintendo Switch in RCM mode";
+    longDescription = "A mod of falquinhos Fusée Launcher for use with Nintendo Homebrew Switch Guide. It also adds the ability to mount SD while in RCM. 
+    Must be run as sudo.";
+    maintainers = with maintainers; [ kristian-brucaj ];
+    license = licenses.gpl2;
+  };
+} 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3453,6 +3453,8 @@ in
   fuse-7z-ng = callPackage ../tools/filesystems/fuse-7z-ng { };
 
   fuse-overlayfs = callPackage ../tools/filesystems/fuse-overlayfs {};
+  
+  fusee-interfacee-tk = callPackage ../applications/misc/fusee-interfacee-tk { };
 
   fusee-launcher = callPackage ../development/tools/fusee-launcher { };
 
@@ -6679,6 +6681,8 @@ in
   systrayhelper = callPackage ../tools/misc/systrayhelper {};
 
   Sylk = callPackage ../applications/networking/Sylk {};
+
+  otter-browser = qt5.callPackage ../applications/networking/browsers/otter {};
 
   privoxy = callPackage ../tools/networking/privoxy {
     w3m = w3m-batch;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6682,8 +6682,6 @@ in
 
   Sylk = callPackage ../applications/networking/Sylk {};
 
-  otter-browser = qt5.callPackage ../applications/networking/browsers/otter {};
-
   privoxy = callPackage ../tools/networking/privoxy {
     w3m = w3m-batch;
   };


### PR DESCRIPTION
Package fusee-interfacee-tk utility to applications/misc for use with RCM Nintendo Switch
###### Motivation for this change

Add fusee-interfacee-tk package
Add fusee-interfacee-tk to all-applications
###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
