### PR TITLE
libphonenumber: 8.10.20 -> 8.11.3

### DIFF
--- a/pkgs/development/libraries/libphonenumber/default.nix
+++ b/pkgs/development/libraries/libphonenumber/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "phonenumber";
-  version = "8.10.20";
+  version = "8.11.3";
 
   src = fetchFromGitHub {
     owner = "googlei18n";
     repo = "libphonenumber";
     rev = "v${version}";
-    sha256 = "12xszrd4mrjabhzsp0xvy2qx2rxl36y5a00xfsh0w7bc299rq13v";
+    sha256 = "06y3mh1d1mks6d0ynxp3980g712nkf8l5nyljpybsk326b246hg9";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
There have been quite a few releases: https://github.com/google/libphonenumber/blob/master/release_notes.txt

Doesn't sound like anything would break by upgrading this package.
I haven't tried anything that uses it because there is no such package in nixpkgs.

cc @illegalprime 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
