### PR TITLE
libvdpau: 1.2 -> 1.3, vdpauinfo: 1.0 -> 1.3

### DIFF
--- a/pkgs/development/libraries/libvdpau/default.nix
+++ b/pkgs/development/libraries/libvdpau/default.nix
@@ -1,27 +1,26 @@
-{ stdenv, fetchurl, pkgconfig, xorg, mesa }:
+{ stdenv, fetchurl, pkgconfig, xorg, mesa, meson, ninja }:
 
 stdenv.mkDerivation rec {
   pname = "libvdpau";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchurl {
-    url = "https://gitlab.freedesktop.org/vdpau/libvdpau/uploads/14b620084c027d546fa0b3f083b800c6/${pname}-${version}.tar.bz2";
-    sha256 = "6a499b186f524e1c16b4f5b57a6a2de70dfceb25c4ee546515f26073cd33fa06";
+    url = "https://gitlab.freedesktop.org/vdpau/libvdpau/-/archive/${version}/${pname}-${version}.tar.bz2";
+    sha256 = "b5a52eeac9417edbc396f26c40591ba5df0cd18285f68d84614ef8f06196e50e";
   };
+  patches = [ ./installdir.patch ];
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkgconfig ];
   buildInputs = with xorg; [ xorgproto libXext ];
 
   propagatedBuildInputs = [ xorg.libX11 ];
 
-  configureFlags = stdenv.lib.optional stdenv.isLinux
-    "--with-module-dir=${mesa.drivers.driverLink}/lib/vdpau";
+  mesonFlags = stdenv.lib.optional stdenv.isLinux
+    [ "-Dmoduledir=${mesa.drivers.driverLink}/lib/vdpau" ];
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lX11";
-
-  installFlags = [ "moduledir=$(out)/lib/vdpau" ];
 
   meta = with stdenv.lib; {
     homepage = https://people.freedesktop.org/~aplattner/vdpau/;

--- a/pkgs/development/libraries/libvdpau/installdir.patch
+++ b/pkgs/development/libraries/libvdpau/installdir.patch
@@ -1,0 +1,9 @@
+--- a/trace/meson.build	2020-02-15 16:34:58.698832000 +0100
++++ b/trace/meson.build	2020-02-15 16:39:05.359952802 +0100
+@@ -4,5 +4,5 @@
+     dependencies : libdl,
+     version : '1.0.0',
+     install : true,
+-    install_dir : moduledir,
++    install_dir : get_option('prefix') + '/lib/libvdpau',
+ )

--- a/pkgs/tools/X11/vdpauinfo/default.nix
+++ b/pkgs/tools/X11/vdpauinfo/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, pkgconfig, libvdpau }:
 
 stdenv.mkDerivation rec {
-  name = "vdpauinfo-1.0";
+  pname = "vdpauinfo";
+  version = "1.3";
 
   src = fetchurl {
-    url = "https://people.freedesktop.org/~aplattner/vdpau/${name}.tar.gz";
-    sha256 = "1i2b0k9h8r0lnxlrkgqzmrjakgaw3f1ygqqwzx8w6676g85rcm20";
+    url = "https://gitlab.freedesktop.org/vdpau/vdpauinfo/uploads/6fa9718c507ef0fb6966170ef55344bf/${pname}-${version}.tar.gz";
+    sha256 = "0s6jdadnycyd1agsnfx7hrf17hmipasx1fpmppd4m1z6i9sp1i6g";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
libvdpau 1.3 adds support for VP9 decoding.
Fixes #74211

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
