### PR TITLE
ogdf: init at 2020.02

### DIFF
--- a/pkgs/development/libraries/ogdf/default.nix
+++ b/pkgs/development/libraries/ogdf/default.nix
@@ -1,27 +1,25 @@
 { stdenv, fetchFromGitHub, cmake, doxygen }:
 
 stdenv.mkDerivation rec {
-  name = "ogdf-${version}";
+  pname = "ogdf";
   version = "2020.02";
   src = fetchFromGitHub {
-    owner = "ogdf";
-    repo = "ogdf";
-    rev = "be4452b6c36575d11a04d5bb1b362edeb8173eaa";
+    owner = pname;
+    repo = pname;
+    rev = "catalpa-202002";
     sha256 = "0drrs8zh1097i5c60z9g658vs9k1iinkav8crlwk722ihfm1vxqd";
   };
 
   hardeningDisable = [ "all" ];
   nativeBuildInputs = [ cmake doxygen ];
-  cmakeFlags = [ "-DOGDF_WARNING_ERRORS=OFF"
-                 "-DCMAKE_CXX_FLAGS=-fPIC"
-               ];
+  cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-fPIC" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Open Graph Drawing Framework/Open Graph algorithms and Data structure Framework";
-    homepage = http://www.ogdf.net;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ ianwookim ];
-    platforms = stdenv.lib.platforms.all;
+    homepage = "http://www.ogdf.net";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.ianwookim ];
+    platforms = platforms.all;
     longDescription = ''
       OGDF stands both for Open Graph Drawing Framework (the original name) and
       Open Graph algorithms and Data structures Framework.

--- a/pkgs/development/libraries/ogdf/default.nix
+++ b/pkgs/development/libraries/ogdf/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.ogdf.net";
     license = licenses.gpl2;
     maintainers = [ maintainers.ianwookim ];
-    platforms = platforms.all;
+    platforms = platforms.i686 ++ platforms.x86_64;
     longDescription = ''
       OGDF stands both for Open Graph Drawing Framework (the original name) and
       Open Graph algorithms and Data structures Framework.

--- a/pkgs/development/libraries/ogdf/default.nix
+++ b/pkgs/development/libraries/ogdf/default.nix
@@ -10,7 +10,13 @@ stdenv.mkDerivation rec {
     sha256 = "0drrs8zh1097i5c60z9g658vs9k1iinkav8crlwk722ihfm1vxqd";
   };
 
-  hardeningDisable = [ "all" ];
+  # Without disabling hardening for format, the build fails with
+  # the following error.
+  #> /build/source/src/coin/CoinUtils/CoinMessageHandler.cpp:766:35: error: format not a string literal and no format arguments [-Werror=format-security]
+  #> 766 |      sprintf(messageOut_,format_+2);
+
+  hardeningDisable = [ "format" ];
+
   nativeBuildInputs = [ cmake doxygen ];
   cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-fPIC" ];
 

--- a/pkgs/development/libraries/ogdf/default.nix
+++ b/pkgs/development/libraries/ogdf/default.nix
@@ -3,6 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "ogdf";
   version = "2020.02";
+
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
@@ -10,15 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "0drrs8zh1097i5c60z9g658vs9k1iinkav8crlwk722ihfm1vxqd";
   };
 
+  nativeBuildInputs = [ cmake doxygen ];
+
+  cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-fPIC" ];
+
   # Without disabling hardening for format, the build fails with
   # the following error.
   #> /build/source/src/coin/CoinUtils/CoinMessageHandler.cpp:766:35: error: format not a string literal and no format arguments [-Werror=format-security]
   #> 766 |      sprintf(messageOut_,format_+2);
-
   hardeningDisable = [ "format" ];
-
-  nativeBuildInputs = [ cmake doxygen ];
-  cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-fPIC" ];
 
   meta = with stdenv.lib; {
     description = "Open Graph Drawing Framework/Open Graph algorithms and Data structure Framework";
@@ -39,5 +40,4 @@ stdenv.mkDerivation rec {
       University of Cologne, University of Konstanz, and TU Ilmenau.
     '';
    };
-
 }

--- a/pkgs/development/libraries/ogdf/default.nix
+++ b/pkgs/development/libraries/ogdf/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, cmake, doxygen }:
+
+stdenv.mkDerivation rec {
+  name = "ogdf-${version}";
+  version = "2020.02";
+  src = fetchFromGitHub {
+    owner = "ogdf";
+    repo = "ogdf";
+    rev = "be4452b6c36575d11a04d5bb1b362edeb8173eaa";
+    sha256 = "0drrs8zh1097i5c60z9g658vs9k1iinkav8crlwk722ihfm1vxqd";
+  };
+
+  hardeningDisable = [ "all" ];
+  nativeBuildInputs = [ cmake doxygen ];
+  cmakeFlags = [ "-DOGDF_WARNING_ERRORS=OFF"
+                 "-DCMAKE_CXX_FLAGS=-fPIC"
+               ];
+
+  meta = {
+    description = "Open Graph Drawing Framework/Open Graph algorithms and Data structure Framework";
+    homepage = http://www.ogdf.net;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ ianwookim ];
+    platforms = stdenv.lib.platforms.all;
+    longDescription = ''
+      OGDF stands both for Open Graph Drawing Framework (the original name) and
+      Open Graph algorithms and Data structures Framework.
+
+      OGDF is a self-contained C++ library for graph algorithms, in particular
+      for (but not restricted to) automatic graph drawing. It offers sophisticated
+      algorithms and data structures to use within your own applications or
+      scientific projects.
+
+      OGDF is developed and supported by Osnabrück University, TU Dortmund,
+      University of Cologne, University of Konstanz, and TU Ilmenau.
+    '';
+   };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5461,6 +5461,8 @@ in
 
   ofono-phonesim = libsForQt5.callPackage ../development/tools/ofono-phonesim/default.nix { };
 
+  ogdf = callPackage ../development/libraries/ogdf { };
+
   oh-my-zsh = callPackage ../shells/zsh/oh-my-zsh { };
 
   ola = callPackage ../applications/misc/ola { };


### PR DESCRIPTION
###### Motivation for this change
OGDF: Open Graph Drawing Framework C++ library is initially packaged.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
