### PR TITLE
gi-gdkx11: restrict to versions below 4

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -69,6 +69,9 @@ core-packages:
 default-package-overrides:
   # pandoc-2.9 does not accept the 0.3 version yet
   - doclayout < 0.3
+  # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
+  # not yet available in Nixpkgs
+  - gi-gdkx11 < 4
   # LTS Haskell 14.23
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
@@ -5068,7 +5071,6 @@ broken-packages:
   - ghcprofview
   - ght
   - gi-cairo-again
-  - gi-gdkx11
   - gi-graphene
   - gi-gsk
   - gi-gstpbutils


### PR DESCRIPTION
###### Motivation for this change

...because later versions depend on gtk4 which is not provided

Fixes #77588

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
