### PR TITLE
nawk: 20121220 -> 20180827

### DIFF
--- a/pkgs/tools/text/nawk/default.nix
+++ b/pkgs/tools/text/nawk/default.nix
@@ -1,20 +1,17 @@
-{ stdenv, fetchurl, yacc }:
+{ stdenv, fetchFromGitHub, yacc }:
 
 stdenv.mkDerivation rec {
-  name = "nawk-20121220";
+  pname = "nawk";
+  version = "20180827";
 
-  src = fetchurl {
-    url = "https://www.cs.princeton.edu/~bwk/btl.mirror/awk.tar.gz";
-    sha256 = "10wvdn7xwc5bbp5h7l0b9fxby3bds21n8a34z54i8kjsbhb95h4d";
+  src = fetchFromGitHub {
+    owner = "onetrueawk";
+    repo = "awk";
+    rev = version;
+    sha256 = "0qcsxhcwg6g3c0zxmbipqa8d8d5n8zxrq0hymb8yavsaz103fcl6";
   };
 
   nativeBuildInputs = [ yacc ];
-
-  unpackPhase = ''
-    mkdir build
-    cd build
-    tar xvf ${src}
-  '';
 
   patchPhase = ''
     substituteInPlace ./makefile \


### PR DESCRIPTION
##### Motivation for this change

awk.tar.gz can no longer be fetched from princeton.edu; The One True Awk is now on GitHub.


###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@konimex