### PR TITLE
nixos/nixos-option: add `--nesting-limit` option to avoid infinite recursions

### DIFF
--- a/nixos/doc/manual/man-nixos-option.xml
+++ b/nixos/doc/manual/man-nixos-option.xml
@@ -27,6 +27,18 @@
    </arg>
 
    <arg>
+    <group choice='req'>
+     <arg choice='plain'><option>--nesting-limit</option></arg>
+     <arg choice='plain'><option>-n</option></arg>
+    </group>
+    <replaceable>limit</replaceable>
+   </arg>
+
+   <arg>
+    <option>--no-nesting-limit</option>
+   </arg>
+
+   <arg>
     <replaceable>option.name</replaceable>
    </arg>
   </cmdsynopsis>
@@ -66,6 +78,27 @@
      <para>
       This option is passed to the underlying
       <command>nix-instantiate</command> invocation.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><option>-n</option></term>
+    <term><option>--no-nesting-limit</option></term>
+    <listitem>
+     <para>
+      Specify how many levels of lists and attributes should
+      be shown.
+     </para>
+     <para>
+      Please note that this doesn't have any effect if <literal>--recursive</literal> is set.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><option>--no-nesting-limit</option></term>
+    <listitem>
+     <para>
+      Render all levels of attributes.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
###### Motivation for this change

Until now, `nixos-option` tried to show all sub-attributes of a config
value which can result in a never-ending output e.g. when running
`nixos-option nixpkgs.pkgs` due to the fixpoint in this attribute set.

By default, `nixos-option` only steps three levels into a data-structure
(unless `--no-nesting-limit` is set). The limit can be modified using
`--nesting-limit`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
