### PR TITLE
zoom-us: fix launch

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -5,7 +5,8 @@
 , qtimageformats, qtlocation, qtquickcontrols, qtquickcontrols2, qtscript, qtsvg
 , qttools, qtwayland, qtwebchannel, qtwebengine
 # Runtime
-, coreutils, libjpeg_turbo, pciutils, procps, utillinux, libv4l
+, coreutils, libjpeg_turbo, pciutils, procps, utillinux
+, enableV4l ? false, libv4l
 , pulseaudioSupport ? true, libpulseaudio ? null
 }:
 
@@ -101,11 +102,10 @@ in mkDerivation {
 
   qtWrapperArgs = [
     ''--prefix PATH : ${makeBinPath [ coreutils glib.dev pciutils procps qttools.dev utillinux ]}''
-    ''--prefix LD_PRELOAD : ${libv4l}/lib/libv4l/v4l2convert.so''
     # --run "cd ${placeholder "out"}/share/zoom-us"
     # ^^ unfortunately, breaks run arg into multiple array elements, due to
     # some bad array propagation. We'll do that in bash below
-  ];
+  ] ++ stdenv.lib.optional enableV4l ''--prefix LD_PRELOAD : ${libv4l}/lib/libv4l/v4l2convert.so'';
 
   postFixup = ''
     # Zoom expects "zopen" executable (needed for web login) to be present in CWD. Or does it expect

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -6,7 +6,6 @@
 , qttools, qtwayland, qtwebchannel, qtwebengine
 # Runtime
 , coreutils, libjpeg_turbo, pciutils, procps, utillinux
-, enableV4l ? false, libv4l
 , pulseaudioSupport ? true, libpulseaudio ? null
 }:
 
@@ -105,7 +104,7 @@ in mkDerivation {
     # --run "cd ${placeholder "out"}/share/zoom-us"
     # ^^ unfortunately, breaks run arg into multiple array elements, due to
     # some bad array propagation. We'll do that in bash below
-  ] ++ stdenv.lib.optional enableV4l ''--prefix LD_PRELOAD : ${libv4l}/lib/libv4l/v4l2convert.so'';
+  ];
 
   postFixup = ''
     # Zoom expects "zopen" executable (needed for web login) to be present in CWD. Or does it expect


### PR DESCRIPTION
Probably due to glibc update, ZoomLauncher became broken when v4l is present in
LD_PRELOAD path. It can be fixed by a) removing ZoomLauncher from startup chain,
so `zoom` is started directly or b) removing v4l from LD_PRELOAD.

The reason v4l was added before was because my video was rotated upside down without it.
Seem like nowadays this is fixed by Zoom itself, so I'm disabling it.

Fixes https://github.com/NixOS/nixpkgs/issues/79954

Co-authored-by: @mmlb

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
