### PR TITLE
pythonPackages.signedjson: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/signedjson/default.nix
+++ b/pkgs/development/python-modules/signedjson/default.nix
@@ -1,25 +1,31 @@
-{ stdenv
+{ lib
+, stdenv
 , buildPythonPackage
-, fetchgit
+, pythonOlder
+, fetchFromGitHub
 , canonicaljson
 , unpaddedbase64
 , pynacl
+, typing
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "signedjson";
-  version = "1.0.0";
+  version = "1.1.0";
 
-  src = fetchgit {
-    url = "https://github.com/matrix-org/python-signedjson.git";
-    rev = "refs/tags/v${version}";
-    sha256 = "0b8xxhc3npd4567kqapfp4gs7m0h057xam3an7424az262ind82n";
+  src = fetchFromGitHub {
+    owner = "matrix-org";
+    repo = "python-signedjson";
+    rev = "v${version}";
+    sha256 = "18s388hm3babnvakbbgfqk0jzq25nnznvhygywd3azp9b4yzmd5c";
   };
 
-  propagatedBuildInputs = [ canonicaljson unpaddedbase64 pynacl ];
+  propagatedBuildInputs = [ canonicaljson unpaddedbase64 pynacl typing-extensions ]
+    ++ lib.optionals (pythonOlder "3.5") [ typing ];
 
   meta = with stdenv.lib; {
-    homepage = https://pypi.org/project/signedjson/;
+    homepage = "https://pypi.org/project/signedjson/";
     description = "Sign JSON with Ed25519 signatures";
     license = licenses.asl20;
   };


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing #80447 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
