### PR TITLE
OSMPythonTools: init at 0.2.6

### DIFF
--- a/pkgs/development/python-modules/osmpythontools/default.nix
+++ b/pkgs/development/python-modules/osmpythontools/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, beautifulsoup4
+, geojson
+, lxml
+, matplotlib
+, numpy
+, pandas
+, ujson
+, xarray
+}:
+
+buildPythonPackage rec {
+  pname = "osmpythontools";
+  version = "0.2.6";
+
+  src = fetchPypi {
+    pname = "OSMPythonTools";
+    inherit version;
+    sha256 = "efc72e3963971c6c7fd94bd374704a5b78eb6c07397a4ffb5f9176c1e4aee096";
+  };
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    geojson
+    lxml
+    matplotlib
+    numpy
+    pandas
+    ujson
+    xarray
+  ];
+
+  patches = [ ./remove-unused-dependency.patch ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "OSMPythonTools"
+    "OSMPythonTools.api"
+    "OSMPythonTools.data"
+    "OSMPythonTools.element"
+    "OSMPythonTools.nominatim"
+    "OSMPythonTools.overpass"
+  ];
+
+  meta = with lib; {
+    description = "A library to access OpenStreetMap-related services";
+    longDescription = ''
+      The python package OSMPythonTools provides easy access to
+      OpenStreetMap-related services, among them an Overpass endpoint,
+      Nominatim, and the OpenStreetMap editing API.
+    '';
+    homepage = "https://github.com/mocnik-science/osm-python-tools";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ das-g ];
+  };
+}

--- a/pkgs/development/python-modules/osmpythontools/remove-unused-dependency.patch
+++ b/pkgs/development/python-modules/osmpythontools/remove-unused-dependency.patch
@@ -1,0 +1,22 @@
+diff --git a/OSMPythonTools.egg-info/requires.txt b/OSMPythonTools.egg-info/requires.txt
+index 16a5019..e58155c 100644
+--- a/OSMPythonTools.egg-info/requires.txt
++++ b/OSMPythonTools.egg-info/requires.txt
+@@ -1,5 +1,4 @@
+ beautifulsoup4
+-datetime
+ geojson
+ lxml
+ matplotlib
+diff --git a/setup.py b/setup.py
+index 08e9455..1a6435e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -14,7 +14,6 @@ setup(
+     packages = ['OSMPythonTools', 'OSMPythonTools.internal'],
+     install_requires = [
+         'beautifulsoup4',
+-        'datetime',
+         'geojson',
+         'lxml',
+         'matplotlib',

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -937,6 +937,8 @@ in {
 
   osmnx = callPackage ../development/python-modules/osmnx { };
 
+  osmpythontools = callPackage ../development/python-modules/osmpythontools { };
+
   outcome = callPackage ../development/python-modules/outcome {};
 
   ovito = toPythonModule (pkgs.libsForQt5.callPackage ../development/python-modules/ovito {


### PR DESCRIPTION
###### Motivation for this change

I'd like to use [this library](https://wiki.openstreetmap.org/wiki/OSMPythonTools) in Python scripts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
   - (there are none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
