### PR TITLE
rubyWithPackages.libv8: fix compilation

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -294,6 +294,12 @@ in
   libv8 = attrs: {
     buildInputs = [ which v8 python ];
     buildFlags = [ "--with-system-v8=true" ];
+    dontBuild = false;
+    postPatch = ''
+      substituteInPlace ext/libv8/extconf.rb \
+        --replace "location = Libv8::Location::Vendor.new" \
+                  "location = Libv8::Location::System.new"
+    '';
   };
 
   execjs = attrs: {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This works around the removed option to build with a system libv8 that happened in https://github.com/rubyjs/libv8/commit/c714ddf12c4c16f5a66814f12e1ecc81d9c3cf3a#diff-e4644139217623558c4f0b5fd4e07805 and uses the still existing code to simply hardcode the option for now.

This should be good enough for 20.03 but we'll probably have to find a more future-proof way to do this later.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ZHF: #80379
rubyPackages: update #76595

@alyssais @zimbatm 