### PR TITLE
gnupg: apply patch to allow import of key updates without user ids

### DIFF
--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -33,6 +33,9 @@ stdenv.mkDerivation rec {
   patches = [
     ./fix-libusb-include-path.patch
     ./0001-dirmngr-Only-use-SKS-pool-CA-for-SKS-pool.patch
+    ./tests-add-test-cases-for-import-without-uid.patch
+    ./allow-import-of-previously-known-keys-even-without-UI.patch
+    ./accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
   ];
   postPatch = ''
     sed -i 's,hkps://hkps.pool.sks-keyservers.net,hkps://keys.openpgp.org,g' \

--- a/pkgs/tools/security/gnupg/accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
+++ b/pkgs/tools/security/gnupg/accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
@@ -1,0 +1,32 @@
+From: Vincent Breitmoser <look@my.amazin.horse>
+Date: Thu, 13 Jun 2019 21:27:43 +0200
+Subject: gpg: accept subkeys with a good revocation but no self-sig during
+ import
+
+* g10/import.c (chk_self_sigs): Set the NODE_GOOD_SELFSIG flag when we
+encounter a valid revocation signature. This allows import of subkey
+revocation signatures, even in the absence of a corresponding subkey
+binding signature.
+
+--
+
+This fixes the remaining test in import-incomplete.scm.
+
+GnuPG-Bug-id: 4393
+Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+---
+ g10/import.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/g10/import.c b/g10/import.c
+index 4fdf248..ee2fed8 100644
+--- a/g10/import.c
++++ b/g10/import.c
+@@ -3613,6 +3613,7 @@ chk_self_sigs (ctrl_t ctrl, kbnode_t keyblock, u32 *keyid, int *non_self)
+                   /* It's valid, so is it newer? */
+                   if (sig->timestamp >= rsdate)
+                     {
++                      knode->flag |= NODE_GOOD_SELFSIG; /* Subkey is valid.  */
+                       if (rsnode)
+                         {
+                           /* Delete the last revocation sig since

--- a/pkgs/tools/security/gnupg/allow-import-of-previously-known-keys-even-without-UI.patch
+++ b/pkgs/tools/security/gnupg/allow-import-of-previously-known-keys-even-without-UI.patch
@@ -1,0 +1,106 @@
+From: Vincent Breitmoser <look@my.amazin.horse>
+Date: Thu, 13 Jun 2019 21:27:42 +0200
+Subject: gpg: allow import of previously known keys, even without UIDs
+
+* g10/import.c (import_one): Accept an incoming OpenPGP certificate that
+has no user id, as long as we already have a local variant of the cert
+that matches the primary key.
+
+--
+
+This fixes two of the three broken tests in import-incomplete.scm.
+
+GnuPG-Bug-id: 4393
+Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+---
+ g10/import.c | 44 +++++++++++---------------------------------
+ 1 file changed, 11 insertions(+), 33 deletions(-)
+
+diff --git a/g10/import.c b/g10/import.c
+index 95d419a..4fdf248 100644
+--- a/g10/import.c
++++ b/g10/import.c
+@@ -1792,7 +1792,6 @@ import_one_real (ctrl_t ctrl,
+   size_t an;
+   char pkstrbuf[PUBKEY_STRING_SIZE];
+   int merge_keys_done = 0;
+-  int any_filter = 0;
+   KEYDB_HANDLE hd = NULL;
+ 
+   if (r_valid)
+@@ -1829,14 +1828,6 @@ import_one_real (ctrl_t ctrl,
+       log_printf ("\n");
+     }
+ 
+-
+-  if (!uidnode )
+-    {
+-      if (!silent)
+-        log_error( _("key %s: no user ID\n"), keystr_from_pk(pk));
+-      return 0;
+-    }
+-
+   if (screener && screener (keyblock, screener_arg))
+     {
+       log_error (_("key %s: %s\n"), keystr_from_pk (pk),
+@@ -1911,17 +1902,10 @@ import_one_real (ctrl_t ctrl,
+ 	  }
+     }
+ 
+-  if (!delete_inv_parts (ctrl, keyblock, keyid, options ) )
+-    {
+-      if (!silent)
+-        {
+-          log_error( _("key %s: no valid user IDs\n"), keystr_from_pk(pk));
+-          if (!opt.quiet )
+-            log_info(_("this may be caused by a missing self-signature\n"));
+-        }
+-      stats->no_user_id++;
+-      return 0;
+-    }
++  /* Delete invalid parts, and note if we have any valid ones left.
++   * We will later abort import if this key is new but contains
++   * no valid uids.  */
++  delete_inv_parts (ctrl, keyblock, keyid, options);
+ 
+   /* Get rid of deleted nodes.  */
+   commit_kbnode (&keyblock);
+@@ -1931,24 +1915,11 @@ import_one_real (ctrl_t ctrl,
+     {
+       apply_keep_uid_filter (ctrl, keyblock, import_filter.keep_uid);
+       commit_kbnode (&keyblock);
+-      any_filter = 1;
+     }
+   if (import_filter.drop_sig)
+     {
+       apply_drop_sig_filter (ctrl, keyblock, import_filter.drop_sig);
+       commit_kbnode (&keyblock);
+-      any_filter = 1;
+-    }
+-
+-  /* If we ran any filter we need to check that at least one user id
+-   * is left in the keyring.  Note that we do not use log_error in
+-   * this case. */
+-  if (any_filter && !any_uid_left (keyblock))
+-    {
+-      if (!opt.quiet )
+-        log_info ( _("key %s: no valid user IDs\n"), keystr_from_pk (pk));
+-      stats->no_user_id++;
+-      return 0;
+     }
+ 
+   /* The keyblock is valid and ready for real import.  */
+@@ -2006,6 +1977,13 @@ import_one_real (ctrl_t ctrl,
+       err = 0;
+       stats->skipped_new_keys++;
+     }
++  else if (err && !any_uid_left (keyblock))
++    {
++      if (!silent)
++        log_info( _("key %s: new key but contains no user ID - skipped\n"), keystr(keyid));
++      err = 0;
++      stats->no_user_id++;
++    }
+   else if (err)  /* Insert this key. */
+     {
+       /* Note: ERR can only be NO_PUBKEY or UNUSABLE_PUBKEY.  */

--- a/pkgs/tools/security/gnupg/tests-add-test-cases-for-import-without-uid.patch
+++ b/pkgs/tools/security/gnupg/tests-add-test-cases-for-import-without-uid.patch
@@ -1,0 +1,201 @@
+From: Vincent Breitmoser <look@my.amazin.horse>
+Date: Thu, 13 Jun 2019 21:27:41 +0200
+Subject: tests: add test cases for import without uid
+
+This commit adds a test case that does the following, in order:
+- Import of a primary key plus user id
+- Check that import of a subkey works, without a user id present in the
+imported key
+- Check that import of a subkey revocation works, without a user id or
+subkey binding signature present in the imported key
+- Check that import of a primary key revocation works, without a user id
+present in the imported key
+
+--
+
+Note that this test currently fails.  The following changesets will
+fix gpg so that the tests pass.
+
+GnuPG-Bug-id: 4393
+Signed-Off-By: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+---
+ tests/openpgp/Makefile.am                          |  1 +
+ tests/openpgp/import-incomplete.scm                | 68 ++++++++++++++++++++++
+ .../import-incomplete/primary+revocation.asc       |  9 +++
+ .../primary+subkey+sub-revocation.asc              | 10 ++++
+ .../import-incomplete/primary+subkey+sub-sig.asc   | 10 ++++
+ .../openpgp/import-incomplete/primary+uid-sig.asc  | 10 ++++
+ tests/openpgp/import-incomplete/primary+uid.asc    | 10 ++++
+ 7 files changed, 118 insertions(+)
+ create mode 100755 tests/openpgp/import-incomplete.scm
+ create mode 100644 tests/openpgp/import-incomplete/primary+revocation.asc
+ create mode 100644 tests/openpgp/import-incomplete/primary+subkey+sub-revocation.asc
+ create mode 100644 tests/openpgp/import-incomplete/primary+subkey+sub-sig.asc
+ create mode 100644 tests/openpgp/import-incomplete/primary+uid-sig.asc
+ create mode 100644 tests/openpgp/import-incomplete/primary+uid.asc
+
+diff --git a/tests/openpgp/Makefile.am b/tests/openpgp/Makefile.am
+index f6014c9..6423da1 100644
+--- a/tests/openpgp/Makefile.am
++++ b/tests/openpgp/Makefile.am
+@@ -78,6 +78,7 @@ XTESTS = \
+ 	gpgv-forged-keyring.scm \
+ 	armor.scm \
+ 	import.scm \
++	import-incomplete.scm \
+ 	import-revocation-certificate.scm \
+ 	ecc.scm \
+ 	4gb-packet.scm \
+diff --git a/tests/openpgp/import-incomplete.scm b/tests/openpgp/import-incomplete.scm
+new file mode 100755
+index 0000000..727a027
+--- /dev/null
++++ b/tests/openpgp/import-incomplete.scm
+@@ -0,0 +1,68 @@
++#!/usr/bin/env gpgscm
++
++;; Copyright (C) 2016 g10 Code GmbH
++;;
++;; This file is part of GnuPG.
++;;
++;; GnuPG is free software; you can redistribute it and/or modify
++;; it under the terms of the GNU General Public License as published by
++;; the Free Software Foundation; either version 3 of the License, or
++;; (at your option) any later version.
++;;
++;; GnuPG is distributed in the hope that it will be useful,
++;; but WITHOUT ANY WARRANTY; without even the implied warranty of
++;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++;; GNU General Public License for more details.
++;;
++;; You should have received a copy of the GNU General Public License
++;; along with this program; if not, see <http://www.gnu.org/licenses/>.
++
++(load (in-srcdir "tests" "openpgp" "defs.scm"))
++(setup-environment)
++
++(call-check `(,(tool 'gpg) --import ,(in-srcdir "tests" "openpgp" "import-incomplete" "primary+uid.asc")))
++
++(info "Test import of new subkey, from a certificate without uid")
++(define keyid "573EA710367356BB")
++(call-check `(,(tool 'gpg) --import ,(in-srcdir "tests" "openpgp" "import-incomplete" "primary+subkey+sub-sig.asc")))
++(tr:do
++ (tr:pipe-do
++  (pipe:gpg `(--list-keys --with-colons ,keyid)))
++ (tr:call-with-content
++  (lambda (c)
++    ;; XXX we do not have a regexp library
++    (unless (any (lambda (line)
++		   (and (string-prefix? line "sub:")
++			(string-contains? line "573EA710367356BB")))
++		 (string-split-newlines c))
++	    (exit 1)))))
++
++(info "Test import of a subkey revocation, from a certificate without uid")
++(define keyid "573EA710367356BB")
++(call-check `(,(tool 'gpg) --import ,(in-srcdir "tests" "openpgp" "import-incomplete" "primary+subkey+sub-revocation.asc")))
++(tr:do
++ (tr:pipe-do
++  (pipe:gpg `(--list-keys --with-colons ,keyid)))
++ (tr:call-with-content
++  (lambda (c)
++    ;; XXX we do not have a regexp library
++    (unless (any (lambda (line)
++		   (and (string-prefix? line "sub:r:")
++			(string-contains? line "573EA710367356BB")))
++		 (string-split-newlines c))
++	    (exit 1)))))
++
++(info "Test import of revocation, from a certificate without uid")
++(call-check `(,(tool 'gpg) --import ,(in-srcdir "tests" "openpgp" "import-incomplete" "primary+revocation.asc")))
++(tr:do
++ (tr:pipe-do
++  (pipe:gpg `(--list-keys --with-colons ,keyid)))
++ (tr:call-with-content
++  (lambda (c)
++    ;; XXX we do not have a regexp library
++    (unless (any (lambda (line)
++		   (and (string-prefix? line "pub:r:")
++			(string-contains? line "0843DA969AA8DAFB")))
++		 (string-split-newlines c))
++	    (exit 1)))))
++
+diff --git a/tests/openpgp/import-incomplete/primary+revocation.asc b/tests/openpgp/import-incomplete/primary+revocation.asc
+new file mode 100644
+index 0000000..6b7b608
+--- /dev/null
++++ b/tests/openpgp/import-incomplete/primary+revocation.asc
+@@ -0,0 +1,9 @@
++-----BEGIN PGP PUBLIC KEY BLOCK-----
++Comment: [E] primary key, revocation signature over primary (no user ID)
++
++mDMEXNmUGRYJKwYBBAHaRw8BAQdA75R8VlchvmEd2Iz/8l07RoKUaUPDB71Ao1zZ
++631VAN2IeAQgFggAIBYhBLRpj5W82H/gSMzKKQhD2paaqNr7BQJc2ZQZAh0AAAoJ
++EAhD2paaqNr7qAwA/2jBUpnN0BxwRO/4CrxvrLIsL+C9aSXJUOTv8XkP4lvtAQD3
++XsDFfFNgEueiTfF7HtOGt5LPmRqVvUpQSMVgJJW6CQ==
++=tM90
++-----END PGP PUBLIC KEY BLOCK-----
+diff --git a/tests/openpgp/import-incomplete/primary+subkey+sub-revocation.asc b/tests/openpgp/import-incomplete/primary+subkey+sub-revocation.asc
+new file mode 100644
+index 0000000..83a51a5
+--- /dev/null
++++ b/tests/openpgp/import-incomplete/primary+subkey+sub-revocation.asc
+@@ -0,0 +1,10 @@
++-----BEGIN PGP PUBLIC KEY BLOCK-----
++Comment: [D] primary key, subkey, subkey revocation (no user ID)
++
++mDMEXNmUGRYJKwYBBAHaRw8BAQdA75R8VlchvmEd2Iz/8l07RoKUaUPDB71Ao1zZ
++631VAN24OARc2ZQhEgorBgEEAZdVAQUBAQdABsd5ha0AWXdXcSmfeiWIfrNcGqQK
++j++lwwWDAOlkVicDAQgHiHgEKBYIACAWIQS0aY+VvNh/4EjMyikIQ9qWmqja+wUC
++XNmnkAIdAgAKCRAIQ9qWmqja+ylaAQDmIKf86BJEq4OpDqU+V9D+wn2cyuxbyWVQ
++3r9LiL9qNwD/QAjyrhSN8L3Mfq+wdTHo5i0yB9ZCCpHLXSbhCqfWZwQ=
++=dwx2
++-----END PGP PUBLIC KEY BLOCK-----
+diff --git a/tests/openpgp/import-incomplete/primary+subkey+sub-sig.asc b/tests/openpgp/import-incomplete/primary+subkey+sub-sig.asc
+new file mode 100644
+index 0000000..dc47a02
+--- /dev/null
++++ b/tests/openpgp/import-incomplete/primary+subkey+sub-sig.asc
+@@ -0,0 +1,10 @@
++-----BEGIN PGP PUBLIC KEY BLOCK-----
++Comment: [B] primary key, subkey, subkey binding sig (no user ID)
++
++mDMEXNmUGRYJKwYBBAHaRw8BAQdA75R8VlchvmEd2Iz/8l07RoKUaUPDB71Ao1zZ
++631VAN24OARc2ZQhEgorBgEEAZdVAQUBAQdABsd5ha0AWXdXcSmfeiWIfrNcGqQK
++j++lwwWDAOlkVicDAQgHiHgEGBYIACAWIQS0aY+VvNh/4EjMyikIQ9qWmqja+wUC
++XNmUIQIbDAAKCRAIQ9qWmqja++vFAP98G1L+1/rWTGbsnxOAV2RocBYIroAvsbkR
++Ly6FdP8YNwEA7jOgT05CoKIe37MstpOz23mM80AK369Ca3JMmKKCQgg=
++=xuDu
++-----END PGP PUBLIC KEY BLOCK-----
+diff --git a/tests/openpgp/import-incomplete/primary+uid-sig.asc b/tests/openpgp/import-incomplete/primary+uid-sig.asc
+new file mode 100644
+index 0000000..134607d
+--- /dev/null
++++ b/tests/openpgp/import-incomplete/primary+uid-sig.asc
+@@ -0,0 +1,10 @@
++-----BEGIN PGP PUBLIC KEY BLOCK-----
++Comment: [C] primary key and self-sig expiring in 2024 (no user ID)
++
++mDMEXNmUGRYJKwYBBAHaRw8BAQdA75R8VlchvmEd2Iz/8l07RoKUaUPDB71Ao1zZ
++631VAN2IlgQTFggAPgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBLRpj5W8
++2H/gSMzKKQhD2paaqNr7BQJc2ZR1BQkJZgHcAAoJEAhD2paaqNr79soA/0lWkUsu
++3NLwgbni6EzJxnTzgeNMpljqNpipHAwfix9hAP93AVtFdC8g7hdUZxawobl9lnSN
++9ohXOEBWvdJgVv2YAg==
++=KWIK
++-----END PGP PUBLIC KEY BLOCK-----
+diff --git a/tests/openpgp/import-incomplete/primary+uid.asc b/tests/openpgp/import-incomplete/primary+uid.asc
+new file mode 100644
+index 0000000..055f300
+--- /dev/null
++++ b/tests/openpgp/import-incomplete/primary+uid.asc
+@@ -0,0 +1,10 @@
++-----BEGIN PGP PUBLIC KEY BLOCK-----
++Comment: [A] primary key, user ID, and self-sig expiring in 2021
++
++mDMEXNmUGRYJKwYBBAHaRw8BAQdA75R8VlchvmEd2Iz/8l07RoKUaUPDB71Ao1zZ
++631VAN20CHRlc3Qga2V5iJYEExYIAD4WIQS0aY+VvNh/4EjMyikIQ9qWmqja+wUC
++XNmUGQIbAwUJA8JnAAULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRAIQ9qWmqja
+++0G1AQDdQiwhXxjXLMqoth+D4SigVHTJK8ORwifzsy3UE7mPGwD/aZ67XbAF/lgI
++kv2O1Jo0u9BL9RNNF+L0DM7rAFbfMAs=
++=1eII
++-----END PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
This adds a patch series which allows GnuPG to import updates
(revocations and subkeys) from certificates that contain no user ids.
This is relevant for refreshing keys from the default keyserver
keys.openpgp.org, where only user ids that contain verified email
addresses will be distributed, and revoked keys never contain any user
ids.

This patch series was originally authored and submitted to upstream half
a year ago (by me), but now comes from Debian packaging where it's been
included since then.

Relates to the following upstream issue: https://dev.gnupg.org/T4393

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of gnupg and dirmngr binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
