### PR TITLE
wafHook: allow overriding phases and disabling of cross flags

### DIFF
--- a/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
@@ -11,11 +11,13 @@ wafConfigurePhase() {
     fi
 
     local flagsArray=(
-        @crossFlags@
         "${flagsArray[@]}"
         $wafConfigureFlags "${wafConfigureFlagsArray[@]}"
         ${configureTargets:-configure}
     )
+    if [ -z "${dontAddWafCrossFlags:-}" ]; then
+        flagsArray+=(@crossFlags@)
+    fi
     echoCmd 'configure flags' "${flagsArray[@]}"
     python "$wafPath" "${flagsArray[@]}"
 

--- a/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
@@ -61,7 +61,7 @@ wafInstallPhase() {
     local flagsArray=(
         $wafFlags ${wafFlagsArray[@]}
         $installFlags ${installFlagsArray[@]}
-	${installTargets:-install}
+        ${installTargets:-install}
     )
 
     echoCmd 'install flags' "${flagsArray[@]}"

--- a/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
@@ -22,6 +22,10 @@ wafConfigurePhase() {
     runHook postConfigure
 }
 
+if [ -z "${dontUseWafConfigure-}" -a -z "${configurePhase-}" ]; then
+    configurePhase=wafConfigurePhase
+fi
+
 wafBuildPhase () {
     runHook preBuild
 
@@ -40,6 +44,10 @@ wafBuildPhase () {
 
     runHook postBuild
 }
+
+if [ -z "${dontUseWafBuild-}" -a -z "${buildPhase-}" ]; then
+    buildPhase=wafBuildPhase
+fi
 
 wafInstallPhase() {
     runHook preInstall
@@ -60,6 +68,6 @@ wafInstallPhase() {
     runHook postInstall
 }
 
-configurePhase=wafConfigurePhase
-buildPhase=wafBuildPhase
-installPhase=wafInstallPhase
+if [ -z "${dontUseWafInstall-}" -a -z "${installPhase-}" ]; then
+    installPhase=wafInstallPhase
+fi


### PR DESCRIPTION
###### Motivation for this change

Overall motivation: working towards cross-compilaton of mpv.

The current wafHook passes cross compilation flags which are not always appropriate, and doesn't allow the phases to be overridden like most other setup hooks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
