### PR TITLE
pythonPackages.scan-build: init at 2.0.18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4412,6 +4412,12 @@
     githubId = 115218;
     name = "Felix Richter";
   };
+  malo = {
+    email = "mbourgon@gmail.com";
+    github = "malob";
+    githubId = 2914269;
+    name = "Malo Bourgon";
+  };
   malyn = {
     email = "malyn@strangeGizmo.com";
     github = "malyn";

--- a/pkgs/development/python-modules/scan-build/default.nix
+++ b/pkgs/development/python-modules/scan-build/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27, nose, clang }:
+
+buildPythonPackage rec {
+  pname = "scan-build";
+  version = "2.0.18";
+  disabled = isPy27;
+
+  src = fetchFromGitHub{
+    owner = "rizsotto";
+    repo = pname;
+    rev = version;
+    sha256 = "1fpmpg41314qwy6prwknh0hkclcqc1lm7lbmh4r8scsfzs3zch6b";
+  };
+
+  # ignore odd clang tests
+  checkInputs = [ nose clang ];
+  checkPhase = "nosetests -e test_get_clang_arguments_fails tests/unit";
+
+  meta = with lib; {
+    homepage = "https://github.com/rizsotto/scan-build";
+    license = licenses.ncsa;
+    description = "Static code analyzer wrapper for Clang";
+    maintainers = with maintainers; [ malo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3180,6 +3180,8 @@ in {
 
   pyrtlsdr = callPackage ../development/python-modules/pyrtlsdr { };
 
+  scan-build = callPackage ../development/python-modules/scan-build { };
+
   scandir = callPackage ../development/python-modules/scandir { };
 
   schema = callPackage ../development/python-modules/schema {};


### PR DESCRIPTION
###### Motivation for this change

`scan-build` is a useful tool for C/C++ development that I use frequently, and it would be nice if it were included in `nixpkgs`.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
