### PR TITLE
lmdb: build static and dynamic libs separately

### DIFF
--- a/pkgs/development/libraries/lmdb/default.nix
+++ b/pkgs/development/libraries/lmdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, static ? false }:
 
 stdenv.mkDerivation rec {
   pname = "lmdb";
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
 
   patches = [ ./hardcoded-compiler.patch ];
   patchFlags = [ "-p3" ];
+
+  # Only build one library version, either static or dynamic.
+  postPatch = ''
+    sed '/^ILIBS\t/s/liblmdb${if static then "\\$(SOEXT)" else "\.a"}//' -i Makefile
+  '';
 
   outputs = [ "bin" "out" "dev" ];
 

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -268,4 +268,6 @@ in {
   python27 = super.python27.override { static = true; };
 
   libev = super.libev.override { static = true; };
+
+  lmdb = super.lmdb.override { static = true; };
 }


### PR DESCRIPTION
and halve closure as a result (the dynamic case is interesting there).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev 5314c69"`
    8 build failures (22 transitively), all clearly unrelated.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] N/A Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
