### PR TITLE
google-cloud-sdk: fix gsutil startup crash

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -42,6 +42,7 @@ in stdenv.mkDerivation rec {
 
   patches = [
     ./gcloud-path.patch
+    ./gsutil-disable-updates.patch
   ];
 
   installPhase = ''

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -84,6 +84,7 @@ in stdenv.mkDerivation rec {
 
     # remove tests and test data
     find $out -name tests -type d -exec rm -rf '{}' +
+    rm $out/google-cloud-sdk/platform/gsutil/gslib/commands/test.py
 
     # compact all the JSON
     find $out -name \*.json | while read path; do

--- a/pkgs/tools/admin/google-cloud-sdk/gsutil-disable-updates.patch
+++ b/pkgs/tools/admin/google-cloud-sdk/gsutil-disable-updates.patch
@@ -1,0 +1,50 @@
+diff --git a/platform/gsutil/gslib/command_runner.py b/platform/gsutil/gslib/command_runner.py
+index 06ca5e5..4a4e225 100644
+--- a/platform/gsutil/gslib/command_runner.py
++++ b/platform/gsutil/gslib/command_runner.py
+@@ -61,7 +61,6 @@ from gslib.utils.text_util import InsistAsciiHeaderValue
+ from gslib.utils.text_util import print_to_fd
+ from gslib.utils.unit_util import SECONDS_PER_DAY
+ from gslib.utils.update_util import LookUpGsutilVersion
+-from gslib.tests.util import HAS_NON_DEFAULT_GS_HOST
+ 
+ 
+ def HandleHeaderCoding(headers):
+@@ -331,17 +330,6 @@ class CommandRunner(object):
+     Returns:
+       Return value(s) from Command that was run.
+     """
+-    command_changed_to_update = False
+-    if (not skip_update_check and
+-        self.MaybeCheckForAndOfferSoftwareUpdate(command_name, debug)):
+-      command_name = 'update'
+-      command_changed_to_update = True
+-      args = [_StringToSysArgType('-n')]
+-
+-      # Check for opt-in analytics.
+-      if system_util.IsRunningInteractively() and collect_analytics:
+-        metrics.CheckAndMaybePromptForAnalyticsEnabling()
+-
+     if not args:
+       args = []
+ 
+@@ -414,18 +402,10 @@ class CommandRunner(object):
+       ShutDownGsutil()
+     if GetFailureCount() > 0:
+       return_code = 1
+-    if command_changed_to_update:
+-      # If the command changed to update, the user's original command was
+-      # not executed.
+-      return_code = 1
+-      print('\n'.join(
+-          textwrap.wrap(
+-              'Update was successful. Exiting with code 1 as the original command '
+-              'issued prior to the update was not executed and should be re-run.'
+-          )))
+     return return_code
+ 
+   def MaybeCheckForAndOfferSoftwareUpdate(self, command_name, debug):
++    return False
+     """Checks the last time we checked for an update and offers one if needed.
+ 
+     Offer is made if the time since the last update check is longer


### PR DESCRIPTION
This fixes https://github.com/NixOS/nixpkgs/issues/79754, by removing the two places where the tests are referenced by runtime code.

There's still a bunch of chaff that we could cull left, although it won't buy us much in closure size:

    edef@vixen ~> rg -li '^(from.*tests.*import|import.*test)' (nix-build '<nixpkgs>' -A google-cloud-sdk --no-out-link) | wc -l
    63
    edef@vixen ~> du -ch (rg -li '^(from.*tests.*import|import.*test)' (nix-build '<nixpkgs>' -A google-cloud-sdk --no-out-link)) | tail -n1
    858K	total

 - [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
 - Built on platform(s)
    - [x] NixOS
    - [ ] macOS
    - [ ] other Linux distributions
 - [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
 - [x] Tested execution of all binary files (usually in `./result/bin/`)
 - [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
 - [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).