### PR TITLE
xprite-editor: fix build by migrating off legacy fetchCargo

### DIFF
--- a/pkgs/tools/misc/xprite-editor/default.nix
+++ b/pkgs/tools/misc/xprite-editor/default.nix
@@ -29,10 +29,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ pkg-config python3 ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0cd58888l7pjmghin31ha780yhs2pz67b10jysyasdw0a88m0dwy";
+  cargoSha256 = "1a0zy8gfc1gdk8nnv5qr4yspqy1jsip5nql3w74rl6h46cplpf5y";
 
   cargoBuildFlags = [ "--bin" "xprite-native" ];
 


### PR DESCRIPTION
Currently broken; see #79975 for details. Would also be fixed by #80153
eventually, but since we want to upgrade either way we might as well do so now.

https://hydra.nixos.org/job/nixpkgs/trunk/xprite-editor.x86_64-linux