### PR TITLE
Kicad-unstable: update update.sh and update

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -35,8 +35,8 @@ let
   python = python3;
   wxPython = python3Packages.wxPython_4_0;
 
-  kicad-libraries = callPackages ./libraries.nix versionConfig.libVersion;
-  kicad-base = callPackage ./base.nix {
+  libraries = callPackages ./libraries.nix versionConfig.libVersion;
+  base = callPackage ./base.nix {
     pname = baseName;
     inherit versions stable baseName;
     inherit wxGTK python wxPython;
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   inherit pname;
   version = versions.${baseName}.kicadVersion.version;
 
-  src = kicad-base;
+  src = base;
   dontUnpack = true;
   dontConfigure = true;
   dontBuild = true;
@@ -61,10 +61,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = optionals (scriptingSupport)
     [ pythonPackages.wrapPython ];
 
-  # wrapGAppsHook added the equivalent to ${kicad-base}/share
+  # wrapGAppsHook added the equivalent to ${base}/share
   # though i noticed no difference without it
   makeWrapperArgs = [
-    "--prefix XDG_DATA_DIRS : ${kicad-base}/share"
+    "--prefix XDG_DATA_DIRS : ${base}/share"
     "--prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share"
     "--prefix XDG_DATA_DIRS : ${gnome3.defaultIconTheme}/share"
     "--prefix XDG_DATA_DIRS : ${wxGTK.gtk}/share/gsettings-schemas/${wxGTK.gtk.name}"
@@ -73,13 +73,13 @@ stdenv.mkDerivation rec {
     "--prefix XDG_DATA_DIRS : ${cups}/share"
     "--prefix GIO_EXTRA_MODULES : ${gnome3.dconf}/lib/gio/modules"
 
-    "--set KISYSMOD ${kicad-libraries.footprints}/share/kicad/modules"
-    "--set KICAD_SYMBOL_DIR ${kicad-libraries.symbols}/share/kicad/library"
-    "--set KICAD_TEMPLATE_DIR ${kicad-libraries.templates}/share/kicad/template"
-    "--prefix KICAD_TEMPLATE_DIR : ${kicad-libraries.symbols}/share/kicad/template"
-    "--prefix KICAD_TEMPLATE_DIR : ${kicad-libraries.footprints}/share/kicad/template"
+    "--set KISYSMOD ${libraries.footprints}/share/kicad/modules"
+    "--set KICAD_SYMBOL_DIR ${libraries.symbols}/share/kicad/library"
+    "--set KICAD_TEMPLATE_DIR ${libraries.templates}/share/kicad/template"
+    "--prefix KICAD_TEMPLATE_DIR : ${libraries.symbols}/share/kicad/template"
+    "--prefix KICAD_TEMPLATE_DIR : ${libraries.footprints}/share/kicad/template"
   ]
-  ++ optionals (with3d) [ "--set KISYS3DMOD ${kicad-libraries.packages3d}/share/kicad/modules/packages3d" ]
+  ++ optionals (with3d) [ "--set KISYS3DMOD ${libraries.packages3d}/share/kicad/modules/packages3d" ]
   ++ optionals (ngspiceSupport) [ "--prefix LD_LIBRARY_PATH : ${libngspice}/lib" ]
 
   # infinisil's workaround for #39493
@@ -88,30 +88,30 @@ stdenv.mkDerivation rec {
 
   # dunno why i have to add $makeWrapperArgs manually...
   # $out and $program_PYTHONPATH don't exist when makeWrapperArgs gets set?
-  # not sure if anything has to be done with the other stuff in kicad-base/bin
+  # not sure if anything has to be done with the other stuff in base/bin
   # dxf2idf, idf2vrml, idfcyl, idfrect, kicad2step, kicad-ogltest
   installPhase =
-    optionalString (scriptingSupport) '' buildPythonPath "${kicad-base} $pythonPath"
+    optionalString (scriptingSupport) '' buildPythonPath "${base} $pythonPath"
     '' +
-    '' makeWrapper ${kicad-base}/bin/kicad $out/bin/kicad $makeWrapperArgs ''
+    '' makeWrapper ${base}/bin/kicad $out/bin/kicad $makeWrapperArgs ''
     + optionalString (scriptingSupport) '' --set PYTHONPATH "$program_PYTHONPATH"
     '' +
-    '' makeWrapper ${kicad-base}/bin/pcbnew $out/bin/pcbnew $makeWrapperArgs ''
+    '' makeWrapper ${base}/bin/pcbnew $out/bin/pcbnew $makeWrapperArgs ''
     + optionalString (scriptingSupport) '' --set PYTHONPATH "$program_PYTHONPATH"
     '' +
-    '' makeWrapper ${kicad-base}/bin/eeschema $out/bin/eeschema $makeWrapperArgs ''
+    '' makeWrapper ${base}/bin/eeschema $out/bin/eeschema $makeWrapperArgs ''
     + optionalString (scriptingSupport) '' --set PYTHONPATH "$program_PYTHONPATH"
     '' +
-    '' makeWrapper ${kicad-base}/bin/gerbview $out/bin/gerbview $makeWrapperArgs ''
+    '' makeWrapper ${base}/bin/gerbview $out/bin/gerbview $makeWrapperArgs ''
     + optionalString (scriptingSupport) '' --set PYTHONPATH "$program_PYTHONPATH"
     '' +
-    '' makeWrapper ${kicad-base}/bin/pcb_calculator $out/bin/pcb_calculator $makeWrapperArgs ''
+    '' makeWrapper ${base}/bin/pcb_calculator $out/bin/pcb_calculator $makeWrapperArgs ''
     + optionalString (scriptingSupport) '' --set PYTHONPATH "$program_PYTHONPATH"
     '' +
-    '' makeWrapper ${kicad-base}/bin/pl_editor $out/bin/pl_editor $makeWrapperArgs ''
+    '' makeWrapper ${base}/bin/pl_editor $out/bin/pl_editor $makeWrapperArgs ''
     + optionalString (scriptingSupport) '' --set PYTHONPATH "$program_PYTHONPATH"
     '' +
-    '' makeWrapper ${kicad-base}/bin/bitmap2component $out/bin/bitmap2component $makeWrapperArgs ''
+    '' makeWrapper ${base}/bin/bitmap2component $out/bin/bitmap2component $makeWrapperArgs ''
     + optionalString (scriptingSupport) '' --set PYTHONPATH "$program_PYTHONPATH"
     ''
   ;

--- a/pkgs/applications/science/electronics/kicad/update.sh
+++ b/pkgs/applications/science/electronics/kicad/update.sh
@@ -5,13 +5,12 @@
 # this should contain the versions' revs and hashes
 # the stable revs are stored only for ease of skipping
 
-# if you get something like "tar: no space left on device"
-# you may need a bigger tmpfs, this can be set as such
-# services.logind.extraConfig = "RuntimeDirectorySize=8G";
-# this is most likely only needed for the packages3d
-# this can be checked without that config by manual TOFU
-# copy the generated items from ,versions.nix to versions.nix
-# then nix-build and see what it actually gets
+# by default nix-prefetch-url uses XDG_RUNTIME_DIR as tmp
+# which is /run/user/1000, which defaults to 10% of your RAM
+# unless you have over 64GB of ram that'll be insufficient
+# resulting in "tar: no space left on device" for packages3d
+# hence:
+export TMPDIR=/tmp
 
 # if something goes unrepairably wrong, run 'update.sh all clean'
 
@@ -19,7 +18,8 @@
 # support parallel instances for each pname
 #   currently risks reusing old data
 # no getting around manually checking if the build product works...
-# if there is, default to commiting
+# if there is, default to commiting?
+#   won't work when running in parallel?
 # remove items left in /nix/store?
 
 # get the latest tag that isn't an RC or *.99

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,25 +27,25 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2020-01-08";
+      version =			"2020-02-10";
       src = {
-        rev =			"ca34ade00c554157f106fde97af5f08a202808ef";
-        sha256 =		"0xx5qkc5pi3qdrdikgq3902ws8zilv2476fb4bbgh95d9wpgr35v";
+        rev =			"1190e60dd426d246661e478db3287f266ec6cda2";
+        sha256 =		"0cgfad07j69cks97llj4hf3kga0d5qf728s89xwxrzcwm06k62bi";
       };
     };
     libVersion = {
-      version =			"2020-01-08";
+      version =			"2020-02-10";
       libSources = {
-        i18n.rev =		"e7439fd76f27cfc26e269c4e6c4d56245345c28b";
-        i18n.sha256 =		"1nqm1kx5b4f7s0f9q8bg4rdhqnp0128yp6bgnrkia1kwmfnf5gmy";
-        symbols.rev =		"ad58768b88d564fd188c6667841adec436da53f2";
-        symbols.sha256 =	"1rdplf04bff0hmgjwr81fbcr9nkqi21n0n88nzs5fdp73mqiywcy";
+        i18n.rev =		"26786c4ca804bad7eb072f1ef381f00b5a2ff3ee";
+        i18n.sha256 =		"0iqr1xfw4s677afjy9bn5y41z4isp327f9y90wypkxiwwq3dfkfl";
+        symbols.rev =		"35b7da2d211d7cc036b37ad7f5e40ef03faa1bc7";
+        symbols.sha256 =	"0wbfw1swbfvfp47cn48pxpqlygjs3xh568ydrrs51v3w102x8y64";
         templates.rev =		"0c0490897f803ab8b7c3dad438b7eb1f80e0417c";
         templates.sha256 =	"0cs3bm3zb5ngw5ldn0lzw5bvqm4kvcidyrn76438alffwiz2b15g";
-        footprints.rev =	"973867de7f33f202e9fd1b3455bd1f7e7fe4a074";
-        footprints.sha256 =	"0yvidpnqbfxjdwaiscl5bdchsg0l4d769vp456dc8h0f3802mibi";
-        packages3d.rev =	"c2b92a411adc93ddeeed74b36b542e1057f81a2a";
-        packages3d.sha256 =	"05znc6y2lc31iafspg308cxdda94zg6c7mwslmys76npih1pb8qc";
+        footprints.rev =	"9357b6f09312966c57fec9f66a516941d79c3038";
+        footprints.sha256 =	"0cgah1q0h012ffwfl220k7qb6hgbs0i91spq2j4v3lgpfr4g638d";
+        packages3d.rev =	"de368eb739abe41dfc3163e0e370477e857f9cc1";
+        packages3d.sha256 =	"0b3p5v8g24h6l7q3sbqz7ns0gnrf9l89glj86m5ybhizvls9vrrs";
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change
fix update.sh to work for most people

###### Things done
use /tmp instead of /run/user/1000 (the default for nix-prefetch-url) which is usually set to 10% of RAM
bump unstable to latest
shorten a some internal names

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
