### PR TITLE
haskellPackages.http-streams: mark not broken

### DIFF
--- a/pkgs/applications/networking/esniper/default.nix
+++ b/pkgs/applications/networking/esniper/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchgit, openssl, curl, coreutils, gawk, bash, which }:
 
 stdenv.mkDerivation {
-  name = "esniper-2.35.0-18-g4a59da0";
+  name = "esniper-2.35.0-21-g6379846";
 
   src = fetchgit {
     url    = "https://git.code.sf.net/p/esniper/git";
-    rev    = "4a59da032aa4536b9e5ea95633247650412511db";
-    sha256 = "0d3vazh5q7wymqahggbb2apl9hgrm037y4s3j91d24hjgk2pzzyd";
+    rev    = "637984623984ef36782d52d8968df7fae7bbb0a7";
+    sha256 = "1md3fzs0k88f6mgvrj1yrh96mn0qlca2p6vfqj6dnpyb8pjjwp8w";
   };
 
   buildInputs = [ openssl curl ];

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1398,4 +1398,9 @@ self: super: {
     HsYAML = self.HsYAML_0_2_1_0;
   };
 
+  # it depends on HsYAML >=0.2.0 && < 0.3, so use 0.2.1.0
+  stylish-haskell = super.stylish-haskell.override {
+    HsYAML = self.HsYAML_0_2_1_0;
+  };
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1393,4 +1393,9 @@ self: super: {
   # See https://github.com/ekmett/perhaps/pull/5
   perhaps = doJailbreak super.perhaps;
 
+  # it depends on HsYAML >=0.2.0 && < 0.3, so use 0.2.1.0
+  HsYAML-aeson = super.HsYAML-aeson.override {
+    HsYAML = self.HsYAML_0_2_1_0;
+  };
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6245,7 +6245,6 @@ broken-packages:
   - http-querystring
   - http-response-decoder
   - http-shed
-  - http-streams
   - http-wget
   - http2-client
   - http2-client-exe

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9388,7 +9388,6 @@ broken-packages:
   - structures
   - stt
   - stunts
-  - stylish-haskell
   - stylist
   - stylized
   - suavemente

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6204,7 +6204,6 @@ broken-packages:
   - hsx-xhtml
   - hsx2hs
   - hsXenCtrl
-  - HsYAML-aeson
   - hsyscall
   - hsyslog-tcp
   - hsyslog-udp


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).