### PR TITLE
StevenBlack-hosts: init at 2.5.52

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -714,6 +714,7 @@
   ./services/networking/sslh.nix
   ./services/networking/ssh/lshd.nix
   ./services/networking/ssh/sshd.nix
+  ./services/networking/StevenBlack-hosts.nix
   ./services/networking/strongswan.nix
   ./services/networking/strongswan-swanctl/module.nix
   ./services/networking/stunnel.nix

--- a/nixos/modules/services/networking/StevenBlack-hosts.nix
+++ b/nixos/modules/services/networking/StevenBlack-hosts.nix
@@ -1,21 +1,22 @@
 {config, lib, pkgs, ...}:
 with lib;
 {
-  options.services.stevenBlackHost = {
+  options.services.stevenBlackHosts = {
     enable = mkEnableOption "filtering hosts via StevenBlack's hosts file";
     flags = mkOption {
       description = ''
         Flags to passs while building the hosts file.
         Note that compress and skipstatichosts are passed by default.
         See also <link xlink:href="https://github.com/StevenBlack/hosts#command-line-options>here</link> for details.
-        Note that options thet modify directly the hosts file or he global DNS cache will error out as the hosts file is first built in the standard nix sandbox.
+        Note that options that modify directly the hosts file or he global DNS cache will error out
+        as the host file is first built in the standard nix sandbox.
       '';
       default = {};
       #TODO: cli setting type
       type = with types; attrsOf (
         oneOf [bool str (listOf bool) (listOf str)]
       );
-      
+
     };
     whitelist = mkOption {
       description = " List of hosts to allow";
@@ -24,21 +25,19 @@ with lib;
 
     };
   };
-  
+
   config =
     let
-      cfg = config.services.stevenBlackHost;
+      cfg = config.services.stevenBlackHosts;
     in mkIf cfg.enable {
-      
-      services.stevenBlackHost.flags={
+
+      services.stevenBlackHosts.flags={
         compress = mkDefault true;
         skipstatichosts = mkDefault true;
       };
-      
-      networking.extraHosts = 
-        builtins.readFile (pkgs.StevenBlack-hosts.override{
-          inherit (cfg) flags whitelist;
-        })
-      ;
+
+      networking.hostFiles = [( pkgs.StevenBlack-hosts.override {
+        inherit (cfg) flags whitelist;
+      })];
     };
 }

--- a/nixos/modules/services/networking/StevenBlack-hosts.nix
+++ b/nixos/modules/services/networking/StevenBlack-hosts.nix
@@ -36,8 +36,10 @@ with lib;
         skipstatichosts = mkDefault true;
       };
 
-      networking.hostFiles = [( pkgs.StevenBlack-hosts.override {
-        inherit (cfg) flags whitelist;
-      })];
+      networking.hostFiles = let
+        hosts = pkgs.StevenBlack-hosts.override {
+          inherit (cfg) flags whitelist;
+        };
+      in [( "${hosts}/share/StevenBlack-hosts/hosts" )];
     };
 }

--- a/nixos/modules/services/networking/StevenBlack-hosts.nix
+++ b/nixos/modules/services/networking/StevenBlack-hosts.nix
@@ -19,7 +19,7 @@ with lib;
 
     };
     whitelist = mkOption {
-      description = "List of hosts to allow";
+      description = "List of hosts to allow,one host per line.";
       default = "";
       type = types.lines;
 

--- a/nixos/modules/services/networking/StevenBlack-hosts.nix
+++ b/nixos/modules/services/networking/StevenBlack-hosts.nix
@@ -8,7 +8,7 @@ with lib;
         Flags to passs while building the hosts file.
         Note that compress and skipstatichosts are passed by default.
         See also <link xlink:href="https://github.com/StevenBlack/hosts#command-line-options>here</link> for details.
-        Note that options that modify directly the hosts file or he global DNS cache will error out
+        Note that options that modify directly the hosts file or the global DNS cache will error out
         as the host file is first built in the standard nix sandbox.
       '';
       default = {};
@@ -18,7 +18,7 @@ with lib;
       );
 
     };
