### PR TITLE
handbrake: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -49,11 +49,11 @@ assert stdenv.isDarwin -> AudioToolbox != null && Foundation != null
 
 stdenv.mkDerivation rec {
   pname = "handbrake";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchurl {
-    url = ''https://download2.handbrake.fr/${version}/HandBrake-${version}-source.tar.bz2'';
-    sha256 = "15hxncswmaj62hb40fxixsa6d519zb712z9xbdq979q4rasjxa59";
+    url = ''https://download.handbrake.fr/releases/${version}/HandBrake-${version}-source.tar.bz2'';
+    sha256 = "09rcrq0kjs1lc1as7w3glbpbfvzldwpx3xv0pfmkn4pl7acxw1f0";
   };
 
   nativeBuildInputs = [
@@ -102,8 +102,6 @@ stdenv.mkDerivation rec {
   # NOTE: 2018-12-27: Check NixOS HandBrake test if changing
   NIX_LDFLAGS = toString [
     "-lx265"
-    # NOTE: The -ldl flag was fixed upstream for a release after 1.3.0
-    "-ldl"
   ];
 
   preBuild = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/j04a75bb47xq3zc43x78vkqbanw2l4ld-handbrake-1.3.0	 638.2M
/nix/store/12hv0y40c1fvx8gafh2h8l9kw22fla01-handbrake-1.3.1	 638.2M

**Note** The URL changed... Wouldn't it be better to fetch from github instead?