### PR TITLE
cvsq: init at 1.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1340,6 +1340,12 @@
     githubId = 25088352;
     name = "Christian Kögler";
   };
+  clkamp = {
+    email = "c@lkamp.de";
+    github = "clkamp";
+    githubId = 46303707;
+    name = "Christian Lütke-Stetzkamp";
+  };
   kampka = {
     email = "christian@kampka.net";
     github = "kampka";

--- a/pkgs/applications/version-management/cvsq/default.nix
+++ b/pkgs/applications/version-management/cvsq/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, fetchurl
+, makeWrapper
+, cvs
+, perl
+, nettools
+, findutils
+, rsync
+, coreutils
+, diffutils
+} :
+
+stdenv.mkDerivation rec {
+  pname = "cvsq";
+  version = "1.10";
+
+  src = fetchurl {
+    url = "http://www.linta.de/~aehlig/cvsq/cvsq-${version}.tgz";
+    sha256 = "1a2e5666d4d23f1eb673a505caeb771ac62a86ed69c9ab89c4e2696c2ccd0621";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cvs perl nettools findutils rsync coreutils diffutils ];
+
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  postInstall = ''
+    substituteInPlace $out/bin/cvsq --replace "/bin/sh" "${stdenv.shell}"
+    substituteInPlace $out/bin/lcvs --replace "/bin/sh" "${stdenv.shell}"
+    wrapProgram $out/bin/cvsq --prefix PATH : ${stdenv.lib.makeBinPath
+      [ cvs nettools findutils rsync coreutils diffutils ]}
+    wrapProgram $out/bin/cvsq-branch --prefix PATH : ${stdenv.lib.makeBinPath
+      [ cvs nettools findutils rsync coreutils diffutils ]}
+    wrapProgram $out/bin/cvsq-merge --prefix PATH : ${stdenv.lib.makeBinPath
+      [ cvs nettools findutils rsync coreutils diffutils ]}
+    wrapProgram $out/bin/cvsq-switch --prefix PATH : ${stdenv.lib.makeBinPath
+      [ cvs nettools findutils rsync coreutils diffutils ]}
+    wrapProgram $out/bin/lcvs --prefix PATH : ${stdenv.lib.makeBinPath
+      [ cvs nettools findutils rsync coreutils diffutils ]}
+  '';
+
+  meta = {
+    description = ''A collection of tools to work locally with CVS'';
+    longDescription = ''
+      cvsq is a collection of tools to work locally with CVS.
+
+      cvsq queues commits and other cvs commands in a queue to be executed later,
+      when the machine is online again. In case of a commit (the default action)
+      an actual copy of the working directory is made, so that you can continue
+      editing without affecting the scheduled commit. You can even schedule
+      several successive commits to the same file and they will be correctly
+      committed as successive commits at the time of upload. This is different
+      from an earlier script also named cvsq that you might have seen elsewhere.
+
+      lcvs uses rsync to maintain a local copy of a cvs repository. It also
+      gives a convenient interface to call cvs in such a way that it believes the
+      current working directory refers to the local copy rather than to the actual
+      repository. This is useful for commands like log, diff, etc; however it cannot
+      be used for commits (that's what cvsq is for).
+    '';
+    homepage = https://www.linta.de/~aehlig/cvsq/;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ clkamp ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18531,6 +18531,8 @@ in
 
   cvsps = callPackage ../applications/version-management/cvsps { };
 
+  cvsq = callPackage ../applications/version-management/cvsq { };
+
   cvs2svn = callPackage ../applications/version-management/cvs2svn { };
 
   cwm = callPackage ../applications/window-managers/cwm { };


### PR DESCRIPTION

###### Motivation for this change


###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
