### PR TITLE
fish: 3.0.2 -> 3.1.0

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -90,7 +90,7 @@ let
 
   fish = stdenv.mkDerivation rec {
     pname = "fish";
-    version = "3.0.2";
+    version = "3.1.0";
 
     etcConfigAppendix = builtins.toFile "etc-config.appendix.fish" etcConfigAppendixText;
 
@@ -98,7 +98,7 @@ let
       # There are differences between the release tarball and the tarball github packages from the tag
       # Hence we cannot use fetchFromGithub
       url = "https://github.com/fish-shell/fish-shell/releases/download/${version}/${pname}-${version}.tar.gz";
-      sha256 = "03j3jl9jzlnhq4p86zj8wqsh5sx45j1d1fvfa80ks1cfdg68qwhl";
+      sha256 = "0s2356mlx7fp9kgqgw91lm5ds2i9iq9hq071fbqmcp3875l1xnz5";
     };
 
     nativeBuildInputs = [ cmake ];
@@ -109,11 +109,10 @@ let
     '';
 
     patches = [
-      # Fixes "Integer 243 in '243 (243)' followed by non-digit" error with systemctl completion.
-      # https://github.com/fish-shell/fish-shell/issues/5689 (will be included in fish 3.1.0)
+      # Fixes compilation on old Apple SDKs
       (fetchpatch {
-        url = "https://github.com/fish-shell/fish-shell/commit/c6ec4235136e82c709e8d7b455f7c463f9714b48.patch";
-        sha256 = "02m6pkhhx6y21csydznsxkbpnwhcpzyz99xgd9ryh7s03v7wbigw";
+        url = "https://github.com/fish-shell/fish-shell/commit/10385d422b3e2a823faebfdaf13edd0e7f48a27f.patch";
+        sha256 = "0hj13kyjf5wr9j5afd4mfylcr7mz68ilbncbcf307drk1lv1lvrn";
       })
     ];
 
@@ -128,7 +127,7 @@ let
       sed -r "s|command grep|command ${gnugrep}/bin/grep|" \
           -i "$out/share/fish/functions/grep.fish"
       sed -i "s|which |${which}/bin/which |"               \
-              "$out/share/fish/functions/type.fish"
+             "$out/share/fish/functions/type.fish"
       sed -e "s|\|cut|\|${coreutils}/bin/cut|"             \
           -i "$out/share/fish/functions/fish_prompt.fish"
       sed -e "s|gettext |${gettext}/bin/gettext |"         \
@@ -136,18 +135,18 @@ let
           -i "$out/share/fish/functions/_.fish"
       sed -e "s|uname|${coreutils}/bin/uname|"             \
           -i "$out/share/fish/functions/__fish_pwd.fish"   \
-            "$out/share/fish/functions/prompt_pwd.fish"
+             "$out/share/fish/functions/prompt_pwd.fish"
       sed -e "s|sed |${gnused}/bin/sed |"                  \
           -i "$out/share/fish/functions/alias.fish"        \
-            "$out/share/fish/functions/prompt_pwd.fish"
+             "$out/share/fish/functions/prompt_pwd.fish"
       sed -i "s|nroff |${groff}/bin/nroff |"               \
-            "$out/share/fish/functions/__fish_print_help.fish"
-      sed -i "s|/sbin /usr/sbin||" \
-            "$out/share/fish/functions/__fish_complete_subcommand_root.fish"
-      sed -e "s|clear;|${getBin ncurses}/bin/clear;|" \
+             "$out/share/fish/functions/__fish_print_help.fish"
+      sed -e "s|clear;|${getBin ncurses}/bin/clear;|"      \
           -i "$out/share/fish/functions/fish_default_key_bindings.fish"
-      sed -e "s|python3|${getBin python3}/bin/python3|" \
+      sed -e "s|python3|${getBin python3}/bin/python3|"    \
           -i $out/share/fish/functions/{__fish_config_interactive.fish,fish_config.fish,fish_update_completions.fish}
+      sed -i "s|/usr/local/sbin /sbin /usr/sbin||"         \
+             $out/share/fish/completions/{sudo.fish,doas.fish}
 
     '' + optionalString stdenv.isLinux ''
       sed -e "s| ul| ${utillinux}/bin/ul|" \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

fish-shell 3.1.0 was just released today with many niceties (including
the ability to have bash-like temporary env vars e.g. `VAR="var1"
command` instead of needing to use `env VAR="var1" command`). To see the
full list of changes, please visit
https://github.com/fish-shell/fish-shell/releases/tag/3.1.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc: @ocharles

---

Closes https://github.com/NixOS/nixpkgs/issues/79934.