### PR TITLE
ocaml-ng.ocamlPackages_4_10.ocaml: 4.10.0+rc1 → 4.10.0+rc2

### DIFF
--- a/pkgs/development/compilers/ocaml/4.10.nix
+++ b/pkgs/development/compilers/ocaml/4.10.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "10";
-  patch_version = "0+rc1";
-  sha256 = "1nzmn9wszixsyzz4bhpwqw8dx0m1iy83xmanp4g9f5dfywgcss2c";
+  patch_version = "0+rc2";
+  sha256 = "1iv8x9xr4k2s1x1p4rj4fqdh2iwzhgi56lyshvh6gg224i14rkbz";
 }


### PR DESCRIPTION
###### Motivation for this change

https://inbox.ocaml.org/caml-list/3db2ed80-7ef0-ccaa-0a26-c8df3f455f84@polychoron.fr/T/#u

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
