### PR TITLE
gitlab: 12.7.5 -> 12.7.6

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,9 +1,9 @@
 {
-  "version": "12.7.5",
-  "repo_hash": "0jlhaakpg6bycajbhm3100gs2ka9f6iv529dvj3y1k6gysd2dpvs",
+  "version": "12.7.6",
+  "repo_hash": "092c6n2jg8himmcc23gh3gvmx0y272kwk00cj1s2k4b92dlzvm18",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.7.5-ee",
+  "rev": "v12.7.6-ee",
   "passthru": {
     "GITALY_SERVER_VERSION": "1.83.0",
     "GITLAB_PAGES_VERSION": "1.12.0",

--- a/pkgs/applications/version-management/gitlab/gitaly/deps.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/deps.nix
@@ -1319,8 +1319,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/ugorji/go";
-      rev = "v1.1.4";
-      sha256 = "0ma2qvn5wqvjidpdz74x832a813qnr1cxbx6n6n125ak9b3wbn5w";
+      rev = "d75b2dcb6bc8";
+      sha256 = "0di1k35gpq9bp958ywranpbskx2vdwlb38s22vl9rybm3wa5g3ps";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change
https://about.gitlab.com/releases/2020/02/13/critical-security-release-gitlab-12-dot-7-dot-6-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
