### PR TITLE
rxvt-unicode: fix typo in aliases.nix

### DIFF
--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -88,10 +88,10 @@ in {
       default = with pkgs; [
         swaylock swayidle
         xwayland alacritty dmenu
-        rxvt_unicode # For backward compatibility (old default terminal)
+        rxvt-unicode # For backward compatibility (old default terminal)
       ];
       defaultText = literalExample ''
-        with pkgs; [ swaylock swayidle xwayland rxvt_unicode dmenu ];
+        with pkgs; [ swaylock swayidle xwayland rxvt-unicode dmenu ];
       '';
       example = literalExample ''
         with pkgs; [

--- a/nixos/modules/services/x11/urxvtd.nix
+++ b/nixos/modules/services/x11/urxvtd.nix
@@ -18,10 +18,10 @@ in {
     };
 
     package = mkOption {
-      default = pkgs.rxvt_unicode-with-plugins;
-      defaultText = "pkgs.rxvt_unicode-with-plugins";
+      default = pkgs.rxvt-unicode;
+      defaultText = "pkgs.rxvt-unicode";
       description = ''
-        Package to install. Usually pkgs.rxvt_unicode-with-plugins or pkgs.rxvt_unicode
+        Package to install. Usually pkgs.rxvt-unicode.
       '';
       type = types.package;
     };

--- a/pkgs/applications/misc/rxvt-unicode-plugins/urxvt-vtwheel/default.nix
+++ b/pkgs/applications/misc/rxvt-unicode-plugins/urxvt-vtwheel/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
 
-  name = "rxvt_unicode-vtwheel-0.3.2";
+  name = "rxvt-unicode-vtwheel-0.3.2";
 
   src = fetchgit {
    url = "https://aur.archlinux.org/urxvt-vtwheel.git";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -384,7 +384,7 @@ mapAliases ({
   ruby_2_5_0 = throw "deprecated 2018-0213: use a newer version of ruby";
   rubyPackages_2_4 = throw "deprecated 2019-12: use a newer version of rubyPackages instead";
   rubygems = throw "deprecated 2016-03-02: rubygems is now bundled with ruby";
-  rxvt_unicode_with-plugins = rxvt-unicode; # added 2020-02-02
+  rxvt_unicode-with-plugins = rxvt-unicode; # added 2020-02-02
   rxvt_unicode = rxvt-unicode-unwrapped; # added 2020-02-02
   urxvt_autocomplete_all_the_things = rxvt-unicode-plugins.autocomplete-all-the-things; # added 2020-02-02
   urxvt_perl = rxvt-unicode-plugins.perl; # added 2020-02-02


### PR DESCRIPTION
###### Motivation for this change
Fixup of #77347 

###### Things done
- [x] Evaluated NixOS
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
