### PR TITLE
geant4: 10.6.0 -> 10.6.1

### DIFF
--- a/pkgs/development/libraries/physics/geant4/datasets.nix
+++ b/pkgs/development/libraries/physics/geant4/datasets.nix
@@ -42,8 +42,8 @@ in
 
     {
       name = "G4EMLOW";
-      version = "7.9";
-      sha256 = "1zrsvk2ahlwss6mgjrma6d2ii49vlzcd5r3ccw94c7m9rnk9mgsa";
+      version = "7.9.1";
+      sha256 = "1jrw0izw732bywq1k1srs3x2z0m3y2h377kcvwbwcr0wa1p10342";
       envvar = "LE";
     }
 

--- a/pkgs/development/libraries/physics/geant4/default.nix
+++ b/pkgs/development/libraries/physics/geant4/default.nix
@@ -36,22 +36,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "10.6.0";
+  version = "10.6.1";
   pname = "geant4";
 
   src = fetchurl{
-    url = "https://geant4-data.web.cern.ch/geant4-data/releases/geant4.10.06.tar.gz";
-    sha256 = "169ikv2sssfbqml7bs146dj035xifxm9b12r4rzmgpvswfhca90l";
+    url = "https://geant4-data.web.cern.ch/geant4-data/releases/geant4.10.06.p01.tar.gz";
+    sha256 = "0ssxg7dd7vxljb3fdyb0llg7gsxack21qjfsb3n23k107a19yibk";
   };
-
-  # This patch fixes crash when set -u is enabled
-  patches = [
-    (fetchpatch {
-      name = "bash-variable-fix.patch";
-      url = "https://bugzilla-geant4.kek.jp/attachment.cgi?id=606&action=diff&collapsed=&headers=1&format=raw";
-      sha256 = "1bg9wg174fbqbjsjm1gz9584a7rq9p1szxr2fq9yfvqaf78289k6";
-    })
-  ];
 
   cmakeFlags = [
     "-DGEANT4_INSTALL_DATA=OFF"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updating to the latest version.  Removing the now merged patch.  Updating the datafiles to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
