### PR TITLE
romdirfs: init at 1.2

### DIFF
--- a/pkgs/tools/filesystems/romdirfs/default.nix
+++ b/pkgs/tools/filesystems/romdirfs/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, fuse }:
+
+stdenv.mkDerivation rec {
+  pname = "romdirfs";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "mlafeldt";
+    repo = "romdirfs";
+    rev = "v${version}";
+    sha256 = "1jbsmpklrycz5q86qmzvbz4iz2g5fvd7p9nca160aw2izwpws0g7";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ fuse ];
+
+  meta = with stdenv.lib; {
+    description = "FUSE for access Playstation 2 IOP IOPRP images and BIOS dumps";
+    homepage = https://github.com/mlafeldt/romdirfs;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ genesis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25281,6 +25281,8 @@ in
 
   rmount = callPackage ../tools/filesystems/rmount {};
 
+  romdirfs = callPackage ../tools/filesystems/romdirfs {};
+
   rss-glx = callPackage ../misc/screensavers/rss-glx { };
 
   run-scaled = callPackage ../tools/X11/run-scaled { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Mentioned on https://nixos.wiki/wiki/Playstation2#PCSX2