### PR TITLE
terraform-provider-keycloak: init at 1.20.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -140,8 +140,9 @@ let
 
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
-    gandi = callPackage ./gandi {};
     elasticsearch = callPackage ./elasticsearch {};
+    gandi = callPackage ./gandi {};
+    keycloak = callPackage ./keycloak {};
     libvirt = callPackage ./libvirt {};
     lxd = callPackage ./lxd {};
     shell = callPackage ./shell {};

--- a/pkgs/applications/networking/cluster/terraform-providers/keycloak/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/keycloak/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, fetchFromGitHub
+, buildGoModule
+}:
+
+buildGoModule rec {
+  name = "terraform-provider-keycloak-${version}";
+  version = "1.20.0";
+
+  src = fetchFromGitHub {
+    owner = "mrparkers";
+    repo = "terraform-provider-keycloak";
+    rev = version;
+    sha256 = "1h8780k8345pf0s14k1pmwdjbv2j08h4rq3jwds81mmv6qgj1r2n";
+  };
+
+  vendorSha256 = "12iary7p5qsbl4xdhfd1wh92mvf2fiylnb3m1d3m7cdcn32rfimq";
+  postInstall = "mv $out/bin/terraform-provider-keycloak{,_v${version}}";
+
+  meta = with stdenv.lib; {
+    description = "Terraform provider for keycloak";
+    homepage = "https://github.com/mrparkers/terraform-provider-keycloak";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ eonpatapon ];
+  };
+
+}


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).