### PR TITLE
pythonPackages.imagecorruptions: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/imagecorruptions/default.nix
+++ b/pkgs/development/python-modules/imagecorruptions/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage
+, fetchPypi
+, numpy
+, scikitimage
+, stdenv
+, opencv3
+}:
+
+buildPythonPackage rec {
+  pname = "imagecorruptions";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14j8x6axnyrn6y7bsjyh4yqm7af68mqpxy7gg2xh3d577d852zgm";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'opencv-python >= 3.4.5'," ""
+  '';
+  
+  propagatedBuildInputs = [
+    numpy
+    scikitimage
+    opencv3
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/bethgelab/imagecorruptions;
+    description = "This package provides a set of image corruptions";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rakesh4g ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3867,6 +3867,8 @@ in {
 
   ifaddr = callPackage ../development/python-modules/ifaddr { };
 
+  imagecorruptions = callPackage ../development/python-modules/imagecorruptions { };
+
   imageio = callPackage ../development/python-modules/imageio { };
 
   imageio-ffmpeg = callPackage ../development/python-modules/imageio-ffmpeg { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
pythonPackages.imagecorruptions: init at 1.1.0

This is needed by imgaug tests
https://github.com/NixOS/nixpkgs/pull/80098
https://github.com/NixOS/nixpkgs/pull/79982
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
@CMCDragonkai @jonringer 