### PR TITLE
python3Packages.snowflake-connector-python: 2.1.2 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/snowflake-connector-python/default.nix
+++ b/pkgs/development/python-modules/snowflake-connector-python/default.nix
@@ -1,4 +1,5 @@
 { buildPythonPackage
+, isPy27
 , asn1crypto
 , azure-storage-blob
 , boto3
@@ -24,11 +25,12 @@
 
 buildPythonPackage rec {
   pname = "snowflake-connector-python";
-  version = "2.1.2";
+  version = "2.2.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "06061d59lapqrlg3gzdk4bi3v9c3q5zxfs0if5v2chg1f2l80ncr";
+    sha256 = "1d3qxjqc79fi2l4sns5svbc6kfaihivsrpycflmh50h7x0k9sv7f";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
was broken
```
  Requirement already satisfied: idna<3.0.0 in /nix/store/gz66km41kna7ra24z3i0890whins2vqj-python2.7-idna-2.8/lib/python2.7/site-packages (from snowflake-connector-python==2.1.2) (2.8)
  Requirement already satisfied: cryptography<3.0.0,>=1.8.2 in /nix/store/lvj2s04cigjj5g4997qjdwqhjckclhd5-python2.7-cryptography-2.8/lib/python2.7/site-packages (from snowflake-connector-python==2.1.2) (2.8)
  Requirement already satisfied: enum34; python_version < "3.4" in /nix/store/1c99n4gh7hlm0k4yc3ycr186vhrkfy9h-python2.7-enum34-1.1.6/lib/python2.7/site-packages (from snowflake-connector-python==2.1.2) (1.1.6)
  Requirement already satisfied: pyOpenSSL<21.0.0,>=16.2.0 in /nix/store/rw79wlf69n3qjxwfpd3iyvgas09rzgca-python2.7-pyOpenSSL-19.1.0/lib/python2.7/site-packages (from snowflake-connector-python==2.1.2) (19.1.0)
  Requirement already satisfied: requests<2.23.0 in /nix/store/b6x46svpq60pdlaxxvijslxriw1av4jy-python2.7-requests-2.22.0/lib/python2.7/site-packages (from snowflake-connector-python==2.1.2) (2.22.0)
  ERROR: Could not find a version that satisfies the requirement boto3<1.11.0,>=1.4.4 (from snowflake-connector-python==2.1.2) (from versions: none)
  ERROR: No matching distribution found for boto3<1.11.0,>=1.4.4 (from snowflake-connector-python==2.1.2)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/79986
4 package built:
python37Packages.snowflake-connector-python python37Packages.snowflake-sqlalchemy python38Packages.snowflake-connector-python python38Packages.snowflake-sqlalchemy
```