### PR TITLE
ocamlPackages.apron: 2016-01-25 → 0.9.12

### DIFF
--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchzip, perl, gmp, mpfr, ppl, ocaml, findlib, camlidl, mlgmpidl }:
+{ stdenv, fetchFromGitHub, perl, gmp, mpfr, ppl, ocaml, findlib, camlidl, mlgmpidl }:
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-apron-${version}";
-  version = "20160125";
-  src = fetchzip {
-    url = "http://apron.gforge.inria.fr/apron-${version}.tar.gz";
-    sha256 = "1a7b7b9wsd0gdvm41lgg6ayb85wxc2a3ggcrghy4qiphs4b9v4m4";
+  version = "0.9.12";
+  src = fetchFromGitHub {
+    owner = "antoinemine";
+    repo = "apron";
+    rev = "v${version}";
+    sha256 = "0bciv4wz52p57q0aggmvixvqrsd1slflfyrm1z6fy5c44f4fmjjn";
   };
 
   buildInputs = [ perl gmp mpfr ppl ocaml findlib camlidl ];
   propagatedBuildInputs = [ mlgmpidl ];
 
   prefixKey = "-prefix ";
-  createFindlibDestdir = true;
+  preBuild = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs";
 
   meta = {
     license = stdenv.lib.licenses.lgpl21;


### PR DESCRIPTION
##### Motivation for this change

Bug fixes.

Fix the installation of shared libraries (aka stubs).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
