### PR TITLE
cpp-utilities: patch upstream issue #18

### DIFF
--- a/pkgs/development/libraries/cpp-utilities/default.nix
+++ b/pkgs/development/libraries/cpp-utilities/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchFromGitHub, cmake, cppunit }:
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, cppunit
+}:
 
 stdenv.mkDerivation rec {
   pname = "cpp-utilities";
@@ -10,6 +15,17 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0cghk1a0ki1063ci63imakmggwzkky1hx6lhrvc0wjfv754wsklb";
   };
+  # See https://github.com/Martchus/cpp-utilities/issues/18
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/Martchus/cpp-utilities/commit/b2a2773cdfb2b0017a3fa3d0ed2259a9a5fda666.patch";
+      sha256 = "01js90ba4xxljifncm48zbxmg7mwwz1gla1hn87yzbic47d85hfj";
+    })
+    (fetchpatch {
+      url = "https://github.com/Martchus/cpp-utilities/commit/4dd2179f191d1ace113f26177944684fa1561dc1.patch";
+      sha256 = "0chw33mwsvj7cigd1c4xl2zhpbfsp5rrijdm46qpn78bq70xcz9j";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   checkInputs = [ cppunit ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Fix build of libsForQt5.qtutilities with patches that fixed https://github.com/Martchus/cpp-utilities/issues/18.
- Fix #80908 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).