### PR TITLE
pythonPackages.googletrans: init at 2.4.0

### DIFF
--- a/pkgs/development/python-modules/googletrans/default.nix
+++ b/pkgs/development/python-modules/googletrans/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchFromGitHub, requests, pytest, coveralls }:
+
+buildPythonPackage rec {
+  pname = "googletrans";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "ssut";
+    repo = "py-googletrans";
+    rev = "v${version}";
+    sha256 = "0wzzinn0k9rfv9z1gmfk9l4kljyd4n6kizsjw4wjxv91kfhj92hz";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  checkInputs = [ pytest coveralls ];
+
+  # majority of tests just try to ping Google's Translate API endpoint
+  doCheck = false;
+  checkPhase = ''
+    pytest
+  '';
+
+  pythonImportsCheck = [ "googletrans" ];
+
+  meta = with lib; {
+    description = "Googletrans is python library to interact with Google Translate API";
+    homepage = "https://py-googletrans.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ unode ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2735,6 +2735,8 @@ in {
 
   google-pasta = callPackage ../development/python-modules/google-pasta { };
 
+  googletrans = callPackage ../development/python-modules/googletrans { };
+
   gpapi = callPackage ../development/python-modules/gpapi { };
   gplaycli = callPackage ../development/python-modules/gplaycli { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Needed for `mnemosyne` - see: https://github.com/NixOS/nixpkgs/issues/80324

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
