### PR TITLE
julia: 1.1 -> 1.3

### DIFF
--- a/pkgs/development/compilers/julia/1.3.nix
+++ b/pkgs/development/compilers/julia/1.3.nix
@@ -1,0 +1,168 @@
+{ stdenv, fetchurl, fetchzip, fetchFromGitHub
+# build tools
+, gfortran, m4, makeWrapper, patchelf, perl, which, python2
+, cmake
+# libjulia dependencies
+, libunwind, readline, utf8proc, zlib
+# standard library dependencies
+, curl, fftwSinglePrec, fftw, gmp, libgit2, mpfr, openlibm, openspecfun, pcre2
+# linear algebra
+, openblas, arpack
+# llvm
+, llvm
+}:
+
+with stdenv.lib;
+
+# All dependencies must use the same OpenBLAS.
+let
+  arpack_ = arpack;
+in
+let
+  arpack = arpack_.override { inherit openblas; };
+in
+
+let 
+  majorVersion = "1";
+  minorVersion = "3";
+  maintenanceVersion = "1";
+  src_sha256 = "0q9a7yc3b235psrwl5ghyxgwly25lf8n818l8h6bkf2ymdbsv5p6";
+  version = "${majorVersion}.${minorVersion}.${maintenanceVersion}";
+in 
+
+stdenv.mkDerivation rec {
+  pname = "julia";
+  inherit version;
+
+   src = fetchzip {
+     url = "https://github.com/JuliaLang/julia/releases/download/v${majorVersion}.${minorVersion}.${maintenanceVersion}/julia-${majorVersion}.${minorVersion}.${maintenanceVersion}-full.tar.gz";
+     sha256 = src_sha256;
+   };
+
+  prePatch = ''
+    export PATH=$PATH:${cmake}/bin
+    '';
+
+  patches = [
+    ./use-system-utf8proc-julia-1.3.patch
+
+    # Julia recompiles a precompiled file if the mtime stored *in* the
+    # .ji file differs from the mtime of the .ji file.  This
+    # doesn't work in Nix because Nix changes the mtime of files in
+    # the Nix store to 1. So patch Julia to accept mtimes of 1.
+    ./allow_nix_mtime.patch
+  ];
+
+  postPatch = ''
+    patchShebangs . contrib
+    for i in backtrace cmdlineargs; do
+      mv test/$i.jl{,.off}
+      touch test/$i.jl
+    done
+    rm stdlib/Sockets/test/runtests.jl && touch stdlib/Sockets/test/runtests.jl
+    rm stdlib/Distributed/test/runtests.jl && touch stdlib/Distributed/test/runtests.jl
+    sed -e 's/Invalid Content-Type:/invalid Content-Type:/g' -i ./stdlib/LibGit2/test/libgit2.jl
+    sed -e 's/Failed to resolve /failed to resolve /g' -i ./stdlib/LibGit2/test/libgit2.jl
+  '';
+
+  buildInputs = [
+    arpack fftw fftwSinglePrec gmp libgit2 libunwind mpfr
+    pcre2.dev openblas openlibm openspecfun readline utf8proc
+    zlib
+  ]
+  ++ stdenv.lib.optionals stdenv.isDarwin [CoreServices ApplicationServices]
+  ;
+
+  nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which ];
+
+  makeFlags =
+    let
+      arch = head (splitString "-" stdenv.system);
+      march = { x86_64 = stdenv.hostPlatform.platform.gcc.arch or "x86-64"; i686 = "pentium4"; }.${arch}
+              or (throw "unsupported architecture: ${arch}");
+      # Julia requires Pentium 4 (SSE2) or better
+      cpuTarget = { x86_64 = "x86-64"; i686 = "pentium4"; }.${arch}
+                  or (throw "unsupported architecture: ${arch}");
+    in [
+      "ARCH=${arch}"
+      "MARCH=${march}"
+      "JULIA_CPU_TARGET=${cpuTarget}"
+      "PREFIX=$(out)"
+      "prefix=$(out)"
+      "SHELL=${stdenv.shell}"
+
+      "USE_SYSTEM_BLAS=1"
+      "USE_BLAS64=${if openblas.blas64 then "1" else "0"}"
+      "LIBBLAS=-lopenblas"
+      "LIBBLASNAME=libopenblas"
+
+      "USE_SYSTEM_LAPACK=1"
+      "LIBLAPACK=-lopenblas"
+      "LIBLAPACKNAME=libopenblas"
+
+      "USE_SYSTEM_ARPACK=1"
+      "USE_SYSTEM_FFTW=1"
+      "USE_SYSTEM_GMP=1"
+      "USE_SYSTEM_LIBGIT2=1"
+      "USE_SYSTEM_LIBUNWIND=1"
+
+      "USE_SYSTEM_MPFR=1"
+      "USE_SYSTEM_OPENLIBM=1"
+      "USE_SYSTEM_OPENSPECFUN=1"
+      "USE_SYSTEM_PATCHELF=1"
+      "USE_SYSTEM_PCRE=1"
+      "PCRE_CONFIG=${pcre2.dev}/bin/pcre2-config"
+      "PCRE_INCL_PATH=${pcre2.dev}/include/pcre2.h"
+      "USE_SYSTEM_READLINE=1"
+      "USE_SYSTEM_UTF8PROC=1"
+      "USE_SYSTEM_ZLIB=1"
+
+      "USE_BINARYBUILDER=0"
+    ];
+
+  LD_LIBRARY_PATH = makeLibraryPath [
+    arpack fftw fftwSinglePrec gmp libgit2 mpfr openblas openlibm
+    openspecfun pcre2
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = !stdenv.isDarwin;
+  checkTarget = "testall";
+  # Julia's tests require read/write access to $HOME
+  preCheck = ''
+    export HOME="$NIX_BUILD_TOP"
+  '';
+
+  preBuild = ''
+    sed -e '/^install:/s@[^ ]*/doc/[^ ]*@@' -i Makefile
+    sed -e '/[$](DESTDIR)[$](docdir)/d' -i Makefile
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+  '';
+
+  postInstall = ''
+    # Symlink shared libraries from LD_LIBRARY_PATH into lib/julia,
+    # as using a wrapper with LD_LIBRARY_PATH causes segmentation
+    # faults when program returns an error:
+    #   $ julia -e 'throw(Error())'
+    find $(echo $LD_LIBRARY_PATH | sed 's|:| |g') -maxdepth 1 -name '*.${if stdenv.isDarwin then "dylib" else "so"}*' | while read lib; do
+      if [[ ! -e $out/lib/julia/$(basename $lib) ]]; then
+        ln -sv $lib $out/lib/julia/$(basename $lib)
+      fi
+    done
+  '';
+
+  passthru = {
+    inherit majorVersion minorVersion maintenanceVersion;
+    site = "share/julia/site/v${majorVersion}.${minorVersion}";
+  };
+
+  meta = {
+    description = "High-level performance-oriented dynamical language for technical computing";
+    homepage = https://julialang.org/;
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ raskin rob garrison ];
+    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
+    broken = stdenv.isi686;
+  };
+}

