### PR TITLE
hunspellDicts: add Czech and Slovak dictionary

### DIFF
--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -732,4 +732,26 @@ in rec {
     shortDescription = "Russian (Russian)";
     license = with stdenv.lib.licenses; [ mpl20 lgpl3 ];
   };
+
+  /* CZECH */
+
+  cs_CZ = cs-cz;
+  cs-cz = mkDictFromLibreOffice {
+    shortName = "cs-cz";
+    dictFileName = "cs_CZ";
+    shortDescription = "Czech (Czechia)";
+    readmeFile = "README_cs.txt";
+    license = with stdenv.lib.licenses; [ gpl2 ];
+  };
+
+  /* SLOVAK */
+
+  sk_SK = sk-sk;
+  sk-sk = mkDictFromLibreOffice {
+    shortName = "sk-sk";
+    dictFileName = "sk_SK";
+    shortDescription = "Slovak (Slovakia)";
+    readmeFile = "README_sk.txt";
+    license = with stdenv.lib.licenses; [ gpl2 lgpl21 mpl11 ];
+  };
 }

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -272,13 +272,13 @@ let
     , sourceRoot ? dictFileName }:
     mkDict rec {
       name = "hunspell-dict-${shortName}-libreoffice-${version}";
-      version = "6.2.0.3";
+      version = "6.3.0.4";
       inherit dictFileName readmeFile;
       src = fetchFromGitHub {
         owner = "LibreOffice";
         repo = "dictionaries";
         rev = "libreoffice-${version}";
-        sha256 = "0rw9ahhynia5wsgyd67lrhinqqn1s1rizgiykb3palbyk0lv72xj";
+        sha256 = "14z4b0grn7cw8l9s7sl6cgapbpwhn1b3gwc3kn6b0k4zl3dq7y63";
       };
       buildPhase = ''
         cp -a ${sourceRoot}/* .


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

Also bumps libreoffice dicts version `6.2.0.3 -> 6.3.0.4`.

###### Motivation for this change

* missing Czech dictionary

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
