### PR TITLE
pythonPackages.pysaml2: 4.9.0 -> 5.0.0, addressing CVE-2020-5390

### DIFF
--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , buildPythonPackage
+, isPy3k
 , fetchFromGitHub
 , substituteAll
 , xmlsec
@@ -9,14 +10,16 @@
 
 buildPythonPackage rec {
   pname = "pysaml2";
-  version = "4.9.0";
+  version = "5.0.0";
+
+  disabled = !isPy3k;
 
   # No tests in PyPI tarball
   src = fetchFromGitHub {
     owner = "IdentityPython";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ww1l34zn25vxifs8nr0bg7gkhbpy5g45mj0jj4d8hzimahb1brx";
+    sha256 = "0hwhxz45h8l1b0615hf855z7valfcmm0nb7k31bcj84v68zp5rjs";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2020-5390

Disabled for python 2.7 as support is being removed from this release on. Will probably try and patch 19.09 so we don't need to disable for 2.7 mid-release.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
