### PR TITLE
merriweather{,-sans}: add new fonts

### DIFF
--- a/pkgs/data/fonts/merriweather-sans/default.nix
+++ b/pkgs/data/fonts/merriweather-sans/default.nix
@@ -1,0 +1,34 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "merriweather-sans";
+  version = "1.008";
+
+  src = fetchFromGitHub {
+    owner = "SorkinType";
+    repo = "Merriweather-Sans";
+    rev = "8a1b078e3aeec6aecc856c3422898816af9b9dc7";
+    sha256 = "1f6a64bv4b4b1v3g2pgrzxcys8rk12wq6wfxamgzligcq5fxaffd";
+  };
+
+  # TODO: it would be nice to build this from scratch, but lots of
+  # Python dependencies to package (fontmake, gftools)
+
+  installPhase = ''
+    install -m444 -Dt $out/share/fonts/truetype/${pname} fonts/ttfs/*.ttf
+    install -m444 -Dt $out/share/fonts/woff/${pname} fonts/woff/*.woff
+    install -m444 -Dt $out/share/fonts/woff2/${pname} fonts/woff2/*.woff2
+    # TODO: install variable version?
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/SorkinType/Merriweather-Sans";
+    description = "Merriweather Sans is a low-contrast semi-condensed sans-serif text typeface family designed to be pleasant to read at very small sizes";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ emily ];
+  };
+}

--- a/pkgs/data/fonts/merriweather/default.nix
+++ b/pkgs/data/fonts/merriweather/default.nix
@@ -1,0 +1,35 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "merriweather";
+  version = "2.005";
+
+  src = fetchFromGitHub {
+    owner = "SorkinType";
+    repo = "Merriweather";
+    rev = "4fd88c9299009d1c1d201e7da3ff75cf1de5153a";
+    sha256 = "1ndycja2jzhcfbqbm0p6ka2zl1i1pdbkf0crw2lp3pi4k89wlm29";
+  };
+
+  # TODO: it would be nice to build this from scratch, but lots of
+  # Python dependencies to package (fontmake, gftools)
+
+  installPhase = ''
+    install -m444 -Dt $out/share/fonts/opentype/${pname} fonts/otf/*.otf
+    install -m444 -Dt $out/share/fonts/truetype/${pname} fonts/ttfs/*.ttf
+    install -m444 -Dt $out/share/fonts/woff/${pname} fonts/woff/*.woff
+    install -m444 -Dt $out/share/fonts/woff2/${pname} fonts/woff2/*.woff2
+    # TODO: install variable version?
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/SorkinType/Merriweather";
+    description = "Merriweather was designed to be a text face that is pleasant to read on screens";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ emily ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1953,6 +1953,8 @@ in
 
   merriweather = callPackage ../data/fonts/merriweather { };
 
+  merriweather-sans = callPackage ../data/fonts/merriweather-sans { };
+
   meson = callPackage ../development/tools/build-managers/meson { };
 
   meson-tools = callPackage ../misc/meson-tools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1951,6 +1951,8 @@ in
 
   opendune = callPackage ../games/opendune { };
 
+  merriweather = callPackage ../data/fonts/merriweather { };
+
   meson = callPackage ../development/tools/build-managers/meson { };
 
   meson-tools = callPackage ../misc/meson-tools { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[Merriweather](https://fonts.google.com/specimen/Merriweather) is a popular OFL-licensed font on Google Fonts; its metrics are comparable to Georgia, making it a good freely-licensed replacement. I've also included its sister [Sans face](https://fonts.google.com/specimen/Merriweather+Sans). It's already packaged in [openSUSE](https://build.opensuse.org/package/show/openSUSE:Factory/google-merriweather-fonts), [Alpine](https://pkgs.alpinelinux.org/packages?name=font-merriweather) and the [Arch User Repository](https://aur.archlinux.org/packages/ttf-merriweather/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).