### PR TITLE
next: 1.3.4 -> 1.4.0

### DIFF
--- a/pkgs/applications/networking/browsers/next/default.nix
+++ b/pkgs/applications/networking/browsers/next/default.nix
@@ -15,13 +15,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "next";
-  version = "1.3.4";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "atlas-engineer";
     repo = "next";
     rev = version;
-    sha256 = "00iqv4xarabl98gdl1rzqkc5v0vfljx1nawsxqsx9x3a9mnxmgxi";
+    sha256 = "1gkmr746rqqg94698a051gv79fblc8n9dq0zg04llba44adhpmjl";
   };
 
   nativeBuildInputs = [
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
     cl-annot
     cl-ansi-text
     cl-css
-    cl-hooks
     cl-json
     cl-markup
     cl-ppcre
@@ -52,12 +51,15 @@ stdenv.mkDerivation rec {
     lparallel
     mk-string-metrics
     parenscript
+    plump
     quri
+    serapeum
     sqlite
     str
     swank
     trivia
     trivial-clipboard
+    trivial-types
     unix-opts
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/jyp17bxcqc34a427wnrcc9wfnp2b1wqv-next-1.3.4	1017.8M
/nix/store/zs5q9b4flmzpavzn2kx6a2ifpkli59by-next-1.4.0	   1.0G

to have an idea to the deps changes (check next.asd or maybe the guix files):
https://github.com/atlas-engineer/next/compare/1.3.4...1.4.0