### PR TITLE
corerad: 0.1.9 -> 0.2.1

### DIFF
--- a/nixos/tests/corerad.nix
+++ b/nixos/tests/corerad.nix
@@ -17,7 +17,7 @@ import ./make-test-python.nix (
             configFile = pkgs.writeText "corerad.toml" ''
               [[interfaces]]
               name = "eth1"
-              send_advertisements = true
+              advertise = true
                 [[interfaces.prefix]]
                 prefix = "::/64"
             '';

--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -2,18 +2,16 @@
 
 buildGoModule rec {
   pname = "corerad";
-  version = "0.1.9";
-
-  goPackagePath = "github.com/mdlayher/corerad";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "mdlayher";
     repo = "corerad";
     rev = "v${version}";
-    sha256 = "1m23f318qr6b8c7hxrhihrm09pmdwab988k3bn4ygfm49z5phy4s";
+    sha256 = "04w77cahnphgd8b09a67dkrgx9jh8mvgjfjydj6drcw67v0d18c0";
   };
 
-  modSha256 = "0idlpkn6krs77akn3p6gxsbc8zpj1rnjkhhwmb8ns98x82g6bln0";
+  modSha256 = "0vbbpndqwwz1mc59j7liaayxaj53cs8s3javgj3pvhkn4vp65p7c";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mdlayher/corerad";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version bump and minor configuration change for CoreRAD and its NixOS module test. Same ideas as my previous PR: https://github.com/NixOS/nixpkgs/pull/78034.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Tests pass:

```
router # [   84.260566] corerad[762]: 2020/02/07 03:04:14 CoreRAD v0.2.0 (BETA) starting with configuration file "/nix/store/2sj89rv38pfp9a9zp4cbaimad3039qx9-corerad.toml"
router # [   84.716619] corerad[762]: 2020/02/07 03:04:15 eth1: "prefix": ::/64 [on-link, autonomous], preferred: 4h0m0s, valid: 24h0m0s
router # [   84.784834] corerad[762]: 2020/02/07 03:04:15 eth1: "lla": source link-layer address: 52:54:00:12:01:02
router # [   84.874558] corerad[762]: 2020/02/07 03:04:15 eth1: initialized, advertising from fe80::5054:ff:fe12:102
client: waiting for the VM to finish booting
client: connected to guest root shell
client: (connecting took 0.00 seconds)
(0.12 seconds)
client: waiting for success: ping -c 1 fd00:dead:beef:dead::1
(0.18 seconds)
(94.61 seconds)
Verify SLAAC on client
client: waiting for success: rdisc6 -1 -r 10 eth1
(0.63 seconds)
client: waiting for success: ip -6 addr show dev eth1 | grep -q 'fd00:dead:beef:dead:'
client # [   90.410541] systemd-logind[819]: New seat seat0.
client # [   90.455299] systemd-logind[819]: Watching system buttons on /dev/input/event2 (Power Button)
(0.36 seconds)
client: must succeed: ip -6 addr show dev eth1
(0.08 seconds)
2 out of 2 tests succeeded
test script finished in 97.47s
cleaning up
killing client (pid 9)
killing router (pid 21)
(0.01 seconds)
/nix/store/r30aymks0ks21v7g3hfa7q583a3ga00h-vm-test-run-unnamed
```

/cc @danderson @jonringer (thanks again for the reviews!)