### PR TITLE
pfsshell: init at 1.1.0

### DIFF
--- a/pkgs/tools/filesystems/pfsshell/default.nix
+++ b/pkgs/tools/filesystems/pfsshell/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, meson, ninja }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.0";
+  pname = "pfsshell";
+
+  src = fetchFromGitHub {
+    owner = "uyjulian";
+    repo = "pfsshell";
+    rev = "v${version}";
+    sha256 = "10bkihb6qwh2difmrrxsaszq1rhgq0gw55l1hry0nilkr7l6i62v";
+  };
+
+  nativeBuildInputs = [ meson ninja ];
+  hardeningDisable = [ "format" "fortify" ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "PFS (PlayStation File System) shell for POSIX-based systems";
+    platforms = platforms.unix;
+    license = licenses.gpl2; #The APA, PFS, and iomanX libraries are licensed under the The Academic Free License version 2.
+    maintainers = with maintainers; [ genesis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8730,6 +8730,8 @@ in
 
   pforth = callPackage ../development/compilers/pforth {};
 
+  pfsshell = callPackage ../tools/filesystems/pfsshell {};
+
   picat = callPackage ../development/compilers/picat { };
 
   ponyc = callPackage ../development/compilers/ponyc {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
