### PR TITLE
goldendict: enable on darwin

### DIFF
--- a/pkgs/applications/misc/goldendict/0001-dont-check-for-updates.patch
+++ b/pkgs/applications/misc/goldendict/0001-dont-check-for-updates.patch
@@ -1,0 +1,49 @@
+diff --git i/config.cc w/config.cc
+index 04b63f5..7a453d9 100644
+--- i/config.cc
++++ w/config.cc
+@@ -182,7 +182,7 @@ Preferences::Preferences():
+   pronounceOnLoadPopup( false ),
+   useInternalPlayer( InternalPlayerBackend::anyAvailable() ),
+   internalPlayerBackend( InternalPlayerBackend::defaultBackend() ),
+-  checkForNewReleases( true ),
++  checkForNewReleases( false ),
+   disallowContentFromOtherSites( false ),
+   enableWebPlugins( false ),
+   hideGoldenDictHeader( false ),
+@@ -867,8 +867,8 @@ Class load() THROW_SPEC( exError )
+       c.preferences.proxyServer.systemProxyPassword = proxy.namedItem( "systemProxyPassword" ).toElement().text();
+     }
+ 
+-    if ( !preferences.namedItem( "checkForNewReleases" ).isNull() )
+-      c.preferences.checkForNewReleases = ( preferences.namedItem( "checkForNewReleases" ).toElement().text() == "1" );
++    //if ( !preferences.namedItem( "checkForNewReleases" ).isNull() )
++    //  c.preferences.checkForNewReleases = ( preferences.namedItem( "checkForNewReleases" ).toElement().text() == "1" );
+ 
+     if ( !preferences.namedItem( "disallowContentFromOtherSites" ).isNull() )
+       c.preferences.disallowContentFromOtherSites = ( preferences.namedItem( "disallowContentFromOtherSites" ).toElement().text() == "1" );
+@@ -1819,9 +1819,9 @@ void save( Class const & c ) THROW_SPEC( exError )
+       proxy.appendChild( opt );
+     }
+ 
+-    opt = dd.createElement( "checkForNewReleases" );
+-    opt.appendChild( dd.createTextNode( c.preferences.checkForNewReleases ? "1" : "0" ) );
+-    preferences.appendChild( opt );
++    //opt = dd.createElement( "checkForNewReleases" );
++    //opt.appendChild( dd.createTextNode( c.preferences.checkForNewReleases ? "1" : "0" ) );
++    //preferences.appendChild( opt );
+ 
+     opt = dd.createElement( "disallowContentFromOtherSites" );
+     opt.appendChild( dd.createTextNode( c.preferences.disallowContentFromOtherSites ? "1" : "0" ) );
+diff --git i/preferences.cc w/preferences.cc
+index 72c3147..7e48f00 100644
+--- i/preferences.cc
++++ w/preferences.cc
+@@ -314,6 +314,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
+            this, SLOT( customProxyToggled( bool ) ) );
+ 
+   ui.checkForNewReleases->setChecked( p.checkForNewReleases );
++  ui.checkForNewReleases->setEnabled( false );
+   ui.disallowContentFromOtherSites->setChecked( p.disallowContentFromOtherSites );
+   ui.enableWebPlugins->setChecked( p.enableWebPlugins );
+   ui.hideGoldenDictHeader->setChecked( p.hideGoldenDictHeader );

