### PR TITLE
editorconfig-checker: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/development/tools/misc/editorconfig-checker/default.nix
+++ b/pkgs/development/tools/misc/editorconfig-checker/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "editorconfig-checker";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
     owner = "editorconfig-checker";
     repo = "editorconfig-checker";
     rev = "${version}";
-    sha256 = "0v2ml9r8b5admi3sv80wa1pwl9qnz03q2p84vgcmgg2nv1v6yxf3";
+    sha256 = "1gn7q6wg7byhr1l5ly60rbb700xrww9slbq7gbxbw5c1fl0pp3yk";
   };
 
-  modSha256 = "09b1v9gyh6827yqlfxxxq3lcqhd5snn3n7gdlbjmga3wyp2x4g2r";
+  modSha256 = "1iiv12ginb3ky739z7v8wf4z5lv24gmghbybs3lzay0kqn449n4x";
 
   meta = with lib; {
     description = "A tool to verify that your files are in harmony with your .editorconfig";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bump to the latest version [0] and additionally fix package build as it's failing currently with module hash mismatch:
```
hash mismatch in fixed-output derivation '/nix/store/6ghdnnzr7w8ah9p6pym8mik67bp580jy-editorconfig-checker-2.0.2-go-modules':
  wanted: sha256:09b1v9gyh6827yqlfxxxq3lcqhd5snn3n7gdlbjmga3wyp2x4g2r
  got:    sha256:1iiv12ginb3ky739z7v8wf4z5lv24gmghbybs3lzay0kqn449n4x
cannot build derivation '/nix/store/dhickjqkym3hgr7ispji7yi7argwbnpj-editorconfig-checker-2.0.2.drv': 1 dependencies couldn't be built
```

[0] https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/2.0.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/79145)
<!-- Reviewable:end -->
