### PR TITLE
envypn-font: split outputs in out and otb

### DIFF
--- a/pkgs/data/fonts/envypn-font/default.nix
+++ b/pkgs/data/fonts/envypn-font/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation {
     '';
     homepage = "http://ywstd.fr/p/pj/#envypn";
     license = licenses.miros;
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/data/fonts/envypn-font/default.nix
+++ b/pkgs/data/fonts/envypn-font/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, mkfontdir, mkfontscale }:
+{ stdenv, fetchurl, libfaketime
+, fonttosfnt, mkfontscale
+}:
 
 stdenv.mkDerivation {
   name = "envypn-font-1.7.1";
@@ -8,26 +10,28 @@ stdenv.mkDerivation {
     sha256 = "bda67b6bc6d5d871a4d46565d4126729dfb8a0de9611dae6c68132a7b7db1270";
   };
 
-  nativeBuildInputs = [ mkfontdir mkfontscale ];
+  nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];
 
   unpackPhase = ''
     tar -xzf $src --strip-components=1
   '';
 
-  installPhase = ''
-    # install the pcf fonts (for xorg applications)
-    fontDir="$out/share/fonts/envypn"
-    mkdir -p "$fontDir"
-    mv *.pcf.gz "$fontDir"
-
-    cd "$fontDir"
-    mkfontdir
-    mkfontscale
+  buildPhase = ''
+    # convert pcf fonts to otb
+    for i in *e.pcf.gz; do
+      faketime -f "1970-01-01 00:00:01" \
+      fonttosfnt -v -o "$(basename "$i" .pcf.gz)".otb "$i"
+    done
   '';
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "04sjxfrlvjc2f0679cy4w366mpzbn3fp6gnrjb8vy12vjd1ffnc1";
+  installPhase = ''
+    install -D -m 644 -t "$out/share/fonts/misc" *.pcf.gz
+    install -D -m 644 -t "$otb/share/fonts/misc" *.otb
+    mkfontdir "$out/share/fonts/misc"
+    mkfontdir "$otb/share/fonts/misc"
+  '';
+
+  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17464,7 +17464,8 @@ in
 
   encode-sans = callPackage ../data/fonts/encode-sans { };
 
-  envypn-font = callPackage ../data/fonts/envypn-font { };
+  envypn-font = callPackage ../data/fonts/envypn-font
+    { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
 
   envdir = callPackage ../tools/misc/envdir-go { };
 


### PR DESCRIPTION
###### Motivation for this change
Issue #75160

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested fonts are working in X11 and GTK application
- [x] Tested compilation of all pkgs that depend on this change using
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).