### PR TITLE
Change `nix.maxJobs` default to reflect remote builds

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -443,7 +443,19 @@ in
         fi
       '';
 
-    nix.nrBuildUsers = mkDefault (lib.max 32 (if cfg.maxJobs == "auto" then 0 else cfg.maxJobs));
+    nix.nrBuildUsers =
+      let
+        remoteJobs =
+          if cfg.distributedBuilds
+          then
+            builtins.foldl' builtins.add 0
+              (map (machine: machine.maxJobs) cfg.buildMachines)
+          else 0;
+
+        totalJobs = cfg.maxJobs + remoteJobs;
+
+      in
+        mkDefault (lib.max 32 (if cfg.maxJobs == "auto" then 0 else totalJobs));
 
     users.users = nixbldUsers;
 


### PR DESCRIPTION
See: https://github.com/NixOS/nix/issues/1216#issuecomment-581609266

This ensures that remote builds don't inadvertently exhaust the available
`nixbld*` users when dealing with over 32 cores

###### Things done

I did an ad-hoc test of this change against the following file:

```nix
let
  nixos = import ../nixpkgs/nixos {
    system = "x86_64-linux";

    configuration.nix = {
      distributedBuilds = true;

      maxJobs = 32;

      buildMachines = [
        { hostName = "example.com";
          sshUser = "example";
          sshKey = "/root/.ssh/id_rsa";
          system = "x86_64-linux";
          maxJobs = 32;
          speedFactor = 1;
          supportedFeatures = [ "kvm" ];
          mandatoryFeatures = [ "perf" ];
        }
      ];
    };
  };

in
  nixos.config.nix.nrBuildUsers
```

Before this change the above file evaluates to `32`.  After this change it evaluates to `64`.  When I set `distributedBuilds` to `false` the result changes back to `32`.