### PR TITLE
btcdeb: init at 0.2.19

### DIFF
--- a/pkgs/applications/blockchains/btcdeb/default.nix
+++ b/pkgs/applications/blockchains/btcdeb/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, openssl
+}:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  pname = "btcdeb";
+  version = "0.2.19";
+
+  src = fetchFromGitHub {
+    owner = "kallewoof";
+    repo = pname;
+    rev = "fb2dace4cd115dc9529a81515cee855b8ce94784";
+    sha256 = "0l0niamcjxmgyvc6w0wiygfgwsjam3ypv8mvjglgsj50gyv1vnb3";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "Bitcoin Script Debugger";
+    homepage = "https://github.com/kallewoof/btcdeb";
+    license = licenses.mit;
+    maintainers = with maintainers; [ akru ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26168,4 +26168,6 @@ in
   go-license-detector = callPackage ../development/tools/misc/go-license-detector { };
 
   fluxboxlauncher = callPackage ../applications/misc/fluxboxlauncher {};
+
+  btcdeb = callPackage ../applications/blockchains/btcdeb {};
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Introducing the [Bitcoin Script Debugger](https://github.com/kallewoof/btcdeb) tool that used in tutorial https://github.com/ChristopherA/Learning-Bitcoin-from-the-Command-Line. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
