### PR TITLE
slack: add Darwin target

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -8,120 +8,146 @@ let
 
   version = "4.2.0";
 
-  rpath = stdenv.lib.makeLibraryPath [
-    alsaLib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    curl
-    dbus
-    expat
-    fontconfig
-    freetype
-    glib
-    gnome2.GConf
-    gdk-pixbuf
-    gtk3
-    pango
-    libnotify
-    libxcb
-    libappindicator-gtk3
-    nspr
-    nss
-    stdenv.cc.cc
-    systemd
-    libuuid
-    libpulseaudio
+  inherit (stdenv.hostPlatform) system;
 
-    xorg.libxkbfile
-    xorg.libX11
-    xorg.libXcomposite
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXtst
-    xorg.libXScrnSaver
-  ] + ":${stdenv.cc.cc.lib}/lib64";
+  throwSystem = throw "Unsupported system: ${system}";
 
-  src =
-    if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        url = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "01b2klhky04fijdqcpfafgdqx2c5nh2fpnzvzgvz10hv7h16cinv";
-      }
-    else
-      throw "Slack is not supported on ${stdenv.hostPlatform.system}";
-
-in stdenv.mkDerivation {
   pname = "slack";
-  inherit version;
 
-  inherit src;
+  sha256 = {
+    x86_64-darwin = "0947a98m7yz4hldjvcqnv9s17dpvlsk9sflc1zc99hf500zck0w1";
+    x86_64-linux = "01b2klhky04fijdqcpfafgdqx2c5nh2fpnzvzgvz10hv7h16cinv";
+  }.${system} or throwSystem;
 
-  buildInputs = [
-    gtk3  # needed for GSETTINGS_SCHEMAS_PATH
-  ];
-
-  nativeBuildInputs = [ dpkg makeWrapper nodePackages.asar ];
-
-  dontUnpack = true;
-  dontBuild = true;
-  dontPatchELF = true;
-
-  installPhase = ''
-    # The deb file contains a setuid binary, so 'dpkg -x' doesn't work here
-    dpkg --fsys-tarfile $src | tar --extract
-    rm -rf usr/share/lintian
-
-    mkdir -p $out
-    mv usr/* $out
-
-    # Otherwise it looks "suspicious"
-    chmod -R g-w $out
-
-    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
-      patchelf --set-rpath ${rpath}:$out/lib/slack $file || true
-    done
-
-    # Replace the broken bin/slack symlink with a startup wrapper
-    rm $out/bin/slack
-    makeWrapper $out/lib/slack/slack $out/bin/slack \
-      --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH \
-      --prefix PATH : ${xdg_utils}/bin
-
-    # Fix the desktop link
-    substituteInPlace $out/share/applications/slack.desktop \
-      --replace /usr/bin/ $out/bin/ \
-      --replace /usr/share/ $out/share/
-  '' + stdenv.lib.optionalString (theme != null) ''
-    asar extract $out/lib/slack/resources/app.asar $out/lib/slack/resources/app.asar.unpacked
-    cat <<EOF >> $out/lib/slack/resources/app.asar.unpacked/dist/ssb-interop.bundle.js
-
-    var fs = require('fs');
-    document.addEventListener('DOMContentLoaded', function() {
-      fs.readFile('${theme}/theme.css', 'utf8', function(err, css) {
-        let s = document.createElement('style');
-        s.type = 'text/css';
-        s.innerHTML = css;
-        document.head.appendChild(s);
-      });
-    });
-    EOF
-    asar pack $out/lib/slack/resources/app.asar.unpacked $out/lib/slack/resources/app.asar
-  '';
 
   meta = with stdenv.lib; {
     description = "Desktop client for Slack";
     homepage = https://slack.com;
     license = licenses.unfree;
     maintainers = [ maintainers.mmahut ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
   };
-}
+
+  linux = stdenv.mkDerivation rec {
+    inherit pname version meta;
+    src = fetchurl {
+      url = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${version}-amd64.deb";
+      inherit sha256;
+    };
+
+    rpath = stdenv.lib.makeLibraryPath [
+      alsaLib
+      at-spi2-atk
+      at-spi2-core
+      atk
+      cairo
+      cups
+      curl
+      dbus
+      expat
+      fontconfig
+      freetype
+      glib
+      gnome2.GConf
+      gdk-pixbuf
+      gtk3
+      pango
+      libnotify
+      libxcb
+      libappindicator-gtk3
+      nspr
+      nss
+      stdenv.cc.cc
+      systemd
+      libuuid
+      libpulseaudio
+  
+      xorg.libxkbfile
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libXScrnSaver
+    ] + ":${stdenv.cc.cc.lib}/lib64";
+
+    buildInputs = [
+      gtk3  # needed for GSETTINGS_SCHEMAS_PATH
+    ];
+  
+    nativeBuildInputs = [ dpkg makeWrapper nodePackages.asar ];
+  
+    dontUnpack = true;
+    dontBuild = true;
+    dontPatchELF = true;
+  
+    installPhase = ''
+      # The deb file contains a setuid binary, so 'dpkg -x' doesn't work here
+      dpkg --fsys-tarfile $src | tar --extract
+      rm -rf usr/share/lintian
+  
+      mkdir -p $out
+      mv usr/* $out
+  
+      # Otherwise it looks "suspicious"
+      chmod -R g-w $out
+  
+      for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+        patchelf --set-rpath ${rpath}:$out/lib/slack $file || true
+      done
+  
+      # Replace the broken bin/slack symlink with a startup wrapper
+      rm $out/bin/slack
+      makeWrapper $out/lib/slack/slack $out/bin/slack \
+        --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH \
+        --prefix PATH : ${xdg_utils}/bin
+  
+      # Fix the desktop link
+      substituteInPlace $out/share/applications/slack.desktop \
+        --replace /usr/bin/ $out/bin/ \
+        --replace /usr/share/ $out/share/
+    '' + stdenv.lib.optionalString (theme != null) ''
+      asar extract $out/lib/slack/resources/app.asar $out/lib/slack/resources/app.asar.unpacked
+      cat <<EOF >> $out/lib/slack/resources/app.asar.unpacked/dist/ssb-interop.bundle.js
+  
+      var fs = require('fs');
+      document.addEventListener('DOMContentLoaded', function() {
+        fs.readFile('${theme}/theme.css', 'utf8', function(err, css) {
+          let s = document.createElement('style');
+          s.type = 'text/css';
+          s.innerHTML = css;
+          document.head.appendChild(s);
+        });
+      });
+      EOF
+      asar pack $out/lib/slack/resources/app.asar.unpacked $out/lib/slack/resources/app.asar
+    '';
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    phases = [ "installPhase" ];
+
+    src = fetchurl {
+      url = "https://downloads.slack-edge.com/mac_releases/Slack-${version}-macOS.dmg";
+      inherit sha256;
+    };
+
+    installPhase = ''
+      /usr/bin/hdiutil mount -nobrowse -mountpoint slack-mnt $src
+      mkdir -p $out/Applications
+      cp -r ./slack-mnt/Slack.app $out/Applications
+      /usr/bin/hdiutil unmount slack-mnt
+      defaults write com.tinyspeck.slackmacgap SlackNoAutoUpdates -bool YES
+    '';
+  };
+in if stdenv.isDarwin
+  then darwin
+  else linux

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -6,7 +6,7 @@ at-spi2-atk, at-spi2-core, libuuid, nodePackages, libpulseaudio, xdg_utils
 
 let
 
-  version = "4.2.0";
+  version = "4.3.3";
 
   inherit (stdenv.hostPlatform) system;
 

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -6,7 +6,7 @@ at-spi2-atk, at-spi2-core, libuuid, nodePackages, libpulseaudio, xdg_utils
 
 let
 
-  version = "4.3.3";
+  version = "4.2.0";
 
   inherit (stdenv.hostPlatform) system;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This PR adds Darwin as a target for `slack` ~~and bumps the version from 4.2.0 to 4.3.3~~.

For the Darwin target, we have to use `hdiutil` to mount the dmg and copy the app bundle from there. Using `undmg` or `xpwn` to extract the app from the dmg unfortunately yields corrupted binaries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
