### PR TITLE
softmaker-office: 972 -> 974

### DIFF
--- a/pkgs/applications/office/softmaker/softmaker_office.nix
+++ b/pkgs/applications/office/softmaker/softmaker_office.nix
@@ -2,13 +2,13 @@
 
 callPackage ./generic.nix (args // rec {
   pname = "softmaker-office";
-  version = "972";
+  version = "974";
   edition = "2018";
   suiteName = "SoftMaker Office";
 
   src = fetchurl {
     url = "https://www.softmaker.net/down/softmaker-office-${edition}-${version}-amd64.tgz";
-    sha256 = "06kgkmqg5269a4vm14i89mw8m1x9yy9ajw0dhfcvjizadyzmlqn1";
+    sha256 = "0z1g76lhja92s25x6y0h55wmqza2d3pjbshn5b9rn2784gjgj7hn";
   };
 
   archive = "office${edition}.tar.lzma";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changelog:
https://www.softmaker.com/en/servicepacks-office-changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
