### PR TITLE
hyperfine: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/hyperfine/default.nix
+++ b/pkgs/tools/misc/hyperfine/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0jx2lqhayp14c51dfvgmqrmmadyvxf0p4dsn770ndqpzv66rh6zb";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0sqmqfig40ragjx3jvwrng6hqz8l1zbmxzq470lk66x0gy4gziag";
+  cargoSha256 = "0n0hizldhr026mrzzz1wlw4g0b1z6ybxarybq3fzchs722iqpsis";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.