### PR TITLE
p4: init at 2017.3.1601999

### DIFF
--- a/pkgs/applications/version-management/p4/default.nix
+++ b/pkgs/applications/version-management/p4/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "p4";
+  version = "2019.2.1915892";
+
+  src = fetchurl {
+    url = "https://cdist2.perforce.com/perforce/r19.2/bin.linux26x86_64/helix-core-server.tgz";
+    sha256 = "42ff4c630722910f09e93eeb9ed948f4e02171e3e3ea72bd15f944ffef7e7a34";
+  };
+
+  # Work around the "unpacker appears to have produced no directories"
+  # case that happens when the archive doesn't have a subdirectory.
+  setSourceRoot = "sourceRoot=`pwd`";
+
+  dontBuild = true;
+
+  ldLibraryPath = lib.makeLibraryPath [
+      stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r p* $out/bin/
+
+    for f in $out/bin/* ; do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $f
+    done
+  '';
+
+  meta = {
+    description = "Perforce Command-Line Client";
+    homepage = https://www.perforce.com;
+    license = stdenv.lib.licenses.unfreeRedistributable;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with stdenv.lib.maintainers; [ nathyong nioncode ];
+  };
+}

--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "p4v";
-  version = "2017.3.1601999";
+  version = "2019.2.1904275";
 
   src = fetchurl {
-    url = "https://cdist2.perforce.com/perforce/r17.3/bin.linux26x86_64/p4v.tgz";
-    sha256 = "9ded42683141e1808535ec3e87d3149f890315c192d6e97212794fd54862b9a4";
+    url = "https://cdist2.perforce.com/perforce/r19.2/bin.linux26x86_64/p4v.tgz";
+    sha256 = "c5c3de2d3809cd32892da2162bf44f3faecf2c657ad92ba4144a3a72fb3afb13";
   };
 
   dontBuild = true;
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     mkdir $out
     cp -r bin $out
     mkdir -p $out/lib/p4v
-    cp -r lib/p4v/P4VResources $out/lib/p4v
+    cp -r lib/P4VResources $out/lib/p4v
 
     for f in $out/bin/*.bin ; do
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $f

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20465,6 +20465,7 @@ in
 
   ostinato = callPackage ../applications/networking/ostinato { };
 
+  p4 = callPackage ../applications/version-management/p4 { };
   p4v = libsForQt5.callPackage ../applications/version-management/p4v { };
 
   partio = callPackage ../development/libraries/partio {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The visual client p4v already has a package, this adds the command-line client.
@nioncode, @nathyong, I set you as maintainers because you already have the p4v package and this is pretty similar, I hope that’s ok.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
