### PR TITLE
pythonPackages.imgaug: 0.4.0 - Fixed disabled/broken augmenters tests

### DIFF
--- a/pkgs/development/python-modules/imgaug/default.nix
+++ b/pkgs/development/python-modules/imgaug/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , fetchFromGitHub
 , imageio
+, imagecorruptions
 , numpy
 , opencv3
 , pytest
@@ -33,6 +34,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     imageio
+    imagecorruptions
     numpy
     opencv3
     scikitimage
@@ -41,9 +43,8 @@ buildPythonPackage rec {
     six
   ];
 
-  # augmenters requires a significant increase in packages requires
   checkPhase = ''
-     pytest ./test --ignore=test/augmenters
+     pytest ./test
   '';
 
   checkInputs = [ opencv3 pytest ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
pythonPackages.imgaug: 0.4.0 - Fixed disabled/broken augmenters tests
fixes disabled tests from : https://github.com/NixOS/nixpkgs/pull/79982
Tests pass post changes.
[imgaug_tests.txt](https://github.com/NixOS/nixpkgs/files/4203327/imgaug_tests.txt)

**Depends upon**: https://github.com/NixOS/nixpkgs/pull/80095

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
@CMCDragonkai @jonringer 