### PR TITLE
safe: init at 1.5.1

### DIFF
--- a/pkgs/tools/security/safe/default.nix
+++ b/pkgs/tools/security/safe/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildGoPackage
+, fetchFromGitHub
+}:
+
+with builtins;
+
+buildGoPackage rec {
+  pname = "safe";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "starkandwayne";
+    repo = "safe";
+    rev = "v${version}";
+    sha256 = "12gzxrnyl890h79z9yx23m1wwgy8ahm74q4qwi8n2nh7ydq6mn2d";
+  };
+
+  goPackagePath = "github.com/starkandwayne/safe";
+
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-X main.Version=${version}")
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Vault CLI";
+    homepage = "https://github.com/starkandwayne/safe";
+    license = licenses.mit;
+    maintainers = with maintainers; [ eonpatapon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6251,6 +6251,8 @@ in
 
   safecopy = callPackage ../tools/system/safecopy { };
 
+  safe = callPackage ../tools/security/safe { };
+
   safe-rm = callPackage ../tools/system/safe-rm { };
 
   safeeyes = callPackage ../applications/misc/safeeyes { };


### PR DESCRIPTION
###### Motivation for this change

Provides a more user friendly cli to interact with vault

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
