### PR TITLE
spirv-cross: init at 2020-01-16

### DIFF
--- a/pkgs/tools/graphics/spirv-cross/default.nix
+++ b/pkgs/tools/graphics/spirv-cross/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, python3 }:
+
+stdenv.mkDerivation rec {
+  pname = "spirv-cross";
+  version = "2020-04-03";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "SPIRV-Cross";
+    rev = version;
+    sha256 = "0489s29kqgq20clxqg22y299yxz23p0yjh87yhka705hm9skx4sa";
+  };
+
+  nativeBuildInputs = [ cmake python3 ];
+
+  meta = with stdenv.lib; {
+    description = "A tool designed for parsing and converting SPIR-V to other shader languages";
+    homepage = "https://github.com/KhronosGroup/SPIRV-Cross";
+    platforms = platforms.linux;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Flakebi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14447,6 +14447,8 @@ in
 
   spice-up = callPackage ../applications/office/spice-up { };
 
+  spirv-cross = callPackage ../tools/graphics/spirv-cross { };
+
   sratom = callPackage ../development/libraries/audio/sratom { };
 
   srm = callPackage ../tools/security/srm { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add a package for SPIRV-Cross, a disassembler for SPIR-V to glsl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
