### PR TITLE
python3Packages.mailman-web: prevent error from crashing eval

### DIFF
--- a/pkgs/development/python-modules/django-compat/default.nix
+++ b/pkgs/development/python-modules/django-compat/default.nix
@@ -1,12 +1,12 @@
 { stdenv, buildPythonPackage, fetchFromGitHub, python,
   django, six
 }:
-if stdenv.lib.versionAtLeast django.version "2.0"
-then throw "django-compat requires django < 2.0"
-else
+
 buildPythonPackage rec {
   pname = "django-compat";
   version = "1.0.15";
+  # django-compat requires django < 2.0
+  disabled = stdenv.lib.versionAtLeast django.version "2.0";
 
   # the pypi packages don't include everything required for the tests
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/mezzanine/default.nix
+++ b/pkgs/development/python-modules/mezzanine/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , isPyPy
@@ -18,9 +19,6 @@
 , chardet
 }:
 
-if stdenv.lib.versionOlder django.version "1.11" || stdenv.lib.versionAtLeast django.version "2.0"
-then throw "mezzanine requires django-1.11. Consider overriding python package set to use django_1_11"
-else
 buildPythonPackage rec {
   version = "4.3.1";
   pname = "Mezzanine";
@@ -30,7 +28,8 @@ buildPythonPackage rec {
     sha256 = "42c7909953cc5aea91921b47d804b61e14893bf48a2a476ce49a96559a0fa1d3";
   };
 
-  disabled = isPyPy;
+  disabled = isPyPy || stdenv.lib.versionOlder django.version "1.11"
+    || stdenv.lib.versionAtLeast django.version "2.0";
 
   buildInputs = [ pyflakes pep8 ];
   propagatedBuildInputs = [ django django_contrib_comments filebrowser_safe grappelli_safe bleach tzlocal beautifulsoup4 requests requests_oauthlib future pillow chardet ];
@@ -44,7 +43,7 @@ buildPythonPackage rec {
 
   LC_ALL="en_US.UTF-8";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = ''
       A content management platform built using the Django framework
     '';
@@ -63,11 +62,13 @@ buildPythonPackage rec {
       Mezzanine provides most of its functionality by default. This
       approach yields a more integrated and efficient platform.
     '';
-    homepage = http://mezzanine.jupo.org/;
-    downloadPage = https://github.com/stephenmcd/mezzanine/releases;
+    homepage = "http://mezzanine.jupo.org/";
+    downloadPage = "https://github.com/stephenmcd/mezzanine/releases";
     license = licenses.free;
     maintainers = with maintainers; [ prikhi ];
     platforms = platforms.unix;
+    # mezzanine requires django-1.11. Consider overriding python package set to use django_1_11"
+    broken = versionOlder django.version "1.11" || versionAtLeast django.version "2.0";
   };
 
 }

--- a/pkgs/servers/mail/mailman/web.nix
+++ b/pkgs/servers/mail/mailman/web.nix
@@ -3,9 +3,6 @@
 , django
 }:
 
-if lib.versionOlder "2.2" django.version
-then throw "mailman-web requires django < 2.2"
-else
 buildPythonPackage rec {
   pname = "mailman-web-unstable";
   version = "2019-09-29";
@@ -39,5 +36,7 @@ buildPythonPackage rec {
     description = "Django project for Mailman 3 web interface";
     license = licenses.gpl3;
     maintainers = with maintainers; [ peti qyliss ];
+    # mailman-web requires django < 2.2
+    broken = versionOlder "2.2" django.version;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
throwing an error prevents nix-review from evaluating if the package is affected

```
$ nixpkgs-review pr 78754
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/78754/head:refs/nixpkgs-review/1
$ git worktree add /home/jon/.cache/nixpkgs-review/pr-78754-3/nixpkgs f77e057cda60a3f96a4010a698ff3be311bf18c6
Preparing worktree (detached HEAD f77e057cda6)
HEAD is now at f77e057cda6 pythonPackages.pysaml2: fix tests with fixed & now-expired timestamps
$ git merge --no-commit a7b890985513cad46c7a158553890d9b52f11d87
Automatic merge went well; stopped before committing as requested
error: mailman-web requires django < 2.2
(use '--show-trace' to show detailed location information)
nix eval --json (import /nix/store/9yy1gv7az9mqxak6jsqkyppb4g1zvzl0-nixpkgs-review-2.1.1/lib/python3.7/site-packages/nixpkgs_review/nix/evalAttrs.nix /tmp/tmpbcmvt646) failed to run, /tmp/tmpbcmvt646 was stored inspection
https://github.com/NixOS/nixpkgs/pull/78754 failed to build
```

regression introduced in https://github.com/NixOS/nixpkgs/commit/2711c7477db765cabb0cad506bfb1b6f3b1e0fc2
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
Nothing changed
https://github.com/NixOS/nixpkgs/pull/79869
$ nix-shell /home/jon/.cache/nixpkgs-review/pr-79869/shell.nix
```