### PR TITLE
maintainers: fix 0x4A6F

### DIFF
--- a/pkgs/applications/qubes/qubes-core-vchan-xen/default.nix
+++ b/pkgs/applications/qubes/qubes-core-vchan-xen/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "Libraries required for the higher-level Qubes daemons and tools";
     homepage = "https://qubes-os.org";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ "0x4A6F" ];
+    maintainers = [ maintainers."0x4A6F" ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/window-managers/cwm/default.nix
+++ b/pkgs/applications/window-managers/cwm/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A lightweight and efficient window manager for X11";
     homepage    = "https://github.com/leahneukirchen/cwm";
-    maintainers = with maintainers; [ "0x4A6F" mkf ];
+    maintainers = with maintainers; [ maintainers."0x4A6F" mkf ];
     license     = licenses.isc;
     platforms   = platforms.linux;
   };

--- a/pkgs/tools/networking/pmacct/default.nix
+++ b/pkgs/tools/networking/pmacct/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.pmacct.net/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ "0x4A6F" ];
+    maintainers = [ maintainers."0x4A6F" ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Catching all packages, I'm maintaining.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
