### PR TITLE
fonts/gdouros: correct license to unfree

### DIFF
--- a/pkgs/data/fonts/gdouros/default.nix
+++ b/pkgs/data/fonts/gdouros/default.nix
@@ -26,10 +26,11 @@ let
 
     meta = {
       inherit description;
-      # In lieu of a license:
-      # Fonts in this site are offered free for any use;
-      # they may be installed, embedded, opened, edited, modified, regenerated, posted, packaged and redistributed.
-      license = lib.licenses.free;
+      # see http://users.teilar.gr/~g1951d/License.pdf
+      # quite draconian: non-commercial, no modifications,
+      # no redistribution, "a single instantiation and no
+      # network installation"
+      license = lib.licenses.unfree;
       homepage = http://users.teilar.gr/~g1951d/;
     };
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I assume the licence for these fonts changed at some point, but the [current licensing conditions](http://users.teilar.gr/~g1951d/License.pdf) are actually rather byzantine and definitely non-Free. They actually prohibit redistribution, so the existing Hydra builds of these packages ([example](https://hydra.nixos.org/build/93627626)) are a liability; I'm not sure who (if anyone) would be able to purge them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
