### PR TITLE
mps-youtube: 0.2.8 -> unstable-2020-01-28

### DIFF
--- a/pkgs/applications/misc/mps-youtube/default.nix
+++ b/pkgs/applications/misc/mps-youtube/default.nix
@@ -1,17 +1,16 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
-, pafy
-}:
+{ lib, python3Packages, fetchFromGitHub }:
 
-buildPythonPackage rec {
+with python3Packages;
+
+buildPythonApplication rec {
   pname = "mps-youtube";
-  version = "0.2.8";
-  disabled = (!isPy3k);
+  version = "unstable-2020-01-28";
 
   src = fetchFromGitHub {
     owner = "mps-youtube";
     repo = "mps-youtube";
-    rev = "v${version}";
-    sha256 = "1w1jhw9rg3dx7vp97cwrk5fymipkcy2wrbl1jaa38ivcjhqg596y";
+    rev = "b808697133ec2ad7654953232d1e841b20aa7cc3";
+    sha256 = "0lqprlpc0v092xqkjc0cc395ag45lijwgd34dpg2jy6i0f2szywv";
   };
 
   propagatedBuildInputs = [ pafy ];
@@ -30,6 +29,6 @@ buildPythonPackage rec {
     description = "Terminal based YouTube player and downloader";
     homepage = "https://github.com/mps-youtube/mps-youtube";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ odi ];
+    maintainers = with maintainers; [ koral odi ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20371,6 +20371,8 @@ in
 
   mpc-qt = libsForQt5.callPackage ../applications/video/mpc-qt { };
 
+  mps-youtube = callPackage ../applications/misc/mps-youtube { };
+
   mplayer = callPackage ../applications/video/mplayer ({
     libdvdnav = libdvdnav_4_2_1;
   } // (config.mplayer or {}));

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6383,8 +6383,6 @@ in {
 
   maildir-deduplicate = callPackage ../development/python-modules/maildir-deduplicate { };
 
-  mps-youtube = callPackage ../development/python-modules/mps-youtube { };
-
   d2to1 = callPackage ../development/python-modules/d2to1 { };
 
   ovh = callPackage ../development/python-modules/ovh { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
mps-youtube-0.2.8 is no longer compatible with the version of mpv included in nixpkgs (cf [this issue](https://github.com/mps-youtube/mps-youtube/issues/1052)).
There haven't been any mps-youtube release since then, so the only way to fix it is to point at a git revision.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
