### PR TITLE
nixos/gdm: Fix pulseaudio tmpfiles structure

### DIFF
--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -166,7 +166,7 @@ in
       };
 
     systemd.tmpfiles.rules = [
-      "d /run/gdm/.config 0711 gdm gdm -"
+      "d /run/gdm/.config 0711 gdm gdm"
     ] ++ optionals config.hardware.pulseaudio.enable [
       "d /run/gdm/.config/pulse 0711 gdm gdm"
       "L+ /run/gdm/.config/pulse/${pulseConfig.name} - - - - ${pulseConfig}"

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -168,7 +168,8 @@ in
     systemd.tmpfiles.rules = [
       "d /run/gdm/.config 0711 gdm gdm -"
     ] ++ optionals config.hardware.pulseaudio.enable [
-      "L+ /run/gdm/.config/pulse - - - - ${pulseConfig}"
+      "d /run/gdm/.config/pulse 0711 gdm gdm"
+      "L+ /run/gdm/.config/pulse/${pulseConfig.name} - - - - ${pulseConfig}"
     ] ++ optionals config.services.gnome3.gnome-initial-setup.enable [
       # Create stamp file for gnome-initial-setup to prevent it starting in GDM.
       "f /run/gdm/.config/gnome-initial-setup-done 0711 gdm gdm - yes"


### PR DESCRIPTION
Fix the following startup failure of the sound service in the gdm
session that was introduced by #75893:
```
Feb 16 11:44:15 qp pulseaudio[1432]: W: [pulseaudio] core-util.c: Failed to open configuration file '/run/gdm/.config/pulse//daemon.conf': Not a directory
Feb 16 11:44:15 qp pulseaudio[1432]: W: [pulseaudio] daemon-conf.c: Failed to open configuration file: Not a directory
Feb 16 11:44:15 qp systemd[1380]: pulseaudio.service: Main process exited, code=exited, status=1/FAILURE
Feb 16 11:44:15 qp systemd[1380]: pulseaudio.service: Failed with result 'exit-code'.
Feb 16 11:44:15 qp systemd[1380]: Failed to start Sound Service.
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
