### PR TITLE
r128gain: 0.9.3 -> 1.0.1

### DIFF
--- a/pkgs/applications/audio/r128gain/default.nix
+++ b/pkgs/applications/audio/r128gain/default.nix
@@ -1,19 +1,37 @@
-{ lib, python3Packages, ffmpeg }:
+{ lib
+, fetchFromGitHub
+, substituteAll
+, ffmpeg
+, python3Packages
+, sox
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "r128gain";
-  version = "0.9.3";
+  version = "1.0.1";
 
-  src = python3Packages.fetchPypi {
-    inherit pname version;
-    sha256 = "0dx2grryp0lj58bawx1zcq9a6b4ijz9r5qrg8h6nvm92kqlya26i";
+  src = fetchFromGitHub {
+    owner = "desbma";
+    repo = "r128gain";
+    rev = version;
+    sha256 = "0fnxis2g7mw8mb0cz9bws909lrndli7ml54nnzda49vc2fhbjwxr";
   };
 
-  propagatedBuildInputs = [ ffmpeg ]
-    ++ (with python3Packages; [ crcmod mutagen tqdm ])
-    ;
+  patches = [
+    (
+      substituteAll {
+        src = ./ffmpeg-location.patch;
+        inherit ffmpeg;
+      }
+    )
+  ];
 
-  doCheck = false; # downloads media files for testing
+  propagatedBuildInputs = with python3Packages; [ crcmod ffmpeg-python mutagen tqdm ];
+  checkInputs = with python3Packages; [ requests sox ];
+
+  # Testing downloads media files for testing, which requires the
+  # sandbox to be disabled.
+  doCheck = false;
 
   meta = with lib; {
     description = "Fast audio loudness scanner & tagger (ReplayGain v2 / R128)";

--- a/pkgs/applications/audio/r128gain/ffmpeg-location.patch
+++ b/pkgs/applications/audio/r128gain/ffmpeg-location.patch
@@ -1,0 +1,31 @@
+diff --git i/r128gain/__init__.py w/r128gain/__init__.py
+index 53fc3ef..f144e15 100755
+--- i/r128gain/__init__.py
++++ w/r128gain/__init__.py
+@@ -78,7 +78,7 @@ def get_ffmpeg_lib_versions(ffmpeg_path=None):
+   Example: 0x3040100 for FFmpeg 3.4.1
+   """
+   r = collections.OrderedDict()
+-  cmd = (ffmpeg_path or "ffmpeg", "-version")
++  cmd = (ffmpeg_path or "@ffmpeg@/bin/ffmpeg", "-version")
+   output = subprocess.run(cmd,
+                           check=True,
+                           stdout=subprocess.PIPE,
+@@ -156,7 +156,7 @@ def get_r128_loudness(audio_filepaths, *, calc_peak=True, enable_ffmpeg_threadin
+                                      os.devnull,
+                                      **additional_ffmpeg_args,
+                                      f="null"),
+-                       cmd=ffmpeg_path or "ffmpeg")
++                       cmd=ffmpeg_path or "@ffmpeg@/bin/ffmpeg")
+ 
+   # run
+   logger().debug(cmd_to_string(cmd))
+@@ -740,7 +740,7 @@ def cl_main():
+                           help="Maximum number of tracks to scan in parallel. If not specified, autodetect CPU count")
+   arg_parser.add_argument("-f",
+                           "--ffmpeg-path",
+-                          default=shutil.which("ffmpeg"),
++                          default="@ffmpeg@/bin/ffmpeg",
+                           help="""Full file path of ffmpeg executable (only needed if not in PATH).
+                                   If not specified, autodetect""")
+   arg_parser.add_argument("-d",

--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, substituteAll
+, ffmpeg
+, future
+, pytest
+, pytestrunner
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "ffmpeg-python";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "kkroening";
+    repo = "ffmpeg-python";
+    rev = version;
+    sha256 = "0mmydmfz3yiclbgi4lqrv9fh2nalafg4bkm92y2qi50mwqgffk8f";
+  };
+
+  patches = [
+    (
+      substituteAll {
+        src = ./ffmpeg-location.patch;
+        inherit ffmpeg;
+      }
+    )
+  ];
+
+  buildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [ future ];
+  checkInputs = [ pytest pytest-mock ];
+
+  meta = with lib; {
+    description = "Python bindings for FFmpeg - with complex filtering support";
+    homepage = "https://github.com/kkroening/ffmpeg-python";
+    license = licenses.asl20;
+    maintainers = [ maintainers.AluisioASG ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/ffmpeg-python/ffmpeg-location.patch
+++ b/pkgs/development/python-modules/ffmpeg-python/ffmpeg-location.patch
@@ -1,0 +1,84 @@
+diff --git i/ffmpeg/_probe.py w/ffmpeg/_probe.py
+index 41e8168..eb83b54 100644
+--- i/ffmpeg/_probe.py
++++ w/ffmpeg/_probe.py
+@@ -4,7 +4,7 @@ from ._run import Error
+ from ._utils import convert_kwargs_to_cmd_line_args
+ 
+ 
+-def probe(filename, cmd='ffprobe', **kwargs):
++def probe(filename, cmd='@ffmpeg@/bin/ffprobe', **kwargs):
+     """Run ffprobe on the specified file and return a JSON representation of the output.
+ 
+     Raises:
+diff --git i/ffmpeg/_run.py w/ffmpeg/_run.py
+index afc504d..9445cca 100644
+--- i/ffmpeg/_run.py
++++ w/ffmpeg/_run.py
+@@ -172,7 +172,7 @@ def get_args(stream_spec, overwrite_output=False):
+ 
+ 
+ @output_operator()
+-def compile(stream_spec, cmd='ffmpeg', overwrite_output=False):
++def compile(stream_spec, cmd='@ffmpeg@/bin/ffmpeg', overwrite_output=False):
+     """Build command-line for invoking ffmpeg.
+ 
+     The :meth:`run` function uses this to build the commnad line
+@@ -193,7 +193,7 @@ def compile(stream_spec, cmd='ffmpeg', overwrite_output=False):
+ @output_operator()
+ def run_async(
+     stream_spec,
+-    cmd='ffmpeg',
++    cmd='@ffmpeg@/bin/ffmpeg',
+     pipe_stdin=False,
+     pipe_stdout=False,
+     pipe_stderr=False,
+@@ -289,7 +289,7 @@ def run_async(
+ @output_operator()
+ def run(
+     stream_spec,
+-    cmd='ffmpeg',
++    cmd='@ffmpeg@/bin/ffmpeg',
+     capture_stdout=False,
+     capture_stderr=False,
+     input=None,
+diff --git i/ffmpeg/tests/test_ffmpeg.py w/ffmpeg/tests/test_ffmpeg.py
+index 279a323..8d3b35c 100644
+--- i/ffmpeg/tests/test_ffmpeg.py
++++ w/ffmpeg/tests/test_ffmpeg.py
+@@ -24,7 +24,7 @@ TEST_OUTPUT_FILE2 = os.path.join(SAMPLE_DATA_DIR, 'out2.mp4')
+ BOGUS_INPUT_FILE = os.path.join(SAMPLE_DATA_DIR, 'bogus')
+ 
+ 
+-subprocess.check_call(['ffmpeg', '-version'])
++subprocess.check_call(['@ffmpeg@/bin/ffmpeg', '-version'])
+ 
+ 
+ def test_escape_chars():
+@@ -423,7 +423,7 @@ def test_filter_text_arg_str_escape():
+ 
+ def test__compile():
+     out_file = ffmpeg.input('dummy.mp4').output('dummy2.mp4')
+-    assert out_file.compile() == ['ffmpeg', '-i', 'dummy.mp4', 'dummy2.mp4']
++    assert out_file.compile() == ['@ffmpeg@/bin/ffmpeg', '-i', 'dummy.mp4', 'dummy2.mp4']
+     assert out_file.compile(cmd='ffmpeg.old') == [
+         'ffmpeg.old',
+         '-i',
+@@ -490,7 +490,7 @@ def test__run__input_output(mocker):
+ @pytest.mark.parametrize('capture_stdout', [True, False])
+ @pytest.mark.parametrize('capture_stderr', [True, False])
+ def test__run__error(mocker, capture_stdout, capture_stderr):
+-    mocker.patch.object(ffmpeg._run, 'compile', return_value=['ffmpeg'])
++    mocker.patch.object(ffmpeg._run, 'compile', return_value=['@ffmpeg@/bin/ffmpeg'])
+     stream = _get_complex_filter_example()
+     with pytest.raises(ffmpeg.Error) as excinfo:
+         out, err = ffmpeg.run(
+@@ -684,7 +684,7 @@ def test_pipe():
+         'pipe:1',
+     ]
+ 
+-    cmd = ['ffmpeg'] + args
++    cmd = ['@ffmpeg@/bin/ffmpeg'] + args
+     p = subprocess.Popen(
+         cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+     )

--- a/pkgs/development/python-modules/mutagen/default.nix
+++ b/pkgs/development/python-modules/mutagen/default.nix
@@ -6,24 +6,20 @@
 , pycodestyle
 , pyflakes
 , pytest
+, setuptools
 , pkgs
 }:
 
 buildPythonPackage rec {
   pname = "mutagen";
-  version = "1.42.0";
+  version = "1.43.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bb61e2456f59a9a4a259fbc08def6d01ba45a42da8eeaa97d00633b0ec5de71c";
+    sha256 = "3a982d39f1b800520a32afdebe3543f972e83a6ddd0c0198739a161ee705b588";
   };
 
-  # fix tests with updated pycodestyle
-  patches = fetchpatch {
-    url = https://github.com/quodlibet/mutagen/commit/0ee86ef9d7e06639a388d0638732810b79998608.patch;
-    sha256 = "1bj3mpbv7krh5m1mvfl0z18s8wdxb1949zcnkcqxp2xl5fzsi288";
-  };
-
+  propagatedBuildInputs = [ setuptools ];
   checkInputs = [
     pkgs.faad2 pkgs.flac pkgs.vorbis-tools pkgs.liboggz
     pkgs.glibcLocales pycodestyle pyflakes pytest hypothesis
@@ -32,7 +28,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python multimedia tagging library";
-    homepage = https://mutagen.readthedocs.io/;
+    homepage = "https://mutagen.readthedocs.io";
     license = licenses.lgpl2Plus;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -177,6 +177,7 @@ in pythonPackages.buildPythonApplication rec {
   patches = [
     ./replaygain-default-bs1770gain.patch
     ./keyfinder-default-bin.patch
+    ./mutagen-1.43.patch
   ];
 
   postPatch = ''

--- a/pkgs/tools/audio/beets/mutagen-1.43.patch
+++ b/pkgs/tools/audio/beets/mutagen-1.43.patch
@@ -1,0 +1,29 @@
+Backport https://github.com/beetbox/mediafile/commit/b3343c4ee08d1251ae5e2344401a2f5892b4e868
+to Beets 1.4.9.
+
+diff --git i/setup.py w/setup.py
+index 79278f8..b8d6068 100755
+--- i/setup.py
++++ w/setup.py
+@@ -87,7 +87,7 @@ setup(
+ 
+     install_requires=[
+         'six>=1.9',
+-        'mutagen>=1.33',
++        'mutagen>=1.43',
+         'unidecode',
+         'musicbrainzngs>=0.4',
+         'pyyaml',
+diff --git i/test/test_mediafile.py w/test/test_mediafile.py
+index 36a2c53..54ef9dd 100644
+--- i/test/test_mediafile.py
++++ w/test/test_mediafile.py
+@@ -912,7 +912,7 @@ class AIFFTest(ReadWriteTestBase, unittest.TestCase):
+         'bitrate': 705600,
+         'format': u'AIFF',
+         'samplerate': 44100,
+-        'bitdepth': 0,
++        'bitdepth': 16,
+         'channels': 1,
+     }
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2634,6 +2634,8 @@ in {
 
   fb-re2 = callPackage ../development/python-modules/fb-re2 { };
 
+  ffmpeg-python = callPackage ../development/python-modules/ffmpeg-python { };
+
   filetype = callPackage ../development/python-modules/filetype { };
 
   flammkuchen = callPackage ../development/python-modules/flammkuchen { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @FRidh for mutagen update