### PR TITLE
sd: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/text/sd/default.nix
+++ b/pkgs/tools/text/sd/default.nix
@@ -12,10 +12,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1vxljmd1vh245yhv095i3l44pk915zr2pix4v9r8pz2fynp2nnmj";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1shqphbpn3ib28hnyib7mh1i5q56nshj864jm209s8qggbp96wp1";
+  cargoSha256 = "0n4c0snmjfyk3z2mbzpqgb6ggyv4nqszdda035g3rzpbavzx9xb5";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; ran `nixpkgs-review wip` successfully.