### PR TITLE
minc_tools: 2017-09-11 -> unstable-2019-12-04

### DIFF
--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -1,15 +1,17 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper, flex, bison, perlPackages, libminc, libjpeg, zlib }:
 
 stdenv.mkDerivation rec {
-  pname = "minc-tools";
-  name  = "${pname}-2017-09-11";
+  pname   = "minc-tools";
+  version = "unstable-2019-12-04";
 
   src = fetchFromGitHub {
     owner  = "BIC-MNI";
     repo   = pname;
-    rev    = "5b7c40425cd4f67a018055cb85c0157ee50a3056";
-    sha256 = "0zkcs05svp1gj5h0cdgc0k20c7lrk8m7wg3ks3xc5mkaiannj8g7";
+    rev    = "d4dddfdb4e4fa0cea389b8fdce51cfc076565d94";
+    sha256 = "1wwdss59qq4hz1jp35qylfswzzv0d37if23al0srnxkkgc5f8zng";
   };
+
+  patches = [ ./fix-netcdf-header.patch ];
 
   nativeBuildInputs = [ cmake flex bison makeWrapper ];
   buildInputs = [ libminc libjpeg zlib ];

--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, cmake, makeWrapper, flex, bison, perlPackages, libminc, libjpeg, zlib }:
+{ stdenv, fetchFromGitHub, cmake, makeWrapper, flex, bison, perl, TextFormat,
+  libminc, libjpeg, nifticlib, zlib }:
 
 stdenv.mkDerivation rec {
   pname   = "minc-tools";
@@ -15,9 +16,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake flex bison makeWrapper ];
   buildInputs = [ libminc libjpeg zlib ];
-  propagatedBuildInputs = with perlPackages; [ perl TextFormat ];
+  propagatedBuildInputs = [ perl TextFormat ];
 
-  cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" ];
+  cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/"
+                 "-DZNZ_INCLUDE_DIR=${nifticlib}/include/"
+                 "-DZNZ_LIBRARY=${nifticlib}/lib/libznz.a"
+                 "-DNIFTI_INCLUDE_DIR=${nifticlib}/include/nifti/"
+                 "-DNIFTI_LIBRARY=${nifticlib}/lib/libniftiio.a" ];
 
   postFixup = ''
     for prog in minccomplete minchistory mincpik; do

--- a/pkgs/applications/science/biology/minc-tools/fix-netcdf-header.patch
+++ b/pkgs/applications/science/biology/minc-tools/fix-netcdf-header.patch
@@ -1,0 +1,12 @@
+diff --git a/progs/mincdump/mincdump.h b/progs/mincdump/mincdump.h
+index 14c95cd..117ab26 100644
+--- a/progs/mincdump/mincdump.h
++++ b/progs/mincdump/mincdump.h
+@@ -3,6 +3,7 @@
+  *   See netcdf/COPYRIGHT file for copying and redistribution conditions.
+  *   $Header: /private-cvsroot/minc/progs/mincdump/mincdump.h,v 1.1 2004-04-27 15:35:15 bert Exp $
+  *********************************************************************/
++#include <netcdf_meta.h>
+ 
+ 
+ /* error checking macro */

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23898,7 +23898,9 @@ in
 
   messer-slim = callPackage ../applications/science/biology/messer-slim { };
 
-  minc_tools = callPackage ../applications/science/biology/minc-tools { };
+  minc_tools = callPackage ../applications/science/biology/minc-tools {
+    inherit (perlPackages) perl TextFormat;
+  };
 
   minc_widgets = callPackage ../applications/science/biology/minc-widgets { };
 


### PR DESCRIPTION
and enable building conversion tools (mnc<->nii, etc.)
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Enable building some additional tools and bump to latest unstable version (for bugfixes in those tools).  Based on rebasing #76107.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
