### PR TITLE
dxx-rebirth: 0.59.100 -> 0.59.20200202

### DIFF
--- a/pkgs/games/dxx-rebirth/default.nix
+++ b/pkgs/games/dxx-rebirth/default.nix
@@ -1,5 +1,15 @@
-{ gcc6Stdenv, fetchurl, fetchpatch, scons, pkgconfig
-, SDL, SDL_mixer, libGLU, libGL, physfs
+{ stdenv
+, fetchFromGitHub
+, fetchurl
+, fetchpatch
+, scons
+, pkgconfig
+, SDL
+, SDL_mixer
+, libGLU
+, libGL
+, libpng
+, physfs
 }:
 
 let
@@ -8,46 +18,38 @@ let
     sha256 = "05mz77vml396mff43dbs50524rlm4fyds6widypagfbh5hc55qdc";
   };
 
-in gcc6Stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "dxx-rebirth";
-  version = "0.59.100";
+  version = "0.59.20200202";
 
-  src = fetchurl {
-    url = "https://www.dxx-rebirth.com/download/dxx/dxx-rebirth_v${version}-src.tar.gz";
-    sha256 = "0m9k34zyr8bbni9szip407mffdpwbqszgfggavgqjwq0k9c1w7ka";
+  src = fetchFromGitHub {
+    owner = "dxx-rebirth";
+    repo = "dxx-rebirth";
+    rev = "8ebb66c5c9c74ebb93d49741cc9545f2bb7fa05d";
+    sha256 = "1lsrlp47aby2m9hh7i3nv5rb0srlkmnq1w2ca6vyvlga9m9h7jrk";
   };
-
-  # TODO: drop these when upgrading to version > 0.59.100
-  patches = [
-    (fetchpatch {
-      name   = "dxx-gcc7-fix1.patch";
-      url    = "https://github.com/dxx-rebirth/dxx-rebirth/commit/1ed7cec714c623758e3418ec69eaf3b3ff03e9f6.patch";
-      sha256 = "026pn8xglmxryaj8555h5rhzkx30lxmksja1fzdlfyb1vll75gq0";
-    })
-    (fetchpatch {
-      name   = "dxx-gcc7-fix2.patch";
-      url    = "https://github.com/dxx-rebirth/dxx-rebirth/commit/73057ad8ec6977ac747637db1080686f11b4c3cc.patch";
-      sha256 = "0s506vdd2djrrm3xl0ygn9ylpg6y8qxii2nnzk3sf9133glp3swy";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig scons ];
 
-  buildInputs = [ libGLU libGL physfs SDL SDL_mixer ];
+  buildInputs = [ libGLU libGL libpng physfs SDL SDL_mixer ];
 
   enableParallelBuilding = true;
 
-  NIX_CFLAGS_COMPILE = "-Wno-format-nonliteral";
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-format-nonliteral"
+    "-Wno-format-truncation"
+  ];
 
   postInstall = ''
-    install -Dm644 ${music} $out/share/games/dxx-rebirth/d2xr-sc55-music.dxa
+    install -Dm644 ${music} $out/share/games/dxx-rebirth/${music.name}
     install -Dm644 -t $out/share/doc/dxx-rebirth *.txt
   '';
 
-  meta = with gcc6Stdenv.lib; {
+  meta = with stdenv.lib; {
     description = "Source Port of the Descent 1 and 2 engines";
     homepage = "https://www.dxx-rebirth.com/";
-    license = licenses.free;
+    license = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = with platforms; linux;
   };


### PR DESCRIPTION
###### Motivation for this change

It's very been long since a formal release, but we need to pick a commit from master in order for everything to build using scons3 ref https://github.com/NixOS/nixpkgs/pull/75877

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
