### PR TITLE
tests: fix more loaOf deprecation warnings

### DIFF
--- a/nixos/tests/glusterfs.nix
+++ b/nixos/tests/glusterfs.nix
@@ -4,10 +4,11 @@ let
   client = { pkgs, ... } : {
     environment.systemPackages = [ pkgs.glusterfs ];
     fileSystems = pkgs.lib.mkVMOverride
-    [ { mountPoint = "/gluster";
-        fsType = "glusterfs";
-        device = "server1:/gv0";
-    } ];
+      { "/gluster" =
+          { device = "server1:/gv0";
+            fsType = "glusterfs";
+          };
+      };
   };
 
   server = { pkgs, ... } : {
@@ -22,11 +23,11 @@ let
     virtualisation.emptyDiskImages = [ 1024 ];
 
     fileSystems = pkgs.lib.mkVMOverride
-      [ { mountPoint = "/data";
-          device = "/dev/disk/by-label/data";
-          fsType = "ext4";
-        }
-      ];
+      { "/data" =
+          { device = "/dev/disk/by-label/data";
+            fsType = "ext4";
+          };
+      };
   };
 in {
   name = "glusterfs";

--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -5,13 +5,13 @@ let
   client =
     { pkgs, ... }:
     { fileSystems = pkgs.lib.mkVMOverride
-        [ { mountPoint = "/data";
-            # nfs4 exports the export with fsid=0 as a virtual root directory
-            device = if (version == 4) then "server:/" else "server:/data";
-            fsType = "nfs";
-            options = [ "vers=${toString version}" ];
-          }
-        ];
+        { "/data" =
+           { # nfs4 exports the export with fsid=0 as a virtual root directory
+             device = if (version == 4) then "server:/" else "server:/data";
+             fsType = "nfs";
+             options = [ "vers=${toString version}" ];
+           };
+        };
       networking.firewall.enable = false; # FIXME: only open statd
     };
 

--- a/nixos/tests/orangefs.nix
+++ b/nixos/tests/orangefs.nix
@@ -10,11 +10,11 @@ let
     virtualisation.emptyDiskImages = [ 4096 ];
 
     fileSystems = pkgs.lib.mkVMOverride
-      [ { mountPoint = "/data";
-          device = "/dev/disk/by-label/data";
-          fsType = "ext4";
-        }
-      ];
+      { "/data" =
+          { device = "/dev/disk/by-label/data";
+            fsType = "ext4";
+          };
+      };
 
     services.orangefs.server = {
       enable = true;


### PR DESCRIPTION
###### Motivation for this change
Issue #77189

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via nixosTests.glusterfs ✔, nixosTests.orangefs ✗, nixosTests.nfs{3,4} ✔
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The orangefs test is failing because the package doesn't build.