### PR TITLE
libssh2-1.9.0: apply patch for CVE-2019-17498

### DIFF
--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -14,6 +14,15 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl zlib ]
     ++ stdenv.lib.optional stdenv.hostPlatform.isMinGW windows.mingw_w64;
 
+  patches = [
+    # not able to use fetchpatch here: infinite recursion
+    (fetchurl {
+      name = "CVE-2019-17498.patch";
+      url = "https://github.com/libssh2/libssh2/pull/402.patch";
+      sha256 = "1n9s2mcz5dkw0xpm3c5x4hzj8bar4i6z0pr1rmqjplhfg888vdvc";
+    })
+  ];
+
   meta = with stdenv.lib; {
     description = "A client-side C library implementing the SSH2 protocol";
     homepage = https://www.libssh2.org;


### PR DESCRIPTION
###### Motivation for this change

Apply patch [upstream patch](https://github.com/libssh2/libssh2/pull/402) as there is no new release yet. According to the [original advisory](https://blog.semmle.com/libssh2-integer-overflow-CVE-2019-17498/), this one fixes the vulnerability. Upstream PR402 is also mentioned in the CVE as patch.

Re #73662

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions -> Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` -> partially - tested `curl` with SFTP target
- [x] Tested execution of all binary files (usually in `./result/bin/`) -> partially, see above
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) -> minimal
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
