### PR TITLE
Lexicon 3.3.17 and dependencies

### DIFF
--- a/pkgs/development/python-modules/localzone/default.nix
+++ b/pkgs/development/python-modules/localzone/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, dnspython
+, sphinx
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "localzone";
+  version = "0.9.5";
+
+  src = fetchFromGitHub {
+    owner = "ags-slc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zziqyhbg8vg901b4hjzzab0paag5cng48vk9xf1hchxk5naf58n";
+  };
+
+  propagatedBuildInputs = [ dnspython sphinx ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple DNS library for managing zone files";
+    homepage = https://localzone.iomaestro.com;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ flyfloh ];
+  };
+}

--- a/pkgs/development/python-modules/pynamecheap/default.nix
+++ b/pkgs/development/python-modules/pynamecheap/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "PyNamecheap";
+  version = "0.0.3";
+
+  propagatedBuildInputs = [ requests ];
+
+  # Tests require access to api.sandbox.namecheap.com
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "Bemmu";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1g1cd2yc6rpdsc5ax7s93y5nfkf91gcvbgcaqyl9ida6srd9hr97";
+  };
+
+  meta = with lib; {
+    description = "Namecheap API client in Python.";
+    homepage = https://github.com/Bemmu/PyNamecheap;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/softlayer/default.nix
+++ b/pkgs/development/python-modules/softlayer/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, ptable
+, click
+, requests
+, prompt_toolkit
+, pygments
+, urllib3
+, pytest
+, pytestcov
+, mock
+, sphinx
+, testtools
+}:
+
+buildPythonPackage rec {
+  pname = "softlayer-python";
+  version = "5.8.4";
+
+  propagatedBuildInputs = [ ptable click requests prompt_toolkit pygments urllib3 ];
+
+  checkInputs = [ pytest pytestcov mock sphinx testtools ptable click requests prompt_toolkit pygments urllib3 ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  src = fetchFromGitHub {
+    owner = "softlayer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "10kzi7kvvifr21a46q2xqsibs0bx5ys22nfym0bg605ka37vcz88";
+  };
+
+  meta = with lib; {
+    description = "A set of Python libraries that assist in calling the SoftLayer API.";
+    homepage = https://github.com/softlayer/softlayer-python;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/transip/default.nix
+++ b/pkgs/development/python-modules/transip/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+, cryptography
+, suds-jurko
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "transip-api";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "benkonrath";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "153x8ph7cp432flaqiy2zgp060ddychcqcrssxkcmjvbm86xrz17";
+  };
+
+  checkInputs = [ pytest ];
+
+  # Constructor Tests require network access
+  checkPhase = ''
+    pytest --deselect=tests/service_tests/test_domain.py::TestDomainService::test_constructor \
+           --deselect tests/service_tests/test_vps.py::TestVPSService::testConstructor \
+           --deselect tests/service_tests/test_webhosting.py::TestWebhostingService::testConstructor
+  '';
+
+
+  propagatedBuildInputs = [ requests cryptography suds-jurko ];
+
+  meta = with stdenv.lib; {
+    description = "TransIP API Connector";
+    homepage = https://github.com/benkonrath/transip-api;
+    license = licenses.mit;
+    maintainers = with maintainers; [ flyfloh ];
+  };
+}

--- a/pkgs/tools/admin/lexicon/default.nix
+++ b/pkgs/tools/admin/lexicon/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "lexicon";
+  version = "3.3.17";
+
+  propagatedBuildInputs = with python3Packages; [ requests tldextract future cryptography pyyaml boto3 zeep xmltodict beautifulsoup4 dnspython pynamecheap softlayer transip localzone ];
+
+  checkInputs = with python3Packages; [ pytest pytestcov pytest_xdist vcrpy mock ];
+
+  checkPhase = ''
+    pytest --ignore=lexicon/tests/providers/test_auto.py
+  '';
+
+  src = fetchFromGitHub {
+    owner = "AnalogJ";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wrsw759am6yp2m9b34iv82m371df3ssp2vhdjr18ys3xk7dvj89";
+  };
+
+  meta = with lib; {
+    description = "Manipulate DNS records on various DNS providers in a standardized way.";
+    homepage = https://github.com/AnalogJ/lexicon;
+    maintainers = with maintainers; [ flyfloh ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1903,6 +1903,8 @@ in
 
   lepton = callPackage ../tools/graphics/lepton { };
 
+  lexicon = callPackage ../tools/admin/lexicon { };
+
   lief = callPackage ../development/libraries/lief {};
 
   libndtypes = callPackage ../development/libraries/libndtypes { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1396,6 +1396,8 @@ in {
     usePython = true;
   });
 
+  softlayer = callPackage ../development/python-modules/softlayer { };
+
   sparse = callPackage ../development/python-modules/sparse { };
 
   spglib = callPackage ../development/python-modules/spglib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6860,6 +6860,8 @@ in {
     inherit python;
   })).python;
 
+  localzone = callPackage ../development/python-modules/localzone { };
+
   scour = callPackage ../development/python-modules/scour { };
 
   pymssql = callPackage ../development/python-modules/pymssql { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6760,6 +6760,8 @@ in {
 
   tldextract = callPackage ../development/python-modules/tldextract { };
 
+  transip = callPackage ../development/python-modules/transip { };
+
   pyemd  = callPackage ../development/python-modules/pyemd { };
 
   pulp  = callPackage ../development/python-modules/pulp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -996,6 +996,8 @@ in {
 
   pymupdf = callPackage ../development/python-modules/pymupdf { };
 
+  pynamecheap = callPackage ../development/python-modules/pynamecheap { };
+
   Pmw = callPackage ../development/python-modules/Pmw { };
 
   py_stringmatching = callPackage ../development/python-modules/py_stringmatching { };


### PR DESCRIPTION
###### Motivation for this change

lexicon can be used with dehydrated to get Let's Encrypt Certificates with the `dns-01` method. It's really useful to talk to a bunch of DNS providers and update DNS records automatically for this use-case.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
