### PR TITLE
liberfa: init at 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4520,6 +4520,12 @@
     github = "minijackson";
     name = "Rémi Nicole";
   };
+  mir06 = {
+    email = "armin.leuprecht@uni-graz.at";
+    github = "mir06";
+    githubId = 8479244;
+    name = "Armin Leuprecht";
+  };
   mirdhyn = {
     email = "mirdhyn@gmail.com";
     github = "mirdhyn";

--- a/pkgs/development/libraries/liberfa/default.nix
+++ b/pkgs/development/libraries/liberfa/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "erfa";
+  version = "1.7.0";
+
+  buildInputs = [ autoreconfHook ];
+
+  src = fetchFromGitHub {
+    owner = "liberfa";
+    repo = "erfa";
+    rev = "v${version}";
+    sha256 = "1z4k2phrw6wwi0kax6ac80jk9c036gi7pmhmg6gaf3lk81k6xz2r";
+  };
+
+  configureFlags = [ "--enable-shared" ];
+
+  meta = with stdenv.lib; {
+    description = "Essential Routines for Fundamental Astronomy";
+    homepage = "https://github.com/liberfa/erfa";
+    maintainers = with maintainers; [ mir06 ];
+    license = {
+      url = "https://github.com/liberfa/erfa/blob/master/LICENSE";
+      free = true;
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4670,6 +4670,8 @@ in
 
   libepc = callPackage ../development/libraries/libepc { };
 
+  liberfa = callPackage ../development/libraries/liberfa { };
+
   libestr = callPackage ../development/libraries/libestr { };
 
   libevdev = callPackage ../development/libraries/libevdev { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
