### PR TITLE
mopidy-mpd: init at version 3.0.0

### DIFF
--- a/pkgs/applications/audio/mopidy/mpd.nix
+++ b/pkgs/applications/audio/mopidy/mpd.nix
@@ -1,0 +1,24 @@
+{ stdenv, python3Packages, mopidy }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "Mopidy-MPD";
+  version = "3.0.0";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0prjli4352521igcsfcgmk97jmzgbfy4ik8hnli37wgvv252wiac";
+  };
+
+  propagatedBuildInputs = [mopidy];
+
+  # no tests implemented
+  doCheck = false;
+  pythonImportsCheck = [ "mopidy_mpd" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mopidy/mopidy-mpd";
+    description = "Mopidy extension for controlling playback from MPD clients";
+    license = licenses.asl20;
+    maintainers = [ maintainers.tomahna ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20528,6 +20528,8 @@ in
 
   mopidy-iris = callPackage ../applications/audio/mopidy/iris.nix { };
 
+  mopidy-mpd = callPackage ../applications/audio/mopidy/mpd.nix { };
+
   motif = callPackage ../development/libraries/motif { };
 
   mozplugger = callPackage ../applications/networking/browsers/mozilla-plugins/mozplugger {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change
It looks like that since version 3.0.0, Mopidy has separated it's mpd functionality to a separate library.

###### Things done
Add mopidy-mpd package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
