### PR TITLE
nixdoc: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/nix/nixdoc/default.nix
+++ b/pkgs/tools/nix/nixdoc/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs =  stdenv.lib.optional stdenv.isDarwin [ darwin.Security ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1hy8w73fir4wnqx7zfvfqh7s24w95x9nkw55kmizvrwf0glw9m4n";
+  cargoSha256 = "1vamwynkbnffs8ryr2zb1a41cymjvr8zzh1bifyh9hpkx2k11rs3";
 
   meta = with stdenv.lib; {
     description = "Generate documentation for Nix functions";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.