### PR TITLE
rgp: init at 1.7.0.29

### DIFF
--- a/pkgs/development/tools/rgp/default.nix
+++ b/pkgs/development/tools/rgp/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, makeWrapper
+, fetchurl
+, autoPatchelfHook
+, dbus
+, fontconfig
+, freetype
+, glib
+, libglvnd
+, libX11
+, libxcb
+, libXi
+, ncurses5
+, qtbase
+, zlib
+}:
+with lib;
+
+stdenv.mkDerivation rec {
+  pname = "rgp";
+  version = "1.7.0.29";
+
+  src = fetchurl {
+    url = "https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/download/v${lib.versions.majorMinor version}/RadeonGPUProfiler_${version}.tgz";
+    sha256 = "d7d4aa92231796a509dfcf92e9618cac98ae6572c12efd0871eb43afa4e8240a";
+  };
+
+  nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
+
+  buildInputs = [
+    dbus
+    fontconfig
+    freetype
+    glib
+    libglvnd
+    libX11
+    libxcb
+    libXi
+    ncurses5
+    qtbase
+    zlib
+  ];
+
+  runtimeDependencies = [
+    "${placeholder "out"}/opt/rgp"
+    "${placeholder "out"}/opt/rgp/qt"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/opt/rgp $out/bin
+    cp -r . $out/opt/rgp/
+    # Breaks autoPatchelfHook and has no known usage
+    rm $out/opt/rgp/AMDToolsDownloader
+
+    for prog in RadeonGPUProfiler RadeonDeveloperPanel RadeonDeveloperService RadeonDeveloperServiceCLI; do
+      # makeWrapper is needed so that executables are started from the opt
+      # directory, where qt.conf is
+      makeWrapper \
+        $out/opt/rgp/$prog \
+        $out/bin/$prog
+    done
+  '';
+
+  meta = with lib; {
+    description = "A tool from AMD that allows for deep inspection of GPU workloads";
+    homepage = "https://gpuopen.com/gaming-product/radeon-gpu-profiler-rgp/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ Flakebi ];
+  };
+}

--- a/pkgs/development/tools/rgp/default.nix
+++ b/pkgs/development/tools/rgp/default.nix
@@ -15,7 +15,6 @@
 , qtbase
 , zlib
 }:
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "rgp";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21551,6 +21551,8 @@ in
   retroshare = libsForQt5.callPackage ../applications/networking/p2p/retroshare { };
   retroshare06 = retroshare;
 
+  rgp = libsForQt5.callPackage ../development/tools/rgp { };
+
   ricochet = libsForQt5.callPackage ../applications/networking/instant-messengers/ricochet { };
 
   ries = callPackage ../applications/science/math/ries { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add a package for the Radeon GPU Profiler, a useful tool to profile graphics applications on AMD GPUs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
