### PR TITLE
eggdrop: 1.6.21-nix1 -> 1.8.4

### DIFF
--- a/pkgs/tools/networking/eggdrop/default.nix
+++ b/pkgs/tools/networking/eggdrop/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, tcl }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "eggdrop";
-  version = "1.6.21-nix1";
+  version = "1.8.4";
 
   src = fetchFromGitHub {
     owner = "eggheads";
     repo = "eggdrop";
-    rev = "9ec109a13c016c4cdc7d52b7e16e4b9b6fbb9331";
-    sha256 = "0mf1vcbmpnvmf5mxk7gi3z32fxpcbynsh9jni8z8frrscrdf5lp5";
+    rev = "v${version}";
+    sha256 = "0xqdrv4ydxw72a740lkmpg3fs7ldicaf08b0sfqdyaj7cq8l5x5l";
   };
 
   buildInputs = [ tcl ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     license = licenses.gpl2;
     platforms = platforms.unix;
-    homepage = http://www.eggheads.org;
+    homepage = "http://www.eggheads.org";
     description = "An Internet Relay Chat (IRC) bot";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

eggdrop: 1.6.21-nix1 -> 1.8.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
