### PR TITLE
pythonPackages.robotframework-debuglibrary: init at 1.2

### DIFF
--- a/pkgs/development/python-modules/robotframework-debuglibrary/default.nix
+++ b/pkgs/development/python-modules/robotframework-debuglibrary/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, prompt_toolkit
+, pygments
+, robotframework
+}:
+buildPythonPackage rec {
+  version = "1.2";
+  pname = "robotframework-debuglibrary";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a464f1241d8ea113468119936789ffaf6b49714769fd5f3dde236de2ddee208c";
+  };
+  # unit tests are impure
+  doCheck = false;
+  propagatedBuildInputs = [
+    prompt_toolkit
+    pygments
+    robotframework
+  ];
+  meta = with stdenv.lib; {
+    description = "Robotframework-DebugLibrary is a debug library for RobotFramework";
+    homepage = https://github.com/xyb/robotframework-debuglibrary/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ talkara ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1487,7 +1487,7 @@ in {
   webapp2 = callPackage ../development/python-modules/webapp2 { };
 
   wordcloud = callPackage ../development/python-modules/wordcloud { };
-  
+
   wrf-python = callPackage ../development/python-modules/wrf-python { };
 
   pyunbound = callPackage ../tools/networking/unbound/python.nix { };
@@ -1681,7 +1681,7 @@ in {
 
   asn1ate = callPackage ../development/python-modules/asn1ate { };
 
-  atlassian-python-api = callPackage ../development/python-modules/atlassian-python-api { };  
+  atlassian-python-api = callPackage ../development/python-modules/atlassian-python-api { };
 
   atomiclong = callPackage ../development/python-modules/atomiclong { };
 
@@ -4375,7 +4375,7 @@ in {
 
   nbconvert = callPackage ../development/python-modules/nbconvert { };
 
-  nbformat = if isPy3k then 
+  nbformat = if isPy3k then
     callPackage ../development/python-modules/nbformat { }
   else callPackage ../development/python-modules/nbformat/2.nix { };
 
@@ -5342,6 +5342,8 @@ in {
   robotframework = callPackage ../development/python-modules/robotframework { };
 
   robotframework-databaselibrary = callPackage ../development/python-modules/robotframework-databaselibrary { };
+
+  robotframework-debuglibrary = callPackage ../development/python-modules/robotframework-debuglibrary { };
 
   robotframework-requests = callPackage ../development/python-modules/robotframework-requests { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
