### PR TITLE
python3Packages.docker: 4.1.0 -> 4.2.0

### DIFF
--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "docker";
-  version = "4.1.0";
+  version = "4.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1hdgics03fz2fbhalzys7a7kjj54jnl5a37h6lzdgym41gkwa1kf";
+    sha256 = "0bkj1xfp6mnvk1i9hl5awsmwi07q6iwwsjznd7kvrx5m19i6dbnx";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
routine update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[8 built (35 failed), 0.0 MiB DL]
error: build of '/nix/store/6h70cx3kwl6hir9dwvwdkij2cfdnvbq8-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/80058
5 package marked as broken and skipped:
python37Packages.blaze python37Packages.odo python38Packages.blaze python38Packages.nipype python38Packages.odo

40 package failed to build:
python27Packages.cnvkit python37Packages.acoustics python37Packages.aplpy python37Packages.arviz python37Packages.cirq python37Packages.cnvkit python37Packages.cufflinks python37Packages.dask-jobqueue python37Packages.datashader python37Packages.google_cloud_bigquery python37Packages.ibis-framework python37Packages.imbalanced-learn python37Packages.intake python37Packages.optuna python37Packages.pymc3 python37Packages.rl-coach python37Packages.rpy2 python37Packages.streamz python37Packages.sunpy python37Packages.trackpy python38Packages.acoustics python38Packages.apache-airflow python38Packages.aplpy python38Packages.arviz python38Packages.cirq python38Packages.cnvkit python38Packages.cufflinks python38Packages.dask-jobqueue python38Packages.datashader python38Packages.google_cloud_bigquery python38Packages.ibis-framework python38Packages.imbalanced-learn python38Packages.intake python38Packages.optuna python38Packages.pymc3 python38Packages.rl-coach python38Packages.rpy2 python38Packages.streamz python38Packages.trackpy tebreak

186 package built:
apache-airflow arion aws-sam-cli buildbot buildbot-full buildbot-ui csvs-to-sqlite docker-compose fdroidserver paperwork python27Packages.Quandl python27Packages.apptools python27Packages.awkward python27Packages.bkcharts python27Packages.celery python27Packages.colorcet python27Packages.cufflinks python27Packages.docker python27Packages.drms python27Packages.envisage python27Packages.flammkuchen python27Packages.flower python27Packages.geopandas python27Packages.holoviews python27Packages.hvplot python27Packages.imbalanced-learn python27Packages.mapsplotlib python27Packages.mayavi python27Packages.moto python27Packages.nbsmoke python27Packages.pandas python27Packages.pyarrow python27Packages.pytrends python27Packages.runway-python python27Packages.statsmodels python27Packages.trackpy python27Packages.uproot python27Packages.uproot-methods python27Packages.vega python27Packages.vega_datasets python27Packages.vidstab python37Packages.Quandl python37Packages.altair python37Packages.atomman python37Packages.awkward python37Packages.bkcharts python37Packages.caffe python37Packages.celery python37Packages.colorcet python37Packages.dask python37Packages.dask-glm python37Packages.dask-image python37Packages.dask-ml python37Packages.dask-mpi python37Packages.dask-xgboost python37Packages.dftfit python37Packages.distributed python37Packages.django-raster python37Packages.djmail python37Packages.docker python37Packages.drms python37Packages.fastparquet python37Packages.flammkuchen python37Packages.flower python37Packages.geopandas python37Packages.glymur python37Packages.google_cloud_monitoring python37Packages.holoviews python37Packages.hvplot python37Packages.image-match python37Packages.imgaug python37Packages.jupyter-repo2docker python37Packages.lammps-cython python37Packages.mesa python37Packages.moto python37Packages.nbsmoke python37Packages.nilearn python37Packages.nipype python37Packages.osmnx python37Packages.pandas python37Packages.partd python37Packages.phik python37Packages.pims python37Packages.pvlib python37Packages.pyarrow python37Packages.pybids python37Packages.pyfftw python37Packages.pymatgen python37Packages.pymatgen-lammps python37Packages.pytrends python37Packages.runway-python python37Packages.scikit-bio python37Packages.scikitimage python37Packages.seaborn python37Packages.sentry-sdk python37Packages.statsmodels python37Packages.stumpy python37Packages.stytra python37Packages.sumo python37Packages.tablib python37Packages.uproot python37Packages.uproot-methods python37Packages.vega python37Packages.vega_datasets python37Packages.vidstab python37Packages.wrf-python python37Packages.xarray python37Packages.xgboost python38Packages.Quandl python38Packages.altair python38Packages.atomman python38Packages.awkward python38Packages.bkcharts python38Packages.buildbot python38Packages.buildbot-full python38Packages.buildbot-ui python38Packages.caffe python38Packages.celery python38Packages.colorcet python38Packages.csvs-to-sqlite python38Packages.dask python38Packages.dask-glm python38Packages.dask-image python38Packages.dask-ml python38Packages.dask-mpi python38Packages.dask-xgboost python38Packages.dftfit python38Packages.distributed python38Packages.django-raster python38Packages.djmail python38Packages.docker python38Packages.drms python38Packages.fastparquet python38Packages.flammkuchen python38Packages.flower python38Packages.geopandas python38Packages.glymur python38Packages.google_cloud_monitoring python38Packages.holoviews python38Packages.hvplot python38Packages.image-match python38Packages.imgaug python38Packages.jupyter-repo2docker python38Packages.lammps-cython python38Packages.moto python38Packages.nbsmoke python38Packages.nilearn python38Packages.osmnx python38Packages.pandas python38Packages.partd python38Packages.phik python38Packages.pims python38Packages.pvlib python38Packages.pyarrow python38Packages.pybids python38Packages.pyfftw python38Packages.pymatgen python38Packages.pymatgen-lammps python38Packages.pytrends python38Packages.runway-python python38Packages.scikit-bio python38Packages.scikitimage python38Packages.seaborn python38Packages.statsmodels python38Packages.stytra python38Packages.sumo python38Packages.tablib python38Packages.uproot python38Packages.uproot-methods python38Packages.vega python38Packages.vega_datasets python38Packages.vidstab python38Packages.wrf-python python38Packages.xarray python38Packages.xgboost sourcehut.buildsrht sourcehut.dispatchsrht sourcehut.gitsrht sourcehut.hgsrht sourcehut.listssrht sourcehut.mansrht sourcehut.metasrht sourcehut.pastesrht sourcehut.todosrht streamlit visidata
```