### PR TITLE
Update Haskell package set to LTS 14.23 (plus other fixes)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1389,4 +1389,7 @@ self: super: {
   # prettyprinter-1.6.0 fails its doctest suite.
   prettyprinter_1_6_0 = dontCheck super.prettyprinter_1_6_0;
 
+  # the test suite has an overly tight restriction on doctest
+  perhaps = doJailbreak super.perhaps;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1350,7 +1350,7 @@ self: super: {
   # There are more complicated ways of doing this but I was able to make it fairly simple -- kiwi
   matterhorn = doJailbreak (super.matterhorn.override {
     brick-skylighting = self.brick-skylighting.override {
-      brick = self.brick_0_50_1;
+      brick = self.brick_0_51;
     };
   });
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1390,6 +1390,7 @@ self: super: {
   prettyprinter_1_6_0 = dontCheck super.prettyprinter_1_6_0;
 
   # the test suite has an overly tight restriction on doctest
+  # See https://github.com/ekmett/perhaps/pull/5
   perhaps = doJailbreak super.perhaps;
 
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1236,7 +1236,7 @@ self: super: {
   constraints-deriving = dontCheck super.constraints-deriving;
 
   # Use a matching version of ghc-lib-parser.
-  ghc-lib-parser-ex = super.ghc-lib-parser-ex.override { ghc-lib-parser = self.ghc-lib-parser_8_8_2; };
+  ghc-lib-parser-ex = super.ghc-lib-parser-ex.override { ghc-lib-parser = self.ghc-lib-parser_8_8_2_20200205; };
 
   # https://github.com/sol/hpack/issues/366
   hpack = self.hpack_0_33_0;
@@ -1380,7 +1380,7 @@ self: super: {
 
   # Needs ghc-lib-parser 8.8.1 (does not build with 8.8.0)
   ormolu = doJailbreak (super.ormolu.override {
-    ghc-lib-parser = self.ghc-lib-parser_8_8_2;
+    ghc-lib-parser = self.ghc-lib-parser_8_8_2_20200205;
   });
 
   # krank-0.1.0 does not accept PyF-0.9.0.0.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -74,7 +74,7 @@ self: super: {
       name = "git-annex-${super.git-annex.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + super.git-annex.version;
-      sha256 = "0s8sv6h90l2a9xdabj0nirhpr6d2k8s5cddjdkm50x395i014w31";
+      sha256 = "1shb1jgm78bx88rbsr1nmimjzzfqw96qdr38mcrr1c2qz5ky820v";
     };
   }).override {
     dbus = if pkgs.stdenv.isLinux then self.dbus else null;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -81,4 +81,7 @@ self: super: {
     hackage-db = self.hackage-db_2_1_0;
   });
 
+  # cabal2spec needs a recent version of Cabal
+  cabal2spec = super.cabal2spec.overrideScope (self: super: { Cabal = self.Cabal_3_0_0_0; });
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -84,4 +84,7 @@ self: super: {
   # cabal2spec needs a recent version of Cabal
   cabal2spec = super.cabal2spec.overrideScope (self: super: { Cabal = self.Cabal_3_0_0_0; });
 
+  # Builds only with ghc-8.8.x and beyond.
+  policeman = markBroken super.policeman;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -82,7 +82,7 @@ self: super: {
   HaTeX = self.HaTeX_3_22_0_0;
   HsYAML = self.HsYAML_0_2_1_0;
   json-autotype = doJailbreak super.json-autotype;
-  lens = self.lens_4_18_1;
+  lens = self.lens_4_19;
   memory = self.memory_0_15_0;
   microlens = self.microlens_0_4_11_2;
   microlens-ghc = self.microlens-ghc_0_4_12;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -70,7 +70,7 @@ self: super: {
   xmobar = doJailbreak super.xmobar;
 
   # use latest version to fix the build
-  brick = self.brick_0_50_1;
+  brick = self.brick_0_51;
   dbus = self.dbus_1_2_11;
   doctemplates = self.doctemplates_0_8;
   exact-pi = doJailbreak super.exact-pi;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -7942,7 +7942,6 @@ broken-packages:
   - perfect-vector-shuffle
   - PerfectHash
   - perfecthash
-  - perhaps
   - periodic
   - perm
   - permutations

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -69,7 +69,7 @@ core-packages:
 default-package-overrides:
   # pandoc-2.9 does not accept the 0.3 version yet
   - doclayout < 0.3
-  # LTS Haskell 14.22
+  # LTS Haskell 14.23
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
   - abstract-par ==0.3.3
@@ -116,7 +116,7 @@ default-package-overrides:
   - ansi-wl-pprint ==0.6.9
   - ANum ==0.2.0.2
   - aos-signature ==0.1.1
-  - apecs ==0.8.2
+  - apecs ==0.8.3
   - apecs-gloss ==0.2.3
   - apecs-physics ==0.4.2
   - api-field-json-th ==0.1.0.2
@@ -132,7 +132,6 @@ default-package-overrides:
   - arrow-extras ==0.1.0.1
   - asciidiagram ==1.3.3.3
   - ascii-progress ==0.3.3.0
-  - asif ==6.0.4
   - asn1-encoding ==0.9.6
   - asn1-parse ==0.9.5
   - asn1-types ==0.3.3
@@ -183,7 +182,7 @@ default-package-overrides:
   - base-compat-batteries ==0.10.5
   - basement ==0.0.11
   - base-noprelude ==4.12.0.0
-  - base-orphans ==0.8.1
+  - base-orphans ==0.8.2
   - base-prelude ==1.3
   - base-unicode-symbols ==0.2.3
   - basic-prelude ==0.7.0
@@ -202,7 +201,7 @@ default-package-overrides:
   - bencoding ==0.4.5.2
   - between ==0.11.0.0
   - bibtex ==0.1.0.6
-  - bifunctors ==5.5.6
+  - bifunctors ==5.5.7
   - bimap ==0.4.0
   - bimap-server ==0.1.0.1
   - binary-bits ==0.5
@@ -406,7 +405,7 @@ default-package-overrides:
   - conduit-throttle ==0.3.1.0
   - conduit-zstd ==0.0.1.1
   - config-ini ==0.2.4.0
-  - configuration-tools ==0.4.1
+  - configuration-tools ==0.4.2
   - configurator ==0.3.0.0
   - configurator-export ==0.1.0.1
   - configurator-pg ==0.1.0.3
@@ -640,7 +639,7 @@ default-package-overrides:
   - errors ==2.3.0
   - errors-ext ==0.4.2
   - error-util ==0.0.1.2
-  - ersatz ==0.4.7
+  - ersatz ==0.4.8
   - esqueleto ==3.0.0
   - etc ==0.4.1.0
   - eventful-core ==0.2.0
@@ -677,13 +676,13 @@ default-package-overrides:
   - fast-logger ==2.4.17
   - fast-math ==1.0.2
   - fb ==2.0.0
-  - fclabels ==2.0.3.3
+  - fclabels ==2.0.4
   - feature-flags ==0.1.0.1
   - fedora-dists ==1.0.1
   - feed ==1.2.0.1
   - FenwickTree ==0.1.2.1
   - fft ==0.1.8.6
-  - fgl ==5.7.0.1
+  - fgl ==5.7.0.2
   - fib ==0.1
   - filecache ==0.4.1
   - file-embed ==0.0.11.1
@@ -709,7 +708,7 @@ default-package-overrides:
   - flac ==0.2.0
   - flac-picture ==0.1.2
   - flags-applicative ==0.1.0.2
-  - flat-mcmc ==1.5.0
+  - flat-mcmc ==1.5.1
   - flay ==0.4
   - flexible-defaults ==0.0.3
   - FloatingHex ==0.4
@@ -742,7 +741,7 @@ default-package-overrides:
   - free-vl ==0.1.4
   - friendly-time ==0.4.1
   - frisby ==0.2.2
-  - from-sum ==0.2.2.0
+  - from-sum ==0.2.3.0
   - frontmatter ==0.1.0.2
   - fsnotify ==0.3.0.1
   - fsnotify-conduit ==0.1.1.1
@@ -848,7 +847,7 @@ default-package-overrides:
   - graph-core ==0.3.0.0
   - graphite ==0.10.0.1
   - graphs ==0.7.1
-  - graphviz ==2999.20.0.3
+  - graphviz ==2999.20.0.4
   - graph-wrapper ==0.2.6.0
   - gravatar ==0.8.0
   - graylog ==0.1.0.1
@@ -1059,7 +1058,7 @@ default-package-overrides:
   - hw-dsv ==0.3.5
   - hweblib ==0.6.3
   - hw-eliasfano ==0.1.1.0
-  - hw-excess ==0.2.2.2
+  - hw-excess ==0.2.2.3
   - hw-fingertree ==0.1.1.1
   - hw-fingertree-strict ==0.1.1.3
   - hw-hedgehog ==0.1.0.5
@@ -1171,7 +1170,7 @@ default-package-overrides:
   - js-jquery ==3.3.1
   - json ==0.9.3
   - json-alt ==1.0.0
-  - json-feed ==1.0.7
+  - json-feed ==1.0.8
   - jsonpath ==0.1.0.2
   - json-rpc ==1.0.1
   - json-rpc-client ==0.2.5.0
@@ -1183,13 +1182,13 @@ default-package-overrides:
   - justified-containers ==0.3.0.0
   - jwt ==0.10.0
   - kan-extensions ==5.2
-  - kanji ==3.4.0.2
+  - kanji ==3.4.1
   - katip ==0.8.3.0
   - kawhi ==0.3.0
   - kazura-queue ==0.1.0.4
   - kdt ==0.2.4
   - keycode ==0.2.2
-  - keys ==3.12.2
+  - keys ==3.12.3
   - kind-apply ==0.3.2.0
   - kind-generics ==0.3.0.0
   - kind-generics-th ==0.1.1.0
@@ -1199,7 +1198,7 @@ default-package-overrides:
   - kraken ==0.1.0
   - l10n ==0.1.0.1
   - labels ==0.3.3
-  - lackey ==1.0.10
+  - lackey ==1.0.11
   - lambdabot-core ==5.2
   - lambdabot-irc-plugins ==5.2
   - LambdaHack ==0.9.5.0
@@ -1211,7 +1210,7 @@ default-package-overrides:
   - language-haskell-extract ==0.2.4
   - language-java ==0.2.9
   - language-javascript ==0.6.0.14
-  - language-puppet ==1.4.6.1
+  - language-puppet ==1.4.6.2
   - lapack ==0.3.1
   - lapack-carray ==0.0.3
   - lapack-comfort-array ==0.0.0.1
@@ -1247,10 +1246,10 @@ default-package-overrides:
   - libffi ==0.1
   - libgit ==0.3.1
   - libgraph ==1.14
-  - libmpd ==0.9.0.10
+  - libmpd ==0.9.1.0
   - liboath-hs ==0.0.1.1
   - libraft ==0.5.0.0
-  - libyaml ==0.1.1.1
+  - libyaml ==0.1.2
   - LibZip ==1.0.1
   - lifted-async ==0.10.0.4
   - lifted-base ==0.2.3.12
@@ -1278,7 +1277,7 @@ default-package-overrides:
   - log-domain ==0.12
   - logfloat ==0.13.3.3
   - logger-thread ==0.1.0.2
-  - logging-effect ==1.3.8
+  - logging-effect ==1.3.9
   - logging-facade ==0.3.0
   - logging-facade-syslog ==1
   - logict ==0.7.0.2
@@ -1404,7 +1403,6 @@ default-package-overrides:
   - mono-traversable-keys ==0.1.0
   - more-containers ==0.2.2.0
   - mountpoints ==1.0.2
-  - mpi-hs ==0.5.3.0
   - msgpack ==1.0.1.0
   - msgpack-aeson ==0.1.0.0
   - mtl ==2.2.2
@@ -1438,7 +1436,7 @@ default-package-overrides:
   - natural-sort ==0.1.2
   - natural-transformation ==0.4
   - ndjson-conduit ==0.1.0.5
-  - neat-interpolation ==0.3.2.5
+  - neat-interpolation ==0.3.2.6
   - netlib-carray ==0.1
   - netlib-comfort-array ==0.0.0.1
   - netlib-ffi ==0.1.1
@@ -1463,7 +1461,7 @@ default-package-overrides:
   - network-simple-tls ==0.3.2
   - network-transport ==0.5.4
   - network-transport-composed ==0.2.1
-  - network-uri ==2.6.1.0
+  - network-uri ==2.6.2.0
   - newtype ==0.2.2.0
   - newtype-generics ==0.5.4
   - nicify-lib ==1.0.1
@@ -1536,7 +1534,7 @@ default-package-overrides:
   - palette ==0.3.0.2
   - pandoc ==2.7.3
   - pandoc-citeproc ==0.16.2
-  - pandoc-csv2table ==1.0.7
+  - pandoc-csv2table ==1.0.8
   - pandoc-markdown-ghci-filter ==0.1.0.0
   - pandoc-pyplot ==2.1.5.1
   - pandoc-types ==1.17.6.1
@@ -1587,7 +1585,7 @@ default-package-overrides:
   - persistent-iproute ==0.2.4
   - persistent-mysql ==2.9.0
   - persistent-mysql-haskell ==0.5.2
-  - persistent-pagination ==0.1.1.0
+  - persistent-pagination ==0.1.1.1
   - persistent-postgresql ==2.9.1
   - persistent-qq ==2.9.1
   - persistent-sqlite ==2.9.3
@@ -1743,7 +1741,7 @@ default-package-overrides:
   - range-set-list ==0.1.3.1
   - rank1dynamic ==0.4.0
   - rank2classes ==1.3.2.1
-  - Rasterific ==0.7.5
+  - Rasterific ==0.7.5.1
   - rasterific-svg ==0.3.3.2
   - ratel ==1.0.9
   - ratel-wai ==1.1.1
@@ -1859,7 +1857,7 @@ default-package-overrides:
   - scientific ==0.3.6.2
   - scotty ==0.11.5
   - scrypt ==0.5.0
-  - sdl2 ==2.5.0.0
+  - sdl2 ==2.5.1.0
   - sdl2-gfx ==0.2
   - sdl2-image ==2.0.0
   - sdl2-mixer ==1.1.0
@@ -1930,7 +1928,7 @@ default-package-overrides:
   - sexpr-parser ==0.1.1.2
   - SHA ==1.6.4.4
   - shake-language-c ==0.12.0
-  - shakespeare ==2.0.23
+  - shakespeare ==2.0.24
   - shared-memory ==0.2.0.0
   - shell-conduit ==4.7.0
   - shell-escape ==0.2.0
@@ -1972,7 +1970,7 @@ default-package-overrides:
   - slack-web ==0.2.0.11
   - smallcheck ==1.1.5
   - smallcheck-series ==0.6.1
-  - smoothie ==0.4.2.9
+  - smoothie ==0.4.2.10
   - snap-blaze ==0.2.1.5
   - snap-core ==1.0.4.1
   - snap-server ==1.1.1.1
@@ -2020,10 +2018,9 @@ default-package-overrides:
   - stm-split ==0.0.2.1
   - stopwatch ==0.1.0.6
   - storable-complex ==0.2.3.0
-  - storable-record ==0.0.4
+  - storable-record ==0.0.4.1
   - storable-tuple ==0.0.3.3
   - storablevector ==0.2.13
-  - store ==0.5.1.2
   - store-core ==0.4.4.2
   - Strafunski-StrategyLib ==5.0.1.0
   - stratosphere ==0.40.0
@@ -2054,7 +2051,7 @@ default-package-overrides:
   - stripe-signature ==1.0.0.1
   - stripe-wreq ==1.0.1.0
   - strive ==5.0.9
-  - structs ==0.1.2
+  - structs ==0.1.3
   - structured-cli ==2.5.2.0
   - summoner ==1.3.0.1
   - sum-type-boilerplate ==0.1.1
@@ -2102,9 +2099,9 @@ default-package-overrides:
   - tasty-hunit ==0.10.0.2
   - tasty-kat ==0.0.3
   - tasty-leancheck ==0.0.1
-  - tasty-lua ==0.2.0.1
+  - tasty-lua ==0.2.2
   - tasty-program ==1.0.5
-  - tasty-quickcheck ==0.10.1
+  - tasty-quickcheck ==0.10.1.1
   - tasty-silver ==3.1.13
   - tasty-smallcheck ==0.8.1
   - tasty-th ==0.1.7
@@ -2303,7 +2300,7 @@ default-package-overrides:
   - users-test ==0.5.0.1
   - utf8-light ==0.4.2
   - utf8-string ==1.0.1.1
-  - util ==0.1.17.0
+  - util ==0.1.17.1
   - utility-ht ==0.0.14
   - uuid ==1.3.13
   - uuid-types ==1.0.3
@@ -2322,7 +2319,7 @@ default-package-overrides:
   - valor ==0.1.0.0
   - vault ==0.3.1.3
   - vec ==0.1.1.1
-  - vector ==0.12.0.3
+  - vector ==0.12.1.2
   - vector-algorithms ==0.8.0.3
   - vector-binary-instances ==0.2.5.1
   - vector-buffer ==0.4.1
@@ -2335,7 +2332,7 @@ default-package-overrides:
   - vector-split ==1.0.0.2
   - vector-th-unbox ==0.2.1.7
   - verbosity ==0.3.0.0
-  - versions ==3.5.2
+  - versions ==3.5.3
   - ViennaRNAParser ==1.3.3
   - viewprof ==0.0.0.32
   - vinyl ==0.11.0
@@ -2397,7 +2394,7 @@ default-package-overrides:
   - wizards ==1.0.3
   - wl-pprint-annotated ==0.1.0.1
   - wl-pprint-console ==0.1.0.2
-  - wl-pprint-text ==1.2.0.0
+  - wl-pprint-text ==1.2.0.1
   - word24 ==2.0.1
   - word8 ==0.1.3
   - wordpress-auth ==1.0.0.0
@@ -2452,13 +2449,13 @@ default-package-overrides:
   - yeshql ==4.1.0.1
   - yeshql-core ==4.1.0.2
   - yeshql-hdbc ==4.1.0.2
-  - yesod ==1.6.0
+  - yesod ==1.6.0.1
   - yesod-alerts ==0.1.3.0
-  - yesod-auth ==1.6.8
+  - yesod-auth ==1.6.8.1
   - yesod-auth-hashdb ==1.7.1.2
   - yesod-auth-oauth2 ==0.6.1.2
   - yesod-bin ==1.6.0.4
-  - yesod-core ==1.6.17
+  - yesod-core ==1.6.17.2
   - yesod-csp ==0.2.5.0
   - yesod-eventsource ==1.6.0
   - yesod-fb ==0.5.0

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3075,6 +3075,7 @@ broken-packages:
   - atomic-primops-vector
   - atomo
   - ats-format
+  - ats-pkg
   - ats-setup
   - ats-storable
   - attic-schedule
@@ -6065,6 +6066,7 @@ broken-packages:
   - hs-twitterarchiver
   - hs-vcard
   - hs-watchman
+  - hs2ats
   - hs2bf
   - Hs2lib
   - hsaml2
@@ -6781,6 +6783,7 @@ broken-packages:
   - lame
   - lame-tester
   - lang
+  - language-ats
   - language-bash
   - language-boogie
   - language-c-comments
@@ -7081,6 +7084,7 @@ broken-packages:
   - lxd-client
   - lye
   - Lykah
+  - lz4-bytes
   - lz4-conduit
   - lzma-enumerator
   - lzma-streams
@@ -8946,6 +8950,7 @@ broken-packages:
   - sha-streams
   - shade
   - shadower
+  - shake-ats
   - shake-cabal-build
   - shake-extras
   - shake-minify
@@ -9031,6 +9036,7 @@ broken-packages:
   - simseq
   - singleton-dict
   - singleton-typelits
+  - singletons-presburger
   - singnal
   - singular-factory
   - sink
@@ -10005,6 +10011,7 @@ broken-packages:
   - uuagc-bootstrap
   - uuagc-diagrams
   - uuid-aeson
+  - uuid-bytes
   - uuid-orphans
   - uvector
   - uvector-algorithms

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -530,6 +530,9 @@ self: super: builtins.intersectAttrs super {
     '';
   });
 
+  # Break infinite recursion cycle with criterion and network-uri.
+  js-flot = dontCheck super.js-flot;
+
   # Break infinite recursion cycle between QuickCheck and splitmix.
   splitmix = dontCheck super.splitmix;
 


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-02-07 [20:00 CET](http://www.thetimezoneconverter.com/?t=21:00&tz=Berlin). You can watch this live on Twitch at https://www.twitch.tv/peti343.

## TODO

- [ ] Try to revive `haskell-ci` build.
- [x] Try `krank`.