### PR TITLE
pythonPackages.babelgladeextractor: disable for python2

### DIFF
--- a/pkgs/development/python-modules/babelgladeextractor/default.nix
+++ b/pkgs/development/python-modules/babelgladeextractor/default.nix
@@ -9,6 +9,7 @@
 buildPythonPackage rec {
   pname = "babelgladeextractor";
   version = "0.7.0";
+  disabled = (!isPy3k); # uses python3 specific file io in setup.py
 
   src = fetchPypi {
     pname = "BabelGladeExtractor";


### PR DESCRIPTION
###### Motivation for this change
Uses python3 specific calls in setup.py:
```
  File "setup.py", line 23, in _slurp
    with open(path, encoding="utf-8") as fp:
TypeError: 'encoding' is an invalid keyword argument for this function
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
