### PR TITLE
Update pykms to 20190611, adapt pykms service

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -66,6 +66,8 @@ with lib;
 
     (mkRenamedOptionModule [ "services" "clamav" "updater" "config" ] [ "services" "clamav" "updater" "extraConfig" ])
 
+    (mkRemovedOptionModule [ "services" "pykms" "verbose" ] "Use services.pykms.logLevel instead")
+
     (mkRemovedOptionModule [ "security" "setuidOwners" ] "Use security.wrappers instead")
     (mkRemovedOptionModule [ "security" "setuidPrograms" ] "Use security.wrappers instead")
 

--- a/nixos/modules/services/misc/pykms.nix
+++ b/nixos/modules/services/misc/pykms.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   cfg = config.services.pykms;
+  libDir = "/var/lib/pykms";
 
 in {
   meta.maintainers = with lib.maintainers; [ peterhoeg ];
@@ -28,12 +29,6 @@ in {
         description = "The port on which to listen.";
       };
 
-      verbose = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Show verbose output.";
-      };
-
       openFirewallPort = mkOption {
         type = types.bool;
         default = false;
@@ -45,30 +40,44 @@ in {
         default = "64M";
         description = "How much memory to use at most.";
       };
+
+      logLevel = mkOption {
+        type = types.enum [ "CRITICAL" "ERROR" "WARNING" "INFO" "DEBUG" "MINI" ];
+        default = "INFO";
+        description = "How much to log";
+      };
+
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Additional arguments";
+      };
     };
   };
 
   config = mkIf cfg.enable {
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewallPort [ cfg.port ];
 
-    systemd.services.pykms = let
-      home = "/var/lib/pykms";
-    in {
+    systemd.services.pykms = {
       description = "Python KMS";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       # python programs with DynamicUser = true require HOME to be set
-      environment.HOME = home;
+      environment.HOME = libDir;
       serviceConfig = with pkgs; {
         DynamicUser = true;
-        StateDirectory = baseNameOf home;
-        ExecStartPre = "${getBin pykms}/bin/create_pykms_db.sh ${home}/clients.db";
+        StateDirectory = baseNameOf libDir;
+        ExecStartPre = "${getBin pykms}/libexec/create_pykms_db.sh ${libDir}/clients.db";
         ExecStart = lib.concatStringsSep " " ([
-          "${getBin pykms}/bin/server.py"
+          "${getBin pykms}/bin/server"
+          "--logfile STDOUT"
+          "--loglevel ${cfg.logLevel}"
+        ] ++ cfg.extraArgs ++ [
           cfg.listenAddress
           (toString cfg.port)
-        ] ++ lib.optional cfg.verbose "--verbose");
-        WorkingDirectory = home;
+        ]);
+        ProtectHome = "tmpfs";
+        WorkingDirectory = libDir;
         Restart = "on-failure";
         MemoryLimit = cfg.memoryLimit;
       };

--- a/pkgs/tools/networking/pykms/default.nix
+++ b/pkgs/tools/networking/pykms/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, python3Packages, writeText, writeScript
+{ stdenv, runtimeShell, fetchFromGitHub, python3, writeText, writeScript
 , coreutils, sqlite }:
 
-with python3Packages;
+with python3.pkgs;
 
 let
   dbSql = writeText "create_pykms_db.sql" ''
@@ -18,38 +18,45 @@ let
   '';
 
   dbScript = writeScript "create_pykms_db.sh" (with stdenv.lib; ''
-    #!${stdenv.shell} -eu
+    #!${runtimeShell}
+
+    set -eEuo pipefail
 
     db=$1
-
-    ${getBin coreutils}/bin/install -d $(dirname $db)
 
     if [ ! -e $db ] ; then
       ${getBin sqlite}/bin/sqlite3 $db < ${dbSql}
     fi
   '');
 
-in buildPythonApplication {
+in buildPythonApplication rec {
   pname = "pykms";
-  version = "20180208";
+  version = "20190611";
 
   src = fetchFromGitHub {
-    owner  = "ThunderEX";
+    owner  = "SystemRage";
     repo   = "py-kms";
-    rev    = "a1666a0ee5b404569a234afd05b164accc9a8845";
-    sha256 = "17yj5n8byxp09l5zkap73hpphjy35px84wy68ps824w8l0l8kcd4";
+    rev    = "dead208b1593655377fe8bc0d74cc4bead617103";
+    sha256 = "065qpkfqrahsam1rb43vnasmzrangan5z1pr3p6s0sqjz5l2jydp";
   };
 
-  propagatedBuildInputs = [ pytz ];
+  sourceRoot = "source/py-kms";
 
-  prePatch = ''
-    siteDir=$out/${python.sitePackages}
+  propagatedBuildInputs = [ systemd pytz tzlocal ];
 
-    substituteInPlace kmsBase.py \
+  postPatch = ''
+    siteDir=$out/${python3.sitePackages}
+
+    substituteInPlace pykms_DB2Dict.py \
       --replace "'KmsDataBase.xml'" "'$siteDir/KmsDataBase.xml'"
+
+    # we are logging to journal
+    sed -i pykms_Misc.py \
+      -e '6ifrom systemd import journal' \
+      -e 's/log_obj.addHandler(log_handler)/log_obj.addHandler(journal.JournalHandler())/'
   '';
 
-  dontBuild = true;
+  format = "other";
 
   # there are no tests
   doCheck = false;
@@ -57,18 +64,19 @@ in buildPythonApplication {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,share/doc/pykms} $siteDir
+    mkdir -p $siteDir
 
     mv * $siteDir
-    for b in client server ; do
-      makeWrapper ${python.interpreter} $out/bin/$b.py \
-        --argv0 $b \
-        --add-flags $siteDir/$b.py
+    for b in Client Server ; do
+      makeWrapper ${python.interpreter} $out/bin/''${b,,} \
+        --argv0 ''${b,,} \
+        --add-flags $siteDir/pykms_$b.py \
+        --prefix PYTHONPATH : "$(toPythonPath ${systemd})"
     done
 
-    install -m755 ${dbScript} $out/bin/create_pykms_db.sh
+    install -Dm755 ${dbScript} $out/libexec/create_pykms_db.sh
 
-    mv $siteDir/README.md $out/share/doc/pykms/
+    install -Dm644 ../README.md -t $out/share/doc/pykms
 
     ${python.interpreter} -m compileall $siteDir
 
@@ -77,7 +85,7 @@ in buildPythonApplication {
 
   meta = with stdenv.lib; {
     description = "Windows KMS (Key Management Service) server written in Python";
-    homepage    = https://github.com/ThunderEX/py-kms;
+    homepage    = "https://github.com/SystemRage/py-kms";
     license     = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
   };


### PR DESCRIPTION
This updates the currently broken `pykms` package from 20180208 to 20190611 (with a new upstream), and adapts the `pykms` module to the changes (different binary names, `--logfile` option required).

###### Motivation for this change

Fixes #81355.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
