### PR TITLE
jost: 3.3 -> 3.5

### DIFF
--- a/pkgs/data/fonts/jost/default.nix
+++ b/pkgs/data/fonts/jost/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchzip}:
 
 let
-  version = "3.3";
+  version = "3.5";
 in fetchzip {
   name = "jost-${version}";
   url = "https://github.com/indestructible-type/Jost/releases/download/${version}/Jost.zip";
@@ -11,7 +11,7 @@ in fetchzip {
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256="00nrhs3aif2hc4yhjhbn9ywmydl2w0g0hv5m5is8gv7wx8yi2j9z";
+  sha256="0l78vhmbsyfmrva5wc76pskhxqryyg8q5xddpj9g5wqsddy525dq";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/indestructible-type/Jost;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/indestructible-type/Jost/releases/tag/3.5
https://github.com/indestructible-type/Jost/releases/tag/3.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).