### PR TITLE
bash-my-aws: add runtime dependencies

### DIFF
--- a/pkgs/tools/admin/bash-my-aws/default.nix
+++ b/pkgs/tools/admin/bash-my-aws/default.nix
@@ -1,6 +1,8 @@
 { lib, stdenv
+, makeWrapper
 , awscli
 , jq
+, unixtools
 , fetchgit
 , installShellFiles
 , bashInteractive
@@ -22,9 +24,10 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     awscli
     jq
+    unixtools.column
     bashInteractive
   ];
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   checkPhase = ''
     pushd test
@@ -50,6 +53,7 @@ stdenv.mkDerivation rec {
         --replace .bash-my-aws ""
     substituteInPlace bin/bma \
         --replace '~/.bash-my-aws' $out
+    wrapProgram $out/bin/bma --prefix PATH : ${lib.makeBinPath [awscli jq unixtools.column bashInteractive ]}
     installShellCompletion --bash --name bash-my-aws.bash bash_completion.sh
     chmod +x $out/lib/*
     patchShebangs --host $out/lib


### PR DESCRIPTION
###### Motivation for this change
Missing runtime dependencies. Is there a canonical location for these, or just place the dependency paths into a comment for the "runtime-dependency hash search" to find?

###### Things done
Added column and coreutils as dependencies.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
