### PR TITLE
wishbone-utils: 0.2.8 -> 0.6.9

### DIFF
--- a/pkgs/development/tools/misc/wishbone-tool/default.nix
+++ b/pkgs/development/tools/misc/wishbone-tool/default.nix
@@ -1,26 +1,31 @@
 { lib, fetchFromGitHub, rustPlatform, libusb }:
+
 let
-  version = "0.2.8";
+  version = "0.6.9";
   src = fetchFromGitHub {
-    owner = "xobs";
+    owner = "litex-hub";
     repo = "wishbone-utils";
     rev = "v${version}";
-    sha256 = "0v6s5yl0y6bd2snf12x6c77rwvqkg6ybi1sm4wr7qdgbwq563nxp";
+    sha256 = "0gq359ybxnqvcp93cn154bs9kwlai62gnm71yvl2nhzjdlcr3fhp";
   };
 in
 rustPlatform.buildRustPackage {
   pname = "wishbone-tool";
   inherit version;
-  src = "${src}/wishbone-tool";
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
 
-  cargoSha256 = "0pj8kf6s1c666p4kc6q1hlvaqm0lm9aqnsx5r034g1y8sxnnyri2";
+  src = "${src}/wishbone-tool";
+
+  # N.B. The cargo vendor consistency checker searches in "source" for lockfile
+  cargoDepsHook = ''
+    ln -s wishbone-tool source
+  '';
+  cargoSha256 = "0d5kcwy0cgxqfxf2xysw65ng84q4knhp4fgvh6dwqhf0nsca9gvs";
+
   buildInputs = [ libusb ];
 
   meta = with lib; {
     description = "Manipulate a Wishbone device over some sort of bridge";
-    homepage = "https://github.com/xobs/wishbone-utils#wishbone-tool";
+    homepage = "https://github.com/litex-hub/wishbone-utils";
     license = licenses.bsd2;
     maintainers = with maintainers; [ edef ];
     platforms = platforms.linux;


### PR DESCRIPTION
The upstream repository has moved its URL here:
https://github.com/xobs/wishbone-utils

This also contains some cleanup to make the cargo tarball checker find the cargo
lockfile in the source directory; see #79975 for details.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).