### PR TITLE
nanod | nixos/nanod: init at 20.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5797,6 +5797,16 @@
     githubId = 4579165;
     name = "Danny Bautista";
   };
+  qasaur = {
+    email = "marcus.engvall@engvall.company";
+    github = "qasaur";
+    githubId = 1158421;
+    name = "Marcus Engvall";
+    keys = [{
+      longkeyid = "rsa4096/0x745ECB0AF17BF30C";
+      fingerprint = "9116F648B20388E300CC110C745ECB0AF17BF30C";
+    }];
+  };
   q3k = {
     email = "q3k@q3k.org";
     github = "q3k";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -650,6 +650,7 @@
   ./services/networking/mtprotoproxy.nix
   ./services/networking/murmur.nix
   ./services/networking/mxisd.nix
+  ./services/networking/nanod.nix
   ./services/networking/namecoind.nix
   ./services/networking/nat.nix
   ./services/networking/ndppd.nix

--- a/nixos/modules/services/networking/nanod.nix
+++ b/nixos/modules/services/networking/nanod.nix
@@ -1,0 +1,106 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.nanod;
+
+in {
+
+  options.services.nanod = {
+
+    enable = mkEnableOption "nanod";
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/nano";
+      description =
+        "The data directory where nanod will store its state, including the block-lattice";
+    };
+
+    nodeConfig = mkOption {
+      type = types.path;
+      description =
+        "The path to the config-node.toml file. Setting this option will overwrite any other configuration setting";
+      default = pkgs.runCommand "config-node.toml" {
+        json = builtins.toJSON cfg.nodeConfigOptions;
+        passAsFile = [ "json" ];
+      } ''
+        ${pkgs.remarshal}/bin/json2toml < $jsonPath > $out
+      '';
+      defaultText =
+        "Generates a TOML configuration from services.nanod.nodeConfigOptions";
+    };
+
+    nodeConfigOptions = mkOption {
+      type = types.attrs;
+      description =
+        "Configuration options for the nano node daemon. See: https://docs.nano.org/running-a-node/configuration/";
+      example = {
+        node = { enable-voting = true; };
+        websocket = {
+          address = "::1";
+          enable = true;
+          port = 7078;
+        };
+      };
+    };
+
+    rpcConfig = mkOption {
+      type = types.path;
+      description =
+        "The path to the config-rpc.toml file. Setting this option will overwrite any other configuration setting";
+      default = pkgs.runCommand "config-rpc.toml" {
+        json = builtins.toJSON cfg.rpcConfigOptions;
+        passAsFile = [ "json" ];
+      } ''
+        ${pkgs.remarshal}/bin/json2toml < $jsonPath > $out
+      '';
+      defaultText =
+        "Generates a TOML configuration from services.nanod.rpcConfigOptions";
+    };
+
+    rpcConfigOptions = mkOption {
+      type = types.attrs;
+      description =
+        "Configuration options for the nano node RPC interface. See: https://docs.nano.org/running-a-node/configuration/";
+      example = {
+        enable-control = true;
+        address = "::1";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.nanod = {
+      name = "nanod";
+      group = "nanod";
+      uid = config.ids.uids.nanod;
+      description = "nanod daemon user";
+    };
+    users.groups.nanod.gid = config.ids.gids.nanod;
+
+    systemd.services.nanod = {
+      description = "NANO node daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = ''
+        cp ${nodeConfig} ${cfg.dataDir}/config-node.toml
+        cp ${rpcConfig} ${cfg.dataDir}/config-rpc.toml
+      '';
+
+      serviceConfig = {
+        User = "nanod";
+        Group = "nanod";
+        ExecStart = "${pkgs.nanod}/bin/nanod --data_path ${cfg.dataDir}";
+        ExecReload = "${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
+        Restart = "on-failure";
+
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectSystem = "full";
+        NoNewPrivileges = true;
+      };
+    };
+  };
+}

--- a/pkgs/applications/blockchains/nanod/CMakeLists.txt.patch
+++ b/pkgs/applications/blockchains/nanod/CMakeLists.txt.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b43f02f6..4470abbf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,7 +119,7 @@ endif (RAIBLOCKS_SECURE_RPC)
+ 
+ include_directories (${CMAKE_SOURCE_DIR})
+ 
+-set(Boost_USE_STATIC_LIBS        ON)
++add_definitions(-DBOOST_LOG_DYN_LINK)
+ set(Boost_USE_MULTITHREADED      ON)
+ 
+ if (BOOST_CUSTOM)

--- a/pkgs/applications/blockchains/nanod/default.nix
+++ b/pkgs/applications/blockchains/nanod/default.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkgconfig, boost, darwin, ocl-icd, opencl-headers, Foundation, OpenCL}:
+
+stdenv.mkDerivation rec {
+
+  pname = "nanod";
+  version = "20.0";
+
+  src = fetchFromGitHub {
+    owner = "nanocurrency";
+    repo = "nano-node";
+    rev = "V${version}";
+    sha256 = "12nrjjd89yjzx20d85ccmp395pl0djpx0x0qb8dgka8xfy11k7xn";
+    fetchSubmodules = true;
+  };
+
+  # Use a patch to force dynamic linking
+  patches = [
+    ./CMakeLists.txt.patch
+  ];
+
+  cmakeFlags = let
+    options = {
+      BOOST_ROOT = boost;
+      Boost_USE_STATIC_LIBS = "OFF";
+    };
+    optionToFlag = name: value: "-D${name}=${value}";
+  in lib.mapAttrsToList optionToFlag options;
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ boost ]
+                ++ stdenv.lib.optionals (!stdenv.isDarwin) [ ocl-icd opencl-headers ]
+                ++ stdenv.lib.optionals stdenv.isDarwin [ Foundation OpenCL ];
+
+  buildPhase = ''
+    make nano_node
+  '';
+
+  # Move executables under bin directory
+  postInstall = ''
+    mkdir -p $out/bin
+    mv nano_node $out/bin/nanod
+  '';
+
+  meta = {
+    inherit version;
+    description = "Nano is a digital payment protocol designed to be accessible and lightweight";
+    longDescription = "This package includes the Nano node software (nanod) that enables a machine to participate as a node on the live Nano network.";
+    homepage = https://nano.org;
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ qasaur ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22693,6 +22693,10 @@ in
 
   nano-wallet = libsForQt5.callPackage ../applications/blockchains/nano-wallet { };
 
+  nanod = callPackage ../applications/blockchains/nanod {
+    inherit (darwin.apple_sdk.frameworks) Foundation OpenCL;
+  };
+
   namecoin  = callPackage ../applications/blockchains/namecoin.nix  { withGui = true; };
   namecoind = callPackage ../applications/blockchains/namecoin.nix { withGui = false; };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This change introduces `nanod`, which is the daemon that is used to participate on the nano cryptocurrency network. Much of the derivation is based off the `nano-wallet` package that already exists in `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
