### PR TITLE
rxvt-unicode-plugins.perls: 2.2 -> 2.3

### DIFF
--- a/pkgs/applications/misc/rxvt-unicode-plugins/urxvt-perls/default.nix
+++ b/pkgs/applications/misc/rxvt-unicode-plugins/urxvt-perls/default.nix
@@ -2,21 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "urxvt-perls";
-  version = "2.2";
+  version = "2.3";
 
   src = fetchFromGitHub {
     owner = "muennich";
     repo = "urxvt-perls";
     rev = version;
-    sha256 = "1cb0jbjmwfy2dlq2ny8wpc04k79jp3pz9qhbmgagsxs3sp1jg2hz";
+    sha256 = "0xvwfw7965ghhd9g6rl6y6fgpd444l46rjqmlgg0rfjypbh6c0p1";
   };
 
   installPhase = ''
     mkdir -p $out/lib/urxvt/perl
-    cp clipboard \
-       keyboard-select \
-       url-select \
-    $out/lib/urxvt/perl
+    cp keyboard-select $out/lib/urxvt/perl
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/rxvt-unicode-plugins/urxvt-perls/default.nix
+++ b/pkgs/applications/misc/rxvt-unicode-plugins/urxvt-perls/default.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/lib/urxvt/perl
     cp keyboard-select $out/lib/urxvt/perl
+    cp deprecated/clipboard \
+       deprecated/url-select \
+    $out/lib/urxvt/perl
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Version 2.3 of urxvt-perls adds a useful option to the `keyboard-select` plugin:
```
URxvt.keyboard-select.clipboard: If true, copy to clipboard too
```
meaning pressing `y` or `Return` will yank the selected text into the clipboard in addition to the primary selection.

This version also deprecates the `clipboard` and `url-select` plugins, as versions 9.20 and 9.21 of urxvt made them unnecessary. In the first commit, I removed these plugins, but then thought better of it, as many users are likely still using them, so I added them back in the second commit.
https://github.com/muennich/urxvt-perls/blob/master/deprecated/README.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
