### PR TITLE
pythonPackages.vertica-python: init at 0.10.2

### DIFF
--- a/pkgs/development/python-modules/vertica-python/default.nix
+++ b/pkgs/development/python-modules/vertica-python/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, future, dateutil, six, pytest, mock, parameterized }:
+
+buildPythonPackage rec {
+  pname = "vertica-python";
+  version = "0.10.2";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c35d0e7ac8da2af47a65efc72d5d8351caa93e4829e549f229aa7e375593f896";
+  };
+  
+  propagatedBuildInputs = [ future dateutil six ];
+  
+  checkInputs = [ pytest mock parameterized ];
+  
+  # Integration tests require an accessible Vertica db
+  checkPhase = ''
+    pytest --ignore vertica_python/tests/integration_tests
+  '';
+  
+  meta = with lib; {
+    description = "Native Python client for Vertica database";
+    homepage = "https://github.com/vertica/vertica-python";
+    license = licenses.asl20;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5615,6 +5615,8 @@ in {
 
   vega_datasets = callPackage ../development/python-modules/vega_datasets { };
 
+  vertica-python = callPackage ../development/python-modules/vertica-python { };
+
   virtkey = callPackage ../development/python-modules/virtkey {
     inherit (pkgs) pkgconfig;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module `vertica-python` in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
