### PR TITLE
redeclipse: 1.6.0 -> 2.0.0

### DIFF
--- a/pkgs/games/redeclipse/default.nix
+++ b/pkgs/games/redeclipse/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchFromGitHub, fetchurl, fetchpatch
-, curl, ed, pkgconfig, zlib, libX11
+, curl, ed, pkgconfig, freetype, zlib, libX11
 , SDL2, SDL2_image, SDL2_mixer
 }:
 
 stdenv.mkDerivation rec {
   pname = "redeclipse";
-  version = "1.6.0";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "https://github.com/redeclipse/base/releases/download/v${version}/redeclipse_${version}_nix.tar.bz2";
-    sha256 = "0j98zk7nivdsap4y50dlqnql17hdila1ikvps6vicwaqb3l4gaa8";
+    sha256 = "143i713ggbk607qr4n39pi0pn8d93x9x6fcbh8rc51jb9qhi8p5i";
   };
 
   buildInputs = [
-    libX11 zlib
+    libX11 freetype zlib
     SDL2 SDL2_image SDL2_mixer
   ];
 
@@ -22,15 +22,6 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags = [ "-C" "src/" "prefix=$(out)" ];
-
-  patches = [
-    # "remove gamma name hack" - Can't find `____gammaf128_r_finite` otherwise
-    # Is likely to be included in next release
-    (fetchpatch {
-       url = "https://github.com/red-eclipse/base/commit/b16b4963c1ad81bb9ef784bc4913a4c8ab5f1bb4.diff";
-       sha256 = "1bm07qrq60bbmbf5k9255qq115mcyfphfy2f7xl1yx40mb9ns65p";
-    })
-  ];
 
   enableParallelBuilding = true;
 
@@ -49,7 +40,7 @@ stdenv.mkDerivation rec {
       environments.
     '';
     homepage = "https://www.redeclipse.net";
-    license = with licenses; [ licenses.zlib cc-by-sa-30 ];
+    license = with licenses; [ zlib cc-by-sa-30 ];
     maintainers = with maintainers; [ lambda-11235 ];
     platforms = platforms.linux;
     hydraPlatforms = [];


### PR DESCRIPTION
###### Motivation for this change
I should have updated this several months ago...

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
