### PR TITLE
fwupd: split daemon again

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -53,7 +53,7 @@ in {
 
       blacklistPlugins = mkOption {
         type = types.listOf types.str;
-        default = [ "test" ];
+        default = [];
         example = [ "udev" ];
         description = ''
           Allow blacklisting specific plugins
@@ -91,6 +91,9 @@ in {
 
   ###### implementation
   config = mkIf cfg.enable {
+    # Disable test related plug-ins implicitly so that users do not have to care about them.
+    services.fwupd.blacklistPlugins = cfg.package.defaultBlacklistedPlugins;
+
     environment.systemPackages = [ cfg.package ];
 
     environment.etc = {

--- a/nixos/tests/installed-tests/fwupd.nix
+++ b/nixos/tests/installed-tests/fwupd.nix
@@ -1,11 +1,11 @@
-{ pkgs, makeInstalledTest, ... }:
+{ pkgs, lib, makeInstalledTest, ... }:
 
 makeInstalledTest {
   tested = pkgs.fwupd;
 
   testConfig = {
     services.fwupd.enable = true;
-    services.fwupd.blacklistPlugins = []; # don't blacklist test plugin
+    services.fwupd.blacklistPlugins = lib.mkForce []; # don't blacklist test plugin
     services.fwupd.enableTestRemote = true;
     virtualisation.memorySize = 768;
   };

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -1,4 +1,4 @@
-# Updating? Keep $out/etc synchronized with passthru.filesInstalledToEtc
+# Updating? Keep $out/etc synchronized with passthru keys
 
 { stdenv
 , fetchurl
@@ -272,6 +272,12 @@ stdenv.mkDerivation rec {
       "pki/fwupd-metadata/GPG-KEY-Linux-Foundation-Metadata"
       "pki/fwupd-metadata/GPG-KEY-Linux-Vendor-Firmware-Service"
       "pki/fwupd-metadata/LVFS-CA.pem"
+    ];
+
+    # BlacklistPlugins key in fwupd/daemon.conf
+    defaultBlacklistedPlugins = [
+      "test"
+      "invalid"
     ];
 
     tests = {

--- a/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
@@ -1,0 +1,37 @@
+diff --git a/libfwupdplugin/meson.build b/libfwupdplugin/meson.build
+index 0abcd45c..51cbc912 100644
+--- a/libfwupdplugin/meson.build
++++ b/libfwupdplugin/meson.build
+@@ -114,7 +114,8 @@
+   ],
+   link_args : vflag,
+   link_depends : fwupdplugin_mapfile,
+-  install : true
++  install : true,
++  install_dir : bindir / '..' / 'lib',
+ )
+ 
+ fwupdplugin_pkgg = import('pkgconfig')
+@@ -167,7 +168,8 @@
+       'GUsb-1.0',
+       fwupd_gir[0],
+     ],
+-    install : true
++    install : true,
++    install_dir_typelib : bindir / '..' / 'lib' / 'girepository-1.0',
+   )
+   gnome.generate_vapi('fwupdplugin',
+     sources : fwupd_gir[0],
+diff --git a/meson.build b/meson.build
+index b1a523d2..00125997 100644
+--- a/meson.build
++++ b/meson.build
+@@ -389,7 +389,7 @@
+ if host_machine.system() == 'windows'
+   plugin_dir = 'fwupd-plugins-3'
+ else
+-  plugin_dir = join_paths(libdir, 'fwupd-plugins-3')
++  plugin_dir = join_paths(bindir, '..', 'lib', 'fwupd-plugins-3')
+ endif
+ conf.set_quoted('FWUPD_PLUGINDIR', plugin_dir)
+ endif


### PR DESCRIPTION
In [1.3.5](https://github.com/NixOS/nixpkgs/pull/79309), fwupdprivate library was made into a shared fwupdplugin library. This library is considered semi-private and is used by fwupd daemon and fwupd plug-ins and now possibly third party plug-ins.

The fwupdplugin library refers to the plug-in directory in fwupd.out causing a dependency cycle. For that reason we need to move it to out.

- [x] `tests.fwupd` succeeded.
- [x] Rebuilt system with this.
    - [x] Daemon starts
        - [x] no weird journal entries
    - [x] `fwupdmgr get-devices` prints devices