### PR TITLE
gnash: fix build with pangox-compat

### DIFF
--- a/pkgs/development/libraries/pango/1.43.nix
+++ b/pkgs/development/libraries/pango/1.43.nix
@@ -1,0 +1,88 @@
+{ stdenv, fetchurl, fetchpatch, pkgconfig, cairo, harfbuzz
+, libintl, gobject-introspection, darwin, fribidi, gnome3
+, gtk-doc, docbook_xsl, docbook_xml_dtd_43, makeFontsConf, freefont_ttf
+, meson, ninja, glib
+, x11Support? !stdenv.isDarwin, libXft
+}:
+
+with stdenv.lib;
+
+let
+  pname = "pango";
+  version = "1.43.0";
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    sha256 = "1lnxldmv1a12dq5h0dlq5jyzl4w75k76dp8cn360x2ijlm9w5h6j";
+  };
+
+  # FIXME: docs fail on darwin
+  outputs = [ "bin" "dev" "out" ] ++ optional (!stdenv.isDarwin) "devdoc";
+
+  nativeBuildInputs = [
+    meson ninja
+    pkgconfig gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_43
+  ];
+  buildInputs = [
+    harfbuzz fribidi
+  ] ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    ApplicationServices
+    Carbon
+    CoreGraphics
+    CoreText
+  ]);
+  propagatedBuildInputs = [ cairo glib libintl ] ++
+    optional x11Support libXft;
+
+  patches = [
+    (fetchpatch {
+      # Add gobject-2 to .pc file
+      url = "https://gitlab.gnome.org/GNOME/pango/commit/546f4c242d6f4fe312de3b7c918a848e5172e18d.patch";
+      sha256 = "1cqhy4xbwx3ad7z5d1ks7smf038b9as8c6qy84rml44h0fgiq4m2";
+    })
+    (fetchpatch {
+      # Fixes CVE-2019-1010238
+      url = "https://gitlab.gnome.org/GNOME/pango/commit/490f8979a260c16b1df055eab386345da18a2d54.diff";
+      sha256 = "1s0qclbaknkx3dkc3n6mlmx3fnhlr2pkncqjkywprpvahmmypr7k";
+    })
+  ];
+
+  mesonFlags = [
+    "-Denable_docs=${if stdenv.isDarwin then "false" else "true"}"
+  ];
+
+  enableParallelBuilding = true;
+
+  # Fontconfig error: Cannot load default config file
+  FONTCONFIG_FILE = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
+  };
+
+  doCheck = false; # /layout/valid-1.markup: FAIL
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "A library for laying out and rendering of text, with an emphasis on internationalization";
+
+    longDescription = ''
+      Pango is a library for laying out and rendering of text, with an
+      emphasis on internationalization.  Pango can be used anywhere
+      that text layout is needed, though most of the work on Pango so
+      far has been done in the context of the GTK widget toolkit.
+      Pango forms the core of text and font handling for GTK.
+    '';
+
+    homepage = https://www.pango.org/;
+    license = licenses.lgpl2Plus;
+
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/libraries/pangox-compat/default.nix
+++ b/pkgs/development/libraries/pangox-compat/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, glib, pango, libX11 }:
+
+stdenv.mkDerivation rec {
+  pname = "pangox-compat";
+  version = "0.0.2";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0ip0ziys6mrqqmz4n71ays0kf5cs1xflj1gfpvs4fgy2nsrr482m";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ glib pango libX11 ];
+
+  meta = {
+    description = "A compatibility library for pango>1.30.*";
+    homepage = "https://gitlab.gnome.org/Archive/pangox-compat";
+    license = stdenv.lib.licenses.lgpl2Plus;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/misc/gnash/default.nix
+++ b/pkgs/misc/gnash/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, fetchpatch, autoreconfHook
 , pkgconfig, libtool, boost, SDL
-, glib, pango, gettext, curl, xorg
+, glib, pangox_compat, gettext, curl, xorg
 , libpng, libjpeg, giflib, speex, atk
 
 # renderers
@@ -84,7 +84,7 @@ stdenv.mkDerivation {
   buildInputs = [
     glib gettext boost curl SDL speex
     xorg.libXmu xorg.libSM xorg.libXt
-    libpng libjpeg giflib pango atk
+    libpng libjpeg giflib pangox_compat atk
   ] ++ optional  enableAGG       agg
     ++ optional  enableCairo     cairo
     ++ optional  enableQt        qt4

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11777,7 +11777,7 @@ in
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
-  pangox_compat = callPackage ../development/libraries/pangox-compat { };
+  pangox_compat = callPackage ../development/libraries/pangox-compat { pango = pango_1_43; };
 
   gdata-sharp = callPackage ../development/libraries/gdata-sharp { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11767,6 +11767,8 @@ in
     harfbuzz = harfbuzz.override { withCoreText = stdenv.isDarwin; };
   };
 
+  pango_1_43 = callPackage ../development/libraries/pango/1.43.nix { };
+
   pangolin = callPackage ../development/libraries/pangolin {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11775,6 +11775,8 @@ in
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
+  pangox_compat = callPackage ../development/libraries/pangox-compat { };
+
   gdata-sharp = callPackage ../development/libraries/gdata-sharp { };
 
   gdk-pixbuf = callPackage ../development/libraries/gdk-pixbuf { };


### PR DESCRIPTION
###### Motivation for this change
So, this is far from ideal but it's the only way to fix the build.
Right know gnash is really the only viable solution to play swf files, so I think it's worth keeping it around.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (pangox-compat, gnash)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
