### PR TITLE
uni-vga: generate otb, psf and split output

### DIFF
--- a/pkgs/data/fonts/uni-vga/default.nix
+++ b/pkgs/data/fonts/uni-vga/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, mkfontdir, mkfontscale }:
+{ stdenv, fetchurl, perl, kbd, bdftopcf
+, libfaketime, fonttosfnt, mkfontscale
+}:
 
 stdenv.mkDerivation {
   name = "uni-vga";
@@ -8,19 +10,43 @@ stdenv.mkDerivation {
     sha256 = "05sns8h5yspa7xkl81ri7y1yxf5icgsnl497f3xnaryhx11s2rv6";
   };
 
-  nativeBuildInputs = [ mkfontdir mkfontscale ];
+  nativeBuildInputs =
+    [ perl kbd bdftopcf libfaketime
+      fonttosfnt mkfontscale
+    ];
 
-  installPhase = ''
-    mkdir -p $out/share/fonts
-    cp *.bdf $out/share/fonts
-    cd $out/share/fonts
-    mkfontdir
-    mkfontscale
+  postPatch = "patchShebangs .";
+
+  buildPhase = ''
+    # convert font to compressed pcf
+    bdftopcf u_vga16.bdf | gzip -c -9 -n  > u_vga16.pcf.gz
+
+    # convert font to compressed psf
+    ./bdf2psf.pl -s UniCyrX.sfm u_vga16.bdf \
+      | psfaddtable - UniCyrX.sfm - \
+      | gzip -c -9 -n > u_vga16.psf.gz
+
+    # convert bdf font to otb
+    faketime -f "1970-01-01 00:00:01" \
+    fonttosfnt -v -o u_vga16.otb u_vga16.bdf
   '';
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "0rfly7r6blr2ykxlv0f6my2w41vvxcw85chspljd2p1fxlr28jd7";
+  installPhase = ''
+    # install pcf (for X11 applications) and psf (virtual terminal)
+    install -m 644 -D *.pcf.gz -t "$out/share/fonts"
+    install -m 644 -D *.psf.gz -t "$out/share/consolefonts"
+    mkfontdir "$out/share/fonts"
+
+    # install bdf font
+    install -m 644 -D *.bdf -t "$bdf/share/fonts"
+    mkfontdir "$bdf/share/fonts"
+
+    # install otb font (for GTK applications)
+    install -m 644 -D *.otb -t "$otb/share/fonts"
+    mkfontdir "$otb/share/fonts"
+  '';
+
+  outputs = [ "out" "bdf" "otb" ];
 
   meta = {
     description = "Unicode VGA font";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18005,7 +18005,8 @@ in
 
   undefined-medium = callPackage ../data/fonts/undefined-medium { };
 
-  uni-vga = callPackage ../data/fonts/uni-vga { };
+  uni-vga = callPackage ../data/fonts/uni-vga
+     { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
 
   unicode-character-database = callPackage ../data/misc/unicode-character-database { };
 


### PR DESCRIPTION
###### Motivation for this change
Issue #75160 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested PCF font in xfontsel
- [x] Tested OTB font with pango-view
- [x] Tested PSF font in the linux vt
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
