### PR TITLE
Python3 Packages - digi-xbee and srp

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3275,6 +3275,12 @@
     githubId = 1198065;
     name = "Jeffrey David Johnson";
   };
+  jefflabonte = {
+    email = "grimsleepless@protonmail.com";
+    github = "jefflabonte";
+    githubId = 9425955;
+    name = "Jean-François Labonté";
+  };
   jensbin = {
     email = "jensbin+git@pm.me";
     github = "jensbin";

--- a/pkgs/development/python-modules/digi-xbee/default.nix
+++ b/pkgs/development/python-modules/digi-xbee/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy27, pyserial, srp, lib }:
+
+buildPythonPackage rec {
+  pname = "digi-xbee";
+  version = "1.3.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2ed798faee0853bf7ae9ca5aa4bdcbab496e3c2d56c9f0719a8e3e0d13270891";
+  };
+
+  propagatedBuildInputs = [ pyserial srp ];
+
+  # Upstream doesn't contain unit tests, only functional tests which require specific hardware
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python library to interact with Digi International's XBee radio frequency modules";
+    homepage = "https://github.com/digidotcom/xbee-python";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ jefflabonte ];
+  };
+}

--- a/pkgs/development/python-modules/srp/default.nix
+++ b/pkgs/development/python-modules/srp/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, six, lib }:
+
+buildPythonPackage rec {
+  pname = "srp";
+  version = "1.0.15";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d5b8ed6dc7d3ae2845a16590ef37763bbf15d6049848b85a8c96dfb8a83c984a";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  # Tests ends up with libssl.so cannot load shared
+  doCheck = false;
+
+  meta = with lib; {
+    longDescription = ''
+     This package provides an implementation of the Secure Remote Password protocol (SRP).
+     SRP is a cryptographically strong authentication protocol for password-based, mutual authentication over an insecure network connection.
+    '';
+    homepage = "https://github.com/cocagne/pysrp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jefflabonte ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2438,6 +2438,8 @@ in {
 
   digital-ocean = callPackage ../development/python-modules/digitalocean { };
 
+  digi-xbee = callPackage ../development/python-modules/digi-xbee { };
+
   leather = callPackage ../development/python-modules/leather { };
 
   libais = callPackage ../development/python-modules/libais { };
@@ -6922,7 +6924,11 @@ in {
 
   importlib-resources = callPackage ../development/python-modules/importlib-resources {};
 
+  srp = callPackage ../development/python-modules/srp { };
+
   srptools = callPackage ../development/python-modules/srptools { };
+
+  srp = callPackage ../development/python-modules/srp { };
 
   curve25519-donna = callPackage ../development/python-modules/curve25519-donna { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6924,8 +6924,6 @@ in {
 
   importlib-resources = callPackage ../development/python-modules/importlib-resources {};
 
-  srp = callPackage ../development/python-modules/srp { };
-
   srptools = callPackage ../development/python-modules/srptools { };
 
   srp = callPackage ../development/python-modules/srp { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Those are packages that I use at work for some of my devices, I felt like it would be a good idea
to share with the community packages I made for myself.

###### Things done

Create package called digi-xbee 1.3.0 and srp 1.0.15

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
