### PR TITLE
gnome-tour: init at 0.0.1

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-tour/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-tour/default.nix
@@ -1,0 +1,81 @@
+{ stdenv
+, rustPlatform
+, gettext
+, meson
+, ninja
+, fetchFromGitLab
+, pkg-config
+, gtk3
+, glib
+, gdk-pixbuf
+, desktop-file-utils
+, appstream-glib
+, wrapGAppsHook
+, python3
+, gnome3
+, config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gnome-tour";
+  version = "0.0.1";
+
+  # We don't use the uploaded tar.xz because it comes pre-vendored
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "gnome-tour";
+    rev = version;
+    sha256 = "0lbkspnlziq3z177071w3jpghmdwflzra1krdwchzmkfmrhy50ch";
+  };
+
+  cargoSha256 = "0k1wp9wswr57fv2d9bysxn97fchd4vz29n5r8gfyp0gcm8rclmij";
+
+  mesonFlags = [
+    "-Ddistro_name=NixOS"
+    "-Ddistro_icon_name=nix-snowflake"
+    "-Ddistro_version=20.09"
+  ];
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    gettext
+    meson
+    ninja
+    pkg-config
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gdk-pixbuf
+    glib
+    gtk3
+  ];
+
+  # Don't use buildRustPackage phases, only use it for rust deps setup
+  configurePhase = null;
+  buildPhase = null;
+  checkPhase = null;
+  installPhase = null;
+
+  postPatch = ''
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
+  '';
+
+  # passthru = {
+  #   updateScript = gnome3.updateScript {
+  #     packageName = pname;
+  #   };
+  # };
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-tour";
+    description = "GNOME Greeter & Tour";
+    maintainers = gnome3.maintainers;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23695,6 +23695,8 @@ in
     mediaplayer = throw "gnomeExtensions.mediaplayer deprecated since 2019-09-23: retired upstream https://github.com/JasonLG1979/gnome-shell-extensions-mediaplayer/blob/master/README.md";
   };
 
+  gnome-tour = callPackages ../desktops/gnome-3/core/gnome-tour { };
+
   hsetroot = callPackage ../tools/X11/hsetroot { };
 
   imwheel = callPackage ../tools/X11/imwheel { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
It was talked that gnome might recommend this as a default application for first run.
https://gitlab.gnome.org/GNOME/gnome-build-meta/issues/243, they will likely link it into gnome-initial-setup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
