### PR TITLE
rust-cbindgen: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/rust/cbindgen/default.nix
+++ b/pkgs/development/tools/rust/cbindgen/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1x21g66gri6z9bnnfn7zmnf2lwdf5ing76pcmw0ilx4nzpvfhkg0";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "13fb8cdg6r0g5jb3vaznvv5aaywrnsl2yp00h4k8028vl8jwwr79";
+  cargoSha256 = "13fbahdih5whll09pfgyb1bjag1f0d0xfwgm2s342bs1krxsrbh3";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.