### PR TITLE
alure2: unstable-2020-01-09 -> unstable-2020-02-06

### DIFF
--- a/pkgs/development/libraries/alure2/default.nix
+++ b/pkgs/development/libraries/alure2/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "alure2";
-  version = "unstable-2020-01-09";
+  version = "unstable-2020-02-06";
 
   src = fetchFromGitHub {
     owner = "kcat";
     repo = "alure";
-    rev = "4b7b58d3f0de444d6f26aa705704deb59145f586";
-    sha256 = "0ds18hhy2wpvx498z5hcpzfqz9i60ixsi0cjihyvk20rf4qy12vg";
+    rev = "50f92fe528e77da82197fd947d1cf9b0a82a0c7d";
+    sha256 = "1gmc1yfhwaj6lik0vn7zv8y23i05f4rw25v2jg34n856jcs02svx";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
The newer version have better exceptions

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
