### PR TITLE
chit: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/chit/default.nix
+++ b/pkgs/development/tools/chit/default.nix
@@ -15,10 +15,7 @@ buildRustPackage rec {
     sha256 = "0iixczy3cad44j2d7zzj8f3lnmp4jwnb0snmwfgiq3vj9wrn28pz";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0k6z69a09ps55w2rdgnf92yscw6rlbcpb4q9yf3rsav15pgpqvw8";
+  cargoSha256 = "1w25k3bqmmcrhpkw510vbwph0rfmrzi2wby0z2rz1q4k1f9k486m";
 
   nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ pkgconfig ];
   buildInputs = []


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.