### PR TITLE
flatpak: use correct p11-kit output

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     # Hardcode paths used by Flatpak itself.
     (substituteAll {
       src = ./fix-paths.patch;
-      p11 = p11-kit;
+      p11kit = "${p11-kit.dev}/bin/p11-kit";
     })
 
     # Adapt paths exposed to sandbox for NixOS.

--- a/pkgs/development/libraries/flatpak/fix-paths.patch
+++ b/pkgs/development/libraries/flatpak/fix-paths.patch
@@ -7,7 +7,7 @@ index 5dd7629e..ddc71a4c 100644
    int i;
    char *p11_argv[] = {
 -    "p11-kit", "server",
-+    "@p11@/bin/p11-kit", "server",
++    "@p11kit@", "server",
      /* We explicitly request --sh here, because we then fail on earlier versions that doesn't support
       * this flag. This is good, because those earlier versions did not properly daemonize and caused
       * the spawn_sync to hang forever, waiting for the pipe to close.


### PR DESCRIPTION
Fixes #80452

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
