### PR TITLE
glibc, openssl: unbreak cross eval (with minor caveats)

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -111,6 +111,10 @@ stdenv.mkDerivation ({
       # nscd needs libgcc, and we don't want it dynamically linked
       # because we don't want it to depend on bootstrap-tools libs.
       echo "LDFLAGS-nscd += -static-libgcc" >> nscd/Makefile
+    ''
+    # FIXME: find a solution for infinite recursion in cross builds.
+    # For now it's hopefully acceptable that IDN from libc doesn't reliably work.
+    + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
 
       # Ensure that libidn2 is found.
       patch -p 1 <<EOF

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -36,7 +36,9 @@ let
 
     outputs = [ "bin" "dev" "out" "man" ] ++ optional withDocs "doc";
     setOutputFlags = false;
-    separateDebugInfo = !(stdenv.hostPlatform.useLLVM or false) && stdenv.cc.isGNU;
+    separateDebugInfo = !(stdenv.hostPlatform.useLLVM or false)
+      && stdenv.hostPlatform == stdenv.buildPlatform # unable to fix infinite recursion on stdenv.cc
+      && stdenv.cc.isGNU;
 
     nativeBuildInputs = [ perl ];
     buildInputs = stdenv.lib.optional withCryptodev cryptodev;


### PR DESCRIPTION
It's certainly better to have those two caveats than not evaluate.
Both seem rather niche.  Unfortunately I failed to find a better way.
I started testing builds of several cross variants; all seem OK.

Fixes https://github.com/NixOS/nixpkgs/issues/79610 (with minor caveats)