### PR TITLE
creep: split outputs in out and otb

### DIFF
--- a/pkgs/data/fonts/creep/default.nix
+++ b/pkgs/data/fonts/creep/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, fontforge }:
+{ stdenv, fetchFromGitHub, libfaketime
+, fonttosfnt, mkfontscale
+}:
 
 stdenv.mkDerivation rec {
   pname = "creep";
@@ -11,13 +13,20 @@ stdenv.mkDerivation rec {
     sha256 = "0zs21kznh1q883jfdgz74bb63i4lxlv98hj3ipp0wvsi6zw0vs8n";
   };
 
-  nativeBuildInputs = [ fontforge ];
+  nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];
 
-  dontBuild = true;
+  buildPhase = ''
+    faketime -f "1970-01-01 00:00:01" fonttosfnt -g 2 -m 2 -o creep.otb creep.bdf
+  '';
 
   installPhase = ''
-    install -D -m644 creep.bdf "$out/usr/share/fonts/misc/creep.bdf"
+    install -D -m644 creep.bdf "$out/share/fonts/misc/creep.bdf"
+    mkfontdir "$out/share/fonts/misc"
+    install -D -m644 creep.otb "$otb/share/fonts/misc/creep.otb"
+    mkfontdir "$otb/share/fonts/misc"
   '';
+
+  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "A pretty sweet 4px wide pixel font";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17366,7 +17366,8 @@ in
 
   cm_unicode = callPackage ../data/fonts/cm-unicode {};
 
-  creep = callPackage ../data/fonts/creep { };
+  creep = callPackage ../data/fonts/creep
+    { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
 
   crimson = callPackage ../data/fonts/crimson {};
 


### PR DESCRIPTION
###### Motivation for this change
Issue #75160

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested fonts are working in X11 and GTK application
- [x] Tested compilation of all pkgs that depend on this change using
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).