### PR TITLE
dwarf-fortress-packages.dwarf-fortress_0_47_02: init

### DIFF
--- a/pkgs/games/dwarf-fortress/game.json
+++ b/pkgs/games/dwarf-fortress/game.json
@@ -93,5 +93,19 @@
     "win32": "07mqhm64c1ddjc3vpyhf9qf14lp19xwz3pgg4c2pvcwy4yyrys22",
     "win32_s": "07acbxai8g04yxg7n68nyx4jwcqqkgjn7n96q2lzxdvc988kiivz",
     "legacy32_s": "1gxmc3rsl9glai3wb4wzsda3qyhdimd8s5kbr5m753n8lmzasafx"
+  },
+  "0.47.02": {
+    "linux": "1zbsygbfiqxxs767qxkxjp3ayywi5q0d8xlrqlbd0l8a3ccg5avw",
+    "linux32": "1ddc9s4n408j8gidgign51bgv2wgy5z4cy74jzx00pvnhsfp2mpy",
+    "osx": "1mwy88yxip1wys1kxpfsbg7wlvfrkc4lg04gqw0d266a88dj7a30",
+    "osx32": "08ssnzl52gqqgcqhl0ynyikbxz76825kpcg1d6yx8g7ifjndf19n",
+    "win": "08g7fy18y8q32l0158314bny0qg57xz37qj9fri9r4xbhci67ldk",
+    "win_s": "0x56s1md62yk661aqcdgnz8k0zir0zr8qwan5vrqc0q9yh069yl1",
+    "win32": "0ww64mymbilb235n93d7w4c9axq3ww2mxa0f7bl4x8yrxwc8k942",
+    "win32_s": "0r801vip807v88icf47i3s82v7lshx67q4ilzfjirqfslh1x00bs",
+    "legacy": "14f4d6r7swfjnlaalg4l5916ihj6wvhlsgjp7cygamzp4c2wgng8",
+    "legacy_s": "1jxf52kaijf4crwxj30a4f6z7rzs6xa91y6vn5s8jr0cvbr5pz64",
+    "legacy32": "0j7shqdv3gimacj03cil2y0fmr0j0fp57cwmdjwnxwx3m96k3xwm",
+    "legacy32_s": "1wc7pcp9dwz0q1na3i5pbqknya595qdkmr7hsmgh2kk8rsp3g9g2"
   }
 }

--- a/pkgs/games/dwarf-fortress/game.nix
+++ b/pkgs/games/dwarf-fortress/game.nix
@@ -96,6 +96,6 @@ stdenv.mkDerivation {
     inherit homepage;
     license = licenses.unfreeRedistributable;
     platforms = attrNames platforms;
-    maintainers = with maintainers; [ a1russell robbinch roconnor the-kenny abbradar numinit ];
+    maintainers = with maintainers; [ a1russell robbinch roconnor the-kenny abbradar numinit shazow ];
   };
 }

