### PR TITLE
pythonPackages.ydiff: init at 1.1

### DIFF
--- a/pkgs/development/python-modules/ydiff/default.nix
+++ b/pkgs/development/python-modules/ydiff/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "ydiff";
+  version = "1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mxcl17sx1d4vaw22ammnnn3y19mm7r6ljbarcjzi519klz26bnf";
+  };
+
+  # test suite requires a multitude of other version control tooling
+  # currently only a single file, an import/usage should suffice
+  checkPhase = ''
+    $out/bin/ydiff --help
+  '';
+
+  meta = with stdenv.lib; {
+    description = "View colored, incremental diff in workspace or from stdin with side by side and auto pager support (Was \"cdiff\")";
+    longDescription = ''
+      Term based tool to view colored, incremental diff in a Git/Mercurial/Svn
+      workspace or from stdin, with side by side (similar to diff -y) and auto
+      pager support
+    '';
+    homepage = "https://github.com/ymattw/ydiff";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.limeytexan ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5703,6 +5703,8 @@ in {
 
   xxhash = callPackage ../development/python-modules/xxhash { };
 
+  ydiff = callPackage ../development/python-modules/ydiff { };
+
   yoda = toPythonModule (pkgs.yoda.override {
     inherit python;
   });


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
