### PR TITLE
spleen: install otf font

### DIFF
--- a/pkgs/data/fonts/spleen/default.nix
+++ b/pkgs/data/fonts/spleen/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, mkfontdir }:
+{ lib, fetchurl, mkfontscale }:
 
 let
   pname = "spleen";
@@ -11,14 +11,15 @@ in fetchurl {
   recursiveHash = true;
   postFetch = ''
     tar xvf $downloadedFile --strip=1
-    d="$out/share/fonts/X11/misc/spleen"
-    install -Dm644 *.{pcf.gz,psfu,bdf} -t $d
+    d="$out/share/fonts/misc"
+    install -D -m 644 *.{pcf,bdf,otf} -t "$d"
+    install -D -m 644 *.psfu -t "$out/share/consolefonts"
     install -m644 fonts.alias-spleen $d/fonts.alias
 
     # create fonts.dir so NixOS xorg module adds to fp
-    ${mkfontdir}/bin/mkfontdir $d
+    ${mkfontscale}/bin/mkfontdir "$d"
   '';
-  sha256 = "0h9gj7syn87hl5rhwckih92r228zac6b1dvh3034caml8ad3fyla";
+  sha256 = "0x1xiw4gyfkyvwqg0f47rl92zq76d0c6jfncdnq8m2wwpxz9697b";
 
   meta = with lib; {
     description = "Monospaced bitmap fonts";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17897,7 +17897,7 @@ in
   source-han-serif-simplified-chinese = sourceHanSerifPackages.simplified-chinese;
   source-han-serif-traditional-chinese = sourceHanSerifPackages.traditional-chinese;
 
-  spleen = callPackage ../data/fonts/spleen { inherit (xorg) mkfontdir; };
+  spleen = callPackage ../data/fonts/spleen { inherit (buildPackages.xorg) mkfontscale; };
 
   stilo-themes = callPackage ../data/themes/stilo { };
 


### PR DESCRIPTION
###### Motivation for this change
Issue #75160

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested fonts are working in X11 and GTK application
- [x] Tested compilation of all pkgs that depend on this change using
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).