### PR TITLE
scribusUnstable: Fix build with Poppler 0.84

### DIFF
--- a/pkgs/applications/office/scribus/unstable.nix
+++ b/pkgs/applications/office/scribus/unstable.nix
@@ -1,12 +1,41 @@
-{ stdenv, fetchurl, fetchpatch, mkDerivation, pkgconfig, cmake, qtbase, cairo, pixman,
-boost, cups, fontconfig, freetype, hunspell, libjpeg, libtiff, libxml2, lcms2,
-podofo, poppler, poppler_data, python2, qtimageformats, qttools, harfbuzzFull }:
+{ boost
+, cairo
+, cmake
+, cups
+, fetchpatch
+, fetchurl
+, fontconfig
+, freetype
+, harfbuzzFull
+, hunspell
+, lcms2
+, libjpeg
+, libtiff
+, libxml2
+, mkDerivation
+, pixman
+, pkgconfig
+, podofo
+, poppler
+, poppler_data
+, python2
+, qtbase
+, qtimageformats
+, qttools
+, stdenv
+}:
 
 let
-  pythonEnv = python2.withPackages(ps: [ps.tkinter ps.pillow]);
+  pythonEnv = python2.withPackages (
+    ps: [
+      ps.pillow
+      ps.tkinter
+    ]
+  );
 in
 mkDerivation rec {
   pname = "scribus";
+
   version = "1.5.5";
 
   src = fetchurl {
@@ -16,31 +45,72 @@ mkDerivation rec {
 
   patches = [
     # fix build with Poppler 0.82
-    (fetchpatch {
-      url = "https://github.com/scribusproject/scribus/commit/6db15ec1af791377b28981601f8c296006de3c6f.patch";
-      sha256 = "1y6g3avmsmiyaj8xry1syaz8sfznsavh6l2rp13pj2bwsxfcf939";
-    })
+    (
+      fetchpatch {
+        url = "https://github.com/scribusproject/scribus/commit/6db15ec1af791377b28981601f8c296006de3c6f.patch";
+        sha256 = "1y6g3avmsmiyaj8xry1syaz8sfznsavh6l2rp13pj2bwsxfcf939";
+      }
+    )
     # fix build with Poppler 0.83
-    (fetchpatch {
-      url = "https://github.com/scribusproject/scribus/commit/b51c2bab4d57d685f96d427d6816bdd4ecfb4674.patch";
-      sha256 = "031yy9ylzksczfnpcc4glfccz025sn47zg6fqqzjnqqrc16bgdlx";
-    })
+    (
+      fetchpatch {
+        url = "https://github.com/scribusproject/scribus/commit/b51c2bab4d57d685f96d427d6816bdd4ecfb4674.patch";
+        sha256 = "031yy9ylzksczfnpcc4glfccz025sn47zg6fqqzjnqqrc16bgdlx";
+      }
+    )
+    # fix build with Poppler 0.84
+    # TODO: Remove patches with scribus version > 1.5.5 as it should be fixed upstream in next version
+    (
+      fetchpatch {
+        url = "https://github.com/scribusproject/scribus/commit/3742559924136c2471ab15081c5b600dd5feaeb0.patch";
+        sha256 = "1d72h7jbajy9w83bnxmhn1ca947hpfxnfbmq30g5ljlj824c7y9y";
+      }
+    )
   ];
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig cmake  ];
-  buildInputs = [
-    qtbase cairo pixman boost cups fontconfig
-    freetype hunspell libjpeg libtiff libxml2 lcms2 podofo poppler
-    poppler_data pythonEnv qtimageformats qttools harfbuzzFull
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
   ];
 
-  meta = {
-    maintainers = [ stdenv.lib.maintainers.erictapen ];
-    platforms = stdenv.lib.platforms.linux;
+  buildInputs = [
+    boost
+    cairo
+    cups
+    fontconfig
+    freetype
+    harfbuzzFull
+    hunspell
+    lcms2
+    libjpeg
+    libtiff
+    libxml2
+    pixman
+    podofo
+    poppler
+    poppler_data
+    pythonEnv
+    qtbase
+    qtimageformats
+    qttools
+  ];
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [
+      erictapen
+      kiwi
+    ];
+    platforms = platforms.linux;
     description = "Desktop Publishing (DTP) and Layout program for Linux";
-    homepage = http://www.scribus.net;
-    license = stdenv.lib.licenses.gpl2;
+    homepage = "http://www.scribus.net";
+    # There are a lot of licenses... https://github.com/scribusproject/scribus/blob/20508d69ca4fc7030477db8dee79fd1e012b52d2/COPYING#L15-L19
+    license = with licenses; [
+      bsd3
+      gpl2
+      mit
+      publicDomain
+    ];
   };
 }

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "poppler-${suffix}-${version}";
-  version = "0.84.0"; # beware: updates often break cups-filters build, check texlive too!
+  version = "0.84.0"; # beware: updates often break cups-filters build, check texlive and scribusUnstable too!
 
   src = fetchurl {
     url = "${meta.homepage}/poppler-${version}.tar.xz";


### PR DESCRIPTION
see: https://github.com/NixOS/nixpkgs/pull/77186#issuecomment-583800213

it seems poppler updates (almost?) always break scribusUnstable

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
