### PR TITLE
nixos/unbound: add enableRemoteAccess option

### DIFF
--- a/nixos/modules/services/networking/unbound.nix
+++ b/nixos/modules/services/networking/unbound.nix
@@ -14,6 +14,18 @@ let
 
   isLocalAddress = x: substring 0 3 x == "::1" || substring 0 9 x == "127.0.0.1";
 
+  remote =
+    optionalString (cfg.enableRemoteAccess) ''
+    remote-control:
+      control-enable: "yes"
+      server-key-file: ${stateDir}/unbound_server.key
+      server-cert-file: ${stateDir}/unbound_server.pem
+      control-key-file: ${stateDir}/unbound_control.key
+      control-cert-file: ${stateDir}/unbound_control.pem
+      control-port: ${toString cfg.remoteAccessPort}
+      ${concatMapStringsSep "\n  " (x: "control-interface: ${x}") cfg.remoteAccessInterfaces}
+    '';
+
   forward =
     optionalString (any isLocalAddress cfg.forwardAddresses) ''
       do-not-query-localhost: no
@@ -29,6 +41,22 @@ let
   trustAnchor = optionalString cfg.enableRootTrustAnchor
     "auto-trust-anchor-file: ${rootTrustAnchorFile}";
 
+  unboundWrapped = pkgs.stdenv.mkDerivation {
+      name = "unbound-wrapped";
+
+      buildInputs = [ pkgs.makeWrapper pkgs.unbound ];
+
+      phases = [ "installPhase" ];
+
+      installPhase = ''
+        mkdir -p "$out/bin"
+        makeWrapper ${pkgs.unbound}/bin/unbound-control $out/bin/unbound-control \
+          --add-flags "-c ${stateDir}/unbound.conf"
+        makeWrapper ${pkgs.unbound}/bin/unbound-checkconf $out/bin/unbound-checkconf \
+          --add-flags "${stateDir}/unbound.conf"
+      '';
+    };
+
   confFile = pkgs.writeText "unbound.conf" ''
     server:
       directory: "${stateDir}"
@@ -40,6 +68,7 @@ let
       ${trustAnchor}
     ${cfg.extraConfig}
     ${forward}
+    ${remote}
   '';
 
 in
@@ -94,6 +123,37 @@ in
         '';
       };
 
+      enableRemoteAccess = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Sets the remote-control option to 'yes' in the config and generates keys + certificates under ${stateDir}
+          with <literal>unbound-control-setup</literal>.
+          Sets the default addresses to <literal>127.0.0.1</literal> <literal>::1</literal> and port <literal>8953</literal>.
+          Interfaces the server listens to can be set with <literal>remoteAccessInterfaces</literal>.
+          The port can be set with <literal>remoteAccessPort</literal>.
+          NOTE: This option doesn't open any ports.
+        '';
+      };
+
+      remoteAccessInterfaces = mkOption {
+        default = [ "127.0.0.1" ] ++ optional config.networking.enableIPv6 "::1";
+        type = types.listOf types.str;
+        description = ''
+          What addresses/interfaces are allowed to remote-control the unbound server.
+          Requires <literal>enableRemoteAccess</literal> set to true.
+        '';
+      };
+
+      remoteAccessPort = mkOption {
+        default = 8953;
+        type = types.port;
+        description = ''
+          What port the unbound server will listen on for remote-control.
+          Requires <literal>enableRemoteAccess</literal> set to true.
+        '';
+      };
+
     };
   };
 
@@ -101,7 +161,7 @@ in
 
   config = mkIf cfg.enable {
 
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package (hiPrio unboundWrapped) ];
 
     users.users.unbound = {
       description = "unbound daemon user";
@@ -117,6 +177,8 @@ in
       wants = [ "nss-lookup.target" ];
       wantedBy = [ "multi-user.target" ];
 
+      path = mkIf cfg.enableRemoteAccess [ pkgs.openssl ];
+
       preStart = ''
         mkdir -m 0755 -p ${stateDir}/dev/
         cp ${confFile} ${stateDir}/unbound.conf
@@ -126,11 +188,12 @@ in
         ''}
         touch ${stateDir}/dev/random
         ${pkgs.utillinux}/bin/mount --bind -n /dev/urandom ${stateDir}/dev/random
+        ${optionalString cfg.enableRemoteAccess "${pkgs.unbound}/bin/unbound-control-setup -d ${stateDir}"}
       '';
 
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/unbound -d -c ${stateDir}/unbound.conf";
-        ExecStopPost="${pkgs.utillinux}/bin/umount ${stateDir}/dev/random";
+        ExecStopPost = "${pkgs.utillinux}/bin/umount ${stateDir}/dev/random";
 
         ProtectSystem = true;
         ProtectHome = true;


### PR DESCRIPTION
###### Motivation for this change

`unbound-control` which is installed with package `unbound` when activating the module wasn't able to access the server because it was looking for the config file in /etc so I thought I'd make options to enable this more easily. 

###### Things done

* Implemented an option `enableRemoteAccess`, an option that sets remote-control setting to true in unbound.conf
* The option also generates key + certificate and listens to `127.0.0.1` and `::1` by default. The interface + port can be altered with the other options `remoteAccessInterfaces` and `remoteAccessPort` for remote access.
* Wrapped `unbound-control` and `unbound-checkconf` so it points to the config file in `stateDir` instead of the packages default configuration dir in /etc
  * I don't know if that's what [these lines](https://github.com/NixOS/nixpkgs/blob/c704c07ff17d95a358e315c2ffd5ad2732f47b47/pkgs/tools/networking/unbound/default.nix#L52-L54) are supposed to do. Somehow `unbound-anchor` say the default dir for root key fil is under /nix/store


###### Thoughts

I added the wrapping to systemPackages because I added `unbound-checkconf` to the wrapping.
I could change [this](https://github.com/NixOS/nixpkgs/compare/master...kraem:nixos/unbound?expand=1#diff-af0e676aa026493eac8384bd688abbdfR164) to
```
    environment.systemPackages = [ cfg.package ] 
      ++ optionals cfg.enableRemoteAccess [ (hiPrio unboundWrapped) ];
```
if that's better.

**I am happy for pointers and tips** of course :) 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
###### Checkboxes
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
