### PR TITLE
WIP: gettext: refactor and split in multiple packages

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -623,6 +623,14 @@ auth required pam_succeed_if.so uid >= 1000 quiet
     via <option>boot.initrd.luks.fido2Support</option>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <package>gettext</package> has been split into 3 components:
+     <package>gettext-runtime</package>, <package>gettext-tools</package>
+     and <package>libtextstyle</package>. As a convenience, <package>gettext</package>
+     now points to <package>gettext-runtime</package>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/pkgs/applications/misc/metamorphose2/default.nix
+++ b/pkgs/applications/misc/metamorphose2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, makeWrapper, gettext
+{ stdenv, fetchgit, makeWrapper, gettext-tools
 , python27, python2Packages
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace messages/Makefile \
-      --replace "\$(shell which msgfmt)" "${gettext}/bin/msgfmt"
+      --replace "\$(shell which msgfmt)" "${gettext-tools}/bin/msgfmt"
   '';
 
   postInstall = ''
@@ -27,8 +27,8 @@ stdenv.mkDerivation {
       --add-flags "-O $out/share/metamorphose2/metamorphose2.py -w=3"
   '';
 
-  buildInput = [ gettext python27 ];
-  nativeBuildInputs = [ makeWrapper ];
+  buildInput = [ python27 ];
+  nativeBuildInputs = [ makeWrapper gettext-tools ];
   propagatedBuildInputs = [ python2Packages.wxPython python2Packages.pillow ];
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, buildPackages
-, curl, openssl, zlib, expat, perlPackages, python3, gettext, cpio
+, curl, openssl, zlib, expat, perlPackages, python3, gettext-runtime, gettext-tools, cpio
 , gnugrep, gnused, gawk, coreutils # needed at runtime by git-filter-branch etc
 , openssh, pcre2
 , asciidoc, texinfo, xmlto, docbook2x, docbook_xsl, docbook_xml_dtd_45
@@ -60,10 +60,10 @@ stdenv.mkDerivation {
 
     # Fix references to gettext introduced by ./git-sh-i18n.patch
     substituteInPlace git-sh-i18n.sh \
-        --subst-var-by gettext ${gettext}
+        --subst-var-by gettext ${gettext-runtime}
   '';
 
-  nativeBuildInputs = [ gettext perlPackages.perl ]
+  nativeBuildInputs = [ gettext-tools perlPackages.perl ]
     ++ stdenv.lib.optionals withManual [ asciidoc texinfo xmlto docbook2x
          docbook_xsl docbook_xml_dtd_45 libxslt ];
   buildInputs = [curl openssl zlib expat cpio makeWrapper libiconv]

--- a/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
@@ -7,7 +7,7 @@ index e1d917fd27..e90f8e1414 100644
  then
  	: no probing necessary
 -elif type gettext.sh >/dev/null 2>&1
-+elif type @gettext@/bin/gettext.sh >/dev/null 2>&1
++elif type @gettext-runtime@/bin/gettext.sh >/dev/null 2>&1
  then
  	# GNU libintl's gettext.sh
  	GIT_INTERNAL_GETTEXT_SH_SCHEME=gnu
@@ -16,8 +16,8 @@ index e1d917fd27..e90f8e1414 100644
  gnu)
  	# Use libintl's gettext.sh, or fall back to English if we can't.
 -	. gettext.sh
-+	. @gettext@/bin/gettext.sh
-+	export PATH=@gettext@/bin:$PATH
++	. @gettext-runtime@/bin/gettext.sh
++	export PATH=@gettext-runtime@/bin:$PATH
  	;;
  gettext_without_eval_gettext)
  	# Solaris has a gettext(1) but no eval_gettext(1)

--- a/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , fetchFromGitHub
-, gettext
+, gettext-tools
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    gettext
+    gettext-tools
   ];
 
   installPhase = ''

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, autoreconfHook, docbook_xml_dtd_412, docbook_xml_dtd_42, docbook_xml_dtd_43, docbook_xsl, which, libxml2
 , gobject-introspection, gtk-doc, intltool, libxslt, pkgconfig, xmlto, appstream-glib, substituteAll, glibcLocales, yacc, xdg-dbus-proxy, p11-kit
-, bubblewrap, bzip2, dbus, glib, gpgme, json-glib, libarchive, libcap, libseccomp, coreutils, gettext, hicolor-icon-theme, fuse, nixosTests
+, bubblewrap, bzip2, dbus, glib, gpgme, json-glib, libarchive, libcap, libseccomp, coreutils, gettext-tools, hicolor-icon-theme, fuse, nixosTests
 , libsoup, lzma, ostree, polkit, python3, systemd, xorg, valgrind, glib-networking, wrapGAppsHook, dconf, gsettings-desktop-schemas, librsvg }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-test-paths.patch;
