### PR TITLE
prometheus: 2.14.0 -> 2.15.2

### DIFF
--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -1,13 +1,13 @@
 { lib, go, buildGoPackage, fetchFromGitHub, mkYarnPackage }:
 
 let
-  version = "2.14.0";
+  version = "2.15.2";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "prometheus";
     repo = "prometheus";
-    sha256 = "0zmxj78h3cnqbhsqab940hyzpim5i9r81b15a57f3dnrrd10p287";
+    sha256 = "0gl11qqbq57vkx226n8z4x07fwvly5f21y6dn20kjh2fxigmrb2n";
   };
 
   webui = mkYarnPackage {
@@ -57,12 +57,6 @@ in buildGoPackage rec {
     mkdir -p "$bin/share/doc/prometheus" "$bin/etc/prometheus"
     cp -a $src/documentation/* $bin/share/doc/prometheus
     cp -a $src/console_libraries $src/consoles $bin/etc/prometheus
-  '';
-
-  # Disable module-mode, because Go 1.13 automatically enables it if there is
-  # go.mod file. Remove after https://github.com/NixOS/nixpkgs/pull/73380
-  preCheck = ''
-    export GO111MODULE=off
   '';
 
   doCheck = true;

--- a/pkgs/servers/monitoring/prometheus/webui-yarndeps.nix
+++ b/pkgs/servers/monitoring/prometheus/webui-yarndeps.nix
@@ -11074,11 +11074,11 @@
       };
     }
     {
-      name = "typescript___typescript_3.6.4.tgz";
+      name = "typescript___typescript_3.7.2.tgz";
       path = fetchurl {
-        name = "typescript___typescript_3.6.4.tgz";
-        url  = "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz";
-        sha1 = "b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d";
+        name = "typescript___typescript_3.7.2.tgz";
+        url  = "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz";
+        sha1 = "27e489b95fa5909445e9fef5ee48d81697ad18fb";
       };
     }
     {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/prometheus/prometheus/releases/tag/v2.15.0
https://github.com/prometheus/prometheus/releases/tag/v2.15.1
https://github.com/prometheus/prometheus/releases/tag/v2.15.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

`nixpkgs/nixos/tests/prometheus.nix` pass OK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/79400)
<!-- Reviewable:end -->
