### PR TITLE
pythonPackages.hglib: fix tests

### DIFF
--- a/pkgs/development/python-modules/hglib/default.nix
+++ b/pkgs/development/python-modules/hglib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, substituteAll, python, nose, mercurial }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, substituteAll, python, nose, mercurial }:
 
 buildPythonPackage rec {
   pname = "python-hglib";
@@ -14,12 +14,24 @@ buildPythonPackage rec {
       src = ./hgpath.patch;
       hg = "${mercurial}/bin/hg";
     })
+
+    # These two patches are needed to fix the tests.
+    # They will need to be removed on the next update.
+    (fetchpatch {
+      url = "https://www.mercurial-scm.org/repo/python-hglib/raw-rev/12e6aaef0f6e";
+      sha256 = "159pmhy23gqcc6rkh5jrni8fba4xbhxwcc0jf02wqr7f82kv8a7x";
+    })
+    (fetchpatch {
+      url = "https://www.mercurial-scm.org/repo/python-hglib/raw-rev/1a318162f06f";
+      sha256 = "04lxfc15m3yw5kvp133xg8zv09l8kndi146xk3lnbbm07fgcnn1z";
+    })
   ];
 
   checkInputs = [ nose ];
 
   checkPhase = ''
-    ${python.interpreter} test.py --with-hg "${mercurial}/bin/hg"
+    ${python.interpreter} test.py --with-hg "${mercurial}/bin/hg" -v \
+      --exclude=test_merge_prompt_cb # https://bz.mercurial-scm.org/show_bug.cgi?id=6265
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixing hglib for #76677
https://hydra.nixos.org/job/nixpkgs/trunk/python37Packages.hglib.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
