### PR TITLE
ifmetric: init at 0.3

### DIFF
--- a/pkgs/os-specific/linux/ifmetric/default.nix
+++ b/pkgs/os-specific/linux/ifmetric/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, lynx }:
+
+stdenv.mkDerivation rec {
+  pname = "ifmetric";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "http://0pointer.de/lennart/projects/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1v0s5x81jzwnnl7hr254d4nkyc8qcv983pzr6vqmbr9l9q553a0g";
+  };
+
+  buildInputs = [ lynx ];
+
+  patches = [
+    # Fixes an issue related to the netlink API.
+    # Upstream is largely inactive; this is a Debian patch.
+    (fetchurl {
+      url = "https://launchpadlibrarian.net/85974387/10_netlink_fix.patch";
+      sha256 = "1pnlcr0qvk0bd5243wpg14i387zp978f4xhwwkcqn1cir91x7fbc";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Tool for setting IP interface metrics";
+    longDescription = ''
+      ifmetric is a Linux tool for setting the metrics of all IPv4 routes
+      attached to a given network interface at once. This may be used to change
+      the priority of routing IPv4 traffic over the interface. Lower metrics
+      correlate with higher priorities.
+    '';
+    homepage = "http://0pointer.de/lennart/projects/ifmetric";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.anna328p ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17028,6 +17028,8 @@ in
 
   pcm = callPackage ../os-specific/linux/pcm { };
 
+  ifmetric = callPackage ../os-specific/linux/ifmetric {};
+
   ima-evm-utils = callPackage ../os-specific/linux/ima-evm-utils {
     openssl = openssl_1_0_2;
   };


### PR DESCRIPTION
###### Motivation for this change

Adds ifmetric, a tool for setting network interface metrics, to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
