### PR TITLE
python/aiohttp: disable test on 32bit platforms

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
@@ -54,6 +55,7 @@ buildPythonPackage rec {
                and not handle_keepalive_on_closed_connection \
                and not proxy_https_bad_response \
                and not partially_applied_handler \
+               ${lib.optionalString stdenv.is32bit "and not test_cookiejar"} \
                and not middleware" \
       --ignore=test_connector.py
   '';


### PR DESCRIPTION
###### Motivation for this change
The test `test_cookiejar` is failing because a time_t constant can't be represented on 32bit platforms. This is causing failures of all nixos tests on i686-linux.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
