### PR TITLE
nixpkgs-fmt: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/nix/nixpkgs-fmt/default.nix
+++ b/pkgs/tools/nix/nixpkgs-fmt/default.nix
@@ -10,10 +10,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1iylldgyvrcarfigpbhicg6j6qyipfiqn7gybza7qajfzyprjqfa";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "04my7dlp76dxs1ydy2sbbca8sp3n62wzdxyc4afcmrg8anb0ghaf";
+  cargoSha256 = "1jxvy4w9jxv898wgqyj9bpkhnc7pkj9dxg5x0b39xsnkzl2lr239";
 
   meta = with lib; {
     description = "Nix code formatter for nixpkgs";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.