### PR TITLE
cri-o: v1.16.1 -> v1.17.0

### DIFF
--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -4,6 +4,7 @@
 , btrfs-progs
 , buildGoPackage
 , fetchFromGitHub
+, git
 , glibc
 , gpgme
 , libapparmor
@@ -13,13 +14,14 @@
 , libselinux
 , lvm2
 , pkgconfig
+, which
 }:
 
 let
   buildTags = "apparmor seccomp selinux containers_image_ostree_stub";
 in buildGoPackage rec {
   project = "cri-o";
-  version = "1.16.1";
+  version = "1.17.0";
   name = "${project}-${version}${flavor}";
 
   goPackagePath = "github.com/${project}/${project}";
@@ -28,11 +30,11 @@ in buildGoPackage rec {
     owner = "cri-o";
     repo = "cri-o";
     rev = "v${version}";
-    sha256 = "0w690zhc55gdqzc31jc34nrzwd253pfb3rq23z51q22nqwmlsh9p";
+    sha256 = "0xjmylf0ww23qqcg7kw008px6608r4qq6q57pfqis0661kp6f24j";
   };
 
   outputs = [ "bin" "out" ];
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ git pkgconfig which ];
   buildInputs = [ btrfs-progs gpgme libapparmor libassuan libgpgerror
                  libseccomp libselinux lvm2 ]
                 ++ stdenv.lib.optionals (glibc != null) [ glibc glibc.static ];
@@ -40,27 +42,15 @@ in buildGoPackage rec {
   buildPhase = ''
     pushd go/src/${goPackagePath}
 
-    # Build pause
-    make -C pause
-
-    # Build the crio binaries
-    function build() {
-      go build \
-        -tags "${buildTags}" \
-        -o bin/"$1" \
-        -buildmode=pie \
-        -ldflags '-s -w ${ldflags}' \
-        ${goPackagePath}/cmd/"$1"
-    }
-    build crio
-    build crio-status
+    make BUILDTAGS='${buildTags}' \
+      bin/crio \
+      bin/crio-status \
+      bin/pinns
   '';
   installPhase = ''
     install -Dm755 bin/crio $bin/bin/crio${flavor}
     install -Dm755 bin/crio-status $bin/bin/crio-status${flavor}
-
-    mkdir -p $bin/libexec/crio
-    install -Dm755 bin/pause $bin/libexec/crio/pause${flavor}
+    install -Dm755 bin/pinns $bin/bin/pinns${flavor}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update CRI-O to the latest version and adapt build.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
