### PR TITLE
gdb: 8.3.1 -> 9.1

### DIFF
--- a/pkgs/development/tools/misc/gdb/darwin-target-match.patch
+++ b/pkgs/development/tools/misc/gdb/darwin-target-match.patch
@@ -1,6 +1,6 @@
 --- a/configure	2017-06-05 00:51:26.000000000 +0900
 +++ b/configure	2018-03-06 23:12:58.000000000 +0900
-@@ -3603,7 +3603,7 @@
+@@ -3644,7 +3644,7 @@
      noconfigdirs="$noconfigdirs ld gprof"
      noconfigdirs="$noconfigdirs sim target-rda"
      ;;

--- a/pkgs/development/tools/misc/gdb/debug-info-from-env.patch
+++ b/pkgs/development/tools/misc/gdb/debug-info-from-env.patch
@@ -1,15 +1,24 @@
-Initialize debug-file-directory from NIX_DEBUG_INFO_DIRS, a colon-separated list
-of directories with separate debugging information files.
-
---- a/gdb/main.c
-+++ b/gdb/main.c
-@@ -556,3 +556,8 @@ captured_main_1 (struct captured_main_args *context)
+diff -ur a/gdb/main.c b/gdb/main.c
+--- a/gdb/main.c	2020-02-08 13:50:14.000000000 +0100
++++ b/gdb/main.c	2020-02-24 10:02:07.731806739 +0100
+@@ -567,9 +567,17 @@
+       gdb_sysroot = xstrdup (TARGET_SYSROOT_PREFIX);
+     }
  
--  debug_file_directory = relocate_gdb_directory (DEBUGDIR,
-+  debug_file_directory = getenv("NIX_DEBUG_INFO_DIRS");
-+
+-  debug_file_directory
+-    = xstrdup (relocate_gdb_directory (DEBUGDIR,
+-				     DEBUGDIR_RELOCATABLE).c_str ());
++  debug_file_directory = getenv ("NIX_DEBUG_INFO_DIRS");
 +  if (debug_file_directory != NULL)
-+    debug_file_directory = xstrdup(debug_file_directory);
++    // This might be updated later using
++    // $ set debug-file-directory /to/some/path
++    // which will use xfree. We must then have a xmallocated
++    // copy of the string that can be xfeed later.
++    debug_file_directory = xstrdup (debug_file_directory);
 +  else
-+    debug_file_directory = relocate_gdb_directory (DEBUGDIR,
- 						 DEBUGDIR_RELOCATABLE);
++    debug_file_directory
++      = xstrdup (relocate_gdb_directory (DEBUGDIR,
++                                         DEBUGDIR_RELOCATABLE).c_str ());
+ 
+   gdb_datadir = relocate_gdb_directory (GDB_DATADIR,
+ 					GDB_DATADIR_RELOCATABLE);

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -18,7 +18,7 @@
 
 let
   basename = "gdb-${version}";
-  version = "8.3.1";
+  version = "9.1";
 in
 
 assert pythonSupport -> python3 != null;
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnu/gdb/${basename}.tar.xz";
-    sha256 = "1i2pjwaafrlz7wqm40b4znr77ai32rjsxkpl2az38yyarpbv8m8y";
+    sha256 = "0dqp1p7w836iwijg1zb4a784n0j4pyjiw5v6h8fg5lpx6b40x7k9";
   };
 
   postPatch = if stdenv.isDarwin then ''
@@ -64,6 +64,13 @@ stdenv.mkDerivation rec {
 
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (stdenv.targetPlatform != stdenv.hostPlatform) "target";
+
+  # GDB have to be built out of tree.
+  preConfigure = ''
+    mkdir _build
+    cd _build
+  '';
+  configureScript = "../configure";
 
   configureFlags = with stdenv.lib; [
     "--enable-targets=all" "--enable-64-bit-bfd"
@@ -100,6 +107,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl3Plus;
 
     platforms = with platforms; linux ++ cygwin ++ darwin;
-    maintainers = with maintainers; [ pierron globin ];
+    maintainers = with maintainers; [ pierron globin lsix ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10778,6 +10778,7 @@ in
 
   gdb = callPackage ../development/tools/misc/gdb {
     guile = null;
+    readline = readline80;
   };
 
   jhiccup = callPackage ../development/tools/java/jhiccup { };


### PR DESCRIPTION
See https://www.gnu.org/software/gdb/download/ANNOUNCEMENT for release
information

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
