### PR TITLE
ngt: init at 1.8.4

### DIFF
--- a/pkgs/development/libraries/ngt/default.nix
+++ b/pkgs/development/libraries/ngt/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, cmake }:
+stdenv.mkDerivation rec {
+  pname = "NGT";
+  version = "v1.8.4";
+  nativeBuildInputs = [ cmake ];
+  src = fetchFromGitHub {
+    owner = "yahoojapan";
+    repo = "NGT";
+    rev = version;
+    sha256 = "f2019e7916b81f8aeabc57d682904c8447776bf9ba94525d20265b329aa43eb5";
+  };
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/yahoojapan/NGT;
+    description = "Nearest Neighbor Search with Neighborhood Graph and Tree for High-dimensional Data";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tomberek ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20641,6 +20641,8 @@ in
 
   nedit = callPackage ../applications/editors/nedit { };
 
+  ngt = callPackage ../development/libraries/ngt { };
+
   nheko = libsForQt5.callPackage ../applications/networking/instant-messengers/nheko { };
 
   nomacs = libsForQt5.callPackage ../applications/graphics/nomacs { };


### PR DESCRIPTION
###### Motivation for this change
Provide a performant vector database with nearest neighbor search.

###### Things done
Simple packaging, minimal dependencies.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