-    whitelist = mkOption {
+    allowList = mkOption {
       description = "List of hosts names to allow,one host per line.";
       default = "";
       example = ''
@@ -42,7 +42,7 @@ with lib;
 
       networking.hostFiles = let
         hosts = pkgs.StevenBlack-hosts.override {
-          inherit (cfg) flags whitelist;
+          inherit (cfg) flags allowList;
         };
       in [( "${hosts}/share/StevenBlack-hosts/hosts" )];
     };

--- a/nixos/modules/services/networking/StevenBlack-hosts.nix
+++ b/nixos/modules/services/networking/StevenBlack-hosts.nix
@@ -19,8 +19,12 @@ with lib;
 
     };
     whitelist = mkOption {
-      description = "List of hosts to allow,one host per line.";
+      description = "List of hosts names to allow,one host per line.";
       default = "";
+      example = ''
+        site.to.allow.example
+        another.to.allow.example.com
+      '';
       type = types.lines;
 
     };

--- a/nixos/modules/services/networking/StevenBlack-hosts.nix
+++ b/nixos/modules/services/networking/StevenBlack-hosts.nix
@@ -8,7 +8,7 @@ with lib;
         Flags to passs while building the hosts file.
         Note that compress and skipstatichosts are passed by default.
         See also <link xlink:href="https://github.com/StevenBlack/hosts#command-line-options>here</link> for details.
-        Note that options thet modify directly the hosts file or he global DNS cache will error out as the hosts file is first built in the standard nix sandbox.
+        Note that options thet modify directly the hosts file or the global DNS cache will error out as the hosts file is first built in the standard nix sandbox.
       '';
       default = {};
       #TODO: cli setting type
@@ -18,7 +18,7 @@ with lib;
       
     };
     whitelist = mkOption {
-      description = " List of hosts to allow";
+      description = "List of hosts to allow";
       default = "";
       type = types.lines;
 

--- a/nixos/modules/services/networking/StevenBlack-hosts.nix
+++ b/nixos/modules/services/networking/StevenBlack-hosts.nix
@@ -1,0 +1,44 @@
+{config, lib, pkgs, ...}:
+with lib;
+{
+  options.services.stevenBlackHost = {
+    enable = mkEnableOption "filtering hosts via StevenBlack's hosts file";
+    flags = mkOption {
+      description = ''
+        Flags to passs while building the hosts file.
+        Note that compress and skipstatichosts are passed by default.
+        See also <link xlink:href="https://github.com/StevenBlack/hosts#command-line-options>here</link> for details.
+        Note that options thet modify directly the hosts file or he global DNS cache will error out as the hosts file is first built in the standard nix sandbox.
+      '';
+      default = {};
+      #TODO: cli setting type
+      type = with types; attrsOf (
+        oneOf [bool str (listOf bool) (listOf str)]
+      );
+      
+    };
+    whitelist = mkOption {
+      description = " List of hosts to allow";
+      default = "";
+      type = types.lines;
+
+    };
+  };
+  
+  config =
+    let
+      cfg = config.services.stevenBlackHost;
+    in mkIf cfg.enable {
+      
+      services.stevenBlackHost.flags={
+        compress = mkDefault true;
+        skipstatichosts = mkDefault true;
+      };
+      
+      networking.extraHosts = 
+        builtins.readFile (pkgs.StevenBlack-hosts.override{
+          inherit (cfg) flags whitelist;
+        })
+      ;
+    };
+}

--- a/pkgs/applications/networking/StevenBlack-hosts/default.nix
+++ b/pkgs/applications/networking/StevenBlack-hosts/default.nix
@@ -8,7 +8,7 @@ stdenvNoCC.mkDerivation rec {
     owner = "StevenBlack";
     repo = "hosts";
     rev = version;
-    sha256 ="zQMzXci1/21PCvi8AGqyDataQl/kQJJ+jszxXd2XMQc=";
+    sha256 ="01 rijzfmvwfcirz94h74bx15maqdn9m01g7q197nvzxmr1fk60yd";
   };
 
   inherit allowList;

--- a/pkgs/applications/networking/StevenBlack-hosts/default.nix
+++ b/pkgs/applications/networking/StevenBlack-hosts/default.nix
@@ -45,5 +45,6 @@ stdenvNoCC.mkDerivation rec {
     # https://github.com/StevenBlack/hosts#sources-of-hosts-data-unified-in-this-variant
     license = licenses.unfreeRedistributable;
     platforms = platforms.all;
+    mantainers = [ mantainers.pasqui23 ];
   };
 }