--- a/pkgs/applications/misc/goldendict/0001-dont-use-maclibs.patch
+++ b/pkgs/applications/misc/goldendict/0001-dont-use-maclibs.patch
@@ -1,0 +1,62 @@
+diff --git i/goldendict.pro w/goldendict.pro
+index 328dc20..5202a07 100644
+--- i/goldendict.pro
++++ w/goldendict.pro
+@@ -210,21 +210,18 @@ mac {
+         -llzo2
+     !CONFIG( no_ffmpeg_player ) {
+         LIBS += -lao \
+-            -lavutil-gd \
+-            -lavformat-gd \
+-            -lavcodec-gd
++            -lavutil \
++            -lavformat \
++            -lavcodec
+     }
+-    INCLUDEPATH = $${PWD}/maclibs/include
+-    LIBS += -L$${PWD}/maclibs/lib -framework AppKit -framework Carbon
++    LIBS += -framework AppKit -framework Carbon
+     OBJECTIVE_SOURCES += lionsupport.mm \
+                          machotkeywrapper.mm \
+                          macmouseover.mm \
+                          speechclient_mac.mm
+     ICON = icons/macicon.icns
+     QMAKE_INFO_PLIST = myInfo.plist
+-    QMAKE_POST_LINK = mkdir -p GoldenDict.app/Contents/Frameworks & \
+-                      cp -nR $${PWD}/maclibs/lib/ GoldenDict.app/Contents/Frameworks/ & \
+-                      mkdir -p GoldenDict.app/Contents/MacOS/locale & \
++    QMAKE_POST_LINK = mkdir -p GoldenDict.app/Contents/MacOS/locale & \
+                       cp -R locale/*.qm GoldenDict.app/Contents/MacOS/locale/ & \
+                       mkdir -p GoldenDict.app/Contents/MacOS/help & \
+                       cp -R $${PWD}/help/*.qch GoldenDict.app/Contents/MacOS/help/
+@@ -232,15 +229,6 @@ mac {
+     CONFIG += zim_support
+     !CONFIG( no_chinese_conversion_support ) {
+         CONFIG += chinese_conversion_support
+-        CONFIG( x86 ) {
+-            QMAKE_POST_LINK += & mkdir -p GoldenDict.app/Contents/MacOS/opencc & \
+-                                 cp -R $${PWD}/opencc/*.json GoldenDict.app/Contents/MacOS/opencc/ & \
+-                                 cp -R $${PWD}/opencc/*.ocd GoldenDict.app/Contents/MacOS/opencc/
+-        } else {
+-            QMAKE_POST_LINK += & mkdir -p GoldenDict.app/Contents/MacOS/opencc & \
+-                                 cp -R $${PWD}/opencc/x64/*.json GoldenDict.app/Contents/MacOS/opencc/ & \
+-                                 cp -R $${PWD}/opencc/x64/*.ocd GoldenDict.app/Contents/MacOS/opencc/
+-        }
+     }
+ }
+ DEFINES += PROGRAM_VERSION=\\\"$$VERSION\\\"
+diff --git i/tiff.cc w/tiff.cc
+index e3cb8bf..9ff880f 100644
+--- i/tiff.cc
++++ w/tiff.cc
+@@ -6,8 +6,8 @@
+ #include "tiff.hh"
+ 
+ #if defined (Q_OS_MAC) || defined (Q_OS_WIN)
+-#include "tiff/tiff.h"
+-#include "tiff/tiffio.h"
++#include "tiff.h"
++#include "tiffio.h"
+ #else
+ #include "tiff.h"
+ #include "tiffio.h"

--- a/pkgs/applications/misc/goldendict/default.nix
+++ b/pkgs/applications/misc/goldendict/default.nix
@@ -1,33 +1,68 @@
-{ mkDerivation, lib, fetchFromGitHub, pkgconfig, libXtst, libvorbis, hunspell
-, libao, ffmpeg, libeb, lzo, xz, libtiff, opencc
-, qtbase, qtsvg, qtwebkit, qtx11extras, qttools, qmake }:
-mkDerivation {
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig
+, libXtst, libvorbis, hunspell, lzo, xz, bzip2, libiconv
+, qtbase, qtsvg, qtwebkit, qtx11extras, qttools, qmake
+, withCC ? true, opencc
+, withEpwing ? true, libeb
+, withExtraTiff ? true, libtiff
+, withFFmpeg ? true, libao, ffmpeg
+, withMultimedia ? true
+, withZim ? true }:
 
-  name = "goldendict-2019-08-01";
+mkDerivation rec {
+  pname = "goldendict";
+  version = "2020-01-09";
+
   src = fetchFromGitHub {
     owner = "goldendict";
-    repo = "goldendict";
-    rev = "0f951b06a55f3a201891cf645a556e773bda5f52";
-    sha256 = "1d1hn95vhvsmbq9q96l5adn90g0hg25dl01knb4y4v6v9x4yrl2x";
+    repo = pname;
+    rev = "da197ff5cd0e7326124c9240a1853a0e8b1de439";
+    sha256 = "0dlzwjh9wg4bzhhib71jycpp21qw762ww63a37dd50z1ymi61lxc";
   };
+
+  patches = [
+    ./0001-dont-check-for-updates.patch
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    ./0001-dont-use-maclibs.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace goldendict.pro \
+      --replace "hunspell-1.6.1" "hunspell-${stdenv.lib.versions.majorMinor hunspell.version}"
+  '';
 
   nativeBuildInputs = [ pkgconfig qmake ];
   buildInputs = [
-    qtbase qtsvg qtwebkit qtx11extras qttools
-    libXtst libvorbis hunspell libao ffmpeg libeb lzo xz libtiff opencc
-  ];
+    qtbase qtsvg qtwebkit qttools
+    libvorbis hunspell xz lzo
+  ] ++ stdenv.lib.optionals stdenv.isLinux [ qtx11extras libXtst ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ bzip2 libiconv ]
+    ++ stdenv.lib.optional withCC opencc
+    ++ stdenv.lib.optional withEpwing libeb
+    ++ stdenv.lib.optional withExtraTiff libtiff
+    ++ stdenv.lib.optionals withFFmpeg [ libao ffmpeg ];
 
-  qmakeFlags = [
+  qmakeFlags = with stdenv.lib; [
     "goldendict.pro"
-    "CONFIG+=zim_support"
-    "CONFIG+=chinese_conversion_support"
+    (optional withCC "CONFIG+=chinese_conversion_support")
+    (optional (!withCC) "CONFIG+=no_chinese_conversion_support")
+    (optional (!withEpwing) "CONFIG+=no_epwing_support")
+    (optional (!withExtraTiff) "CONFIG+=no_extra_tiff_handler")
+    (optional (!withFFmpeg) "CONFIG+=no_ffmpeg_player")
+    (optional (!withMultimedia)"CONFIG+=no_qtmultimedia_player")
+    (optional withZim "CONFIG+=zim_support")
   ];
 
-  meta = with lib; {
-    homepage = http://goldendict.org/;
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv GoldenDict.app $out/Applications
+    wrapQtApp $out/Applications/GoldenDict.app/Contents/MacOS/GoldenDict
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://goldendict.org/";
     description = "A feature-rich dictionary lookup program";
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ gebner astsmtl ];
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ gebner astsmtl sikmir ];
     license = licenses.gpl3Plus;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19033,7 +19033,9 @@ in
 
   gr-osmosdr = callPackage ../applications/radio/gnuradio/osmosdr.nix { };
 
-  goldendict = libsForQt5.callPackage ../applications/misc/goldendict { };
+  goldendict = libsForQt5.callPackage ../applications/misc/goldendict {
+    inherit (darwin) libiconv;
+  };
 
   gomuks = callPackage ../applications/networking/instant-messengers/gomuks { };
 


### PR DESCRIPTION
###### Motivation for this change
* :exclamation: Enable on Darwin
* Update 2019-08-01 -> 2020-01-09 ([diff](https://github.com/goldendict/goldendict/compare/0f951b06a55f3a201891cf645a556e773bda5f52...da197ff5cd0e7326124c9240a1853a0e8b1de439))
* Disable checking for new release
* Added options: `withCC, withEpwing, withExtraTiff, withFFmpeg, withMultimedia, withZim`

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
