### PR TITLE
theme-jade1: 1.5 -> 1.6

### DIFF
--- a/pkgs/data/themes/jade1/default.nix
+++ b/pkgs/data/themes/jade1/default.nix
@@ -2,25 +2,25 @@
 
 stdenv.mkDerivation rec {
   pname = "theme-jade1";
-  version = "1.5";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "madmaxms";
     repo = "theme-jade-1";
     rev = "v${version}";
-    sha256 = "1m3150iyk8421mkwj4x2pv29wjzqdcnvvnp3bsg11k5kszsm27a8";
+    sha256 = "1lnajrsikw6dljf6dvgmj8aqwywmgdp34h3xsc0xiyq07arhp606";
   };
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
   installPhase = ''
     mkdir -p $out/share/themes
-    cp -a Jade-1 $out/share/themes
+    cp -a Jade* $out/share/themes
   '';
 
   meta = with stdenv.lib; {
     description = "Fork of the original Linux Mint theme with dark menus, more intensive green and some other modifications";
-    homepage = https://github.com/madmaxms/theme-jade-1;
+    homepage = "https://github.com/madmaxms/theme-jade-1";
     license = with licenses; [ gpl3 ];
     platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [1.6](https://github.com/madmaxms/theme-jade-1/releases/tag/v1.6)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).