### PR TITLE
paraview: add wrapQtAppsHook

### DIFF
--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -1,9 +1,5 @@
-{
-stdenv, fetchFromGitHub, cmake, makeWrapper
-,qtbase, qttools, python, libGLU, libGL
-,libXt, qtx11extras, qtxmlpatterns
-, mkDerivation
-}:
+{ stdenv, fetchFromGitHub, cmake, makeWrapper, qtbase , qttools, python
+, libGLU, libGL , libXt, qtx11extras, qtxmlpatterns , mkDerivation }:
 
 mkDerivation rec {
   pname = "paraview";
@@ -53,20 +49,20 @@ mkDerivation rec {
 
   # Paraview links into the Python library, resolving symbolic links on the way,
   # so we need to put the correct sitePackages (with numpy) back on the path
-  postInstall = ''
-    wrapProgram $out/bin/paraview \
+  preFixup = ''
+    wrapQtApp $out/bin/paraview \
       --prefix PYTHONPATH "${python.pkgs.numpy}/${python.sitePackages}"
-    wrapProgram $out/bin/pvbatch \
+    wrapQtApp $out/bin/pvbatch \
       --prefix PYTHONPATH "${python.pkgs.numpy}/${python.sitePackages}"
-    wrapProgram $out/bin/pvpython \
+    wrapQtApp $out/bin/pvpython \
       --prefix PYTHONPATH "${python.pkgs.numpy}/${python.sitePackages}"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.paraview.org/;
     description = "3D Data analysis and visualization application";
-    license = stdenv.lib.licenses.free;
-    maintainers = with stdenv.lib.maintainers; [guibert];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.free;
+    maintainers = with maintainers; [ guibert ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Also reformatted meta and arguments

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
