### PR TITLE
ZHF: #80379 xonsh: fix broken tests

### DIFF
--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, fetchFromGitHub, python3Packages, glibcLocales, coreutils, git }:
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, python3Packages
+, glibcLocales
+, coreutils
+, git
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "xonsh";
@@ -11,6 +18,14 @@ python3Packages.buildPythonApplication rec {
     rev    = "refs/tags/${version}";
     sha256 = "0nk6rjdkbxli510iwqspvray48kdxvbdmq1k8nxn14kqfpqzlbcv";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-ptk-tests.patch";
+      url = "https://github.com/xonsh/xonsh/commit/ca7acecc968dcda7dd56c1f5d5b4df349c98d734.patch";
+      sha256 = "00nhbf9wzm6r86r9zq8mnhds30w6gdhkgsx5kpl0jppiz4ll96iw";
+    })
+  ];
 
   LC_ALL = "en_US.UTF-8";
   postPatch = ''


### PR DESCRIPTION
ZHF: #80379

I have just pulled in the relevant commit as a patch, instead of changing the version to unstable.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
