### PR TITLE
haskell-updates: get evaluating again

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1052,19 +1052,19 @@ self: super: {
   # This will probably be able to be removed when we update to LTS-15.
   dhall_1_29_0 =
     dontCheck (super.dhall_1_29_0.override {
-      prettyprinter = self.prettyprinter_1_6_0;
+      prettyprinter = self.prettyprinter_1_6_1;
       prettyprinter-ansi-terminal =
         self.prettyprinter-ansi-terminal.override {
-          prettyprinter = self.prettyprinter_1_6_0;
+          prettyprinter = self.prettyprinter_1_6_1;
         };
     });
   dhall-bash_1_0_27 = super.dhall-bash_1_0_27.override { dhall = self.dhall_1_29_0; };
   dhall-json_1_6_1 = super.dhall-json_1_6_1.override {
     dhall = self.dhall_1_29_0;
-    prettyprinter = self.prettyprinter_1_6_0;
+    prettyprinter = self.prettyprinter_1_6_1;
     prettyprinter-ansi-terminal =
       self.prettyprinter-ansi-terminal.override {
-        prettyprinter = self.prettyprinter_1_6_0;
+        prettyprinter = self.prettyprinter_1_6_1;
       };
   };
 
@@ -1390,7 +1390,7 @@ self: super: {
   krank = doJailbreak super.krank;
 
   # prettyprinter-1.6.0 fails its doctest suite.
-  prettyprinter_1_6_0 = dontCheck super.prettyprinter_1_6_0;
+  prettyprinter_1_6_1 = dontCheck super.prettyprinter_1_6_1;
 
   # the test suite has an overly tight restriction on doctest
   # See https://github.com/ekmett/perhaps/pull/5

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1254,7 +1254,13 @@ self: super: {
   });
 
   # The LTS-14.x version of their dependencies are too old.
-  cabal-plan = super.cabal-plan.overrideScope (self: super: { optparse-applicative = self.optparse-applicative_0_15_1_0; ansi-terminal = self.ansi-terminal_0_10_2; base-compat = self.base-compat_0_11_1; semialign = self.semialign_1_1; time-compat = doJailbreak super.time-compat; });
+  cabal-plan = super.cabal-plan.overrideScope (self: super: {
+    optparse-applicative = self.optparse-applicative_0_15_1_0;
+    ansi-terminal = self.ansi-terminal_0_10_3;
+    base-compat = self.base-compat_0_11_1;
+    semialign = self.semialign_1_1;
+    time-compat = doJailbreak super.time-compat;
+  });
   hoogle = super.hoogle.override { haskell-src-exts = self.haskell-src-exts_1_23_0; };
 
   # Version bounds for http-client are too strict:

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -145,7 +145,10 @@ self: super: {
   haskell-src = markBrokenVersion "1.0.3.0" super.haskell-src;
 
   # The LTS-14.x version of the dependencies are too old.
-  policeman = super.policeman.overrideScope (self: super: { ansi-terminal = self.ansi-terminal_0_10_2; relude = self.relude_0_6_0_0; });
+  policeman = super.policeman.overrideScope (self: super: {
+    ansi-terminal = self.ansi-terminal_0_10_3;
+    relude = self.relude_0_6_0_0;
+  });
 
   # https://github.com/kowainik/relude/issues/241
   relude_0_6_0_0 = dontCheck super.relude_0_6_0_0;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -93,7 +93,7 @@ self: super: {
   optparse-applicative = self.optparse-applicative_0_15_1_0;
   pandoc = dontCheck super.pandoc_2_9_1_1;        # https://github.com/jgm/pandoc/issues/6086
   pandoc-types = self.pandoc-types_1_20;
-  prettyprinter = self.prettyprinter_1_6_0;
+  prettyprinter = self.prettyprinter_1_6_1;
   primitive = dontCheck super.primitive_0_7_0_0;  # evaluating the test suite gives an infinite recursion
   regex-base = self.regex-base_0_94_0_0;
   regex-compat = self.regex-compat_0_95_2_0;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2540,6 +2540,7 @@ extra-packages:
   - patience ^>= 0.1                    # required by chell-0.4.x
   - persistent >=2.5 && <2.8            # pre-lts-11.x versions neeed by git-annex 6.20180227
   - persistent-sqlite < 2.7             # pre-lts-11.x versions neeed by git-annex 6.20180227
+  - prettyprinter == 1.6.1              # required by ghc 8.8.x, and dhall-1.29.0
   - primitive == 0.5.1.*                # required to build alex with GHC 6.12.3
   - proto-lens == 0.2.*                 # required for tensorflow-proto-0.1.x on GHC 8.2.x
   - proto-lens-protobuf-types == 0.2.*  # required for tensorflow-proto-0.1.x on GHC 8.2.x

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2498,6 +2498,7 @@ default-package-overrides:
 
 extra-packages:
   - aeson < 0.8                         # newer versions don't work with GHC 7.6.x or earlier
+  - ansi-terminal == 0.10.3             # required by cabal-plan, and policeman in ghc-8.8.x
   - aeson-pretty < 0.8                  # required by elm compiler
   - apply-refact < 0.4                  # newer versions don't work with GHC 8.0.x
   - aws ^>= 0.18                        # pre-lts-11.x versions neeed by git-annex 6.20180227


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`cabal-plan` and `policeman` weren't evaluating because they were using the latest version of `ansi-terminal`, which got bumped to a later version:

https://hydra.nixos.org/eval/1569658?name=haskell-updates#tabs-removed

This PR fixes `cabal-plan` and `policeman` so they build, and makes sure `haskell-updates` can be evaluated.

Also fixup `prettyprinter` (and `dhall`, which depends on `prettyprinter`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
