### PR TITLE
osm2pgsql: enable on darwin

### DIFF
--- a/pkgs/tools/misc/osm2pgsql/default.nix
+++ b/pkgs/tools/misc/osm2pgsql/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, cmake, expat, proj, bzip2, zlib, boost, postgresql, lua}:
+{ stdenv, fetchFromGitHub, cmake, expat, proj, bzip2, zlib, boost, postgresql
+, withLuaJIT ? false, lua, luajit }:
 
 stdenv.mkDerivation rec {
   pname = "osm2pgsql";
@@ -13,7 +14,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ expat proj bzip2 zlib boost postgresql lua ];
+  buildInputs = [ expat proj bzip2 zlib boost postgresql ]
+    ++ stdenv.lib.optional withLuaJIT luajit
+    ++ stdenv.lib.optional (!withLuaJIT) lua;
+
+  cmakeFlags = stdenv.lib.optional withLuaJIT "-DWITH_LUAJIT:BOOL=ON";
 
   NIX_CFLAGS_COMPILE = "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H";
 
@@ -21,7 +26,7 @@ stdenv.mkDerivation rec {
     description = "OpenStreetMap data to PostgreSQL converter";
     homepage = "https://github.com/openstreetmap/osm2pgsql";
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ jglukasik ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
* Enable on Darwin
* Add `withLuaJIT` option, see [README](https://github.com/openstreetmap/osm2pgsql#luajit-support):
> Performance measurements have shown about 25% runtime reduction for a planet import, with about 40% reduction on parsing time.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
