### PR TITLE
cargo-asm: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/rust/cargo-asm/default.nix
+++ b/pkgs/development/tools/rust/cargo-asm/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0zn5p95hsmhvk2slc9hakrpvim6l4zbpgkks2x64ndwyfmzyykws";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1k9mc29y4487ssf5whvr8xig7j4jh0rpcrhclp6siw8xamygijdm";
+  cargoSha256 = "1xsfwzn2b7hmb7hwgfa4ss7qfas8957gkw7zys0an9hdj5qr3ywb";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.