### PR TITLE
tdesktop: 1.9.9 -> 1.9.12

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,7 +1,8 @@
 { mkDerivation, lib, fetchurl, fetchsvn
 , pkgconfig, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook
-, qtbase, qtimageformats, gtk3, libappindicator-gtk3, enchant2, lz4, xxHash
+, qtbase, qtimageformats, gtk3, libsForQt5, enchant2, lz4, xxHash
 , dee, ffmpeg_4, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
+, tl-expected, microsoft_gsl
 # TODO: Shouldn't be required:
 , pcre, xorg, utillinux, libselinux, libsepol, epoxy, at-spi2-core, libXtst
 , xdg_utils
@@ -18,17 +19,15 @@ with lib;
 
 mkDerivation rec {
   pname = "telegram-desktop";
-  version = "1.9.9";
+  version = "1.9.12";
 
   # Telegram-Desktop with submodules
   src = fetchurl {
     url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "08bxlqiapj9yqj9ywni33n5k7n3ckgfhv200snjqyqy9waqph1i6";
+    sha256 = "1xjf2fh6qry4q6frq2ixmn1k0rsc72h4j0zmahfsggyl3j5mgkx1";
   };
 
   postPatch = ''
-    substituteInPlace Telegram/SourceFiles/platform/linux/linux_libs.cpp \
-      --replace '"appindicator3"' '"${libappindicator-gtk3}/lib/libappindicator3.so"'
     substituteInPlace Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp \
       --replace '"libenchant-2.so.2"' '"${enchant2}/lib/libenchant-2.so.2"'
     substituteInPlace Telegram/CMakeLists.txt \
@@ -42,8 +41,9 @@ mkDerivation rec {
   nativeBuildInputs = [ pkgconfig cmake ninja python3 wrapGAppsHook wrapQtAppsHook ];
 
   buildInputs = [
-    qtbase qtimageformats gtk3 libappindicator-gtk3 enchant2 lz4 xxHash
+    qtbase qtimageformats gtk3 libsForQt5.libdbusmenu enchant2 lz4 xxHash
     dee ffmpeg_4 openalSoft minizip libopus alsaLib libpulseaudio range-v3
+    tl-expected microsoft_gsl
     # TODO: Shouldn't be required:
     pcre xorg.libpthreadstubs xorg.libXdmcp utillinux libselinux libsepol epoxy at-spi2-core libXtst
   ];
@@ -58,6 +58,7 @@ mkDerivation rec {
     "-DDESKTOP_APP_USE_GLIBC_WRAPS=OFF"
     "-DDESKTOP_APP_USE_PACKAGED=ON"
     "-DDESKTOP_APP_USE_PACKAGED_RLOTTIE=OFF"
+    "-DDESKTOP_APP_USE_PACKAGED_VARIANT=OFF"
     "-DDESKTOP_APP_DISABLE_CRASH_REPORTS=ON"
     "-DTDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME=ON"
     "-DTDESKTOP_DISABLE_DESKTOP_FILE_GENERATION=ON"
@@ -80,6 +81,7 @@ mkDerivation rec {
   #   - upstream: https://github.com/grishka/libtgvoip
   # Both of these packages are included in this PR (kotatogram-desktop):
   # https://github.com/NixOS/nixpkgs/pull/75210
+  # TODO: Package mapbox-variant
 
   postFixup = ''
     # This is necessary to run Telegram in a pure environment.

--- a/pkgs/development/libraries/tl-expected/default.nix
+++ b/pkgs/development/libraries/tl-expected/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "tl-expected-unstable";
+  version = "2019-11-11"; # 5 commits ahead of version 1.0.0
+
+  src = fetchFromGitHub {
+    owner = "TartanLlama";
+    repo = "expected";
+    rev = "1d9c5d8c0da84b8ddc54bd3d90d632eec95c1f13";
+    fetchSubmodules = true;
+    sha256 = "0rzfn9yyg70zwpxbmv22qy0015baymi2rdd65ixmcb31fgnap68i";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "C++11/14/17 std::expected with functional-style extensions";
+    homepage = https://tl.tartanllama.xyz/en/latest/api/expected.html;
+    license = licenses.cc0;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14458,6 +14458,8 @@ in
   tk-8_6 = callPackage ../development/libraries/tk/8.6.nix { };
   tk-8_5 = callPackage ../development/libraries/tk/8.5.nix { tcl = tcl-8_5; };
 
+  tl-expected = callPackage ../development/libraries/tl-expected { };
+
   tnt = callPackage ../development/libraries/tnt { };
 
   tntnet = callPackage ../development/libraries/tntnet { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Status

~~Didn't test the executable yet (can do that tomorrow), but at least the build works.~~ Ran fine so far.

###### Motivation for this change

~~cc @ilya-fedin FYI and it probably makes sense to collaborate on this update due to the two new dependencies (if we plan to package them in Nixpkgs).
I'm a bit low on time and didn't have time to package `mapbox-variant` ([GH](https://github.com/mapbox/variant)) if you want to try packaging it (but I suspect I'll be annoying to get it packaged as it uses a Makefile and some custom hacks that don't make sense for Nixpkgs/packaging) for `kotatogram-desktop` I can wait with this PR.~~
Update: Most likely there won't be a `kotatogram-desktop` release very soon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
