### PR TITLE
opencc: enable on darwin

### DIFF
--- a/pkgs/tools/text/opencc/default.nix
+++ b/pkgs/tools/text/opencc/default.nix
@@ -1,24 +1,30 @@
-{ stdenv, fetchurl, cmake, python }:
+{ stdenv, fetchFromGitHub, cmake, python }:
 
-stdenv.mkDerivation {
-  name = "opencc-1.0.5";
-  src = fetchurl {
-    url = "https://github.com/BYVoid/OpenCC/archive/ver.1.0.5.tar.gz";
-    sha256 = "1ce1649ba280cfc88bb76e740be5f54b29a9c034400c97a3ae211c37d7030705";
+stdenv.mkDerivation rec {
+  pname = "opencc";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "BYVoid";
+    repo = "OpenCC";
+    rev = "ver.${version}";
+    sha256 = "1pv5md225qwhbn8ql932zdg6gh1qlx3paiajaks8gfsa07yzvhr4";
   };
 
-  buildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python ];
 
-  preBuild = ''
-    # let intermediate tools find intermediate library
+  # let intermediate tools find intermediate library
+  preBuild = stdenv.lib.optionalString stdenv.isLinux ''
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$(pwd)/src
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$(pwd)/src
   '';
 
   # Parallel building occasionaly fails with: Error copying file "/tmp/nix-build-opencc-1.0.5.drv-0/OpenCC-ver.1.0.5/build/src/libopencc.so.1.0.0" to "/tmp/nix-build-opencc-1.0.5.drv-0/OpenCC-ver.1.0.5/build/src/tools".
   enableParallelBuilding = false;
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/BYVoid/OpenCC;
+    homepage = "https://github.com/BYVoid/OpenCC";
     license = licenses.asl20;
     description = "A project for conversion between Traditional and Simplified Chinese";
     longDescription = ''
@@ -27,7 +33,7 @@ stdenv.mkDerivation {
       phrase-level conversion, variant conversion and regional idioms among Mainland China,
       Taiwan and Hong kong.
     '';
-    maintainers = [ maintainers.sifmelcara ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ sifmelcara ];
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Enable on Darwin.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
