### PR TITLE
gnome-podcasts: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/audio/gnome-podcasts/default.nix
+++ b/pkgs/applications/audio/gnome-podcasts/default.nix
@@ -32,10 +32,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0vy5i77bv8c22ldhrnr4z6kx22zqnb1lg3s7y8673bqjgd7dppi0";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1h0n8zclb8a1b1ri83viiwwzlj3anm38m4cp38aqyf6q40qga35q";
+  cargoSha256 = "1dlbdxsf9p2jzrsclm43k95y8m3zcd41qd9ajg1ii3fpnahi58kd";
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.