### PR TITLE
lorri: unstable-2020-01-09 -> 1.0 (backport to release-19.09)

### DIFF
--- a/nixos/tests/lorri/default.nix
+++ b/nixos/tests/lorri/default.nix
@@ -13,12 +13,12 @@ import ../make-test.nix {
 
     # Start the daemon and wait until it is ready
     $machine->execute("lorri daemon > lorri.stdout 2> lorri.stderr &");
-    $machine->waitUntilSucceeds("grep --fixed-strings 'lorri: ready' lorri.stdout");
+    $machine->waitUntilSucceeds("grep --fixed-strings 'ready' lorri.stdout");
 
     # Ping the daemon
-    $machine->execute("lorri ping_ \$(readlink -f shell.nix)");
+    $machine->succeed("lorri internal__ping shell.nix");
 
     # Wait for the daemon to finish the build
-    $machine->waitUntilSucceeds("grep --fixed-strings 'OutputPaths' lorri.stdout");
+    $machine->waitUntilSucceeds("grep --fixed-strings 'Completed' lorri.stdout");
   '';
 }

--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -15,7 +15,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lorri";
-  version = "unstable-2020-01-09";
+  version = "1.0";
 
   meta = with stdenv.lib; {
     description = "Your project's nix-env";
@@ -28,11 +28,11 @@ rustPlatform.buildRustPackage rec {
     owner = "target";
     repo = pname;
     # Run `eval $(nix-build -A lorri.updater)` after updating the revision!
-    rev = "7b84837b9988d121dd72178e81afd440288106c5";
-    sha256 = "0rkga944jl6i0051vbsddfqbvzy12168cbg4ly2ng1rk0x97dbr8";
+    rev = "88c680c9abf0f04f2e294436d20073ccf26f0781";
+    sha256 = "1415mhdr0pwvshs04clfz1ys76r5qf9jz8jchm63l6llaj6m7mrv";
   };
 
-  cargoSha256 = "0k7l0zhk2vzf4nlwv4xr207irqib2dqjxfdjk1fprff84c4kblx8";
+  cargoSha256 = "1kdpzbn3353yk7i65hll480fcy16wdvppdr6xgfh06x88xhim4mp";
   doCheck = false;
 
   BUILD_REV_COUNT = src.revCount or 1;


### PR DESCRIPTION
Cherry-picked from commit 42a2668eb07b169264bca841a1ae31a11452b178.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/79230. We want lorri 1.0, the first stable version, in NixOS 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
