### PR TITLE
wal-g: 0.2.0 -> 0.2.14

### DIFF
--- a/pkgs/tools/backup/wal-g/default.nix
+++ b/pkgs/tools/backup/wal-g/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "wal-g";
-  version = "0.2.0";
+  version = "0.2.14";
 
   src = fetchFromGitHub {
     owner  = "wal-g";
     repo   = "wal-g";
     rev    = "v${version}";
-    sha256 = "08lk7by1anxpd9v97xbf9443kk4n1w63zaar2nz86w8i3k3b4id9";
+    sha256 = "0rrn9kzcg3nw9qvzy58m4qacghv0pj7iyjh4yspc71n5nkamkfgm";
   };
 
   buildInputs = [ brotli ];
@@ -16,11 +16,21 @@ buildGoPackage rec {
   doCheck = true;
 
   goPackagePath = "github.com/wal-g/wal-g";
+
+  goDeps = ./deps.nix;
+
+  subPackages = [ "main/pg" ];
+
+  buildFlagsArray = [ "-ldflags=-s -w -X ${goPackagePath}/cmd/pg.WalgVersion=${version} -X ${goPackagePath}/cmd/pg.GitRevision=${src.rev}" ];
+
+  postInstall = ''
+    mv $bin/bin/pg $bin/bin/wal-g
+  '';
+
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/wal-g/wal-g";
     license = stdenv.lib.licenses.asl20;
-    description = "An archival restoration tool for Postgres";
+    description = "An archival restoration tool for PostgreSQL";
     maintainers = [ stdenv.lib.maintainers.ocharles ];
-    broken = true;
   };
 }

