### PR TITLE
Fix up haskell updates

### DIFF
--- a/pkgs/applications/networking/esniper/default.nix
+++ b/pkgs/applications/networking/esniper/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchgit, openssl, curl, coreutils, gawk, bash, which }:
 
 stdenv.mkDerivation {
-  name = "esniper-2.35.0-18-g4a59da0";
+  name = "esniper-2.35.0-21-g6379846";
 
   src = fetchgit {
     url    = "https://git.code.sf.net/p/esniper/git";
-    rev    = "4a59da032aa4536b9e5ea95633247650412511db";
-    sha256 = "0d3vazh5q7wymqahggbb2apl9hgrm037y4s3j91d24hjgk2pzzyd";
+    rev    = "637984623984ef36782d52d8968df7fae7bbb0a7";
+    sha256 = "1md3fzs0k88f6mgvrj1yrh96mn0qlca2p6vfqj6dnpyb8pjjwp8w";
   };
 
   buildInputs = [ openssl curl ];

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1068,9 +1068,6 @@ self: super: {
       };
   };
 
-  # Tests for dhall access the network.
-  dhall_1_27_0 = dontCheck super.dhall_1_27_0;
-
   # Missing test files in source distribution, fixed once 1.4.0 is bumped
   # https://github.com/dhall-lang/dhall-haskell/pull/997
   dhall-json =

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1254,7 +1254,13 @@ self: super: {
   });
 
   # The LTS-14.x version of their dependencies are too old.
-  cabal-plan = super.cabal-plan.overrideScope (self: super: { optparse-applicative = self.optparse-applicative_0_15_1_0; ansi-terminal = self.ansi-terminal_0_10_2; base-compat = self.base-compat_0_11_1; semialign = self.semialign_1_1; time-compat = doJailbreak super.time-compat; });
+  cabal-plan = super.cabal-plan.overrideScope (self: super: {
+    optparse-applicative = self.optparse-applicative_0_15_1_0;
+    ansi-terminal = self.ansi-terminal_0_10_3;
+    base-compat = self.base-compat_0_11_1;
+    semialign = self.semialign_1_1;
+    time-compat = doJailbreak super.time-compat;
+  });
   hoogle = super.hoogle.override { haskell-src-exts = self.haskell-src-exts_1_23_0; };
 
   # Version bounds for http-client are too strict:

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1403,4 +1403,11 @@ self: super: {
     HsYAML = self.HsYAML_0_2_1_0;
   };
 
+  # it wants to build a statically linked binary by default
+  hledger-flow = overrideCabal super.hledger-flow ( drv: {
+    postPatch = (drv.postPatch or "") + ''
+      substituteInPlace hledger-flow.cabal --replace "-static" ""
+    '';
+  });
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1398,4 +1398,9 @@ self: super: {
     HsYAML = self.HsYAML_0_2_1_0;
   };
 
