### PR TITLE
satysfi: 0.0.3 -> 0.0.4

### DIFF
--- a/pkgs/tools/typesetting/satysfi/default.nix
+++ b/pkgs/tools/typesetting/satysfi/default.nix
@@ -74,7 +74,7 @@ in
       homepage = https://github.com/gfngfn/SATySFi;
       description = "A statically-typed, functional typesetting system";
       license = licenses.lgpl3;
-      maintainers = [ maintainers.mt-caret ];
+      maintainers = [ maintainers.mt-caret maintainers.marsam ];
       platforms = platforms.all;
     };
   }

--- a/pkgs/tools/typesetting/satysfi/default.nix
+++ b/pkgs/tools/typesetting/satysfi/default.nix
@@ -15,27 +15,35 @@ let
     src = fetchFromGitHub {
       owner = "gfngfn";
       repo = "camlpdf";
-      rev = "v2.2.1+satysfi";
-      sha256 = "1s8v2i8nq52kz038bvc2n0spz68fpdq6kgxrabcs6zvml6n1frzy";
+      rev = "v2.2.2+satysfi";
+      sha256 = "1dkyibjd8qb9fzljlzdsfdhb798vc9m8xqkd7295fm6bcfpr5r5k";
     };
   });
   otfm = ocamlPackages.otfm.overrideAttrs (o: {
     src = fetchFromGitHub {
       owner = "gfngfn";
       repo = "otfm";
-      rev = "v0.3.2+satysfi";
-      sha256 = "1h795pdi5qi2nwymsfvb53x56h9pqi9iiqbzw10mi6fazgd2dzhd";
+      rev = "v0.3.7+satysfi";
+      sha256 = "0y8s0ij1vp1s4h5y1hn3ns76fzki2ba5ysqdib33akdav9krbj8p";
+    };
+  });
+  yojson = ocamlPackages.yojson.overrideAttrs (o: {
+    src = fetchFromGitHub {
+      owner = "gfngfn";
+      repo = "yojson";
+      rev = "v1.4.1+satysfi";
+      sha256 = "06lajzycwmvc6s26cf40s9xn001cjxrpxijgfha3s4f4rpybb1mp";
     };
   });
 in
   stdenv.mkDerivation rec {
     pname = "satysfi";
-    version = "0.0.3";
+    version = "0.0.4";
     src = fetchFromGitHub {
       owner = "gfngfn";
       repo = "SATySFi";
       rev = "v${version}";
-      sha256 = "0qk284jhxnfb69s24j397a6155dhl4dcgamicin7sq04d0wj6c7f";
+      sha256 = "0ilvgixglklqwavf8p9mcbrjq6cjfm9pk4kqx163c0irh0lh0adv";
       fetchSubmodules = true;
     };
 
@@ -49,7 +57,7 @@ in
 
     buildInputs = [ camlpdf otfm ] ++ (with ocamlPackages; [
       ocaml findlib menhir
-      batteries camlimages core_kernel ppx_deriving uutf yojson
+      batteries camlimages core_kernel ppx_deriving uutf yojson omd cppo re
     ]);
 
     installPhase = ''
@@ -58,6 +66,8 @@ in
       cp -r ${lm}/* lib-satysfi/dist/fonts/
       cp -r ${lm-math}/otf/latinmodern-math.otf lib-satysfi/dist/fonts/
       make install PREFIX=$out LIBDIR=$out/share/satysfi
+      mkdir -p $out/share/satysfi/
+      cp -r lib-satysfi/dist/ $out/share/satysfi/
     '';
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/gfngfn/SATySFi/blob/v0.0.4/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
