### PR TITLE
noto-fonts{,-extra,-cjk}: update

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -1,28 +1,44 @@
-{ stdenv, fetchzip, fetchFromGitHub, optipng, cairo, python3Packages, pkgconfig, pngquant, which, imagemagick }:
+{ stdenv
+, stdenvNoCC
+, lib
+, fetchFromGitHub
+, fetchzip
+, optipng
+, cairo
+, python3Packages
+, pkgconfig
+, pngquant
+, which
+, imagemagick
+}:
 
 let
-  mkNoto = { name, weights, sha256, }:
-    let
-      version = "2018-11-30";
-      ref = "85e78f831469323c85847e23f95026c894159135";
-    in
-    fetchzip {
-      name = "${name}-${version}";
-      inherit sha256;
-      url = "https://github.com/googlei18n/noto-fonts/archive/${ref}.zip";
-      postFetch = ''
-        unzip $downloadedFile
-        mkdir -p $out/share/fonts/noto
-        # Also copy unhinted & alpha fonts for better glyph coverage,
-        # if they don't have a hinted version
-        # (see https://groups.google.com/d/msg/noto-font/ZJSkZta4n5Y/tZBnLcPdbS0J)
-        for ttf in noto-fonts-*/{hinted,unhinted,alpha}/*-${weights}.ttf
-        do
-            cp -n "$ttf" -t "$out/share/fonts/noto"
-        done
+  mkNoto = { pname, weights }:
+    stdenvNoCC.mkDerivation {
+      inherit pname;
+      version = "2020-01-23";
+
+      src = fetchFromGitHub {
+        owner = "googlefonts";
+        repo = "noto-fonts";
+        rev = "f4726a2ec36169abd02a6d8abe67c8ff0236f6d8";
+        sha256 = "0zc1r7zph62qmvzxqfflsprazjf6x1qnwc2ma27kyzh6v36gaykw";
+      };
+
+      installPhase = ''
+        # We copy in reverse preference order -- unhinted first, then
+        # hinted -- to get the "best" version of each font while
+        # maintaining maximum coverage.
+        #
+        # TODO: install OpenType, variable versions?
+        local out_ttf=$out/share/fonts/truetype/noto
+        install -m444 -Dt $out_ttf phaseIII_only/unhinted/ttf/*/*-${weights}.ttf
+        install -m444 -Dt $out_ttf phaseIII_only/hinted/ttf/*/*-${weights}.ttf
+        install -m444 -Dt $out_ttf unhinted/*/*-${weights}.ttf
+        install -m444 -Dt $out_ttf hinted/*/*-${weights}.ttf
       '';
-      meta = with stdenv.lib; {
-        inherit version;
+
+      meta = with lib; {
         description = "Beautiful and free fonts for many languages";
         homepage = https://www.google.com/get/noto/;
         longDescription =
@@ -39,24 +55,24 @@ let
 
           This package also includes the Arimo, Cousine, and Tinos fonts.
         '';
-        license = licenses.asl20;
+        license = licenses.ofl;
         platforms = platforms.all;
-        maintainers = with maintainers; [ mathnerd314 ];
+        maintainers = with maintainers; [ mathnerd314 emily ];
       };
     };
 in
 
 {
   noto-fonts = mkNoto {
-    name = "noto-fonts";
+    pname = "noto-fonts";
     weights = "{Regular,Bold,Light,Italic,BoldItalic,LightItalic}";
-    sha256 = "0kvq5ldip2ra2njlxg9fxj46nfqzq5l3n359d3kwfbsld7hixm2d";
   };
+
   noto-fonts-extra = mkNoto {
-    name = "noto-fonts-extra";
+    pname = "noto-fonts-extra";
     weights = "{Black,Condensed,Extra,Medium,Semi,Thin}*";
-    sha256 = "0l94aiy1b3qirg2mmbagbr0014vqk32za79pzck1acy2hgy716kq";
   };
+
   noto-fonts-cjk = let version = "1.004"; in fetchzip {
     name = "noto-fonts-cjk-${version}";
 
@@ -68,7 +84,7 @@ in
     '';
     sha256 = "0ghw2azqq3nkcxsbvf53qjmrhcfsnry79rq7jsr0wwi2pn7d3dsq";
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       inherit version;
       description = "Beautiful and free fonts for CJK languages";
       homepage = https://www.google.com/get/noto/help/cjk/;
@@ -89,6 +105,7 @@ in
       maintainers = with maintainers; [ mathnerd314 ];
     };
   };
+
   noto-fonts-emoji = let
     version = "unstable-2019-10-22";
   in stdenv.mkDerivation {
@@ -118,7 +135,7 @@ in
       cp NotoColorEmoji.ttf fonts/NotoEmoji-Regular.ttf $out/share/fonts/noto
     '';
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       inherit version;
       description = "Color and Black-and-White emoji fonts";
       homepage = https://github.com/googlei18n/noto-emoji;

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -73,19 +73,21 @@ in
     weights = "{Black,Condensed,Extra,Medium,Semi,Thin}*";
   };
 
-  noto-fonts-cjk = let version = "1.004"; in fetchzip {
-    name = "noto-fonts-cjk-${version}";
+  noto-fonts-cjk = let zip = fetchzip {
+    url = let rev = "be6c059ac1587e556e2412b27f5155c8eb3ddbe6"; in
+      "https://raw.githubusercontent.com/googlefonts/noto-cjk/${rev}/NotoSansCJK.ttc.zip";
+    # __MACOSX...
+    stripRoot = false;
+    sha256 = "0ik4z2b15i0pghskgfm3adzb0h35fr4gyzvz3bq49hhkhn9h85vi";
+  }; in stdenvNoCC.mkDerivation {
+    pname = "noto-fonts-cjk";
+    version = "2.001";
 
-    # Same as https://noto-website.storage.googleapis.com/pkgs/NotoSansCJK.ttc.zip but versioned & with no extra SIL license file
-    url = "https://raw.githubusercontent.com/googlei18n/noto-cjk/40d9f5b179a59a06b98373c76bdc3e2119e4e6b2/NotoSansCJK.ttc.zip";
-    postFetch = ''
-      mkdir -p $out/share/fonts
-      unzip -j $downloadedFile \*.ttc -d $out/share/fonts/noto
+    buildCommand = ''
+      install -m444 -Dt $out/share/fonts/opentype/noto-cjk ${zip}/*.ttc
     '';
-    sha256 = "0ghw2azqq3nkcxsbvf53qjmrhcfsnry79rq7jsr0wwi2pn7d3dsq";
 
     meta = with lib; {
-      inherit version;
       description = "Beautiful and free fonts for CJK languages";
       homepage = https://www.google.com/get/noto/help/cjk/;
       longDescription =
@@ -102,7 +104,7 @@ in
       '';
       license = licenses.ofl;
       platforms = platforms.all;
-      maintainers = with maintainers; [ mathnerd314 ];
+      maintainers = with maintainers; [ mathnerd314 emily ];
     };
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It's been over a year since the Noto package has been updated, so I refactored and bumped it. This new version adds support for multiple new Unicode scripts previously not covered in NixOS to my knowledge, including [Siddham](https://en.wikipedia.org/wiki/Siddha%E1%B9%83_script) and [Tangut](https://en.wikipedia.org/wiki/Tangut_script). The license also [changed to SIL OFL 1.1](https://github.com/googlefonts/noto-fonts/blob/master/NEWS.md#all-noto-fonts-now-licensed-under-open-font-license-11).

@GrahamcOfBorg build noto-fonts noto-fonts-extra noto-fonts-cjk

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).