### PR TITLE
haskell.compiler.ghc822Binary: propagate llvm dependency

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.2-binary.nix
@@ -1,12 +1,15 @@
 { stdenv, substituteAll
 , fetchurl, perl, gcc, llvm
 , ncurses5, gmp, glibc, libiconv
+, llvmPackages
 }:
 
 # Prebuilt only does native
 assert stdenv.targetPlatform == stdenv.hostPlatform;
 
 let
+  useLLVM = !stdenv.targetPlatform.isx86;
+
   libPath = stdenv.lib.makeLibraryPath ([
     ncurses5 gmp
   ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
@@ -53,7 +56,7 @@ stdenv.mkDerivation rec {
     or (throw "cannot bootstrap GHC on this platform"));
 
   nativeBuildInputs = [ perl ];
-  buildInputs = stdenv.lib.optionals (stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64) [ llvm ];
+  propagatedBuildInputs = stdenv.lib.optionals useLLVM [ llvmPackages.llvm ];
 
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
   # the final install location/


### PR DESCRIPTION
Fixes the following error when attempting to build packages using this
compiler:

```
  <no location info>: error:
      Warning: Couldn't figure out LLVM version!
               Make sure you have installed LLVM 3.9

  <no location info>: error: ghc: could not execute: opt
```

I don't know why this worked before, but it seems an appropriate fix.

###### Motivation for this change

Motivation is to make ghc build on aarch64. Fixes #80176 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (aarch64 only)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
