### PR TITLE
emacsPackages.org-roam: init at 0.1.2

### DIFF
--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -110,6 +110,27 @@
   org-mac-link =
     callPackage ./org-mac-link { };
 
+  org-roam = melpaBuild rec {
+    pname = "org-roam";
+    version = "0.1.1";
+    src = pkgs.fetchFromGitHub {
+      owner = "jethrokuan";
+      repo = "org-roam";
+      rev = "v${version}";
+      sha256 = "0srbqx6i21qdb9cn2cx5fk8a4477xflfx0ybfbx95rwcciz20zn6";
+    };
+    recipe = pkgs.writeText "recipe" ''
+      (org-roam
+       :repo "jethrokuan/org-roam"
+       :fetcher github
+       :files ("*.el"))
+    '';
+    packageRequires = [ dash f s async ];
+    meta = {
+      license = gpl3;
+    };
+  };
+
   perl-completion =
     callPackage ./perl-completion { };
 

--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -112,12 +112,12 @@
 
   org-roam = melpaBuild rec {
     pname = "org-roam";
-    version = "0.1.1";
+    version = "0.1.2";
     src = pkgs.fetchFromGitHub {
       owner = "jethrokuan";
       repo = "org-roam";
       rev = "v${version}";
-      sha256 = "0srbqx6i21qdb9cn2cx5fk8a4477xflfx0ybfbx95rwcciz20zn6";
+      sha256 = "1p8bhj09s0iyb3fcjibsl1p61wiac17sn1w7hwm1wqrcydj8h8hx";
     };
     recipe = pkgs.writeText "recipe" ''
       (org-roam


### PR DESCRIPTION
###### Motivation for this change
org-roam seems to be a nice package, but it's not packaged into melpa/elpa

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I'm running it now and it works fine.