### PR TITLE
manual: use quoted homepage urls

### DIFF
--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -42,7 +42,7 @@ pet = buildGoModule rec {
 
   meta = with lib; {
     description = "Simple command-line snippet manager, written in Go";
-    homepage = https://github.com/knqyf263/pet;
+    homepage = "https://github.com/knqyf263/pet";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/doc/languages-frameworks/idris.section.md
+++ b/doc/languages-frameworks/idris.section.md
@@ -96,7 +96,7 @@ build-idris-package  {
 
   meta = {
     description = "Idris YAML lib";
-    homepage = https://github.com/Heather/Idris.Yaml;
+    homepage = "https://github.com/Heather/Idris.Yaml";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
   };

--- a/doc/languages-frameworks/ocaml.xml
+++ b/doc/languages-frameworks/ocaml.xml
@@ -36,7 +36,7 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = {
-    homepage = https://github.com/inhabitedtype/angstrom;
+    homepage = "https://github.com/inhabitedtype/angstrom";
     description = "OCaml parser combinators built for speed and memory efficiency";
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
@@ -63,7 +63,7 @@ buildDunePackage rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/flowtype/ocaml-wtf8;
+    homepage = "https://github.com/flowtype/ocaml-wtf8";
     description = "WTF-8 is a superset of UTF-8 that allows unpaired surrogates.";
     license = licenses.mit;
     maintainers = [ maintainers.eqyiel ];

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -241,7 +241,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    homepage = https://github.com/pytoolz/toolz;
+    homepage = "https://github.com/pytoolz/toolz";
     description = "List processing tools and functional utilities";
     license = licenses.bsd3;
     maintainers = with maintainers; [ fridh ];
@@ -335,7 +335,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ numpy multipledispatch dateutil ];
 
   meta = with lib; {
-    homepage = https://github.com/ContinuumIO/datashape;
+    homepage = "https://github.com/ContinuumIO/datashape";
     description = "A data description language";
     license = licenses.bsd2;
     maintainers = with maintainers; [ fridh ];
@@ -369,7 +369,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Pythonic binding for the libxml2 and libxslt libraries";
-    homepage = https://lxml.de;
+    homepage = "https://lxml.de";
     license = licenses.bsd3;
     maintainers = with maintainers; [ sjourdois ];
   };

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with stdenv.lib; {
     description = "A fast line-oriented regex search tool, similar to ag and ack";
-    homepage = https://github.com/BurntSushi/ripgrep;
+    homepage = "https://github.com/BurntSushi/ripgrep";
     license = licenses.unlicense;
     maintainers = [ maintainers.tailhook ];
     platforms = platforms.all;

--- a/doc/stdenv/meta.xml
+++ b/doc/stdenv/meta.xml
@@ -11,7 +11,7 @@ meta = with stdenv.lib; {
     GNU Hello is a program that prints "Hello, world!" when you run it.
     It is fully customizable.
   '';
-  homepage = https://www.gnu.org/software/hello/manual/;
+  homepage = "https://www.gnu.org/software/hello/manual/";
   license = licenses.gpl3Plus;
   maintainers = [ maintainers.eelco ];
   platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change
was brought to my attention that the manual examples don't reflect https://github.com/NixOS/rfcs/pull/45

https://github.com/NixOS/nixpkgs/pull/80188#discussion_r379914031

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
