### PR TITLE
libreoffice: wrapper: add hunspell dirs to DICPATH

### DIFF
--- a/pkgs/applications/office/libreoffice/src-fresh/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/primary.nix
@@ -26,7 +26,8 @@ rec {
     sha256 = "0730fw2kr00b2d56jkdzjdz49c4k4mxiz879c7ikw59c5zvrh009";
   };
 
-  # TODO: dictionaries
+  # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
+  # it and LibreOffice can use these by pointing DICPATH environment variable at the hunspell directory
 
   help = fetchSrc {
     name = "help";

--- a/pkgs/applications/office/libreoffice/src-still/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-still/primary.nix
@@ -25,7 +25,8 @@ rec {
     sha256 = "1l5v9bb7n9s6i24q4mdyqyp5v4f8iy0a9dmpgw649vngj1zxdxfh";
   };
 
-  # TODO: dictionaries
+  # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
+  # it and LibreOffice can use these by pointing DICPATH environment variable at the hunspell directory
 
   help = fetchSrc {
     name = "help";

--- a/pkgs/applications/office/libreoffice/wrapper.sh
+++ b/pkgs/applications/office/libreoffice/wrapper.sh
@@ -17,6 +17,13 @@ if uname | grep Linux > /dev/null &&
     export DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_socket_dir/session"
 fi
 
+for PROFILE in $NIX_PROFILES; do
+    HDIR="$PROFILE/share/hunspell"
+    if [ -d "$HDIR" ]; then
+        export DICPATH=$DICPATH''${DICPATH:+:}$HDIR
+    fi
+done
+
 "@libreoffice@/bin/$(basename "$0")" "$@"
 code="$?"
 


### PR DESCRIPTION
LibreOffice doesn't know where to look for hunspell dictionaries on NixOS but we can use the `DICPATH` env var to point to them. Now spellchecking with system dictionaries (`nixpkgs.hunspellDicts.xx-yy`) works.

Note that some of these dictionaries are built from LibreOffice repos - this is preferable to building them as part of LO as other applications can use them.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Spellchecking with hunspell dictionaries doesn't work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
