### PR TITLE
sky: change

### DIFF
--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -16,14 +16,14 @@
   });
 in
 stdenv.mkDerivation rec {
-  version_major = "2.1.7369";
+  version_major = "2.1.7520";
   version_minor = "1";
   version = version_major + "." + version_minor;
   pname = "sky";
   unpackCmd = "ar x $curSrc; tar -xf data.tar.xz";
   src = fetchurl {
     url = "https://tel.red/repos/ubuntu/pool/non-free/sky_${version_major + "-" + version_minor}ubuntu+xenial_amd64.deb";
-    sha256 = "0b3j90km3rp5bgaklxw881g0gcy09mqzbhjdfrq4s2np026ql3d9";
+    sha256 = "078gdk4dbw7aqfrrc5xlhhzpiy3br8wpn0mbfbqfxrnbpgn5ya2w";
   };
   buildInputs = [ 
     file


### PR DESCRIPTION
sky: 2.1.7369 -> 2.1.7520

###### Motivation for this change
Resolve 404 on .deb package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
