### PR TITLE
pythonPackages.pyosmium: init at 2.15.3

### DIFF
--- a/pkgs/development/python-modules/pyosmium/default.nix
+++ b/pkgs/development/python-modules/pyosmium/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub, cmake, python
+, libosmium, protozero, boost, expat, bzip2, zlib, pybind11
+, nose, shapely, mock, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "pyosmium";
+  version = "2.15.3";
+
+  src = fetchFromGitHub {
+    owner = "osmcode";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1523ym9i4rnwi5kcp7n2lm67kxlhar8xlv91s394ixzwax9bgg7w";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libosmium protozero boost expat bzip2 zlib pybind11 ];
+
+  preBuild = "cd ..";
+
+  checkInputs = [ nose shapely ] ++ lib.optionals (!isPy3k) [ mock ];
+
+  checkPhase = "(cd test && ${python.interpreter} run_tests.py)";
+
+  meta = with lib; {
+    description = "Python bindings for libosmium";
+    homepage = "https://osmcode.org/pyosmium";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4896,6 +4896,8 @@ in {
 
   pyopencl = callPackage ../development/python-modules/pyopencl { };
 
+  pyosmium = callPackage ../development/python-modules/pyosmium { };
+
   pyotp = callPackage ../development/python-modules/pyotp { };
 
   pyproj = callPackage ../development/python-modules/pyproj { };


### PR DESCRIPTION
###### Motivation for this change
[PyOsmium](https://osmcode.org/pyosmium/) - Python bindings to Osmium Library.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
