### PR TITLE
cargo-bloat: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/rust/cargo-bloat/default.nix
+++ b/pkgs/development/tools/rust/cargo-bloat/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0h535fnmwm1ix08a3ifasppqcm7z4fiwf6kn32vhqqpn7x9vvl53";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1jc1lx0yk8galkyc4a67d39ywsfrgc2sjjsz08p47gpz7228d64w";
+  cargoSha256 = "00j2czhb0ag10hwq7ycdwr2ndb6gz99kg12hlmaq4mkaf8h254nn";
 
   meta = with lib; {
     description = "A tool and Cargo subcommand that helps you find out what takes most of the space in your executable";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.