### PR TITLE
python3Packages.fastparquet: 0.3.2 -> 0.3.3

### DIFF
--- a/pkgs/development/python-modules/fastparquet/default.nix
+++ b/pkgs/development/python-modules/fastparquet/default.nix
@@ -3,13 +3,13 @@ thrift, pytest, python-snappy, lz4 }:
 
 buildPythonPackage rec {
   pname = "fastparquet";
-  version = "0.3.2";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = pname;
     rev = version;
-    sha256 = "142kmyddaq6mvmca23abwns1csn8f3lk9c8mbxwxrg4wa1dh0lb4";
+    sha256 = "1vnxr4r0bia2zi9csjw342l507nic6an4hr5xb3a36ggqlbaa0g5";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
fixes build with new pandas

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[2 built (2 failed), 0.0 MiB DL]
error: build of '/nix/store/9pjd33yzyck27hgpzvparwj0l4kjdgv4-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/80123
2 package failed to build:
python37Packages.datashader python38Packages.datashader

2 package built:
python37Packages.fastparquet python38Packages.fastparquet
```