### PR TITLE
php: add `buildEnv` function for additional config on the CLI SAPI

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -664,6 +664,8 @@ let
 
     doCheck = true;
     checkTarget = "test";
+
+    zendExtension = true;
   };
 
   yaml = buildPecl {


### PR DESCRIPTION
##### Motivation for this change

Initially discussed in #55460.

This patch adds a `withPackages` function to `php` that has the
following features:

* `php.buildEnv { extraConfig = /* ... */; }` to specify custom
  `php.ini` args for the CLI.

* `php.buildEnv { exts = phpPackages: [phpPackages.apcu] }` to
  create a PHP interpreter for the CLI with the `apcu` extension.

-----

Just realized that it isn't that simple to implement a completely generic wrapper for the PHP ecosystem. I intentionally didn't add any docs, at first I'd like to know if the direction is correct :) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
