### PR TITLE
wayland: 1.17.0 -> 1.18.0

### DIFF
--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkgconfig
+{ lib, stdenv, fetchurl, meson, pkgconfig, ninja
 , libffi, libxml2, wayland
 , expat ? null # Build wayland-scanner (currently cannot be disabled as of 1.7.0)
 }:
@@ -8,23 +8,19 @@ assert expat != null;
 
 stdenv.mkDerivation rec {
   pname = "wayland";
-  version = "1.17.0";
+  version = "1.18.0";
 
   src = fetchurl {
     url = "https://wayland.freedesktop.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "194ibzwpdcn6fvk4xngr4bf5axpciwg2bj82fdvz88kfmjw13akj";
+    sha256 = "0k995rn96xkplrapz5k648j651wc43kq817xk1x8280h16gsfxa6";
   };
 
   separateDebugInfo = true;
 
-  configureFlags = [
-    "--disable-documentation"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    "--with-host-scanner"
-  ];
+  mesonFlags = [ "-Ddocumentation=false" ];
 
   nativeBuildInputs = [
-    pkgconfig
+    meson pkgconfig ninja
   ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     # for wayland-scanner during build
     wayland
@@ -33,11 +29,19 @@ stdenv.mkDerivation rec {
   buildInputs = [ libffi /* docbook_xsl doxygen graphviz libxslt xmlto */ expat libxml2 ];
 
   meta = {
-    description = "Reference implementation of the wayland protocol";
+    description = "Core Wayland window system code and protocol";
+    longDescription = ''
+      Wayland is a project to define a protocol for a compositor to talk to its
+      clients as well as a library implementation of the protocol.
+      The wayland protocol is essentially only about input handling and buffer
+      management, but also handles drag and drop, selections, window management
+      and other interactions that must go through the compositor (but not
+      rendering).
+    '';
     homepage    = https://wayland.freedesktop.org/;
-    license     = lib.licenses.mit;
+    license     = lib.licenses.mit; # Expat version
     platforms   = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = with lib.maintainers; [ primeos codyopel ];
   };
 
   passthru.version = version;

--- a/pkgs/development/libraries/wayland/fix-wayland-cross-compilation.patch
+++ b/pkgs/development/libraries/wayland/fix-wayland-cross-compilation.patch
@@ -1,0 +1,14 @@
+diff --git a/src/meson.build b/src/meson.build
+index 3e8c9bf..75241cb 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -55,8 +55,7 @@ pkgconfig.generate(
+ )
+ 
+ if meson.is_cross_build()
+-	scanner_dep = dependency('wayland-scanner', native: true, version: '>=1.14.0')
+-	wayland_scanner_for_build = find_program(scanner_dep.get_pkgconfig_variable('wayland_scanner'))
++	wayland_scanner_for_build = find_program('wayland-scanner', native: true, version: '>=1.14.0')
+ else
+ 	wayland_scanner_for_build = wayland_scanner
+ endif

--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -17,10 +17,17 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Wayland protocol extensions";
-    homepage    = https://wayland.freedesktop.org/;
-    license     = lib.licenses.mit;
+    longDescription = ''
+      wayland-protocols contains Wayland protocols that add functionality not
+      available in the Wayland core protocol. Such protocols either add
+      completely new functionality, or extend the functionality of some other
+      protocol either in Wayland core, or some other protocol in
+      wayland-protocols.
+    '';
+    homepage    = https://gitlab.freedesktop.org/wayland/wayland-protocols;
+    license     = lib.licenses.mit; # Expat version
     platforms   = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ primeos ];
   };
 
   passthru.version = version;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Testing progress:
- [x] Build (native)
- [x] Cross compilation
- [x] Documentation (`withDocumentation = true`)
- [x] Some important rebuilds (subset of `nix-review`)
- [x] Some Wayland compositors (e.g. Weston, Sway, Cage, and tinywl).

TODOs:
- [x] Wait for the final release
- [x] Switch back to the tarball
  - The next tarball should work: https://gitlab.freedesktop.org/wayland/wayland/issues/141
- [x] Squash the commits (but I should probably keep some of them)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
