### PR TITLE
gitAndTools.gh: init at 0.5.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -28,6 +28,8 @@ let
 
   diff-so-fancy = callPackage ./diff-so-fancy { };
 
+  gh = callPackage ./gh { };
+
   ghq = callPackage ./ghq { };
 
   git = appendToName "minimal" gitBase;

--- a/pkgs/applications/version-management/git-and-tools/gh/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gh/default.nix
@@ -1,0 +1,36 @@
+{ lib, fetchFromGitHub, buildGoModule, installShellFiles }:
+
+buildGoModule rec {
+  pname = "gh";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "cli";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "033y9bwdaj8735nmj22k8lrgkgimji7hyly9i4jyp11iaa7cgd7a";
+  };
+
+  modSha256 = "0ina3m2ixkkz2fws6ifwy34pmp6kn5s3j7w40alz6vmybn2smy1h";
+
+  buildFlagsArray = [
+    "-ldflags=-X github.com/cli/cli/command.Version=${version}"
+  ];
+
+  subPackages = [ "cmd/gh" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    for shell in bash fish zsh; do
+      $out/bin/gh completion -s $shell > gh.$shell
+      installShellCompletion gh.$shell
+    done
+  '';
+
+  meta = with lib; {
+    description = "GitHub CLI tool";
+    homepage = "https://github.com/cli/cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zowoq ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

https://github.com/cli/cli