### PR TITLE
qutebrowser: 1.9.0 -> 1.10.0

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -21,12 +21,12 @@ let
 
 in mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "qutebrowser";
-  version = "1.9.0";
+  version = "1.10.0";
 
   # the release tarballs are different from the git checkout!
   src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "1y0yq1qfr6g1s7kf3w2crd0b025dv2dfknhlz3v0001ns3rgwj17";
+    sha256 = "1prvd3cysmcjfybn0dmr3ih0bl6lm5ml9i7wd09fn8hb7047mkby";
   };
 
   # Needs tox

--- a/pkgs/applications/networking/browsers/qutebrowser/fix-restart.patch
+++ b/pkgs/applications/networking/browsers/qutebrowser/fix-restart.patch
@@ -1,8 +1,8 @@
-diff --git a/qutebrowser/app.py b/qutebrowser/app.py
-index a47b5d2f4..f23ee23ef 100644
---- a/qutebrowser/app.py
-+++ b/qutebrowser/app.py
-@@ -573,13 +573,8 @@ class Quitter(QObject):
+diff --git a/quitter.py b/quitterb.py
+index a42b9d0..f544ccb 100644
+--- a/qutebrowser/misc/quitter.py
++++ b/qutebrowser/misc/quitter.py
+@@ -112,13 +112,7 @@ class Quitter(QObject):
          Return:
              The commandline as a list of strings.
          """
@@ -14,7 +14,6 @@ index a47b5d2f4..f23ee23ef 100644
 -        else:
 -            args = [sys.executable, '-m', 'qutebrowser']
 +        args = ['@qutebrowser@']
-+        cwd = None
  
          # Add all open pages so they get reopened.
          page_args = []  # type: typing.MutableSequence[str]


### PR DESCRIPTION
###### Motivation for this change
Regular version bump

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (qutebrowser)
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
