### PR TITLE
[19.09] nixos/release-combined; migrate constituents list to strings

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -38,7 +38,7 @@ in rec {
     nixpkgs = nixpkgsSrc;
   })) [ "unstable" ];
 
-  tested = pkgs.lib.hydraJob (pkgs.releaseTools.aggregate {
+  tested = pkgs.releaseTools.aggregate {
     name = "nixos-${nixos.channel.version}";
     meta = {
       description = "Release-critical builds for the NixOS channel";
@@ -47,103 +47,103 @@ in rec {
     constituents =
       let
         # Except for the given systems, return the system-specific constituent
-        except = systems: x: map (system: x.${system}) (pkgs.lib.subtractLists systems supportedSystems);
+        except = systems: x: map (system: x + ".${system}") (pkgs.lib.subtractLists systems supportedSystems);
         all = x: except [] x;
-      in [
-        nixos.channel
-        (all nixos.dummy)
-        (all nixos.manual)
+      in pkgs.lib.flatten [
+        "nixos.channel"
+        (all "nixos.dummy")
+        (all "nixos.manual")
 
-        nixos.iso_graphical.x86_64-linux or []
-        nixos.iso_minimal.aarch64-linux or []
-        nixos.iso_minimal.i686-linux or []
-        nixos.iso_minimal.x86_64-linux or []
-        nixos.ova.x86_64-linux or []
-        nixos.sd_image.aarch64-linux or []
+        "nixos.iso_graphical.x86_64-linux"
+        "nixos.iso_minimal.aarch64-linux"
+        "nixos.iso_minimal.i686-linux"
+        "nixos.iso_minimal.x86_64-linux"
+        "nixos.ova.x86_64-linux"
+        "nixos.sd_image.aarch64-linux"
 
         #(all nixos.tests.containers)
-        (all nixos.tests.containers-imperative)
-        (all nixos.tests.containers-ipv4)
-        (all nixos.tests.containers-ipv6)
-        nixos.tests.chromium.x86_64-linux or []
-        (all nixos.tests.firefox)
-        (all nixos.tests.firewall)
-        (all nixos.tests.fontconfig-default-fonts)
-        (all nixos.tests.gnome3-xorg)
-        (all nixos.tests.gnome3)
-        (all nixos.tests.pantheon)
-        nixos.tests.installer.zfsroot.x86_64-linux or [] # ZFS is 64bit only
-        (except ["aarch64-linux"] nixos.tests.installer.lvm)
-        (except ["aarch64-linux"] nixos.tests.installer.luksroot)
-        (except ["aarch64-linux"] nixos.tests.installer.separateBoot)
-        (except ["aarch64-linux"] nixos.tests.installer.separateBootFat)
-        (except ["aarch64-linux"] nixos.tests.installer.simple)
-        (except ["aarch64-linux"] nixos.tests.installer.simpleLabels)
-        (except ["aarch64-linux"] nixos.tests.installer.simpleProvided)
-        (except ["aarch64-linux"] nixos.tests.installer.simpleUefiSystemdBoot)
-        (except ["aarch64-linux"] nixos.tests.installer.swraid)
-        (except ["aarch64-linux"] nixos.tests.installer.btrfsSimple)
-        (except ["aarch64-linux"] nixos.tests.installer.btrfsSubvols)
-        (except ["aarch64-linux"] nixos.tests.installer.btrfsSubvolDefault)
-        (except ["aarch64-linux"] nixos.tests.boot.biosCdrom)
-        #(except ["aarch64-linux"] nixos.tests.boot.biosUsb) # disabled due to issue #15690
-        (except ["aarch64-linux"] nixos.tests.boot.uefiCdrom)
-        (except ["aarch64-linux"] nixos.tests.boot.uefiUsb)
-        (all nixos.tests.boot-stage1)
-        (all nixos.tests.hibernate)
-        nixos.tests.docker.x86_64-linux or []
-        (all nixos.tests.ecryptfs)
-        (all nixos.tests.env)
-        (all nixos.tests.ipv6)
-        (all nixos.tests.i3wm)
+        (all "nixos.tests.containers-imperative")
+        (all "nixos.tests.containers-ipv4")
+        (all "nixos.tests.containers-ipv6")
+        "nixos.tests.chromium.x86_64-linux"
+        (all "nixos.tests.firefox")
+        (all "nixos.tests.firewall")
+        (all "nixos.tests.fontconfig-default-fonts")
+        (all "nixos.tests.gnome3-xorg")
+        (all "nixos.tests.gnome3")
+        (all "nixos.tests.pantheon")
+        "nixos.tests.installer.zfsroot.x86_64-linux" # ZFS is 64bit only
+        (except ["aarch64-linux"] "nixos.tests.installer.lvm")
+        (except ["aarch64-linux"] "nixos.tests.installer.luksroot")
+        (except ["aarch64-linux"] "nixos.tests.installer.separateBoot")
+        (except ["aarch64-linux"] "nixos.tests.installer.separateBootFat")
+        (except ["aarch64-linux"] "nixos.tests.installer.simple")
+        (except ["aarch64-linux"] "nixos.tests.installer.simpleLabels")
+        (except ["aarch64-linux"] "nixos.tests.installer.simpleProvided")
+        (except ["aarch64-linux"] "nixos.tests.installer.simpleUefiSystemdBoot")
+        (except ["aarch64-linux"] "nixos.tests.installer.swraid")
+        (except ["aarch64-linux"] "nixos.tests.installer.btrfsSimple")
+        (except ["aarch64-linux"] "nixos.tests.installer.btrfsSubvols")
+        (except ["aarch64-linux"] "nixos.tests.installer.btrfsSubvolDefault")
+        (except ["aarch64-linux"] "nixos.tests.boot.biosCdrom")
+        #(except ["aarch64-linux"] "nixos.tests.boot.biosUsb") # disabled due to issue #15690
+        (except ["aarch64-linux"] "nixos.tests.boot.uefiCdrom")
+        (except ["aarch64-linux"] "nixos.tests.boot.uefiUsb")
+        (all "nixos.tests.boot-stage1")
+        (all "nixos.tests.hibernate")
+        "nixos.tests.docker.x86_64-linux"
+        (all "nixos.tests.ecryptfs")
+        (all "nixos.tests.env")
+        (all "nixos.tests.ipv6")
+        (all "nixos.tests.i3wm")
         # 2018-06-06: keymap tests temporarily removed from tested job
         # since non-deterministic failure are blocking the channel (#41538)
-        #(all nixos.tests.keymap.azerty)
-        #(all nixos.tests.keymap.colemak)
-        #(all nixos.tests.keymap.dvorak)
-        #(all nixos.tests.keymap.dvp)
-        #(all nixos.tests.keymap.neo)
-        #(all nixos.tests.keymap.qwertz)
-        (all nixos.tests.plasma5)
-        (all nixos.tests.lightdm)
-        (all nixos.tests.login)
-        (all nixos.tests.misc)
-        (all nixos.tests.mutableUsers)
-        (all nixos.tests.nat.firewall)
-        (all nixos.tests.nat.firewall-conntrack)
-        (all nixos.tests.nat.standalone)
-        (all nixos.tests.networking.scripted.loopback)
-        (all nixos.tests.networking.scripted.static)
-        (all nixos.tests.networking.scripted.dhcpSimple)
-        (all nixos.tests.networking.scripted.dhcpOneIf)
-        (all nixos.tests.networking.scripted.bond)
-        (all nixos.tests.networking.scripted.bridge)
-        (all nixos.tests.networking.scripted.macvlan)
-        (all nixos.tests.networking.scripted.sit)
-        (all nixos.tests.networking.scripted.vlan)
-        (all nixos.tests.nfs3)
-        (all nixos.tests.nfs4)
-        (all nixos.tests.openssh)
-        (all nixos.tests.php-pcre)
-        (all nixos.tests.predictable-interface-names.predictable)
-        (all nixos.tests.predictable-interface-names.unpredictable)
-        (all nixos.tests.predictable-interface-names.predictableNetworkd)
-        (all nixos.tests.predictable-interface-names.unpredictableNetworkd)
-        (all nixos.tests.printing)
-        (all nixos.tests.proxy)
-        (all nixos.tests.sddm.default)
-        (all nixos.tests.simple)
-        (all nixos.tests.slim)
-        (all nixos.tests.switchTest)
-        (all nixos.tests.udisks2)
-        (all nixos.tests.xfce)
-        (all nixos.tests.xfce4-14)
+        #(all nixos.tests.keymap.azerty")
+        #(all "nixos.tests.keymap.colemak")
+        #(all "nixos.tests.keymap.dvorak")
+        #(all "nixos.tests.keymap.dvp")
+        #(all "nixos.tests.keymap.neo")
+        #(all "nixos.tests.keymap.qwertz")
+        (all "nixos.tests.plasma5")
+        (all "nixos.tests.lightdm")
+        (all "nixos.tests.login")
+        (all "nixos.tests.misc")
+        (all "nixos.tests.mutableUsers")
+        (all "nixos.tests.nat.firewall")
+        (all "nixos.tests.nat.firewall-conntrack")
+        (all "nixos.tests.nat.standalone")
+        (all "nixos.tests.networking.scripted.loopback")
+        (all "nixos.tests.networking.scripted.static")
+        (all "nixos.tests.networking.scripted.dhcpSimple")
+        (all "nixos.tests.networking.scripted.dhcpOneIf")
+        (all "nixos.tests.networking.scripted.bond")
+        (all "nixos.tests.networking.scripted.bridge")
+        (all "nixos.tests.networking.scripted.macvlan")
+        (all "nixos.tests.networking.scripted.sit")
+        (all "nixos.tests.networking.scripted.vlan")
+        (all "nixos.tests.nfs3")
+        (all "nixos.tests.nfs4")
+        (all "nixos.tests.openssh")
+        (all "nixos.tests.php-pcre")
+        (all "nixos.tests.predictable-interface-names.predictable")
+        (all "nixos.tests.predictable-interface-names.unpredictable")
+        (all "nixos.tests.predictable-interface-names.predictableNetworkd")
+        (all "nixos.tests.predictable-interface-names.unpredictableNetworkd")
+        (all "nixos.tests.printing")
+        (all "nixos.tests.proxy")
+        (all "nixos.tests.sddm.default")
+        (all "nixos.tests.simple")
+        (all "nixos.tests.slim")
+        (all "nixos.tests.switchTest")
+        (all "nixos.tests.udisks2")
+        (all "nixos.tests.xfce")
+        (all "nixos.tests.xfce4-14")
 
-        nixpkgs.tarball
-        (all allSupportedNixpkgs.emacs)
+        "nixpkgs.tarball"
+        (all "allSupportedNixpkgs.emacs")
         # The currently available aarch64 JDK is unfree
-        (except ["aarch64-linux"] allSupportedNixpkgs.jdk)
+        (except ["aarch64-linux"] "allSupportedNixpkgs.jdk")
       ];
-  });
+  };
 
 }

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -90,11 +90,33 @@ in rec {
       maintainers = [ lib.maintainers.eelco ];
     };
     constituents =
-      let all = x: map (system: x.${system}) supportedSystems; in
-      [ nixpkgs.tarball
-        (all nixpkgs.jdk)
-      ]
-      ++ lib.collect lib.isDerivation nixos;
+      let all = x: map (system: x + ".${system}") supportedSystems; in
+      lib.flatten [
+        "nixpkgs.tarball"
+        (all "nixpkgs.jdk")
+        "nixos.channel"
+        "nixos.manual"
+        (all "nixos.iso_minimal")
+        (all "nixos.dummy")
+        (all "nixos.tests.containers-imperative")
+        (all "nixos.tests.containers-ipv4")
+        (all "nixos.tests.containers-ipv6")
+        (all "nixos.tests.firewall")
+        (all "nixos.tests.ipv6")
+        (all "nixos.tests.login")
+        (all "nixos.tests.misc")
+        (all "nixos.tests.nat")
+        (all "nixos.tests.nfs3")
+        (all "nixos.tests.openssh")
+        (all "nixos.tests.php-pcre")
+        (all "nixos.tests.predictable-interface-names")
+        (all "nixos.tests.proxy")
+        (all "nixos.tests.simple")
+        (all "nixos.tests.installer.lvm")
+        (all "nixos.tests.installer.separateBoot")
+        (all "nixos.tests.installer.simple")
+        (all "nixos.tests.boot.biosCdrom")
+      ];
   });
 
 }


### PR DESCRIPTION
###### Motivation for this change

As of a few days ago hydra has a different GC configuration that leads
to eval failures when the tested job has a direct dependency on all
the tests. This is an attempt at migrating the old list of jobs to the
new format while keeping the logic and the tests the same.

Currently channel bumps of nixos-19.09 are being blocked. This should unblock it.

###### Things done
Testing eval for the new format doesn't seem to be straight forward from my point of view and my laptop lacks enough memory to do it..

Hopefully someone with the right flavor and version of nix installed can use the new `nix hydra-eval-jobs` command to test this.

----
cc @edolstra 