### PR TITLE
jftui: init at 0.2.2

### DIFF
--- a/pkgs/applications/video/jftui/default.nix
+++ b/pkgs/applications/video/jftui/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, fetchpatch, clang,
+  pkg-config, curl, mpv, yajl }:
+
+stdenv.mkDerivation rec {
+  pname = "jftui";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Aanok";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0g93w8ahyh2v0cv2fyj5a7v6qyznavwk0dcxx1qw4kczdgmlxnkx";
+  };
+
+  patches = [
+    # Remove this patch with next version
+    (fetchpatch {
+      name = "curl-capability-check-fix";
+      url = "https://github.com/Aanok/jftui/commit/d63996b8bc0d2ac4b04c5de4169bc7f8ec9b2a30.patch";
+      sha256 = "1d595mkzgx3carq2cykxpvmf5klgdlyaq94fk9wj8812yswqlsr7";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    clang
+    curl
+    mpv
+    yajl
+  ];
+
+  installPhase = ''
+    install -Dm555 build/jftui $out/bin/jftui
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Jellyfin Terminal User Interface ";
+    homepage = "https://github.com/Aanok/jftui";
+    license = licenses.unlicense;
+    maintainers = [ maintainers.nyanloutre ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20063,6 +20063,8 @@ in
     inherit (darwin) libobjc;
   };
 
+  jftui = callPackage ../applications/video/jftui { };
+
   lilyterm = callPackage ../applications/misc/lilyterm {
     inherit (gnome2) vte;
     gtk = gtk2;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

CLI frontend for Jellyfin. It uses MPV for video playback.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).