### PR TITLE
fetchzip, fetchgit: cleanup handling of optional features and whitespace

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -1,4 +1,4 @@
-{stdenvNoCC, git, cacert}: let
+{ stdenvNoCC, git, cacert }: let
   urlToName = url: rev: let
     inherit (stdenvNoCC.lib) removeSuffix splitString last;
     base = last (splitString ":" (baseNameOf (removeSuffix "/" url)));

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -1,6 +1,5 @@
-#! /usr/bin/env bash
-
-set -e -o pipefail
+#!/usr/bin/env bash
+set -eo pipefail
 
 url=
 rev=
@@ -38,17 +37,17 @@ usage(){
     echo  >&2 "syntax: nix-prefetch-git [options] [URL [REVISION [EXPECTED-HASH]]]
 
 Options:
-      --out path      Path where the output would be stored.
-      --url url       Any url understood by 'git clone'.
-      --rev ref       Any sha1 or references (such as refs/heads/master)
-      --hash h        Expected hash.
-      --branch-name   Branch name to check out into
-      --deepClone     Clone the entire repository.
-      --no-deepClone  Make a shallow clone of just the required ref.
-      --leave-dotGit  Keep the .git directories.
+      --out path         Path where the output would be stored.
+      --url url          Any url understood by 'git clone'.
+      --rev ref          Any sha1 or references (such as refs/heads/master).
+      --hash h           Expected hash.
+      --branch-name      Branch name to check out into.
+      --deepClone        Clone the entire repository.
+      --no-deepClone     Make a shallow clone of just the required ref.
+      --leave-dotGit     Keep the .git directories.
       --fetch-submodules Fetch submodules.
-      --builder       Clone as fetchgit does, but url, rev, and out option are mandatory.
-      --quiet         Only print the final json summary.
+      --builder          Clone as fetchgit does, but url, rev, and out option are mandatory.
+      --quiet            Only print the final json summary.
 "
     exit 1
 }

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -5,47 +5,46 @@
 # (e.g. due to minor changes in the compression algorithm, or changes
 # in timestamps).
 
-{ fetchurl, unzip }:
+{ lib, fetchurl, unzip }:
 
-{ # Optionally move the contents of the unpacked tree up one level.
-  stripRoot ? true
+{ name ? "source"
 , url
+  # Optionally move the contents of the unpacked tree up one level.
+, stripRoot ? true
 , extraPostFetch ? ""
-, name ? "source"
 , ... } @ args:
 
 (fetchurl ({
   inherit name;
 
   recursiveHash = true;
-
   downloadToTemp = true;
 
-  postFetch =
-    ''
-      unpackDir="$TMPDIR/unpack"
-      mkdir "$unpackDir"
-      cd "$unpackDir"
+  postFetch = ''
+    unpackDir="$TMPDIR/unpack"
+    mkdir "$unpackDir"
+    cd "$unpackDir"
 
-      renamed="$TMPDIR/${baseNameOf url}"
-      mv "$downloadedFile" "$renamed"
-      unpackFile "$renamed"
-    ''
-    + (if stripRoot then ''
-      if [ $(ls "$unpackDir" | wc -l) != 1 ]; then
-        echo "error: zip file must contain a single file or directory."
-        echo "hint: Pass stripRoot=false; to fetchzip to assume flat list of files."
-        exit 1
-      fi
-      fn=$(cd "$unpackDir" && echo *)
-      if [ -f "$unpackDir/$fn" ]; then
-        mkdir $out
-      fi
-      mv "$unpackDir/$fn" "$out"
-    '' else ''
-      mv "$unpackDir" "$out"
-    '') #*/
-    + extraPostFetch;
+    renamed="$TMPDIR/${baseNameOf url}"
+    mv "$downloadedFile" "$renamed"
+    unpackFile "$renamed"
+    result=$unpackDir
+  ''
+  # Most src disted tarballs have a parent directory like foo-1.2.3/ to strip
+  + lib.optionalString stripRoot ''
+    if [ $(ls "$unpackDir" | wc -l) != 1 ]; then
+      echo "error: zip file must contain a single file or directory."
+      echo "hint: Pass stripRoot=false; to fetchzip to assume flat list of files."
+      exit 1
+    fi
+    fn=$(cd "$unpackDir" && echo *)
+    result="$unpackDir/$fn"
+  '' + ''
+    mkdir $out
+    mv "$result" "$out"
+  ''
+  + extraPostFetch;
+
 } // removeAttrs args [ "stripRoot" "extraPostFetch" ])).overrideAttrs (x: {
   # Hackety-hack: we actually need unzip hooks, too
   nativeBuildInputs = x.nativeBuildInputs ++ [ unzip ];


### PR DESCRIPTION
No intended functional difference, just trying to polish to make this easier to
extend and more aligned with other nix conventions.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).