### PR TITLE
mesos: fix insecure maven domain

### DIFF
--- a/pkgs/applications/networking/cluster/mesos/fetch-mesos-deps.sh
+++ b/pkgs/applications/networking/cluster/mesos/fetch-mesos-deps.sh
@@ -4,7 +4,7 @@ header "fetching Apache Mesos maven repo"
 function fetchArtifact {
   repoPath="$1"
   echo "Fetching $repoPath"
-  url="http://repo.maven.apache.org/maven2/$repoPath"
+  url="http://insecure.repo1.maven.org/maven2/$repoPath"
   mkdir -p $(dirname $out/$repoPath)
   curl --fail --location --insecure --retry 3 --max-redirs 20 "$url" --output "$out/$repoPath"
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Maven insecure domain was changed in favor of https.
Closes: #78702

###### Things done
Fix maven domain for mesos derivation.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
