### PR TITLE
vispy: init at 0.6.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2910,6 +2910,12 @@
     githubId = 25820499;
     name = "Roman Kretschmer";
   };
+  goertzenator = {
+    email = "daniel.goertzen@gmail.com";
+    github = "goertzenator";
+    githubId = 605072;
+    name = "Daniel Goertzen";
+  };
   goibhniu = {
     email = "cillian.deroiste@gmail.com";
     github = "cillianderoiste";

--- a/pkgs/development/python-modules/freetype-py/default.nix
+++ b/pkgs/development/python-modules/freetype-py/default.nix
@@ -21,9 +21,9 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ freetype ];
 
   meta = with lib; {
-    homepage = https://github.com/rougier/freetype-py;
+    homepage = "https://github.com/rougier/freetype-py";
     description = "FreeType (high-level Python API)";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ goertzenator ];
   };
 }

--- a/pkgs/development/python-modules/freetype-py/default.nix
+++ b/pkgs/development/python-modules/freetype-py/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, substituteAll, stdenv, setuptools_scm, freetype }:
+
+buildPythonPackage rec {
+  pname = "freetype-py";
+  version = "2.1.0.post1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1k62fx53qrv9nb73mpqi2r11wzbx41qfv5qppvh6rylywnrknf3n";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./library-paths.patch;
+      freetype = "${freetype.out}/lib/libfreetype${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [ freetype ];
+
+  meta = with lib; {
+    homepage = https://github.com/rougier/freetype-py;
+    description = "FreeType (high-level Python API)";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/freetype-py/default.nix
+++ b/pkgs/development/python-modules/freetype-py/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ freetype ];
 
+  pythonImportsCheck =  [ "freetype" ];
+
   meta = with lib; {
     homepage = "https://github.com/rougier/freetype-py";
     description = "FreeType (high-level Python API)";

--- a/pkgs/development/python-modules/freetype-py/library-paths.patch
+++ b/pkgs/development/python-modules/freetype-py/library-paths.patch
@@ -1,0 +1,37 @@
+diff --git a/freetype/raw.py b/freetype/raw.py
+index ff3bea3..78c68ab 100644
+--- a/freetype/raw.py
++++ b/freetype/raw.py
+@@ -19,31 +19,7 @@ from freetype.ft_enums import *
+ from freetype.ft_errors import *
+ from freetype.ft_structs import *
+ 
+-# First, look for a bundled FreeType shared object on the top-level of the
+-# installed freetype-py module.
+-system = platform.system()
+-if system == 'Windows':
+-    library_name = 'libfreetype.dll'
+-elif system == 'Darwin':
+-    library_name = 'libfreetype.dylib'
+-else:
+-    library_name = 'libfreetype.so'
+-
+-filename = os.path.join(os.path.dirname(freetype.__file__), library_name)
+-
+-# If no bundled shared object is found, look for a system-wide installed one.
+-if not os.path.exists(filename):
+-    # on windows all ctypes does when checking for the library
+-    # is to append .dll to the end and look for an exact match
+-    # within any entry in PATH.
+-    filename = ctypes.util.find_library('freetype')
+-
+-    if filename is None:
+-        if platform.system() == 'Windows':
+-            # Check current working directory for dll as ctypes fails to do so
+-            filename = os.path.join(os.path.realpath('.'), "freetype.dll")
+-        else:
+-            filename = library_name
++filename = "@freetype@"
+ 
+ try:
+     _lib = ctypes.CDLL(filename)

--- a/pkgs/development/python-modules/vispy/default.nix
+++ b/pkgs/development/python-modules/vispy/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage rec {
   ];
 
   doCheck = false;  # otherwise runs OSX code on linux.
+  pythonImportsCheck = [ "vispy" ];
 
   meta = with lib; {
     homepage = "http://vispy.org/index.html";

--- a/pkgs/development/python-modules/vispy/default.nix
+++ b/pkgs/development/python-modules/vispy/default.nix
@@ -31,9 +31,9 @@ buildPythonPackage rec {
   doCheck = false;  # otherwise runs OSX code on linux.
 
   meta = with lib; {
-    homepage = http://vispy.org/index.html;
+    homepage = "http://vispy.org/index.html";
     description = "Interactive scientific visualization in Python";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ goertzenator ];
   };
 }

--- a/pkgs/development/python-modules/vispy/default.nix
+++ b/pkgs/development/python-modules/vispy/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildPythonPackage, substituteAll, stdenv,
+  fetchPypi, numpy, cython, freetype-py, fontconfig, libGL,
+  setuptools_scm, setuptools-scm-git-archive
+  }:
+
+buildPythonPackage rec {
+  pname = "vispy";
+  version = "0.6.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07sb4qww6mgzm66qsrr3pd66yz39r6jj4ibb3qmfg1kwnxs6ayv2";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./library-paths.patch;
+      fontconfig = "${fontconfig.lib}/lib/libfontconfig${stdenv.hostPlatform.extensions.sharedLibrary}";
+      gl = "${libGL.out}/lib/libGL${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cython setuptools_scm setuptools-scm-git-archive
+  ];
+
+  propagatedBuildInputs = [
+    numpy freetype-py fontconfig libGL
+  ];
+
+  doCheck = false;  # otherwise runs OSX code on linux.
+
+  meta = with lib; {
+    homepage = http://vispy.org/index.html;
+    description = "Interactive scientific visualization in Python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/vispy/library-paths.patch
+++ b/pkgs/development/python-modules/vispy/library-paths.patch
@@ -1,0 +1,39 @@
+diff --git a/vispy/ext/fontconfig.py b/vispy/ext/fontconfig.py
+index ff24662b..6a5079f0 100644
+--- a/vispy/ext/fontconfig.py
++++ b/vispy/ext/fontconfig.py
+@@ -7,10 +7,7 @@ from ..util.wrappers import run_subprocess
+ 
+ # Some code adapted from Pyglet
+ 
+-fc = util.find_library('fontconfig')
+-if fc is None:
+-    raise ImportError('fontconfig not found')
+-fontconfig = cdll.LoadLibrary(fc)
++fontconfig = cdll.LoadLibrary('@fontconfig@')
+ 
+ FC_FAMILY = 'family'.encode('ASCII')
+ FC_SIZE = 'size'.encode('ASCII')
+diff --git a/vispy/gloo/gl/gl2.py b/vispy/gloo/gl/gl2.py
+index d5bd9c38..63350e73 100644
+--- a/vispy/gloo/gl/gl2.py
++++ b/vispy/gloo/gl/gl2.py
+@@ -39,16 +39,8 @@ elif sys.platform.startswith('win'):
+         pass
+ else:
+     # Unix-ish
+-    if sys.platform.startswith('darwin'):
+-        _fname = ctypes.util.find_library('OpenGL')
+-    else:
+-        _fname = ctypes.util.find_library('GL')
+-    if not _fname:
+-        logger.warning('Could not load OpenGL library.')
+-        _lib = None
+-    else:
+-        # Load lib
+-        _lib = ctypes.cdll.LoadLibrary(_fname)
++    # Load lib
++    _lib = ctypes.cdll.LoadLibrary("@gl@")
+ 
+ 
+ def _have_context():

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5973,6 +5973,8 @@ in {
 
   virtualenv = callPackage ../development/python-modules/virtualenv { };
 
+  vispy = callPackage ../development/python-modules/vispy { };
+
   vsts = callPackage ../development/python-modules/vsts { };
 
   vsts-cd-manager = callPackage ../development/python-modules/vsts-cd-manager { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -742,6 +742,8 @@ in {
 
   foxdot = callPackage ../development/python-modules/foxdot { };
 
+  freetype-py = callPackage ../development/python-modules/freetype-py { };
+
   fsspec = callPackage ../development/python-modules/fsspec { };
 
   furl = callPackage ../development/python-modules/furl { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add python module for `vispy` (scientific plotting) and `freetype-py` (needed by `vispy`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
