### PR TITLE
stretchly: 0.21.0 -> 0.21.1, use system electron, simplify

### DIFF
--- a/pkgs/applications/misc/stretchly/default.nix
+++ b/pkgs/applications/misc/stretchly/default.nix
@@ -1,177 +1,38 @@
-{ GConf
-, alsaLib
-, at-spi2-atk
-, at-spi2-core
-, atk
-, buildFHSUserEnv
-, cairo
+{ stdenv, lib, fetchurl, makeWrapper, wrapGAppsHook, electron
 , common-updater-scripts
-, coreutils
-, cups
-, dbus
-, expat
-, fetchurl
-, fontconfig
-, gdk-pixbuf
-, glib
-, gtk2
-, gtk3
-, lib
-, libX11
-, libXScrnSaver
-, libXcomposite
-, libXcursor
-, libXdamage
-, libXext
-, libXfixes
-, libXi
-, libXrandr
-, libXrender
-, libXtst
-, libappindicator
-, libdrm
-, libnotify
-, libpciaccess
-, libpng12
-, libuuid
-, libxcb
-, nspr
-, nss
-, pango
-, pciutils
-, pulseaudio
-, runtimeShell
-, stdenv
-, udev
-, wrapGAppsHook
-, writeScript
-, file
+, writeShellScript
 }:
 
-let
-  libs = [
-    GConf
-    alsaLib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    fontconfig
-    gdk-pixbuf
-    glib
-    gtk2
-    gtk3
-    libX11
-    libXScrnSaver
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXtst
-    libappindicator
-    libdrm
-    libnotify
-    libpciaccess
-    libpng12
-    libuuid
-    libxcb
-    nspr
-    nss
-    pango
-    pciutils
-    pulseaudio
-    stdenv.cc.cc.lib
-    udev
+stdenv.mkDerivation rec {
+  pname = "stretchly";
+  version = "0.21.1";
+
+  src = fetchurl {
+    url = "https://github.com/hovancik/stretchly/releases/download/v${version}/stretchly-${version}.tar.xz";
+    sha256 = "0776pywyqylwd33m85l4wdr89x0q9xkrjgliag10fp1bswz844lf";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
   ];
 
-  libPath = lib.makeLibraryPath libs;
+  installPhase = ''
+    runHook preInstall
 
-  stretchly =
-    stdenv.mkDerivation rec {
-      pname = "stretchly";
-      version = "0.21.0";
+    mkdir -p $out/bin $out/share/${pname}/
+    mv resources/app.asar $out/share/${pname}/
 
-      src = fetchurl {
-        url = "https://github.com/hovancik/stretchly/releases/download/v${version}/stretchly-${version}.tar.xz";
-        sha256 = "1gyyr22xq8s4miiacs8wqhp7lxnwvkvlwhngnq8671l62s6iyjzl";
-      };
+    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
+      --add-flags $out/share/${pname}/app.asar \
+      "''${gappsWrapperArgs[@]}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
 
-      nativeBuildInputs = [
-        wrapGAppsHook
-        coreutils
-      ];
+    runHook postInstall
+  '';
 
-      buildInputs = libs;
-
-      dontPatchELF = true;
-      dontBuild = true;
-      dontConfigure = true;
-
-      installPhase = ''
-        mkdir -p $out/bin $out/lib/stretchly
-        cp -r ./* $out/lib/stretchly/
-        ln -s $out/lib/stretchly/stretchly $out/bin/
-      '';
-
-      preFixup = ''
-        patchelf --set-rpath "${libPath}" $out/lib/stretchly/libffmpeg.so
-        patchelf --set-rpath "${libPath}" $out/lib/stretchly/libEGL.so
-        patchelf --set-rpath "${libPath}" $out/lib/stretchly/libGLESv2.so
-        patchelf --set-rpath "${libPath}" $out/lib/stretchly/swiftshader/libEGL.so
-        patchelf --set-rpath "${libPath}" $out/lib/stretchly/swiftshader/libGLESv2.so
-
-        patchelf \
-          --set-rpath "$out/lib/stretchly:${libPath}" \
-          --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          $out/lib/stretchly/stretchly
-
-        patchelf \
-          --set-rpath "$out/lib/stretchly:${libPath}" \
-          --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          $out/lib/stretchly/chrome-sandbox
-      '';
-
-      meta = with stdenv.lib; {
-        description = "A break time reminder app";
-        longDescription = ''
-          stretchly is a cross-platform electron app that reminds you to take
-          breaks when working on your computer. By default, it runs in your tray
-          and displays a reminder window containing an idea for a microbreak for 20
-          seconds every 10 minutes. Every 30 minutes, it displays a window
-          containing an idea for a longer 5 minute break.
-        '';
-        homepage = https://hovancik.net/stretchly;
-        downloadPage = https://hovancik.net/stretchly/downloads/;
-        license = licenses.bsd2;
-        maintainers = with maintainers; [ cdepillabout ];
-        platforms = platforms.linux;
-      };
-    };
-
-in
-
-buildFHSUserEnv {
-  inherit (stretchly) meta;
-
-  name = "stretchly";
-
-  targetPkgs = pkgs: [
-     stretchly
-  ];
-
-  runScript = "stretchly";
 
   passthru = {
-    updateScript = writeScript "update-stretchly" ''
-      #!${runtimeShell}
-
+    updateScript = writeShellScript "update-stretchly" ''
       set -eu -o pipefail
 
       # get the latest release version
@@ -179,9 +40,23 @@ buildFHSUserEnv {
 
       echo "updating to $latest_version..."
 
-      ${common-updater-scripts}/bin/update-source-version stretchly.passthru.stretchlyWrapped "$latest_version"
+      ${common-updater-scripts}/bin/update-source-version stretchly "$latest_version"
     '';
+  };
 
-    stretchlyWrapped = stretchly;
+  meta = with stdenv.lib; {
+    description = "A break time reminder app";
+    longDescription = ''
+      stretchly is a cross-platform electron app that reminds you to take
+      breaks when working on your computer. By default, it runs in your tray
+      and displays a reminder window containing an idea for a microbreak for 20
+      seconds every 10 minutes. Every 30 minutes, it displays a window
+      containing an idea for a longer 5 minute break.
+    '';
+    homepage = https://hovancik.net/stretchly;
+    downloadPage = https://hovancik.net/stretchly/downloads/;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ cdepillabout ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21529,7 +21529,8 @@ in
   stp = callPackage ../applications/science/logic/stp { };
 
   stretchly = callPackage ../applications/misc/stretchly {
-    inherit (gnome2) GConf;
+    # Error on launch w/electron_8
+    electron = electron_7;
   };
 
   stumpish = callPackage ../applications/window-managers/stumpish {};


### PR DESCRIPTION
###### Motivation for this change

Cleanup and prefer our electron.
Works well here, but let's check with maintainer for approval ;).

Neat app, noticed after electron refactoring PR and am giving a whirl
starting today! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).