### PR TITLE
crun: run tests and show the proper version number

### DIFF
--- a/pkgs/applications/virtualization/crun/default.nix
+++ b/pkgs/applications/virtualization/crun/default.nix
@@ -1,6 +1,36 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, go-md2man, pkgconfig
-, libcap, libseccomp, python3, systemd, yajl }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, go-md2man
+, pkgconfig
+, libcap
+, libseccomp
+, python3
+, systemd
+, yajl
+}:
 
+let
+  # these tests require additional permissions
+  disabledTests = [
+    "test_capabilities.py"
+    "test_cwd.py"
+    "test_detach.py"
+    "test_exec.py"
+    "test_hooks.py"
+    "test_hostname.py"
+    "test_paths.py"
+    "test_pid.py"
+    "test_pid_file.py"
+    "test_preserve_fds.py"
+    "test_start.py"
+    "test_uid_gid.py"
+    "test_update.py"
+    "tests_libcrun_utils"
+  ];
+
+in
 stdenv.mkDerivation rec {
   pname = "crun";
   version = "0.12.1";
@@ -19,16 +49,18 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  preBuild = ''
-    cat > git-version.h <<EOF
-    #ifndef GIT_VERSION
-    # define GIT_VERSION "nixpkgs-${version}"
-    #endif
-    EOF
+  # we need this before autoreconfHook does its thing in order to initialize
+  # config.h with the correct values
+  postPatch = ''
+    echo ${version} > .tarball-version
+    echo '#define GIT_VERSION "${src.rev}"' > git-version.h
+
+    ${lib.concatMapStringsSep "\n" (e:
+      "substituteInPlace Makefile.am --replace 'tests/${e}' ''"
+    ) disabledTests}
   '';
 
-  # the tests require additional permissions
-  doCheck = false;
+  doCheck = true;
 
   meta = with lib; {
     description = "A fast and lightweight fully featured OCI runtime and C library for running containers";


### PR DESCRIPTION
###### Motivation for this change

`crun` didn't show the proper version number and we disabled tests as most of them would fail due to our sandbox. At least run some of them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
