### PR TITLE
skawarePackages: support static builds via pkgsStatic

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -65,6 +65,9 @@ in stdenv.mkDerivation {
 
   configureFlags = configureFlags ++ [
     "--enable-absolute-paths"
+    # We assume every nix-based cross target has urandom.
+    # This might not hold for e.g. BSD.
+    "--with-sysdep-devurandom=yes"
     (if stdenv.isDarwin
       then "--disable-shared"
       else "--enable-shared")

--- a/pkgs/os-specific/linux/sdnotify-wrapper/default.nix
+++ b/pkgs/os-specific/linux/sdnotify-wrapper/default.nix
@@ -23,13 +23,13 @@ in runCommandCC "sdnotify-wrapper" {
   mkdir -p $bin/bin
   mkdir $out
 
-  # just dynamic for now
+  # the -lskarnet has to come at the end to support static builds
   $CC \
     -o $bin/bin/sdnotify-wrapper \
     -I${skalibs.dev}/include \
     -L${skalibs.lib}/lib \
-    -lskarnet \
-    ${src}
+    ${src} \
+    -lskarnet
 
   mkdir -p $doc/share/doc/sdnotify-wrapper
   # copy the documentation comment

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -35,15 +35,21 @@ buildPackage {
     mv examples $doc/share/doc/execline/examples
 
     mv $bin/bin/execlineb $bin/bin/.execlineb-wrapped
-    cc \
+
+    # A wrapper around execlineb, which provides all execline
+    # tools on `execlineb`’s PATH.
+    # It is implemented as a C script, because on non-Linux,
+    # nested shebang lines are not supported.
+    # The -lskarnet has to come at the end to support static builds.
+    $CC \
       -O \
       -Wall -Wpedantic \
       -D "EXECLINEB_PATH()=\"$bin/bin/.execlineb-wrapped\"" \
       -D "EXECLINE_BIN_PATH()=\"$bin/bin\"" \
       -I "${skalibs.dev}/include" \
       -L "${skalibs.lib}/lib" \
-      -lskarnet \
       -o "$bin/bin/execlineb" \
-      ${./execlineb-wrapper.c}
+      ${./execlineb-wrapper.c} \
+      -lskarnet
   '';
 }


### PR DESCRIPTION
Most of the skaware packages already build just fine with pkgsStatic,
however the wrapper scripts for execline and stdnotify-wrapper needed
the `-lskarlib` argument to go at the end.

`utmps` and `nsss` still fail with this error:

```
exec ./tools/install.sh -D -m 600 utmps-utmpd /bin/utmps-utmpd
/build/utmps-0.0.3.1/tools/install.sh: line 48: can't create /bin/utmps-utmpd.tmp.479: Permission denied
make: *** [Makefile:121: /bin/utmps-utmpd] Error 1
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
