### PR TITLE
nixos-container: minor fixes

### DIFF
--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -43,6 +43,7 @@ Usage: nixos-container list
          [--config <string>]
          [--config-file <path>]
          [--flake <flakeref>]
+         [--nixos-path <path>]
        nixos-container login <container-name>
        nixos-container root-login <container-name>
        nixos-container run <container-name> -- args...
@@ -386,6 +387,7 @@ elsif ($action eq "update") {
         system("nix-env", "-p", "$profileDir/system", "--set", $systemPath) == 0
             or die "$0: failed to set container configuration\n";
     } else {
+
         my $nixosConfigFile = "$root/etc/nixos/configuration.nix";
 
         # FIXME: may want to be more careful about clobbering the existing
@@ -395,8 +397,9 @@ elsif ($action eq "update") {
             writeNixOSConfig $nixosConfigFile;
         }
 
+        my $nixenvF = $nixosPath // "<nixpkgs/nixos>";
         system("nix-env", "-p", "$profileDir/system",
-               "-I", "nixos-config=$nixosConfigFile", "-f", "<nixpkgs/nixos>",
+               "-I", "nixos-config=$nixosConfigFile", "-f", $nixenvF,
                "--set", "-A", "system") == 0
             or die "$0: failed to build container configuration\n";
     }


### PR DESCRIPTION

###### Motivation for this change

While there are plans to rework the nixos-container infrastructure (#69414) in the long-term, the imperative `nixos-container` tool is pretty helpful to e.g. test new modules in an isolated environment.

This PR fixes two issues that bothered me for quite some time:

* 3909f50990ef2a33828c2b43b89846f718d72ea2 - to avoid inconsistent state in case of a failing eval during `nixos-container create`, the entire state/config is removed in that case (until now you'd still have the `/etc/containers/<name>.conf`, but no running instance which breaks recreation-attempts).

* 7d51c490b58977f725710d839c8f0aefa39947ba - add `--nixos-path` to `nixos-container update` as well. Helpful when hacking e.g. on new modules in a local checkout.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
