### PR TITLE
moolticute: 0.30.8 -> 0.42.32-testing

### DIFF
--- a/pkgs/applications/misc/moolticute/default.nix
+++ b/pkgs/applications/misc/moolticute/default.nix
@@ -1,36 +1,44 @@
-{ stdenv, fetchurl
-, libusb1, pkgconfig, qmake, qtbase, qttools, qtwebsockets
+{ lib, mkDerivation, fetchFromGitHub
+, libusb1
+, pkg-config
+, qmake
+, qtbase
+, qttools
+, qtwebsockets
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "moolticute";
-  version = "0.30.8";
+  version = "0.42.32-testing";
 
-  src = fetchurl {
-    url = "https://github.com/mooltipass/moolticute/archive/v${version}.tar.gz";
-    sha256 = "1qi18r2v0mpw1y007vjgzhiia89fpgsbg2wirxgngl21yxdns1pf";
+  src = fetchFromGitHub {
+    owner = "mooltipass";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kx1p2h65dilj1pbzf36d1mxwym19kvln1sqg8fb7na8q7lk4b05";
   };
 
+  outputs = [ "out" "udev" ];
+
+  nativeBuildInputs = [ pkg-config qmake qttools ];
+  buildInputs = [ libusb1 qtbase qtwebsockets ];
+
   preConfigure = "mkdir -p build && cd build";
-  nativeBuildInputs = [ pkgconfig qmake qttools ];
   qmakeFlags = [ "../Moolticute.pro" ];
 
-  outputs = [ "out" "udev" ];
   preInstall = ''
     mkdir -p $udev/lib/udev/rules.d
     sed -n '/^ \+cat > "$tmpfile" <<- EOF$/,/^EOF$/p' ../data/moolticute.sh |
         sed '1d;$d' > $udev/lib/udev/rules.d/50-mooltipass.rules
  '';
-  
-  buildInputs = [ libusb1 qtbase qtwebsockets ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "GUI app and daemon to work with Mooltipass device via USB";
     longDescription = ''
       To install udev rules, add `services.udev.packages == [ moolticute.udev ]`
       into `nixos/configuration.nix`.
     '';
-    homepage = https://github.com/mooltipass/moolticute;
+    homepage = "https://github.com/mooltipass/moolticute";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.kirikaza ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
closes #69670

the -testing variations appear to contain bug fixes according to their releases https://github.com/mooltipass/moolticute/releases

so i grabbed the latest

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
