### PR TITLE
Don't replace /etc in fhs-userenv

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/chrootenv/chrootenv.c
+++ b/pkgs/build-support/build-fhs-userenv/chrootenv/chrootenv.c
@@ -18,7 +18,7 @@
   if (expr)                                                                    \
     fail(#expr, errno);
 
-const gchar *bind_blacklist[] = {"bin", "etc", "host", "real-host", "usr", "lib", "lib64", "lib32", "sbin", NULL};
+const gchar *bind_blacklist[] = {"bin", "host", "real-host", "usr", "lib", "lib64", "lib32", "sbin", NULL};
 
 int pivot_root(const char *new_root, const char *put_old) {
   return syscall(SYS_pivot_root, new_root, put_old);

--- a/pkgs/build-support/build-fhs-userenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/default.nix
@@ -19,7 +19,7 @@ let
     [ -d "$1" ] && [ -r "$1" ] && cd "$1"
     shift
 
-    source /etc/profile
+    source ${env.profile}
     exec ${run} "$@"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

buildFHSUserEnv currently replaces /etc, selectively symlinking over some files from the host /etc into the chroot.

This means some things will be missing - which is inconvenient when using buildFHSUserEnv to spin up an interactive nix-shell.

This PR is not yet for merging at this point, but for testing and discussing whether doing this (either by default or somehow as an option) makes sense at all.

It *seems* to work for me ;)

/cc @abbradar looks like you have a lot of background about this part of the system ;)
