### PR TITLE
cargo-deb: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/package-management/cargo-deb/default.nix
+++ b/pkgs/tools/package-management/cargo-deb/default.nix
@@ -17,10 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0j64dcczxdr9zdch4a241d5adgipzz8sgbw00min9k3p8hbljd9n";
+  cargoSha256 = "0ji6d5a23rzhkkk27iigqcf2zw3mx1p1ap0cryqcj43z5ixdygiw";
 
   meta = with lib; {
     description = "Generate Debian packages from information in Cargo.toml";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.