### PR TITLE
nixos/top-level: attrs -> attrsOf for system.build

### DIFF
--- a/nixos/modules/security/lock-kernel-modules.nix
+++ b/nixos/modules/security/lock-kernel-modules.nix
@@ -27,7 +27,7 @@ with lib;
           if x.fsType == "vfat"
             then [ "vfat" "nls-cp437" "nls-iso8859-1" ]
             else [ x.fsType ]
-        else []) config.system.build.fileSystems;
+        else []) config.system.fileSystems;
 
     systemd.services.disable-kernel-module-loading = rec {
       description = "Disable kernel module loading";

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -147,7 +147,7 @@ in
     system.build = mkOption {
       internal = true;
       default = {};
-      type = types.attrs;
+      type = with types; lazyAttrsOf unspecified;
       description = ''
         Attribute set of derivations used to setup the system.
       '';

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -29,7 +29,7 @@ let
   # The initrd only has to mount `/` or any FS marked as necessary for
   # booting (such as the FS containing `/nix/store`, or an FS needed for
   # mounting `/`, like `/` on a loopback).
-  fileSystems = filter utils.fsNeededForBoot config.system.build.fileSystems;
+  fileSystems = filter utils.fsNeededForBoot config.system.fileSystems;
 
   # A utility for enumerating the shared-library dependencies of a program
   findLibs = pkgs.buildPackages.writeShellScriptBin "find-libs" ''

--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  fileSystems = config.system.build.fileSystems ++ config.swapDevices;
+  fileSystems = config.system.fileSystems ++ config.swapDevices;
   encDevs = filter (dev: dev.encrypted.enable) fileSystems;
   keyedEncDevs = filter (dev: dev.encrypted.keyFile != null) encDevs;
   keylessEncDevs = filter (dev: dev.encrypted.keyFile == null) encDevs;

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -178,6 +178,15 @@ in
       '';
     };
 
+    system.fileSystems = mkOption {
+      internal = true;
+      default = [];
+      type = with types; listOf unspecified;
+      description = ''
+        Topologically ordered list of config.fileSystems
+      '';
+    };
+
     system.fsPackages = mkOption {
       internal = true;
       default = [ ];
@@ -223,7 +232,7 @@ in
     ];
 
     # Export for use in other modules
-    system.build.fileSystems = fileSystems;
+    system.fileSystems = fileSystems;
     system.build.earlyMountScript = makeSpecialMounts (toposort fsBefore (attrValues config.boot.specialFileSystems)).result;
 
     boot.supportedFilesystems = map (fs: fs.fsType) fileSystems;

--- a/nixos/modules/tasks/filesystems/f2fs.nix
+++ b/nixos/modules/tasks/filesystems/f2fs.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   inInitrd = any (fs: fs == "f2fs") config.boot.initrd.supportedFilesystems;
-  fileSystems = filter (x: x.fsType == "f2fs") config.system.build.fileSystems;
+  fileSystems = filter (x: x.fsType == "f2fs") config.build.fileSystems;
 in
 {
   config = mkIf (any (fs: fs == "f2fs") config.boot.supportedFilesystems) {

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -39,7 +39,7 @@ let
 
   fsToPool = fs: datasetToPool fs.device;
 
-  zfsFilesystems = filter (x: x.fsType == "zfs") config.system.build.fileSystems;
+  zfsFilesystems = filter (x: x.fsType == "zfs") config.system.fileSystems;
 
   allPools = unique ((map fsToPool zfsFilesystems) ++ cfgZfs.extraPools);
 
@@ -467,7 +467,7 @@ in
 
       systemd.services = let
         getPoolFilesystems = pool:
-          filter (x: x.fsType == "zfs" && (fsToPool x) == pool) config.system.build.fileSystems;
+          filter (x: x.fsType == "zfs" && (fsToPool x) == pool) config.system.fileSystems;
 
         getPoolMounts = pool:
           let


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/62856

But to make it work I've chosen to extract `system.build.fileSystems` into separate option. Let me know if making `with types; lazyAttrsOf unspecified` is more favorable.

EDIT: this is now changed to `attrsOf unspecified`, due to manual present in `system.build`.