### PR TITLE
pythonPackages.redo: init at 2.0.3

### DIFF
--- a/pkgs/development/python-modules/redo/default.nix
+++ b/pkgs/development/python-modules/redo/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchFromGitHub, mock, pytest }:
+
+buildPythonPackage rec {
+  pname = "redo";
+  version = "2.0.3";
+  
+  src = fetchFromGitHub {
+    owner = "bhearsum";
+    repo = "redo";
+    rev = version;
+    sha256 = "0gkl60dm04mbl9bdvsjz95l8zb6di6zw3i41s1rr7sk8k565rbc2";
+  };
+  
+  checkInputs = [ mock pytest ];
+  
+  meta = with lib; {
+    description = "Utilities to retry Python callables";
+    homepage = "https://github.com/bhearsum/redo";
+    license = licenses.mpl20;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1314,6 +1314,8 @@ in {
 
   pyvoro = callPackage ../development/python-modules/pyvoro { };
 
+  redo = callPackage ../development/python-modules/redo { };
+  
   relatorio = callPackage ../development/python-modules/relatorio { };
 
   reproject = callPackage ../development/python-modules/reproject { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module `redo` in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
