### PR TITLE
hobbes: init at latest

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7253,6 +7253,12 @@
     githubId = 844343;
     name = "Thiago K. Okada";
   };
+  thmzlt = {
+    email = "git@thomazleite.com";
+    github = "thmzlt";
+    githubId = 7709;
+    name = "Thomaz Leite";
+  };
   ThomasMader = {
     email = "thomas.mader@gmail.com";
     github = "ThomasMader";

--- a/pkgs/development/tools/hobbes/default.nix
+++ b/pkgs/development/tools/hobbes/default.nix
@@ -35,5 +35,6 @@ stdenv.mkDerivation {
     license = licenses.asl20;
     maintainers = [ maintainers.thmzlt ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/tools/hobbes/default.nix
+++ b/pkgs/development/tools/hobbes/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, cmake, llvm_6, ncurses, readline, zlib }:
+
+stdenv.mkDerivation {
+  name = "hobbes";
+  version = "unstable-2020-03-10";
+
+  src = fetchFromGitHub {
+    owner = "morgan-stanley";
+    repo = "hobbes";
+    rev = "ae956df9da3f3b24630bc1757dfaa2a8952db07a";
+    sha256 = "1a0lb87vb0qcp5wy6swk4jcc88l7vhy6iflsk7zplw547mbjhjsy";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    llvm_6 # LLVM 6 is latest currently supported. See https://git.io/JvK6w.
+    ncurses
+    readline
+    zlib
+  ];
+
+  doCheck = false; # Running tests in NixOS hangs. See https://git.io/JvK7R.
+  checkTarget = "test";
+
+  meta = with stdenv.lib; {
+    description = "A language and an embedded JIT compiler";
+    longDescription = ''
+      Hobbes is a a language, embedded compiler, and runtime for efficient
+      dynamic expression evaluation, data storage and analysis.
+    '';
+    homepage = "https://github.com/Morgan-Stanley/hobbes";
+    license = licenses.asl20;
+    maintainers = [ maintainers.thmzlt ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -171,6 +171,8 @@ in
 
   deadcode = callPackage ../development/tools/deadcode { };
 
+  hobbes = callPackage ../development/tools/hobbes { stdenv = gcc6Stdenv; }; # GCC 6 is latest currently supported. See https://git.io/JvK6M.
+
   proto-contrib = callPackage ../development/tools/proto-contrib {};
 
   protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Introducing the [hobbes](morgan-stanley/hobbes) programming and execution environment build and maintained at Morgan Stanley.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
