### PR TITLE
matomo: 3.13.1 -> 3.13.2

### DIFF
--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -3,103 +3,107 @@
 let
   versions = {
     matomo = {
-      version = "3.13.1";
-      sha256 = "071m3sw3rrhlccbwdyklcn8rwp4mcnii5m2a7zmgx3rv87i9n2ni";
+      version = "3.13.2";
+      sha256 = "1psysdz60h5rvgbsflkfprygxnh3kq60snqamyss07rk0ahbcb16";
     };
 
     matomo-beta = {
-      version = "3.12.0";
-      beta = 3;
-      sha256 = "1n7b8cag7rpi6y4145cll2irz3in4668jkiicy06wm5nq6lb4bdf";
+      version = "3.13.2";
+      # `beta` examples: "b1", "rc1", null
+      # TOOD when updating: use null if stable version is >= latest beta or release candidate
+      beta = null;
+      sha256 = "1psysdz60h5rvgbsflkfprygxnh3kq60snqamyss07rk0ahbcb16";
     };
   };
-  common = pname: {version, sha256, beta ? null}:
-    let fullVersion = version + stdenv.lib.optionalString (beta != null) "-b${toString beta}";
-  name = "${pname}-${fullVersion}";
+  common = pname: { version, sha256, beta ? null }:
+    let
+      fullVersion = version + stdenv.lib.optionalString (beta != null) "-${toString beta}";
+      name = "${pname}-${fullVersion}";
+    in
+
+      stdenv.mkDerivation rec {
+        inherit name;
+        version = fullVersion;
+
+        src = fetchurl {
+          url = "https://builds.matomo.org/matomo-${version}.tar.gz";
+          inherit sha256;
+        };
+
+        nativeBuildInputs = [ makeWrapper ];
+
+        # make-localhost-default-database-server.patch:
+        #   This changes the default value of the database server field
+        #   from 127.0.0.1 to localhost.
+        #   unix socket authentication only works with localhost,
+        #   but password-based SQL authentication works with both.
+        # TODO: is upstream interested in this?
+        # -> discussion at https://github.com/matomo-org/matomo/issues/12646
+        patches = [ ./make-localhost-default-database-host.patch ];
+
+        # this bootstrap.php adds support for getting PIWIK_USER_PATH
+        # from an environment variable. Point it to a mutable location
+        # to be able to use matomo read-only from the nix store
+        postPatch = ''
+          cp ${./bootstrap.php} bootstrap.php
+        '';
+
+        # TODO: future versions might rename the PIWIK_… variables to MATOMO_…
+        # TODO: Move more unnecessary files from share/, especially using PIWIK_INCLUDE_PATH.
+        #       See https://forum.matomo.org/t/bootstrap-php/5926/10 and
+        #       https://github.com/matomo-org/matomo/issues/11654#issuecomment-297730843
+        installPhase = ''
+          runHook preInstall
+
+          # copy everything to share/, used as webroot folder, and then remove what's known to be not needed
+          mkdir -p $out/share
+          cp -ra * $out/share/
+          # tmp/ is created by matomo in PIWIK_USER_PATH
+          rmdir $out/share/tmp
+          # config/ needs to be accessed by PIWIK_USER_PATH anyway
+          ln -s $out/share/config $out/
+
+          makeWrapper ${php}/bin/php $out/bin/matomo-console \
+            --add-flags "$out/share/console"
+
+          runHook postInstall
+        '';
+
+        filesToFix = [
+          "misc/composer/build-xhprof.sh"
+          "misc/composer/clean-xhprof.sh"
+          "misc/cron/archive.sh"
+          "plugins/Installation/FormDatabaseSetup.php"
+          "vendor/leafo/lessphp/package.sh"
+          "vendor/pear/archive_tar/sync-php4"
+          "vendor/szymach/c-pchart/coverage.sh"
+          # drupal_test.sh does not exist in 3.12.0-b3; added for 3.13.0
+          "vendor/twig/twig/drupal_test.sh"
+        ];
+
+        # This fixes the consistency check in the admin interface
+        #
+        # The filesToFix list may contain files that are exclusive to only one of the versions we build
+        # make sure to test for existence to avoid erroring on an incompatible version and failing
+        postFixup = ''
+          pushd $out/share > /dev/null
+          for f in $filesToFix; do
+            if [ -f "$f" ]; then
+              length="$(wc -c "$f" | cut -d' ' -f1)"
+              hash="$(md5sum "$f" | cut -d' ' -f1)"
+              sed -i "s:\\(\"$f\"[^(]*(\\).*:\\1\"$length\", \"$hash\"),:g" config/manifest.inc.php
+            fi
+          done
+          popd > /dev/null
+        '';
+
+        meta = with stdenv.lib; {
+          description = "A real-time web analytics application";
+          license = licenses.gpl3Plus;
+          homepage = https://matomo.org/;
+          platforms = platforms.all;
+          maintainers = with maintainers; [ florianjacob kiwi ];
+        };
+      };
 in
