### PR TITLE
pijul: Fix the build (broke due to a more recent Rust version)

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -20,6 +20,15 @@ in rustPlatform.buildRustPackage rec {
     sha256 = "1rm787kkh3ya8ix0rjvj7sbrg9armm0rnpkga6gjmsbg5bx20y4q";
   };
 
+  postPatch = ''
+    pushd ../${pname}-${version}-vendor/thrussh/
+    patch -p1 < ${./thrussh-build-fix.patch}
+    substituteInPlace .cargo-checksum.json --replace \
+      9696ed2422a483cd8de48ac241178a0441be6636909c76174c536b8b1cba9d45 \
+      a199f2bba520d56e11607b77be4dde0cfae576c90badb9fbd39af4784e8120d1
+    popd
+  '';
+
   nativeBuildInputs = [ pkgconfig clang ];
 
   postInstall = ''

--- a/pkgs/applications/version-management/pijul/thrussh-build-fix.patch
+++ b/pkgs/applications/version-management/pijul/thrussh-build-fix.patch
@@ -1,0 +1,12 @@
+--- a/src/client/connection.rs	2020-02-04 12:48:43.845299096 +0100
++++ b/src/client/connection.rs	2020-02-04 12:50:00.140329310 +0100
+@@ -546,8 +546,8 @@
+                 &[msg::NEWKEYS],
+                 &mut session.0.write_buffer,
+             );
+-            session.0.kex = Some(Kex::NewKeys(newkeys));
+             newkeys.sent = true;
++            session.0.kex = Some(Kex::NewKeys(newkeys));
+         }
+         Ok(())
+     }


### PR DESCRIPTION
This uses an upstream patch [0] to fix a compatibility error with a new
version of Rust. Fix #79150.

Unfortunately patching Rust dependencies in Nixpkgs turned out to be way
more hacky than I expected (maybe there is a nicer way?), but it should
be fine for now.

A new release might follow soonish [1] so that we can drop the patches.

References:
- https://nest.pijul.com/pijul_org/pijul/discussions/401
- https://nest.pijul.com/pijul_org/thrussh/discussions/31

[0]: https://nest.pijul.com/pijul_org/thrussh:master/patches/AsyuWkJg4jAwNaG3H1yv1kbECx5E3GQAtjzXWBDB8yEGMswyfKbxKvYmAGWCohTVaTipdvF8mHh63yU5PTr5F9py
[1]: https://discourse.pijul.org/t/is-this-project-still-active-yes-it-is/451

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
