### PR TITLE
mdbook: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0gcrv54iswphzxxkmak1c7pmmpakiri6jk50j4bxrsplwjr76f7n";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "00grlxjz61vxinr18f28ga6610yjxcq48lr75wmyc5wq317j12fn";
+  cargoSha256 = "12i9w9dgji36yvvdks0vkjjkh32nbnhz76sgrl2827pj49h9vnn0";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; ran `nixpkgs-review wip` successfully.