### PR TITLE
python3Packages.elementpath: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/development/python-modules/elementpath/default.nix
+++ b/pkgs/development/python-modules/elementpath/default.nix
@@ -1,7 +1,7 @@
 { lib, buildPythonPackage, fetchFromGitHub, isPy27 }:
 
 buildPythonPackage rec {
-  version = "1.4.0";
+  version = "1.4.1";
   pname = "elementpath";
   disabled = isPy27; # uses incompatible class syntax
 
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     owner = "sissaschool";
     repo = "elementpath";
     rev = "v${version}";
-    sha256 = "1fmwy7plcgxam09cx3z11068k0c98wcsgclmxdq8chsd6id3632y";
+    sha256 = "1xgz4aml3g3q2011wxarg25xl3g9zny313p52w9abyy16f40vjy0";
   };
 
   # avoid circular dependency with xmlschema which directly depends on this


### PR DESCRIPTION
###### Motivation for this change
routine bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[12 built, 62 copied (341.8 MiB), 35.6 MiB DL]
https://github.com/NixOS/nixpkgs/pull/79958
8 package built:
python37Packages.elementpath python37Packages.fints python37Packages.sepaxml python37Packages.xmlschema python38Packages.elementpath python38Packages.fints python38Packages.sepaxml python38Packages.xmlschema
```