### PR TITLE
[20.03] firefox: 73.0 -> 73.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -16,10 +16,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "73.0";
+    ffversion = "73.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "2da2jn3gwck6qys3ys146jsjl9fgq10s3ii62y4ssnhl76ryir8f1mv9i1d6hyv8381hplasnxb553d5bgwnq87ymgqabakmr48n2p1";
+      sha512 = "1vdz711v44xdiry5vm4rrg7fjkrlnyn5jjkaq0bcf98jwrn9bjklmgwblrrnvmpc9pjd2ff3m7354q7vy6gd6c3yh2jhbq91v2w5yl9";
     };
 
     patches = [


### PR DESCRIPTION
##### Motivation for this change
Backport of #80431

Just a bugfix release for the latest version.

Changes: https://github.com/mozilla/release-notes/blob/master/releases/firefox-73.0.1-release.json

###### Things done

Compiled successfully and worked for browsing around the web for a few minutes.


