### PR TITLE
python3Packages.fix-airflow: fix dependencies

### DIFF
--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -137,6 +137,8 @@ buildPythonPackage rec {
 
    substituteInPlace setup.py \
      --replace "flask>=1.1.0, <2.0" "flask" \
+     --replace "jinja2>=2.10.1, <2.11.0" "jinja2" \
+     --replace "pandas>=0.17.1, <1.0.0" "pandas" \
      --replace "flask-caching>=1.3.3, <1.4.0" "flask-caching" \
      --replace "flask-appbuilder>=1.12.5, <2.0.0" "flask-appbuilder" \
      --replace "pendulum==1.4.4" "pendulum" \
@@ -156,7 +158,7 @@ buildPythonPackage rec {
      --replace "sqlalchemy~=1.3" "sqlalchemy" \
      --replace "gunicorn>=19.5.0, <20.0" "gunicorn" \
      --replace "werkzeug>=0.14.1, <0.15.0" "werkzeug"
- 
+
   # dumb-init is only needed for CI and Docker, not relevant for NixOS.
   substituteInPlace setup.py \
      --replace "'dumb-init>=1.2.2'," ""


### PR DESCRIPTION
###### Motivation for this change
```
builder for '/nix/store/wn5zlcghm9v1lg07amalwy9v5fcw01hm-python3.7-apache-airflow-1.10.5.drv' failed with exit code 1; last 10 log lines:
  adding 'apache_airflow-1.10.5.dist-info/RECORD'
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  installing
  Executing pipInstallPhase
  /build/source/dist /build/source
  Processing ./apache_airflow-1.10.5-py2.py3-none-any.whl
  Requirement already satisfied: tenacity in /nix/store/87cfm9c4hbh0yz2vyxydgsm8p2rsf17m-python3.7-tenacity-6.0.0/lib/python3.7/site-packages (from apache-airflow==1.10.5) (6.0.0)
  ERROR: Could not find a version that satisfies the requirement jinja2<2.11.0,>=2.10.1 (from apache-airflow==1.10.5) (from versions: none)
  ERROR: No matching distribution found for jinja2<2.11.0,>=2.10.1 (from apache-airflow==1.10.5)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
