### PR TITLE
wasm-pack: 0.8.1 -> 0.9.1

### DIFF
--- a/pkgs/development/tools/wasm-pack/default.nix
+++ b/pkgs/development/tools/wasm-pack/default.nix
@@ -2,32 +2,35 @@
 , fetchFromGitHub
 , rustPlatform
 , pkgconfig
-, openssl
+, libressl
 , curl
 , Security
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wasm-pack";
-  version = "0.8.1";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "rustwasm";
     repo = "wasm-pack";
     rev = "v${version}";
-    sha256 = "1z66m16n4r16zqmnv84a5jndr5x6mdqdq4b1wq929sablwqd2rl4";
+    sha256 = "1rqyfg6ajxxyfx87ar25nf5ck9hd0p12qgv98dicniqag8l4rvsr";
   };
 
-  cargoSha256 = "0hp68w5mvk725gzbmlgl8j6wa1dv2fydil7jvq0f09mzxxaqrwcs";
+  cargoSha256 = "095gk6lcck5864wjhrkhgnkxn9pzcg82xk5p94br7lmf15y9gc7j";
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ openssl ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ curl Security ];
+  buildInputs = [
+    # LibreSSL works around segfault issues caused by OpenSSL being unable to
+    # gracefully exit while doing work.
+    # See: https://github.com/rustwasm/wasm-pack/issues/650
+    libressl
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ curl Security ];
 
-
-  # Tests fetch external resources and build artifacts.
-  # Disabled to work with sandboxing
+  # Most tests rely on external resources and build artifacts.
+  # Disabling check here to work with build sandboxing.
   doCheck = false;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Updating wasm-pack to a new minor release.

The updated expression also replaced OpenSSL with LibreSSL to work around a race condition raised in [this issue](https://github.com/rustwasm/wasm-pack/issues/650).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

A template project was generated and built successfully with the following:
    wasm-pack new hello-wasm
    cd hello-wasm
    wasm-pack build

Output for `wasm-pack new hello-wasm`:
```
$ wasm-pack new hello-wasm
[INFO]: Installing cargo-generate...
 Generating a new rustwasm project with name 'hello-wasm'...
 Creating project called `hello-wasm`...
 Done! New project created /tmp/tmp.HiLjhbsbrS/hello-wasm
[INFO]: 🐑 Generated new project at /hello-wasm
```

Output for `wasm-pack build`:
```
[INFO]: Checking for the Wasm target...
[INFO]: Compiling to Wasm...
   Compiling proc-macro2 v1.0.8
   Compiling unicode-xid v0.2.0
   Compiling log v0.4.8
   Compiling syn v1.0.14
   Compiling wasm-bindgen-shared v0.2.58
   Compiling cfg-if v0.1.10
   Compiling lazy_static v1.4.0
   Compiling bumpalo v3.2.0
   Compiling wasm-bindgen v0.2.58
   Compiling quote v1.0.2
   Compiling wasm-bindgen-backend v0.2.58
   Compiling wasm-bindgen-macro-support v0.2.58
   Compiling wasm-bindgen-macro v0.2.58
   Compiling console_error_panic_hook v0.1.6
   Compiling hello-wasm v0.1.0 (/tmp/tmp.HiLjhbsbrS/hello-wasm)
warning: function is never used: `set_panic_hook`
 --> src/utils.rs:1:8
  |
1 | pub fn set_panic_hook() {
  |        ^^^^^^^^^^^^^^
  |
  = note: `#[warn(dead_code)]` on by default

    Finished release [optimized] target(s) in 19.33s
[INFO]: Installing wasm-bindgen...
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[INFO]: Optional fields missing from Cargo.toml: 'description', 'repository', and 'license'. These are not necessary, but recommended
[INFO]: :-) Done in 19.41s
[INFO]: :-) Your wasm pkg is ready to publish at /tmp/tmp.HiLjhbsbrS/hello-wasm/pkg.
```