### PR TITLE
stdenv: update ARM bootstrap tarballs

### DIFF
--- a/pkgs/stdenv/linux/bootstrap-files/armv5tel.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/armv5tel.nix
@@ -1,12 +1,12 @@
 {
   busybox = import <nix/fetchurl.nix> {
-    url = http://nixos-arm.dezgeg.me/bootstrap-2017-04-13-1f32d4b4/armv5tel/busybox;
-    sha256 = "00mxas5xg2j9n1g0q0nklr0dy87qqxk0jja5qz1yi7xl7zzsnpnw";
+    url = https://hydra.nixos.org/build/112609163/download/2/busybox;
+    sha256 = "0dc5471dc6a5f69ad98eb7445f51a61e88aa5792d7a677025bf012bdb513b763";
     executable = true;
   };
 
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = http://nixos-arm.dezgeg.me/bootstrap-2017-04-13-1f32d4b4/armv5tel/bootstrap-tools.tar.xz;
-    sha256 = "0fhiy9l3mbmlhpkby31c2s63bhjiqx25qqr3wdp8cb7fxz8ayx2f";
+    url = https://hydra.nixos.org/build/112609163/download/1/bootstrap-tools.tar.xz;
+    sha256 = "ca0564eca4eb944649ce10ec70859640427bf2241243af62812b163176487e02";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-files/armv6l.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/armv6l.nix
@@ -1,12 +1,12 @@
 {
   busybox = import <nix/fetchurl.nix> {
-    url = http://nixos-arm.dezgeg.me/bootstrap-2017-04-13-1f32d4b4/armv6l/busybox;
-    sha256 = "06n8dy8y2v28yx9ws8x64wxrvn9pszgpd299hc90nv9x21m79jzd";
+    url = https://hydra.nixos.org/build/112609441/download/2/busybox;
+    sha256 = "e6f6aecb675e924a96516f4379445dd2c0ba8b9c438fbfbaa2dc14ccce2802e0";
     executable = true;
   };
 
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = http://nixos-arm.dezgeg.me/bootstrap-2017-04-13-1f32d4b4/armv6l/bootstrap-tools.tar.xz;
-    sha256 = "1gg2q3sw81vi65g1gmpvx0nnd6hxb76vlz73wfp292m90z1mym7f";
+    url = https://hydra.nixos.org/build/112609441/download/1/bootstrap-tools.tar.xz;
+    sha256 = "7a3f20def1a17ebf0edb5a92c403558429bcc2ac3d931b5e1bd88606cb217778";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-files/armv7l.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/armv7l.nix
@@ -1,12 +1,12 @@
 {
   busybox = import <nix/fetchurl.nix> {
-    url = http://nixos-arm.dezgeg.me/bootstrap-2017-04-13-1f32d4b4/armv7l/busybox;
-    sha256 = "187xwzsng5lpak1nanrk88y4mlydmrbhx6la00rrd6kjx376s565";
+    url = https://hydra.nixos.org/build/112609103/download/2/busybox;
+    sha256 = "566a469dac214b31e4abdb0a91d32550bab1be5858d329e1b6074eef05370ca3";
     executable = true;
   };
 
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = http://nixos-arm.dezgeg.me/bootstrap-2017-04-13-1f32d4b4/armv7l/bootstrap-tools.tar.xz;
-    sha256 = "05ayki2kak3i5lw97qidd5h9jv00dmlhx9h7l771bj331yamyqdn";
+    url = https://hydra.nixos.org/build/112609103/download/1/bootstrap-tools.tar.xz;
+    sha256 = "79fa2d7722aeb856c7c9b62a3fd64b6d261fd6f6bcbac486f0a2a7d823210550";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-tools/scripts/unpack-bootstrap-tools.sh
+++ b/pkgs/stdenv/linux/bootstrap-tools/scripts/unpack-bootstrap-tools.sh
@@ -35,12 +35,7 @@ for i in $out/lib/librt-*.so $out/lib/libpcre*; do
     $out/bin/patchelf --set-rpath $out/lib --force-rpath "$i"
 done
 
-# Fix the libc linker script.
 export PATH=$out/bin
-cat $out/lib/libc.so | sed "s|/nix/store/e*-[^/]*/|$out/|g" > $out/lib/libc.so.tmp
-mv $out/lib/libc.so.tmp $out/lib/libc.so
-cat $out/lib/libpthread.so | sed "s|/nix/store/e*-[^/]*/|$out/|g" > $out/lib/libpthread.so.tmp
-mv $out/lib/libpthread.so.tmp $out/lib/libpthread.so
 
 # Provide some additional symlinks.
 ln -s bash $out/bin/sh


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates the 32-bit ARM bootstrap tarballs to the latest cross-compiled versions built by Hydra in the [`cross-trunk`](https://hydra.nixos.org/jobset/nixpkgs/cross-trunk) jobset. This is required because glibc 2.30 requires at least GCC6 (see https://github.com/NixOS/nixpkgs/pull/66528).

This update is based on the previous one in https://github.com/NixOS/nixpkgs/commit/28f87e414186e2f16a094ac354dfe079965e8fe5.

I have not tested this at all yet, but @thefloweringash [reported armv7l build failures](https://logs.nix.samueldr.com/nixos-aarch64/2020-02-11#3059537;).

The tools are currently hosted on my server, but will need to be moved to tarballs.nixos.org before this is merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @samueldr @thefloweringash @vcunat 