### PR TITLE
git-filter-repo: add package to git-and-tools

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -95,6 +95,10 @@ let
 
   git-extras = callPackage ./git-extras { };
 
+  git-filter-repo = callPackage ./git-filter-repo {
+    inherit git python3;
+  };
+
   git-gone = callPackage ./git-gone {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/applications/version-management/git-and-tools/git-filter-repo/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-filter-repo/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, git, python3 }:
+
+stdenv.mkDerivation rec {
+  pname = "git-filter-repo";
+  version = "2.25.0";
+
+  # do NOT fetch the git repo directly:
+  # the 'master' branch is missing documentation files,
+  # and the Makefile borks attempting to use git to check them out
+  src = fetchTarball {
+    url = "https://github.com/newren/${pname}/releases/download/v${version}/${pname}-${version}.tar.xz";
+    sha256 = "10wx1px9hkxxn7li4j97a069sbcyc4za0kzz4v8ij8y0hdxgfhk5";
+  };
+
+  propagatedBuildInputs = [ git python3 ];
+
+  # attempts to call python's coverage framework; needs perl, fails with missing modules ... messy
+  doCheck = false;
+
+  # Makefile makes a mess of this, assumes the Python version etc
+  # ... also, the python setup.py is broken: ignore both
+  installPhase = ''
+    install -Dv ./Documentation/man1/git-filter-repo.1 "$out"/share/man/man1/git-filter-repo.1
+    install -Dv ./Documentation/html/git-filter-repo.html "$out"/share/doc/git-doc/git-filter-repo.html
+    install -Dv ./git-filter-repo "$out"/bin/git-filter-repo
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Quickly rewrite git repository history (filter-branch replacement)";
+    homepage = https://github.com/newren/git-filter-repo;
+    license = licenses.mit;
+    maintainers = [ "https://github.com/newren" ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
This is a platform-agnostic tool to handle git history rewriting.
It is recommended as a replacement for git-filter-branch in
the official Git docs: https://git-scm.com/docs/git-filter-branch/en

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Needed git-filter-repo as a replacement for bfg on macOS and Linux 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
