### PR TITLE
nixos-containers: fix atomic restart

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -129,7 +129,6 @@ let
       # Run systemd-nspawn without startup notification (we'll
       # wait for the container systemd to signal readiness).
       exec ${config.systemd.package}/bin/systemd-nspawn \
-        --keep-unit \
         -M "$INSTANCE" -D "$root" $extraFlags \
         $EXTRA_NSPAWN_FLAGS \
         --notify-ready=yes \

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -158,9 +158,6 @@ let
 
   preStartScript = cfg:
     ''
-      # Clean up existing machined registration and interfaces.
-      machinectl terminate "$INSTANCE" 2> /dev/null || true
-
       if [ -n "$HOST_ADDRESS" ]  || [ -n "$LOCAL_ADDRESS" ] ||
          [ -n "$HOST_ADDRESS6" ] || [ -n "$LOCAL_ADDRESS6" ]; then
         ip link del dev "ve-$INSTANCE" 2> /dev/null || true
@@ -710,6 +707,7 @@ in
 
       preStop = "machinectl poweroff $INSTANCE";
 
+      stopIfChanged = false;
       restartIfChanged = false;
 
       serviceConfig = serviceDirectives dummyConfig;

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -91,6 +91,9 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       with subtest("Start one of them"):
           machine.succeed(f"nixos-container start {id1}")
 
+      with subtest("Perform atomic restart"):
+          machine.succeed(f"systemctl restart container@{id1}")
+
       with subtest("Execute commands via the root shell"):
           assert "Linux" in machine.succeed(f"nixos-container run {id1} -- uname")
 


### PR DESCRIPTION
nixos containers: remove --keep-unit (revert 810680bcae1f8ca23744544e87fbf03b705e9493)
    
Fixes https://github.com/NixOS/nixpkgs/issues/43652
Fixes https://github.com/NixOS/nixpkgs/issues/16753
Alternative fix for https://github.com/NixOS/nixpkgs/pull/39717
The fix in https://github.com/NixOS/nixpkgs/pull/76719 was not enough
    
    `--keep-unit` ties systemd-nspawn container to systemd unit. When
    unit is restarted (ie atomic operation "restart", not two separate
    "stop" and "start") systemd assumes that unit didn't disappear.
    Hence machine didn't disappear. Though it may as well be systemd bug
    that machine is left in `closing` state forever.
    
    If unit is stopped (or stopped due to failure), associated machine is also stopped,
    so service can start fresh.
    
    When --keep-unit is removed, resource slice isn't changed though - it is machine.slice by default for
    nspawn containers.

cc @erikarvstedt @peterhoeg @flokli @edolstra 