### PR TITLE
uq: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/misc/uq/default.nix
+++ b/pkgs/misc/uq/default.nix
@@ -14,10 +14,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1qqqmdk0v1d3ckasmmw5lbrkvhkv0nws4bzi9cfi1ndhrbvbkbxb";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1s22v2wz5h3l5l447zl54bhdk6avkk2ycrbbpxcx1442lllbss4w";
+  cargoSha256 = "1fv13rbghfw7114h7sda04gpqrjrsgnnki0p9kdd6r6sk5cbhn9x";
 
   meta = with lib; {
     description = "A simple, user-friendly alternative to sort | uniq";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.