### PR TITLE
cargo-release: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/package-management/cargo-release/default.nix
+++ b/pkgs/tools/package-management/cargo-release/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1w9w43i5br94vg5m4idabh67p4ffsx2lmc2g0ak2k961vl46wr0q";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "075fvvd4c8f3kz6i6ny835h6jpa3c1v3miwfwwrdyy49a85lzjyj";
+  cargoSha256 = "1x54c6wk5cbnqcy1qpsff8lwqxs0d4qf0v71r7wl0kjp8mrmmhl4";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.