### PR TITLE
cemu: init at 1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4241,6 +4241,12 @@
     github = "ltavard";
     name = "Laure Tavard";
   };
+  luc65r = {
+    email = "lucas@ransan.tk";
+    github = "luc65r";
+    githubId = 59375051;
+    name = "Lucas Ransan";
+  };
   lucus16 = {
     email = "lars.jellema@gmail.com";
     github = "Lucus16";

--- a/pkgs/applications/science/math/cemu/default.nix
+++ b/pkgs/applications/science/math/cemu/default.nix
@@ -1,0 +1,53 @@
+{ fetchFromGitHub
+, stdenv
+, mkDerivation
+, SDL2
+, libGL
+, libarchive
+, libusb
+, qtbase
+, qmake
+, git
+, libpng_apng
+, pkgconfig
+}:
+
+mkDerivation rec {
+  pname = "CEmu";
+  version = "1.3";
+  src = fetchFromGitHub {
+    owner = "CE-Programming";
+    repo = "CEmu";
+    rev = "v${version}";
+    sha256 = "1wcdnzcqscawj6jfdj5wwmw9g9vsd6a1rx0rrramakxzf8b7g47r";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    qmake
+    git
+    pkgconfig
+  ];
+
+  buildInputs = [
+    SDL2
+    libGL
+    libarchive
+    libusb
+    qtbase
+    libpng_apng
+  ];
+
+  qmakeFlags = [
+    "gui/qt"
+  ];
+
+  meta = with stdenv.lib; {
+    changelog = "https://github.com/CE-Programming/CEmu/releases/tag/v${version}";
+    description = "Third-party TI-84 Plus CE / TI-83 Premium CE emulator, focused on developer features";
+    homepage = "https://ce-programming.github.io/CEmu";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ luc65r ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2348,6 +2348,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon IOKit;
   };
 
+  cemu = qt5.callPackage ../applications/science/math/cemu { };
+
   isomd5sum = callPackage ../tools/cd-dvd/isomd5sum { };
 
   mdf2iso = callPackage ../tools/cd-dvd/mdf2iso { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Added cemu app

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
