### PR TITLE
clipman: 1.2.0 -> unstable-2019-12-10

### DIFF
--- a/pkgs/tools/misc/clipman/default.nix
+++ b/pkgs/tools/misc/clipman/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "clipman";
-  version = "1.2.0";
+  version = "unstable-2019-12-10";
 
   src = fetchFromGitHub {
     owner = "yory8";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0266qb8p5l8j25nn51ajsbiij8bh5r7ywphf2x1l7wfhbzgxz12d";
+    rev = "c57453be90bb4496f67275db8c0beb2116a6ce14";
+    sha256 = "0zvqk3gcpx67dsn7qr0p9bgjp0sljl3yrlsfbqzrbrmj2lwr98ys";
   };
 
   modSha256 = "0aw0ng8pk8qzn1iv79iw0v9zr8xdc8p9xnigr3ij86038f7aqdhv";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[clipman support for bemenu was added in December 2019](https://github.com/yory8/clipman/commit/ddfea6b8314333dd25c9e992b90802a933e9408e), but no release has been created since then. The aim of this pull-request is to upgrade clipman up until a more recent changeset that provides this feature.
I'm not sure whether I should update the version number or leave it as is, could you please clarify ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
