### PR TITLE
twinkle: patch manual link since old domain got re-used

### DIFF
--- a/pkgs/applications/networking/instant-messengers/twinkle/default.nix
+++ b/pkgs/applications/networking/instant-messengers/twinkle/default.nix
@@ -47,9 +47,15 @@ mkDerivation rec {
   ];
 
   patches = [
-    (fetchurl { # https://github.com/LubosD/twinkle/pull/152 patch for bcg729 1.0.2+
+    # patch for bcg729 1.0.2+
+    (fetchurl { # https://github.com/LubosD/twinkle/pull/152
       url = "https://github.com/LubosD/twinkle/compare/05082ae12051821b1d969e6672d9e4e5afe1bc07...7a6c533cda387652b5b4cb2a867be1a18585890c.patch";
       sha256 = "39fc6cef3e88cfca8db44612b2d082fb618027b0f99509138d3c0d2777a494c2";
+    })
+    # patch manual link to not link to old url, which now points to NSFW page
+    (fetchurl { # https://github.com/LubosD/twinkle/commit/05082ae12051821b1d969e6672d9e4e5afe1bc07
+      url = "https://github.com/LubosD/twinkle/commit/05082ae12051821b1d969e6672d9e4e5afe1bc07.diff";
+      sha256 = "1iamragr9wp2vczsnp6n261fpr1ai2nc2abp0228jlar9zafksw0";
     })
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
