### PR TITLE
ruamel: moved from bitbucket to sourceforge

### DIFF
--- a/pkgs/development/python-modules/ruamel_base/default.nix
+++ b/pkgs/development/python-modules/ruamel_base/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Common routines for ruamel packages";
-    homepage = https://bitbucket.org/ruamel/base;
+    homepage = https://sourceforge.net/projects/ruamel-base/;
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/ruamel_base/default.nix
+++ b/pkgs/development/python-modules/ruamel_base/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Common routines for ruamel packages";
-    homepage = https://sourceforge.net/projects/ruamel-base/;
+    homepage = "https://sourceforge.net/projects/ruamel-base/";
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/ruamel_ordereddict/default.nix
+++ b/pkgs/development/python-modules/ruamel_ordereddict/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A version of dict that keeps keys in insertion resp. sorted order";
-    homepage = https://bitbucket.org/ruamel/ordereddict;
+    homepage = "https://sourceforge.net/projects/ruamel-ordereddict/";
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/ruamel_yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel_yaml/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";
-    homepage = https://bitbucket.org/ruamel/yaml;
+    homepage = https://sourceforge.net/projects/ruamel-yaml/;
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/ruamel_yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel_yaml/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";
-    homepage = https://sourceforge.net/projects/ruamel-yaml/;
+    homepage = "https://sourceforge.net/projects/ruamel-yaml/";
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/ruamel_yaml_clib/default.nix
+++ b/pkgs/development/python-modules/ruamel_yaml_clib/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";
-    homepage = https://sourceforge.net/projects/ruamel-yaml-clib/;
+    homepage = "https://sourceforge.net/projects/ruamel-yaml-clib/";
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/ruamel_yaml_clib/default.nix
+++ b/pkgs/development/python-modules/ruamel_yaml_clib/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , buildPythonPackage
-, fetchFromBitbucket
+, fetchhg
 , ruamel_base
 , ruamel_ordereddict
 , isPy3k
@@ -10,9 +10,8 @@ buildPythonPackage rec {
   pname = "ruamel.yaml.clib";
   version = "0.2.0";
 
-  src = fetchFromBitbucket {
-    owner = "ruamel";
-    repo = "yaml.clib";
+  src = fetchhg {
+    url = "http://hg.code.sf.net/p/ruamel-yaml-clib/code";
     rev = version;
     sha256 = "0kq6zi96qlm72lzj90fc2rfk6nm5kqhk6qxdl8wl9s3a42b0v6wl";
   };
@@ -22,7 +21,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";
-    homepage = https://bitbucket.org/ruamel/yaml;
+    homepage = https://sourceforge.net/projects/ruamel-yaml-clib/;
     license = licenses.mit;
   };
 


### PR DESCRIPTION
###### Motivation for this change

It looks like the ruamel python packages have moved from bitbucket to sourceforge.  See for example https://bitbucket.org/ruamel/yaml.clib
This mainly affects ruamel.yaml.clib which was getting source from bitbucket, which now 404s.

###### Things done

This switches the source to hg sf.net (not sure if this is the right way to do it -- I couldn't find a better fetch for it). It doesn't look like the hashes have changed. I also updated the urls for all three packages.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
