### PR TITLE
doomseeker: fix build by using qt wrapper hook

### DIFF
--- a/pkgs/applications/misc/doomseeker/default.nix
+++ b/pkgs/applications/misc/doomseeker/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, cmake, fetchFromBitbucket, pkgconfig, qtbase, qttools, qtmultimedia, zlib, bzip2, xxd }:
+{ lib, isClang, mkDerivation, cmake, fetchFromBitbucket, pkgconfig, qtbase, qttools, qtmultimedia, zlib, bzip2, xxd }:
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "doomseeker";
   version = "2018-03-05";
 
@@ -19,9 +19,9 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang "-Wno-error=format-security";
+  NIX_CFLAGS_COMPILE = lib.optionalString isClang "-Wno-error=format-security";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://doomseeker.drdteam.org/;
     description = "Multiplayer server browser for many Doom source ports";
     license = licenses.gpl2;

--- a/pkgs/applications/misc/doomseeker/default.nix
+++ b/pkgs/applications/misc/doomseeker/default.nix
@@ -1,4 +1,4 @@
-{ lib, isClang, mkDerivation, cmake, fetchFromBitbucket, pkgconfig, qtbase, qttools, qtmultimedia, zlib, bzip2, xxd }:
+{ stdenv, mkDerivation, cmake, fetchFromBitbucket, pkgconfig, qtbase, qttools, qtmultimedia, zlib, bzip2, xxd }:
 
 mkDerivation {
   pname = "doomseeker";
@@ -13,15 +13,12 @@ mkDerivation {
 
   patches = [ ./fix_paths.patch ./qt_build_fix.patch ];
 
+  nativeBuildInputs = [ cmake qttools pkgconfig xxd ];
   buildInputs = [ qtbase qtmultimedia zlib bzip2 ];
 
-  nativeBuildInputs = [ cmake qttools pkgconfig xxd ];
+  hardeningDisable = stdenv.lib.optional stdenv.isDarwin "format";
 
-  enableParallelBuilding = true;
-
-  NIX_CFLAGS_COMPILE = lib.optionalString isClang "-Wno-error=format-security";
-
-  meta = with lib; {
+  meta = with stdenv.lib; {
     homepage = http://doomseeker.drdteam.org/;
     description = "Multiplayer server browser for many Doom source ports";
     license = licenses.gpl2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2877,7 +2877,9 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
   };
 
-  doomseeker = qt5.callPackage ../applications/misc/doomseeker { };
+  doomseeker = qt5.callPackage ../applications/misc/doomseeker {
+    inherit (stdenv.cc) isClang;
+  };
 
   doom-bcc = callPackage ../games/zdoom/bcc-git.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2877,9 +2877,7 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
   };
 
-  doomseeker = qt5.callPackage ../applications/misc/doomseeker {
-    inherit (stdenv.cc) isClang;
-  };
+  doomseeker = qt5.callPackage ../applications/misc/doomseeker { };
 
   doom-bcc = callPackage ../games/zdoom/bcc-git.nix { };
 


### PR DESCRIPTION
Current master immediately crashes; this fixes the build and the program runs
successfully. See #65399 for details.

Closed #79128


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).