### PR TITLE
ripcord: init at 0.4.23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1037,6 +1037,12 @@
     githubId = 3465841;
     name = "Boris Sukholitko";
   };
+  bqv = {
+    email = "bqv@fron.io";
+    github = "bqv";
+    githubId = 822863;
+    name = "Tony O";
+  };
   bradediger = {
     email = "brad@bradediger.com";
     github = "bradediger";

--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -1,0 +1,69 @@
+{ lib, mkDerivation, fetchurl, makeFontsConf, appimageTools,
+  qtbase, qtsvg, qtmultimedia, qtwebsockets, qtimageformats,
+  autoPatchelfHook, desktop-file-utils, imagemagick, makeWrapper,
+  twemoji-color-font, xorg, libsodium, libopus, libGL, zlib, alsaLib }:
+
+mkDerivation rec {
+  pname = "ripcord";
+  version = "0.4.23";
+
+  src = let
+    appimage = fetchurl {
+      url = "https://cancel.fm/dl/Ripcord-${version}-x86_64.AppImage";
+      sha256 = "0395w0pwr1cz8ichcbyrsscmm2p7srgjk4vkqvqgwyx41prm0x2h";
+      name = "${pname}-${version}.AppImage";
+    };
+  in appimageTools.extract {
+    name = "${pname}-${version}";
+    src = appimage;
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook desktop-file-utils imagemagick ];
+  buildInputs = [ libsodium libopus libGL alsaLib ] ++
+                [ qtbase qtsvg qtmultimedia qtwebsockets qtimageformats ] ++
+                (with xorg; [ libX11 libXScrnSaver libXcursor xkeyboardconfig ]);
+
+  fontsConf = makeFontsConf {
+    fontDirectories = [ twemoji-color-font ];
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r ${src}/{qt.conf,translations,twemoji.ripdb} $out
+
+    for size in 16 32 48 64 72 96 128 192 256 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert -resize "$size"x"$size" ${src}/Ripcord_Icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/ripcord.png
+    done
+
+    desktop-file-install --dir $out/share/applications \
+      --set-key Exec --set-value ripcord \
+      --set-key Icon --set-value ripcord \
+      --set-key Comment --set-value "${meta.description}" \
+      ${src}/Ripcord.desktop
+    mv $out/share/applications/Ripcord.desktop $out/share/applications/ripcord.desktop
+
+    install -Dm755 ${src}/Ripcord $out/Ripcord
+    patchelf --replace-needed libsodium.so.18 libsodium.so $out/Ripcord
+    makeQtWrapper $out/Ripcord $out/bin/ripcord \
+      --run "cd $out" \
+      --set FONTCONFIG_FILE "${fontsConf}" \
+      --prefix LD_LIBRARY_PATH ":" "${xorg.libXcursor}/lib" \
+      --prefix QT_XKB_CONFIG_ROOT ":" "${xorg.xkeyboardconfig}/share/X11/xkb"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Desktop chat client for Slack and Discord";
+    homepage = "https://cancel.fm/ripcord/";
+
+    # See: https://cancel.fm/ripcord/shareware-redistribution/
+    license = licenses.unfreeRedistributable;
+
+    maintainers = with maintainers; [ bqv ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21373,6 +21373,8 @@ in
 
   ries = callPackage ../applications/science/math/ries { };
 
+  ripcord = qt5.callPackage ../applications/networking/instant-messengers/ripcord { };
+
   ripser = callPackage ../applications/science/math/ripser { };
 
   rkt = callPackage ../applications/virtualization/rkt { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
