### PR TITLE
calibre: add missing dependency, fixes #78642

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -93,7 +93,7 @@ mkDerivation rec {
       netifaces
       pillow
       python
-      pyqt5_with_qtwebkit
+      pyqt5
       sip
       regex
       msgpack

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -99,6 +99,7 @@ mkDerivation rec {
       msgpack
       beautifulsoup4
       html2text
+      pyqtwebengine
       # the following are distributed with calibre, but we use upstream instead
       odfpy
     ]


### PR DESCRIPTION
Fixes #78642
This commit adds pyqtwebengine.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Without pyqtwebengine, when you try to view an ebook, you get the following error 
```
Traceback (most recent call last):
  File "/nix/store/1zqhszwa961qf3nciz5wv854sfff18ph-calibre-4.8.0/bin/.calibre-parallel-wrapped", line 20, in <module>
    sys.exit(main())
  File "/nix/store/1zqhszwa961qf3nciz5wv854sfff18ph-calibre-4.8.0/lib/calibre/calibre/utils/ipc/worker.py", line 209, in main
    result = func(*args, **kwargs)
  File "/nix/store/1zqhszwa961qf3nciz5wv854sfff18ph-calibre-4.8.0/lib/calibre/calibre/gui_launch.py", line 80, in ebook_viewer
    from calibre.gui2.viewer.main import main
  File "/nix/store/1zqhszwa961qf3nciz5wv854sfff18ph-calibre-4.8.0/lib/calibre/calibre/gui2/viewer/main.py", line 12, in <module>
    from PyQt5.QtWebEngineCore import QWebEngineUrlScheme
ImportError: No module named QtWebEngineCore

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
