### PR TITLE
tinycbor: init at 0.5.3

### DIFF
--- a/pkgs/development/libraries/tinycbor/default.nix
+++ b/pkgs/development/libraries/tinycbor/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "tinycbor";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "tinycbor";
+    rev = "v${version}";
+    sha256 = "11y6liyd3fvc28d3dinii16sxgwgg2p29p41snc4h82dvvx5bb2b";
+  };
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Concise Binary Object Representation (CBOR) Library";
+    homepage = "https://github.com/intel/tinycbor";
+    license = licenses.mit;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6795,6 +6795,8 @@ in
 
   tinc_pre = callPackage ../tools/networking/tinc/pre.nix {};
 
+  tinycbor = callPackage ../development/libraries/tinycbor { };
+
   tiny8086 = callPackage ../applications/virtualization/8086tiny { };
 
   tinyemu = callPackage ../applications/virtualization/tinyemu { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
