### PR TITLE
sonic-visualiser

### DIFF
--- a/pkgs/applications/audio/sonic-visualiser/default.nix
+++ b/pkgs/applications/audio/sonic-visualiser/default.nix
@@ -2,21 +2,23 @@
 
 { stdenv, fetchurl, alsaLib, bzip2, fftw, libjack2, libX11, liblo
 , libmad, libogg, librdf, librdf_raptor, librdf_rasqal, libsamplerate
-, libsndfile, pkgconfig, libpulseaudio, qtbase, redland
-, qmake, rubberband, serd, sord, vampSDK, fftwFloat
+, libsndfile, pkgconfig, libpulseaudio, qtbase, qtsvg, redland
+, rubberband, serd, sord, vampSDK, fftwFloat
+, capnproto, liboggz, libfishsound, libid3tag, opusfile
+, wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "sonic-visualiser";
-  version = "2.4.1";
+  version = "4.0.1";
 
   src = fetchurl {
-    url = "https://code.soundsoftware.ac.uk/attachments/download/1185/${pname}-${version}.tar.gz";
-    sha256 = "06nlha70kgrby16nyhngrv5q846xagnxdinv608v7ga7vpywwmyb";
+    url = "https://code.soundsoftware.ac.uk/attachments/download/2607/${pname}-${version}.tar.gz";
+    sha256 = "14674adzp3chilymna236qyvci3b1zmi3wyz696wk7bcd3ndpsg6";
   };
 
   buildInputs =
-    [ libsndfile qtbase fftw fftwFloat bzip2 librdf rubberband
+    [ libsndfile qtbase qtsvg fftw fftwFloat bzip2 librdf rubberband
       libsamplerate vampSDK alsaLib librdf_raptor librdf_rasqal redland
       serd
       sord
@@ -26,23 +28,22 @@ stdenv.mkDerivation rec {
       libpulseaudio
       libmad
       libogg # ?
-      # fishsound
+      libfishsound
       liblo
       libX11
+      capnproto
+      liboggz
+      libid3tag
+      opusfile
     ];
 
-  nativeBuildInputs = [ pkgconfig qmake ];
+  nativeBuildInputs = [ pkgconfig wrapQtAppsHook ];
 
-  configurePhase = ''
-    for i in sonic-visualiser svapp svcore svgui;
-      do cd $i && qmake PREFIX=$out && cd ..;
-    done
-  '';
+  enableParallelBuilding = true;
 
-  installPhase = ''
-    mkdir -p $out/{bin,share/sonic-visualiser}
-    cp sonic-visualiser $out/bin/
-    cp -r samples $out/share/sonic-visualiser/
+  # comment out the tests
+  preConfigure = ''
+    sed -i 's/sub_test_svcore_/#sub_test_svcore_/' sonic-visualiser.pro
   '';
 
   meta = with stdenv.lib; {
@@ -51,6 +52,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.goibhniu maintainers.marcweber ];
     platforms = platforms.linux;
-    broken = true;
   };
 }

--- a/pkgs/development/libraries/libfishsound/default.nix
+++ b/pkgs/development/libraries/libfishsound/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, libvorbis, speex, flac, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "libfishsound-1.0.0";
+
+  src = fetchurl {
+    url = "http://downloads.xiph.org/releases/libfishsound/${name}.tar.gz";
+    sha256 = "1iz7mn6hw2wg8ljaw74f4g2zdj68ib88x4vjxxg3gjgc5z75f2rf";
+  };
+
+  propagatedBuildInputs = [ libvorbis speex flac ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  meta = with stdenv.lib; {
+    homepage = https://xiph.org/fishsound/;
+    description = ''libfishsound by itself is designed to handle raw codec streams from a lower level layer such as UDP datagrams. When these codecs are used in files, they are commonly encapsulated in Ogg to produce Ogg FLAC, Speex and Ogg Vorbis files.
+
+libfishsound is a wrapper around the existing codec libraries and provides a consistent, higher-level programming interface. It has been designed for use in a wide variety of applications; it has no direct dependencies on Ogg encapsulation, though it is most commonly used in conjunction with liboggz to decode or encode FLAC, Speex or Vorbis audio tracks in Ogg files, including Ogg Theora and Annodex.
+
+FishSound has been developed and tested on GNU/Linux, Darwin/MacOSX and Win32. It probably also works on other Unix-like systems via GNU autoconf. For Win32: nmake Makefiles, Visual Studio .NET 2003 solution files and Visual C++ 6.0 workspace files are all provided in the source distribution.'';
+    platforms = platforms.unix;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12438,6 +12438,8 @@ in
 
   libfilezilla = callPackage ../development/libraries/libfilezilla { };
 
+  libfishsound = callPackage ../development/libraries/libfishsound { };
+
   libfm = callPackage ../development/libraries/libfm { };
   libfm-extra = libfm.override {
     extraOnly = true;


### PR DESCRIPTION
###### Motivation for this change

Fix the package which has been marked as broken for years.
The dependency libfishsound from Xiph has been added.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [+] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [+] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [+] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [+] Ensured that relevant documentation is up to date
- [] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