+  # it depends on HsYAML >=0.2.0 && < 0.3, so use 0.2.1.0
+  stylish-haskell = super.stylish-haskell.override {
+    HsYAML = self.HsYAML_0_2_1_0;
+  };
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1393,4 +1393,9 @@ self: super: {
   # See https://github.com/ekmett/perhaps/pull/5
   perhaps = doJailbreak super.perhaps;
 
+  # it depends on HsYAML >=0.2.0 && < 0.3, so use 0.2.1.0
+  HsYAML-aeson = super.HsYAML-aeson.override {
+    HsYAML = self.HsYAML_0_2_1_0;
+  };
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -145,7 +145,9 @@ self: super: {
   haskell-src = markBrokenVersion "1.0.3.0" super.haskell-src;
 
   # The LTS-14.x version of the dependencies are too old.
-  policeman = super.policeman.overrideScope (self: super: { ansi-terminal = self.ansi-terminal_0_10_2; relude = self.relude_0_6_0_0; });
+  policeman = super.policeman.overrideScope (self: super: {
+    ansi-terminal = self.ansi-terminal_0_10_3; relude = self.relude_0_6_0_0;
+  });
 
   # https://github.com/kowainik/relude/issues/241
   relude_0_6_0_0 = dontCheck super.relude_0_6_0_0;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6245,7 +6245,6 @@ broken-packages:
   - http-querystring
   - http-response-decoder
   - http-shed
-  - http-streams
   - http-wget
   - http2-client
   - http2-client-exe

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5874,7 +5874,6 @@ broken-packages:
   - HLearn-distributions
   - hledger-api
   - hledger-chart
-  - hledger-flow
   - hledger-irr
   - hledger-vty
   - hlibBladeRF

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2513,7 +2513,7 @@ extra-packages:
   - control-monad-free < 0.6            # newer versions don't compile with anything but GHC 7.8.x
   - dbus <1                             # for xmonad-0.26
   - deepseq == 1.3.0.1                  # required to build Cabal with GHC 6.12.3
-  - dhall == 1.27.0                     # required for spago 0.13.0.  Probably can be removed when next version of spago is available.
+  - dhall == 1.29.0                     # required for spago 0.14.0.
   - doctemplates == 0.8                 # required by pandoc-2.9.x
   - generic-deriving == 1.10.5.*        # new versions don't compile with GHC 7.10.x
   - gloss < 1.9.3                       # new versions don't compile with GHC 7.8.x

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -69,6 +69,9 @@ core-packages:
 default-package-overrides:
   # pandoc-2.9 does not accept the 0.3 version yet
   - doclayout < 0.3
+  # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
+  # not yet available in Nixpkgs
+  - gi-gdkx11 < 4
   # LTS Haskell 14.23
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
@@ -5068,7 +5071,6 @@ broken-packages:
   - ghcprofview
   - ght
   - gi-cairo-again
-  - gi-gdkx11
   - gi-graphene
   - gi-gsk
   - gi-gstpbutils

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9388,7 +9388,6 @@ broken-packages:
   - structures
   - stt
   - stunts
-  - stylish-haskell
   - stylist
   - stylized
   - suavemente

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6204,7 +6204,6 @@ broken-packages:
   - hsx-xhtml
   - hsx2hs
   - hsXenCtrl
-  - HsYAML-aeson
   - hsyscall
   - hsyslog-tcp
   - hsyslog-udp

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9490,7 +9490,6 @@ broken-packages:
   - Tablify
   - tabloid
   - tabs
-  - taffybar
   - tag-bits
   - tag-stream
   - tagged-exception-core

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2498,6 +2498,7 @@ default-package-overrides:
 
 extra-packages:
   - aeson < 0.8                         # newer versions don't work with GHC 7.6.x or earlier
+  - ansi-terminal == 0.10.3             # required by cabal-plan, and policeman in ghc-8.8.x
   - aeson-pretty < 0.8                  # required by elm compiler
   - apply-refact < 0.4                  # newer versions don't work with GHC 8.0.x
   - aws ^>= 0.18                        # pre-lts-11.x versions neeed by git-annex 6.20180227

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -640,18 +640,22 @@ self: super: builtins.intersectAttrs super {
       # we can safely jailbreak spago and use the older directory package from
       # LTS-14.
       spagoWithOverrides = doJailbreak (super.spago.override {
-        # spago requires dhall_1_27_0.
-        dhall = self.dhall_1_27_0;
+        # spago requires dhall-1.29.0.
+        dhall = self.dhall_1_29_0;
       });
 
+      # This defines the version of the purescript-docs-search release we are using.
+      # This is defined in the src/Spago/Prelude.hs file in the spago source.
+      docsSearchVersion = "v0.0.8";
+
       docsSearchAppJsFile = pkgs.fetchurl {
-        url = "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.5/docs-search-app.js";
-        sha256 = "11721x455qzh40vzfmralaynn9v8b5wix86r107hhs08vhryjib2";
+        url = "https://github.com/spacchetti/purescript-docs-search/releases/download/${docsSearchVersion}/docs-search-app.js";
+        sha256 = "00pzi7pgjicpa0mg0al80gh2q1q2lqiyb3kjarpydlmn8dfjny7v";
       };
 
       purescriptDocsSearchFile = pkgs.fetchurl {
-        url = "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.5/purescript-docs-search";
-        sha256 = "16p1fmdvpwz1yswav8qjsd26c9airb22xncqw1rjnbd8lcpqx0p5";
+        url = "https://github.com/spacchetti/purescript-docs-search/releases/download/${docsSearchVersion}/purescript-docs-search";
+        sha256 = "1hsi1hc4p1z2xbw82w2jxmmczw6mravli1r89vrkivb72sqdjya7";
       };
 
       spagoFixHpack = overrideCabal spagoWithOverrides (drv: {

--- a/pkgs/development/tools/purescript/spago/default.nix
+++ b/pkgs/development/tools/purescript/spago/default.nix
@@ -1,14 +1,53 @@
-{ haskellPackages
-, haskell
+{ haskell
+, haskellPackages
 , lib
+, nodejs
+, purescript
+, runCommand
 }:
 
-haskell.lib.justStaticExecutables (haskell.lib.overrideCabal haskellPackages.spago (oldAttrs: {
-  maintainers = (oldAttrs.maintainers or []) ++ [
-    lib.maintainers.cdepillabout
-  ];
+let
+  spago =
+    haskell.lib.justStaticExecutables
+      (haskell.lib.overrideCabal haskellPackages.spago (oldAttrs: {
+        maintainers = (oldAttrs.maintainers or []) ++ [
+          lib.maintainers.cdepillabout
+        ];
+      }));
+in
 
+spago.overrideAttrs (oldAttrs: {
   passthru = (oldAttrs.passthru or {}) // {
     updateScript = ./update.sh;
+
+    # These tests can be run with the following command.  The tests access the
+    # network, so they cannot be run in the nix sandbox.  sudo is needed in
+    # order to change the sandbox option.
+    #
+    # $ sudo nix-build -A spago.passthru.tests --option sandbox relaxed
+    #
+    tests =
+      runCommand
+        "spago-tests"
+        {
+          __noChroot = true;
+          nativeBuildInputs = [
+            nodejs
+            purescript
+            spago
+          ];
+        }
+        ''
+          # spago expects HOME to be set because it creates a cache file under
+          # home.
+          HOME=$(pwd)
+
+          spago --verbose init
+          spago --verbose build
+          spago --verbose test
+
+          touch $out
+        '';
   };
-}))
+})
+

--- a/pkgs/development/tools/purescript/spago/spago.nix
+++ b/pkgs/development/tools/purescript/spago/spago.nix
@@ -11,11 +11,11 @@
 }:
 mkDerivation {
   pname = "spago";
-  version = "0.13.1";
+  version = "0.14.0";
   src = fetchgit {
-    url = "https://github.com/spacchetti/spago.git";
-    sha256 = "0l6sy1hz5dbnrjkvb2f44afhd48nwqx5kx1h29ns93xbbd57hci8";
-    rev = "b87858609c671d8f3dc78f858ce1d8c492bd1062";
+    url = "https://github.com/purescript/spago.git";
+    sha256 = "12i1430prqspy73nwfxc17zf51yprhrxxcnhw4rks6jhkgwxf4a4";
+    rev = "7a99343e4876a465600eaa64b0697a9f0b2a49a9";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -42,6 +42,6 @@ mkDerivation {
   ];
   testToolDepends = [ hspec-discover ];
   prePatch = "hpack";
-  homepage = "https://github.com/spacchetti/spago#readme";
+  homepage = "https://github.com/purescript/spago#readme";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/pkgs/development/tools/purescript/spago/update.sh
+++ b/pkgs/development/tools/purescript/spago/update.sh
@@ -20,11 +20,14 @@ spago_derivation_file="${script_dir}/spago.nix"
 old_version="$(sed -En 's/.*\bversion = "(.*?)".*/\1/p' "$spago_derivation_file")"
 
 # This is the latest release version of spago on GitHub.
-new_version=$(curl --silent "https://api.github.com/repos/spacchetti/spago/releases" | jq '.[0].tag_name' --raw-output)
+new_version=$(curl --silent "https://api.github.com/repos/purescript/spago/releases" | jq '.[0].tag_name' --raw-output)
 
 echo "Updating spago from old version $old_version to new version $new_version."
 echo "Running cabal2nix and outputting to ${spago_derivation_file}..."
 
-cabal2nix --revision "$new_version" "https://github.com/spacchetti/spago.git" > "$spago_derivation_file"
+cabal2nix --revision "$new_version" "https://github.com/purescript/spago.git" > "$spago_derivation_file"
+
+# TODO: This should ideally also automatically update the docsSearchVersion
+# from pkgs/development/haskell/configuration-nix.nix.
 
 echo "Finished."


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`cabal-plan` and `policeman` weren't evaluating because they were using the latest version of `ansi-terminal`, which got bumped to a later version.

This PR fixes `cabal-plan` and `policeman` so they build, and makes sure `haskell-updates` can be evaluated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
