### PR TITLE
dockerTools: fix export

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -378,5 +378,10 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         docker.succeed(
             "docker run --rm ${examples.layeredImageWithFakeRootCommands.imageName} sh -c 'stat -c '%u' /home/jane | grep -E ^1000$'"
         )
+
+    with subtest("exportImage produces a valid tarball"):
+        docker.succeed(
+            "tar -tf ${examples.exportBash} > /dev/null"
+        )
   '';
 })

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -381,7 +381,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
     with subtest("exportImage produces a valid tarball"):
         docker.succeed(
-            "tar -tf ${examples.exportBash} > /dev/null"
+            "tar -tf ${examples.exportBash} | grep '\./bin/bash' > /dev/null"
         )
   '';
 })

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -280,9 +280,13 @@ rec {
         '');
     in
     runCommand name { } ''
-      mkdir -p $out
       cd ${result}
-      cp layer.tar json VERSION $out
+      if [ -e json ] && [ -e VERSION ] ; then
+        mkdir -p $out
+        cp layer.tar json VERSION $out
+      else
+        cp layer.tar $out
+      fi
     '';
 
   exportImage = { name ? fromImage.name, fromImage, fromImageName ? null, fromImageTag ? null, diskSize ? 1024 }:
@@ -291,7 +295,7 @@ rec {
 
       postMount = ''
         echo "Packing raw image..."
-        tar -C mnt --hard-dereference --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cf $out .
+        tar -C mnt --hard-dereference --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cf $out/layer.tar .
       '';
     };
 

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -191,13 +191,13 @@ rec {
     , postMount ? ""
     , postUmount ? ""
     }:
-    let
-      result = vmTools.runInLinuxVM (
+      vmTools.runInLinuxVM (
         runCommand name
           {
             preVM = vmTools.createEmptyImage {
               size = diskSize;
               fullName = "docker-run-disk";
+              destination = "./image";
             };
             inherit fromImage fromImageName fromImageTag;
 
@@ -278,16 +278,6 @@ rec {
 
           ${postUmount}
         '');
-    in
-    runCommand name { } ''
-      cd ${result}
-      if [ -e json ] && [ -e VERSION ] ; then
-        mkdir -p $out
-        cp layer.tar json VERSION $out
-      else
-        cp layer.tar $out
-      fi
-    '';
 
   exportImage = { name ? fromImage.name, fromImage, fromImageName ? null, fromImageTag ? null, diskSize ? 1024 }:
     runWithOverlay {

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -287,6 +287,12 @@ rec {
         echo "Packing raw image..."
         tar -C mnt --hard-dereference --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cf $out/layer.tar .
       '';
+
+      postUmount = ''
+        mv $out/layer.tar .
+        rm -rf $out
+        mv layer.tar $out
+      '';
     };
 
   # Create an executable shell script which has the coreutils in its

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -541,4 +541,7 @@ rec {
     config.Cmd = [ "hello" ];
     includeStorePaths = false;
   };
+
+  # Example export of the bash image
+  exportBash = pkgs.dockerTools.exportImage { fromImage = bash; };
 }

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -257,14 +257,23 @@ rec {
     eval "$postVM"
   '';
 
-
-  createEmptyImage = {size, fullName}: ''
-    mkdir $out
-    diskImage=$out/disk-image.qcow2
+  /*
+    A bash script fragment that produces a disk image at `destination`.
+   */
+  createEmptyImage = {
+    # Disk image size in MiB
+    size,
+    # Name that will be written to ${destination}/nix-support/full-name
+    fullName,
+    # Where to write the image files, defaulting to $out
+    destination ? "$out"
+  }: ''
+    mkdir -p ${destination}
+    diskImage=${destination}/disk-image.qcow2
     ${qemu}/bin/qemu-img create -f qcow2 $diskImage "${toString size}M"
 
-    mkdir $out/nix-support
-    echo "${fullName}" > $out/nix-support/full-name
+    mkdir ${destination}/nix-support
+    echo "${fullName}" > ${destination}/nix-support/full-name
   '';
 
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

exportImage is currently broken due to a change in runWithOverlay. This fixes exportImage by modifying runWithOverlay slightly. An alternative would be to patch only exportImage, but this would require an extra copy and increase garbage which is undesirable with large docker images.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Test expression used:
```
{ pkgs ? import <nixpkgs> { } }:

with pkgs.dockerTools;

let
  img = pullImage {
    imageName = "alpine";
    imageDigest =
      "sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d";
    sha256 = "sha256-x8gTbpAxU0wQXxwDUed1Z+fqN/ETZL8dwpQSehf6UU0=";
    finalImageName = "alpine";
    finalImageTag = "latest";
  };

in exportImage { fromImage = img; }
```
