### PR TITLE
riot-web: add config overrides for privacy

### DIFF
--- a/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
@@ -1,9 +1,16 @@
-{ lib, stdenv, fetchurl, writeText, conf ? null }:
+{ lib, stdenv, fetchurl, writeText, jq, conf ? {} }:
 
 # Note for maintainers:
 # Versions of `riot-web` and `riot-desktop` should be kept in sync.
 
-stdenv.mkDerivation rec {
+let
+  noPhoningHome = {
+    disable_guests = true; # disable automatic guest account registration at matrix.org
+    piwik = false; # disable analytics
+  };
+  configOverrides = writeText "riot-config-overrides.json" (builtins.toJSON (noPhoningHome // conf));
+
+in stdenv.mkDerivation rec {
   pname = "riot-web";
   version = "1.5.8";
 
@@ -12,16 +19,12 @@ stdenv.mkDerivation rec {
     sha256 = "112zjlmxy2s8qcd227laf1lfvbbwwcipn51xb779hy2dci48kpkx";
   };
 
-  installPhase = let
-    configFile = if (conf != null)
-      then writeText "riot-config.json" conf
-      else "$out/config.sample.json";
-  in ''
+  installPhase = ''
     runHook preInstall
 
     mkdir -p $out/
     cp -R . $out/
-    ln -s ${configFile} $out/config.json
+    ${jq}/bin/jq -s '.[0] * .[1]' "config.sample.json" "${configOverrides}" > "$out/config.json"
 
     runHook postInstall
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2115,7 +2115,7 @@ in
   riot-desktop = callPackage ../applications/networking/instant-messengers/riot/riot-desktop.nix { };
 
   riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix {
-    conf = config.riot-web.conf or null;
+    conf = config.riot-web.conf or {};
   };
 
   ripasso-cursive = callPackage ../tools/security/ripasso/cursive.nix {


### PR DESCRIPTION
###### Motivation for this change

Preventing the app from phoning home by default.

GitHub: closes https://github.com/NixOS/nixpkgs/issues/80358


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
