### PR TITLE
nixosTests.docker-preloader: Port to Python

### DIFF
--- a/nixos/tests/docker-preloader.nix
+++ b/nixos/tests/docker-preloader.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "docker-preloader";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ lewo ];
@@ -18,10 +18,10 @@ import ./make-test.nix ({ pkgs, ...} : {
         };
   };
   testScript = ''
-    startAll;
+    start_all()
 
-    $docker->waitForUnit("sockets.target");
-    $docker->succeed("docker run nix nix-store --version");
-    $docker->succeed("docker run bash bash --version");
+    docker.wait_for_unit("sockets.target")
+    docker.succeed("docker run nix nix-store --version")
+    docker.succeed("docker run bash bash --version")
   '';
 })

--- a/nixos/tests/docker-preloader.nix
+++ b/nixos/tests/docker-preloader.nix
@@ -2,6 +2,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   name = "docker-preloader";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ lewo ];
+    broken = true; # fails with "read-only file system" error
   };
 
   nodes = {


### PR DESCRIPTION
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).