### PR TITLE
lwan: use jemalloc (not just ignored buildInput), but not w/musl

### DIFF
--- a/pkgs/servers/http/lwan/default.nix
+++ b/pkgs/servers/http/lwan/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
   # Note: tcmalloc and mimalloc are also supported (and normal malloc)
   cmakeFlags = lib.optional enableJemalloc "-DUSE_ALTERNATIVE_MALLOC=jemalloc";
 
+  hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "pie";
+
   meta = with lib; {
     description = "Lightweight high-performance multi-threaded web server";
     longDescription = "A lightweight and speedy web server with a low memory

--- a/pkgs/servers/http/lwan/default.nix
+++ b/pkgs/servers/http/lwan/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ jemalloc zlib ];
 
+  # Note: tcmalloc and mimalloc are also supported (and normal malloc)
+  cmakeFlags = [ "-DUSE_ALTERNATIVE_MALLOC=jemalloc" ];
+
   meta = with lib; {
     description = "Lightweight high-performance multi-threaded web server";
     longDescription = "A lightweight and speedy web server with a low memory

--- a/pkgs/servers/http/lwan/default.nix
+++ b/pkgs/servers/http/lwan/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, zlib, cmake, jemalloc }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, zlib, cmake, enableJemalloc ? !stdenv.hostPlatform.isMusl, jemalloc }:
 
 stdenv.mkDerivation rec {
   pname = "lwan";
@@ -13,10 +13,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ jemalloc zlib ];
+  buildInputs = [ zlib ] ++ lib.optional enableJemalloc jemalloc;
 
   # Note: tcmalloc and mimalloc are also supported (and normal malloc)
-  cmakeFlags = [ "-DUSE_ALTERNATIVE_MALLOC=jemalloc" ];
+  cmakeFlags = lib.optional enableJemalloc "-DUSE_ALTERNATIVE_MALLOC=jemalloc";
 
   meta = with lib; {
     description = "Lightweight high-performance multi-threaded web server";


### PR DESCRIPTION
###### Motivation for this change

jemalloc and musl don't get along.

Replaces #77844 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).