### PR TITLE
pythonPackages.pytest-mysql: init at 2.0.1 (and its dependencies)

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
       "threadpool_multiple_event_loops" # times out on slow machines
       "get_passwd" # passed on NixOS but failed on other Linuxes
       "tcp_writealot" # times out sometimes
+      "ipc_closed_handle" # times out
     ] ++ stdenv.lib.optionals stdenv.isDarwin [
         # Sometimes: timeout (no output), failed uv_listen. Someone
         # should report these failures to libuv team. There tests should

--- a/pkgs/development/python-modules/mirakuru/default.nix
+++ b/pkgs/development/python-modules/mirakuru/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchFromGitHub, netcat, ps, psutil, pytest, pytestcov, python-daemon }:
+
+buildPythonPackage rec {
+  pname = "mirakuru";
+  version = "2.1.2";
+  
+  src = fetchFromGitHub {
+    owner = "ClearcodeHQ";
+    repo = pname;
+    rev = "v" + version;
+    sha256 = "0nhf3i1yav3nwddcv4pdrj8f7mm5hzfi2ps1d7vrimxr9knkny2c";
+  };
+  
+  propagatedBuildInputs = [ psutil ];
+  
+  checkInputs = [ netcat ps pytest pytestcov python-daemon ];
+  
+  checkPhase = ''
+    pytest tests
+  '';
+  
+  meta = with lib; {
+    description = "Process orchestration tool designed for functional and integration tests";
+    homepage = "https://github.com/ClearcodeHQ/mirakuru";
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/development/python-modules/port-for/default.nix
+++ b/pkgs/development/python-modules/port-for/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, mock, pytest, urllib3 }:
+
+buildPythonPackage rec {
+  pname = "port-for";
+  version = "0.4";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "47b5cb48f8e036497cd73b96de305cecb4070e9ecbc908724afcbd2224edccde";
+  };
+  
+  propagatedBuildInputs = [ urllib3 ];
+  
+  # old dependency is used
+  patchPhase = ''
+    substituteInPlace port_for/_download_ranges.py --replace "urllib2" "urllib3" 
+  '';
+  
+  checkInputs = [ mock pytest ];
+  
+  meta = with lib; {
+    description = "Utility that helps with local TCP ports managment";
+    homepage = "https://github.com/kmike/port-for";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-mysql/default.nix
+++ b/pkgs/development/python-modules/pytest-mysql/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, mock
+, mirakuru
+, mysqlclient
+, port-for
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-mysql";
+  version = "2.0.1";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "ClearcodeHQ";
+    repo = pname;
+    rev = "v" + version;
+    sha256 = "18z7br80hj46cnmj9jflbyzlgxxn5qmwqz7iqwsl4ynzipfx81hd";
+  };
+  
+  propagatedBuildInputs = [ mirakuru mysqlclient port-for pytest ];
+ 
+  checkInputs = [ mock pytest ];
+ 
+  checkPhase = ''
+    # deselect test_mysql.py because that requires a running mysqld 
+    pytest tests -k 'not test_mysql.py'
+  '';
+ 
+  meta = with lib; {
+    description = "MySQL process and client fixtures for pytest";
+    homepage = "https://github.com/ClearcodeHQ/pytest-mysql";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1226,6 +1226,8 @@ in {
 
   pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };
 
+  pytest-mysql = callPackage ../development/python-modules/pytest-mysql { };
+
   pytest-ordering = callPackage ../development/python-modules/pytest-ordering { };
 
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -847,6 +847,8 @@ in {
 
   mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;
 
+  mirakuru = callPackage ../development/python-modules/mirakuru { };
+
   mkl-service = callPackage ../development/python-modules/mkl-service { };
 
   mnist = callPackage ../development/python-modules/mnist { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4730,6 +4730,8 @@ in {
 
   portend = callPackage ../development/python-modules/portend { };
 
+  port-for = callPackage ../development/python-modules/port-for { };
+
   powerline = callPackage ../development/python-modules/powerline { };
 
   pox = callPackage ../development/python-modules/pox { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module 'pytest-mysql' 2.0.1 in Nix, and also its missing dependencies, namely 'mirakuru'  2.1.2 and 'port-for' 0.4.
Please note that the test case ipc_closed_handle is unstable in libuv, it is also submitted as a separate PR (https://github.com/NixOS/nixpkgs/pull/80341)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
