### PR TITLE
Upgrade brave 1.1.23 to 1.3.113

### DIFF
--- a/pkgs/applications/editors/bless/default.nix
+++ b/pkgs/applications/editors/bless/default.nix
@@ -1,0 +1,80 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, mono
+, gtk-sharp-2_0
+, gettext
+, makeWrapper
+, glib
+, gtk2-x11
+, gnome2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bless";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "afrantzis";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04ra2mcx3pkhzbhcz0zwfmbpqj6cwisrypi6xbc2d6pxd4hdafn1";
+  };
+
+  buildInputs = [
+    gtk-sharp-2_0
+    mono
+    # runtime only deps
+    glib
+    gtk2-x11
+    gnome2.libglade
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    autoreconfHook
+    gettext
+    makeWrapper
+  ];
+
+  configureFlags = [
+    # scrollkeeper is a gnome2 package, so it must be old and we shouldn't really support it
+    # NOTE: that sadly doesn't turn off the compilation of the manual with scrollkeeper, so we have to fake the binaries below
+    "--without-scrollkeeper"
+  ];
+
+  autoreconfPhase = ''
+    mkdir _bin
+
+    # this fakes the scrollkeeper commands, to keep the build happy
+    for f in scrollkeeper-preinstall scrollkeeper-update; do
+      echo "true" > ./_bin/$f
+      chmod +x ./_bin/$f
+    done
+
+    export PATH="$PWD/_bin:$PATH"
+
+    # and it also wants to install that file
+    touch ./doc/user/bless-manual.omf
+
+    # patch mono path
+    sed "s|^mono|${mono}/bin/mono|g" -i src/bless-script.in
+
+    ./autogen.sh
+    '';
+
+  preFixup = ''
+    MPATH="${gtk-sharp-2_0}/lib/mono/gtk-sharp-2.0:${glib.out}/lib:${gtk2-x11}/lib:${gnome2.libglade}/lib:${gtk-sharp-2_0}/lib"
+    wrapProgram $out/bin/bless --prefix MONO_PATH : "$MPATH" --prefix LD_LIBRARY_PATH : "$MPATH"
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/afrantzis/bless";
+    description = "Gtk# Hex Editor";
+    maintainers = [ maintainers.mkg20001 ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    badPlatforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -82,11 +82,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "brave";
-  version = "1.1.23";
+  version = "1.3.113";
 
   src = fetchurl {
     url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-    sha256 = "1kb40h5d76k6p338h75p8lxs0cb88jaasss0cmb7bfc7zykfqmd3";
+    sha256 = "71438aff64146541731f6fb072114eab1cbb0699fd04fc00cd252c9d41a76b62";
   };
 
   dontConfigure = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1222,6 +1222,8 @@ in
 
   behdad-fonts = callPackage ../data/fonts/behdad-fonts { };
 
+  bless = callPackage ../applications/editors/bless { };
+
   blink1-tool = callPackage ../tools/misc/blink1-tool { };
 
   bliss = callPackage ../applications/science/math/bliss { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I wanted the latest version of brave and thought that the community would benifit as well

###### Things done
Changed the version to the latest stable version available today, changed the checksum to 
match the checksum of the new deb.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
