### PR TITLE
clojure 1.10.1.492 -> 1.10.1.507 plus bugfix

### DIFF
--- a/pkgs/development/interpreters/clojure/TDEPS-150.patch
+++ b/pkgs/development/interpreters/clojure/TDEPS-150.patch
@@ -1,0 +1,23 @@
+--- a/clojure
++++ b/clojure
+@@ -317,17 +317,17 @@ if "$stale" || "$pom"; then
+     tools_args+=("--threads" "$threads")
+   fi
+   if "$trace"; then
+     tools_args+=("--trace")
+   fi
+ fi
+
+ # If stale, run make-classpath to refresh cached classpath
+-if [[ "$stale" = true && "$describe" = false ]]; then
++if [[ "$stale" = true && "$describe" = false && -z "$force_cp" ]]; then
+   if "$verbose"; then
+     echo "Refreshing classpath"
+   fi
+
+   "$JAVA_CMD" -classpath "$tools_cp" clojure.main -m clojure.tools.deps.alpha.script.make-classpath2 --config-user "$config_user" --config-project "$config_project" --libs-file "$libs_file" --cp-file "$cp_file" --jvm-file "$jvm_file" --main-file "$main_file" "${tools_args[@]}"
+ fi
+
+ if "$describe"; then
+--
+2.25.0

--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1k0jwa3481g3mkalwlb9gkcz9aq9zjpwmzckv823fr2d8djp41cc";
   };
 
+  patches = [ ./TDEPS-150.patch ];
+
   buildInputs = [ makeWrapper ];
 
   installPhase =
@@ -22,11 +24,6 @@ stdenv.mkDerivation rec {
         cp deps.edn $out
 
         substituteInPlace clojure --replace PREFIX $out
-
-        # hotfixes https://clojure.atlassian.net/browse/TDEPS-150
-        substituteInPlace clojure --replace \
-          'if [[ "$stale" = true && "$describe" = false ]];' \
-          'if [[ "$stale" = true && "$describe" = false && -z "$force_cp" ]];'
 
         install -Dt $out/bin clj clojure
         wrapProgram $out/bin/clj --prefix PATH : $out/bin:${binPath}

--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -2,31 +2,44 @@
 
 stdenv.mkDerivation rec {
   pname = "clojure";
-  version = "1.10.1.492";
+  version = "1.10.1.507";
 
   src = fetchurl {
     url = "https://download.clojure.org/install/clojure-tools-${version}.tar.gz";
-    sha256 = "09mhy5xw9kdr10a1xpbn5v97qyyhngw5s1n1alrs45a4m3l11iky";
+    sha256 = "1k0jwa3481g3mkalwlb9gkcz9aq9zjpwmzckv823fr2d8djp41cc";
   };
 
   buildInputs = [ makeWrapper ];
 
-  installPhase = let
-    binPath = stdenv.lib.makeBinPath [ rlwrap jdk11 ];
-  in
-    ''
-      mkdir -p $out/libexec
-      cp clojure-tools-${version}.jar $out/libexec
-      cp example-deps.edn $out
-      cp deps.edn $out
+  installPhase =
+    let
+      binPath = stdenv.lib.makeBinPath [ rlwrap jdk11 ];
+    in
+      ''
+        mkdir -p $out/libexec
+        cp clojure-tools-${version}.jar $out/libexec
+        cp example-deps.edn $out
+        cp deps.edn $out
 
-      substituteInPlace clojure --replace PREFIX $out
+        substituteInPlace clojure --replace PREFIX $out
 
-      install -Dt $out/bin clj clojure
-      wrapProgram $out/bin/clj --prefix PATH : $out/bin:${binPath}
-      wrapProgram $out/bin/clojure --prefix PATH : $out/bin:${binPath}
-    '';
+        # hotfixes https://clojure.atlassian.net/browse/TDEPS-150
+        substituteInPlace clojure --replace \
+          'if [[ "$stale" = true && "$describe" = false ]];' \
+          'if [[ "$stale" = true && "$describe" = false && -z "$force_cp" ]];'
 
+        install -Dt $out/bin clj clojure
+        wrapProgram $out/bin/clj --prefix PATH : $out/bin:${binPath}
+        wrapProgram $out/bin/clojure --prefix PATH : $out/bin:${binPath}
+      '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    CLJ_CONFIG=$out CLJ_CACHE=$out/libexec $out/bin/clojure \
+      -Spath \
+      -Sverbose \
+      -Scp $out/libexec/clojure-tools-${version}.jar
+  '';
   meta = with stdenv.lib; {
     description = "A Lisp dialect for the JVM";
     homepage = https://clojure.org/;


### PR DESCRIPTION
###### Motivation for this change

I've been tagged few times in last couple of days due to clojurescript/lumo build failing. I tracked the bug down to bootstrapping problems in clojure, or cache invalidation. After discussion about the problem on clojurian slack, it was identified as a bug https://clojure.atlassian.net/browse/TDEPS-150 in our case, this causes clojure to start to recalculate the classpath cache, despite a classpath being directly provided for.

###### Things done

1. I bumped the version
2. I added a bugfix via substituteInPlace which I intend to remove after it's fixed upstream
3. I added installCheckPhase for sanity, this installCheckPhase will fail without this fix, since it tries to connect with maven repositories.

@Mic92 

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
