### PR TITLE
dumpasn1: init at unstable-2014-06-26

### DIFF
--- a/pkgs/tools/security/dumpasn1/default.nix
+++ b/pkgs/tools/security/dumpasn1/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "dumpasn1";
+  version = "unstable-2014-06-26";
+
+  hardeningDisable = [ "all" ];
+
+  src = fetchFromGitHub {
+    owner = "clibs";
+    repo = "dumpasn1";
+    rev = "a73ca41a1ec1a44e655e98b627e24f91d8ae2477";
+    sha256 = "06bc3qhf137aj5dd1vjxgnfpd41mg00c9qvgfd5dijzrgfl66fa1";
+  };
+
+  buildPhase = "gcc ./dumpasn1.c";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./a.out $out/bin/dumpasn1
+  '';
+
+  meta = with stdenv.lib; {
+    description =
+      "object dump program that will dump data encoded using any of the ASN.1 encoding rules in a variety of user-specified formats";
+    homepage = "https://www.cs.auckland.ac.nz/~pgut001/";
+    maintainers = with maintainers; [ btlvr ];
+    license = licenses.bsdOriginal;
+  };
+}

--- a/pkgs/tools/security/dumpasn1/default.nix
+++ b/pkgs/tools/security/dumpasn1/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description =
-      "object dump program that will dump data encoded using any of the ASN.1 encoding rules in a variety of user-specified formats";
+      "Object dump program that will dump data encoded using any of the ASN.1 encoding rules in a variety of user-specified formats";
     homepage = "https://www.cs.auckland.ac.nz/~pgut001/";
     maintainers = with maintainers; [ btlvr ];
     license = licenses.bsdOriginal;

--- a/pkgs/tools/security/dumpasn1/default.nix
+++ b/pkgs/tools/security/dumpasn1/default.nix
@@ -4,7 +4,8 @@ stdenv.mkDerivation rec {
   pname = "dumpasn1";
   version = "unstable-2014-06-26";
 
-  hardeningDisable = [ "all" ];
+  # uses constant for indenting
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
 
   src = fetchFromGitHub {
     owner = "clibs";

--- a/pkgs/tools/security/dumpasn1/default.nix
+++ b/pkgs/tools/security/dumpasn1/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "06bc3qhf137aj5dd1vjxgnfpd41mg00c9qvgfd5dijzrgfl66fa1";
   };
 
-  buildPhase = "gcc ./dumpasn1.c";
+  buildPhase = "$CC ./dumpasn1.c";
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2901,6 +2901,8 @@ in
 
   duff = callPackage ../tools/filesystems/duff { };
 
+  dumpasn1 = callPackage ../tools/security/dumpasn1 { };
+
   dumptorrent = callPackage ../tools/misc/dumptorrent { };
 
   duo-unix = callPackage ../tools/security/duo-unix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This tool is in the official repositories for Debian and Fedora.

###### Things done
Created package for `dumpasn1`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
