### PR TITLE
crc-reveng: init at 2.1.0

### DIFF
--- a/pkgs/tools/security/crc-reveng/default.nix
+++ b/pkgs/tools/security/crc-reveng/default.nix
@@ -8,12 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "0d13w6xp47zdsz8x2sxm1708i6h0bis1q5b49bbw032mwk8jpklx";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace config.h --replace "BMP_BIT   32" "BMP_BIT 64"
     substituteInPlace config.h --replace "BMP_SUB   16" "BMP_SUB 32"
   '';
-
-  buildPhase = "make";
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/tools/security/crc-reveng/default.nix
+++ b/pkgs/tools/security/crc-reveng/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl }:
+stdenv.mkDerivation rec {
+  pname = "crc-reveng";
+  version = "2.1.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/reveng/${version}/reveng-${version}.tar.xz";
+    sha256 = "0d13w6xp47zdsz8x2sxm1708i6h0bis1q5b49bbw032mwk8jpklx";
+  };
+
+  patchPhase = ''
+    substituteInPlace config.h --replace "BMP_BIT   32" "BMP_BIT 64"
+    substituteInPlace config.h --replace "BMP_SUB   16" "BMP_SUB 32"
+  '';
+
+  buildPhase = "make";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./reveng $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Arbitrary-precision CRC calculator and algorithm finder";
+    homepage = "http://reveng.sourceforge.net/";
+    maintainers = with maintainers; [ btlvr ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/security/crc-reveng/default.nix
+++ b/pkgs/tools/security/crc-reveng/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = "http://reveng.sourceforge.net/";
     maintainers = with maintainers; [ btlvr ];
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.x86_64;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -855,6 +855,8 @@ in
 
   crc32c = callPackage ../development/libraries/crc32c { };
 
+  crc-reveng = callPackage ../tools/security/crc-reveng { };
+
   cue = callPackage ../development/tools/cue { };
 
   deskew = callPackage ../applications/graphics/deskew { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is a useful utility for dealing with CRC. It did not exist as a package, so I added it.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
