### PR TITLE
treewide: batched rust cargoSha256 upgrades

### DIFF
--- a/pkgs/games/system-syzygy/default.nix
+++ b/pkgs/games/system-syzygy/default.nix
@@ -23,10 +23,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ SDL2 ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "03724z33dqxbbrzpvz172qh45qrgnyb801algjdcm32v8xsx81qg";
+  cargoSha256 = "001cwdq8zxji56yahwfsydi7s0j7c5zsip60lxk3qmn078wcipdp";
 
   postInstall = ''
     mkdir -p $out/share/syzygy/

--- a/pkgs/misc/uq/default.nix
+++ b/pkgs/misc/uq/default.nix
@@ -14,10 +14,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1qqqmdk0v1d3ckasmmw5lbrkvhkv0nws4bzi9cfi1ndhrbvbkbxb";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1s22v2wz5h3l5l447zl54bhdk6avkk2ycrbbpxcx1442lllbss4w";
+  cargoSha256 = "1fv13rbghfw7114h7sda04gpqrjrsgnnki0p9kdd6r6sk5cbhn9x";
 
   meta = with lib; {
     description = "A simple, user-friendly alternative to sort | uniq";

--- a/pkgs/servers/routinator/default.nix
+++ b/pkgs/servers/routinator/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1hbqvjv9h1aghpyrl03w5f4j8gjy6n9lx83rmpsh5p7yd9ahwmf9";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "08lizhag7aqz3a59gaapsymn7sf9c6im1aw64n0r9a5advhwdh18";
+  cargoSha256 = "1chf1l9jlnhi9cyqpmcz8yfzwzmkn4lfxqhdhclvl8j4b2zvbcgc";
 
   meta = with stdenv.lib; {
     description = "An RPKI Validator written in Rust";

--- a/pkgs/servers/webmetro/default.nix
+++ b/pkgs/servers/webmetro/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1n2c7ygs8qsd5zgii6fqqcwg427bsij082bg4ijnzkq5630dx651";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "03ncwj9bn21590phcnqyclclcird7rikbhxbwhg8i9i0nad81aaa";
+  cargoSha256 = "0xifc3jwj0c6ynx0gzm5zlnfcq023fjpjmdg9x0vs1fh3b42pdsy";
 
   meta = with stdenv.lib; {
     description = "Simple relay server for broadcasting a WebM stream";

--- a/pkgs/tools/nix/nixdoc/default.nix
+++ b/pkgs/tools/nix/nixdoc/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs =  stdenv.lib.optional stdenv.isDarwin [ darwin.Security ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1hy8w73fir4wnqx7zfvfqh7s24w95x9nkw55kmizvrwf0glw9m4n";
+  cargoSha256 = "1vamwynkbnffs8ryr2zb1a41cymjvr8zzh1bifyh9hpkx2k11rs3";
 
   meta = with stdenv.lib; {
     description = "Generate documentation for Nix functions";

--- a/pkgs/tools/package-management/cargo-about/default.nix
+++ b/pkgs/tools/package-management/cargo-about/default.nix
@@ -10,10 +10,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0bsay1vqi5b3z7qjwbkwx3ikmpjzc0kswbajm50xmcwlg8jrn420";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1mqicibpa9sxac8v2kk8vfvxcis2wkdkklia2pbspc0pz3h0c8if";
+  cargoSha256 = "1ynalwaqa70ihgras3frp5l3xniz58hwp108wkxn6zj8lwxbxfgx";
 
   meta = with lib; {
     description = "Cargo plugin to generate list of all licenses for a crate";

--- a/pkgs/tools/package-management/cargo-audit/default.nix
+++ b/pkgs/tools/package-management/cargo-audit/default.nix
@@ -10,10 +10,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1977ykablfi4mc6j2iil0bxc6diy07vi5hm56xmqj3n37ziavf1m";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0zbnsq0cif0yppn8ygxhcsrshkbf1c801f8waqqb2d1rjsrhb93y";
+  cargoSha256 = "0bpqsg8mv94ivwmbfxfcnd89yx5vry33395ynqrzhqq9s1jwq0dq";
 
   buildInputs = [ openssl libiconv ] ++ lib.optionals stdenv.isDarwin [ Security ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/tools/package-management/cargo-deps/default.nix
+++ b/pkgs/tools/package-management/cargo-deps/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "16181p7ghvy9mqippg1xi2cw7yxvicis8v6n39wly5qw05i57aw2";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1a9svdw1cgk6s7gqpsq3r25wxa2gr2xddqkc1cjk7hf6sk327cpv";
+  cargoSha256 = "1zk6pf7agqs1mpld40rn05cwp4wy0vpjnn5ip6m83bxm8b3i87wk";
 
   meta = with lib; {
     description = "Cargo subcommand for building dependency graphs of Rust projects";

--- a/pkgs/tools/package-management/cargo-edit/default.nix
+++ b/pkgs/tools/package-management/cargo-edit/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "16gpljbzk6cibry9ssnl22xbcsx2cr57mrs3x3n6cfmldbp6bhbr";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1cjpbfgbqzlfs5hck2j3d2v719fwandpnc7bdk4243j7j0k1ng9q";
+  cargoSha256 = "1zwkar914zyghky09lgk0s374m5d6yccn0m15bqlgxxyymg4b59y";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.Security ];

--- a/pkgs/tools/package-management/cargo-graph/default.nix
+++ b/pkgs/tools/package-management/cargo-graph/default.nix
@@ -12,10 +12,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0myg26cssmbakz53dl61lswsbaqnjqlbc30c2571pq8f7gvz2qv5";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1k4byg77s1iqhry96pl57mbsvd32sbnvf60dlbd62pvan39rispg";
+  cargoSha256 = "0fzj88iy57c39yi8pf3agfmsf2dck06f0yqmlnsaxvvp4cknkw1n";
 
   meta = with lib; {
     description = "A cargo subcommand for creating GraphViz DOT files and dependency graphs";

--- a/pkgs/tools/package-management/cargo-release/default.nix
+++ b/pkgs/tools/package-management/cargo-release/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1w9w43i5br94vg5m4idabh67p4ffsx2lmc2g0ak2k961vl46wr0q";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "075fvvd4c8f3kz6i6ny835h6jpa3c1v3miwfwwrdyy49a85lzjyj";
+  cargoSha256 = "1x54c6wk5cbnqcy1qpsff8lwqxs0d4qf0v71r7wl0kjp8mrmmhl4";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;

--- a/pkgs/tools/package-management/emplace/default.nix
+++ b/pkgs/tools/package-management/emplace/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1y77cla6bgy8pjb21cawx7cb69hhri4r7gyjkhnjyiixkh945mwj";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "119llsc8m7qda2cjnd45ndml148z8074f76xygkz6fp3m1c2z3pw";
+  cargoSha256 = "1vkcr239axxqya0iin74jxkmx6z9nwb67pjjdh89v4qwjvwhiqg3";
 
   meta = with lib; {
     description = "Mirror installed software on multiple machines";

--- a/pkgs/tools/package-management/nix-index/default.nix
+++ b/pkgs/tools/package-management/nix-index/default.nix
@@ -12,10 +12,7 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "05fqfwz34n4ijw7ydw2n6bh4bv64rhks85cn720sy5r7bmhfmfa8";
   };
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "06idjb5h5fahqklyxnss2zffrvvfbcw0hjh1mcrf1872s4x78ags";
+  cargoSha256 = "0apdr9z18p6m4lfjv8k9zv2mqc7vssd2d536zfv1pns0pdqsfw50";
   nativeBuildInputs = [ pkgconfig makeWrapper ];
   buildInputs = [ openssl curl ]
     ++ stdenv.lib.optional stdenv.isDarwin Security;


### PR DESCRIPTION
This batches together a handful of relatively straightforward upgrades. Since
there's a lot of compilation and fixed-output merge conflict risk, I think this
is too big to build and test in one huge treewide PR, but also want to be
conscientious about not spamming the PR inbox for NixPkgs by sending them all
1-by-1. Let me know what you'd prefer.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).