-      inherit coreutils gettext glibcLocales;
+      inherit coreutils gettext-tools glibcLocales;
       hicolorIconTheme = hicolor-icon-theme;
     })
     (substituteAll {

--- a/pkgs/development/libraries/flatpak/fix-test-paths.patch
+++ b/pkgs/development/libraries/flatpak/fix-test-paths.patch
@@ -35,14 +35,14 @@ index 0a0a28f1..16fd51fe 100755
  EOF
  mkdir -p ${DIR}/files/de/share/de/LC_MESSAGES
 -msgfmt --output-file ${DIR}/files/de/share/de/LC_MESSAGES/helloworld.mo de.po
-+@gettext@/bin/msgfmt --output-file ${DIR}/files/de/share/de/LC_MESSAGES/helloworld.mo de.po
++@gettext-tools@/bin/msgfmt --output-file ${DIR}/files/de/share/de/LC_MESSAGES/helloworld.mo de.po
  cat > fr.po <<EOF
  msgid "Hello world"
  msgstr "Bonjour le monde"
  EOF
  mkdir -p ${DIR}/files/fr/share/fr/LC_MESSAGES
 -msgfmt --output-file ${DIR}/files/fr/share/fr/LC_MESSAGES/helloworld.mo fr.po
-+@gettext@/bin/msgfmt --output-file ${DIR}/files/fr/share/fr/LC_MESSAGES/helloworld.mo fr.po
++@gettext-tools@/bin/msgfmt --output-file ${DIR}/files/fr/share/fr/LC_MESSAGES/helloworld.mo fr.po
  
  flatpak build-finish ${DIR}
  mkdir -p repos

--- a/pkgs/development/libraries/gettext-runtime/absolute-paths.diff
+++ b/pkgs/development/libraries/gettext-runtime/absolute-paths.diff
@@ -1,7 +1,7 @@
-diff --git a/gettext-runtime/src/gettext.sh.in b/gettext-runtime/src/gettext.sh.in
+diff --git a/src/gettext.sh.in b/src/gettext.sh.in
 index 1dfa3bb..d6ef8a8 100644
---- a/gettext-runtime/src/gettext.sh.in
-+++ b/gettext-runtime/src/gettext.sh.in
+--- a/src/gettext.sh.in
++++ b/src/gettext.sh.in
 @@ -86,14 +86,14 @@ fi
  # looks up the translation of MSGID and substitutes shell variables in the
  # result.

--- a/pkgs/development/libraries/gettext-runtime/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext-runtime/gettext-setup-hook.sh
@@ -1,13 +1,3 @@
-gettextDataDirsHook() {
-    # See pkgs/build-support/setup-hooks/role.bash
-    getHostRoleEnvHook
-    if [ -d "$1/share/gettext" ]; then
-        addToSearchPath "GETTEXTDATADIRS${role_post}" "$1/share/gettext"
-    fi
-}
-
-addEnvHooks "$hostOffset" gettextDataDirsHook
-
 # libintl must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
 if [ -n "@gettextNeedsLdflags@" -a -z "${dontAddExtraLibs-}" ]; then

--- a/pkgs/development/libraries/gettext-runtime/gettext.git-ec0e6b307456ceab352669ae6bccca9702108753.patch
+++ b/pkgs/development/libraries/gettext-runtime/gettext.git-ec0e6b307456ceab352669ae6bccca9702108753.patch
@@ -1,0 +1,670 @@
+From ec0e6b307456ceab352669ae6bccca9702108753 Mon Sep 17 00:00:00 2001
+From: Bruno Haible <bruno@clisp.org>
+Date: Mon, 20 May 2019 21:26:30 +0200
+Subject: Update after gnulib changed.
+
+* gettext-runtime/intl/setlocale.c (search): Optimize away a redundant strcmp()
+invocation.
+(locales_with_principal_territory): New array.
+(langcmp, get_main_locale_with_same_language): New functions.
+(locales_with_principal_language): New array.
+(terrcmp, get_main_locale_with_same_territory): New functions.
+(rpl_setlocale): When setlocale_single failed, try again with a locale that is
+more likely to exist. Don't warn if the environment variable SETLOCALE_VERBOSE
+is not set.
+---
+ gettext-runtime/intl/setlocale.c | 600 +++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 579 insertions(+), 21 deletions(-)
+
+diff --git a/intl/setlocale.c b/intl/setlocale.c
+index a9ee5470f..2995db1c8 100644
+--- a/intl/setlocale.c
++++ b/intl/setlocale.c
+@@ -625,7 +625,7 @@ search (const struct table_entry *table, size_t table_size, const char *string,
+           {
+             size_t i;
+ 
+-            for (i = mid; i < hi; i++)
++            for (i = mid + 1; i < hi; i++)
+               {
+                 if (strcmp (table[i].code, string) > 0)
+                   {
+@@ -865,6 +865,527 @@ setlocale_single (int category, const char *locale)
+ #  define setlocale_single setlocale_unixlike
+ # endif
+ 
++# if defined __APPLE__ && defined __MACH__
++
++/* Mapping from language to main territory where that language is spoken.  */
++static char const locales_with_principal_territory[][6 + 1] =
++  {
++                /* Language     Main territory */
++    "ace_ID",   /* Achinese     Indonesia */
++    "af_ZA",    /* Afrikaans    South Africa */
++    "ak_GH",    /* Akan         Ghana */
++    "am_ET",    /* Amharic      Ethiopia */
++    "an_ES",    /* Aragonese    Spain */
++    "ang_GB",   /* Old English  Britain */
++    "arn_CL",   /* Mapudungun   Chile */
++    "as_IN",    /* Assamese     India */
++    "ast_ES",   /* Asturian     Spain */
++    "av_RU",    /* Avaric       Russia */
++    "awa_IN",   /* Awadhi       India */
++    "az_AZ",    /* Azerbaijani  Azerbaijan */
++    "ban_ID",   /* Balinese     Indonesia */
++    "be_BY",    /* Belarusian   Belarus */
++    "bej_SD",   /* Beja         Sudan */
++    "bem_ZM",   /* Bemba        Zambia */
++    "bg_BG",    /* Bulgarian    Bulgaria */
++    "bho_IN",   /* Bhojpuri     India */
++    "bi_VU",    /* Bislama      Vanuatu */
++    "bik_PH",   /* Bikol        Philippines */
++    "bin_NG",   /* Bini         Nigeria */
++    "bm_ML",    /* Bambara      Mali */
++    "bn_IN",    /* Bengali      India */
++    "bo_CN",    /* Tibetan      China */
++    "br_FR",    /* Breton       France */
++    "bs_BA",    /* Bosnian      Bosnia */
++    "bug_ID",   /* Buginese     Indonesia */
++    "ca_ES",    /* Catalan      Spain */
++    "ce_RU",    /* Chechen      Russia */
++    "ceb_PH",   /* Cebuano      Philippines */
++    "co_FR",    /* Corsican     France */
++    "cr_CA",    /* Cree         Canada */
++    /* Don't put "crh_UZ" or "crh_UA" here.  That would be asking for fruitless
++       political discussion.  */
++    "cs_CZ",    /* Czech        Czech Republic */
++    "csb_PL",   /* Kashubian    Poland */
++    "cy_GB",    /* Welsh        Britain */
++    "da_DK",    /* Danish       Denmark */
++    "de_DE",    /* German       Germany */
++    "din_SD",   /* Dinka        Sudan */
++    "doi_IN",   /* Dogri        India */
++    "dsb_DE",   /* Lower Sorbian        Germany */
++    "dv_MV",    /* Divehi       Maldives */
++    "dz_BT",    /* Dzongkha     Bhutan */
++    "ee_GH",    /* Éwé          Ghana */
++    "el_GR",    /* Greek        Greece */
++    /* Don't put "en_GB" or "en_US" here.  That would be asking for fruitless
++       political discussion.  */
++    "es_ES",    /* Spanish      Spain */
++    "et_EE",    /* Estonian     Estonia */
++    "fa_IR",    /* Persian      Iran */
++    "fi_FI",    /* Finnish      Finland */
++    "fil_PH",   /* Filipino     Philippines */
++    "fj_FJ",    /* Fijian       Fiji */
++    "fo_FO",    /* Faroese      Faeroe Islands */
++    "fon_BJ",   /* Fon          Benin */
++    "fr_FR",    /* French       France */
++    "fur_IT",   /* Friulian     Italy */
++    "fy_NL",    /* Western Frisian      Netherlands */
++    "ga_IE",    /* Irish        Ireland */
++    "gd_GB",    /* Scottish Gaelic      Britain */
++    "gon_IN",   /* Gondi        India */
++    "gsw_CH",   /* Swiss German Switzerland */
++    "gu_IN",    /* Gujarati     India */
++    "he_IL",    /* Hebrew       Israel */
++    "hi_IN",    /* Hindi        India */
++    "hil_PH",   /* Hiligaynon   Philippines */
++    "hr_HR",    /* Croatian     Croatia */
++    "hsb_DE",   /* Upper Sorbian        Germany */
++    "ht_HT",    /* Haitian      Haiti */
++    "hu_HU",    /* Hungarian    Hungary */
++    "hy_AM",    /* Armenian     Armenia */
++    "id_ID",    /* Indonesian   Indonesia */
++    "ig_NG",    /* Igbo         Nigeria */
++    "ii_CN",    /* Sichuan Yi   China */
++    "ilo_PH",   /* Iloko        Philippines */
++    "is_IS",    /* Icelandic    Iceland */
++    "it_IT",    /* Italian      Italy */
++    "ja_JP",    /* Japanese     Japan */
++    "jab_NG",   /* Hyam         Nigeria */
++    "jv_ID",    /* Javanese     Indonesia */
++    "ka_GE",    /* Georgian     Georgia */
++    "kab_DZ",   /* Kabyle       Algeria */
++    "kaj_NG",   /* Jju          Nigeria */
++    "kam_KE",   /* Kamba        Kenya */
++    "kmb_AO",   /* Kimbundu     Angola */
++    "kcg_NG",   /* Tyap         Nigeria */
++    "kdm_NG",   /* Kagoma       Nigeria */
++    "kg_CD",    /* Kongo        Democratic Republic of Congo */
++    "kk_KZ",    /* Kazakh       Kazakhstan */
++    "kl_GL",    /* Kalaallisut  Greenland */
++    "km_KH",    /* Central Khmer        Cambodia */
++    "kn_IN",    /* Kannada      India */
++    "ko_KR",    /* Korean       Korea (South) */
++    "kok_IN",   /* Konkani      India */
++    "kr_NG",    /* Kanuri       Nigeria */
++    "kru_IN",   /* Kurukh       India */
++    "ky_KG",    /* Kyrgyz       Kyrgyzstan */
++    "lg_UG",    /* Ganda        Uganda */
++    "li_BE",    /* Limburgish   Belgium */
++    "lo_LA",    /* Laotian      Laos */
++    "lt_LT",    /* Lithuanian   Lithuania */
++    "lu_CD",    /* Luba-Katanga Democratic Republic of Congo */
++    "lua_CD",   /* Luba-Lulua   Democratic Republic of Congo */
++    "luo_KE",   /* Luo          Kenya */
++    "lv_LV",    /* Latvian      Latvia */
++    "mad_ID",   /* Madurese     Indonesia */
++    "mag_IN",   /* Magahi       India */
++    "mai_IN",   /* Maithili     India */
++    "mak_ID",   /* Makasar      Indonesia */
++    "man_ML",   /* Mandingo     Mali */
++    "men_SL",   /* Mende        Sierra Leone */
++    "mfe_MU",   /* Mauritian Creole     Mauritius */
++    "mg_MG",    /* Malagasy     Madagascar */
++    "mi_NZ",    /* Maori        New Zealand */
++    "min_ID",   /* Minangkabau  Indonesia */
++    "mk_MK",    /* Macedonian   North Macedonia */
++    "ml_IN",    /* Malayalam    India */
++    "mn_MN",    /* Mongolian    Mongolia */
++    "mni_IN",   /* Manipuri     India */
++    "mos_BF",   /* Mossi        Burkina Faso */
++    "mr_IN",    /* Marathi      India */
++    "ms_MY",    /* Malay        Malaysia */
++    "mt_MT",    /* Maltese      Malta */
++    "mwr_IN",   /* Marwari      India */
++    "my_MM",    /* Burmese      Myanmar */
++    "na_NR",    /* Nauru        Nauru */
++    "nah_MX",   /* Nahuatl      Mexico */
++    "nap_IT",   /* Neapolitan   Italy */
++    "nb_NO",    /* Norwegian Bokmål    Norway */
++    "nds_DE",   /* Low Saxon    Germany */
++    "ne_NP",    /* Nepali       Nepal */
++    "nl_NL",    /* Dutch        Netherlands */
++    "nn_NO",    /* Norwegian Nynorsk    Norway */
++    "no_NO",    /* Norwegian    Norway */
++    "nr_ZA",    /* South Ndebele        South Africa */
++    "nso_ZA",   /* Northern Sotho       South Africa */
++    "ny_MW",    /* Chichewa     Malawi */
++    "nym_TZ",   /* Nyamwezi     Tanzania */
++    "nyn_UG",   /* Nyankole     Uganda */
++    "oc_FR",    /* Occitan      France */
++    "oj_CA",    /* Ojibwa       Canada */
++    "or_IN",    /* Oriya        India */
++    "pa_IN",    /* Punjabi      India */
++    "pag_PH",   /* Pangasinan   Philippines */
++    "pam_PH",   /* Pampanga     Philippines */
++    "pap_AN",   /* Papiamento   Netherlands Antilles - this line can be removed in 2018 */
++    "pbb_CO",   /* Páez         Colombia */
++    "pl_PL",    /* Polish       Poland */
++    "ps_AF",    /* Pashto       Afghanistan */
++    "pt_PT",    /* Portuguese   Portugal */
++    "raj_IN",   /* Rajasthani   India */
++    "rm_CH",    /* Romansh      Switzerland */
++    "rn_BI",    /* Kirundi      Burundi */
++    "ro_RO",    /* Romanian     Romania */
++    "ru_RU",    /* Russian      Russia */
++    "rw_RW",    /* Kinyarwanda  Rwanda */
++    "sa_IN",    /* Sanskrit     India */
++    "sah_RU",   /* Yakut        Russia */
++    "sas_ID",   /* Sasak        Indonesia */
++    "sat_IN",   /* Santali      India */
++    "sc_IT",    /* Sardinian    Italy */
++    "scn_IT",   /* Sicilian     Italy */
++    "sg_CF",    /* Sango        Central African Republic */
++    "shn_MM",   /* Shan         Myanmar */
++    "si_LK",    /* Sinhala      Sri Lanka */
++    "sid_ET",   /* Sidamo       Ethiopia */
++    "sk_SK",    /* Slovak       Slovakia */
++    "sl_SI",    /* Slovenian    Slovenia */
++    "sm_WS",    /* Samoan       Samoa */
++    "smn_FI",   /* Inari Sami   Finland */
++    "sms_FI",   /* Skolt Sami   Finland */
++    "so_SO",    /* Somali       Somalia */
++    "sq_AL",    /* Albanian     Albania */
++    "sr_RS",    /* Serbian      Serbia */
++    "srr_SN",   /* Serer        Senegal */
++    "suk_TZ",   /* Sukuma       Tanzania */
++    "sus_GN",   /* Susu         Guinea */
++    "sv_SE",    /* Swedish      Sweden */
++    "te_IN",    /* Telugu       India */
++    "tem_SL",   /* Timne        Sierra Leone */
++    "tet_ID",   /* Tetum        Indonesia */
++    "tg_TJ",    /* Tajik        Tajikistan */
++    "th_TH",    /* Thai         Thailand */
++    "ti_ER",    /* Tigrinya     Eritrea */
++    "tiv_NG",   /* Tiv          Nigeria */
++    "tk_TM",    /* Turkmen      Turkmenistan */
++    "tl_PH",    /* Tagalog      Philippines */
++    "to_TO",    /* Tonga        Tonga */
++    "tpi_PG",   /* Tok Pisin    Papua New Guinea */
++    "tr_TR",    /* Turkish      Turkey */
++    "tum_MW",   /* Tumbuka      Malawi */
++    "ug_CN",    /* Uighur       China */
++    "uk_UA",    /* Ukrainian    Ukraine */
++    "umb_AO",   /* Umbundu      Angola */
++    "ur_PK",    /* Urdu         Pakistan */
++    "uz_UZ",    /* Uzbek        Uzbekistan */
++    "ve_ZA",    /* Venda        South Africa */
++    "vi_VN",    /* Vietnamese   Vietnam */
++    "wa_BE",    /* Walloon      Belgium */
++    "wal_ET",   /* Walamo       Ethiopia */
++    "war_PH",   /* Waray        Philippines */
++    "wen_DE",   /* Sorbian      Germany */
++    "yao_MW",   /* Yao          Malawi */
++    "zap_MX"    /* Zapotec      Mexico */
++  };
++
++/* Compare just the language part of two locale names.  */
++static int
++langcmp (const char *locale1, const char *locale2)
++{
++  size_t locale1_len;
++  size_t locale2_len;
++  int cmp;
++
++  {
++    const char *locale1_end = strchr (locale1, '_');
++    if (locale1_end != NULL)
++      locale1_len = locale1_end - locale1;
++    else
++      locale1_len = strlen (locale1);
++  }
++  {
++    const char *locale2_end = strchr (locale2, '_');
++    if (locale2_end != NULL)
++      locale2_len = locale2_end - locale2;
++    else
++      locale2_len = strlen (locale2);
++  }
++
++  if (locale1_len < locale2_len)
++    {
++      cmp = memcmp (locale1, locale2, locale1_len);
++      if (cmp == 0)
++        cmp = -1;
++    }
++  else
++    {
++      cmp = memcmp (locale1, locale2, locale2_len);
++      if (locale1_len > locale2_len && cmp == 0)
++        cmp = 1;
++    }
++
++  return cmp;
++}
++
++/* Given a locale name, return the main locale with the same language,
++   or NULL if not found.
++   For example: "fr_DE" -> "fr_FR".  */
++static const char *
++get_main_locale_with_same_language (const char *locale)
++{
++#  define table locales_with_principal_territory
++  /* The table is sorted.  Perform a binary search.  */
++  size_t hi = sizeof (table) / sizeof (table[0]);
++  size_t lo = 0;
++  while (lo < hi)
++    {
++      /* Invariant:
++         for i < lo, langcmp (table[i], locale) < 0,
++         for i >= hi, langcmp (table[i], locale) > 0.  */
++      size_t mid = (hi + lo) >> 1; /* >= lo, < hi */
++      int cmp = langcmp (table[mid], locale);
++      if (cmp < 0)
++        lo = mid + 1;
++      else if (cmp > 0)
++        hi = mid;
++      else
++        {
++          /* Found an i with
++               langcmp (language_table[i], locale) == 0.
++             Verify that it is the only such i.  */
++          if (mid > lo && langcmp (table[mid - 1], locale) >= 0)
++            abort ();
++          if (mid + 1 < hi && langcmp (table[mid + 1], locale) <= 0)
++            abort ();
++          return table[mid];
++        }
++    }
++#  undef table
++  return NULL;
++}
++
++/* Mapping from territory to main language that is spoken in that territory.  */
++static char const locales_with_principal_language[][6 + 1] =
++  {
++    /* This is based on the set of existing locales in glibc, with duplicates
++       removed, and on the Wikipedia pages named "Languages of <territory>".
++       If in doubt, use the locale that exists in macOS.  For example, the only
++       "*_IN" locale in macOS 10.13 is "hi_IN", so use that.  */
++    /* A useful shell function for producing a line of this table is:
++         func_line ()
++         {
++           # Usage: func_line ll_CC
++           ll=`echo "$1" | sed -e 's|_.*||'`
++           cc=`echo "$1" | sed -e 's|^.*_||'`
++           llx=`sed -n -e "s|^${ll} ||p" < gettext-tools/doc/ISO_639`
++           ccx=`expand gettext-tools/doc/ISO_3166 | sed -n -e "s|^${cc}  *||p"`
++           echo "    \"$1\",    /$X* ${llx} ${ccx} *$X/"
++         }
++     */
++              /* Main language  Territory */
++    "ca_AD",    /* Catalan      Andorra */
++    "ar_AE",    /* Arabic       United Arab Emirates */
++    "ps_AF",    /* Pashto       Afghanistan */
++    "en_AG",    /* English      Antigua and Barbuda */
++    "sq_AL",    /* Albanian     Albania */
++    "hy_AM",    /* Armenian     Armenia */
++    "pap_AN",   /* Papiamento   Netherlands Antilles - this line can be removed in 2018 */
++    "pt_AO",    /* Portuguese   Angola */
++    "es_AR",    /* Spanish      Argentina */
++    "de_AT",    /* German       Austria */
++    "en_AU",    /* English      Australia */
++    /* Aruba has two official languages: "nl_AW", "pap_AW".  */
++    "az_AZ",    /* Azerbaijani  Azerbaijan */
++    "bs_BA",    /* Bosnian      Bosnia */
++    "bn_BD",    /* Bengali      Bangladesh */
++    "nl_BE",    /* Dutch        Belgium */
++    "fr_BF",    /* French       Burkina Faso */
++    "bg_BG",    /* Bulgarian    Bulgaria */
++    "ar_BH",    /* Arabic       Bahrain */
++    "rn_BI",    /* Kirundi      Burundi */
++    "fr_BJ",    /* French       Benin */
++    "es_BO",    /* Spanish      Bolivia */
++    "pt_BR",    /* Portuguese   Brazil */
++    "dz_BT",    /* Dzongkha     Bhutan */
++    "en_BW",    /* English      Botswana */
++    "be_BY",    /* Belarusian   Belarus */
++    "en_CA",    /* English      Canada */
++    "fr_CD",    /* French       Democratic Republic of Congo */
++    "sg_CF",    /* Sango        Central African Republic */
++    "de_CH",    /* German       Switzerland */
++    "es_CL",    /* Spanish      Chile */
++    "zh_CN",    /* Chinese      China */
++    "es_CO",    /* Spanish      Colombia */
++    "es_CR",    /* Spanish      Costa Rica */
++    "es_CU",    /* Spanish      Cuba */
++    /* Curaçao has three official languages: "nl_CW", "pap_CW", "en_CW".  */
++    "el_CY",    /* Greek        Cyprus */
++    "cs_CZ",    /* Czech        Czech Republic */
++    "de_DE",    /* German       Germany */
++    /* Djibouti has two official languages: "ar_DJ" and "fr_DJ".  */
++    "da_DK",    /* Danish       Denmark */
++    "es_DO",    /* Spanish      Dominican Republic */
++    "ar_DZ",    /* Arabic       Algeria */
++    "es_EC",    /* Spanish      Ecuador */
++    "et_EE",    /* Estonian     Estonia */
++    "ar_EG",    /* Arabic       Egypt */
++    "ti_ER",    /* Tigrinya     Eritrea */
++    "es_ES",    /* Spanish      Spain */
++    "am_ET",    /* Amharic      Ethiopia */
++    "fi_FI",    /* Finnish      Finland */
++    /* Fiji has three official languages: "en_FJ", "fj_FJ", "hif_FJ".  */
++    "fo_FO",    /* Faroese      Faeroe Islands */
++    "fr_FR",    /* French       France */
++    "en_GB",    /* English      Britain */
++    "ka_GE",    /* Georgian     Georgia */
++    "en_GH",    /* English      Ghana */
++    "kl_GL",    /* Kalaallisut  Greenland */
++    "fr_GN",    /* French       Guinea */
++    "el_GR",    /* Greek        Greece */
++    "es_GT",    /* Spanish      Guatemala */
++    "zh_HK",    /* Chinese      Hong Kong */
++    "es_HN",    /* Spanish      Honduras */
++    "hr_HR",    /* Croatian     Croatia */
++    "ht_HT",    /* Haitian      Haiti */
++    "hu_HU",    /* Hungarian    Hungary */
++    "id_ID",    /* Indonesian   Indonesia */
++    "en_IE",    /* English      Ireland */
++    "he_IL",    /* Hebrew       Israel */
++    "hi_IN",    /* Hindi        India */
++    "ar_IQ",    /* Arabic       Iraq */
++    "fa_IR",    /* Persian      Iran */
++    "is_IS",    /* Icelandic    Iceland */
++    "it_IT",    /* Italian      Italy */
++    "ar_JO",    /* Arabic       Jordan */
++    "ja_JP",    /* Japanese     Japan */
++    "sw_KE",    /* Swahili      Kenya */
++    "ky_KG",    /* Kyrgyz       Kyrgyzstan */
++    "km_KH",    /* Central Khmer        Cambodia */
++    "ko_KR",    /* Korean       Korea (South) */
++    "ar_KW",    /* Arabic       Kuwait */
++    "kk_KZ",    /* Kazakh       Kazakhstan */
++    "lo_LA",    /* Laotian      Laos */
++    "ar_LB",    /* Arabic       Lebanon */
++    "de_LI",    /* German       Liechtenstein */
++    "si_LK",    /* Sinhala      Sri Lanka */
++    "lt_LT",    /* Lithuanian   Lithuania */
++    /* Luxembourg has three official languages: "lb_LU", "fr_LU", "de_LU".  */
++    "lv_LV",    /* Latvian      Latvia */
++    "ar_LY",    /* Arabic       Libya */
++    "ar_MA",    /* Arabic       Morocco */
++    "sr_ME",    /* Serbian      Montenegro */
++    "mg_MG",    /* Malagasy     Madagascar */
++    "mk_MK",    /* Macedonian   North Macedonia */
++    "fr_ML",    /* French       Mali */
++    "my_MM",    /* Burmese      Myanmar */
++    "mn_MN",    /* Mongolian    Mongolia */
++    "mt_MT",    /* Maltese      Malta */
++    "mfe_MU",   /* Mauritian Creole     Mauritius */
++    "dv_MV",    /* Divehi       Maldives */
++    "ny_MW",    /* Chichewa     Malawi */
++    "es_MX",    /* Spanish      Mexico */
++    "ms_MY",    /* Malay        Malaysia */
++    "en_NG",    /* English      Nigeria */
++    "es_NI",    /* Spanish      Nicaragua */
++    "nl_NL",    /* Dutch        Netherlands */
++    "no_NO",    /* Norwegian    Norway */
++    "ne_NP",    /* Nepali       Nepal */
++    "na_NR",    /* Nauru        Nauru */
++    "niu_NU",   /* Niuean       Niue */
++    "en_NZ",    /* English      New Zealand */
++    "ar_OM",    /* Arabic       Oman */
++    "es_PA",    /* Spanish      Panama */
++    "es_PE",    /* Spanish      Peru */
++    "tpi_PG",   /* Tok Pisin    Papua New Guinea */
++    "fil_PH",   /* Filipino     Philippines */
++    "pa_PK",    /* Punjabi      Pakistan */
++    "pl_PL",    /* Polish       Poland */
++    "es_PR",    /* Spanish      Puerto Rico */
++    "pt_PT",    /* Portuguese   Portugal */
++    "es_PY",    /* Spanish      Paraguay */
++    "ar_QA",    /* Arabic       Qatar */
++    "ro_RO",    /* Romanian     Romania */
++    "sr_RS",    /* Serbian      Serbia */
++    "ru_RU",    /* Russian      Russia */
++    "rw_RW",    /* Kinyarwanda  Rwanda */
++    "ar_SA",    /* Arabic       Saudi Arabia */
++    "en_SC",    /* English      Seychelles */
++    "ar_SD",    /* Arabic       Sudan */
++    "sv_SE",    /* Swedish      Sweden */
++    "en_SG",    /* English      Singapore */
++    "sl_SI",    /* Slovenian    Slovenia */
++    "sk_SK",    /* Slovak       Slovakia */
++    "en_SL",    /* English      Sierra Leone */
++    "fr_SN",    /* French       Senegal */
++    "so_SO",    /* Somali       Somalia */
++    "ar_SS",    /* Arabic       South Sudan */
++    "es_SV",    /* Spanish      El Salvador */
++    "ar_SY",    /* Arabic       Syria */
++    "th_TH",    /* Thai         Thailand */
++    "tg_TJ",    /* Tajik        Tajikistan */
++    "tk_TM",    /* Turkmen      Turkmenistan */
++    "ar_TN",    /* Arabic       Tunisia */
++    "to_TO",    /* Tonga        Tonga */
++    "tr_TR",    /* Turkish      Turkey */
++    "zh_TW",    /* Chinese      Taiwan */
++    "sw_TZ",    /* Swahili      Tanzania */
++    "uk_UA",    /* Ukrainian    Ukraine */
++    "lg_UG",    /* Ganda        Uganda */
++    "en_US",    /* English      United States of America */
++    "es_UY",    /* Spanish      Uruguay */
++    "uz_UZ",    /* Uzbek        Uzbekistan */
++    "es_VE",    /* Spanish      Venezuela */
++    "vi_VN",    /* Vietnamese   Vietnam */
++    "bi_VU",    /* Bislama      Vanuatu */
++    "sm_WS",    /* Samoan       Samoa */
++    "ar_YE",    /* Arabic       Yemen */
++    "en_ZA",    /* English      South Africa */
++    "en_ZM",    /* English      Zambia */
++    "en_ZW"     /* English      Zimbabwe */
++  };
++
++/* Compare just the territory part of two locale names.  */
++static int
++terrcmp (const char *locale1, const char *locale2)
++{
++  const char *territory1 = strrchr (locale1, '_') + 1;
++  const char *territory2 = strrchr (locale2, '_') + 1;
++
++  return strcmp (territory1, territory2);
++}
++
++/* Given a locale name, return the locale corresponding to the main language
++   with the same territory, or NULL if not found.
++   For example: "fr_DE" -> "de_DE".  */
++static const char *
++get_main_locale_with_same_territory (const char *locale)
++{
++  if (strrchr (locale, '_') != NULL)
++    {
++#  define table locales_with_principal_language
++      /* The table is sorted.  Perform a binary search.  */
++      size_t hi = sizeof (table) / sizeof (table[0]);
++      size_t lo = 0;
++      while (lo < hi)
++        {
++          /* Invariant:
++             for i < lo, terrcmp (table[i], locale) < 0,
++             for i >= hi, terrcmp (table[i], locale) > 0.  */
++          size_t mid = (hi + lo) >> 1; /* >= lo, < hi */
++          int cmp = terrcmp (table[mid], locale);
++          if (cmp < 0)
++            lo = mid + 1;
++          else if (cmp > 0)
++            hi = mid;
++          else
++            {
++              /* Found an i with
++                   terrcmp (language_table[i], locale) == 0.
++                 Verify that it is the only such i.  */
++              if (mid > lo && terrcmp (table[mid - 1], locale) >= 0)
++                abort ();
++              if (mid + 1 < hi && terrcmp (table[mid + 1], locale) <= 0)
++                abort ();
++              return table[mid];
++            }
++        }
++#  undef table
++    }
++  return NULL;
++}
++
++# endif
++
+ DLL_EXPORTED
+ char *
+ libintl_setlocale (int category, const char *locale)
+@@ -950,16 +1471,18 @@ libintl_setlocale (int category, const char *locale)
+                     /* On Mac OS X 10.13, some locales can be set through
+                        System Preferences > Language & Region, that are not
+                        supported by libc.  The system's setlocale() falls
+-                       back to "C" for these locale categories.  We can possibly
+-                       do better.  If we can't, print a warning, to limit user
++                       back to "C" for these locale categories.  We can do
++                       better, by trying an existing locale with the same
++                       language or an existing locale with the same territory.
++                       If we can't, print a warning, to limit user
+                        expectations.  */
+-                    int warn = 1;
++                    int warn = 0;
+ 
+                     if (cat == LC_CTYPE)
+                       warn = (setlocale_single (cat, "UTF-8") == NULL);
+-#  if HAVE_CFLOCALECOPYPREFERREDLANGUAGES || HAVE_CFPREFERENCESCOPYAPPVALUE /* MacOS X 10.4 or newer */
+                     else if (cat == LC_MESSAGES)
+                       {
++#  if HAVE_CFLOCALECOPYPREFERREDLANGUAGES || HAVE_CFPREFERENCESCOPYAPPVALUE /* MacOS X 10.4 or newer */
+                         /* Take the primary language preference.  */
+ #   if HAVE_CFLOCALECOPYPREFERREDLANGUAGES /* MacOS X 10.5 or newer */
+                         CFArrayRef prefArray = CFLocaleCopyPreferredLanguages ();
+@@ -994,7 +1517,15 @@ libintl_setlocale (int category, const char *locale)
+                                     gl_locale_name_canonicalize (buf);
+ 
+                                     /* Try setlocale with this value.  */
+-                                    warn = (setlocale_single (cat, buf) == NULL);
++                                    if (setlocale_single (cat, buf) == NULL)
++                                      {
++                                        const char *last_try =
++                                          get_main_locale_with_same_language (buf);
++
++                                        if (last_try == NULL
++                                            || setlocale_single (cat, last_try) == NULL)
++                                          warn = 1;
++                                      }
+                                   }
+                               }
+ #   if HAVE_CFLOCALECOPYPREFERREDLANGUAGES /* MacOS X 10.5 or newer */
+@@ -1002,24 +1533,51 @@ libintl_setlocale (int category, const char *locale)
+ #   elif HAVE_CFPREFERENCESCOPYAPPVALUE /* MacOS X 10.4 or newer */
+                           }
+ #   endif
+-                      }
++#  else
++                        const char *last_try =
++                          get_main_locale_with_same_language (name);
++
++                        if (last_try == NULL
++                            || setlocale_single (cat, last_try) == NULL)
++                          warn = 1;
+ #  endif
+-                    /* No fallback possible for LC_NUMERIC.  The application
+-                       should use the locale properties
+-                       kCFLocaleDecimalSeparator, kCFLocaleGroupingSeparator.
+-                       No fallback possible for LC_TIME.  The application should
+-                       use the locale property kCFLocaleCalendarIdentifier.
+-                       No fallback possible for LC_COLLATE.  The application
+-                       should use the locale properties
+-                       kCFLocaleCollationIdentifier, kCFLocaleCollatorIdentifier.
+-                       No fallback possible for LC_MONETARY.  The application
+-                       should use the locale properties
+-                       kCFLocaleCurrencySymbol, kCFLocaleCurrencyCode.  */
++                      }
++                    else
++                      {
++                        /* For LC_NUMERIC, the application should use the locale
++                           properties kCFLocaleDecimalSeparator,
++                           kCFLocaleGroupingSeparator.
++                           For LC_TIME, the application should use the locale
++                           property kCFLocaleCalendarIdentifier.
++                           For LC_COLLATE, the application should use the locale
++                           properties kCFLocaleCollationIdentifier,
++                           kCFLocaleCollatorIdentifier.
++                           For LC_MONETARY, the applicationshould use the locale
++                           properties kCFLocaleCurrencySymbol,
++                           kCFLocaleCurrencyCode.
++                           But since most applications don't have macOS specific
++                           code like this, try an existing locale with the same
++                           territory.  */
++                        const char *last_try =
++                          get_main_locale_with_same_territory (name);
++
++                        if (last_try == NULL
++                            || setlocale_single (cat, last_try) == NULL)
++                          warn = 1;
++                      }
+ 
+                     if (warn)
+-                      fprintf (stderr,
+-                               "Warning: Failed to set locale category %s to %s.\n",
+-                               category_to_name (cat), name);
++                      {
++                        /* Warn only if the environment variable
++                           SETLOCALE_VERBOSE is set.  Otherwise these warnings
++                           are just annoyances, since normal users won't invoke
++                           'localedef'.  */
++                        const char *verbose = getenv ("SETLOCALE_VERBOSE");
++                        if (verbose != NULL && verbose[0] != '\0')
++                          fprintf (stderr,
++                                   "Warning: Failed to set locale category %s to %s.\n",
++                                   category_to_name (cat), name);
++                      }
+                   }
+ # else
+                   goto fail;
+-- 
+cgit v1.2.1
+
+

--- a/pkgs/development/libraries/gettext/common.nix
+++ b/pkgs/development/libraries/gettext/common.nix
@@ -1,0 +1,13 @@
+# gettext-runtime, gettext-tools and libtextstyle are shipped
+# together. This file is a central point used to share information
+# between the three package definitions.
+{ fetchurl }:
+rec {
+  pname = "gettext";
+  version = "0.20.1";
+
+  src = fetchurl {
+    url = "mirror://gnu/gettext/${pname}-${version}.tar.gz";
+    sha256 = "0p3zwkk27wm2m2ccfqm57nj7vqkmfpn7ja1nf65zmhz8qqs5chb6";
+  };
+}

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -1,4 +1,4 @@
-{ config, stdenv, fetchurl, gettext, meson, ninja, pkgconfig, perl, python3
+{ config, stdenv, fetchurl, gettext-runtime, gettext-tools, meson, ninja, pkgconfig, perl, python3
 , libiconv, zlib, libffi, pcre, libelf, gnome3, libselinux, bash, gnum4, gtk-doc, docbook_xsl, docbook_xml_dtd_45
 # use utillinuxMinimal to avoid circular dependency (utillinux, systemd, glib)
 , utillinuxMinimal ? null
@@ -105,10 +105,10 @@ stdenv.mkDerivation rec {
   ]);
 
   nativeBuildInputs = [
-    meson ninja pkgconfig perl python3 gettext gtk-doc docbook_xsl docbook_xml_dtd_45
+    meson ninja pkgconfig perl python3 gettext-tools gtk-doc docbook_xsl docbook_xml_dtd_45
   ];
 
-  propagatedBuildInputs = [ zlib libffi gettext libiconv ];
+  propagatedBuildInputs = [ zlib libffi gettext-runtime libiconv ];
 
   mesonFlags = [
     # Avoid the need for gobject introspection binaries in PATH in cross-compiling case.

--- a/pkgs/development/libraries/libtextstyle/default.nix
+++ b/pkgs/development/libraries/libtextstyle/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchurl }:
+
+let common = import ../gettext/common.nix { inherit fetchurl; };
+in stdenv.mkDerivation rec {
+  pname = "libtextstyle";
+  inherit (common) version src;
+
+  sourceRoot = "${common.pname}-${common.version}/${pname}/";
+
+  outputs = [ "out" "doc" "info" ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = with lib; {
+    description = "Console/terminal emulator text styling library";
+
+    longDescription = ''
+      GNU libtextstyle provides an easy way to add styling to programs
+      that produce output to a console or terminal emulator window
+    '';
+
+    homepage = "https://www.gnu.org/software/gettext/";
+
+    maintainers = with maintainers; [ lsix ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/gettext-tools/default.nix
+++ b/pkgs/development/tools/gettext-tools/default.nix
@@ -1,0 +1,105 @@
+{ stdenv, lib, fetchurl, libiconv, gettext-runtime, libtextstyle,
+  makeSetupHook, autoconf, automake, libtool
+}:
+
+
+let common = import ../../libraries/gettext/common.nix { inherit fetchurl; };
+in
+stdenv.mkDerivation rec {
+  pname = "gettext-tools";
+  inherit (common) version src;
+
+  sourceRoot = "${common.pname}-${common.version}/${pname}/";
+
+  # Sources are within a subdir of the upstream directory. Given
+  # that patches are applied from sourceRoot, we cannot just
+  # fetch patches upstream in order to backport them. We have
+  # to update them to accomodate the effective root.
+  patches = [
+    # Originaly commited in d9e4fc31ea7728b39c1ff2f2963e4f3df716b6b7:
+    # gettext 0.20 fixed a bug with handling locale on macOS, but this caused
+    # it to report an annoying warning on systems where “language”
+    # differs from “region”. See Homebrew issue for details:
+    # <https://github.com/Homebrew/homebrew-core/issues/41139>.
+    # See also
+    # <https://www.mail-archive.com/bug-gnulib@gnu.org/msg36768.html>.
+    ./gettext.git-2336451ed68d91ff4b5ae1acbc1eca30e47a86a9.patch
+
+    # TODO when upgrading from 0.20.1
+    #
+    #   - remove the this patch (this is an updated backport from upstream)
+    #   - remove the makeSetupHook and and its dependencies (autoconf, automake, libtool)
+    #   - remove the 'cp ../libtextstyle/m4/libtextstyle.m4 gnulib-m4/' from postPach
+    ./restore_the_ability_to_build_gettext-tools_separately.patch
+  ];
+
+  outputs = [ "out" "man" "doc" "info" ];
+
+  configureFlags = [
+    "--disable-csharp"
+    "--with-xz"
+    "--with-installed-libtextstyle"
+  ];
+
+  postPatch = ''
+   cp ../libtextstyle/m4/libtextstyle.m4 gnulib-m4/
+   substituteInPlace projects/KDE/trigger --replace "/bin/pwd" pwd
+   substituteInPlace projects/GNOME/trigger --replace "/bin/pwd" pwd
+   substituteInPlace src/project-id --replace "/bin/pwd" pwd
+  '' + lib.optionalString stdenv.hostPlatform.isCygwin ''
+    sed -i -e "s/\(cldr_plurals_LDADD = \)/\\1..\/gnulib-lib\/libxml_rpl.la /" src/Makefile.in
+    sed -i -e "s/\(libgettextsrc_la_LDFLAGS = \)/\\1..\/gnulib-lib\/libxml_rpl.la /" src/Makefile.in
+  '';
+
+  nativeBuildInputs = [
+    # This is basically autoreconfHook, but without gettext-tools in deps
+    # to avoid circular dependency
+    (makeSetupHook {
+      deps = [ autoconf automake libtool ]; }
+      ../../../build-support/setup-hooks/autoreconf.sh
+    )
+  ];
+
+  buildInputs = [
+    gettext-runtime
+    libtextstyle
+  ] # HACK, see #10874 (and 14664)
+    ++ stdenv.lib.optional (!stdenv.isLinux && !stdenv.hostPlatform.isCygwin) libiconv;
+
+  setupHooks = [
+    ../../../build-support/setup-hooks/role.bash
+    ./gettext-setup-hook.sh
+  ];
+
+  enableParallelBuilding = true;
+  enableParallelChecking = false; # fails sometimes
+
+  meta = with lib; {
+    description = "Well integrated set of translation tools and documentation";
+
+    longDescription = ''
+      Usually, programs are written and documented in English, and use
+      English at execution time for interacting with users.  Using a common
+      language is quite handy for communication between developers,
+      maintainers and users from all countries.  On the other hand, most
+      people are less comfortable with English than with their own native
+      language, and would rather be using their mother tongue for day to
+      day's work, as far as possible.  Many would simply love seeing their
+      computer screen showing a lot less of English, and far more of their
+      own language.
+
+      GNU `gettext' is an important step for the GNU Translation Project, as
+      it is an asset on which we may build many other steps. This package
+      offers to programmers, translators, and even users, a well integrated
+      set of tools and documentation. Specifically, the GNU `gettext'
+      utilities are a set of tools that provides a framework to help other
+      GNU packages produce multi-lingual messages.
+    '';
+
+    homepage = https://www.gnu.org/software/gettext/;
+
+    maintainers = with maintainers; [ zimbatm vrthra lsix ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/gettext-tools/gettext-setup-hook.sh
+++ b/pkgs/development/tools/gettext-tools/gettext-setup-hook.sh
@@ -1,0 +1,9 @@
+gettextDataDirsHook() {
+    # See pkgs/build-support/setup-hooks/role.bash
+    getHostRoleEnvHook
+    if [ -d "$1/share/gettext" ]; then
+        addToSearchPath "GETTEXTDATADIRS${role_post}" "$1/share/gettext"
+    fi
+}
+
+addEnvHooks "$hostOffset" gettextDataDirsHook

--- a/pkgs/development/tools/gettext-tools/gettext.git-2336451ed68d91ff4b5ae1acbc1eca30e47a86a9.patch
+++ b/pkgs/development/tools/gettext-tools/gettext.git-2336451ed68d91ff4b5ae1acbc1eca30e47a86a9.patch
@@ -9,18 +9,18 @@ in <https://lists.freedesktop.org/archives/p11-glue/2019-May/000700.html>
 via Daiki Ueno
 in <https://lists.gnu.org/archive/html/bug-gettext/2019-05/msg00124.html>.
 
-* gettext-tools/src/msgmerge.c (main): Treat force_po like true if for_msgfmt
+* src/msgmerge.c (main): Treat force_po like true if for_msgfmt
 is true.
-* gettext-tools/tests/msgmerge-26: Add test of PO file with no translations.
+* tests/msgmerge-26: Add test of PO file with no translations.
 ---
- gettext-tools/src/msgmerge.c    |  4 ++--
- gettext-tools/tests/msgmerge-26 | 36 +++++++++++++++++++++++++++++++++---
+ src/msgmerge.c    |  4 ++--
+ tests/msgmerge-26 | 36 +++++++++++++++++++++++++++++++++---
  2 files changed, 35 insertions(+), 5 deletions(-)
 
-diff --git a/gettext-tools/src/msgmerge.c b/gettext-tools/src/msgmerge.c
+diff --git a/src/msgmerge.c b/src/msgmerge.c
 index cd762c0..92c9b7a 100644
---- a/gettext-tools/src/msgmerge.c
-+++ b/gettext-tools/src/msgmerge.c
+--- a/src/msgmerge.c
++++ b/src/msgmerge.c
 @@ -520,8 +520,8 @@ There is NO WARRANTY, to the extent permitted by law.\n\
    else
      {
@@ -32,10 +32,10 @@ index cd762c0..92c9b7a 100644
      }
  
    exit (EXIT_SUCCESS);
-diff --git a/gettext-tools/tests/msgmerge-26 b/gettext-tools/tests/msgmerge-26
+diff --git a/tests/msgmerge-26 b/tests/msgmerge-26
 index cd3862e..b86f7a0 100755
---- a/gettext-tools/tests/msgmerge-26
-+++ b/gettext-tools/tests/msgmerge-26
+--- a/tests/msgmerge-26
++++ b/tests/msgmerge-26
 @@ -73,7 +73,37 @@ msgstr "Papaya"
  EOF
  

--- a/pkgs/development/tools/gettext-tools/restore_the_ability_to_build_gettext-tools_separately.patch
+++ b/pkgs/development/tools/gettext-tools/restore_the_ability_to_build_gettext-tools_separately.patch
@@ -1,0 +1,64 @@
+based on https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=commitdiff_plain;h=e4b3a3f56fa6fc2a51769e286545f0631bb4837c
+---
+
+diff --git a/configure.ac b/configure.ac
+index 0ddc236..09564bf 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -124,6 +124,22 @@ AM_CONDITIONAL([PACKAGE_IS_GETTEXT_TOOLS], [true])
+ AM_CONDITIONAL([PRELOADABLE_LIBINTL],
+   [test $USE_INCLUDED_LIBINTL = no && test $GLIBC2 = yes && test "$enable_shared" = yes])
+ 
++dnl This option allows to build gettext-tools without (re)building libtextstyle.
++AC_ARG_WITH([installed-libtextstyle],
++  [AS_HELP_STRING([--with-installed-libtextstyle],
++     [Use an already installed libtextstyle.])],
++  [gt_use_installed_libtextstyle=$withval],
++  [gt_use_installed_libtextstyle=no])
++if test "$gt_use_installed_libtextstyle" != no; then
++  gl_LIBTEXTSTYLE
++else
++  test -f ../libtextstyle/Makefile || {
++    AC_MSG_ERROR([When building the gettext-tools package without building the entire gettext package, you need to pass the --with-installed-libtextstyle option to configure.])
++  }
++fi
++AM_CONDITIONAL([USE_INSTALLED_LIBTEXTSTYLE],
++  [test "$gt_use_installed_libtextstyle" != no])
++
+ dnl This line internationalizes the bison generated parsers.
+ BISON_I18N
+ 
+diff --git a/src/Makefile.am b/src/Makefile.am
+index b98b7ab..af3dcee 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -250,6 +250,9 @@ cldr_plurals_SOURCES = cldr-plural.y cldr-plural-exp.c cldr-plurals.c
+ cldr_plurals_CFLAGS = $(AM_CFLAGS) $(INCXML)
+ cldr_plurals_LDADD = libgettextsrc.la $(LDADD)
+ 
++if USE_INSTALLED_LIBTEXTSTYLE
++LT_LIBTEXTSTYLE = @LTLIBTEXTSTYLE@
++else
+ # How to get the include files of libtextstyle.
+ textstyle.h textstyle/stdbool.h textstyle/version.h textstyle/woe32dll.h:
+ 	here=`pwd`; \
+@@ -257,6 +260,9 @@ textstyle.h textstyle/stdbool.h textstyle/version.h textstyle/woe32dll.h:
+ 	  $(MAKE) install-nobase_includeHEADERS install-nobase_nodist_includeHEADERS includedir="$$here"
+ BUILT_SOURCES    += textstyle.h textstyle/stdbool.h textstyle/version.h textstyle/woe32dll.h
+ MOSTLYCLEANFILES += textstyle.h textstyle/stdbool.h textstyle/version.h textstyle/woe32dll.h
++# Where to find the built libtextstyle library.
++LT_LIBTEXTSTYLE = ../../libtextstyle/lib/libtextstyle.la
++endif
+ 
+ # How to build libgettextsrc.la.
+ # Need ../gnulib-lib/libgettextlib.la.
+@@ -268,7 +274,7 @@ MOSTLYCLEANFILES += textstyle.h textstyle/stdbool.h textstyle/version.h textstyl
+ # use iconv().
+ libgettextsrc_la_LDFLAGS = \
+   -release @VERSION@ \
+-  ../gnulib-lib/libgettextlib.la $(LTLIBUNISTRING) ../../libtextstyle/lib/libtextstyle.la @LTLIBINTL@ @LTLIBICONV@ -lc -no-undefined
++  ../gnulib-lib/libgettextlib.la $(LTLIBUNISTRING) $(LT_LIBTEXTSTYLE) @LTLIBINTL@ @LTLIBICONV@ -lc -no-undefined
+ 
+ # OS/2 does not support a DLL name longer than 8 characters.
+ if OS2
+

--- a/pkgs/development/tools/misc/intltool/default.nix
+++ b/pkgs/development/tools/misc/intltool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, gettext, perlPackages }:
+{ stdenv, fetchurl, fetchpatch, gettext-tools, perlPackages }:
 
 stdenv.mkDerivation rec {
   pname = "intltool";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "12q2140867r5d0dysly72khi7b0mm2gd7nlm1k81iyg7fxgnyz45";
   })];
 
-  propagatedBuildInputs = [ gettext ] ++ (with perlPackages; [ perl XMLParser ]);
+  propagatedBuildInputs = [ gettext-tools ] ++ (with perlPackages; [ perl XMLParser ]);
 
   meta = with stdenv.lib; {
     description = "Translation helper tool";

--- a/pkgs/os-specific/linux/cpufrequtils/default.nix
+++ b/pkgs/os-specific/linux/cpufrequtils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libtool, gettext }:
+{ stdenv, fetchurl, libtool, gettext-tools }:
 
 stdenv.mkDerivation rec {
   name = "cpufrequtils-008";
@@ -19,7 +19,8 @@ stdenv.mkDerivation rec {
       -i Makefile
   '';
 
-  buildInputs = [ stdenv.cc.libc.linuxHeaders libtool gettext ];
+  nativeBuildInputs = [ gettext-tools ];
+  buildInputs = [ stdenv.cc.libc.linuxHeaders libtool ];
 
   meta = with stdenv.lib; {
     description = "Tools to display or change the CPU governor settings";

--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, lib
-, autoconf, automake, gnum4, libtool, perl, gnulib, uthash, pkgconfig, gettext
+, autoconf, automake, gnum4, libtool, perl, gnulib, uthash, pkgconfig, gettext-tools
 , python, freetype, zlib, glib, libungif, libpng, libjpeg, libtiff, libxml2, cairo, pango
 , readline, woff2, zeromq
 , withSpiro ? false, libspiro
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   # do not use x87's 80-bit arithmetic, rouding errors result in very different font binaries
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isi686 "-msse2 -mfpmath=sse";
 
-  nativeBuildInputs = [ pkgconfig autoconf automake gnum4 libtool perl gettext ];
+  nativeBuildInputs = [ pkgconfig autoconf automake gnum4 libtool perl gettext-tools ];
   buildInputs = [
     readline uthash woff2 zeromq
     python freetype zlib glib libungif libpng libjpeg libtiff libxml2

--- a/pkgs/tools/text/poedit/default.nix
+++ b/pkgs/tools/text/poedit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, libtool, gettext, pkgconfig, wxGTK30,
+{ stdenv, fetchurl, autoconf, automake, libtool, gettext-tools, pkgconfig, wxGTK30,
   boost, icu, lucenepp, asciidoc, libxslt, xmlto, gtk2, gtkspell2, pugixml,
   nlohmann_json, hicolor-icon-theme, wrapGAppsHook }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ lucenepp nlohmann_json wxGTK30 icu pugixml gtk2 gtkspell2 hicolor-icon-theme ];
 
-  propagatedBuildInputs = [ gettext ];
+  propagatedBuildInputs = [ gettext-tools ];
   
   preConfigure = "
     patchShebangs bootstrap
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   ];
  
   preFixup = ''
-    gappsWrapperArgs+=(--prefix PATH : "${stdenv.lib.makeBinPath [ gettext ]}")
+    gappsWrapperArgs+=(--prefix PATH : "${stdenv.lib.makeBinPath [ gettext-tools ]}")
   '';
  
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -105,11 +105,11 @@ in
   ### BUILD SUPPORT
 
   autoreconfHook = makeSetupHook
-    { deps = [ autoconf automake gettext libtool ]; }
+    { deps = [ autoconf automake gettext-tools libtool ]; }
     ../build-support/setup-hooks/autoreconf.sh;
 
   autoreconfHook264 = makeSetupHook
-    { deps = [ autoconf264 automake111x gettext libtool ]; }
+    { deps = [ autoconf264 automake111x gettext-tools libtool ]; }
     ../build-support/setup-hooks/autoreconf.sh;
 
   autoPatchelfHook = makeSetupHook { name = "auto-patchelf-hook"; }
@@ -11463,7 +11463,14 @@ in
 
   getdns = callPackage ../development/libraries/getdns { };
 
-  gettext = callPackage ../development/libraries/gettext { };
+  gettext-tools = callPackages ../development/tools/gettext-tools { };
+
+  gettext-runtime = callPackages ../development/libraries/gettext-runtime { };
+
+  libtextstyle = callPackage ../development/libraries/libtextstyle { };
+
+  # Ease transition between one-package gettext to split packages (tools - runtime)
+  gettext = gettext-runtime;
 
   gf2x = callPackage ../development/libraries/gf2x {};
 


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This PR solves  #73288

Following upstream recommendations, gettext is split into 3 distinct
packages:
- gettext-runtime
- gettext-tools
- libtextstyle

See https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=blob;f=PACKAGING;h=f4bae4561ec70a9de2532502b5c2358bb976036c;hb=55b8fe9a2f12b22eb3ee6baf973e03e60b3a9915

Given that for each sub-package we use `sourceRoot`, the patches do not
apply directly when fetch from upstream git and have to be editted to
strip the top level dir.

For the time being, `gettext` is turned into an alias to
`gettext-runtime` to ease transition.

A tree-wide update could be tried to replace all occurances of a `gettext` dependency with `gettext-runtime` if required by review.

I am also very open to discussions on how I did implement the 3 packages that share 1 source tarball.

If we are too close to the last staging changes before release-20.03, I have no problem to postpone this MR (cc @FRidh ).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
