### PR TITLE
xidlehook: fix build by migrating off legacy fetchCargo

### DIFF
--- a/pkgs/tools/X11/xidlehook/default.nix
+++ b/pkgs/tools/X11/xidlehook/default.nix
@@ -16,10 +16,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoBuildFlags = lib.optionals (!stdenv.isLinux) ["--no-default-features" "--features" "pulse"];
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0jdkcxvlw7s8pz1ka3d2w97356a2axvlwfgyh2dz7nmfzpjx64x0";
+  cargoSha256 = "0wakw3pqgwfwarjfb3h0a2javrhnf509v3j547a7p9k5kbjb5np0";
 
   buildInputs = [ xlibsWrapper xorg.libXScrnSaver libpulseaudio ] ++ lib.optional stdenv.isDarwin Security;
   nativeBuildInputs = [ pkgconfig patchelf python3 ];


### PR DESCRIPTION
Currently broken; see #79975 for details. Would also be fixed by #80153
eventually, but since we want to upgrade either way we might as well do so now.

https://hydra.nixos.org/job/nixpkgs/trunk/xidlehook.x86_64-linux