### PR TITLE
rbtools: 0.7.2 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/rbtools/default.nix
+++ b/pkgs/development/python-modules/rbtools/default.nix
@@ -1,26 +1,29 @@
 { stdenv
 , buildPythonPackage
 , fetchurl
-, nose
-, six
-, setuptools
 , isPy3k
+, setuptools
+, colorama
+, six
+, texttable
+, tqdm
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "rbtools";
-  version = "0.7.2";
-  disabled = isPy3k;
+  version = "1.0.2";
+
+  disabled = !isPy3k;
 
   src = fetchurl {
-    url = "http://downloads.reviewboard.org/releases/RBTools/0.7/RBTools-0.7.2.tar.gz";
-    sha256 = "1ng8l8cx81cz23ls7fq9wz4ijs0zbbaqh4kj0mj6plzcqcf8na4i";
+    url = "https://downloads.reviewboard.org/releases/RBTools/${stdenv.lib.versions.majorMinor version}/RBTools-${version}.tar.gz";
+    sha256 = "577c2f8bbf88f77bda84ee95af0310b59111c156f48a5aab56ca481e2f77eaf4";
   };
 
-  checkInputs = [ nose ];
-  propagatedBuildInputs = [ six setuptools ];
+  propagatedBuildInputs = [ six texttable tqdm colorama setuptools ];
 
-  checkPhase = "LC_ALL=C nosetests";
+  # The kgb test dependency is not in nixpkgs
+  doCheck = false;
 
   meta = with stdenv.lib; {
     homepage = https://www.reviewboard.org/docs/rbtools/dev/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update to 1.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).