### PR TITLE
hdl_dump: init at unstable-2019-12-25

### DIFF
--- a/pkgs/games/hdl_dump/default.nix
+++ b/pkgs/games/hdl_dump/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2019-12-25";
+  pname = "hdl_dump";
+
+  src = fetchFromGitHub {
+    owner = "AKuHAK";
+    repo = "hdl-dump";
+    rev = "299aec48c5fffe31b0dc3a35d490eeacac3bd066";
+    sha256 = "18pahyf4c823g4ar6kmz5m8wfkf9gc5lgciqh14ni8qmkb3mc0gg";
+  };
+
+  installPhase = ''
+    install -Dm755 hdl_dump -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "PlayStation 2 HDLoader image dump/install utility";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ genesis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4009,6 +4009,8 @@ in
     javac = jdk;
   };
 
+  hdl_dump = callPackage ../games/hdl_dump { };
+
   hecate = callPackage ../applications/editors/hecate { };
 
   heaptrack = libsForQt5.callPackage ../development/tools/profiling/heaptrack {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Usage is described here https://nixos.wiki/wiki/Playstation2#Install_games
