### PR TITLE
pythonPackages.autograd-gamma: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/autograd-gamma/default.nix
+++ b/pkgs/development/python-modules/autograd-gamma/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchFromGitHub, autograd, pytest, scipy }:
+
+buildPythonPackage rec {
+  pname = "autograd-gamma";
+  version = "0.4.1";
+  
+  src = fetchFromGitHub {
+    owner = "CamDavidsonPilon";
+    repo = pname;
+    rev = "v" + version;
+    sha256 = "07fbc3nndr3qc3svja393ip4zcm3v7z94gv10w8ni5sjkj1fw24k";
+  };
+  
+  propagatedBuildInputs = [ autograd scipy ];
+  
+  checkInputs = [ pytest ];
+  
+  checkPhase = ''
+    pytest tests
+  '';
+  
+  meta = with lib; {
+    description = "Autograd compatible approximations to the gamma family of functions";
+    homepage = "https://github.com/CamDavidsonPilon/autograd-gamma";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -232,6 +232,8 @@ in {
 
   autograd = callPackage ../development/python-modules/autograd { };
 
+  autograd-gamma = callPackage ../development/python-modules/autograd-gamma { };
+
   autologging = callPackage ../development/python-modules/autologging { };
 
   automat = callPackage ../development/python-modules/automat { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module `autograd-gamma` in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