--- a/pkgs/applications/networking/StevenBlack-hosts/default.nix
+++ b/pkgs/applications/networking/StevenBlack-hosts/default.nix
@@ -56,6 +56,6 @@ stdenvNoCC.mkDerivation rec {
     # https://github.com/StevenBlack/hosts#sources-of-hosts-data-unified-in-this-variant
     license = licenses.unfreeRedistributable;
     platforms = platforms.all;
-    mantainers = [ mantainers.pasqui23 ];
+    maintainers = [ mantainers.pasqui23 ];
   };
 }

--- a/pkgs/applications/networking/StevenBlack-hosts/default.nix
+++ b/pkgs/applications/networking/StevenBlack-hosts/default.nix
@@ -1,5 +1,10 @@
-{ stdenvNoCC, fetchFromGitHub, python3, lib
-, flags ? {} ,allowList ? ""}:
+{ stdenvNoCC
+, fetchFromGitHub
+, python3
+, lib
+, flags ? {}
+, allowList ? ""
+}:
 
 stdenvNoCC.mkDerivation rec {
   pname = "StevenBlack-hosts";
@@ -8,27 +13,33 @@ stdenvNoCC.mkDerivation rec {
     owner = "StevenBlack";
     repo = "hosts";
     rev = version;
-    sha256 ="01 rijzfmvwfcirz94h74bx15maqdn9m01g7q197nvzxmr1fk60yd";
+    sha256 = "01rijzfmvwfcirz94h74bx15maqdn9m01g7q197nvzxmr1fk60yd";
   };
 
   inherit allowList;
-  passAsFile = ["allowList"];
+  passAsFile = [ "allowList" ];
   buildPhase =
     let
-      py = python3.withPackages (ps: with ps;[
-        lxml beautifulsoup4
-      ]);
-    in ''
-      ln -s $allowListPath whitelist
-      ${py}/bin/python updateHostsFile.py \
-        ${lib.cli.toGNUCommandLineShell
-          {} (flags // {
-            auto = true;
-            noupdate = true;
-            out = ".";
-          })
+      py = python3.withPackages (
+        ps: with ps;[
+          lxml
+          beautifulsoup4
+        ]
+      );
+    in
+      ''
+        ln -s $allowListPath whitelist
+        ${py}/bin/python updateHostsFile.py \
+          ${lib.cli.toGNUCommandLineShell
+        {} (
+        flags // {
+          auto = true;
+          noupdate = true;
+          out = ".";
         }
-    '';
+      )
+      }
+      '';
 
   installPhase = ''
     odir=$out/share/StevenBlack-hosts

--- a/pkgs/applications/networking/StevenBlack-hosts/default.nix
+++ b/pkgs/applications/networking/StevenBlack-hosts/default.nix
@@ -44,7 +44,7 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     odir=$out/share/StevenBlack-hosts
     mkdir -p $odir
