### PR TITLE
cargo-deps: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/package-management/cargo-deps/default.nix
+++ b/pkgs/tools/package-management/cargo-deps/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "16181p7ghvy9mqippg1xi2cw7yxvicis8v6n39wly5qw05i57aw2";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1a9svdw1cgk6s7gqpsq3r25wxa2gr2xddqkc1cjk7hf6sk327cpv";
+  cargoSha256 = "1zk6pf7agqs1mpld40rn05cwp4wy0vpjnn5ip6m83bxm8b3i87wk";
 
   meta = with lib; {
     description = "Cargo subcommand for building dependency graphs of Rust projects";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.