### PR TITLE
nixpkgs/brlaser: upgrade to v6

### DIFF
--- a/pkgs/misc/cups/drivers/brlaser/default.nix
+++ b/pkgs/misc/cups/drivers/brlaser/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "brlaser";
-  version = "5";
+  version = "6";
 
   src = fetchFromGitHub {
     owner = "pdewacht";
     repo = "brlaser";
     rev = "v${version}";
-    sha256 = "133fx49wkg1v8r4kcishd035hlsscv8kc2q4jnln5qmyhpyygjyy";
+    sha256 = "1995s69ksq1fz0vb34v0ndiqncrinbrlpmp70rkl6az7kag99s80";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -34,13 +34,19 @@ stdenv.mkDerivation rec {
            Brother DCP-7065DN
            Brother DCP-7080
            Brother DCP-L2500D
+           Brother DCP-L2520D
            Brother DCP-L2540DW
-           Brother HL-1110 series
-           Brother HL-1200 series
-           Brother HL-L2300D series
-           Brother HL-L2320D series
-           Brother HL-L2340D series
-           Brother HL-L2360D series
+           Brother HL-1110
+           Brother HL-1200
+           Brother HL-2030
+           Brother HL-2140
+           Brother HL-2220
+           Brother HL-2270DW
+           Brother HL-5030
+           Brother HL-L2300D
+           Brother HL-L2320D
+           Brother HL-L2340D
+           Brother HL-L2360D
            Brother MFC-1910W
            Brother MFC-7240
            Brother MFC-7360N


### PR DESCRIPTION
### Why

It introduces support for several additional Brother printers:
```
Brother HL-2030 series
Brother HL-2140 series
Brother HL-2220 series
Brother HL-2270DW series
Brother HL-5030 series
Brother DCP-L2520D series
```
https://github.com/pdewacht/brlaser/releases/tag/v6

### Testing

I've tested this on Linux with HL-2140 and it works without any issues.

### Notify maintainers

@StijnDW