### PR TITLE
xournalpp: 1.0.16 -> 1.0.17

### DIFF
--- a/pkgs/applications/graphics/xournalpp/default.nix
+++ b/pkgs/applications/graphics/xournalpp/default.nix
@@ -1,5 +1,4 @@
 { stdenv
-, lib
 , fetchFromGitHub
 
 , cmake
@@ -23,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xournalpp";
-  version = "1.0.16";
+  version = "1.0.17";
 
   src = fetchFromGitHub {
     owner = "xournalpp";
     repo = pname;
     rev = version;
-    sha256 = "1bdmxxkcqpjvkckizmrz2839b4yspw4xv69bqkrrgkcyvxsr804w";
+    sha256 = "0xw2mcgnm4sa9hrhfgp669lfypw97drxjmz5w8i5whaprpvmkxzw";
   };
 
   nativeBuildInputs = [ cmake gettext pkgconfig wrapGAppsHook ];
@@ -45,7 +44,9 @@ stdenv.mkDerivation rec {
       portaudio
       zlib
     ]
-    ++ lib.optional withLua lua;
+    ++ stdenv.lib.optional withLua lua;
+
+  buildFlags = "translations";
 
   hardeningDisable = [ "format" ];
 
@@ -53,9 +54,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Xournal++ is a handwriting Notetaking software with PDF annotation support";
-    homepage    = https://github.com/xournalpp/xournalpp;
+    homepage    = "https://github.com/xournalpp/xournalpp";
     license     = licenses.gpl2;
-    maintainers = with maintainers; [ andrew-d ];
+    maintainers = with maintainers; [ andrew-d sikmir ];
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/xournalpp/xournalpp/releases/tag/1.0.17)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
$ nix path-info -Sh /nix/store/n5hckcmfjr1d2666f2fn07z473znxy0x-xournalpp-1.0.16
/nix/store/n5hckcmfjr1d2666f2fn07z473znxy0x-xournalpp-1.0.16	207.8M
$ nix path-info -Sh /nix/store/1qyzarqmj9191vds2dyqgmj0nj908qiv-xournalpp-1.0.17
/nix/store/1qyzarqmj9191vds2dyqgmj0nj908qiv-xournalpp-1.0.17	207.8M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
