### PR TITLE
delly: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/applications/science/biology/delly/default.nix
+++ b/pkgs/applications/science/biology/delly/default.nix
@@ -1,15 +1,24 @@
-{ stdenv, fetchFromGitHub, htslib, zlib, bzip2, lzma, ncurses, boost }:
+{ stdenv, fetchpatch, fetchFromGitHub, htslib, zlib, bzip2, lzma, ncurses, boost }:
 
-stdenv.mkDerivation rec {
+let
+  htslibPatch = fetchpatch {
+    url = "https://github.com/dellytools/delly/commit/0e5c710b0c5ea790bb39699d4cbd49cf4fb86f14.diff";
+    sha256 = "09bz1qqvzhdzm99hf9zgrv80kq9jlr1m2mdvx96p2hk5lpnbdl7y";
+    excludes = [ "src/htslib" ];
+  };
+
+in stdenv.mkDerivation rec {
   pname = "delly";
-  version = "0.8.1";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
       owner = "dellytools";
       repo = pname;
       rev = "v${version}";
-      sha256 = "18gm86j1g1k4z1cjv2m5v9rsl1xqs2w3dhwcsnzx2mhkrvmlc4i1";
+      sha256 = "14bkmixz7737xj192ww96s3a20zc7xs7r04db8avw3ggi3i1s1cs";
   };
+
+  patches = [ htslibPatch ];
 
   buildInputs = [ zlib htslib bzip2 lzma ncurses boost ];
 


### PR DESCRIPTION
Bumped version and backported patch to fix building with htslib 1.10.2.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Previous expression was broken by 940d12bf5daba9b0af846646b58b84a81107089c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@scalavision 

