### PR TITLE
pythonPackages.qiskit-terra: init at 0.12.0

### DIFF
--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -1,0 +1,119 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, dill
+, jsonschema
+, numpy
+, marshmallow
+, marshmallow-polyfield
+, matplotlib
+, networkx
+, ply
+, psutil
+, scipy
+, sympy
+  # test requirements
+, ddt
+, hypothesis
+, ipywidgets
+, nbformat
+, nbconvert
+, pillow
+, pydot
+, python
+, pygraphviz
+, pylatexenc
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-terra";
+  version = "0.12.0";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = pname;
+    rev = version;
+    sha256 = "1yarfziy2w8n1d7zyyxykfs68608j8md4kwfyhbyc6wy483fk9sy";
+  };
+
+  nativeBuildInputs = [ cython ];
+
+  propagatedBuildInputs = [
+    dill
+    jsonschema
+    numpy
+    marshmallow
+    marshmallow-polyfield
+    matplotlib
+    networkx
+    ply
+    psutil
+    scipy
+    sympy
+  ];
+
+
+  # *** Tests ***
+  checkInputs = [
+    ddt
+    hypothesis
+    ipywidgets
+    nbformat
+    nbconvert
+    pillow
+    pydot
+    pygraphviz
+    pylatexenc
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "qiskit"
+    "qiskit.transpiler.passes.routing.cython.stochastic_swap.swap_trial"
+  ];
+
+  dontUseSetuptoolsCheck = true;  # can't find setup.py, so fails. tested by pytest
+
+  disabledTests = [
+    "test_long_name"  # generated circuit images differ for some reason
+    "test_jupyter_jobs_pbars" # needs IBMQ provider package (qiskit-ibmq-provider), circular dependency
+  ];
+
+  pytestFlagsArray = [
+    "--ignore=test/randomized/test_transpiler_equivalence.py" # collection requires qiskit-aer, which would cause circular dependency
+  ];
+
+  # Moves tests to $PACKAGEDIR/test. They can't be run from /build because of finding
+  # cythonized modules and expecting to find some resource files in the test directory.
+  preCheck = ''
+    export PACKAGEDIR=$out/${python.sitePackages}
+    echo "Moving Qiskit test files to package directory"
+    cp -r $TMP/source/test $PACKAGEDIR
+    cp -r $TMP/source/examples $PACKAGEDIR
+    cp -r $TMP/source/qiskit/schemas/examples $PACKAGEDIR/qiskit/schemas/
+
+    # run pytest from Nix's $out path
+    pushd $PACKAGEDIR
+  '';
+  postCheck = ''
+    rm -rf test
+    rm -rf examples
+    popd
+  '';
+
+
+  meta = with lib; {
+    description = "Provides the foundations for Qiskit.";
+    longDescription = ''
+      Allows the user to write quantum circuits easily, and takes care of the constraints of real hardware.
+    '';
+    homepage = "https://github.com/QISKit/qiskit-terra";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6948,6 +6948,8 @@ in {
 
   qiskit = callPackage ../development/python-modules/qiskit { };
 
+  qiskit-terra = callPackage ../development/python-modules/qiskit-terra { };
+
   qasm2image = callPackage ../development/python-modules/qasm2image { };
 
   simpy = callPackage ../development/python-modules/simpy { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update qiskit according to new upstream package structure (collection of subpackages). This is broken out of #78772. Would like to get it into 20.03 if at all possible. Has one out-of-tree dependency: pythonPackages.pylatexenc (#78878). Will rebase & remove that commit when #78878 is approved.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
