### PR TITLE
virglrenderer: 0.7.0 -> 0.8.1

### DIFF
--- a/pkgs/development/libraries/virglrenderer/default.nix
+++ b/pkgs/development/libraries/virglrenderer/default.nix
@@ -1,24 +1,21 @@
-{ stdenv, fetchurl, pkgconfig, libGLU, epoxy, libX11, libdrm, mesa }:
-
+{ stdenv, fetchurl, cmake, meson, ninja, pkgconfig, python3
+, libGLU, epoxy, libX11, libdrm, mesa
+}:
 
 stdenv.mkDerivation rec {
-
   pname = "virglrenderer";
-  version = "0.7.0";
+  version = "0.8.1";
 
   src = fetchurl {
-    url = "https://www.freedesktop.org/software/virgl/${pname}-${version}.tar.bz2";
-    sha256 = "041agg1d6i8hg250y30f08n3via0hs9rbijxdrfifb8ara805v0m";
+    url = "https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/virglrenderer-${version}/virglrenderer-virglrenderer-${version}.tar.bz2";
+    sha256 = "0ac39mplmy6lmcd6cljmfsrfby7m6ac3dzvmnn5pv200drl415l4";
   };
 
   buildInputs = [ libGLU epoxy libX11 libdrm mesa ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake meson ninja pkgconfig python3 ];
 
-  # Fix use of fd_set without proper include
-  prePatch = ''
-    sed -e '1i#include <sys/select.h>' -i vtest/util.c
-  '';
+  dontUseCmakeConfigure = true;
 
   meta = with stdenv.lib; {
     description = "A virtual 3D GPU library that allows a qemu guest to use the host GPU for accelerated 3D rendering";
@@ -27,5 +24,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ maintainers.xeji ];
   };
-
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

freedesktop.org tarballs haven't been published since 0.7.0.  I've
sent a message to the mailing list (<87eev3cgcz.fsf@alyssa.is>),
suggesting newer tarballs be published.

Build system has changed from autoconf to meson+cmake/ninja, and the
vtest/util.c patch doesn't seem to be necessary any more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
