### PR TITLE
python3Packages.asyncssh: fix build

### DIFF
--- a/pkgs/development/python-modules/asyncssh/fix-sftp-chmod-test-nixos.patch
+++ b/pkgs/development/python-modules/asyncssh/fix-sftp-chmod-test-nixos.patch
@@ -1,14 +1,14 @@
 diff --git a/tests/test_sftp.py b/tests/test_sftp.py
-index db9cc88..234004b 100644
+index d94379f..4ee46a9 100644
 --- a/tests/test_sftp.py
 +++ b/tests/test_sftp.py
-@@ -957,8 +957,8 @@ class _TestSFTP(_CheckSFTP):
+@@ -955,8 +955,8 @@ class _TestSFTP(_CheckSFTP):
  
          try:
              self._create_file('file')
--            yield from sftp.chmod('file', 0o4321)
+-            await sftp.chmod('file', 0o4321)
 -            self.assertEqual(stat.S_IMODE(os.stat('file').st_mode), 0o4321)
-+            yield from sftp.chmod('file', 0o1234)
++            await sftp.chmod('file', 0o1234)
 +            self.assertEqual(stat.S_IMODE(os.stat('file').st_mode), 0o1234)
          finally:
              remove('file')


### PR DESCRIPTION
###### Motivation for this change

The test changed from `yield from` to `await`, which broke our patch.
Fix our patch.

Closes #79380

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

r? @worldofpeace 