### PR TITLE
 flashrom: switch to Meson build and update deps

### DIFF
--- a/pkgs/tools/misc/flashrom/default.nix
+++ b/pkgs/tools/misc/flashrom/default.nix
@@ -1,4 +1,13 @@
-{ lib, stdenv, fetchurl, pkgconfig, libftdi, pciutils }:
+{ lib
+, stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, libftdi1
+, libusb1
+, pciutils
+}:
 
 stdenv.mkDerivation rec {
   pname = "flashrom";
@@ -9,23 +18,16 @@ stdenv.mkDerivation rec {
     sha256 = "0ax4kqnh7kd3z120ypgp73qy1knz47l6qxsqzrfkd97mh5cdky71";
   };
 
-  # Newer versions of libusb deprecate some API flashrom uses.
-  #postPatch = ''
-  #  substituteInPlace Makefile \
-  #    --replace "-Werror" "-Werror -Wno-error=deprecated-declarations -Wno-error=unused-const-variable="
-  #'';
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libftdi pciutils ];
-
-  preConfigure = "export PREFIX=$out";
+  nativeBuildInputs = [ meson pkgconfig ninja ];
+  buildInputs = [ libftdi1 libusb1 pciutils ];
 
   meta = with lib; {
     homepage = http://www.flashrom.org;
     description = "Utility for reading, writing, erasing and verifying flash ROM chips";
     license = licenses.gpl2;
     maintainers = with maintainers; [ funfunctor fpletz ];
-    platforms = with platforms; linux;
+    platforms = platforms.all;
+    # https://github.com/flashrom/flashrom/issues/125
     badPlatforms = [ "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[New upstream release](https://mail.coreboot.org/hyperkitty/list/flashrom@flashrom.org/message/C2M3PZO2EVV4UGY7YIT7CGRTPVPCWYLO/). Also switches to the Meson build system, and libftdi1 (which I am slowly trying to kill the older version of).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).