### PR TITLE
pythonPackages.python-irodsclient: init at 0.8.2

### DIFF
--- a/pkgs/development/python-modules/python-irodsclient/default.nix
+++ b/pkgs/development/python-modules/python-irodsclient/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi, prettytable, six }:
+
+buildPythonPackage rec {
+  pname = "python-irodsclient";
+  version = "0.8.2";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e77c345bea028c748047656f35f576210528b1332087b5f0a7e2ddd179301447";
+  };
+  
+  # xmlrunner is not necessary
+  patchPhase = ''
+    substituteInPlace setup.py --replace "'xmlrunner>=1.7.7'" ""
+  '';
+  
+  propagatedBuildInputs = [ prettytable six ];
+  
+  # Test depends on existing iRODS installation
+  doCheck = false;
+  
+  meta = with lib; {
+    description = "Python API for iRODS";
+    homepage = "https://github.com/irods/python-irodsclient";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6548,6 +6548,8 @@ in {
 
   irc = callPackage ../development/python-modules/irc { };
 
+  python-irodsclient = callPackage ../development/python-modules/python-irodsclient { };
+
   jaraco_logging = callPackage ../development/python-modules/jaraco_logging { };
 
   jaraco_text = callPackage ../development/python-modules/jaraco_text { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module `python-irodsclient` in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
