### PR TITLE
ucs-fonts: generate pcf, otb and split output

### DIFF
--- a/pkgs/data/fonts/ucs-fonts/default.nix
+++ b/pkgs/data/fonts/ucs-fonts/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, mkfontdir, mkfontscale }:
+{ stdenv, fetchurl, bdftopcf
+, libfaketime, fonttosfnt, mkfontscale
+}:
 
 stdenv.mkDerivation {
   pname = "ucs-fonts";
@@ -21,25 +23,40 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ mkfontdir mkfontscale ];
+  nativeBuildInputs =
+    [ bdftopcf libfaketime fonttosfnt
+      mkfontscale
+    ];
 
-  phases = [ "unpackPhase" "installPhase" ];
+  buildPhase = ''
+    for i in *.bdf; do
+      name=$(basename "$i" .bdf)
 
-  installPhase = ''
-    mkdir -p $out/share/fonts
-    cp *.bdf $out/share/fonts
-    cd $out/share/fonts
-    mkfontdir
-    mkfontscale
+      # generate pcf fonts (for X11 applications)
+      bdftopcf -t "$i" | gzip -n -9 -c > "$name.pcf.gz"
+
+      # generate otb fonts (for GTK applications)
+      faketime -f "1970-01-01 00:00:01" \
+      fonttosfnt -v -o "$name.otb" "$i"
+    done
   '';
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "12fh3kbsib0baqwk6148fnzqrj9gs4vnl7yd5n9km72sic1z1xwk";
+  installPhase = ''
+    install -m 644 -D *.pcf.gz -t "$out/share/fonts/misc"
+    install -m 644 -D *.bdf    -t "$bdf/share/fonts/misc"
+    install -m 644 -D *.otb    -t "$otb/share/fonts/misc"
+
+    mkfontdir "$out/share/fonts/misc"
+    mkfontdir "$bdf/share/fonts/misc"
+    mkfontdir "$otb/share/fonts/misc"
+  '';
+
+  outputs = [ "out" "bdf" "otb" ];
 
   meta = with stdenv.lib; {
-    homepage = https://www.cl.cam.ac.uk/~mgk25/ucs-fonts.html;
+    homepage = "https://www.cl.cam.ac.uk/~mgk25/ucs-fonts.html";
     description = "Unicode bitmap fonts";
+    license = licenses.publicDomain;
     maintainers = [ maintainers.raskin ];
     platforms = platforms.all;
   };

--- a/pkgs/data/fonts/ucs-fonts/default.nix
+++ b/pkgs/data/fonts/ucs-fonts/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation {
   outputHash = "12fh3kbsib0baqwk6148fnzqrj9gs4vnl7yd5n9km72sic1z1xwk";
 
   meta = with stdenv.lib; {
+    homepage = https://www.cl.cam.ac.uk/~mgk25/ucs-fonts.html;
     description = "Unicode bitmap fonts";
     maintainers = [ maintainers.raskin ];
     platforms = platforms.all;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17986,7 +17986,9 @@ in
 
   ubuntu_font_family = callPackage ../data/fonts/ubuntu-font-family { };
 
-  ucs-fonts = callPackage ../data/fonts/ucs-fonts { };
+  ucs-fonts = callPackage ../data/fonts/ucs-fonts
+    { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
+
 
   ultimate-oldschool-pc-font-pack = callPackage ../data/fonts/ultimate-oldschool-pc-font-pack { };
 


### PR DESCRIPTION
###### Motivation for this change
Issue #75160 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested PCF fonts in xfontsel
- [x] Tested OTB fonts with pango-view
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
