### PR TITLE
pythonPackages.cvxpy: init at 1.0.25 (and its dependencies)

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
       "threadpool_multiple_event_loops" # times out on slow machines
       "get_passwd" # passed on NixOS but failed on other Linuxes
       "tcp_writealot" # times out sometimes
+      "ipc_closed_handle" # times out
     ] ++ stdenv.lib.optionals stdenv.isDarwin [
         # Sometimes: timeout (no output), failed uv_listen. Someone
         # should report these failures to libuv team. There tests should

--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ecos-python
+, multiprocess
+, nose
+, numpy
+, osqp-python
+, scipy
+, scs-python
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "cvxpy";
+  version = "1.0.25";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8535529ddb807067b0d59661dce1d9a6ddb2a218398a38ea7772328ad8a6ea13";
+  };
+
+  propagatedBuildInputs = [ ecos-python numpy multiprocess osqp-python scipy scs-python six ];
+
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    nosetests cvxpy 
+  '';
+ 
+  meta = with lib; {
+    description = "Embedded modeling language for convex optimization problems";
+    homepage = "https://github.com/cvxgrp/cvxpy";
+    license = licenses.asl20;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/development/python-modules/ecos-python/default.nix
+++ b/pkgs/development/python-modules/ecos-python/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchFromGitHub, fetchPypi, nose, numpy, scipy }:
+
+buildPythonPackage rec {
+  pname = "ecos";
+  version = "2.0.7.post1";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "83e90f42b3f32e2a93f255c3cfad2da78dbd859119e93844c45d2fca20bdc758";
+  };
+  
+  # submodule is only part of PyPI tarball, which does not include the test files
+  testSrc = fetchFromGitHub {
+    owner = "embotech";
+    repo = "ecos-python";
+    rev = "2.0.7";
+    sha256 = "0y7rgn3329sx7i82wf567x3cq0jxs27cnif299mj8y4zdglmvfqn";
+  };
+  
+  patchPhase = ''
+    cp ${testSrc}/src/test_interface.py ${testSrc}/src/test_interface_bb.py src
+  '';
+
+  propagatedBuildInputs = [ numpy scipy ];
+  
+  checkInputs = [ nose ];
+  
+  meta = with lib; {
+    description = "Lightweight conic solver for second-order cone programming";
+    homepage = "https://github.com/embotech/ecos";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/development/python-modules/osqp-python/default.nix
+++ b/pkgs/development/python-modules/osqp-python/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchPypi, cmake, future, numpy, python, pytest, scipy }:
+
+buildPythonPackage rec {
+  pname = "osqp";
+  version = "0.6.1";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "47b17996526d6ecdf35cfaead6e3e05d34bc2ad48bcb743153cefe555ecc0e8c";
+  };
+  
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ future numpy scipy ];
+  dontUseCmakeConfigure = true;
+  
+  # deselect mkl_pardiso_tests: raises WorkspaceAllocationError in setup
+  patchPhase = ''
+    substituteInPlace module/tests/mkl_pardiso_test.py --replace \
+      "class mkl_pardiso_tests(unittest.TestCase):" \
+      "@unittest.skip('raises WorkspaceAllocationError')
+    class mkl_pardiso_tests(unittest.TestCase):"
+  '';
+  
+  checkInputs = [ pytest ];
+  
+  checkPhase = ''
+    pytest module/tests -k 'not mkl_paradiso_tests'
+  '';
+  
+  meta = with lib; {
+    description = "Python wrapper for OSQP, the Operator Splitting QP Solver";
+    homepage = "https://github.com/oxfordcontrol/osqp-python";
+    license = licenses.asl20;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/development/python-modules/scs-python/default.nix
+++ b/pkgs/development/python-modules/scs-python/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, nose, numpy, scipy }:
+
+buildPythonPackage rec {
+  pname = "scs";
+  version = "2.1.1-2";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f816cfe3d4b4cff3ac2b8b96588c5960ddd2a3dc946bda6b09db04e7bc6577f2";
+  };
+
+  propagatedBuildInputs = [ numpy scipy ];
+  
+  checkInputs = [ nose ];
+  
+  checkPhase = ''
+    nosetests test
+  '';
+  
+  meta = with lib; {
+    description = "Interface for Splitting Conic Solver";
+    homepage = "https://github.com/bodono/scs-python";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5376,6 +5376,8 @@ in {
 
   scp = callPackage ../development/python-modules/scp {};
 
+  scs-python = callPackage ../development/python-modules/scs-python { };
+
   seaborn = callPackage ../development/python-modules/seaborn { };
 
   seabreeze = callPackage ../development/python-modules/seabreeze { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2553,6 +2553,8 @@ in {
     pythonPackages = self;
   });
 
+  ecos-python = callPackage ../development/python-modules/ecos-python { };
+
   edward = callPackage ../development/python-modules/edward { };
 
   elasticsearch = callPackage ../development/python-modules/elasticsearch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1878,6 +1878,8 @@ in {
 
   cvxopt = callPackage ../development/python-modules/cvxopt { };
 
+  cvxpy = callPackage ../development/python-modules/cvxpy { };
+  
   cycler = callPackage ../development/python-modules/cycler { };
 
   cysignals = callPackage ../development/python-modules/cysignals { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -926,6 +926,8 @@ in {
 
   osmnx = callPackage ../development/python-modules/osmnx { };
 
+  osqp-python = callPackage ../development/python-modules/osqp-python { };
+
   outcome = callPackage ../development/python-modules/outcome {};
 
   ovito = toPythonModule (pkgs.libsForQt5.callPackage ../development/python-modules/ovito {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module 'cvxpy' 1.0.25 in Nix, and its missing dependencies: 'ecos-python' 2.0.7.post1, 'osqp-python' 0.6.1 and 'scs-python' 2.1.1-2. 
Please note that test case ipc_closed_handle in libuv times out, disabling that test is submitted as a separate PR as well: https://github.com/NixOS/nixpkgs/pull/80341.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