-    cp {.,$odir}/hosts
+    cp ./hosts $odir/hosts
   '';
 
   meta = with lib;{

--- a/pkgs/applications/networking/StevenBlack-hosts/default.nix
+++ b/pkgs/applications/networking/StevenBlack-hosts/default.nix
@@ -14,14 +14,14 @@ stdenvNoCC.mkDerivation rec {
   inherit whitelist;
   passAsFile = ["whitelist"];
   buildPhase =
-    let 
+    let
       py = python3.withPackages (ps: with ps;[
         lxml beautifulsoup4
       ]);
     in ''
       ln -s $whitelistPath whitelist
       ${py}/bin/python updateHostsFile.py \
-        ${lib.cli.toGNUCommandLineShell 
+        ${lib.cli.toGNUCommandLineShell
           {} (flags // {
             auto = true;
             noupdate = true;
@@ -29,14 +29,18 @@ stdenvNoCC.mkDerivation rec {
           })
         }
     '';
-  
+
   installPhase = ''
     cp hosts $out
   '';
-  
+
   meta = with lib;{
     homepage = "https://github.com/StevenBlack/hosts";
     description = "Extending and consolidating hosts files from several well-curated sources";
+    # While the python script may be MIT
+    # the various sources are under various licenses
+    # not all host sources are under free licenses,let alone permissive one
+    # https://github.com/StevenBlack/hosts#sources-of-hosts-data-unified-in-this-variant
     license = licenses.unfreeRedistributable;
     platforms = platforms.all;
   };

--- a/pkgs/applications/networking/StevenBlack-hosts/default.nix
+++ b/pkgs/applications/networking/StevenBlack-hosts/default.nix
@@ -31,7 +31,9 @@ stdenvNoCC.mkDerivation rec {
     '';
 
   installPhase = ''
-    cp hosts $out
+    odir=$out/share/StevenBlack-hosts
+    mkdir -p $odir
+    cp {.,$odir}/hosts
   '';
 
   meta = with lib;{

--- a/pkgs/applications/networking/StevenBlack-hosts/default.nix
+++ b/pkgs/applications/networking/StevenBlack-hosts/default.nix
@@ -1,5 +1,5 @@
 { stdenvNoCC, fetchFromGitHub, python3, lib
-, flags ? {} ,whitelist ? ""}:
+, flags ? {} ,allowList ? ""}:
 
 stdenvNoCC.mkDerivation rec {
   pname = "StevenBlack-hosts";
@@ -11,15 +11,15 @@ stdenvNoCC.mkDerivation rec {
     sha256 ="zQMzXci1/21PCvi8AGqyDataQl/kQJJ+jszxXd2XMQc=";
   };
 
-  inherit whitelist;
-  passAsFile = ["whitelist"];
+  inherit allowList;
+  passAsFile = ["allowList"];
   buildPhase =
     let
       py = python3.withPackages (ps: with ps;[
         lxml beautifulsoup4
       ]);
     in ''
-      ln -s $whitelistPath whitelist
+      ln -s $allowListPath whitelist
       ${py}/bin/python updateHostsFile.py \
         ${lib.cli.toGNUCommandLineShell
           {} (flags // {

--- a/pkgs/applications/networking/StevenBlack-hosts/default.nix
+++ b/pkgs/applications/networking/StevenBlack-hosts/default.nix
@@ -1,0 +1,43 @@
+{ stdenvNoCC, fetchFromGitHub, python3, lib
+, flags ? {} ,whitelist ? ""}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "StevenBlack-hosts";
+  version = "2.5.52";
+  src = fetchFromGitHub {
+    owner = "StevenBlack";
+    repo = "hosts";
+    rev = version;
+    sha256 ="zQMzXci1/21PCvi8AGqyDataQl/kQJJ+jszxXd2XMQc=";
+  };
+
+  inherit whitelist;
+  passAsFile = ["whitelist"];
+  buildPhase =
+    let 
+      py = python3.withPackages (ps: with ps;[
+        lxml beautifulsoup4
+      ]);
+    in ''
+      ln -s $whitelistPath whitelist
+      ${py}/bin/python updateHostsFile.py \
+        ${lib.cli.toGNUCommandLineShell 
+          {} (flags // {
+            auto = true;
+            noupdate = true;
+            out = ".";
+          })
+        }
+    '';
+  
+  installPhase = ''
+    cp hosts $out
+  '';
+  
+  meta = with lib;{
+    homepage = "https://github.com/StevenBlack/hosts";
+    description = "Extending and consolidating hosts files from several well-curated sources";
+    license = licenses.unfreeRedistributable;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6469,7 +6469,7 @@ in
     tex = texlive.combined.scheme-small;
   };
 
-  StevenBlack-hosts = callPackage ../applications/networking/StevenBlack-hosts {};
+  stevenblack-hosts = callPackage ../applications/networking/StevenBlack-hosts { };
 
   sleuthkit = callPackage ../tools/system/sleuthkit {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6469,6 +6469,8 @@ in
     tex = texlive.combined.scheme-small;
   };
 
+  StevenBlack-hosts = callPackage ../applications/networking/StevenBlack-hosts {};
+
   sleuthkit = callPackage ../tools/system/sleuthkit {};
 
   sleepyhead = callPackage ../applications/misc/sleepyhead {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adbloking based on @StevenBlack 's excellent hosts file

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
