### PR TITLE
arrow-cpp: 0.15.1 -> 0.16.0

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, lib, fetchurl, fetchFromGitHub, fixDarwinDylibNames, autoconf, boost
-, brotli, cmake, double-conversion, flatbuffers, gflags, glog, gtest, lz4, perl
-, python, rapidjson, snappy, thrift, uriparser, which, zlib, zstd
+{ stdenv, lib, fetchurl, fetchFromGitHub, fetchpatch, fixDarwinDylibNames, autoconf, boost
+, brotli, cmake, flatbuffers, gflags, glog, gtest, lz4, perl
+, python, rapidjson, snappy, thrift, which, zlib, zstd
 , enableShared ? true }:
 
 let
   parquet-testing = fetchFromGitHub {
     owner = "apache";
     repo = "parquet-testing";
-    rev = "a277dc4e55ded3e3ea27dab1e4faf98c112442df";
-    sha256 = "1yh5a8l4ship36hwmgmp2kl72s5ac9r8ly1qcs650xv2g9q7yhnq";
+    rev = "46c9e977f58f6c5ef1b81f782f3746b3656e5a8c";
+    sha256 = "1z2s6zh58nf484s0yraw7b1aqgx66dn2wzp1bzv9ndq03msklwly";
   };
 
 in stdenv.mkDerivation rec {
   pname = "arrow-cpp";
-  version = "0.15.1";
+  version = "0.16.0";
 
   src = fetchurl {
     url =
       "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "1jbghpppabsix2rkxbnh41inj9lcxfz4q94p96xzxshh4g3mhb4s";
+    sha256 = "1xdp1yni9i1cpml326s78qql1g832m800h7zjlqmk89983g94696";
   };
 
   sourceRoot = "apache-arrow-${version}/cpp";
@@ -35,6 +35,14 @@ in stdenv.mkDerivation rec {
   patches = [
     # patch to fix python-test
     ./darwin.patch
+    # Adjust CMake target names to make -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON work.
+    # Remove this when updating to the next version.
+    (fetchpatch {
+      name = "arrow-use-upstream-cmake-target-names.patch";
+      url = "https://github.com/apache/arrow/commit/396861b38d2f4e805db7c2ecd2c96fff0ca2678b.patch";
+      sha256 = "0ki7nx858374anvwyi4szz5hgnnzv4fghdd05c38bzry9rfljgb1";
+      stripLen = 1;
+    })
   ] ++ lib.optionals (!enableShared) [
     # The shared jemalloc lib is unused and breaks in static mode due to missing -fpic.
     ./jemalloc-disable-shared.patch
@@ -48,7 +56,6 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     boost
     brotli
-    double-conversion
     flatbuffers
     gflags
     glog
@@ -57,7 +64,6 @@ in stdenv.mkDerivation rec {
     rapidjson
     snappy
     thrift
-    uriparser
     zlib
     zstd
     python.pkgs.python
@@ -71,15 +77,28 @@ in stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
+    "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
     "-DARROW_BUILD_TESTS=ON"
     "-DARROW_DEPENDENCY_SOURCE=SYSTEM"
-    "-DARROW_PARQUET=ON"
     "-DARROW_PLASMA=ON"
     # Disable Python for static mode because openblas is currently broken there.
     "-DARROW_PYTHON=${if enableShared then "ON" else "OFF"}"
-    "-Duriparser_SOURCE=SYSTEM"
+    "-DARROW_USE_GLOG=ON"
+    "-DARROW_WITH_BROTLI=ON"
+    "-DARROW_WITH_LZ4=ON"
+    "-DARROW_WITH_SNAPPY=ON"
+    "-DARROW_WITH_ZLIB=ON"
+    "-DARROW_WITH_ZSTD=ON"
+    # Parquet options:
+    "-DARROW_PARQUET=ON"
+    "-DPARQUET_BUILD_EXECUTABLES=ON"
+    "-DTHRIFT_COMPILER=${thrift}/bin/thrift"
+    "-DTHRIFT_VERSION=${thrift.version}"
   ] ++ lib.optionals (!enableShared) [
     "-DARROW_BUILD_SHARED=OFF"
+    "-DARROW_BOOST_USE_SHARED=OFF"
+    "-DARROW_GFLAGS_USE_SHARED=OFF"
+    "-DARROW_PROTOBUF_USE_SHARED=OFF"
     "-DARROW_TEST_LINKAGE=static"
     "-DOPENSSL_USE_STATIC_LIBS=ON"
   ] ++ lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF";

--- a/pkgs/development/libraries/arrow-cpp/jemalloc-disable-shared.patch
+++ b/pkgs/development/libraries/arrow-cpp/jemalloc-disable-shared.patch
@@ -1,11 +1,11 @@
 diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
 --- a/cmake_modules/ThirdpartyToolchain.cmake
 +++ b/cmake_modules/ThirdpartyToolchain.cmake
-@@ -1428,6 +1428,7 @@ if(ARROW_JEMALLOC)
-                       "--with-jemalloc-prefix=je_arrow_"
-                       "--with-private-namespace=je_arrow_private_"
-                       "--without-export"
-+                      "--disable-shared"
-                       # Don't override operator new()
-                       "--disable-cxx" "--disable-libdl"
-                       # See https://github.com/jemalloc/jemalloc/issues/1237
+@@ -1317,6 +1317,7 @@ if(ARROW_JEMALLOC)
+               "--with-jemalloc-prefix=je_arrow_"
+               "--with-private-namespace=je_arrow_private_"
+               "--without-export"
++              "--disable-shared"
+               # Don't override operator new()
+               "--disable-cxx" "--disable-libdl"
+               # See https://github.com/jemalloc/jemalloc/issues/1237

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, python, isPy3k, arrow-cpp, cmake, cython, futures, hypothesis, numpy, pandas, pytest, pkgconfig, setuptools_scm, six }:
+{ lib, buildPythonPackage, python, isPy3k, arrow-cpp, cmake, cython, futures, hypothesis, numpy, pandas, pytest, pytest-lazy-fixture, pkgconfig, setuptools_scm, six }:
 
 let
   _arrow-cpp = arrow-cpp.override { inherit python; };
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ cmake cython pkgconfig setuptools_scm ];
   propagatedBuildInputs = [ numpy six ] ++ lib.optionals (!isPy3k) [ futures ];
-  checkInputs = [ hypothesis pandas pytest ];
+  checkInputs = [ hypothesis pandas pytest pytest-lazy-fixture ];
 
   PYARROW_BUILD_TYPE = "release";
   PYARROW_WITH_PARQUET = true;

--- a/pkgs/development/python-modules/pytest-lazy-fixture/default.nix
+++ b/pkgs/development/python-modules/pytest-lazy-fixture/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -14,12 +14,8 @@ buildPythonPackage rec {
   };
 
   checkInputs = [
-    pytest
+    pytestCheckHook
   ];
-
-  checkPhase = ''
-    pytest
-  '';
 
   meta = with lib; {
     description = "Helps to use fixtures in pytest.mark.parametrize";

--- a/pkgs/development/python-modules/pytest-lazy-fixture/default.nix
+++ b/pkgs/development/python-modules/pytest-lazy-fixture/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-lazy-fixture";
+  version = "0.6.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b0hmnsxw4s2wf9pks8dg6dfy5cx3zcbzs8517lfccxsfizhqz8f";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Helps to use fixtures in pytest.mark.parametrize";
+    homepage = "https://github.com/pytest-dev/pytest-repeat";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tobim ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2332,6 +2332,8 @@ in {
 
   pytest-isort = callPackage ../development/python-modules/pytest-isort { };
 
+  pytest-lazy-fixture = callPackage ../development/python-modules/pytest-lazy-fixture { };
+
   pytest-mpl = callPackage ../development/python-modules/pytest-mpl { };
 
   pytest-mock = callPackage ../development/python-modules/pytest-mock { };


### PR DESCRIPTION
Changelog: https://arrow.apache.org/release/0.16.0.html

This switches to explicitly enabling dependency lookups for optional features (they were not picked up before).
It also enables building of the Parquet command line tools.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
