### PR TITLE
texlive: fix build broken by poppler update

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "poppler-${suffix}-${version}";
-  version = "0.84.0"; # beware: updates often break cups-filters build
+  version = "0.84.0"; # beware: updates often break cups-filters build, check texlive too!
 
   src = fetchurl {
     url = "${meta.homepage}/poppler-${version}.tar.xz";

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -68,6 +68,9 @@ let
       done
       cp -pv ${pdftoepdf} texk/web2c/pdftexdir/pdftoepdf.cc
       cp -pv ${pdftosrc} texk/web2c/pdftexdir/pdftosrc.cc
+
+      # poppler 0.84 compat fixups, use 0.83 files otherwise
+      patch -p1 -i ${./poppler84.patch}
     '';
 
     # remove when removing synctex-missing-header.patch

--- a/pkgs/tools/typesetting/tex/texlive/poppler84.patch
+++ b/pkgs/tools/typesetting/tex/texlive/poppler84.patch
@@ -1,0 +1,43 @@
+From cf05aae9685e5c6a46b4313e7bfce49edc6f51f9 Mon Sep 17 00:00:00 2001
+From: Mikle Kolyada <zlogene@gentoo.org>
+Date: Tue, 31 Dec 2019 11:29:30 +0300
+Subject: [PATCH] poppler-0.84 compat
+
+Upstream report: https://tug.org/pipermail/tex-k/2019-December/003096.html
+
+Signed-off-by: Mikle Kolyada <zlogene@gentoo.org>
+---
+ texk/web2c/pdftexdir/utils.c    | 1 -
+ texk/web2c/xetexdir/XeTeX_ext.c | 3 +++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/texk/web2c/pdftexdir/utils.c b/texk/web2c/pdftexdir/utils.c
+index c93a8781..6f866e76 100644
+--- a/texk/web2c/pdftexdir/utils.c
++++ b/texk/web2c/pdftexdir/utils.c
+@@ -33,7 +33,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include "ptexlib.h"
+ #include <png.h>
+ #ifdef POPPLER_VERSION
+-#include <poppler-config.h>
+ #define xpdfVersion POPPLER_VERSION
+ #define xpdfString "poppler"
+ #else
+diff --git a/texk/web2c/xetexdir/XeTeX_ext.c b/texk/web2c/xetexdir/XeTeX_ext.c
+index 4968ee41..0aee4ee3 100644
+--- a/texk/web2c/xetexdir/XeTeX_ext.c
++++ b/texk/web2c/xetexdir/XeTeX_ext.c
+@@ -38,7 +38,10 @@ authorization from the copyright holders.
+ 
+ #include <w2c/config.h>
+ 
++#ifndef POPPLER_VERSION
+ #include <poppler-config.h>
++#endif
++
+ #include <png.h>
+ #include <zlib.h>
+ #include <graphite2/Font.h>
+-- 
+2.24.1
+


### PR DESCRIPTION
###### Motivation for this change

Vendored patch, or even patching texlive at all vs. patching poppler
(see mailing list thread and linked issues, arguably poppler bug)
might make this not the best, but it's what I have right now :).

So this is a bit of an issue reporting the breakage :).

The patch included has been working well for me, FWIW.

Check breakage vs fixing with: `texlive.bin.core` for example.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).