### PR TITLE
proggyfonts: cleanup

### DIFF
--- a/pkgs/data/fonts/proggyfonts/default.nix
+++ b/pkgs/data/fonts/proggyfonts/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchurl, mkfontdir, mkfontscale }:
-
-# adapted from https://aur.archlinux.org/packages/proggyfonts/
+{ stdenv, fetchurl, mkfontscale }:
 
 stdenv.mkDerivation {
   name = "proggyfonts-0.1";
@@ -10,31 +8,28 @@ stdenv.mkDerivation {
     sha256 = "1plcm1sjpa3hdqhhin48fq6zmz3ndm4md72916hd8ff0w6596q0n";
   };
 
-  nativeBuildInputs = [ mkfontdir mkfontscale ];
+  nativeBuildInputs = [ mkfontscale ];
 
   installPhase =
     ''
-      mkdir -p $out/share/doc/$name $out/share/fonts/misc $out/share/fonts/truetype
-
-      cp Licence.txt $out/share/doc/$name/LICENSE
-
+      # compress pcf fonts
+      mkdir -p $out/share/fonts/misc
       rm Speedy.pcf # duplicated as Speedy11.pcf
       for f in *.pcf; do
-        gzip -c "$f" > $out/share/fonts/misc/"$f".gz
+        gzip -n -9 -c "$f" > $out/share/fonts/misc/"$f".gz
       done
-      cp *.bdf $out/share/fonts/misc
-      cp *.ttf $out/share/fonts/truetype
 
-      for f in misc truetype; do
-        cd $out/share/fonts/$f
-        mkfontscale
-        mkfontdir
-      done
+      install -D -m 644 *.bdf -t "$out/share/fonts/misc"
+      install -D -m 644 *.ttf -t "$out/share/fonts/truetype"
+      install -D -m 644 Licence.txt -t "$out/share/doc/$name"
+
+      mkfontscale "$out/share/fonts/truetype"
+      mkfontdir   "$out/share/fonts/misc"
     '';
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "1l1sxmzp3gcd2d32nxar6xwd1v1w18a9gfh57zmsrfpspnfbz7y1";
+  outputHash = "1x196rp3wqjd7m57bgp5kfy5jmj97qncxi1vwibs925ji7dqzfgf";
 
   meta = with stdenv.lib; {
     homepage = http://upperbounds.net;


### PR DESCRIPTION

###### Motivation for this change
Tried to fix #75160 but couldn't get any result with either fonttosfnt (completely fails) or fontforge (completely unreadable). So here's a cleanup anyway.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested fonts in X11
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
