### PR TITLE
qlandkartegt: fix broken download links

### DIFF
--- a/pkgs/applications/misc/qlandkartegt/default.nix
+++ b/pkgs/applications/misc/qlandkartegt/default.nix
@@ -7,7 +7,7 @@ mkDerivation rec {
   version = "1.8.1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/maproom/qlandkarte-gt/downloads/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
     sha256 = "1rwv5ar5jv15g1cc6pp0lk69q3ip10pjazsh3ds2ggaciymha1ly";
   };
 

--- a/pkgs/applications/misc/qlandkartegt/garmindev.nix
+++ b/pkgs/applications/misc/qlandkartegt/garmindev.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.3.4";
 
   src = fetchurl {
-    url = "https://bitbucket.org/maproom/qlandkarte-gt/downloads/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/qlandkartegt/${pname}-${version}.tar.gz";
     sha256 = "1mc7rxdn9790pgbvz02xzipxp2dp9h4hfq87xgawa18sp9jqzhw6";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Source tarball is not available on Bitbucket any more, use Sourceforge instead.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
