### PR TITLE
pythonPackages.wordcloud: init at 1.6.0

### DIFF
--- a/pkgs/development/python-modules/wordcloud/default.nix
+++ b/pkgs/development/python-modules/wordcloud/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, codecov, coverage
+, flake8
+, matplotlib
+, mock
+, numpy
+, pillow
+, pytest
+, pytestcov
+, pytest-sugar
+, setuptools
+, twine
+, wheel
+}:
+  
+buildPythonPackage rec {
+  pname = "word_cloud";
+  version = "1.6.0";
+
+  # tests are not included in pypi tarball
+  src = fetchFromGitHub {
+    owner = "amueller";
+    repo = pname;
+    rev = version;
+    sha256 = "1ncjr90m3w3b4zi23kw6ai11gxahdyah96x8jb2yn2x4573022x2";
+  };
+
+  propagatedBuildInputs = [ matplotlib numpy pillow ];
+
+  # Tests require extra dependencies
+  checkInputs = [ codecov coverage flake8 mock pytest pytestcov pytest-sugar setuptools twine wheel ];
+  # skip tests which make assumptions about installation
+  checkPhase = ''
+    pytest -k 'not cli_as_executable'
+  '';
+  
+  meta = with stdenv.lib; {
+    description = "A little word cloud generator in Python";
+    homepage = "https://github.com/amueller/word_cloud";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jm2dev ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1473,6 +1473,8 @@ in {
 
   webapp2 = callPackage ../development/python-modules/webapp2 { };
 
+  wordcloud = callPackage ../development/python-modules/wordcloud { };
+  
   wrf-python = callPackage ../development/python-modules/wrf-python { };
 
   pyunbound = callPackage ../tools/networking/unbound/python.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
