### PR TITLE
dstat: fix pluginpath

### DIFF
--- a/pkgs/os-specific/linux/dstat/default.nix
+++ b/pkgs/os-specific/linux/dstat/default.nix
@@ -12,6 +12,8 @@ python2Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python2Packages; [ python-wifi ];
 
+  patches = [ ./fix_pluginpath.patch ];
+
   makeFlags = [ "prefix=$(out)" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/dstat/fix_pluginpath.patch
+++ b/pkgs/os-specific/linux/dstat/fix_pluginpath.patch
@@ -1,0 +1,15 @@
+diff --git a/dstat b/dstat
+index 3ac7087..c5f089d 100755
+--- a/dstat
++++ b/dstat
+@@ -66,9 +66,7 @@ if sys.version_info < (2, 3):
+ 
+ pluginpath = [
+     os.path.expanduser('~/.dstat/'),                                # home + /.dstat/
+-    os.path.abspath(os.path.dirname(sys.argv[0])) + '/plugins/',    # binary path + /plugins/
+-    '/usr/share/dstat/',
+-    '/usr/local/share/dstat/',
++    os.path.abspath(os.path.dirname(sys.argv[0])) + '/../share/dstat/', # binary path + /../share/dstat/
+ ]
+ 
+ class Options:


### PR DESCRIPTION
##### Motivation for this change
`dstat` has a lot of plugins which are currently not usable because they're looked after in `/usr/share/dstat/`.

###### Things done
Patch `dstat` to make it find its plugins in the `share/dstat/` directory of the derivation.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
