### PR TITLE
tealdeer: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/tealdeer/default.nix
+++ b/pkgs/tools/misc/tealdeer/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1v9wq4k7k4lmdz6xy6kabchjpbx9lds20yh6va87shypdh9iva29";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0y1y74fgxcv8a3cmyf30p6gg12r79ln7inir8scj88wbmwgkbxsp";
+  cargoSha256 = "0rr9mqylcs3nb7wgilp810qia0rv2pnalyhh28q0wnqyz0kqfrzr";
 
   buildInputs = [ openssl cacert curl ]
     ++ (stdenv.lib.optional stdenv.isDarwin Security);


### PR DESCRIPTION
Infra upgrade as part of #79975; ran `nixpkgs-review wip` successfully.