### PR TITLE
ezquake: 3.0.1 -> 3.1

### DIFF
--- a/pkgs/games/ezquake/default.nix
+++ b/pkgs/games/ezquake/default.nix
@@ -1,21 +1,21 @@
 { stdenv, fetchFromGitHub, curl, expat
 , jansson, libpng, libjpeg, libGLU, libGL, libXxf86vm, pcre
-, pkgconfig, SDL2, vim }:
+, pkgconfig, SDL2, vim, speex }:
 
 stdenv.mkDerivation rec {
   pname = "ezquake";
-  version = "3.0.1";
+  version = "3.1";
 
   src = fetchFromGitHub {
     owner = "ezQuake";
     repo = pname + "-source";
-    rev = "v" + version;
-    sha256 = "14wck0r64z5haacp7g7qb2qrbhff3x6jfjmn4268dyb9dl5663f2";
+    rev = version;
+    sha256 = "0375jndynhkl59m80fhmq12v5g24zy16c7ly08h004cmjzqsikn4";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    expat curl jansson libpng libjpeg libGLU libGL libXxf86vm pcre SDL2 vim
+    expat curl jansson libpng libjpeg libGLU libGL libXxf86vm pcre SDL2 vim speex
   ];
 
   installPhase = with stdenv.lib; let
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://ezquake.github.io/;
-    description = "A modern QuakeWorld client focused on competitive online play.";
+    homepage = "http://ezquake.github.io/";
+    description = "A modern QuakeWorld client focused on competitive online play";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ edwtjo ];


### PR DESCRIPTION
###### Motivation for this change

ezquake: 3.0.1 -> 3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
