### PR TITLE
qttools: Add qtdeclarative to buildInputs

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -4,7 +4,7 @@ with lib;
 
 qtModule {
   name = "qttools";
-  qtInputs = [ qtbase ];
+  qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 
   # fixQtBuiltinPaths overwrites a builtin path we should keep


### PR DESCRIPTION
qtdeclarative is an optional dependency for some parts of qttools:
without it, the lupdate binary is not able to process qml files for
translatable strings.

###### Motivation for this change

I tried to run lupdate on some qml files and it did nothing and output the following warning:
```
warning: Some files have been ignored due to missing qml/javascript support
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
