### PR TITLE
unifont: generate otb and split output

### DIFF
--- a/pkgs/data/fonts/unifont/default.nix
+++ b/pkgs/data/fonts/unifont/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, mkfontscale, mkfontdir }:
+{ stdenv, fetchurl, mkfontscale
+, libfaketime, fonttosfnt
+}:
 
 stdenv.mkDerivation rec {
   pname = "unifont";
@@ -14,23 +16,32 @@ stdenv.mkDerivation rec {
     sha256 = "1cd1fnk3m7giqp099kynnjj4m7q00lqm4ybqb1vzd2wi3j4a1awf";
   };
 
-  nativeBuildInputs = [ mkfontscale mkfontdir ];
+  nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];
 
-  phases = "installPhase";
+  phases = [ "buildPhase" "installPhase" ];
+
+  buildPhase =
+    ''
+      # convert pcf font to otb
+      faketime -f "1970-01-01 00:00:01" \
+      fonttosfnt -g 2 -m 2 -v -o "unifont.otb" "${pcf}"
+    '';
 
   installPhase =
     ''
-      mkdir -p $out/share/fonts $out/share/fonts/truetype
-      cp -v ${pcf} $out/share/fonts/unifont.pcf.gz
-      cp -v ${ttf} $out/share/fonts/truetype/unifont.ttf
-      cd $out/share/fonts
+      # install otb fonts
+      install -m 644 -D unifont.otb "$otb/share/fonts/unifont.otb"
+      mkfontdir "$otb/share/fonts"
+
+      # install pcf and ttf fonts
+      install -m 644 -D ${pcf} $out/share/fonts/unifont.pcf.gz
+      install -m 644 -D ${ttf} $out/share/fonts/truetype/unifont.ttf
+      cd "$out/share/fonts"
       mkfontdir
       mkfontscale
     '';
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "0n3ms2k2mk7j6144l05c45smggwf3j5cwkaxhw93wf9hd1lhpwq1";
+  outputs = [ "out" "otb" ];
 
   meta = with stdenv.lib; {
     description = "Unicode font for Base Multilingual Plane";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18013,7 +18013,8 @@ in
 
   unihan-database = callPackage ../data/misc/unihan-database { };
 
-  unifont = callPackage ../data/fonts/unifont { };
+  unifont = callPackage ../data/fonts/unifont
+     { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
 
   unifont_upper = callPackage ../data/fonts/unifont_upper { };
 


### PR DESCRIPTION
###### Motivation for this change
Issue #75160 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested PCF fonts in xfontsel
- [x] Tested OTB, TTF fonts with pango-view
- [x] Tested change with `nix-review`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
