### PR TITLE
polar-bookshelf: 1.13.10 -> 1.90.18

### DIFF
--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   pname = "polar-bookshelf";
-  version = "1.13.10";
+  version = "1.90.18";
 
   # fetching a .deb because there's no easy way to package this Electron app
   src = fetchurl {
     url = "https://github.com/burtonator/polar-bookshelf/releases/download/v${version}/polar-bookshelf-${version}-amd64.deb";
-    sha256 = "1bxcyf6n2m5x1z8ic6kzskinyyc6lh6nj0bycbwc524n6ms5j99p";
+    sha256 = "1yl679szhb38a4dkb0aviyyp5qi7sc5vxhpjrrzzkrbzqrgnx1x2";
   };
 
   buildInputs = [
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     wrapGAppsHook
     autoPatchelfHook
-    makeWrapper
     dpkg
   ];
 
@@ -69,7 +68,7 @@ stdenv.mkDerivation rec {
 
     mv usr/share/* $out/share/
 
-    ln -s $out/share/polar-bookshelf/polar-bookshelf $out/bin/polar-bookshelf
+    ln -s $out/share/polar-bookshelf/polar-bookshelf.bin $out/bin/polar-bookshelf
 
     # Correct desktop file `Exec`
     substituteInPlace $out/share/applications/polar-bookshelf.desktop \


### PR DESCRIPTION
###### Motivation for this change

Version in nixpkgs was outdated and I wanted a newer version.  
Had to change the executable target of the symlink otherwise it would complain about not finding `polar-bokshelf.bin`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
