### PR TITLE
Revert "rsyslog: 8.1911.0 -> 8.2001.0"

### DIFF
--- a/pkgs/tools/system/rsyslog/default.nix
+++ b/pkgs/tools/system/rsyslog/default.nix
@@ -13,11 +13,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "rsyslog";
-  version = "8.2001.0";
+  version = "8.1911.0";
 
   src = fetchurl {
     url = "https://www.rsyslog.com/files/download/rsyslog/${pname}-${version}.tar.gz";
-    sha256 = "1nm83s9abknli46sknjs50cmdhhqzkznbsjspjbdg96likshdgsq";
+    sha256 = "01713vwz3w5fx9b97286h1rx9hxhjsdah96nyhh75bb23impgx71";
   };
 
   #patches = [ ./fix-gnutls-detection.patch ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#78824 since it blocks the unstable channel: https://github.com/NixOS/nixpkgs/issues/79304