### PR TITLE
python3Packages.openapi-spec-validator: add setuptools

### DIFF
--- a/pkgs/development/python-modules/openapi-spec-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-spec-validator/default.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonPackage, isPy27, fetchPypi
 , jsonschema, pyyaml, six, pathlib
-, mock, pytest, pytestcov, pytest-flake8, tox }:
+, mock, pytest, pytestcov, pytest-flake8, tox, setuptools }:
 
 buildPythonPackage rec {
   pname = "openapi-spec-validator";
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "1kav0jlgdpgwx4am09ja7cr8s1g8h8a7j8mcfy1cfjr8fficg2g4";
   };
 
-  propagatedBuildInputs = [ jsonschema pyyaml six ]
+  propagatedBuildInputs = [ jsonschema pyyaml six setuptools ]
     ++ (lib.optionals (isPy27) [ pathlib ]);
 
   checkInputs = [ mock pytest pytestcov pytest-flake8 tox ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fails to run:
```
openapi-spec-validator --help
Traceback (most recent call last):
  File "/nix/store/1kqp8dslskvhzj60y4h13hf3ys5ha11p-python3.7-openapi-spec-validator-0.2.8/bin/.openapi-spec-validator-wrapped", line 6, in <module>
    from openapi_spec_validator.__main__ import main
  File "/nix/store/1kqp8dslskvhzj60y4h13hf3ys5ha11p-python3.7-openapi-spec-validator-0.2.8/lib/python3.7/site-packages/openapi_spec_validator/__init__.py", line 6, in <module>
    from openapi_spec_validator.schemas import get_openapi_schema
  File "/nix/store/1kqp8dslskvhzj60y4h13hf3ys5ha11p-python3.7-openapi-spec-validator-0.2.8/lib/python3.7/site-packages/openapi_spec_validator/schemas.py", line 4, in <module>
    from pkg_resources import resource_filename
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
