### PR TITLE
dwarf-fortress: 0.44.12 -> 0.47.02

### DIFF
--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -40,7 +40,7 @@ let
   # The latest Dwarf Fortress version. Maintainers: when a new version comes
   # out, ensure that (unfuck|dfhack|twbt) are all up to date before changing
   # this.
-  latestVersion = "0.44.12";
+  latestVersion = "0.47.02";
 
   # Converts a version to a package name.
   versionToName = version: "dwarf-fortress_${lib.replaceStrings ["."] ["_"] version}";
@@ -101,7 +101,7 @@ let
     dwarf-fortress-full = callPackage ./lazy-pack.nix {
       inherit df-games versionToName latestVersion;
     };
-    
+
     soundSense = callPackage ./soundsense.nix { };
 
     legends-browser = callPackage ./legends-browser {};

--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -46,6 +46,12 @@ let
       xmlRev = "23500e4e9bd1885365d0a2ef1746c321c1dd5094";
       prerelease = false;
     };
+    "0.47.02" = {
+      dfHackRelease = "0.47.02-alpha0";
+      sha256 = "19lgykgqm0si9vd9hx4zw8b5m9188gg8r1a6h25np2m2ziqwbjj9";
+      xmlRev = "23500e4e9bd1885365d0a2ef1746c321c1dd509a";
+      prerelease = true;
+    };
   };
 
   release = if hasAttr dfVersion dfhack-releases

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dwarf-therapist";
-  version = "41.1.2";
+  version = "41.1.3";
 
   src = fetchFromGitHub {
     owner = "Dwarf-Therapist";
     repo = "Dwarf-Therapist";
     rev = "v${version}";
-    sha256 = "1qyyny2v4wxqs4ar02s8aawaxnkibz5aa5xgjm421k6v04iqxgcl";
+    sha256 = "15f6npbfgsxsr6pm2vxpali8f6nyyk80bcyhy9s77n064q0qg2nj";
   };
 
   nativeBuildInputs = [ texlive cmake ninja ];

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -36,6 +36,11 @@ let
       sha256 = "10gfd6vv0vk4v1r5hjbz7vf1zqys06dsad695gysc7fbcik2dakh";
       prerelease = false;
     };
+    "0.47.02" = {
+      twbtRelease = "6.61";
+      sha256 = "07bqy9rkd64h033sxdpigp5zq4xrr0xd36wdr1b21g649mv8j6yw";
+      prerelease = false;
+    };
   };
 
   release = if hasAttr dfVersion twbt-releases


### PR DESCRIPTION
###### Motivation for this change
The rest of the ecosystem is slowly catching up.

This adds:
 - 0.47.02 compatible dwarf-therapist
 - 0.47.02 compatible df-hack, even if pre-release
 - latest twbt

Then sets the default df package to be the latest.

There might be some instability with the df-hack prelease and an outdated twbt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
