### PR TITLE
rsclock: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/misc/rsclock/default.nix
+++ b/pkgs/applications/misc/rsclock/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1i93qkz6d8sbk78i4rvx099hnn4lklp4cjvanpm9ssv8na4rqvh2";
   };
    
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "03mhlp5hi3nlybb9dkwf1gxgsg056mjq2zsxnb5qh8pdxw7fmdxk";
+  cargoSha256 = "01dhkis6zswq1y40n7sdq9xv1sp61f2v7nfqbkicyjngmdrmcgrl";
 
   meta = with stdenv.lib; {
     description = "A simple terminal clock written in Rust";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.