### PR TITLE
just: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/just/default.nix
+++ b/pkgs/development/tools/just/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0a4bml9nxvyh110a60l4lc11yr2ds5r8d3iplslccrkq1ka96av9";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0dbgjc21q0zaadsjvq3s6y6f4dmsybxb6g2sg8w2d3phkm9j921z";
+  cargoSha256 = "0wp61zjws9r1aapkapvq2vmad5kylkpw03wa82qhhq30knkpvr7b";
 
   checkInputs = [ coreutils bash dash ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; ran `nixpkgs-review wip` successfully.