### PR TITLE
milkytracker: set cmake sdl variable to fix build (20.03)

### DIFF
--- a/pkgs/applications/audio/milkytracker/default.nix
+++ b/pkgs/applications/audio/milkytracker/default.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL2 alsaLib libjack2 lhasa perl rtmidi zlib zziplib ];
 
+  # Somehow this does not get set automatically
+  cmakeFlags = [ "-DSDL2MAIN_LIBRARY=${SDL2}/lib/libSDL2.so" ];
+
   meta = with stdenv.lib; {
     description = "Music tracker application, similar to Fasttracker II";
     homepage = http://milkytracker.org;


### PR DESCRIPTION
###### Motivation for this change

ZHF: #80379
port of #80414, cherry picked from commit eb2ab1861494302e749ddd31f4622e2f0517c921

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
