### PR TITLE
dnnl: run tests, fix install tree

### DIFF
--- a/pkgs/development/libraries/dnnl/default.nix
+++ b/pkgs/development/libraries/dnnl/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "17xpdwqjfb2bq586gnk3hq94r06jd8pk6qfs703qqd7155fkbil9";
   };
 
-  # Generic fix upstreamed in https://github.com/intel/mkl-dnn/pull/631
-  # Delete patch when 1.2.0 is released
+  # Generic fix merged upstream in https://github.com/intel/mkl-dnn/pull/631
+  # Delete after next release
   patches = [ (substituteAll {
     src = ./bash-to-sh.patch;
     inherit bash;
@@ -22,12 +22,18 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  doCheck = true;
+
   # The test driver doesn't add an RPath to the build libdir
   preCheck = ''
     export LD_LIBRARY_PATH=$PWD/src
   '';
 
-  doCheck = true;
+  # The cmake install gets tripped up and installs a nix tree into $out, in
+  # addition to the correct install; clean it up.
+  postInstall = ''
+    rm -r $out/nix
+  '';
 
   meta = with lib; {
     description = "Deep Neural Network Library (DNNL)";


### PR DESCRIPTION
With the new update to 1.2 in https://github.com/NixOS/nixpkgs/pull/79426, some
the install tree coming out of cmake seems to have produced a duplicate copy of
the nix tree.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).