### PR TITLE
seabios: Update src URL

### DIFF
--- a/pkgs/applications/virtualization/seabios/default.nix
+++ b/pkgs/applications/virtualization/seabios/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "1.11.0";
 
   src = fetchurl {
-    url = "http://code.coreboot.org/p/seabios/downloads/get/${pname}-${version}.tar.gz";
+    url = "https://www.seabios.org/downloads/${pname}-${version}.tar.gz";
     sha256 = "1xwvp77djxbxbxg82hzj26pv6zka3556vkdcp09hnfwapcp46av2";
   };
 


### PR DESCRIPTION
https://github.com/coreboot/coreboot.git endorses seabios.org as
the official seabios website since Stefan Reinauer's 2011 commit
f58b63d6dc30e9400002fd0e791948a6be4384ef.

(Content hash is unchanged because content is identical.)

###### Motivation for this change

Fix "hash mismatch" fetch error.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
