### PR TITLE
gitea 1.10.3 -> 1.11.0

### DIFF
--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -8,13 +8,13 @@ with stdenv.lib;
 
 buildGoPackage rec {
   pname = "gitea";
-  version = "1.10.3";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "go-gitea";
     repo = "gitea";
     rev = "v${version}";
-    sha256 = "04jg1b0d1fbhnk434dnffc2c118gs084za3m33lxwf5lxzlbbimc";
+    sha256 = "1gjmaf5hcq06ckx649byf9ckz5x2mmqnjl5bgrhh5v37m5ajllf7";
     # Required to generate the same checksum on MacOS due to unicode encoding differences
     # More information: https://github.com/NixOS/nixpkgs/pull/48128
     extraPostFetch = ''

--- a/pkgs/applications/version-management/gitea/static-root-path.patch
+++ b/pkgs/applications/version-management/gitea/static-root-path.patch
@@ -1,13 +1,13 @@
-diff --git i/modules/setting/setting.go w/modules/setting/setting.go
-index aafe2d1b..1e4a8064 100644
---- i/modules/setting/setting.go
-+++ w/modules/setting/setting.go
-@@ -730,7 +730,7 @@ func NewContext() {
- 	LocalURL = sec.Key("LOCAL_ROOT_URL").MustString(defaultLocalURL)
+diff --git a/modules/setting/setting.go b/modules/setting/setting.go
+index 714015c47..a2f85337e 100644
+--- a/modules/setting/setting.go
++++ b/modules/setting/setting.go
+@@ -641,7 +641,7 @@ func NewContext() {
+ 	PortToRedirect = sec.Key("PORT_TO_REDIRECT").MustString("80")
  	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
  	DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
 -	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString(AppWorkPath)
 +	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString("@data@")
-	AppDataPath = sec.Key("APP_DATA_PATH").MustString(path.Join(AppWorkPath, "data"))
+ 	StaticCacheTime = sec.Key("STATIC_CACHE_TIME").MustDuration(6 * time.Hour)
+ 	AppDataPath = sec.Key("APP_DATA_PATH").MustString(path.Join(AppWorkPath, "data"))
  	EnableGzip = sec.Key("ENABLE_GZIP").MustBool()
- 	EnablePprof = sec.Key("ENABLE_PPROF").MustBool(false)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Gitea major update: https://blog.gitea.io/2020/02/gitea-1.11.0-is-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
