### PR TITLE
vscode: Added libdbusmenu support

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, makeDesktopItem
 , unzip, libsecret, libXScrnSaver, wrapGAppsHook
 , gtk2, atomEnv, at-spi2-atk, autoPatchelfHook
-, systemd, fontconfig
+, systemd, fontconfig, libdbusmenu-gtk3
 
 # Attributes inherit from specific versions
 , version, src, meta, sourceRoot
@@ -59,7 +59,7 @@ in
 
     buildInputs = (if stdenv.isDarwin
       then [ unzip ]
-      else [ gtk2 at-spi2-atk wrapGAppsHook ] ++ atomEnv.packages)
+      else [ gtk2 at-spi2-atk libdbusmenu-gtk3 wrapGAppsHook ] ++ atomEnv.packages)
         ++ [ libsecret libXScrnSaver ];
 
     nativeBuildInputs = lib.optional (!stdenv.isDarwin) autoPatchelfHook;
@@ -95,7 +95,7 @@ in
       '';
 
     preFixup = lib.optionalString (system == "i686-linux" || system == "x86_64-linux") ''
-      gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ systemd fontconfig ]})
+      gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ systemd fontconfig libdbusmenu-gtk3 ]})
     '';
 
     inherit meta;

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -59,7 +59,7 @@ in
 
     buildInputs = (if stdenv.isDarwin
       then [ unzip ]
-      else [ gtk2 at-spi2-atk libdbusmenu-gtk3 wrapGAppsHook ] ++ atomEnv.packages)
+      else [ gtk2 at-spi2-atk wrapGAppsHook ] ++ atomEnv.packages)
         ++ [ libsecret libXScrnSaver ];
 
     nativeBuildInputs = lib.optional (!stdenv.isDarwin) autoPatchelfHook;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I wanted to enable global menus (appmenus, unity menus, dbusmenus, …) for VSCode and VSCodium. It's worth mentioning the issue: #65680

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

As can be seen on the following screenshot, I've built the VSCode package and it now works with DBusMenus as it should. The only thing I did was to add libdbusmenu-gtk3 to dependencies in several places in the file. I've also tried to honor the Darwin target by adding libdbusmenu-gtk3 only where it didn't apply to Darwin, but, since I don't have a Mac to test this change, nor am I overly versed in Nix{,OS,Pkgs,…} ecosystem, I implore you to check that before accepting this push request. I'm guessing libdbusmenu doesn't work in Mac to provide global menus, but perhaps I'm wrong about that.

![Screenshot_20200212_042855](https://user-images.githubusercontent.com/37038/74300663-bce3f580-4d50-11ea-8f52-bc32d8ef9a20.png)
