### PR TITLE
octave: Use qt5 and other improvements

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -124,6 +124,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # See https://savannah.gnu.org/bugs/?50339
+  F77_INTEGER_8_FLAG = if openblas.blas64 then "-fdefault-integer-8" else "";
+
   configureFlags = [
     "--enable-readline"
     "--with-blas=openblas"

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , fetchurl
 , gfortran
-, readline
 , ncurses
 , perl
 , flex
@@ -31,18 +30,23 @@
 , glpk ? null
 , suitesparse ? null
 , gnuplot ? null
+# - Include support for GNU readline:
+, enableReadline ? true
+, readline ? null
+# - Build Java interface:
+, enableJava ? true
 , jdk ? null
 , python ? null
 , overridePlatforms ? null
 , sundials_2 ? null
-# Qt / GUI is disabled by default
+# - Build Octave Qt GUI:
 , enableQt ? false
 , qtbase ? null
 , qtsvg ? null
 , qtscript ? null
 , qscintilla ? null
 , qttools ? null
-# JIT is disabled by default
+# - JIT compiler for loops:
 , enableJIT ? false
 , llvm ? null
 }:
@@ -98,7 +102,7 @@ stdenv.mkDerivation rec {
   ++ (stdenv.lib.optional (hdf5 != null) hdf5)
   ++ (stdenv.lib.optional (glpk != null) glpk)
   ++ (stdenv.lib.optional (suitesparse != null) suitesparse)
-  ++ (stdenv.lib.optional (jdk != null) jdk)
+  ++ (stdenv.lib.optional (enableJava) jdk)
   ++ (stdenv.lib.optional (sundials_2 != null) sundials_2)
   ++ (stdenv.lib.optional (gnuplot != null) gnuplot)
   ++ (stdenv.lib.optional (python != null) python)
@@ -128,10 +132,10 @@ stdenv.mkDerivation rec {
   F77_INTEGER_8_FLAG = if openblas.blas64 then "-fdefault-integer-8" else "";
 
   configureFlags = [
-    "--enable-readline"
     "--with-blas=openblas"
     "--with-lapack=openblas"
   ]
+    ++ stdenv.lib.optionals enableReadline [ "--enable-readline" ]
     ++ stdenv.lib.optionals openblas.blas64 [ "--enable-64" ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ "--with-x=no" ]
     ++ stdenv.lib.optionals enableQt [ "--with-qt=5" ]

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -116,6 +116,8 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [raskin];
     description = "Scientific Pragramming Language";
+    # https://savannah.gnu.org/bugs/?func=detailitem&item_id=56425 is the best attempt to fix JIT
+    broken = enableJIT;
     platforms = if overridePlatforms == null then
       (with stdenv.lib.platforms; linux ++ darwin)
     else overridePlatforms;

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -89,9 +89,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # See https://savannah.gnu.org/bugs/?50339
-  F77_INTEGER_8_FLAG = if openblas.blas64 then "-fdefault-integer-8" else "";
-
   configureFlags = [
     "--enable-readline"
     "--with-blas=openblas"

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -68,22 +68,57 @@ stdenv.mkDerivation rec {
     sha256 = "1qcmcpsq1lfka19fxzvxjwjhg113c39a9a0x8plkhvwdqyrn5sig";
   };
 
-  buildInputs = [ gfortran readline ncurses perl flex texinfo qhull
-    graphicsmagick pcre pkgconfig fltk zlib curl openblas libsndfile fftw
-    fftwSinglePrec portaudio qrupdate arpack libwebp gl2ps ]
-    ++ (stdenv.lib.optional (qt != null) qt)
-    ++ (stdenv.lib.optional (qscintilla != null) qscintilla)
-    ++ (stdenv.lib.optional (ghostscript != null) ghostscript)
-    ++ (stdenv.lib.optional (llvm != null) llvm)
-    ++ (stdenv.lib.optional (hdf5 != null) hdf5)
-    ++ (stdenv.lib.optional (glpk != null) glpk)
-    ++ (stdenv.lib.optional (suitesparse != null) suitesparse)
-    ++ (stdenv.lib.optional (jdk != null) jdk)
-    ++ (stdenv.lib.optional (gnuplot != null) gnuplot)
-    ++ (stdenv.lib.optional (python != null) python)
-    ++ (stdenv.lib.optionals (!stdenv.isDarwin) [ libGL libGLU libX11 ])
-    ;
-
+  buildInputs = [
+    readline
+    ncurses
+    perl
+    flex
+    qhull
+    graphicsmagick
+    pcre
+    fltk
+    zlib
+    curl
+    openblas
+    libsndfile
+    fftw
+    fftwSinglePrec
+    portaudio
+    qrupdate
+    arpack
+    libwebp
+    gl2ps
+  ]
+  ++ (stdenv.lib.optionals enableQt [
+    qtbase
+    qtsvg
+    qscintilla
+  ])
+  ++ (stdenv.lib.optional (ghostscript != null) ghostscript)
+  ++ (stdenv.lib.optional (hdf5 != null) hdf5)
+  ++ (stdenv.lib.optional (glpk != null) glpk)
+  ++ (stdenv.lib.optional (suitesparse != null) suitesparse)
+  ++ (stdenv.lib.optional (jdk != null) jdk)
+  ++ (stdenv.lib.optional (sundials != null) sundials)
+  ++ (stdenv.lib.optional (gnuplot != null) gnuplot)
+  ++ (stdenv.lib.optional (python != null) python)
+  ++ (stdenv.lib.optionals (!stdenv.isDarwin) [ libGL libGLU libX11 ])
+  ;
+  nativeBuildInputs = [
+    pkgconfig
+    gfortran 
+    # Listed here as well because it's outputs are split
+    fftw
+    fftwSinglePrec
+    texinfo
+  ]
+  ++ (stdenv.lib.optional (sundials != null) sundials)
+  ++ (stdenv.lib.optional enableJIT llvm)
+  ++ (stdenv.lib.optionals enableQt [
+    qtscript
+    qttools
+  ])
+  ;
 
   doCheck = !stdenv.isDarwin;
 

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -1,8 +1,50 @@
-{ stdenv, fetchurl, gfortran, readline, ncurses, perl, flex, texinfo, qhull
-, libsndfile, portaudio, libX11, graphicsmagick, pcre, pkgconfig, libGL, libGLU, fltk
-, fftw, fftwSinglePrec, zlib, curl, qrupdate, openblas, arpack, libwebp, gl2ps
-, qt ? null, qscintilla ? null, ghostscript ? null, llvm ? null, hdf5 ? null,glpk ? null
-, suitesparse ? null, gnuplot ? null, jdk ? null, python ? null, overridePlatforms ? null
+{ stdenv
+, fetchurl
+, gfortran
+, readline
+, ncurses
+, perl
+, flex
+, texinfo
+, qhull
+, libsndfile
+, portaudio
+, libX11
+, graphicsmagick
+, pcre
+, pkgconfig
+, libGL
+, libGLU
+, fltk
+# Both are needed for discrete Fourier transform
+, fftw
+, fftwSinglePrec
+, zlib
+, curl
+, qrupdate
+, openblas
+, arpack
+, libwebp
+, gl2ps
+, ghostscript ? null
+, hdf5 ? null
+, glpk ? null
+, suitesparse ? null
+, gnuplot ? null
+, jdk ? null
+, python ? null
+, overridePlatforms ? null
+, sundials ? null
+# Qt / GUI is disabled by default
+, enableQt ? false
+, qtbase ? null
+, qtsvg ? null
+, qtscript ? null
+, qscintilla ? null
+, qttools ? null
+# JIT is disabled by default
+, enableJIT ? false
+, llvm ? null
 }:
 
 let

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -34,7 +34,7 @@
 , jdk ? null
 , python ? null
 , overridePlatforms ? null
-, sundials ? null
+, sundials_2 ? null
 # Qt / GUI is disabled by default
 , enableQt ? false
 , qtbase ? null
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
   ++ (stdenv.lib.optional (glpk != null) glpk)
   ++ (stdenv.lib.optional (suitesparse != null) suitesparse)
   ++ (stdenv.lib.optional (jdk != null) jdk)
-  ++ (stdenv.lib.optional (sundials != null) sundials)
+  ++ (stdenv.lib.optional (sundials_2 != null) sundials_2)
   ++ (stdenv.lib.optional (gnuplot != null) gnuplot)
   ++ (stdenv.lib.optional (python != null) python)
   ++ (stdenv.lib.optionals (!stdenv.isDarwin) [ libGL libGLU libX11 ])
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
     fftwSinglePrec
     texinfo
   ]
-  ++ (stdenv.lib.optional (sundials != null) sundials)
+  ++ (stdenv.lib.optional (sundials_2 != null) sundials_2)
   ++ (stdenv.lib.optional enableJIT llvm)
   ++ (stdenv.lib.optionals enableQt [
     qtscript

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -92,15 +92,16 @@ stdenv.mkDerivation rec {
   # See https://savannah.gnu.org/bugs/?50339
   F77_INTEGER_8_FLAG = if openblas.blas64 then "-fdefault-integer-8" else "";
 
-  configureFlags =
-    [ "--enable-readline"
-      "--enable-dl"
-      "--with-blas=openblas"
-      "--with-lapack=openblas"
-    ]
-    ++ stdenv.lib.optional openblas.blas64 "--enable-64"
-    ++ stdenv.lib.optionals stdenv.isDarwin ["--with-x=no"]
-    ;
+  configureFlags = [
+    "--enable-readline"
+    "--with-blas=openblas"
+    "--with-lapack=openblas"
+  ]
+    ++ stdenv.lib.optionals openblas.blas64 [ "--enable-64" ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ "--with-x=no" ]
+    ++ stdenv.lib.optionals enableQt [ "--with-qt=5" ]
+    ++ stdenv.lib.optionals enableJIT [ "--enable-jit" ]
+  ;
 
   # Keep a copy of the octave tests detailed results in the output
   # derivation, because someone may care

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -62,6 +62,7 @@ in
 stdenv.mkDerivation rec {
   version = "5.2.0";
   pname = "octave";
+
   src = fetchurl {
     url = "mirror://gnu/octave/${pname}-${version}.tar.gz";
     sha256 = "1qcmcpsq1lfka19fxzvxjwjhg113c39a9a0x8plkhvwdqyrn5sig";
@@ -83,12 +84,6 @@ stdenv.mkDerivation rec {
     ++ (stdenv.lib.optionals (!stdenv.isDarwin) [ libGL libGLU libX11 ])
     ;
 
-  # makeinfo is required by Octave at runtime to display help
-  prePatch = ''
-    substituteInPlace libinterp/corefcn/help.cc \
-      --replace 'Vmakeinfo_program = "makeinfo"' \
-                'Vmakeinfo_program = "${texinfo}/bin/makeinfo"'
-  '';
 
   doCheck = !stdenv.isDarwin;
 

--- a/pkgs/development/libraries/sundials/2.x.nix
+++ b/pkgs/development/libraries/sundials/2.x.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, cmake
+, fetchurl
+, python
+# GNU Octave needs KLU for ODE solvers
+, suitesparse
+, liblapack
+, gfortran
+, lapackSupport ? true }:
+
+let liblapackShared = liblapack.override {
+  shared = true;
+};
+
+in stdenv.mkDerivation rec {
+  pname = "sundials";
+  version = "2.7.0";
+
+  buildInputs = [ python ] ++ stdenv.lib.optionals (lapackSupport) [
+    gfortran
+    suitesparse
+  ];
+  nativeBuildInputs = [ cmake ];
+
+  src = fetchurl {
+    url = "https://computation.llnl.gov/projects/${pname}/download/${pname}-${version}.tar.gz";
+    sha256 = "01513g0j7nr3rh7hqjld6mw0mcx5j9z9y87bwjc16w2x2z3wm7yk";
+  };
+
+  patches = [
+    (fetchurl {
+      # https://github.com/LLNL/sundials/pull/19
+      url = "https://github.com/LLNL/sundials/commit/1350421eab6c5ab479de5eccf6af2dcad1eddf30.patch";
+      sha256 = "0g67lixp9m85fqpb9rzz1hl1z8ibdg0ldwq5z6flj5zl8a7cw52l";
+    })
+  ];
+
+  cmakeFlags = [
+    "-DEXAMPLES_INSTALL_PATH=${placeholder "out"}/share/examples"
+  ] ++ stdenv.lib.optionals (lapackSupport) [
+    "-DSUNDIALS_INDEX_TYPE=int32_t"
+    # GNU Octave needs KLU for ODE solvers
+    "-DKLU_ENABLE=ON"
+    "-DKLU_INCLUDE_DIR=${suitesparse}/include"
+    "-DKLU_LIBRARY_DIR=${suitesparse}/lib"
+    "-DLAPACK_ENABLE=ON"
+    "-DLAPACK_LIBRARIES=${liblapackShared}/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary};${liblapackShared}/lib/libblas${stdenv.hostPlatform.extensions.sharedLibrary}"
+  ];
+
+  # flaky tests, and patch in https://github.com/LLNL/sundials/pull/21 doesn't apply cleanly for sundials_3
+  doCheck = false;
+  checkPhase = "make test";
+
+  meta = with stdenv.lib; {
+    description = "Suite of nonlinear differential/algebraic equation solvers";
+    homepage    = https://computation.llnl.gov/projects/sundials;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ flokli idontgetoutmuch ];
+    license     = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9220,58 +9220,15 @@ in
     git = gitMinimal;
   };
 
-  # Build summary for this flavor
-  # - Build Octave Qt GUI:                  no (missing:QtCore QtGui QtNetwork QtHelp QtXml)
-  # - JIT compiler for loops:               no
-  # - Build Java interface:                 yes
-  # - Build static libraries:               no
-  # - Build shared libraries:               yes
-  # - Dynamic Linking API:                  dlopen
-  # - Include support for GNU readline:     yes
-  # - 64-bit array dims and indexing:       yes
-  # - 64-bit BLAS array dims and indexing:  yes
-  # - OpenMP SMP multithreading:            yes
-  # - Truncate intermediate FP results:     yes
-  # - Build cross tools:                    no
-  # - Build docs:                           yes
   octave = callPackage ../development/interpreters/octave {
     python = python3;
     openblas = if stdenv.isDarwin then openblasCompat else openblas;
   };
-  # Build summary for this flavor
-  # - Build Octave Qt GUI:                  no (missing:QtCore QtGui QtNetwork QtHelp QtXml)
-  # - JIT compiler for loops:               yes
-  # - Build Java interface:                 yes
-  # - Build static libraries:               no
-  # - Build shared libraries:               yes
-  # - Dynamic Linking API:                  dlopen
-  # - Include support for GNU readline:     yes
-  # - 64-bit array dims and indexing:       yes
-  # - 64-bit BLAS array dims and indexing:  yes
-  # - OpenMP SMP multithreading:            yes
-  # - Truncate intermediate FP results:     yes
-  # - Build cross tools:                    no
-  # - Build docs:                           yes
   octave-jit = callPackage ../development/interpreters/octave {
     python = python3;
     openblas = if stdenv.isDarwin then openblasCompat else openblas;
     enableJIT = true;
   };
-  # Build summary for this flavor
-  # - Build Octave Qt GUI:                  yes
-  # - JIT compiler for loops:               no
-  # - Build Java interface:                 yes
-  # - Build static libraries:               no
-  # - Build shared libraries:               yes
-  # - Dynamic Linking API:                  dlopen
-  # - Include support for GNU readline:     yes
-  # - 64-bit array dims and indexing:       yes
-  # - 64-bit BLAS array dims and indexing:  yes
-  # - OpenMP SMP multithreading:            yes
-  # - Truncate intermediate FP results:     yes
-  # - Build cross tools:                    no
-  # - Build docs:                           yes
-  # Build summary for this flavor
   octaveFull = (lowPrio (libsForQt512.callPackage ../development/interpreters/octave {
     python = python3;
     openblas = if stdenv.isDarwin then openblasCompat else openblas;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14437,7 +14437,9 @@ in
     withQt5 = false;
   };
 
-  sundials = callPackage ../development/libraries/sundials { };
+  sundials = callPackage ../development/libraries/sundials {
+    python = python3;
+  };
 
   sundials_2 = callPackage ../development/libraries/sundials/2.x.nix {
     python = python3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9220,24 +9220,66 @@ in
     git = gitMinimal;
   };
 
+  # Build summary for this flavor
+  # - Build Octave Qt GUI:                  no (missing:QtCore QtGui QtNetwork QtHelp QtXml)
+  # - JIT compiler for loops:               no
+  # - Build Java interface:                 yes
+  # - Build static libraries:               no
+  # - Build shared libraries:               yes
+  # - Dynamic Linking API:                  dlopen
+  # - Include support for GNU readline:     yes
+  # - 64-bit array dims and indexing:       yes
+  # - 64-bit BLAS array dims and indexing:  yes
+  # - OpenMP SMP multithreading:            yes
+  # - Truncate intermediate FP results:     yes
+  # - Build cross tools:                    no
+  # - Build docs:                           yes
   octave = callPackage ../development/interpreters/octave {
-    qt = null;
-    qscintilla = null;
-    ghostscript = null;
-    graphicsmagick = null;
-    llvm = null;
-    hdf5 = null;
-    glpk = null;
-    suitesparse = null;
-    jdk = null;
+    python = python3;
+    sundials = sundials_2;
     openblas = if stdenv.isDarwin then openblasCompat else openblas;
   };
-
-  octaveFull = (lowPrio (octave.override {
-    qt = qt4;
-    inherit qscintilla;
-    overridePlatforms = ["x86_64-linux" "x86_64-darwin"];
+  # Build summary for this flavor
+  # - Build Octave Qt GUI:                  no (missing:QtCore QtGui QtNetwork QtHelp QtXml)
+  # - JIT compiler for loops:               yes
+  # - Build Java interface:                 yes
+  # - Build static libraries:               no
+  # - Build shared libraries:               yes
+  # - Dynamic Linking API:                  dlopen
+  # - Include support for GNU readline:     yes
+  # - 64-bit array dims and indexing:       yes
+  # - 64-bit BLAS array dims and indexing:  yes
+  # - OpenMP SMP multithreading:            yes
+  # - Truncate intermediate FP results:     yes
+  # - Build cross tools:                    no
+  # - Build docs:                           yes
+  octave-jit = callPackage ../development/interpreters/octave {
+    python = python3;
+    sundials = sundials_2;
     openblas = if stdenv.isDarwin then openblasCompat else openblas;
+    enableJIT = true;
+  };
+  # Build summary for this flavor
+  # - Build Octave Qt GUI:                  yes
+  # - JIT compiler for loops:               no
+  # - Build Java interface:                 yes
+  # - Build static libraries:               no
+  # - Build shared libraries:               yes
+  # - Dynamic Linking API:                  dlopen
+  # - Include support for GNU readline:     yes
+  # - 64-bit array dims and indexing:       yes
+  # - 64-bit BLAS array dims and indexing:  yes
+  # - OpenMP SMP multithreading:            yes
+  # - Truncate intermediate FP results:     yes
+  # - Build cross tools:                    no
+  # - Build docs:                           yes
+  # Build summary for this flavor
+  octaveFull = (lowPrio (libsForQt512.callPackage ../development/interpreters/octave {
+    python = python3;
+    sundials = sundials_2;
+    openblas = if stdenv.isDarwin then openblasCompat else openblas;
+    enableQt = true;
+    overridePlatforms = ["x86_64-linux" "x86_64-darwin"];
   }));
 
   ocropus = callPackage ../applications/misc/ocropus { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9236,7 +9236,6 @@ in
   # - Build docs:                           yes
   octave = callPackage ../development/interpreters/octave {
     python = python3;
-    sundials = sundials_2;
     openblas = if stdenv.isDarwin then openblasCompat else openblas;
   };
   # Build summary for this flavor
@@ -9255,7 +9254,6 @@ in
   # - Build docs:                           yes
   octave-jit = callPackage ../development/interpreters/octave {
     python = python3;
-    sundials = sundials_2;
     openblas = if stdenv.isDarwin then openblasCompat else openblas;
     enableJIT = true;
   };
@@ -9276,7 +9274,6 @@ in
   # Build summary for this flavor
   octaveFull = (lowPrio (libsForQt512.callPackage ../development/interpreters/octave {
     python = python3;
-    sundials = sundials_2;
     openblas = if stdenv.isDarwin then openblasCompat else openblas;
     enableQt = true;
     overridePlatforms = ["x86_64-linux" "x86_64-darwin"];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14400,6 +14400,10 @@ in
 
   sundials = callPackage ../development/libraries/sundials { };
 
+  sundials_2 = callPackage ../development/libraries/sundials/2.x.nix {
+    python = python3;
+  };
+
   sutils = callPackage ../tools/misc/sutils { };
 
   svrcore = callPackage ../development/libraries/svrcore { };


### PR DESCRIPTION
###### Motivation for this change

- QT4 is deprecated both here and upstream.
- Fix https://github.com/NixOS/nixpkgs/issues/57900
- Close https://github.com/NixOS/nixpkgs/pull/57950 Which was meant to fix #57900
- Fix octave's ability to solve ODEs.

###### Things done

Sundials was added a new version ~~2.7.5~~ 2.7.0 named `sundials_2` - this is the version GNU octave needs so it'll be able to solve ODEs, according to the configure report.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### ccs:

- @matthiasbeyer who originally wanted this to be done in #57950.
- @aanderse who's a devoted reviewer who was involved in #57950.
- @lsix who also wanted this done.
- @raskin - octave's maintainer.
- @flokli & @idontgetoutmuch - sundials maintainers.