### PR TITLE
pythonPackages.mimesis: init at 3.3.0

### DIFF
--- a/pkgs/development/python-modules/mimesis/default.nix
+++ b/pkgs/development/python-modules/mimesis/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27, pytest, pytest-flake8, pytest-isort, pytest-mock, pytz }:
+
+buildPythonPackage rec {
+  pname = "mimesis";
+  version = "3.3.0";
+  disabled = isPy27;
+  
+  src = fetchFromGitHub {
+    owner = "lk-geimfari";
+    repo = "mimesis";
+    rev = "v" + version;
+    sha256 = "0rqbpqznp5d54nfdyazywb9vw6v38vzcbkfwl0h2d2l48fc0mifh";
+  };
+  
+  propagatedBuildInputs = [ pytz ];
+  
+  checkInputs = [ pytest pytest-flake8 pytest-isort pytest-mock ];
+  
+  checkPhase = ''
+    # deselect test_download_image and test_stock_image: the tests require access to external network
+    # deselect test_cpf_with_666_prefix: mocker cannot be used as context manager
+    pytest tests -k 'not test_download_image and not test_stock_image and not test_cpf_with_666_prefix' 
+  '';
+  
+  meta = with lib; {
+    description = "Fake data generator";
+    homepage = "https://github.com/lk-geimfari/mimesis";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -845,6 +845,8 @@ in {
 
   maxminddb = callPackage ../development/python-modules/maxminddb { };
 
+  mimesis = callPackage ../development/python-modules/mimesis { };
+  
   mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;
 
   mkl-service = callPackage ../development/python-modules/mkl-service { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module `mimesis` in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
