### PR TITLE
megatools: build on darwin, update src

### DIFF
--- a/pkgs/tools/networking/megatools/default.nix
+++ b/pkgs/tools/networking/megatools/default.nix
@@ -1,13 +1,12 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, glib, fuse, curl, glib-networking
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, glib, fuse, curl, glib-networking
 , asciidoc, libxml2, docbook_xsl, docbook_xml_dtd_45, libxslt, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "megatools";
   version = "1.10.2";
 
-  src = fetchFromGitHub {
-    owner = "megous";
-    repo = "megatools";
+  src = fetchgit {
+    url = "https://megous.com/git/megatools";
     rev = version;
     sha256 = "001hw8j36ld03wwaphq3xdaazf2dpl36h84k8xmk524x8vlia8lk";
   };
@@ -16,7 +15,8 @@ stdenv.mkDerivation rec {
     autoreconfHook pkgconfig wrapGAppsHook asciidoc libxml2
     docbook_xsl docbook_xml_dtd_45 libxslt
   ];
-  buildInputs = [ glib glib-networking fuse curl ];
+  buildInputs = [ glib glib-networking curl ]
+  ++ stdenv.lib.optionals stdenv.isLinux [ fuse ];
 
   enableParallelBuilding = true;
 
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = https://megatools.megous.com/;
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.viric maintainers.AndersonTorres ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Source has been removed from the GitHub repo.

https://github.com/megous/megatools#repostiory-has-been-moved