### PR TITLE
tinyprog: fix pkg_resources crash

### DIFF
--- a/pkgs/development/tools/misc/tinyprog/default.nix
+++ b/pkgs/development/tools/misc/tinyprog/default.nix
@@ -24,6 +24,7 @@ with python3Packages; buildPythonApplication rec {
     tqdm
     six
     packaging
+    setuptools
     pyusb
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Before this change, running tinyprog would always result in the error
```
Traceback (most recent call last):
  File "/nix/store/zn8djv3qzz0pxpf19agjnsi5319xz13w-tinyprog-1.0.24.dev114+g97f6353/bin/.tinyprog-wrapped", line 6, in <module>
    from tinyprog.__main__ import main
  File "/nix/store/zn8djv3qzz0pxpf19agjnsi5319xz13w-tinyprog-1.0.24.dev114+g97f6353/lib/python3.7/site-packages/tinyprog/__init__.py", line 8, in <module>
    from pkg_resources import get_distribution, DistributionNotFound
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done
Add `setuptools` to `propagatedBuildInputs`, fixing this error.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
