### PR TITLE
corrected postgresql support for gdal 3.0+

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
   # - teach gdal that libdf is the legacy name for libhdf
   preConfigure = ''
     substituteInPlace configure \
-    --replace "-lmfhdf -ldf" "-lmfhdf -lhdf"
+      --replace "-lmfhdf -ldf" "-lmfhdf -lhdf"
   '';
 
   preBuild = ''

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch, unzip, libjpeg, libtiff, zlib, postgresql
 , libmysqlclient, libgeotiff, pythonPackages, proj, geos, openssl, libpng
 , sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat, libiconv, libxml2
-, autoreconfHook, netcdfSupport ? true, netcdf, hdf5, curl }:
+, autoreconfHook, netcdfSupport ? true, netcdf, hdf5, curl, pkg-config }:
 
 with stdenv.lib;
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "source/gdal";
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [
     unzip
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
     giflib
     expat
     libxml2
+    postgresql
   ] ++ (with pythonPackages; [ python numpy wrapPython ])
     ++ stdenv.lib.optional stdenv.isDarwin libiconv
     ++ stdenv.lib.optionals netcdfSupport [ netcdf hdf5 curl ];
@@ -47,7 +48,7 @@ stdenv.mkDerivation rec {
     "--with-png=${libpng.dev}" # optional
     "--with-poppler=${poppler.dev}" # optional
     "--with-libz=${zlib.dev}" # optional
-    "--with-pg=${postgresql}/bin/pg_config"
+    "--with-pg=yes" # since gdal 3.0 doesn't use ${postgresql}/bin/pg_config
     "--with-mysql=${libmysqlclient}/bin/mysql_config"
     "--with-geotiff=${libgeotiff}"
     "--with-sqlite3=${sqlite.dev}"

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,9 +1,7 @@
-{ stdenv, fetchFromGitHub, fetchpatch, unzip, libjpeg, libtiff, zlib
-, postgresql, libmysqlclient, libgeotiff, pythonPackages, proj, geos, openssl
-, libpng, sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat
-, libiconv, libxml2, autoreconfHook
-, netcdfSupport ? true, netcdf, hdf5, curl
-}:
+{ stdenv, fetchFromGitHub, fetchpatch, unzip, libjpeg, libtiff, zlib, postgresql
+, libmysqlclient, libgeotiff, pythonPackages, proj, geos, openssl, libpng
+, sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat, libiconv, libxml2
+, autoreconfHook, netcdfSupport ? true, netcdf, hdf5, curl }:
 
 with stdenv.lib;
 
@@ -22,27 +20,41 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  buildInputs = [ unzip libjpeg libtiff libpng proj openssl sqlite
-    libspatialite libgeotiff poppler hdf4 qhull giflib expat libxml2 ]
-  ++ (with pythonPackages; [ python numpy wrapPython ])
-  ++ stdenv.lib.optional stdenv.isDarwin libiconv
-  ++ stdenv.lib.optionals netcdfSupport [ netcdf hdf5 curl ];
+  buildInputs = [
+    unzip
+    libjpeg
+    libtiff
+    libpng
+    proj
+    openssl
+    sqlite
+    libspatialite
+    libgeotiff
+    poppler
+    hdf4
+    qhull
+    giflib
+    expat
+    libxml2
+  ] ++ (with pythonPackages; [ python numpy wrapPython ])
+    ++ stdenv.lib.optional stdenv.isDarwin libiconv
+    ++ stdenv.lib.optionals netcdfSupport [ netcdf hdf5 curl ];
 
   configureFlags = [
     "--with-expat=${expat.dev}"
     "--with-jpeg=${libjpeg.dev}"
     "--with-libtiff=${libtiff.dev}" # optional (without largetiff support)
-    "--with-png=${libpng.dev}"      # optional
+    "--with-png=${libpng.dev}" # optional
     "--with-poppler=${poppler.dev}" # optional
-    "--with-libz=${zlib.dev}"       # optional
+    "--with-libz=${zlib.dev}" # optional
     "--with-pg=${postgresql}/bin/pg_config"
     "--with-mysql=${libmysqlclient}/bin/mysql_config"
     "--with-geotiff=${libgeotiff}"
     "--with-sqlite3=${sqlite.dev}"
     "--with-spatialite=${libspatialite}"
-    "--with-python"               # optional
+    "--with-python" # optional
     "--with-proj=${proj.dev}" # optional
-    "--with-geos=${geos}/bin/geos-config"# optional
+    "--with-geos=${geos}/bin/geos-config" # optional
     "--with-hdf4=${hdf4.dev}" # optional
     "--with-xml2=${libxml2.dev}/bin/xml2-config" # optional
     (if netcdfSupport then "--with-netcdf=${netcdf}" else "")
@@ -55,9 +67,9 @@ stdenv.mkDerivation rec {
   # - Unset CC and CXX as they confuse libtool.
   # - teach gdal that libdf is the legacy name for libhdf
   preConfigure = ''
-      substituteInPlace configure \
-      --replace "-lmfhdf -ldf" "-lmfhdf -lhdf"
-    '';
+    substituteInPlace configure \
+    --replace "-lmfhdf -ldf" "-lmfhdf -lhdf"
+  '';
 
   preBuild = ''
     substituteInPlace swig/python/GNUmakefile \
@@ -72,7 +84,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Translator library for raster geospatial data formats";
-    homepage = https://www.gdal.org/;
+    homepage = "https://www.gdal.org/";
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
     platforms = with stdenv.lib.platforms; linux ++ darwin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11487,7 +11487,9 @@ in
     libXpm = null;
   };
 
-  gdal = callPackage ../development/libraries/gdal { };
+  gdal = callPackage ../development/libraries/gdal {
+    pythonPackages = python3Packages; 
+  };
 
   gdal_1_11 = callPackage ../development/libraries/gdal/gdal-1_11.nix { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Configure parameters for PostgreSQL support in GDAL has changes since 3.0, see https://github.com/OSGeo/gdal/issues/1657.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
