### PR TITLE
uw-ttyp0: split outputs in out and otb

### DIFF
--- a/pkgs/data/fonts/uw-ttyp0/default.nix
+++ b/pkgs/data/fonts/uw-ttyp0/default.nix
@@ -19,10 +19,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl bdftopcf bdf2psf fonttosfnt mkfontdir ];
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash     = "0hzhaakbbcnz5ksi5p8mavw9578rsqlqadkrirrkhfnyqqlrii4j";
-
   # configure sizes, encodings and variants
   preConfigure =
     (if targetsDat == null
@@ -45,7 +41,7 @@ stdenv.mkDerivation rec {
       else ''cp "${variantsDat}" VARIANTS.dat'');
 
   postBuild = ''
-    # convert bdf to psf and otb fonts
+    # convert bdf fonts to psf
     build=$(pwd)
     mkdir {psf,otb}
     cd ${bdf2psf}/share/bdf2psf
@@ -55,18 +51,36 @@ stdenv.mkDerivation rec {
         --fb "$i" standard.equivalents \
         ascii.set+useful.set+linux.set 512 \
         "$build/psf/$name.psf"
+    done
+    cd -
+
+    # convert unicode bdf fonts to otb
+    for i in $build/genbdf/*-uni.bdf; do
+      name="$(basename $i .bdf)"
       fonttosfnt -v -o "$build/otb/$name.otb" "$i"
     done
-    cd $build
   '';
 
   postInstall = ''
     # install psf fonts
     fontDir="$out/share/consolefonts"
-    mkdir -p "$fontDir"
-    mv -t "$fontDir" psf/*.psf
-    mv -t "$out/share/fonts/X11/misc" otb/*.otb
+    install -m 644 -D psf/*.psf -t "$fontDir"
+
+    # install otb fonts
+    fontDir="$otb/share/fonts/X11/misc"
+    install -m 644 -D otb/*.otb -t "$fontDir"
+    mkfontdir "$fontDir"
   '';
+
+  # Nix with multiple outputs adds several flags
+  # that the ./configure script doesn't understand.
+  configurePhase = ''
+    runHook preConfigure
+    ./configure --prefix="$out"
+    runHook postConfigure
+  '';
+
+  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "Monospace bitmap screen fonts for X11";


### PR DESCRIPTION
###### Motivation for this change
Issue #75160

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested fonts are working in X11 and GTK application
- [x] Tested compilation of all pkgs that depend on this change using
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
