### PR TITLE
fixed QT problem

### DIFF
--- a/pkgs/applications/radio/inspectrum/default.nix
+++ b/pkgs/applications/radio/inspectrum/default.nix
@@ -7,9 +7,11 @@
 , qt5
 , gnuradio
 , liquid-dsp
+, mkDerivation
+, wrapQtAppsHook
 }:
 
-stdenv.mkDerivation {
+mkDerivation {
   name = "inspectrum-unstable-2017-05-31";
 
   src = fetchFromGitHub {
@@ -19,7 +21,7 @@ stdenv.mkDerivation {
     sha256 = "1fvnr8gca25i6s9mg9b2hyqs0zzr4jicw13mimc9dhrgxklrr1yv";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig wrapQtAppsHook ];
   buildInputs = [
     cmake
     qt5.qtbase

--- a/pkgs/applications/radio/inspectrum/default.nix
+++ b/pkgs/applications/radio/inspectrum/default.nix
@@ -1,18 +1,18 @@
-{ stdenv
+{ lib
+, mkDerivation
 , fetchFromGitHub
 , pkgconfig
 , cmake
 , boost
 , fftwFloat
-, qt5
 , gnuradio
 , liquid-dsp
-, mkDerivation
-, wrapQtAppsHook
+, qtbase
 }:
 
 mkDerivation {
-  name = "inspectrum-unstable-2017-05-31";
+  pname = "inspectrum";
+  version = "unstable-2017-05-31";
 
   src = fetchFromGitHub {
     owner = "miek";
@@ -21,19 +21,18 @@ mkDerivation {
     sha256 = "1fvnr8gca25i6s9mg9b2hyqs0zzr4jicw13mimc9dhrgxklrr1yv";
   };
 
-  nativeBuildInputs = [ pkgconfig wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
-    cmake
-    qt5.qtbase
     fftwFloat
     boost
     gnuradio
     liquid-dsp
+    qtbase
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Tool for analysing captured signals from sdr receivers";
-    homepage = https://github.com/miek/inspectrum;
+    homepage = "https://github.com/miek/inspectrum";
     maintainers = with maintainers; [ mog ];
     platforms = platforms.linux;
     license = licenses.gpl3Plus;


### PR DESCRIPTION
###### Motivation for this change
`inspectrum` wasn't working. It would throw the following error:
```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

###### Things done
I tried to follow the instructions outlined in #65399
This is my first time commiting to `nixpkgs`, so please let me know if I did anything wrong.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).