### PR TITLE
babelstone-han: 12.1.7 -> 13.0.3

### DIFF
--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,16 +1,17 @@
 { lib, fetchzip }:
 
 let
-  version = "12.1.7";
+  version = "13.0.3";
 in fetchzip {
   name = "babelstone-han-${version}";
 
-  url = https://www.babelstone.co.uk/Fonts/Download/BabelStoneHan.zip;
+  # upstream download links are unversioned, so hash changes
+  url = https://web.archive.org/web/20200210125314/https://www.babelstone.co.uk/Fonts/Download/BabelStoneHan.zip;
   postFetch = ''
     mkdir -p $out/share/fonts/truetype
     unzip $downloadedFile '*.ttf' -d $out/share/fonts/truetype
   '';
-  sha256 = "07liv0lmk28ybxccf91gp2wmc17pk3fcshixpj0jx069b64zwf1v";
+  sha256 = "018isk3hbzsihzrxavgjbn485ngzvlm96npqx9y7zpkxsssslc4w";
 
   meta = with lib; {
     description = "Unicode CJK font with over 36000 Han characters";
@@ -18,7 +19,6 @@ in fetchzip {
 
     license = licenses.free;
     platforms = platforms.all;
-    hydraPlatforms = [];
-    maintainers = [ maintainers.volth ];
+    maintainers = with maintainers; [ volth emily ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This font package is currently broken due to the URL pointing to the new version. Not a huge fan of sourcing from an unversioned, breakable link like this, but I guess there's no upstream alternative; Debian caches the source archives, but only has old versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).