### PR TITLE
Remove isArm

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -84,7 +84,7 @@ rec {
         else final.parsed.cpu.name;
 
       qemuArch =
-        if final.isArm then "arm"
+        if final.isAarch32 then "arm"
         else if final.isx86_64 then "x86_64"
         else if final.isx86 then "i386"
         else {

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -55,9 +55,6 @@ rec {
 
     isEfi          = map (family: { cpu.family = family; })
                        [ "x86" "arm" "aarch64" ];
-
-    # Deprecated after 18.03
-    isArm = isAarch32;
   };
 
   matchAnyAttrs = patterns:

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -61,18 +61,18 @@ in
     configureFlags = let
       isCross = stdenv.hostPlatform != stdenv.buildPlatform;
       host = stdenv.hostPlatform.platform;
-      isArm = stdenv.hostPlatform.isArm;
+      isAarch32 = stdenv.hostPlatform.isAarch32;
     in sharedConfigureFlags ++ [
       "--without-dtrace"
     ] ++ (optionals isCross [
       "--cross-compiling"
       "--without-intl"
       "--without-snapshot"
-    ]) ++ (optionals (isCross && isArm && hasAttr "fpu" host.gcc) [
+    ]) ++ (optionals (isCross && isAarch32 && hasAttr "fpu" host.gcc) [
       "--with-arm-fpu=${host.gcc.fpu}"
-    ]) ++ (optionals (isCross && isArm && hasAttr "float-abi" host.gcc) [
+    ]) ++ (optionals (isCross && isAarch32 && hasAttr "float-abi" host.gcc) [
       "--with-arm-float-abi=${host.gcc.float-abi}"
-    ]) ++ (optionals (isCross && isArm) [
+    ]) ++ (optionals (isCross && isAarch32) [
       "--dest-cpu=arm"
     ]) ++ extraConfigFlags;
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -137,9 +137,6 @@ let
         isi686 isx86_32 isx86_64
         is32bit is64bit
         isAarch32 isAarch64 isMips isBigEndian;
-      isArm = lib.warn
-        "`stdenv.isArm` is deprecated after 18.03. Please use `stdenv.isAarch32` instead"
-        hostPlatform.isAarch32;
 
       # The derivation's `system` is `buildPlatform.system`.
       inherit (buildPlatform) system;


### PR DESCRIPTION
###### Motivation for this change

isArm has been deprecated for three releases.  All references have been removed.  Tree-wide substitution was performed in #37401 21 months ago.

The noisy isArm alias causes maintainers/scripts/find-tarballs.nix to generate spurious warnings as it recurses through.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