-
-stdenv.mkDerivation rec {
-  inherit name;
-  version = fullVersion;
-
-  src = fetchurl {
-    url = "https://builds.matomo.org/matomo-${version}.tar.gz";
-    inherit sha256;
-  };
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  # make-localhost-default-database-server.patch:
-  #   This changes the default value of the database server field
-  #   from 127.0.0.1 to localhost.
-  #   unix socket authentication only works with localhost,
-  #   but password-based SQL authentication works with both.
-  # TODO: is upstream interested in this?
-  # -> discussion at https://github.com/matomo-org/matomo/issues/12646
-  patches = [ ./make-localhost-default-database-host.patch ];
-
-  # this bootstrap.php adds support for getting PIWIK_USER_PATH
-  # from an environment variable. Point it to a mutable location
-  # to be able to use matomo read-only from the nix store
-  postPatch = ''
-    cp ${./bootstrap.php} bootstrap.php
-  '';
-
-  # TODO: future versions might rename the PIWIK_… variables to MATOMO_…
-  # TODO: Move more unnecessary files from share/, especially using PIWIK_INCLUDE_PATH.
-  #       See https://forum.matomo.org/t/bootstrap-php/5926/10 and
-  #       https://github.com/matomo-org/matomo/issues/11654#issuecomment-297730843
-  installPhase = ''
-    runHook preInstall
-
-    # copy everything to share/, used as webroot folder, and then remove what's known to be not needed
-    mkdir -p $out/share
-    cp -ra * $out/share/
-    # tmp/ is created by matomo in PIWIK_USER_PATH
-    rmdir $out/share/tmp
-    # config/ needs to be accessed by PIWIK_USER_PATH anyway
-    ln -s $out/share/config $out/
-
-    makeWrapper ${php}/bin/php $out/bin/matomo-console \
-      --add-flags "$out/share/console"
-
-    runHook postInstall
-  '';
-
-  filesToFix = [
-    "misc/composer/build-xhprof.sh"
-    "misc/composer/clean-xhprof.sh"
-    "misc/cron/archive.sh"
-    "plugins/Installation/FormDatabaseSetup.php"
-    "vendor/leafo/lessphp/package.sh"
-    "vendor/pear/archive_tar/sync-php4"
-    "vendor/szymach/c-pchart/coverage.sh"
-    # drupal_test.sh does not exist in 3.12.0-b3; added for 3.13.0
-    "vendor/twig/twig/drupal_test.sh"
-  ];
-
-  # This fixes the consistency check in the admin interface
-  #
-  # The filesToFix list may contain files that are exclusive to only one of the versions we build
-  # make sure to test for existence to avoid erroring on an incompatible version and failing
-  postFixup = ''
-    pushd $out/share > /dev/null
-    for f in $filesToFix; do
-      if [ -f "$f" ]; then
-        length="$(wc -c "$f" | cut -d' ' -f1)"
-        hash="$(md5sum "$f" | cut -d' ' -f1)"
-        sed -i "s:\\(\"$f\"[^(]*(\\).*:\\1\"$length\", \"$hash\"),:g" config/manifest.inc.php
-      fi
-    done
-    popd > /dev/null
-  '';
-
-  meta = with stdenv.lib; {
-    description = "A real-time web analytics application";
-    license = licenses.gpl3Plus;
-    homepage = https://matomo.org/;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ florianjacob kiwi ];
-  };
-};
-in stdenv.lib.mapAttrs common versions
+stdenv.lib.mapAttrs common versions


### PR DESCRIPTION
Updated both matomo and matomo-beta to the latest version

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done
nixpkgs-fmt, updated, tested install, updated my server from my branch

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
