### PR TITLE
ocamlPackages.resource-pooling: 0.6 → 1.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, eliom, ocaml_pcre, pgocaml, macaque, safepass, yojson, ocsigen_deriving, ocsigen_server
+{ stdenv, fetchFromGitHub, ocaml, findlib, camlp4, ocsigen-toolkit, pgocaml, macaque, safepass, yojson
 , js_of_ocaml-camlp4, lwt_camlp4
+, cohttp-lwt-unix
 , resource-pooling
 }:
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-ocsigen-start-${version}";
-  version = "1.8.0";
+  version = "2.7.0";
 
-  buildInputs = [ ocaml findlib eliom js_of_ocaml-camlp4 lwt_camlp4 ];
-  propagatedBuildInputs = [ pgocaml macaque safepass ocaml_pcre ocsigen-toolkit yojson ocsigen_deriving ocsigen_server resource-pooling ];
+  buildInputs = [ ocaml findlib js_of_ocaml-camlp4 lwt_camlp4 ];
+  propagatedBuildInputs = [ pgocaml macaque safepass ocsigen-toolkit yojson resource-pooling cohttp-lwt-unix camlp4 ];
 
   patches = [ ./templates-dir.patch ];
 
@@ -22,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "ocsigen";
     repo = "ocsigen-start";
     rev = version;
-    sha256 = "0h5gp06vxy6jpppz1x840gyf9viiy7lic7spx7fxldpy2jpv058s";
+    sha256 = "1kp9g679xnff2ybwsicnc9c203hi9ri1ijbpp6221b2sj6zxf2wc";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/resource-pooling/default.nix
+++ b/pkgs/development/ocaml-modules/resource-pooling/default.nix
@@ -1,35 +1,26 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, lwt_log }:
+{ lib, fetchFromGitHub, buildDunePackage, lwt_log }:
 
-let pname = "resource-pooling"; in
+buildDunePackage rec {
+  version = "1.1";
+  pname = "resource-pooling";
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.06"
-then throw "${pname} is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  version = "0.6";
-  name = "ocaml${ocaml.version}-${pname}-${version}";
+  minimumOCamlVersion = "4.06";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = pname;
     rev = version;
-    sha256 = "1hw98a4pndq6ms4vfsyz0ynfz8g21fm73fc7s1gx824fhdx4ywgd";
+    sha256 = "0wsbnwszafdv3gsiiaslgf6m6pfx74h7h19i0gp2c4ivdiv3wck9";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ lwt_log ];
 
-  configurePhase = "ocaml setup.ml -configure --prefix $out";
-  buildPhase = "ocaml setup.ml -build";
-  createFindlibDestdir = true;
-  installPhase = "ocaml setup.ml -install";
+  doCheck = true;
 
   meta = {
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
     description = "A library for pooling resources like connections, threads, or similar";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
