### PR TITLE
buildRustCrate: remap the current build dir to / for (more) reproducible builds

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -11,6 +11,7 @@
     baseRustcOpts =
       [(if release then "-C opt-level=3" else "-C debuginfo=2")]
       ++ ["-C codegen-units=$NIX_BUILD_CORES"]
+      ++ ["--remap-path-prefix=$NIX_BUILD_TOP=/" ]
       ++ [(mkRustcDepArgs dependencies crateRenames)]
       ++ [crateFeatures]
       ++ extraRustcOpts


### PR DESCRIPTION
###### Motivation for this change

Distributed remote builds had been haunted by a reproducibility and compiler error due to metadata in crates not lining up. The issue seems to (partially) be that the metadata in the `.rlib` files wouldn't always be the same. One impurity that was found now is the source path that is embedded in the files.

We can simply set those to `/` and have the same root path in all the crates be built. This already allowed me to have bit-by-bit reproducibility for the `brotli` crate used in the `buildRustCrate` tests.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

@GrahamcOfBorg build rustCrateTest
