### PR TITLE
bash_5, readline80: 5p11 -> 5p16, 8p1 -> 8p4 (latest batch of patches)

### DIFF
--- a/pkgs/development/libraries/readline/readline-8.0-patches.nix
+++ b/pkgs/development/libraries/readline/readline-8.0-patches.nix
@@ -2,4 +2,7 @@
 
 patch: [
 (patch "001" "0sfh7wn0pr743xspnb1zndxndlv9rc0hcg14cbw5cmyg6f4ykrfq")
+(patch "002" "1xy8mv8xm8hsfixwp3ci9kfx3dii3y92cq27wwd0jq75y6zzxc1n")
+(patch "003" "1vza7sxjcsr2z295ij12nzgncdil1vb6as3mqy4m7svi1chv5pcl")
+(patch "004" "0k1rfx9w32lglxg564yvp0mw6jg6883p8ac2f2lxxqpf80m3vami")
 ]

--- a/pkgs/shells/bash/bash-5.0-patches.nix
+++ b/pkgs/shells/bash/bash-5.0-patches.nix
@@ -12,4 +12,9 @@ patch: [
 (patch "009" "00yrjjqd95s81b21qq3ba1y7h879q8jaajlkjggc6grhcwbs4g7d")
 (patch "010" "04ca5bjv456v538mkspzvn4xb2zdphh31r4fpvfm9p5my0jw7yyn")
 (patch "011" "1sklyixvsv8993kxzs0jigacpdchjrq7jv5xpdx7kbqyp4rf6k9c")
+(patch "012" "0cz21qg2gbr40lfgza7g02bqi2qknwqgxnq459pjj640d0cywhr9")
+(patch "013" "16h9nwz3yzwj7fnxvlidjymdc4yr30h818433gh9j1x3in6igmzm")
+(patch "014" "12gm5bvv2pd3m72z2ilj26pa08c61az253dsgfl24vpf2ijywvjx")
+(patch "015" "0pm0px758w4i23s55wajcv6lqfiym7zgxvq0pxf6vclkv8nxy5x5")
+(patch "016" "0vdha332km2iwx8g2ld15jy7d24cbplzgr1531dpzylr9ajxglgz")
 ]


### PR DESCRIPTION
###### Motivation for this change

Various upstream fixes, links to patches in commit messages FWIW :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).