### PR TITLE
pythonPackages.arch: init at 4.11

### DIFF
--- a/pkgs/development/python-modules/arch/default.nix
+++ b/pkgs/development/python-modules/arch/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cython
+, matplotlib
+, numpy
+, property-cached
+, python
+, scipy
+, statsmodels
+, pandas
+, pytest 
+}:
+
+buildPythonPackage rec {
+  pname = "arch";
+  version = "4.11";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a3d5cd9086e7c44638286fbe46a4688a3668ab79400a1712c3ce43490be0c3bb";
+  };
+
+  nativeBuildInputs = [ cython ];
+  propagatedBuildInputs = [ numpy property-cached python scipy statsmodels ];
+  
+  preBuild = ''
+    ${python.interpreter} setup.py build_ext -i
+  '';
+    
+  checkInputs = [ matplotlib pandas pytest ];
+
+  # scipy.optimize has been changed in 1.4 which broke test_convergence_warning
+  checkPhase = ''
+    pytest arch/tests -k 'not test_convergence_warning'
+  '';
+
+  meta = with lib; {
+    description = "Autoregressive Conditional Heteroskedasticity";
+    homepage = "https://github.com/bashtage/arch";
+    license = licenses.ncsa;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -183,6 +183,8 @@ in {
 
   arrayqueues = callPackage ../development/python-modules/arrayqueues { };
 
+  arch = callPackage ../development/python-modules/arch { };
+
   aresponses = callPackage ../development/python-modules/aresponses { };
 
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module `arch` in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
