### PR TITLE
coqPackages.mathcomp_1_10: init at 1.10.0

### DIFF
--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -8,6 +8,7 @@ let
   ####################################
   # sha256 of released mathcomp versions
   mathcomp-sha256 = {
+    "1.10.0" = "1b9m6pwxxyivw7rgx82gn5kmgv2mfv3h3y0mmjcjfypi8ydkrlbv";
     "1.9.0" = "0lid9zaazdi3d38l8042lczb02pw5m9wq0yysiilx891hgq2p81r";
     "1.8.0" = "07l40is389ih8bi525gpqs3qp4yb2kl11r9c8ynk1ifpjzpnabwp";
     "1.7.0" = "0wnhj9nqpx2bw6n1l4i8jgrw3pjajvckvj3lr4vzjb3my2lbxdd1";
@@ -15,6 +16,7 @@ let
   };
   # versions of coq compatible with released mathcomp versions
   mathcomp-coq-versions = {
+    "1.10.0" = flip elem [ "8.7" "8.8" "8.9" "8.10" "8.11" ];
     "1.9.0" = flip elem ["8.7" "8.8" "8.9" "8.10"];
     "1.8.0" = flip elem ["8.7" "8.8" "8.9"];
     "1.7.0" = flip elem ["8.6" "8.7" "8.8" "8.9"];
@@ -24,7 +26,7 @@ let
   max-mathcomp-version = last (naturalSort (attrNames mathcomp-coq-versions));
   # mathcomp prefered version by decreasing order
   # (the first version in the list will be tried first)
-  mathcomp-version-preference = [ "1.8.0" "1.9.0" "1.7.0" "1.6.1" ];
+  mathcomp-version-preference = [ "1.8.0" "1.9.0" "1.10.0" "1.7.0" "1.6.1" ];
 
   ##############################################################
   # COMPUTED using the configuration above (edit with caution) #
@@ -133,6 +135,7 @@ getAttrOr = a: n: a.${n} or (throw a.error);
 mathcompCorePkgs_1_7 = mathcompGen "1.7.0";
 mathcompCorePkgs_1_8 = mathcompGen "1.8.0";
 mathcompCorePkgs_1_9 = mathcompGen "1.9.0";
+mathcompCorePkgs_1_10 = mathcompGen "1.10.0";
 mathcompCorePkgs     = recurseIntoAttrs
   (mapDerivationAttrset dontDistribute (mathcompGen default-mathcomp-version));
 
@@ -143,6 +146,7 @@ inherit mathcompGenSingle;
 mathcomp_1_7_single = getAttrOr (mathcompGenSingle "1.7.0") "single";
 mathcomp_1_8_single = getAttrOr (mathcompGenSingle "1.8.0") "single";
 mathcomp_1_9_single = getAttrOr (mathcompGenSingle "1.9.0") "single";
+mathcomp_1_10_single = getAttrOr (mathcompGenSingle "1.10.0") "single";
 mathcomp_single     = dontDistribute
  (getAttrOr (mathcompGenSingle default-mathcomp-version) "single");
 
@@ -151,13 +155,16 @@ mathcomp_single     = dontDistribute
 # each of these have a special attribute overrideMathcomp which
 # must be used instead of overrideAttrs in order to also fix the dependencies
 inherit mathcompGen mathcompCorePkgs
-        mathcompCorePkgs_1_7 mathcompCorePkgs_1_8 mathcompCorePkgs_1_9;
+        mathcompCorePkgs_1_7 mathcompCorePkgs_1_8 mathcompCorePkgs_1_9
+	mathcompCorePkgs_1_10
+	;
 
 
 mathcomp     = getAttrOr mathcompCorePkgs     "all";
 mathcomp_1_7 = getAttrOr mathcompCorePkgs_1_7 "all";
 mathcomp_1_8 = getAttrOr mathcompCorePkgs_1_8 "all";
 mathcomp_1_9 = getAttrOr mathcompCorePkgs_1_9 "all";
+mathcomp_1_10 = getAttrOr mathcompCorePkgs_1_10 "all";
 
 ssreflect     = getAttrOr mathcompCorePkgs    "ssreflect";
 
@@ -165,4 +172,5 @@ ssreflect     = getAttrOr mathcompCorePkgs    "ssreflect";
 (mapAttrs' (n: pkg: {name = "mathcomp-${n}"; value = pkg;}) mathcompCorePkgs) //
 (mapAttrs' (n: pkg: {name = "mathcomp-${n}_1_7"; value = pkg;}) mathcompCorePkgs_1_7) //
 (mapAttrs' (n: pkg: {name = "mathcomp-${n}_1_8"; value = pkg;}) mathcompCorePkgs_1_8) //
-(mapAttrs' (n: pkg: {name = "mathcomp-${n}_1_9"; value = pkg;}) mathcompCorePkgs_1_9)
+(mapAttrs' (n: pkg: {name = "mathcomp-${n}_1_9"; value = pkg;}) mathcompCorePkgs_1_9) //
+(mapAttrs' (n: pkg: {name = "mathcomp-${n}_1_10"; value = pkg;}) mathcompCorePkgs_1_10)

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -54,7 +54,12 @@ let
 
         mathcompCorePkgs_1_9 mathcomp_1_9
         mathcomp-ssreflect_1_9 mathcomp-fingroup_1_9 mathcomp-algebra_1_9
-        mathcomp-solvable_1_9 mathcomp-field_1_9 mathcomp-character_1_9;
+        mathcomp-solvable_1_9 mathcomp-field_1_9 mathcomp-character_1_9
+
+        mathcompCorePkgs_1_10 mathcomp_1_10
+        mathcomp-ssreflect_1_10 mathcomp-fingroup_1_10 mathcomp-algebra_1_10
+        mathcomp-solvable_1_10 mathcomp-field_1_10 mathcomp-character_1_10
+        ;
       inherit (callPackage ../development/coq-modules/mathcomp/extra.nix { })
         mathcompExtraGen multinomials coqeal
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with Coq 8.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
