### PR TITLE
openldap: enable sha2 and pbkdf2 modules

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -19,7 +19,11 @@ stdenv.mkDerivation rec {
 
   # Disable install stripping as it breaks cross-compiling.
   # We strip binaries anyway in fixupPhase.
-  makeFlags= [ "STRIP=" ];
+  makeFlags= [
+    "STRIP="
+    "prefix=$(out)"
+    "moduledir=$(out)/lib/modules"
+  ];
 
   configureFlags = [
     "--enable-overlays"
@@ -35,9 +39,18 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (cyrus_sasl == null) "--without-cyrus-sasl"
     ++ stdenv.lib.optional stdenv.isFreeBSD "--with-pic";
 
+  postBuild = ''
+    make $makeFlags -C contrib/slapd-modules/passwd/sha2
+    make $makeFlags -C contrib/slapd-modules/passwd/pbkdf2
+  '';
+
   doCheck = false; # needs a running LDAP server
 
-  installFlags = [ "sysconfdir=$(out)/etc" "localstatedir=$(out)/var" ];
+  installFlags = [
+    "sysconfdir=$(out)/etc"
+    "localstatedir=$(out)/var"
+    "moduledir=$(out)/lib/modules"
+  ];
 
   # 1. Fixup broken libtool
   # 2. Libraries left in the build location confuse `patchelf --shrink-rpath`
@@ -51,9 +64,12 @@ stdenv.mkDerivation rec {
 
     rm -rf $out/var
     rm -r libraries/*/.libs
+    rm -r contrib/slapd-modules/passwd/*/.libs
   '';
 
   postInstall = ''
+    make $installFlags install -C contrib/slapd-modules/passwd/sha2
+    make $installFlags install -C contrib/slapd-modules/passwd/pbkdf2
     chmod +x "$out"/lib/*.{so,dylib}
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Being able to bind to LDAP using a SHA2 or PBKDF2 scheme in `userPassword`.

###### Things done
Build and install `contrib/slapd-modules/passwd/{sha2,pbkdf2}/` already released within OpenLDAP.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
