### PR TITLE
pythonPackages.pysnow: init at 0.7.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -367,6 +367,12 @@
       fingerprint = "7FDB 17B3 C29B 5BA6 E5A9  8BB2 9FAA 63E0 9750 6D9D";
     }];
   };
+  almac = {
+    email = "alma.cemerlic@gmail.com";
+    github = "a1mac";
+    githubId = 60479013;
+    name = "Alma Cemerlic";
+  };
   alunduil = {
     email = "alunduil@gmail.com";
     github = "alunduil";

--- a/pkgs/development/python-modules/pysnow/default.nix
+++ b/pkgs/development/python-modules/pysnow/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, pythonAtLeast
+, brotli
+, ijson
+, nose
+, requests_oauthlib 
+, python_magic
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "pysnow";
+  version = "0.7.14";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0a6ce8b5f247fbfe5a53829c2f22391161e88646742283f861bce32bfe1626f1";
+  };
+
+  propagatedBuildInputs = [
+    brotli
+    ijson 
+    python_magic 
+    pytz 
+    requests_oauthlib
+  ];
+
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    nosetests --cover-package=pysnow --with-coverage --cover-erase
+  '';
+
+  meta = with lib; {
+    description = "ServiceNow HTTP client library written in Python";
+    homepage = "https://github.com/rbw/pysnow";
+    license = licenses.mit;
+    maintainers = [ maintainers.almac ];  
+  };
+
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4969,6 +4969,8 @@ in {
 
   pyshp = callPackage ../development/python-modules/pyshp { };
 
+  pysnow = callPackage ../development/python-modules/pysnow { };
+
   pysmbc = callPackage ../development/python-modules/pysmbc {
     inherit (pkgs) pkgconfig;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding pysnow into nixpkgs and adding myself as the maintainer for the package.

###### Note
Separate commit with the maintainer info only was denied: https://github.com/NixOS/nixpkgs/pull/79160
I have a few more packages that I would like to add given that this one is accepted

###### Things done
I tested builds with different versions of python on centos with nixpkgs.
I did integration testing with py37 on nixos (nix-shell).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
