### PR TITLE
python27Packages.sphinx-jinja: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/sphinx-jinja/default.nix
+++ b/pkgs/development/python-modules/sphinx-jinja/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "sphinx-jinja";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "02pgp9pbn0zrs0lggrc74mv6cvlnlq8wib84ga6yjvq30gda9v8q";
+    sha256 = "0hz13vc65zi4zmay40nz8wzxickv1q9zzl6x03qc7rvvapz0c91p";
   };
 
   buildInputs = [ pbr ];

--- a/pkgs/development/python-modules/sphinx-jinja/default.nix
+++ b/pkgs/development/python-modules/sphinx-jinja/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pbr, sphinx, sphinx-testing, nose, glibcLocales }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, pbr, sphinx, sphinx-testing, nose, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "sphinx-jinja";
@@ -14,7 +14,10 @@ buildPythonPackage rec {
 
   checkInputs = [ sphinx-testing nose glibcLocales ];
 
-  checkPhase = ''
+  checkPhase = lib.optionalString (!isPy27) ''
+    # prevent python from loading locally and breaking namespace
+    mv sphinxcontrib .sphinxcontrib
+  '' + ''
     # Zip (epub) does not support files with epoch timestamp
     LC_ALL="en_US.UTF-8" nosetests -e test_build_epub
   '';


### PR DESCRIPTION
###### Motivation for this change
closes #80043

I messed up commit name while using the github edit file option

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[3 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/80056
3 package built:
python27Packages.sphinx-jinja python37Packages.sphinx-jinja python38Packages.sphinx-jinja
```