### PR TITLE
postgresqlPackages.periods: init at 1.1

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/periods.nix
+++ b/pkgs/servers/sql/postgresql/ext/periods.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "periods";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "xocolatl";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0gdnlbh7kp7c0kvsrri2kxdbmm2qgib1qqpl37203z6c3fk45kfh";
+  };
+
+  buildInputs = [ postgresql ];
+
+  installPhase = ''
+    install -D -t $out/lib *.so
+    install -D -t $out/share/postgresql/extension *.sql
+    install -D -t $out/share/postgresql/extension *.control
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PostgreSQL extension implementing SQL standard functionality for PERIODs and SYSTEM VERSIONING";
+    homepage = "https://github.com/xocolatl/periods";
+    maintainers = with maintainers; [ ivan ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.postgresql;
+    broken = versionOlder postgresql.version "9.5";
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -1,5 +1,7 @@
 self: super: {
 
+    periods = super.callPackage ./ext/periods.nix { };
+
     postgis = super.callPackage ./ext/postgis.nix {
         gdal = self.gdal.override {
             postgresql = self.postgresql;


### PR DESCRIPTION
###### Motivation for this change

Add https://github.com/xocolatl/periods, which provides temporal querying and system-managed history tables for PostgreSQL 9.5+.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested some system-versioned tables on PostgreSQL 12.1, and they seemed to work fine.

```
psql -d dbname
CREATE EXTENSION IF NOT EXISTS periods VERSION '1.1' CASCADE;
GRANT USAGE ON SCHEMA periods TO username;
GRANT ALL ON ALL TABLES IN SCHEMA periods TO username;
```

cc @marsam @ggpeti