### PR TITLE
redoflacs: 0.30.20150202 -> 0.30.20190903

### DIFF
--- a/pkgs/applications/audio/redoflacs/default.nix
+++ b/pkgs/applications/audio/redoflacs/default.nix
@@ -1,39 +1,49 @@
-{ stdenv, fetchFromGitHub, makeWrapper
-, flac, sox }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, installShellFiles
+, flac
+, sox
+, withAucdtect ? false
+, aucdtect ? null
+}:
 
 stdenv.mkDerivation rec {
   pname = "redoflacs";
-  version = "0.30.20150202";
+  version = "0.30.20190903";
 
   src = fetchFromGitHub {
-    owner  = "sirjaren";
-    repo   = "redoflacs";
-    rev    = "86c6f5becca0909dcb2a0cb9ed747a575d7a4735";
-    sha256 = "1gzlmh4vnf2fl0x8ig2n1f76082ngldsv85i27dv15y2m1kffw2j";
+    owner = "sirjaren";
+    repo = "redoflacs";
+    rev = "4ca544cbc075d0865884906208cb2b8bc318cf9e";
+    sha256 = "19lcl09d4ngz2zzwd8dnnxx41ddvznhar6ggrlf1xvkr5gd7lafp";
   };
 
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   installPhase = ''
     runHook preInstall
 
     install -Dm755 -t $out/bin redoflacs
     install -Dm644 -t $out/share/doc/redoflacs LICENSE *.md
+    installManPage redoflacs.1
 
     runHook postInstall
   '';
 
   postFixup = ''
     wrapProgram $out/bin/redoflacs \
-      --prefix PATH : ${stdenv.lib.makeBinPath [ flac sox ]}
+      --prefix PATH : ${stdenv.lib.makeBinPath ([ flac sox ] ++ lib.optional withAucdtect aucdtect)}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Parallel BASH commandline FLAC compressor, verifier, organizer, analyzer, and retagger";
-    homepage    = src.meta.homepage;
-    license     = licenses.gpl2;
-    platforms   = platforms.all;
+    homepage = src.meta.homepage;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Long overdue upstream update that I have been using locally for ages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
