### PR TITLE
xfce.xfce4-pulseaudio-plugin: 0.4.1 -> 0.4.2, fix volume

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-pulseaudio-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-pulseaudio-plugin/default.nix
@@ -1,13 +1,27 @@
-{ mkXfceDerivation, automakeAddFlags, dbus-glib, dbus, gtk3, libpulseaudio
-, libnotify, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+{ mkXfceDerivation
+, automakeAddFlags
+, dbus-glib
+, dbus
+, gtk3
+, libpulseaudio
+, libnotify
+, libxfce4ui
+, libxfce4util
+, xfce4-panel
+, xfconf
+, keybinder3
+, glib
+}:
 
 mkXfceDerivation {
   category = "panel-plugins";
   pname = "xfce4-pulseaudio-plugin";
-  version = "0.4.1";
-  sha256 = "1c8krpg3l6ki00ldd9hifc4bddysdm0w3x5w43fkr31j0zrscvfp";
+  version = "0.4.2";
+  sha256 = "1s996mcniskq42vv7cb9i165pmrfp9c95p5f9rx14hqq8in9mvc5";
 
-  nativeBuildInputs = [ automakeAddFlags ];
+  nativeBuildInputs = [
+    automakeAddFlags
+  ];
 
   NIX_CFLAGS_COMPILE = "-I${dbus-glib.dev}/include/dbus-1.0 -I${dbus.dev}/include/dbus-1.0";
 
@@ -15,7 +29,17 @@ mkXfceDerivation {
     substituteInPlace configure.ac.in --replace gio-2.0 gio-unix-2.0
   '';
 
-  buildInputs = [ gtk3 libnotify libpulseaudio libxfce4ui libxfce4util xfce4-panel xfconf ];
+  buildInputs = [
+    glib
+    gtk3
+    keybinder3
+    libnotify
+    libpulseaudio
+    libxfce4ui
+    libxfce4util
+    xfce4-panel
+    xfconf
+  ];
 
   meta = {
     description = "Adjust the audio volume of the PulseAudio sound system";


### PR DESCRIPTION
We needed to add keybinder3.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This at least fixes the issues with volume up/down, which I'm betting use keybinder3 here.
But there's another thing with media play/pause/skip for example. I believe that's the mpris feature, so perhaps that's actually broken in the source code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
