### PR TITLE
mint: Pin to crystal 0.30 to fix build

### DIFF
--- a/pkgs/development/compilers/mint/default.nix
+++ b/pkgs/development/compilers/mint/default.nix
@@ -1,5 +1,5 @@
-{ lib, fetchFromGitHub, crystal, zlib, openssl_1_0_2, duktape, which, libyaml }:
-crystal.buildCrystalPackage rec {
+{ lib, fetchFromGitHub, crystal_0_30, zlib, openssl_1_0_2, duktape, which, libyaml }:
+crystal_0_30.buildCrystalPackage rec {
   version = "0.5.0";
   pname = "mint";
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change
Fixes the mint build on 20.03 that was broken due to newer crystal versions

Relevant for ZHF #80379 

Master is fixed by updating mint in #80391 

###### Things done

- [x] Built mint successfully
- [x] Verified that it works with a new project