### PR TITLE
Add Xerox Phaser P3250 cups driver

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1067,8 +1067,8 @@
     githubId = 37037;
     name = "Filip Brcic";
     keys = [{
-      longkeyid = "rsa2048/0x0123456789ABCDEF";
-      fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
+      longkeyid = "rsa4096/0x96577BD3C105EDA4";
+      fingerprint = "9AFC 0A4B D2CE F3D2 2CF6  1081 9657 7BD3 C105 EDA4";
     }];
   };
   brian-dawn = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1061,6 +1061,16 @@
     githubId = 2506621;
     name = "Brayden Willenborg";
   };
+  brcha = {
+    email = "brcha@yandex.com";
+    github = "brcha";
+    githubId = 37037;
+    name = "Filip Brcic";
+    keys = [{
+      longkeyid = "rsa2048/0x0123456789ABCDEF";
+      fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
+    }];
+  };
   brian-dawn = {
     email = "brian.t.dawn@gmail.com";
     github = "brian-dawn";

--- a/pkgs/misc/cups/drivers/xerox/xerox-phaser-p3250.nix
+++ b/pkgs/misc/cups/drivers/xerox/xerox-phaser-p3250.nix
@@ -1,0 +1,87 @@
+# Tested on linux-x86_64.  Might work on linux-i386.  Probably won't work on anything else.
+
+# To use this driver in NixOS, add it to printing.drivers in configuration.nix.
+# configuration.nix might look like this when you're done:
+# { pkgs, ... }: {
+#   printing = {
+#     enable = true;
+#     drivers = [ pkgs.xerox-phaser-p3250 ];
+#   };
+#   (more stuff)
+# }
+# (This advice was tested on the 15th February, 2020.)
+
+# This nix is loosely based on ../samsung/4.01.17.nix
+
+{ stdenv, fetchurl, cups, libusb }:
+
+let
+  installationPath = if stdenv.hostPlatform.system == "x86_64-linux" then "x86_64" else "i386";
+  appendPath = if stdenv.hostPlatform.system == "x86_64-linux" then "64" else "";
+  libPath = stdenv.lib.makeLibraryPath [ cups libusb ] + ":$out/lib:${stdenv.cc.cc.lib}/lib${appendPath}";
+in stdenv.mkDerivation rec {
+  pname = "xerox_phaser_p3250";
+  version = "7-6-09";
+
+  src = fetchurl {
+    url = "http://download.support.xerox.com/pub/drivers/3250/drivers/linux/ar/p3250.tar.gz";
+    sha256 = "63838e4c1487e9efaebbdb6c83d11e4fc9d7598cc985de785e6a98683d32eb2b";
+  };
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    cd P3250/Linux/${installationPath}
+    mkdir -p $out/lib/cups/{backend,filter}
+    pushd at_root/usr/lib${appendPath}/cups/backend
+    install -Dm755 mfp $out/lib/cups/backend/
+    popd
+    pushd at_root/usr/lib${appendPath}/cups/filter
+    install -Dm755 pscms rastertosamsung* smfpautoconf $out/lib/cups/filter/
+    install -Dm755 libscmssc.so libscmssf.so $out/lib/
+    popd
+
+    GLOBIGNORE=*.so
+    for exe in $out/lib/cups/**/*; do
+      echo "Patching $exe"
+      patchelf \
+        --set-rpath ${libPath} \
+        --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+        $exe
+    done
+    unset GLOBIGNORE
+
+    install -v at_root/usr/lib${appendPath}/libmfp.so.1.0.1 $out/lib
+    pushd $out/lib
+    ln -s -f libmfp.so.1.0.1 libmfp.so.1
+    ln -s -f libmfp.so.1 libmfp.so
+    popd
+
+    for lib in $out/lib/*.so; do
+      echo "Patching $lib"
+      patchelf \
+        --set-rpath ${libPath} \
+        $lib
+    done
+
+    mkdir -p $out/share/cups/model/xerox
+    pushd ../noarch/at_opt/share/ppd
+    for i in *.ppd; do
+      sed -i $i -e \
+        "s,rastertosamsung,$out/lib/cups/filter/rastertosamsung,g; \
+         s,pscms,$out/lib/cups/filter/pscms,g; \
+         s,smfpautoconf,$out/lib/cups/filter/smfpautoconf,g"
+    done;
+    cp -r ./* $out/share/cups/model/xerox
+    popd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Xerox's Linux printing driver for Phaser P3250; includes binaries without source code";
+    homepage = http://www.xerox.com/;
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ brcha ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25375,6 +25375,8 @@ in
   samsung-unified-linux-driver_4_01_17 = callPackage ../misc/cups/drivers/samsung/4.01.17.nix { };
   samsung-unified-linux-driver = res.samsung-unified-linux-driver_4_01_17;
 
+  xerox-phaser-p3250 = callPackage ../misc/cups/drivers/xerox/xerox-phaser-p3250.nix {};
+
   sane-backends = callPackage ../applications/graphics/sane/backends (config.sane or {});
 
   sane-backends-git = callPackage ../applications/graphics/sane/backends/git.nix (config.sane or {});


### PR DESCRIPTION
Added CUPS driver for Xeros Phaser P3250 printer.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I have a Xerox Phaser P3250dn printer and, while it can work to an extent using a generic postscript driver, advanced options (such as duplex printing) are available only with the proprietary Xerox's driver. Their driver is based on Samsung's driver, but the available samsung-unified-linux-driver doesn't support my particular printer. So I've wrapped their driver into a nix package. I've installed it on my system and the printer works as it should.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
