### PR TITLE
spago: fix Darwin build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -680,6 +680,11 @@ self: super: builtins.intersectAttrs super {
           # https://github.com/spacchetti/spago/issues/510
           cp ${docsSearchAppJsFile} "$sourceRoot/templates/docs-search-app.js"
           cp ${purescriptDocsSearchFile} "$sourceRoot/templates/purescript-docs-search"
+
+          # For some weird reason, on Darwin, the open(2) call to embed these files
+          # requires write permissions. The easiest resolution is just to permit that
+          # (doesn't cause any harm on other systems).
+          chmod u+w "$sourceRoot/templates/docs-search-app.js" "$sourceRoot/templates/purescript-docs-search"
         '';
       });
 


### PR DESCRIPTION
###### Motivation for this change

[As noted earlier](https://github.com/NixOS/nixpkgs/pull/76084#issuecomment-568150397), Spago is currently broken for Darwin. This fixes that.

It's a weird issue. The problem is that when doing a `fileEmbed` of the [content downloaded at build time](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/configuration-nix.nix#L668-L678), read permissions are insufficient. `dtruss` confirms that ghc requests write permissions when calling `open`.

I don't understand why this should happen, but all the static files in the same `templates` directory have permissions `0644`, and making it the same for the two separately downloaded files seems benign enough as a workaround. Once the build is complete, it all gets deleted anyway.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
