### PR TITLE
steamPackages.chrootenv: add file command

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -100,6 +100,9 @@ in buildFHSUserEnv rec {
 
     # friends options won't display "Launch Game" without it
     lsof
+
+    # called by steam's setup.sh
+    file
   ] ++ (if (!nativeOnly) then [
     (steamPackages.steam-runtime-wrapped.override {
       inherit runtimeOnly;


### PR DESCRIPTION
###### Motivation for this change
I was using strace to figure out why a game wouldn't boot (turned out it just took a long while). But noticed in the strace logs that it was trying to call out to file and zenity.

NixOS steam sometimes has different behaviors than distro's, and I think this gets closer to the other distro's

commit body:
```
Noticed that the setup.sh for steam was trying to call these commands.
I'm not sure what the ramifications are for these missing,
but some steam features are quietly disabled when they
don't follow happy paths.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
