### PR TITLE
nix: fix build

### DIFF
--- a/pkgs/development/libraries/aws-c-event-stream/default.nix
+++ b/pkgs/development/libraries/aws-c-event-stream/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ aws-c-common aws-checksums ] ++ lib.optional stdenv.hostPlatform.isMusl libexecinfo;
 
   cmakeFlags = [
+    "-DBUILD_SHARED_LIBS:BOOL=ON"
     "-DCMAKE_MODULE_PATH=${aws-c-common}/lib/cmake"
   ];
 

--- a/pkgs/development/libraries/aws-checksums/default.nix
+++ b/pkgs/development/libraries/aws-checksums/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS:BOOL=ON" ];
+
   meta = with lib; {
     description = "HW accelerated CRC32c and CRC32";
     homepage = https://github.com/awslabs/aws-checksums;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The recent aws-checksums bump https://github.com/NixOS/nixpkgs/pull/78563 changed the cmake configuration https://github.com/awslabs/aws-checksums/commit/343a0b07876e165280b879fdc63dcf28897a2e15

See: https://hydra.nixos.org/build/111932885

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
