### PR TITLE
python3Packages.csvs-to-sqlite: remove pandas version constraint

### DIFF
--- a/pkgs/development/python-modules/csvs-to-sqlite/default.nix
+++ b/pkgs/development/python-modules/csvs-to-sqlite/default.nix
@@ -23,6 +23,11 @@ buildPythonPackage rec {
     sha256 = "0n80y9a6qhbhhbz64jdpscx0nha9jn9nygp9nkgszmw04ri5j5hm";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace pandas~=0.25.0 pandas
+  '';
+
   propagatedBuildInputs = [
     click
     dateparser


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/80121
2 package built:
csvs-to-sqlite python38Packages.csvs-to-sqlite
```