### PR TITLE
flatpak: propagate glib and ostree

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -128,7 +128,6 @@ stdenv.mkDerivation rec {
     bzip2
     dbus
     dconf
-    glib
     gpgme
     json-glib
     libarchive
@@ -136,7 +135,6 @@ stdenv.mkDerivation rec {
     libseccomp
     libsoup
     lzma
-    ostree
     polkit
     python3
     systemd
@@ -146,6 +144,12 @@ stdenv.mkDerivation rec {
     gsettings-desktop-schemas
     glib-networking
     librsvg # for flatpak-validate-icon
+  ];
+
+  # Required by flatpak.pc
+  propagatedBuildInputs = [
+    glib
+    ostree
   ];
 
   checkInputs = [

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   version = "1.6.1";
 
   # TODO: split out lib once we figure out what to do with triggerdir
-  outputs = [ "out" "man" "doc" "installedTests" ];
+  outputs = [ "out" "dev" "man" "doc" "installedTests" ];
 
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak/releases/download/${version}/${pname}-${version}.tar.xz";


### PR DESCRIPTION
Pantheon's sideload broke:
```
meson.build:17:0: ERROR: Could not generate cargs for flatpak:
Package ostree-1 was not found in the pkg-config search path.
Perhaps you should add the directory containing `ostree-1.pc'
to the PKG_CONFIG_PATH environment variable
Package 'ostree-1', required by 'flatpak', not found
```

https://hydra.nixos.org/build/113077888

ZHF: #80379

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
