### PR TITLE
taizen: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/misc/taizen/default.nix
+++ b/pkgs/applications/misc/taizen/default.nix
@@ -14,10 +14,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ ncurses openssl ] ++ lib.optional stdenv.isDarwin Security;
   nativeBuildInputs = [ pkgconfig ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0h8ybhb17pqhhfjcmq1l70kp8g1yyq38228lcf86byk3r2ar2rkg";
+  cargoSha256 = "0chrgwm97y1a3gj218x25yqk1y1h74a6gzyxjdm023msvs58nkni";
 
   meta = with lib; {
     homepage = https://crates.io/crates/taizen;


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.