### PR TITLE
unscii: cleanup and split outputs

### DIFF
--- a/pkgs/data/fonts/unscii/default.nix
+++ b/pkgs/data/fonts/unscii/default.nix
@@ -1,24 +1,47 @@
-{stdenv, fetchurl, perl, bdftopcf, perlPackages, fontforge, SDL, SDL_image}:
+{ stdenv, fetchurl, perl, bdftopcf
+, fontforge, SDL, SDL_image, mkfontscale
+}:
+
 stdenv.mkDerivation rec {
   pname = "unscii";
   version = "1.1";
-  # or fetchFromGitHub(owner,repo,rev) or fetchgit(rev)
+
   src = fetchurl {
     url = "http://pelulamu.net/${pname}/${pname}-${version}-src.tar.gz";
     sha256 = "0qcxcnqz2nlwfzlrn115kkp3n8dd7593h762vxs6vfqm13i39lq1";
   };
-  nativeBuildInputs = [perl bdftopcf perlPackages.TextCharWidth fontforge
-    SDL SDL_image];
+
+  nativeBuildInputs =
+    [ (perl.withPackages (p: [ p.TextCharWidth ]))
+      bdftopcf fontforge SDL SDL_image
+      mkfontscale
+    ];
+
   preConfigure = ''
     patchShebangs .
   '';
-  installPhase = ''
-    install -m444 -Dt $out/share/fonts          *.hex *.pcf
-    install -m444 -Dt $out/share/fonts/truetype *.ttf
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-    install -m444 -Dt $out/share/fonts/svg      *.svg
-    install -m444 -Dt $out/share/fonts/web      *.woff
+
+  postBuild = ''
+    # compress pcf fonts
+    gzip -9 -n *.pcf
   '';
+
+  installPhase = ''
+    # install fonts for use in X11 and GTK applications
+    install -m444 -Dt "$out/share/fonts/misc"     *.pcf.gz
+    install -m444 -Dt "$out/share/fonts/opentype" *.otf
+    mkfontdir   "$out/share/fonts/misc"
+    mkfontscale "$out/share/fonts/opentype"
+
+    # install other formats in $extra
+    install -m444 -Dt "$extra/share/fonts/truetype" *.ttf
+    install -m444 -Dt "$extra/share/fonts/svg"      *.svg
+    install -m444 -Dt "$extra/share/fonts/web"      *.woff
+    install -m444 -Dt "$extra/share/fonts/misc"     *.hex
+    mkfontscale "$extra"/share/fonts/*
+  '';
+
+  outputs = [ "out" "extra" ];
 
   meta = {
     inherit version;
@@ -26,7 +49,7 @@ stdenv.mkDerivation rec {
     # Basically GPL2+ with font exception — because of the Unifont-augmented
     # version. The reduced version is public domain.
     license = http://unifoundry.com/LICENSE.txt;
-    maintainers = [stdenv.lib.maintainers.raskin];
+    maintainers = [ stdenv.lib.maintainers.raskin ];
     homepage = http://pelulamu.net/unscii/;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The font is very large and duplicated across many formats, some of which cannot be compressed, like `.hex` or `.svg`. For normal use (eg. X11, GTK applications) these formats are not necessary, so I propose to moved them to another output, reducing the default closure size.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested fonts with xfontsel and pango-view
- [x] Tested compilation of all pkgs that depend on this change (unscii)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
