### PR TITLE
opencorsairlink: init at 2019-12-23

### DIFF
--- a/pkgs/tools/misc/opencorsairlink/default.nix
+++ b/pkgs/tools/misc/opencorsairlink/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, libusb1, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "OpenCorsairLink-${version}";
+  version = "2019-12-23";
+
+  buildInputs = [ libusb1 ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  src = fetchFromGitHub {
+    owner = "audiohacked";
+    repo = "OpenCorsairLink";
+    rev = "46dbf206e19a40d6de6bd73142ed93bdb26c5c1a";
+    sha256 = "1nizicl0mc9pslc6065mnrs0fnn8sh7ca8iiw7w9ix57zrhabpld";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Linux and Mac OS support for the CorsairLink Devices ";
+    homepage = "https://github.com/audiohacked/OpenCorsairLink";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = [ stdenv.lib.maintainers.expipiplus1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5418,6 +5418,8 @@ in
 
   ocserv = callPackage ../tools/networking/ocserv { };
 
+  opencorsairlink = callPackage ../tools/misc/opencorsairlink { };
+
   openfortivpn = callPackage ../tools/networking/openfortivpn { };
 
   obexfs = callPackage ../tools/bluetooth/obexfs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).