### PR TITLE
fzf: fix patch for vim plugin; enable tests; avoid direct $src layout dependency

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -19,32 +19,34 @@ buildGoModule rec {
 
   buildInputs = [ ncurses ];
 
+  # The vim plugin expects a relative path to the binary; patch it to abspath.
   patchPhase = ''
-    sed -i -e "s|expand('<sfile>:h:h')|'$bin'|" plugin/fzf.vim
+    sed -i -e "s|expand('<sfile>:h:h')|'$out'|" plugin/fzf.vim
 
-    # Original and output files can't be the same
-    if cmp -s $src/plugin/fzf.vim plugin/fzf.vim; then
-      echo "Vim plugin patch not applied properly. Aborting" && \
-      exit 1
+    if ! grep -q $out plugin/fzf.vim; then
+        echo "Failed to replace vim base_dir path with $out"
+        exit 1
     fi
   '';
 
+  doCheck = true;
+
   preInstall = ''
     mkdir -p $out/share/fish/{vendor_functions.d,vendor_conf.d}
-    cp $src/shell/key-bindings.fish $out/share/fish/vendor_functions.d/fzf_key_bindings.fish
+    cp shell/key-bindings.fish $out/share/fish/vendor_functions.d/fzf_key_bindings.fish
     cp ${fishHook} $out/share/fish/vendor_conf.d/load-fzf-key-bindings.fish
   '';
 
   postInstall = ''
-    cp $src/bin/fzf-tmux $out/bin
+    cp bin/fzf-tmux $out/bin
 
     mkdir -p $man/share/man
-    cp -r $src/man/man1 $man/share/man
+    cp -r man/man1 $man/share/man
 
     mkdir -p $out/share/vim-plugins/${pname}
-    cp -r $src/plugin $out/share/vim-plugins/${pname}
+    cp -r plugin $out/share/vim-plugins/${pname}
 
-    cp -R $src/shell $out/share/fzf
+    cp -R shell $out/share/fzf
     cat <<SCRIPT > $out/bin/fzf-share
     #!${runtimeShell}
     # Run this script to find the fzf shared folder where all the shell


### PR DESCRIPTION
It was previously referencing `$bin`, but this package no longer produces a
`bin` output, just `out` and `share`. Updated to make the comparison check a bit
more robust.

Also updated to avoid direct dependency on the `$src` directory out of the nix
store, instead using the processed src setup in the unpackPhase. This provides a
cleaner abstraction between the build/install phase and the input src phase, and
avoids an unnecessary dependency on whether the source disted tarball comes from
`fetchFromGitHub` (in which case it's an unpacked directory) or something like
`fetchurl`. In either case, stdenv is responsible for processing the input `src`
and setting up a clean build dir for us, so we should use that.

This produces an equivalent directory tree, except that the vim plugin is no
longer broken.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).