### PR TITLE
pyopengl: fix runtime shared library loading failure with 3.1.4

### DIFF
--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage rec {
 
   patchPhase = let
     ext = stdenv.hostPlatform.extensions.sharedLibrary; in ''
+    # Theses lines are patching the name of dynamic libraries
+    # so pyopengl can find them at runtime.
     substituteInPlace OpenGL/platform/glx.py \
       --replace "'GL'" "'${pkgs.libGL}/lib/libGL${ext}'" \
       --replace "'GLU'" "'${pkgs.libGLU}/lib/libGLU${ext}'" \
@@ -26,6 +28,16 @@ buildPythonPackage rec {
     substituteInPlace OpenGL/platform/darwin.py \
       --replace "'OpenGL'" "'${pkgs.libGL}/lib/libGL${ext}'" \
       --replace "'GLUT'" "'${pkgs.freeglut}/lib/libglut${ext}'"
+
+    # https://github.com/NixOS/nixpkgs/issues/76822
+    # pyopengl introduced a new "robust" way of loading libraries in 3.1.4.
+    # The later patch of the filepath does not work anymore because
+    # pyopengl takes the "name" (for us: the path) and tries to add a
+    # few suffix during its loading phase.
+    # The following patch put back the "name" (i.e. the path) in the
+    # list of possible files.
+    substituteInPlace OpenGL/platform/ctypesloader.py \
+      --replace "filenames_to_try = []" "filenames_to_try = [name]"
   '';
 
   # Need to fix test runner


### PR DESCRIPTION
This closes #76822.

pyopengl 3.1.4 introduced a new logic for shared library loading: it
tests a few combinations of library name and suffix (such as .so.X).

Our previous patch was just replacing the library name (e.g. 'glut') by
the full path to the nix store. This does not work anymore with pyopengl
3.1.4 new heuristic.

This commit just keep the behavior of pyopengl but adds the nix store
path to the list of tried paths.

I tested with `friture` which was failing at build time before this commit and is now building. I also tested `pyqtgraph` which was failing at runtime and is now working.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
