### PR TITLE
tempita: fix broken repo

### DIFF
--- a/pkgs/development/python-modules/tempita/default.nix
+++ b/pkgs/development/python-modules/tempita/default.nix
@@ -1,20 +1,18 @@
-{ lib, buildPythonPackage, fetchFromGitHub, nose }:
+{ lib, buildPythonPackage, fetchurl, nose }:
 
 buildPythonPackage {
-  version = "0.5.3-2016-09-28";
+  version = "0.5.3";
   pname = "tempita";
 
-  src = fetchFromGitHub {
-    owner = "gjhiggins";
-    repo = "tempita";
-    rev = "47414a7c6e46a9a9afe78f0bce2ea299fa84d10";
-    sha256 = "0f33jjjs5rvp7ar2j6ggyfykcrsrn04jaqcq71qfvycf6b7nw3rn";
+  src = fetchurl {
+    url = https://bitbucket.org/ianb/tempita/get/97392d008cc8.tar.gz;
+    sha256 = "0nxnkxjvfyxygmws2zxql590mwqsqd1rnhy80m9nbpdh81p7vh9y";
   };
 
   buildInputs = [ nose ];
 
   meta = {
-    homepage = https://github.com/gjhiggins/tempita;
+    homepage = http://pythonpaste.org/tempita/;
     description = "A very small text templating language";
     license = lib.licenses.mit;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Tempita src is broken.

Closes #79207 

###### Things done
Update tempita src to a new existing repo.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
