### PR TITLE
androidenv build-tools: fix old versions under linux

### DIFF
--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -7,8 +7,10 @@ deployAndroidPackage {
   patchInstructions = ''
     ${lib.optionalString (os == "linux") ''
       addAutoPatchelfSearchPath $packageBaseDir/lib
-      addAutoPatchelfSearchPath $packageBaseDir/lib64
-      autoPatchelf --no-recurse $packageBaseDir/lib64
+      if [[ -d $packageBaseDir/lib64 ]]; then
+        addAutoPatchelfSearchPath $packageBaseDir/lib64
+        autoPatchelf --no-recurse $packageBaseDir/lib64
+      fi
       autoPatchelf --no-recurse $packageBaseDir
     ''}
 


### PR DESCRIPTION
###### Motivation for this change

Currently, the android build-tools cannot be built for older versions, as these versions do not contain a `lib64` folder, but the current derivation assumes the existance of that folder.

So this would build on a Mac (which skips the autopatchelf phase), but not in Linux:

```
androidenv.composeAndroidPackages {
        platformVersions = [ "28" "23" ];
        buildToolsVersions = [ "28.0.3" "23.0.1" ];
        abiVersions = [ "x86_64" ];
        useGoogleAPIs = true;
        includeEmulator = false;
        includeSystemImages = true;
}
```

###### Things done


Wrapped `addAutoPatchelfSearchPath` and `autoPatchelf` for the `lib64` folder in `if [[ -d $packageBaseDir/lib64 ]]; then`

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
