### PR TITLE
pythonPackages.pydruid: init at 0.5.8

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
       "threadpool_multiple_event_loops" # times out on slow machines
       "get_passwd" # passed on NixOS but failed on other Linuxes
       "tcp_writealot" # times out sometimes
+      "ipc_closed_handle" # times out
     ] ++ stdenv.lib.optionals stdenv.isDarwin [
         # Sometimes: timeout (no output), failed uv_listen. Someone
         # should report these failures to libuv team. There tests should

--- a/pkgs/development/python-modules/pydruid/default.nix
+++ b/pkgs/development/python-modules/pydruid/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pandas
+, prompt_toolkit
+, pycurl
+, pygments
+, pytest
+, pytestrunner
+, requests
+, six
+, sqlalchemy
+, tabulate
+, tornado
+}:
+
+buildPythonPackage rec {
+  pname = "pydruid";
+  version = "0.5.8";
+
+  src = fetchFromGitHub {
+    owner = "druid-io";
+    repo = pname;
+    rev = version;
+    sha256 = "0zb6zmklib26fzv5dvqzy0h0p1ljjgkklnjm66imc35mx5irpzcv";
+  };
+
+  patchPhase = ''
+    # timestamp is added to the end of the list, and dict keeps keys in insertion order
+    substituteInPlace tests/test_query.py --replace  \
+      "def expected_results_csv_reader():" "
+    EXPECTED_RESULTS_PANDAS = list(map(lambda x: dict(list(x.items())[1:] + [list(x.items())[0]]), EXPECTED_RESULTS_PANDAS))
+    def expected_results_csv_reader():"
+  '';
+ 
+  propagatedBuildInputs = [ pandas prompt_toolkit pycurl pygments requests six sqlalchemy tabulate tornado ];
+
+  checkInputs = [ pytest pytestrunner ];
+  
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = with lib; {
+    description = "A Python connector for Druid";
+    homepage = "https://github.com/druid-io/pydruid";
+    license = licenses.asl20;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1066,6 +1066,8 @@ in {
 
   pydrive = callPackage ../development/python-modules/pydrive { };
 
+  pydruid = callPackage ../development/python-modules/pydruid { };
+
   pydy = callPackage ../development/python-modules/pydy { };
 
   pyexiv2 = disabledIf isPy3k (toPythonModule (callPackage ../development/python-modules/pyexiv2 {}));


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packaging Python module 'pydruid' 0.5.8 in Nix, and a fix for unstable test in libuv (which is also submitted as a separate PR: https://github.com/NixOS/nixpkgs/pull/80341)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
