### PR TITLE
cargo-flamegraph: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/cargo-flamegraph/default.nix
+++ b/pkgs/development/tools/cargo-flamegraph/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1avjq36wnm0gd5zkkv1c8hj8j51ah1prlifadjhpaf788rsng9w1";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1kmxpzgv24hf66gzyapxy48gzwqi0p0jvzv829sfdlp00qgj1kp4";
+  cargoSha256 = "10cw3qgc39id8rzziamvgm5s3yf8vgqrnx9v15dw9miapz88amcy";
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [ makeWrapper ];
   buildInputs = lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.