### PR TITLE
siji: split output into out, bdf, otb

### DIFF
--- a/pkgs/data/fonts/siji/default.nix
+++ b/pkgs/data/fonts/siji/default.nix
@@ -1,26 +1,44 @@
-{ lib, fetchzip }:
+{ stdenv, fetchzip, libfaketime, fonttosfnt, mkfontscale }:
 
-let
-  date = "2016-05-13";
-in fetchzip {
-  name = "siji-${date}";
+stdenv.mkDerivation rec {
+  name = "siji-${version}";
+  version = "2016-05-13";
 
-  url = https://github.com/stark/siji/archive/95369afac3e661cb6d3329ade5219992c88688c1.zip;
+  src = fetchzip {
+    url = https://github.com/stark/siji/archive/95369afac3e661cb6d3329ade5219992c88688c1.zip;
+    sha256 = "1408g4nxwdd682vjqpmgv0cp0bfnzzzwls62cjs9zrds16xa9dpf";
+  };
 
-  postFetch = ''
-    unzip -j $downloadedFile
+  nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];
 
-    install -D *.pcf -t $out/share/fonts/pcf
-    install -D *.bdf -t $out/share/fonts/bdf
+  buildPhase = ''
+    # compress pcf fonts
+    gzip -n -9 pcf/*
+
+    # convert bdf fonts to otb
+    for i in bdf/*; do
+        name=$(basename $i .bdf)
+        faketime -f "1970-01-01 00:00:01" \
+        fonttosfnt -v -o "$name.otb" "$i"
+    done
   '';
 
-  sha256 = "1ymcbirdbkqaf0xs2y00l0wachb4yxh1fgqm5avqwvccs0lsfj1d";
+  postInstall = ''
+    install -m 644 -D pcf/* -t "$out/share/fonts/misc"
+    install -m 644 -D bdf/* -t "$bdf/share/fonts/misc"
+    install -m 644 -D *.otb -t "$otb/share/fonts/misc"
+    mkfontdir "$out/share/fonts/misc"
+    mkfontdir "$bdf/share/fonts/misc"
+    mkfontdir "$otb/share/fonts/misc"
+  '';
 
-  meta = {
+  outputs = [ "out" "bdf" "otb" ];
+
+  meta = with stdenv.lib; {
     homepage = https://github.com/stark/siji;
     description = "An iconic bitmap font based on Stlarch with additional glyphs";
-    license = lib.licenses.gpl2;
-    platforms = lib.platforms.all;
-    maintainers = [ lib.maintainers.asymmetric ];
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.asymmetric ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17920,7 +17920,8 @@ in
   inter-ui = callPackage ../data/fonts/inter-ui { };
   inter = callPackage ../data/fonts/inter { };
 
-  siji = callPackage ../data/fonts/siji { };
+  siji = callPackage ../data/fonts/siji
+    { inherit (buildPackages.xorg) mkfontscale fonttosfnt; };
 
   sound-theme-freedesktop = callPackage ../data/misc/sound-theme-freedesktop { };
 


### PR DESCRIPTION
###### Motivation for this change
Issue #75160 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested BDF and PCF font using xfd
- [x] Tested OTB in lemonbar-xft.
- [x] Tested compilation of all pkgs that depend on this change (siji)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
