### PR TITLE
[20.03] Backport `clippy: add rustc.llvm to buildInputs`

### DIFF
--- a/pkgs/development/compilers/rust/clippy.nix
+++ b/pkgs/development/compilers/rust/clippy.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage {
   # changes hash of vendor directory otherwise
   dontUpdateAutotoolsGnuConfigScripts = true;
 
-  buildInputs = [ rustc ] ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [ rustc rustc.llvm ] ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];
 
   # fixes: error: the option `Z` is only accepted on the nightly compiler
   RUSTC_BOOTSTRAP = 1;
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://rust-lang.github.io/rust-clippy/;
+    homepage = "https://rust-lang.github.io/rust-clippy/";
     description = "A bunch of lints to catch common mistakes and improve your Rust code";
     maintainers = with maintainers; [ basvandijk ];
     license = with licenses; [ mit asl20 ];

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -155,8 +155,10 @@ in stdenv.mkDerivation rec {
 
   requiredSystemFeatures = [ "big-parallel" ];
 
+  passthru.llvm = llvmShared;
+
   meta = with stdenv.lib; {
-    homepage = https://www.rust-lang.org/;
+    homepage = "https://www.rust-lang.org/";
     description = "A safe, concurrent, practical language";
     maintainers = with maintainers; [ madjar cstrahan globin havvy ];
     license = [ licenses.mit licenses.asl20 ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The Hydra build [1] failed because it was unable to link to `LLVM9`; add
`llvmShared` to `passthru` in order to stay up to date with required
LLVM versions. Also quote the homepage URLs, since that's preferred.

[1] https://hydra.nixos.org/build/112989779/nixlog/1

(cherry picked from commit 502c0ee8994b13b14ac77fe3e6e559d3e215bf32)

Part of ZHF: https://github.com/NixOS/nixpkgs/issues/80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Original PR: #80401