### PR TITLE
pounce: 1.0p1 -> 1.1

### DIFF
--- a/pkgs/servers/pounce/default.nix
+++ b/pkgs/servers/pounce/default.nix
@@ -2,30 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "pounce";
-  version = "1.0p1";
+  version = "1.1";
 
   src = fetchzip {
-    url = "https://code.causal.agency/june/pounce/archive/${version}.zip";
-    sha256 = "1fh1cf15ybl962n7x70hlg7zfcmpwgq6q90s74d3jhawmjj01syw";
+    url = "https://git.causal.agency/pounce/snapshot/pounce-${version}.tar.gz";
+    sha256 = "07iyh6ikrlf7y57k462jcr00db6aijk9b2s7n7l7i49hk7kmm6wq";
   };
-
-  patches = [
-    # Don't always create ${ETCDIR}/rc.d
-    (fetchpatch {
-      url = https://code.causal.agency/june/pounce/commit/db65889605a2fa5352e90a573b7584a6b7a59dd5.patch;
-      sha256 = "0bxhig72g4q0hs8lb7g8lb7kf0w9jdy22qwm9yndlwrdw3vi36zq";
-    })
-    # Simplify Linux.mk
-    (fetchpatch {
-      url = https://code.causal.agency/june/pounce/commit/b7dc2e3439a37d23d4847e130b37ece39b8efdd7.patch;
-      sha256 = "0c2pa6w9abkmaaq4957arfmpsrn933vcrs4a2da785v57pgkj4lq";
-    })
-    # Reference openssl(1) by absolute path
-    (fetchpatch {
-      url = https://code.causal.agency/june/pounce/commit/973f19b4fe73ef956fbb4eeaf963bbb83c926203.patch;
-      sha256 = "1w4rhwqfcakzb9a6afq788rrsypay0rw75bjk2f3l66spjb7v3ps";
-    })
-  ];
 
   buildInputs = [ libressl ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
