### PR TITLE
tipp10: init at 3.1.0

### DIFF
--- a/pkgs/applications/misc/tipp10/default.nix
+++ b/pkgs/applications/misc/tipp10/default.nix
@@ -1,0 +1,25 @@
+{ cmake, stdenv, mkDerivation, fetchFromGitLab,
+  qtmultimedia, qttools, ... }:
+
+mkDerivation rec {
+  pname = "tipp10";
+  version = "3.1.0";
+
+  src = fetchFromGitLab {
+    owner = "a_a";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1mksga1zyqz1y2s524nkw86irg36zpjwz7ff87n2ygrlysczvnx1";
+  };
+
+  nativeBuildInputs = [ cmake qttools ];
+  buildInputs = [ qtmultimedia ];
+
+  meta = with stdenv.lib; {
+    description = "Learn and train typing with the ten-finger system";
+    homepage = "https://gitlab.com/a_a/tipp10";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ petabyteboy ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21727,6 +21727,8 @@ in
 
   tiny = callPackage ../applications/networking/irc/tiny { };
 
+  tipp10 = qt5.callPackage ../applications/misc/tipp10 { };
+
   tixati = callPackage ../applications/networking/p2p/tixati { };
 
   tkcvs = callPackage ../applications/version-management/tkcvs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

update of #75664 by @petabyteboy with resolved conflicts

closes #75664

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
