### PR TITLE
(20.03) trezord-go: 2.0.27 -> 2.0.28

### DIFF
--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "trezord-go";
-  version = "2.0.27";
+  version = "2.0.28";
 
   goPackagePath = "github.com/trezor/trezord-go";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner  = "trezor";
     repo   = "trezord-go";
     rev    = "v${version}";
-    sha256 = "00d90qmmk1pays78a2jm8gb7dncvlsjjn4033q1yd1ii3fxc6nh8";
+    sha256 = "02c1mvn01gcfls37sa0c7v2lwffg14x54np8z7d4hjzxxzwg4gpw";
   };
 
   propagatedBuildInputs = [ trezor-udev-rules ];


### PR DESCRIPTION
###### Motivation for this change

2.0.28 contains an important fix yet is a small release, I would like to propose it for a backport.

(cherry picked from commit ab1a14d581b5afd6126c6e474dedb94308ab382c, PR #79857)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