--- a/pkgs/development/compilers/julia/1.3.nix
+++ b/pkgs/development/compilers/julia/1.3.nix
@@ -8,8 +8,8 @@
 , curl, fftwSinglePrec, fftw, gmp, libgit2, mpfr, openlibm, openspecfun, pcre2
 # linear algebra
 , openblas, arpack
-# llvm
-, llvm
+# Darwin frameworks
+, CoreServices, ApplicationServices
 }:
 
 with stdenv.lib;
@@ -83,6 +83,8 @@ stdenv.mkDerivation rec {
       # Julia requires Pentium 4 (SSE2) or better
       cpuTarget = { x86_64 = "x86-64"; i686 = "pentium4"; }.${arch}
                   or (throw "unsupported architecture: ${arch}");
+      # Julia applies a lot of patches to its dependencies, so for now do not use the system LLVM
+      # https://github.com/JuliaLang/julia/tree/master/deps/patches
     in [
       "ARCH=${arch}"
       "MARCH=${march}"

--- a/pkgs/development/compilers/julia/use-system-utf8proc-julia-1.3.patch
+++ b/pkgs/development/compilers/julia/use-system-utf8proc-julia-1.3.patch
@@ -1,0 +1,24 @@
+---
+ src/flisp/Makefile | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+
+diff --git a/src/flisp/Makefile b/src/flisp/Makefile
+index d97075e..6bebca7 100644
+--- a/src/flisp/Makefile
++++ b/src/flisp/Makefile
+@@ -32,9 +32,9 @@ OBJS := $(SRCS:%.c=$(BUILDDIR)/%.o)
+ DOBJS := $(SRCS:%.c=$(BUILDDIR)/%.dbg.obj)
+ LLT_release := $(LLT_BUILDDIR)/libsupport.a
+ LLT_debug := $(LLT_BUILDDIR)/libsupport-debug.a
+-LIBFILES_release := $(LLT_release) $(LIBUV) $(LIBUTF8PROC)
+-LIBFILES_debug := $(LLT_debug) $(LIBUV) $(LIBUTF8PROC)
+-LIBS :=
++LIBFILES_release := $(LLT_release) $(LIBUV)
++LIBFILES_debug := $(LLT_debug) $(LIBUV)
++LIBS := $(LIBUTF8PROC)
+ ifneq ($(OS),WINNT)
+ LIBS += -lpthread
+ endif
+
+-- 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8502,6 +8502,12 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
   };
 
+  julia_13 = callPackage ../development/compilers/julia/1.3.nix {
+    gmp = gmp6;
+    openblas = openblasCompat;
+    inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
+  };
+
   julia_1 = julia_10;
   julia = julia_1;
 


### PR DESCRIPTION
This updates `julia` to version 1.3.1. I couldn't get some of the dependencies as defined in the original build script to work, so this is building the source binary that includes all dependencies as provided by upstream. Over time I guess it would make sense to work on replacing the bundled dependencies with native ones.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