--- a/pkgs/tools/backup/wal-g/deps.nix
+++ b/pkgs/tools/backup/wal-g/deps.nix
@@ -1,0 +1,588 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev =  "0ebda48a7f143b1cce9eb37a8c1106ac762a3430";
+      sha256 = "1kclgclwar3r37zbvb9gg3qxbgzkb50zk3s9778zlh2773qikmai";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Azure/azure-pipeline-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/azure-pipeline-go";
+      rev =  "232aee85e8e3a6223a11c0943f7df2ae0fac00e4";
+      sha256 = "1agn2nzmm1dkwggm4w7h4bnrav4n5jrl0vqbqy2s49vqlr8zirn6";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Azure/azure-storage-blob-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/azure-storage-blob-go";
+      rev =  "fc700035fe4a7020f50d49f420b3c088aed57e03";
+      sha256 = "00gsnk9s1rlrakqvcm917hn4r47jannxwp7rkhrb71pamzm46752";
+    };
+  }
+  {
+    goPackagePath  = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev =  "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+    };
+  }
+  {
+    goPackagePath  = "github.com/DataDog/zstd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/zstd";
+      rev =  "aebefd9fcb99f22cd691ef778a12ed68f0e6a1ab";
+      sha256 = "06wphl43ji23c0cmmm6fd3wszbwq36mdp1jarak2a6hmxl6yf0b8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/RoaringBitmap/roaring";
+    fetch = {
+      type = "git";
+      url = "https://github.com/RoaringBitmap/roaring";
+      rev =  "3d677d3262197ee558b85029301eb69b8239f91a";
+      sha256 = "0v5jbqr7m4x7n8rxcyizhs21ndyinn8kil9hd6y2bifx9b9g6gv9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/aws/aws-sdk-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev =  "02973e4916ed10f78aff1257f45f01d23907a05d";
+      sha256 = "0w5c06l0f8h77p74gmsp2wzl21pcn92yzsycd36746qqav83yyld";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cyberdelia/lzo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cyberdelia/lzo";
+      rev =  "feb520148d8940294afb1e242dc1d2a7c9c34432";
+      sha256 = "0mk93b7vr9hp1xcvzaw5r01zs2blhk24m22pacf6sx5zwx8fd2ld";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev =  "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/glycerine/go-unsnap-stream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/glycerine/go-unsnap-stream";
+      rev =  "9f0cb55181dd3a0a4c168d3dbc72d4aca4853126";
+      sha256 = "1v10z30y9qc8dl34x0s8lr773g6raxilfdxbmzd1176pspzcmm9n";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-redis/redis";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-redis/redis";
+      rev =  "75795aa4236dc7341eefac3bbe945e68c99ef9df";
+      sha256 = "1qf7zl5slnc4bcz0z0vn4fq1pwkphdrmqmjg3wv5q6pv2x29drli";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-sql-driver/mysql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-sql-driver/mysql";
+      rev =  "72cd26f257d44c1114970e19afddcd812016007e";
+      sha256 = "1fvsvwc1v2i0gqn01mynvi1shp5xm0xaym6xng09fcbqb56lbjx1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/mock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/mock";
+      rev =  "51421b967af1f557f93a59e0057aaf15ca02e29c";
+      sha256 = "12ddj2g8ab87id6n2n67vnbhq6p8dvgsq1pzpqfriym4dk8w54fg";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "6c65a5562fc06764971b7c5d05c76c75e84bdbf7";
+      sha256 = "1k1wb4zr0qbwgpvz9q5ws9zhlal8hq7dmq62pwxxriksayl6hzym";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev =  "2e65f85255dbc3072edf28d6b5b8efc472979f5a";
+      sha256 = "05w6mpc4qcy0pv8a2bzng8nf4s5rf5phfang4jwy9rgf808q0nxf";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/brotli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/brotli";
+      rev =  "d6d98957ca8ccb1ef45922e978bb10efca0ea541";
+      sha256 = "0n0ia2sxsj3fnnzhjbigbadpsqxivjs3v78b1xzqvgd1nwalglaj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/googleapis/gax-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gax-go";
+      rev =  "bd5b16380fd03dc758d11cef74ba2e3bc8b0e8c2";
+      sha256 = "1lxawwngv6miaqd25s3ba0didfzylbwisd2nz7r4gmbmin6jsjrx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev =  "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d";
+      sha256 = "1p2igd58xkm8yaj2c2wxiplkf2hj6kxwrg6ss7mx61s5rd71v5xb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hashicorp/hcl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev =  "8cb6e5b959231cc1119e43259c4a608f9c51a241";
+      sha256 = "0q6ml0qqs0yil76mpn4mdx4lp94id8vbv575qm60jzl1ijcl5i66";
+    };
+  }
+  {
+    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jackc/pgx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jackc/pgx";
+      rev =  "c73e7d75061bb42b0282945710f344cfe1113d10";
+      sha256 = "1am1iggch89mn4a99bxnawjhc5yrgd8fjlmzq0b9l9qy5w1gzr1f";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jedib0t/go-pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jedib0t/go-pretty";
+      rev =  "a37e1e030434d93557ca8a6a77b4cf9d31cc21ff";
+      sha256 = "057xwrrqq0cvyq9f0wnfzjpx10807520vl92qq7l7a7s0r56jyrx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jmespath/go-jmespath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev =  "c2b33e84";
+      sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/magiconair/properties";
+    fetch = {
+      type = "git";
+      url = "https://github.com/magiconair/properties";
+      rev =  "c2353362d570a7bfa228149c62842019201cfb71";
+      sha256 = "1a10362wv8a8qwb818wygn2z48lgzch940hvpv81hv8gc747ajxn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-ieproxy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-ieproxy";
+      rev =  "f9202b1cfdeb0c82ddd3dc1e8e9cd94b3c0c1b13";
+      sha256 = "0r8c17znlv32750qy3p96fbyp8ys8xfdccpzv0z9lr2y88jnzhpz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/minio/sio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/minio/sio";
+      rev =  "035b4ef8c449ba2ba21ec143c91964e76a1fb68c";
+      sha256 = "007mh7a61qzgf8ga4pix6qhm6jbph3h71a8iif7l45mvqphabh0z";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev =  "3536a929edddb9a5b34bd6861dc4a9647cb459fe";
+      sha256 = "03bpv28jz9zhn4947saqwi328ydj7f6g6pf1m2d4m5zdh5jlfkrr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mschoch/smat";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mschoch/smat";
+      rev =  "90eadee771aeab36e8bf796039b8c261bebebe4f";
+      sha256 = "141saq6d4z3c7v3jw45zy4gn6wwjlyralqygjff1fzvz1gkvimk3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ncw/swift";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ncw/swift";
+      rev =  "f737f4e00462f79ff2e0ddbcfb09331ce7ec4fa9";
+      sha256 = "0c6vcn3dmhh339wilh71fmjb535kgfkf9dh2dh8ln43whq6mbjbs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev =  "c01d1270ff3e442a8a57cddc1c92dc1138598194";
+      sha256 = "1fjzpcjng60mc3a4b2ql5a00d5gah84wj740dabv9kq67mpg8fxy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/philhofer/fwd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/philhofer/fwd";
+      rev =  "bb6d471dc95d4fe11e432687f8b70ff496cf3136";
+      sha256 = "1pg84khadh79v42y8sjsdgfb54vw2kzv7hpapxkifgj0yvcp30g2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pierrec/lz4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pierrec/lz4";
+      rev =  "5a3d2245f97fc249850e7802e3c01fad02a1c316";
+      sha256 = "1my03x0m72vc2xyy9h0naa1qrzcf0g531gh4cakcwpxrq0z39vmr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pierrec/xxHash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pierrec/xxHash";
+      rev =  "d17cb990ad2d219d5901415ceaeb50d17df59527";
+      sha256 = "07rbr0apyq9m8m2knf1j7g9299r2v2ihvig1b7bq2srszcd9r221";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "ba968bfe8b2f7e042a574c888954fccecfa385b4";
+      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/afero";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/afero";
+      rev =  "f4711e4db9e9a1d3887343acb72b2bbfc2f686f5";
+      sha256 = "14qqj0cz6a595vn4dp747vddx05fd77jdsyl85qjmf9baymaxlam";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cast";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cast";
+      rev =  "8c9545af88b134710ab1cd196795e7f2388358d7";
+      sha256 = "0xq1ffqj8y8h7dcnm0m9lfrh0ga7pssnn2c1dnr09chqbpn4bdc5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev =  "ef82de70bb3f60c65fb8eebacbb2d122ef517385";
+      sha256 = "1q1nsx05svyv9fv3fy6xv6gs9ffimkyzsfm49flvl3wnvf1ncrkd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/jwalterweatherman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/jwalterweatherman";
+      rev =  "94f6ae3ed3bceceafa716478c5fbf8d29ca601a1";
+      sha256 = "1ywmkwci5zyd88ijym6f30fj5c0k2yayxarkmnazf5ybljv50q7b";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "298182f68c66c05229eb03ac171abe6e309ee79a";
+      sha256 = "1cj3cjm7d3zk0mf1xdybh0jywkbbw7a6yr3y22x9sis31scprswd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/viper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/viper";
+      rev =  "6d33b5a963d922d182c91e8a1c88d81fd150cfd4";
+      sha256 = "1190mg04718r03qriav99sf4kx2n7wdgr8vdni15f74bpbzrdjrl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "221dbe5ed46703ee255b1da0dec05086f5035f62";
+      sha256 = "187i5g88sxfy4vxpm7dw1gwv29pa2qaq475lxrdh5livh69wqfjb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/tinsane/tracelog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tinsane/tracelog";
+      rev =  "05cb843fbac1d7693bbbbed8aa8f7b401438ee7f";
+      sha256 = "1fry633qi4iih9za91m90c26p3qpd79d716dggk10cbc0bpvql51";
+    };
+  }
+  {
+    goPackagePath  = "github.com/tinylib/msgp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tinylib/msgp";
+      rev =  "b2b6a672cf1e5b90748f79b8b81fc8c5cf0571a1";
+      sha256 = "0pypfknghg1hcjjrqz3f1riaylk6hcxn9h0qyzynb74rp0qmlxjc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ulikunitz/xz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ulikunitz/xz";
+      rev =  "590df8077fbcb06ad62d7714da06c00e5dd2316d";
+      sha256 = "07mivr4aiw3b8qzwajsxyjlpbkf3my4xx23lv0yryc4pciam5lhy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/wal-g/storages";
+    fetch = {
+      type = "git";
+      url = "https://github.com/wal-g/storages";
+      rev =  "ecd376af8972cd9c3e355831c126a7862de6b2b9";
+      sha256 = "1jmvin93811xxh9sqf6xrrys55dm12zszqf2l3arf92h0bysvniy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/willf/bitset";
+    fetch = {
+      type = "git";
+      url = "https://github.com/willf/bitset";
+      rev =  "e553b05586428962bf7058d1044519d87ca72d74";
+      sha256 = "0davmxzv79qqg7lkj89diqinqx3xkr94d67yfnazqn3h1f7sjkd1";
+    };
+  }
+  {
+    goPackagePath  = "go.opencensus.io";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-instrumentation/opencensus-go";
+      rev =  "9c377598961b706d1542bd2d84d538b5094d596e";
+      sha256 = "05jr8gkr2w34i5wwki4zhl5ch0qrgi7cdgag5iy5gpxplhbrvbg9";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "e657309f52e71501f9934566ac06dc5c2f7f11a1";
+      sha256 = "17jwkjrfj7kz25z8z492xlz88nmb42kpjcxl9dsv5jl28zvzq1bj";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/exp";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/exp";
+      rev =  "ec7cb31e5a562f5e9e31b300128d2f530f55d127";
+      sha256 = "19b4kdwfahq9f809v4lmn9h47sq1y67nkl7csnracn5qd334hp06";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/lint";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/lint";
+      rev =  "959b441ac422379a43da2230f62be024250818b0";
+      sha256 = "1mgcv5f00pkzsbwnq2y7vqvd1b4lr5a3s47cphh2qv4indfk7pck";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "74dc4d7220e7acc4e100824340f3e66577424772";
+      sha256 = "0563yswwqknxx2gsvl0qikn0lmwalilbng8i12iw4d3v40n23s0l";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev =  "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33";
+      sha256 = "06jwpvx0x2gjn2y959drbcir5kd7vg87k0r1216abk6rrdzzrzi2";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev =  "42b317875d0fa942474b76e1b46a6060d720ae6e";
+      sha256 = "0mrjhk7al7yyh76x9flvxy4jm5jyqh2fxbxagpaazxn1xdgkaif3";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "4d1cda033e0619309c606fc686de3adcf599539e";
+      sha256 = "1wgaldbnkmh568v8kkgvnmkskaj96fqrbzhx23yji2kh1432q6gh";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev =  "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd";
+      sha256 = "0yqnxsrarjk4qkda8kcxzmk7y90kkkxzx9iwryzrk7bzs87ky3xc";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev =  "fc82fb2afd64396b05ea9aa0bccd6e8f2257b154";
+      sha256 = "1rnpbhhcnv28k63m7biv2rxrmdxhz9q3p35qi0phcq2qhcf78032";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/api";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/google-api-go-client";
+      rev =  "feb0267beb8644f5088a03be4d5ec3f8c7020152";
+      sha256 = "1lzdzkd2i41v6amxs9jah1q44qbvf1yvm8906jpfjiq6c3ffhqss";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "4a4468ece617fc8205e99368fa2200e9d1fad421";
+      sha256 = "13cyhqwmvc2nia4ssdwwdzscq52aj3z9zjikx17wk4kb0j8vr370";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-genproto";
+      rev =  "24fa4b261c55da65468f2abfdae2b024eef27dfb";
+      sha256 = "109zhaqlfd8zkbr1hk6zqbs6vcxfrk64scjwh2nswph05gr0m84d";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev =  "6eaf6f47437a6b4e2153a190160ef39a92c7eceb";
+      sha256 = "1cn33r2gclmq2v1ndpf1n5bmhf2qs8mms7ii5cnl6f9ch4r2c4k3";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "51d6538a90f86fe93ac480b35f37b2be17fef232";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
+    };
+  }
+  {
+    goPackagePath  = "honnef.co/go/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dominikh/go-tools";
+      rev =  "72554cb117ad340748b3093e7108983fd984c9f2";
+      sha256 = "1vndpwg797z2gw9h9378iq99aqy7nalqx82lgvcsaqnkypdmppnd";
+    };
+  }
+]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
