### PR TITLE
python3Packages.imgaug: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/imgaug/default.nix
+++ b/pkgs/development/python-modules/imgaug/default.nix
@@ -1,5 +1,5 @@
 { buildPythonPackage
-, fetchurl
+, fetchFromGitHub
 , imageio
 , numpy
 , opencv3
@@ -13,18 +13,20 @@
 
 buildPythonPackage rec {
   pname = "imgaug";
-  version = "0.3.0";
+  version = "0.4.0";
 
-  src = fetchurl {
-    url = "https://github.com/aleju/imgaug/archive/c3d99a420efc45652a1264920dc20378a54b1325.zip";
-    sha256 = "sha256:174nvhyhdn3vz0i34rqmkn26840j3mnfr55cvv5bdf9l4y9bbjq2";
+  src = fetchFromGitHub {
+    owner = "aleju";
+    repo = "imgaug";
+    rev = version;
+    sha256 = "17hbxndxphk3bfnq35y805adrfa6gnm5x7grjxbwdw4kqmbbqzah";
   };
 
   postPatch = ''
     substituteInPlace requirements.txt \
       --replace "opencv-python-headless" ""
     substituteInPlace setup.py \
-      --replace "opencv-python-headless" "" 
+      --replace "opencv-python-headless" ""
     substituteInPlace pytest.ini \
       --replace "--xdoctest --xdoctest-global-exec=\"import imgaug as ia\nfrom imgaug import augmenters as iaa\"" ""
   '';
@@ -39,8 +41,9 @@ buildPythonPackage rec {
     six
   ];
 
+  # augmenters requires a significant increase in packages requires
   checkPhase = ''
-     pytest ./test
+     pytest ./test --ignore=test/augmenters
   '';
 
   checkInputs = [ opencv3 pytest ];


### PR DESCRIPTION
###### Motivation for this change
noticed the current package is broken from the pandas update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[8 built, 1 copied (0.9 MiB), 0.2 MiB DL]
https://github.com/NixOS/nixpkgs/pull/79982
2 package built:
python37Packages.imgaug python38Packages.imgaug
```