### PR TITLE
pijul: fix build by migrating off legacy fetchCargo

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -20,8 +20,18 @@ in rustPlatform.buildRustPackage rec {
     sha256 = "1rm787kkh3ya8ix0rjvj7sbrg9armm0rnpkga6gjmsbg5bx20y4q";
   };
 
+  cargoSha256 = "0rf8qmgzgyl718yznbskzafyg963ygibjmqncd93zdandgl9nj5v";
+
+  # N.B. The cargo depfile checker expects us to have unpacked the src tarball
+  # into the standard dirname "source".
+  cargoDepsHook = ''
+    ln -s ${pname}-${version} source
+  '';
+
+  # TODO: Delete once pijul fixes upstream:
+  # https://nest.pijul.com/pijul_org/pijul/discussions/447
   postPatch = ''
-    pushd ../${pname}-${version}-vendor/thrussh/
+    pushd ../${pname}-${version}-vendor.tar.gz/thrussh/
     patch -p1 < ${./thrussh-build-fix.patch}
     substituteInPlace .cargo-checksum.json --replace \
       9696ed2422a483cd8de48ac241178a0441be6636909c76174c536b8b1cba9d45 \
@@ -44,11 +54,6 @@ in rustPlatform.buildRustPackage rec {
     (with darwin.apple_sdk.frameworks; [ CoreServices Security ]);
 
   doCheck = false;
-
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1w77s5q18yr1gqqif15wmrfdvv2chq8rq3w4dnmxg2gn0r7bmz2k";
 
   meta = with stdenv.lib; {
     description = "A distributed version control system";


### PR DESCRIPTION
Currently broken; see #79975 for details. Would also be fixed by #80153
eventually, but since we want to upgrade either way we might as well do so now.

https://hydra.nixos.org/job/nixpkgs/trunk/pijul.x86_64-linux