### PR TITLE
mrtrix: init at 3.0_RC3_latest

### DIFF
--- a/pkgs/applications/science/biology/mrtrix/default.nix
+++ b/pkgs/applications/science/biology/mrtrix/default.nix
@@ -1,0 +1,77 @@
+{ stdenv, lib, fetchFromGitHub, python, makeWrapper
+, eigen, fftw, libtiff, zlib, ants, bc
+, qt5, libGL, libGLU, libX11, libXext
+, withGui ? true }:
+
+stdenv.mkDerivation rec {
+  pname = "mrtrix";
+  version = "3.0_RC3_latest";
+
+  src = fetchFromGitHub {
+    owner  = "MRtrix3";
+    repo   = "mrtrix3";
+    rev    = version;
+    sha256 = "184nv524p8j94qicjy9l288bqcgl2yxqqs55a7042i0gfsnwp51c";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ eigen makeWrapper ] ++ lib.optional withGui qt5.wrapQtAppsHook;
+
+  buildInputs = [
+    ants
+    python
+    fftw
+    libtiff
+    zlib ] ++ lib.optionals withGui [
+    libGL
+    libGLU
+    libX11
+    libXext
+    qt5.qtbase
+    qt5.qtsvg
+  ];
+
+  installCheckInputs = [ bc ];
+
+  postPatch = ''
+    patchShebangs ./build ./configure ./run_tests ./bin/population_template
+    substituteInPlace ./run_tests  \
+      --replace 'git submodule update --init >> $LOGFILE 2>&1' ""
+  '';
+
+  configurePhase = ''
+    export EIGEN_CFLAGS="-isystem ${eigen}/include/eigen3"
+    unset LD  # similar to https://github.com/MRtrix3/mrtrix3/issues/1519
+    ./configure ${lib.optionalString (!withGui) "-nogui"};
+  '';
+
+  buildPhase = ''
+    ./build
+    (cd testing && ../build)
+  '';
+
+  installCheckPhase = "./run_tests";
+  doInstallCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -ar lib $out/lib
+    cp -ar bin $out/bin
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    for prog in $out/bin/*; do
+      wrapProgram $prog --prefix PATH : ${lib.makeBinPath [ ants ]}
+    done
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/MRtrix3/mrtrix3";
+    description = "Suite of tools for diffusion imaging";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.linux;
+    license   = licenses.mpl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23907,6 +23907,8 @@ in
 
   mrbayes = callPackage ../applications/science/biology/mrbayes { };
 
+  mrtrix = callPackage ../applications/science/biology/mrtrix { python = python3; };
+
   megahit = callPackage ../applications/science/biology/megahit { };
 
   messer-slim = callPackage ../applications/science/biology/messer-slim { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

Add a package.  (Note that the slightly strange-looking version is in fact a valid Git tag.)

This package consists mostly of command-line tools, but there are also two qt5-based image viewers (`mrview` and `shview`).  I have provided an option `withGui ? true` to allow users to disable these viewers (primarily in order to remove Qt from the closure).  They work on NixOS but are unlikely to work out-of-the box on non-NixOS Linux (see https://github.com/NixOS/nixpkgs/issues/62169), but I've refrained from `assert`ing that they shouldn't be built since a user might want to fiddle with runtime GL stuff.

Some programs rely on FSL and/or ANTs backends; I have somewhat heavy-handedly wrapped all binaries to point to ANTs, while FSL is not available in Nix at the moment and has a non-commercial license so would be convenient to disable by default for Hydra builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [NA] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [NA] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
