### PR TITLE
pythonPackages.pyparted: 3.10.4 -> 3.11.4

### DIFF
--- a/pkgs/development/python-modules/pyparted/default.nix
+++ b/pkgs/development/python-modules/pyparted/default.nix
@@ -1,18 +1,22 @@
 { stdenv
+, fetchFromGitHub
 , buildPythonPackage
 , isPyPy
 , pkgs
 , python
+, six
 }:
 
 buildPythonPackage rec {
   pname = "pyparted";
-  version = "3.10.7";
+  version = "3.11.4";
   disabled = isPyPy;
 
-  src = pkgs.fetchurl {
-    url = "https://github.com/rhinstaller/pyparted/archive/v${version}.tar.gz";
-    sha256 = "0c9ljrdggwawd8wdzqqqzrna9prrlpj6xs59b0vkxzip0jkf652r";
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "dcantrell";
+    rev = "v${version}";
+    sha256 = "0wd0xhv1y1zw7djzcnimj8irif3mg0shbhgz0jn5yi914is88h6n";
   };
 
   postPatch = ''
@@ -26,11 +30,16 @@ buildPythonPackage rec {
       tests/test__ped_ped.py
   '';
 
+  patches = [
+    ./fix-test-pythonpath.patch
+  ];
+
   preConfigure = ''
     PATH="${pkgs.parted}/sbin:$PATH"
   '';
 
   nativeBuildInputs = [ pkgs.pkgconfig ];
+  checkInputs = [ six ];
   propagatedBuildInputs = [ pkgs.parted ];
 
   checkPhase = ''
@@ -39,10 +48,10 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "https://fedorahosted.org/pyparted/";
+    homepage = "https://github.com/dcantrell/pyparted/";
     description = "Python interface for libparted";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ lsix ];
   };
-
 }

--- a/pkgs/development/python-modules/pyparted/fix-test-pythonpath.patch
+++ b/pkgs/development/python-modules/pyparted/fix-test-pythonpath.patch
@@ -1,0 +1,26 @@
+diff -ur a/Makefile b/Makefile
+--- a/Makefile	1980-01-02 00:00:00.000000000 +0100
++++ b/Makefile	2020-02-18 20:04:14.068243263 +0100
+@@ -39,19 +39,19 @@
+ 	@$(PYTHON) setup.py build
+ 
+ test: all
+-	@env PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src \
++	@env PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src:$$PYTHONPATH \
+ 	$(PYTHON) -m unittest discover -v
+ 
+ coverage: all
+ 	@echo "*** Running unittests with $(COVERAGE) for $(PYTHON) ***"
+-	@env PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src \
++	@env PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src:$$PYTHONPATH \
+ 	$(COVERAGE) run --branch -m unittest discover -v
+ 	$(COVERAGE) report --include="build/lib.*/parted/*" --show-missing
+ 	$(COVERAGE) report --include="build/lib.*/parted/*" > coverage-report.log
+ 
+ check: clean
+ 	env PYTHON=python3 $(MAKE) ; \
+-	env PYTHON=python3 PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src \
++	env PYTHON=python3 PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src:$$PYTHONPATH \
+ 	tests/pylint/runpylint.py
+ 
+ dist:


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