--- a/pkgs/games/dwarf-fortress/themes/default.nix
+++ b/pkgs/games/dwarf-fortress/themes/default.nix
@@ -12,7 +12,7 @@ listToAttrs (map (v: {
     sha256 = v.sha256;
     meta = with lib; {
       platforms = platforms.all;
-      maintainers = [ maintainers.matthewbauer ];
+      maintainers = [ maintainers.matthewbauer maintainers.shazow ];
       license = licenses.free;
     };
   };

--- a/pkgs/games/dwarf-fortress/themes/themes.json
+++ b/pkgs/games/dwarf-fortress/themes/themes.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "afro-graphics",
-    "version": "44.11a",
-    "sha256": "0hxh1qbwj6m780m522cfwjx0qkmiz3328xqwf13vkhlvgbz3azrk"
+    "version": "47.02",
+    "sha256": "0np4jc05905q3bjplbrfi09q4rq3pjbf2vmbrmazfagj2mp8m7z5"
   },
   {
     "name": "autoreiv",
-    "version": "44.03",
-    "sha256": "03w9dp42718p5gnswynw3p9wz85y61gkzz60jf71arw1zhf23wm0"
+    "version": "47.01",
+    "sha256": "1c2xchlfq7ajpcq8qgrzkw5yfgm0k3fiwq6n7l4724dlbim3rjp2"
   },
   {
     "name": "cla",
-    "version": "0.47.xx-v26",
-    "sha256": "04i17rl3gwpfnylvd554nsdi246yb3ih7wdmxmjy9177l14cp0kk"
+    "version": "0.47.xx-v26.3",
+    "sha256": "0ca81r3821jja4pqib75qxcsgg3s0wxzyq1jb4jc0495cvzxw7qa"
   },
   {
     "name": "dfgraphics",
@@ -21,18 +21,18 @@
   },
   {
     "name": "gemset",
-    "version": "44.10a",
-    "sha256": "14q69dyqzhxsfv1a4vh17fx7r7mylfimmjrydz6ygdypblgc9zm6"
+    "version": "47.02",
+    "sha256": "0gz6cfx9kyldh5dxicyw0yl9lq4qw51vvlpzl767ml0bx3w38bwy"
   },
   {
     "name": "ironhand",
-    "version": "47.01",
-    "sha256": "0ndf5gy1c0f8h745gg2j9ljwarq4kqi28anvgxcaj73j9cv6jsgw"
+    "version": "47.02",
+    "sha256": "0j612xxz8g91zslw3a6yls3bzzmz0xdi2n0zx9zkmpzcl67f39ry"
   },
   {
     "name": "jolly-bastion",
-    "version": "44.11",
-    "sha256": "0nziz6c94c9l28m8pp14fzbbnh7if1dnzrfl160ckv7arqpjv5r9"
+    "version": "47.02",
+    "sha256": "1df2hvm72lklmhhphcwsqm1m3dnaqxd8qvpygg5x71cfgkjd41ic"
   },
   {
     "name": "mayday",
@@ -41,37 +41,37 @@
   },
   {
     "name": "obsidian",
-    "version": "44.11",
-    "sha256": "12ij21c47gfws5brxwxhjpcr82q4ghxd1h4k6b0n2zs35071rfrp"
+    "version": "47.02",
+    "sha256": "03b26z557099k0l44lizagh17pz1y6apy496ivzv426xy0mzz684"
   },
   {
     "name": "phoebus",
-    "version": "47.01",
-    "sha256": "1rf47p6a4f6scpzlmy9q3v1pakdjs06f9aingajpaia44lmjdfn6"
+    "version": "47.02a",
+    "sha256": "16zllnkrxi2365rd5m392xv72a9wvai0l3pz8xwkb8nlws8f58lb"
   },
   {
     "name": "rally-ho",
-    "version": "44.11",
-    "sha256": "0v8aixvhhjlfxycbnldk35s757299a8mlgx4ba5qgnl8y2gg7f35"
+    "version": "47.02",
+    "sha256": "0xw2psmfjrgab0267scc7frgl9h1ypc0mbymn8z3x06m5wc3hbdh"
   },
   {
     "name": "spacefox",
-    "version": "47.01",
-    "sha256": "1zbn5z8a40if1yr8kq9v5gnydygqx26jw22jfqqf3hrqfqn4mcb8"
+    "version": "47.02",
+    "sha256": "180fp2s489m2arc2z11j1qjnpcadjjkyami13yr3zd0v7msg64h8"
   },
   {
     "name": "taffer",
-    "version": "44.10a",
-    "sha256": "0gp8hmv55bp34db0caksdpd3kn2glh7sz03gyxknzdymh1cpy0qv"
+    "version": "47.01b",
+    "sha256": "0b5hnli3gg32r7yvb3x1fqrmpxlk33j1hila2wiihybkkfnvxy5f"
   },
   {
     "name": "tergel",
-    "version": "44.03",
-    "sha256": "1kgk0cav5b6v7mca36gm84b2p556ibd8yy4rwbfc4i6i3hlsdw07"
+    "version": "47.01",
+    "sha256": "142sd1i11vvirn68rp4gqzl67ww597df1lc57ycnpnz0n3q39kxy"
   },
   {
     "name": "wanderlust",
-    "version": "44.10",
-    "sha256": "016acv0ab2wj4rn9slhbf626977zas6q4372f7avaf99ihcmwi85"
+    "version": "47.02",
+    "sha256": "0c36nxry189qdyinjk03wwm3j7q9q7b2sabkv7glx8yz2i61j5q9"
   }
 ]

--- a/pkgs/games/dwarf-fortress/unfuck.nix
+++ b/pkgs/games/dwarf-fortress/unfuck.nix
@@ -36,6 +36,10 @@ let
       unfuckRelease = "0.47.01";
       sha256 = "11xvb3qh4crdf59pwfwpi73rzm3ysd1r1xp2k1jp7527jmqapk4k";
     };
+    "0.47.02" = {
+      unfuckRelease = "0.47.01";
+      sha256 = "11xvb3qh4crdf59pwfwpi73rzm3ysd1r1xp2k1jp7527jmqapk4k";
+    };
   };
 
   release = if hasAttr dfVersion unfuck-releases

--- a/pkgs/games/dwarf-fortress/update.sh
+++ b/pkgs/games/dwarf-fortress/update.sh
@@ -8,8 +8,8 @@ systems='linux linux32 osx osx32
 
 if [ $# -eq 0 ]; then
     versions="$(curl http://www.bay12games.com/dwarves/ \
-		   | grep 'DOWNLOAD DWARF FORTRESS' \
-		   | sed 's/.*DOWNLOAD DWARF FORTRESS \([0-9.]*\) .*/\1/')"
+		   | grep 'DWARF FORTRESS CLASSIC ' \
+		   | sed 's/.*DWARF FORTRESS CLASSIC \([0-9.]*\) .*/\1/')"
 else
     versions="$@"
 fi


### PR DESCRIPTION
###### Motivation for this change

Bugfix release for Dwarf Fortress came out. This PR updates the themes.json and games.json (and the update script that updates games.json).

Unfortunately there's no corresponding unfuck release yet, so it's still using the 0.47.01 version of unfuck for 0.47.02 which seems to work fine (as it's a minor bugfix release).

Currently playing this version with:

```
nix-env -f . -iE 'p: (p {}).dwarf-fortress-packages.dwarf-fortress_0_47_02.override { enableTruetype = true; theme = "phoebus"; }'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
