### PR TITLE
powerline-fonts: install psf to share/consolefonts

### DIFF
--- a/pkgs/data/fonts/powerline-fonts/default.nix
+++ b/pkgs/data/fonts/powerline-fonts/default.nix
@@ -13,10 +13,10 @@ fetchFromGitHub {
     find . -name '*.ttf'    -exec install -Dt $out/share/fonts/truetype {} \;
     find . -name '*.bdf'    -exec install -Dt $out/share/fonts/bdf      {} \;
     find . -name '*.pcf.gz' -exec install -Dt $out/share/fonts/pcf      {} \;
-    find . -name '*.psf.gz' -exec install -Dt $out/share/fonts/psf      {} \;
+    find . -name '*.psf.gz' -exec install -Dt $out/share/consolefonts   {} \;
   '';
 
-  sha256 = "0irifak86gn7hawzgxcy53s22y215mxc2kjncv37h7q44jsqdqww";
+  sha256 = "0r8p4z3db17f5p8jr7sv80nglmjxhg83ncfvwg1dszldswr0dhvr";
 
   meta = with lib; {
     homepage = https://github.com/powerline/fonts;


### PR DESCRIPTION
###### Motivation for this change
This will make easier to set the font of the virtual console
in NixOS. Instead of specifing the full filepath of the psf
on can simply do:

    console.font = "ter-powerline-v20b";
    console.packages = [ pkgs.powerline-fonts ];

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox`)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested fonts in virtual console, X11 and GTK applications
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
