### PR TITLE
todoist-electron: init at 1.19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2974,6 +2974,12 @@
     githubId = 12491746;
     name = "Masato Yonekawa";
   };
+  i077 = {
+    email = "nixpkgs@imranhossa.in";
+    github = "i077";
+    githubId = 2789926;
+    name = "Imran Hossain";
+  };
   iand675 = {
     email = "ian@iankduncan.com";
     github = "iand675";

--- a/pkgs/applications/misc/todoist-electron/default.nix
+++ b/pkgs/applications/misc/todoist-electron/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, lib, fetchurl, makeDesktopItem, dpkg, atk, at-spi2-atk, glib, pango, gdk-pixbuf
+, gtk3, cairo, freetype, fontconfig, dbus, xorg, nss, nspr, alsaLib, cups, expat
+, udev, libpulseaudio, utillinux, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "todoist-electron";
+  version = "1.19";
+
+  src = fetchurl {
+    url = "https://github.com/KryDos/todoist-linux/releases/download/${version}/Todoist_${version}.0_amd64.deb";
+    sha256 = "1w0l7k7wmbhwzv71cffsir0q7zg9m0617fmyvd4a01b6flpxrpfx";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "Todoist";
+    exec = "todoist";
+    desktopName = "Todoist";
+    categories = "Utility;Productivity";
+  };
+
+  nativeBuildInputs = [ makeWrapper dpkg ];
+  unpackPhase = ''
+    mkdir pkg
+    dpkg-deb -x $src pkg
+    sourceRoot=pkg
+  '';
+  installPhase = let
+    libPath = lib.makeLibraryPath ([
+      stdenv.cc.cc gtk3 atk at-spi2-atk glib pango gdk-pixbuf cairo freetype fontconfig dbus
+      nss nspr alsaLib libpulseaudio cups expat udev utillinux
+    ] ++ (with xorg; [
+      libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes libxcb
+      libXrender libX11 libXtst libXScrnSaver
+    ]));
+  in ''
+    mkdir -p "$out/bin"
+    mv opt "$out/"
+
+    # Patch binary
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}:\$ORIGIN" \
+      $out/opt/Todoist/todoist
+
+    # Hacky workaround for RPATH problems
+    makeWrapper $out/opt/Todoist/todoist $out/bin/todoist \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio udev ]}
+
+    # Desktop item
+    mkdir -p "$out/share"
+    ln -s "${desktopItem}/share/applications" "$out/share/applications"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/KryDos/todoist-linux";
+    description = "The Linux wrapper for Todoist web version";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.isc;
+    maintainers = with maintainers; [ i077 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10683,6 +10683,8 @@ in
 
   todoist = callPackage ../applications/misc/todoist { };
 
+  todoist-electron = callPackage ../applications/misc/todoist-electron { };
+
   todolist = callPackage ../applications/misc/todolist { };
 
   travis = callPackage ../development/tools/misc/travis { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

`todoist-electron` is an Electron wrapper around the Todoist web app, with some global shortcuts.

Note: The source repository does not have a `COPYING` file to denote a license, so I am basing the license off of the [AUR Package](https://aur.archlinux.org/packages/todoist-electron) (ISC license), maintained by the owner of the source repo. Additionally, while the repo's name is `todoist-linux`, the AUR package name is `todoist-electron`, so I'm going with the latter since it's slightly more descriptive.

(this is also my first PR and first derivation for nixpkgs, so I may have gotten some things wrong)

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
