### PR TITLE
profont: install otb variant

### DIFF
--- a/pkgs/data/fonts/profont/default.nix
+++ b/pkgs/data/fonts/profont/default.nix
@@ -1,29 +1,48 @@
-{ lib, fetchzip }:
+{ stdenv, fetchzip, mkfontscale }:
 
-fetchzip {
-  name = "profont";
+stdenv.mkDerivation {
+  pname = "profont";
+  version = "2019-11";
 
-  url = "http://web.archive.org/web/20160707013914/http://tobiasjung.name/downloadfile.php?file=profont-x11.zip";
+  # Note: stripRoot doesn't work because the archive
+  # constains the metadata directory `__MACOSX`.
+  src = fetchzip {
+    url = "https://tobiasjung.name/downloadfile.php?file=profont-x11.zip";
+    sha256 = "12dbm87wvcpmn7nzgzwlk45cybp091diara8blqm6129ps27z6kb";
+    stripRoot = false;
+  } + /profont-x11;
 
-  postFetch = ''
-    unzip -j $downloadedFile
+  srcOtb = fetchzip {
+    url = "https://tobiasjung.name/downloadfile.php?file=profont-otb.zip";
+    sha256 = "18rfhfqrsj3510by0w1a7ak5as6r2cxh8xv02xc1y30mfa6g24x6";
+    stripRoot = false;
+  } + /profont-otb;
 
-    mkdir -p $out/share/doc/$name $out/share/fonts/misc
+  dontBuild = true;
 
-    cp LICENSE $out/share/doc/$name/LICENSE
+  nativeBuildInputs = [ mkfontscale ];
 
+  installPhase = ''
+    mkdir -p "$out/share/fonts/misc"
     for f in *.pcf; do
-      gzip -c "$f" > $out/share/fonts/misc/"$f".gz
+      gzip -n -9 -c "$f" > "$out/share/fonts/misc/$f.gz"
     done
+    install -D -m 644 LICENSE -t "$out/share/doc/$pname"
+    mkfontdir "$out/share/fonts/misc"
+
+    cd $srcOtb
+    install -D -m 644 profontn.otb -t $otb/share/fonts/misc
+    mkfontdir "$otb/share/fonts/misc"
   '';
 
-  sha256 = "1calqmvrfv068w61f614la8mg8szas6m5i9s0lsmwjhb4qwjyxbw";
+  outputs = [ "out" "otb" ];
 
-  meta = with lib; {
-    homepage = http://tobiasjung.name;
+  meta = with stdenv.lib; {
+    homepage = https://tobiasjung.name/profont/;
     description = "A monospaced font created to be a most readable font for programming";
-    maintainers = with lib.maintainers; [ myrl ];
+    maintainers = with maintainers; [ myrl ];
     license = licenses.mit;
     platforms = platforms.all;
   };
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17777,7 +17777,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  profont = callPackage ../data/fonts/profont { };
+  profont = callPackage ../data/fonts/profont
+    { inherit (buildPackages.xorg) mkfontscale; };
 
   proggyfonts = callPackage ../data/fonts/proggyfonts { };
 


### PR DESCRIPTION
###### Motivation for this change
Issue #75160 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested fonts in X11 and GTK applications
- [x] Tested compilation of all pkgs that depend on this change
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
