### PR TITLE
pythonPackages.superlance: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/superlance/default.nix
+++ b/pkgs/development/python-modules/superlance/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, supervisor }:
+
+buildPythonPackage rec {
+  pname = "superlance";
+  version = "1.0.0";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f697c71341e9a686f3a0ff3f04a82448523eac0a6121484933729ba65a973a63";
+  };
+    
+  propagatedBuildInputs = [ supervisor ];
+  
+  meta = with lib; {
+    description = "Superlance plugins for supervisord";
+    homepage = "https://github.com/Supervisor/superlance";
+    license = licenses.free; # http://www.repoze.org/LICENSE.txt
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5419,6 +5419,8 @@ in {
 
   supervisor = callPackage ../development/python-modules/supervisor {};
 
+  superlance = callPackage ../development/python-modules/superlance { };
+
   subprocess32 = callPackage ../development/python-modules/subprocess32 { };
 
   spark_parser = callPackage ../development/python-modules/spark_parser { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module `superlance` in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
