### PR TITLE
github-cli: init at 0.5.5

### DIFF
--- a/pkgs/applications/version-management/github-cli/default.nix
+++ b/pkgs/applications/version-management/github-cli/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "github-cli";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "cli";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "0jmkcx95kngzylqhllg33s094rggpsrgky704z8v6j4969xgrfnc";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    # Generating completions as per https://github.com/cli/cli/issues/360#issuecomment-585419936
+    $out/bin/gh completion -s bash > gh.bash    
+    $out/bin/gh completion -s zsh > gh.zsh
+    $out/bin/gh completion -s fish > gh.fish
+    installShellCompletion gh.{bash,fish,zsh}
+  '';
+
+  modSha256 = "0ina3m2ixkkz2fws6ifwy34pmp6kn5s3j7w40alz6vmybn2smy1h";
+
+  meta = with lib; {
+    description = "The GitHub CLI tool";
+    homepage = https://github.com/cli/cli;
+    license = licenses.mit;
+    maintainers = with maintainers; [ michaelpj ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -912,6 +912,8 @@ in
 
   git-town = callPackage ../tools/misc/git-town { };
 
+  github-cli = callPackage ../applications/version-management/github-cli { };
+
   github-changelog-generator = callPackage ../development/tools/github-changelog-generator { };
 
   github-commenter = callPackage ../development/tools/github-commenter { };


### PR DESCRIPTION
###### Motivation for this change
There's a new [Github cli](https://github.com/cli/cli).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
