### PR TITLE
gitAndTools.bump2version: init at 1.0.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/bump2version/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bump2version/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, isPy27, pytest, testfixtures, lib }:
+
+buildPythonApplication rec {
+  pname = "bump2version";
+  version = "1.0.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "c4urself";
+    repo = "${pname}";
+    rev = "refs/tags/v${version}";
+    sha256 = "10p7rg569rk3qvzs5kjj17894bqlsg3ihhbln6ciwwfhkfq1kpja";
+  };
+
+  checkInputs = [ pytest testfixtures ];
+  # X's in pytest are git tests which won't run in sandbox
+  checkPhase = ''
+    pytest tests/ -k 'not usage_string_fork'
+  ''; 
+
+  meta = with stdenv.lib; {
+    description = "Version-bump your software with a single command";
+    longDescription = ''
+      A small command line tool to simplify releasing software by updating 
+      all version strings in your source code by the correct increment.
+    '';
+    homepage = "https://github.com/c4urself/bump2version";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jefflabonte ];
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -22,6 +22,8 @@ let
 
   bitbucket-server-cli = callPackage ./bitbucket-server-cli { };
 
+  bump2version = pkgs.python37Packages.callPackage ./bump2version { };
+
   darcsToGit = callPackage ./darcs-to-git { };
 
   delta = callPackage ./delta { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I need it at my work to bump my versions in my software

###### Things done

Create a new package to install in python 3 bump2version from Pypi

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
