### PR TITLE
hpmyroom: 11.1.0.0508 -> 12.0.0.0220

### DIFF
--- a/pkgs/applications/networking/hpmyroom/default.nix
+++ b/pkgs/applications/networking/hpmyroom/default.nix
@@ -4,11 +4,11 @@
 }:
 mkDerivation rec {
   pname = "hpmyroom";
-  version = "11.1.0.0508";
+  version = "12.0.0.0220";
 
   src = fetchurl {
     url = "https://www.myroom.hpe.com/downloadfiles/${pname}-${version}.x86_64.rpm";
-    sha256 = "1j7mzvf349yxb42m8syh73gpvil01hy1a2wrr0rdzb2ijfnkxyaa";
+    sha256 = "0gajj2s6l7jj8520agrv2dyisg7hhacbwzqlsp9a0xdxr0v71jhr";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
It's a new major update!
I can't find any public release notes, though :/

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
