### PR TITLE
docker-containers: Don't unconditionally prune images

### DIFF
--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -39,7 +39,7 @@ let
 
         entrypoint = mkOption {
           type = with types; nullOr str;
-          description = "Overwrite the default entrypoint of the image.";
+          description = "Override the default entrypoint of the image.";
           default = null;
           example = "/bin/my-app";
         };
@@ -145,7 +145,7 @@ let
 
             Note that this is a list of <literal>"src:dst"</literal> strings to
             allow for <literal>src</literal> to refer to
-            <literal>/nix/store</literal> paths, which would difficult with an
+            <literal>/nix/store</literal> paths, which would be difficult with an
             attribute set.  There are also a variety of mount options available
             as a third field; please refer to the
             <link xlink:href="https://docs.docker.com/engine/reference/run/#volume-shared-filesystems">
@@ -220,10 +220,9 @@ let
         ++ map escapeShellArg container.cmd
       );
 
-      ExecStartPre = ["-${pkgs.docker}/bin/docker rm -f ${name}"
-                      "-${pkgs.docker}/bin/docker image prune -f"] ++
-        (optional (container.imageFile != null)
-                ["${pkgs.docker}/bin/docker load -i ${container.imageFile}"]);
+      ExecStartPre =
+        ["-${pkgs.docker}/bin/docker rm -f ${name}"] ++
+        (optional (container.imageFile != null) "${pkgs.docker}/bin/docker load -i ${container.imageFile}");
 
       ExecStop = ''${pkgs.bash}/bin/sh -c "[ $SERVICE_RESULT = success ] || ${pkgs.docker}/bin/docker stop ${name}"'';
       ExecStopPost = "-${pkgs.docker}/bin/docker rm -f ${name}";


### PR DESCRIPTION
###### Motivation for this change
NixOS has `virtualisation.docker.autoPrune.enable` for this functionality; we probably should not do it every time a container starts up.

(also, some trivial documentation fixes)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @yorickvP 