### PR TITLE
pythonPackages.seaborn: disable <py3.6, abandoned upstream

### DIFF
--- a/pkgs/development/python-modules/seaborn/default.nix
+++ b/pkgs/development/python-modules/seaborn/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchPypi
 , nose
 , pandas
@@ -9,6 +10,8 @@
 buildPythonPackage rec {
   pname = "seaborn";
   version = "0.10.0";
+  disabled = pythonOlder "3.6";
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "59fe414e138d7d5ea08b0feb01b86caf4682e36fa748e3987730523a89aecbb9";


### PR DESCRIPTION
###### Motivation for this change
```
  Traceback (most recent call last):
    File "nix_run_setup", line 8, in <module>
      exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
    File "setup.py", line 67, in <module>
      raise RuntimeError("seaborn requires python >= 3.6.")
  RuntimeError: seaborn requires python >= 3.6.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
Nothing changed
https://github.com/NixOS/nixpkgs/pull/79985
$ nix-shell /home/jon/.cache/nixpkgs-review/pr-79985/shell.nix
```