### PR TITLE
[WIP] pythonPackages.nevergrad: init at 0.3.2

### DIFF
--- a/pkgs/development/python-modules/nevergrad/default.nix
+++ b/pkgs/development/python-modules/nevergrad/default.nix
@@ -1,0 +1,45 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, python
+, bayesian-optimization
+, cma
+, gym 
+, matplotlib
+, opencv4
+, pandas
+, pytest
+, pytorch
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "nevergrad";
+  version = "0.3.2";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "facebookresearch";
+    repo = "nevergrad";
+    rev = "v${version}";
+    sha256 = "1rbvlm2bivgi1jslnc52mqhpw2bkznh8crk69yfwkkxifcyl1gl9";
+  };
+
+  propagatedBuildInputs = [
+    bayesian-optimization
+    cma
+    gym 
+    matplotlib
+    opencv4
+    pandas
+    pytorch
+    typing-extensions
+  ];
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
+
+  meta = with lib; {
+    description = "A gradient-free optimization platform";
+    homepage = "https://github.com/facebookresearch/nevergrad";
+    license = licenses.mit;
+    maintainers = with maintainers; [ juliendehos ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -905,6 +905,8 @@ in {
     inherit python;
   };
 
+  nevergrad = callPackage ../development/python-modules/nevergrad { };
+
   nix-prefetch-github = callPackage ../development/python-modules/nix-prefetch-github { };
 
   nixpart = callPackage ../tools/filesystems/nixpart { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add Nevergrad (a Python gradient-free optimization framework).

###### Things done

Tested on NixOS and on Nix+Debian10, using the following `shell.nix`:
```nix
with import (fetchTarball "https://github.com/juliendehos/nixpkgs/archive/6afeb1dd1ff5c79b82d0e0ef697fe9cffc434706.tar.gz") {};
(python3.withPackages ( ps: with ps; [ nevergrad ])).env
```
and with the following example (from [Nevergrad docs](https://facebookresearch.github.io/nevergrad/#quick-start)):
```python
import nevergrad as ng

def square(x):
    return sum((x - .5)**2)

optimizer = ng.optimizers.OnePlusOne(parametrization=2, budget=100)
recommendation = optimizer.minimize(square)
print(recommendation)
```

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
