### PR TITLE
aws-sam-cli: disable telemetry

### DIFF
--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -1,5 +1,6 @@
 { lib
 , python
+, enableTelemetry ? false
 }:
 
 let
@@ -83,7 +84,7 @@ buildPythonApplication rec {
     tomlkit
   ];
 
-  postFixup = ''
+  postFixup = if enableTelemetry then "echo aws-sam-cli TELEMETRY IS ENABLED" else ''
     # Disable telemetry: https://github.com/awslabs/aws-sam-cli/issues/1272
     wrapProgram $out/bin/sam --set  SAM_CLI_TELEMETRY 0
   '';

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -83,6 +83,11 @@ buildPythonApplication rec {
     tomlkit
   ];
 
+  postFixup = ''
+    # Disable telemetry: https://github.com/awslabs/aws-sam-cli/issues/1272
+    wrapProgram $out/bin/sam --set  SAM_CLI_TELEMETRY 0
+  '';
+
   # fix over-restrictive version bounds
   postPatch = ''
     substituteInPlace requirements/base.txt \


### PR DESCRIPTION
###### Motivation for this change

Since v0.19.0 aws-sam-cli sends telemetry data to AWS[1]. To protect the users'
privacy, we opt-out by default.

[1] https://github.com/awslabs/aws-sam-cli/issues/1272

Cc maintainers @andreabedini @dhl 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
