### PR TITLE
fish-foreign-env: git-20170324 -> git-20200209

### DIFF
--- a/pkgs/shells/fish/fish-foreign-env/default.nix
+++ b/pkgs/shells/fish/fish-foreign-env/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "fish-foreign-env";
-  version = "git-20170324";
+  version = "git-20200209";
 
   src = fetchFromGitHub {
     owner = "oh-my-fish";
     repo = "plugin-foreign-env";
-    rev = "baefbd690f0b52cb8746f3e64b326d82834d07c5";
-    sha256 = "0lwp6hy3kfk7xfx4xvbk1ir8zkzm7gfjbm4bf6xg1y6iw9jq9dnl";
+    rev = "dddd9213272a0ab848d474d0cbde12ad034e65bc";
+    sha256 = "00xqlyl3lffc5l0viin1nyp819wf81fncqyz87jx8ljjdhilmgbs";
   };
 
   installPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

"`^` as a redirection deprecated and will be removed in the future."
(see the changelog, under the 3.0b1 release)

The latest fish release (3.1.0 as of time of writing) errors when
encountering `^&1` ~~(though the fact it is now an error has yet to be
documented by them)~~. The plugin was updated last year to account for
this change, and with the release of fish-shell v3.1.0, this
should be fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jgillich 