### PR TITLE
python27Packages.nwdiag: 1.0.4 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/nwdiag/default.nix
+++ b/pkgs/development/python-modules/nwdiag/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "nwdiag";
-  version = "1.0.4";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "mirror://pypi/n/nwdiag/${pname}-${version}.tar.gz";
-    sha256 = "002565875559789a2dfc5f578c07abdf44269c3f7cdf78d4809bdc4bdc2213fa";
+    sha256 = "1qkl1lq7cblr6fra2rjw3zlcccragp8384hpm4n7dkc5c3yzmmsw";
   };
 
   buildInputs = [ pep8 nose unittest2 docutils ];

--- a/pkgs/development/python-modules/nwdiag/default.nix
+++ b/pkgs/development/python-modules/nwdiag/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, buildPythonPackage, pep8, nose, unittest2, docutils
-, blockdiag
+, blockdiag, setuptools
 }:
 
 buildPythonPackage rec {
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   buildInputs = [ pep8 nose unittest2 docutils ];
 
-  propagatedBuildInputs = [ blockdiag ];
+  propagatedBuildInputs = [ blockdiag setuptools ];
 
   # tests fail
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
noticed this:

```
  File "/nix/store/lwrfjajvzwmxqdgz5h5y0sjd9g08kk80-python3.8-blockdiag-1.5.3/lib/python3.8/site-packages/blockdiag/imagedraw/__init__.py", line 16, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

not sure how to add commits to other PRs

closes #79644

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/79654
4 package built:
asciidoc-full-with-plugins nwdiag python27Packages.nwdiag python38Packages.nwdiag
```