### PR TITLE
dockerTools.buildLayeredImage: store all paths passed in final layer (fix 78744)

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -83,5 +83,11 @@ import ./make-test.nix ({ pkgs, ... }: {
 
       # Ensure image with only 2 layers can be loaded
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.two-layered-image}'");
+
+      # Ensure the bulk layer didn't miss store paths
+      # Regression test for https://github.com/NixOS/nixpkgs/issues/78744
+      $docker->succeed("docker load --input='${pkgs.dockerTools.examples.bulk-layer}'");
+      # This ensure the two output paths (ls and hello) are in the layer
+      $docker->succeed("docker run bulk-layer ls /bin/hello");
     '';
 })

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -246,4 +246,5 @@ rec {
     contents = [ pkgs.bash pkgs.hello ];
     maxLayers = 2;
   };
+
 }

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -247,4 +247,15 @@ rec {
     maxLayers = 2;
   };
 
+  # 16. Create a layered image with more packages than max layers.
+  # coreutils and hello are part of the same layer
+  bulk-layer = pkgs.dockerTools.buildLayeredImage {
+    name = "bulk-layer";
+    tag = "latest";
+    contents = with pkgs; [
+      coreutils hello
+    ];
+    maxLayers = 2;
+  };
+
 }

--- a/pkgs/build-support/docker/store-path-to-layer.sh
+++ b/pkgs/build-support/docker/store-path-to-layer.sh
@@ -5,11 +5,8 @@ set -eu
 layerNumber=$1
 shift
 
-storePath="$1"
-shift
-
 layerPath="./layers/$layerNumber"
-echo "Creating layer #$layerNumber for $storePath"
+echo "Creating layer #$layerNumber for $@"
 
 mkdir -p "$layerPath"
 
@@ -35,13 +32,15 @@ tar -cf "$layerPath/layer.tar"  \
 # to /nix/store. In order to create the correct structure
 # in the tar file, we transform the relative nix store
 # path to the absolute store path.
-n=$(basename "$storePath")
-tar -C /nix/store -rpf "$layerPath/layer.tar" \
-    --hard-dereference --sort=name \
-    --mtime="@$SOURCE_DATE_EPOCH" \
-    --owner=0 --group=0 \
-    --transform="s,$n,/nix/store/$n," \
-    $n
+for storePath in "$@"; do
+  n=$(basename "$storePath")
+  tar -C /nix/store -rpf "$layerPath/layer.tar" \
+      --hard-dereference --sort=name \
+      --mtime="@$SOURCE_DATE_EPOCH" \
+      --owner=0 --group=0 \
+      --transform="s,$n,/nix/store/$n," \
+      $n
+done
 
 # Compute a checksum of the tarball.
 tarhash=$(tarsum < $layerPath/layer.tar)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
