### PR TITLE
[r19.09] pythonPackages.pysaml2: add patch for CVE-2020-5390

### DIFF
--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -30,7 +30,16 @@ buildPythonPackage rec {
       url = "https://github.com/IdentityPython/pysaml2/commit/1d97d2d26f63e42611558fdd0e439bb8a7496a27.patch";
       sha256 = "0r6d6hkk6z9yw7aqnsnylii516ysmdsc8dghwmgnwvw6cm7l388p";
     })
+    (fetchpatch {
+      name = "CVE-2020-5390.patch";
+      url = "https://github.com/IdentityPython/pysaml2/commit/5e9d5acbcd8ae45c4e736ac521fd2df5b1c62e25.patch";
+      sha256 = "1axpvb8vhpxn85hgzkd87g88j4izwan6vng1wbpcw736qkr7248m";
+    })
   ];
+
+  postPatch = ''
+    substituteInPlace tests/test_xsw.py --replace "unittest.mock" "mock"
+  '';
 
   propagatedBuildInputs = [ cryptography defusedxml future pyopenssl dateutil pytz requests six ];
 

--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , substituteAll
 , xmlsec
 , cryptography, defusedxml, future, pyopenssl, dateutil, pytz, requests, six
@@ -23,6 +24,11 @@ buildPythonPackage rec {
     (substituteAll {
       src = ./hardcode-xmlsec1-path.patch;
       inherit xmlsec;
+    })
+    (fetchpatch {
+      name = "fix-test-dates.patch";
+      url = "https://github.com/IdentityPython/pysaml2/commit/1d97d2d26f63e42611558fdd0e439bb8a7496a27.patch";
+      sha256 = "0r6d6hkk6z9yw7aqnsnylii516ysmdsc8dghwmgnwvw6cm7l388p";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2020-5390

Patching this instead of bumping allows us to keep it enabled for python 2.7 for this release.

See #79662 for master.

Entertainingly, while I was working on this one of the packages tests with fixed timestamps expired and started failing, which was confusing. Fixed by applying https://github.com/IdentityPython/pysaml2/commit/1d97d2d26f63e42611558fdd0e439bb8a7496a27, which it looks like I'll have to apply to master too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
