### PR TITLE
gunicorn: add 19.x branch for python2.7 support

### DIFF
--- a/pkgs/development/python-modules/gunicorn/19.nix
+++ b/pkgs/development/python-modules/gunicorn/19.nix
@@ -1,0 +1,39 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, coverage
+, mock
+, pytest
+, pytestcov
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "gunicorn";
+  version = "19.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1080jk1ly8j0rc6lv8i33sj94rxjaskd1732cdq5chdqb3ij9ppr";
+  };
+
+  propagatedBuildInputs = [ setuptools ];
+
+  checkInputs = [ pytest mock pytestcov coverage ];
+
+  prePatch = ''
+    substituteInPlace requirements_test.txt --replace "==" ">=" \
+      --replace "coverage>=4.0,<4.4" "coverage"
+  '';
+
+  # better than no tests
+  checkPhase = ''
+    $out/bin/gunicorn --help > /dev/null
+  '';
+
+  pythonImportsCheck = [ "gunicorn" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/benoitc/gunicorn";
+    description = "WSGI HTTP Server for UNIX";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3800,7 +3800,10 @@ in {
 
   rebulk = callPackage ../development/python-modules/rebulk { };
 
-  gunicorn = callPackage ../development/python-modules/gunicorn { };
+  gunicorn = if isPy27 then
+          callPackage ../development/python-modules/gunicorn/19.nix { }
+        else
+          callPackage ../development/python-modules/gunicorn { };
 
   hawkauthlib = callPackage ../development/python-modules/hawkauthlib { };
 


### PR DESCRIPTION
The `nixos/moinmoin` module uses gunicorn, however the 20.0 version dropped python2 support which broke the module as there's no python3 port planned for moinmoin: http://moinmo.in/Python3

###### Motivation for this change

`nix-build nixos/tests/moinmoin.nix` fails

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @FRidh @jonringer 