### PR TITLE
memcached: fix darwin build

### DIFF
--- a/pkgs/servers/memcached/default.nix
+++ b/pkgs/servers/memcached/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, cyrus_sasl, libevent}:
+{stdenv, fetchurl, fetchpatch, cyrus_sasl, libevent}:
 
 stdenv.mkDerivation rec {
   version = "1.5.21";
@@ -8,6 +8,16 @@ stdenv.mkDerivation rec {
     url = "https://memcached.org/files/${pname}-${version}.tar.gz";
     sha256 = "1x4jzrz09aq4nllkarn7d5x77gsys5l3nvfj8c7j4nvmvc30rlg3";
   };
+
+  patches = [
+    # Fixes compilation error on Darwin due to redeclaration of
+    # htonll. The fix should appear in 1.5.23.
+    # https://github.com/memcached/memcached/issues/598
+    (fetchpatch {
+      url = "https://github.com/memcached/memcached/commit/95c67710aaf5cfe188d94b510faef8c66d6f5604.diff";
+      sha256 = "0ab5l24p4n4fpx78ilmg7jvs9nl84pdza90jbpbx3ns5n23pqbfs";
+    })
+  ];
 
   configureFlags = [
      "ac_cv_c_endian=${if stdenv.hostPlatform.isBigEndian then "big" else "little"}"


### PR DESCRIPTION
##### Motivation for this change

Fix the build on Darwin.

I made the patch unconditional since it's a general problem detecting the presence of `htonll` and could affect other platforms. It's also going to be included upstream, see https://github.com/memcached/memcached/issues/598

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
