### PR TITLE
tippecanoe: 1.34.3 -> 1.35.0

### DIFF
--- a/pkgs/applications/misc/tippecanoe/default.nix
+++ b/pkgs/applications/misc/tippecanoe/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tippecanoe";
-  version = "1.34.3";
+  version = "1.35.0";
 
   src = fetchFromGitHub {
     owner = "mapbox";
     repo = pname;
     rev = version;
-    sha256 = "08pkxzwp4w5phrk9b0vszxnx8yymp50v0bcw96pz8qwk48z4xm0i";
+    sha256 = "0v5ycc3gsqnl9pps3m45yrnb1gvw5pk6jdyr0q6516b4ac6x67m5";
   };
 
   buildInputs = [ sqlite zlib ];
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Build vector tilesets from large collections of GeoJSON features";
-    homepage = https://github.com/mapbox/tippecanoe;
+    homepage = "https://github.com/mapbox/tippecanoe";
     license = licenses.bsd2;
     maintainers = with maintainers; [ sikmir ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/mapbox/tippecanoe/releases/tag/1.35.0)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
$ nix path-info -Sh /nix/store/skcjlyw743xg9frzhfxrfrq0gx94gqml-tippecanoe-1.34.3
/nix/store/skcjlyw743xg9frzhfxrfrq0gx94gqml-tippecanoe-1.34.3	 35.6M
$  nix path-info -Sh ./result
/nix/store/i3m52yq62mkg8a648c7m5lmafv2nqm39-tippecanoe-1.35.0	 35.6M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
