### PR TITLE
pythonPackages.bayesian-optimization: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/bayesian-optimization/default.nix
+++ b/pkgs/development/python-modules/bayesian-optimization/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, scikitlearn
+, scipy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "bayesian-optimization";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fmfn";
+    repo = "BayesianOptimization";
+    rev = "v${version}";
+    sha256 = "07sqymg6k5512k7wq4kbp7rsrkb4g90n0ck1f0b9s6glyfpcy4pq";
+  };
+
+  propagatedBuildInputs = [
+    scikitlearn
+    scipy
+  ];
+  
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = with lib; {
+    description = "A Python implementation of global optimization with gaussian processes";
+    homepage = "https://github.com/fmfn/BayesianOptimization";
+    license = licenses.mit;
+    maintainers = [ maintainers.juliendehos ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -484,6 +484,8 @@ in {
 
   bashlex = callPackage ../development/python-modules/bashlex { };
 
+  bayesian-optimization = callPackage ../development/python-modules/bayesian-optimization { };
+
   bayespy = callPackage ../development/python-modules/bayespy { };
 
   beanstalkc = callPackage ../development/python-modules/beanstalkc { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
