### PR TITLE
exodus: 19.5.24 -> 20.1.30

### DIFF
--- a/pkgs/applications/blockchains/exodus/default.nix
+++ b/pkgs/applications/blockchains/exodus/default.nix
@@ -4,11 +4,11 @@ cups, vivaldi-ffmpeg-codecs, libpulseaudio, at-spi2-core }:
 
 stdenv.mkDerivation rec {
   pname = "exodus";
-  version = "19.5.24";
+  version = "20.1.30";
 
   src = fetchurl {
-    url = "https://exodusbin.azureedge.net/releases/${pname}-linux-x64-${version}.zip";
-    sha256 = "1yx296i525qmpqh8f2vax7igffg826nr8cyq1l0if35374bdsqdw";
+    url = "https://downloads.exodus.io/releases/${pname}-linux-x64-${version}.zip";
+    sha256 = "0jns5zqjm0gqn18ypghbgk6gb713mh7p44ax1r8y4vcwijlp5nql";
   };
 
   sourceRoot = ".";

--- a/pkgs/applications/blockchains/exodus/default.nix
+++ b/pkgs/applications/blockchains/exodus/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, unzip, glib, systemd, nss, nspr, gtk3-x11, gnome2,
 atk, cairo, gdk-pixbuf, xorg, xorg_sys_opengl, utillinux, alsaLib, dbus, at-spi2-atk,
-cups, vivaldi-ffmpeg-codecs, libpulseaudio }:
+cups, vivaldi-ffmpeg-codecs, libpulseaudio, at-spi2-core }:
 
 stdenv.mkDerivation rec {
   pname = "exodus";
@@ -57,6 +57,7 @@ stdenv.mkDerivation rec {
       alsaLib
       dbus.lib
       at-spi2-atk
+      at-spi2-core
       cups.lib
       libpulseaudio
       systemd

--- a/pkgs/applications/blockchains/exodus/default.nix
+++ b/pkgs/applications/blockchains/exodus/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     cd Exodus-linux-x64
     cp -r . $out
     ln -s $out/Exodus $out/bin/Exodus
+    ln -s $out/bin/Exodus $out/bin/exodus
     ln -s $out/exodus.desktop $out/share/applications
     substituteInPlace $out/share/applications/exodus.desktop \
           --replace 'Exec=bash -c "cd `dirname %k` && ./Exodus"' "Exec=Exodus"

--- a/pkgs/applications/blockchains/exodus/default.nix
+++ b/pkgs/applications/blockchains/exodus/default.nix
@@ -13,17 +13,17 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
   unpackCmd = ''
-			${unzip}/bin/unzip "$src" -x "Exodus*/lib*so"
+      ${unzip}/bin/unzip "$src" -x "Exodus*/lib*so"
   '';
 
   installPhase = ''
-		mkdir -p $out/bin $out/share/applications
-		cd Exodus-linux-x64
-		cp -r . $out
-		ln -s $out/Exodus $out/bin/Exodus
-		ln -s $out/exodus.desktop $out/share/applications
-		substituteInPlace $out/share/applications/exodus.desktop \
-				  --replace 'Exec=bash -c "cd `dirname %k` && ./Exodus"' "Exec=Exodus"
+    mkdir -p $out/bin $out/share/applications
+    cd Exodus-linux-x64
+    cp -r . $out
+    ln -s $out/Exodus $out/bin/Exodus
+    ln -s $out/exodus.desktop $out/share/applications
+    substituteInPlace $out/share/applications/exodus.desktop \
+          --replace 'Exec=bash -c "cd `dirname %k` && ./Exodus"' "Exec=Exodus"
   '';
 
   dontPatchELF = true;
@@ -31,35 +31,35 @@ stdenv.mkDerivation rec {
 
   preFixup = let
     libPath = lib.makeLibraryPath [
-			glib
-			nss
-			nspr
-			gtk3-x11
-			gnome2.pango
-			atk
-			cairo
-			gdk-pixbuf
-			xorg.libX11
-			xorg.libxcb
-			xorg.libXcomposite
-			xorg.libXcursor
-			xorg.libXdamage
-			xorg.libXext
-			xorg.libXfixes
-			xorg.libXi
-			xorg.libXrender
-			xorg.libXtst
-			xorg_sys_opengl
-			utillinux
-			xorg.libXrandr
-			xorg.libXScrnSaver
-			alsaLib
-			dbus.lib
-			at-spi2-atk
-			cups.lib
-			libpulseaudio
-			systemd
-			vivaldi-ffmpeg-codecs
+      glib
+      nss
+      nspr
+      gtk3-x11
+      gnome2.pango
+      atk
+      cairo
+      gdk-pixbuf
+      xorg.libX11
+      xorg.libxcb
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrender
+      xorg.libXtst
+      xorg_sys_opengl
+      utillinux
+      xorg.libXrandr
+      xorg.libXScrnSaver
+      alsaLib
+      dbus.lib
+      at-spi2-atk
+      cups.lib
+      libpulseaudio
+      systemd
+      vivaldi-ffmpeg-codecs
     ];
   in ''
     patchelf \


### PR DESCRIPTION
#### Motivation for this change

exodus: 19.5.24 -> 20.1.30


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
