### PR TITLE
Update EDA tools

### DIFF
--- a/pkgs/applications/science/logic/symbiyosys/default.nix
+++ b/pkgs/applications/science/logic/symbiyosys/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "symbiyosys";
-  version = "2019.10.11";
+  version = "2020.02.08";
 
   src = fetchFromGitHub {
-    owner  = "yosyshq";
-    repo   = "symbiyosys";
-    rev    = "23f89011b678daa9da406d4f45f790e45f8f68ca";
-    sha256 = "01596yvfj79iywwczjwlb2l9qnh7bsj7jff66jdk1ybjnxf841f0";
+    owner  = "YosysHQ";
+    repo   = "SymbiYosys";
+    rev    = "500b526131f434b9679732fc89515dbed67c8d7d";
+    sha256 = "1pwbirszc80r288x81nx032snniqgmc80i09bbha2i3zd0c3pj5h";
   };
 
   buildInputs = [ python3 yosys ];

--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -14,14 +14,14 @@ let
 in
 with stdenv; mkDerivation rec {
   pname = "nextpnr";
-  version = "2019.10.13";
+  version = "2020.02.04";
 
   srcs = [
     (fetchFromGitHub {
       owner  = "YosysHQ";
       repo   = "nextpnr";
-      rev    = "c365dd1cabc3a4308ab9110534918623622c246b";
-      sha256 = "1344pyq9xb5y1vxsnfgr488drfjsa6ls1jck0z9hwam6vg55s10r";
+      rev    = "ca733561873cd54be047ae30a94efcd71b3f8be5";
+      sha256 = "176drrq6w53qbwmnksa1b22w9qz3gd1db9hy2lyv8svbcdxd9qwp";
       name   = "nextpnr";
     })
     (fetchFromGitHub {
@@ -45,10 +45,11 @@ with stdenv; mkDerivation rec {
 
   enableParallelBuilding = true;
   cmakeFlags =
-    [ "-DARCH=generic;ice40;ecp5"
+    [ "-DCURRENT_GIT_VERSION=${lib.substring 0 7 (lib.elemAt srcs 0).rev}"
+      "-DARCH=generic;ice40;ecp5"
       "-DBUILD_TESTS=ON"
       "-DICEBOX_ROOT=${icestorm}/share/icebox"
-      "-DTRELLIS_ROOT=${trellis}/share/trellis"
+      "-DTRELLIS_INSTALL_PREFIX=${trellis}"
       "-DPYTRELLIS_LIBDIR=${trellis}/lib/trellis"
       "-DUSE_OPENMP=ON"
       # warning: high RAM usage
@@ -58,12 +59,7 @@ with stdenv; mkDerivation rec {
     ++ (lib.optional (enableGui && stdenv.isDarwin)
         "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks");
 
-  # Fix the version number. This is a bit stupid (and fragile) in practice
-  # but works ok. We should probably make this overrideable upstream.
   patchPhase = with builtins; ''
-    substituteInPlace ./CMakeLists.txt \
-      --replace 'git log -1 --format=%h' 'echo ${substring 0 11 (elemAt srcs 0).rev}'
-
     # use PyPy for icestorm if enabled
     substituteInPlace ./ice40/family.cmake \
       --replace ''\'''${PYTHON_EXECUTABLE}' '${icestorm.pythonInterp}'

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -15,14 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "yosys";
-  version = "2020.02.01";
+  version = "2020.02.07";
 
   src = fetchFromGitHub {
-    owner  = "yosyshq";
+    owner  = "YosysHQ";
     repo   = "yosys";
-    rev    = "a1c840ca5d6e8b580e21ae48550570aa9665741a";
-    sha256 = "1vna04dh6l68nifssgs3hxqwn4k529krmm4crj94a8wwhwra52mh";
-    name   = "yosys";
+    rev    = "2e8d6ec0b06b4e51e222c15c8049130bc264ae57";
+    sha256 = "0asnqhxs5r5r2xmvsk9pbgyqgk53j1snh7c9qizcppn4csapda81";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage {
   pname = "fx2";
-  version = "unstable-2019-09-23";
+  version = "unstable-2020-01-25";
 
   src = fetchFromGitHub {
     owner = "whitequark";
     repo = "libfx2";
-    rev = "3adb4fc842f174b0686ed122c0309d68356edc11";
-    sha256 = "0b3zp50mschsxi2v3192dmnpw32gwblyl8aswlz9a0vx1qg3ibzn";
+    rev = "d3e37f640d706aac5e69ae4476f6cd1bd0cd6a4e";
+    sha256 = "1dsyknjpgf4wjkfr64lln1lcy7qpxdx5x3qglidrcswzv9b3i4fg";
   };
 
   nativeBuildInputs = [ sdcc ];

--- a/pkgs/development/python-modules/glasgow/default.nix
+++ b/pkgs/development/python-modules/glasgow/default.nix
@@ -18,15 +18,15 @@
 
 buildPythonPackage rec {
   pname = "glasgow";
-  version = "unstable-2019-10-16";
+  version = "unstable-2020-02-08";
   # python software/setup.py --version
-  realVersion = "0.1.dev1286+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.1.dev1352+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "GlasgowEmbedded";
     repo = "glasgow";
-    rev = "4f968dbe6cf4e9d8e2d0a5163d82e996c24d5e30";
-    sha256 = "1b50n12dc0b3jmim5ywg7daq62k5j4wkgmwzk88ric5ri3b8dl2r";
+    rev = "2a8bfc981b90ba5d86c310911dbd6ffe71acd498";
+    sha256 = "01v5269bv09ggvmq6lqyhr5am51hzmwya1p5n62h84b7rdwd8q9m";
   };
 
   nativeBuildInputs = [ setuptools_scm sdcc ];
@@ -44,6 +44,8 @@ buildPythonPackage rec {
 
   checkInputs = [ yosys icestorm nextpnr ];
 
+  enableParallelBuilding = true;
+
   preBuild = ''
     make -C firmware LIBFX2=${fx2}/share/libfx2
     cp firmware/glasgow.ihex software/glasgow
@@ -55,7 +57,7 @@ buildPythonPackage rec {
   doInstallCheck = false;
 
   checkPhase = ''
-    python -m unittest discover
+    python -W ignore::DeprecationWarning test.py
   '';
 
   makeWrapperArgs = [

--- a/pkgs/development/python-modules/nmigen-boards/default.nix
+++ b/pkgs/development/python-modules/nmigen-boards/default.nix
@@ -8,15 +8,15 @@
 
 buildPythonPackage rec {
   pname = "nmigen-boards";
-  version = "unstable-2019-10-13";
+  version = "unstable-2020-02-06";
   # python setup.py --version
-  realVersion = "0.1.dev79+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.1.dev92+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
-    owner = "m-labs";
+    owner = "nmigen";
     repo = "nmigen-boards";
-    rev = "835c175d7cf9d143aea2c7dbc0c870ede655cfc2";
-    sha256 = "1mbxgfv6k9i3668lr1b3hrvial2vznvgn4ckjzc36hhizp47ypzw";
+    rev = "f37fe0295035db5f1bf82ed086b2eb349ab3a530";
+    sha256 = "16112ahil100anfwggj64nyrj3pf7mngwrjyqyhf2ggxx9ir24cc";
   };
 
   nativeBuildInputs = [ setuptools_scm ];
@@ -28,8 +28,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Board and connector definitions for nMigen";
-    homepage = https://github.com/m-labs/nmigen-boards;
-    license = licenses.bsd0;
+    homepage = https://github.com/nmigen/nmigen-boards;
+    license = licenses.bsd2;
     maintainers = with maintainers; [ emily ];
   };
 }

--- a/pkgs/development/python-modules/nmigen-soc/default.nix
+++ b/pkgs/development/python-modules/nmigen-soc/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nmigen
+, setuptools
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "nmigen-soc";
+  version = "unstable-2020-02-08";
+  # python setup.py --version
+  realVersion = "0.1.dev24+g${lib.substring 0 7 src.rev}";
+
+  src = fetchFromGitHub {
+    owner = "nmigen";
+    repo = "nmigen-soc";
+    rev = "f1b009c7e075bca461d10ec963a7eaa3bf4dfc14";
+    sha256 = "04kjaq9qp6ac3h0r1wlb4jyz56bb52l1rikmz1x7azvnr10xhrad";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ setuptools nmigen ];
+
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}"
+  '';
+
+  meta = with lib; {
+    description = "System on Chip toolkit for nMigen";
+    homepage = https://github.com/nmigen/nmigen-soc;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ emily ];
+  };
+}

--- a/pkgs/development/python-modules/nmigen/default.nix
+++ b/pkgs/development/python-modules/nmigen/default.nix
@@ -5,7 +5,6 @@
 , setuptools
 , setuptools_scm
 , pyvcd
-, bitarray
 , jinja2
 
 # for tests
@@ -16,22 +15,22 @@
 
 buildPythonPackage rec {
   pname = "nmigen";
-  version = "unstable-2019-10-17";
+  version = "unstable-2019-02-08";
   # python setup.py --version
-  realVersion = "0.1.rc2.dev5+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.2.dev49+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
-    owner = "m-labs";
+    owner = "nmigen";
     repo = "nmigen";
-    rev = "9fba5ccb513cfbd53f884b1efca699352d2471b9";
-    sha256 = "02bjry4sqjsrhl0s42zl1zl06gk5na9i6br6vmz7fvxic29vl83v";
+    rev = "66f4510c4465be5d0763d7835770553434e4ee91";
+    sha256 = "19y39c4ywckm4yzrpjzcdl9pqy9d1sf1zsb4zpzajpmnfqccc3b0";
   };
 
   disabled = pythonOlder "3.6";
 
   nativeBuildInputs = [ setuptools_scm ];
 
-  propagatedBuildInputs = [ setuptools pyvcd bitarray jinja2 ];
+  propagatedBuildInputs = [ setuptools pyvcd jinja2 ];
 
   checkInputs = [ yosys symbiyosys yices ];
 
@@ -41,8 +40,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A refreshed Python toolbox for building complex digital hardware";
-    homepage = https://github.com/m-labs/nmigen;
-    license = licenses.bsd0;
+    homepage = https://github.com/nmigen/nmigen;
+    license = licenses.bsd2;
     maintainers = with maintainers; [ emily ];
   };
 }

--- a/pkgs/development/python-modules/pyvcd/default.nix
+++ b/pkgs/development/python-modules/pyvcd/default.nix
@@ -3,15 +3,16 @@
 , fetchPypi
 , setuptools_scm
 , six
-, pytest }:
+, pytest
+}:
 
 buildPythonPackage rec {
-  version = "0.1.6";
+  version = "0.1.7";
   pname = "pyvcd";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "285fcd96c3ee482e7b222bdd01d5dd19c2f5a0ad9b8e950baa98d386a2758c8f";
+    sha256 = "1ixpdl0qiads81h8s9h9r9z0cyc9dlmvi01nfjggxixvbb17305y";
   };
 
   buildInputs = [ setuptools_scm ];
@@ -26,7 +27,8 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python package for writing Value Change Dump (VCD) files";
     homepage = https://github.com/SanDisk-Open-Source/pyvcd;
+    changelog = "https://github.com/SanDisk-Open-Source/pyvcd/blob/${version}/CHANGELOG.rst";
     license = licenses.mit;
-    maintainers = [ maintainers.sb0 ];
+    maintainers = [ maintainers.sb0 maintainers.emily ];
   };
 }

--- a/pkgs/development/tools/icestorm/default.nix
+++ b/pkgs/development/tools/icestorm/default.nix
@@ -13,8 +13,10 @@ stdenv.mkDerivation rec {
   pname = "icestorm";
   version = "2019.09.13";
 
-  pythonPkg = if usePyPy then pypy3 else python3;
-  pythonInterp = pythonPkg.interpreter;
+  passthru = rec {
+    pythonPkg = if usePyPy then pypy3 else python3;
+    pythonInterp = pythonPkg.interpreter;
+  };
 
   src = fetchFromGitHub {
     owner  = "cliffordwolf";
@@ -24,7 +26,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ pythonPkg libftdi1 ];
+  buildInputs = [ passthru.pythonPkg libftdi1 ];
   makeFlags = [ "PREFIX=$(out)" ];
 
   enableParallelBuilding = true;
@@ -39,12 +41,12 @@ stdenv.mkDerivation rec {
       --replace /usr/local/share "$out/share"
 
     for x in icefuzz/Makefile icebox/Makefile icetime/Makefile; do
-      substituteInPlace "$x" --replace python3 "${pythonInterp}"
+      substituteInPlace "$x" --replace python3 "${passthru.pythonInterp}"
     done
 
     for x in $(find . -type f -iname '*.py'); do
       substituteInPlace "$x" \
-        --replace '/usr/bin/env python3' '${pythonInterp}'
+        --replace '/usr/bin/env python3' '${passthru.pythonInterp}'
     done
   '';
 

--- a/pkgs/development/tools/misc/tinyprog/default.nix
+++ b/pkgs/development/tools/misc/tinyprog/default.nix
@@ -6,13 +6,13 @@
 with python3Packages; buildPythonApplication rec {
   pname = "tinyprog";
   # `python setup.py --version` from repo checkout
-  version = "1.0.24.dev99+ga77f828";
+  version = "1.0.24.dev114+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "tinyfpga";
     repo = "TinyFPGA-Bootloader";
-    rev = "a77f828d3d6ae077e323ec96fc3925efab5aa9d7";
-    sha256 = "0jg47q0n1qkdrzri2q6n9a7czicj0qk58asz0xhzkajx1k9z3g5q";
+    rev = "97f6353540bf7c0d27f5612f202b48f41da75299";
+    sha256 = "0zbrvvb957z2lwbfd39ixqdsnd2w4wfjirwkqdrqm27bjz308731";
   };
 
   sourceRoot = "source/programmer";

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -8,24 +8,24 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "trellis";
-  version = "2019.10.13";
+  version = "2020.02.04";
   # git describe --tags
   realVersion = with stdenv.lib; with builtins;
-    "1.0-95-g${substring 0 7 (elemAt srcs 0).rev}";
+    "1.0-130-g${substring 0 7 (elemAt srcs 0).rev}";
 
   srcs = [
     (fetchFromGitHub {
        owner  = "SymbiFlow";
        repo   = "prjtrellis";
-       rev    = "e2e10bfdfaa29fed5d19e83dc7460be9880f5af4";
-       sha256 = "0l59nliv75rdxnajl2plilib0r0bzbr3qqzc88cdal841x1m0izs";
+       rev    = "4e4b95c8e03583d48d76d1229f9c7825e2ee5be1";
+       sha256 = "02kg48393bjiys56r62b4ks2xvfarw9phi5bips2xsnj9c99pmg0";
        name   = "trellis";
      })
     (fetchFromGitHub {
       owner  = "SymbiFlow";
       repo   = "prjtrellis-db";
-      rev    = "5b5bb70bae13e6b8c971b4b2d26931f4a64b51bc";
-      sha256 = "1fi963zdny3gxdvq564037qs22i7b4y7mxc3yij2a1ww8rzrnpdj";
+      rev    = "717478b757a702bbc7e3e11a5fbecee2a64f7922";
+      sha256 = "0q4j8qz3m2hissn2a82ck542cx62bp4f0wwzl3g22yv59i13yg83";
       name   = "trellis-database";
     })
   ];
@@ -33,7 +33,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boostWithPython3 ];
   nativeBuildInputs = [ cmake python3 ];
-  cmakeFlags = [ "-DCURRENT_GIT_VERSION=${realVersion}" ];
+  cmakeFlags = [
+    "-DCURRENT_GIT_VERSION=${realVersion}"
+    # TODO: should this be in stdenv instead?
+    "-DCMAKE_INSTALL_DATADIR=${placeholder "out"}/share"
+  ];
+  enableParallelBuilding = true;
 
   preConfigure = with builtins; ''
     rmdir database && ln -sfv ${elemAt srcs 1} ./database
@@ -50,7 +55,7 @@ stdenv.mkDerivation rec {
       to provide sufficient information to develop a free and
       open Verilog to bitstream toolchain for these devices.
     '';
-    homepage    = https://github.com/symbiflow/prjtrellis;
+    homepage    = https://github.com/SymbiFlow/prjtrellis;
     license     = stdenv.lib.licenses.isc;
     maintainers = with maintainers; [ q3k thoughtpolice emily ];
     platforms   = stdenv.lib.platforms.all;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2928,6 +2928,8 @@ in {
 
   nmigen-boards = callPackage ../development/python-modules/nmigen-boards { };
 
+  nmigen-soc = callPackage ../development/python-modules/nmigen-soc { };
+
   nxt-python = callPackage ../development/python-modules/nxt-python { };
 
   odfpy = callPackage ../development/python-modules/odfpy { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A big batch of updates to the free FPGA tooling, including new package `python3Packages.nmigen-soc`.

This should also fix `trellis` and its integration for ECP5 support in `nextpnr`, which wasn't previously working due to CMake installation path issues.

cc @thoughtpolice if you don't mind taking a look at this? :)

@GrahamcOfBorg build symbiyosys python3Packages.nmigen-boards python3Packages.nmigen-soc glasgow tinyprog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).