### PR TITLE
zopfli: split outputs

### DIFF
--- a/pkgs/tools/compression/zopfli/default.nix
+++ b/pkgs/tools/compression/zopfli/default.nix
@@ -3,6 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "zopfli";
   version = "1.0.3";
+  outputs = [ "out" "lib" "dev" ];
 
   src = fetchFromGitHub {
     owner = "google";

--- a/pkgs/tools/compression/zopfli/default.nix
+++ b/pkgs/tools/compression/zopfli/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.unix;
     license = licenses.asl20;
-    maintainers = with maintainers; [ bobvanderlinden ];
+    maintainers = with maintainers; [ bobvanderlinden edef ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Linking to libzopfli shouldn't necessarily bring along the zopfli CLI tool.

###### Alternatives

The zopfli and zopflipng CLI tools are fairly tiny, and including them doesn't cost much space. 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).