### PR TITLE
pythonPackages.ansible-runner: skip failing test on Catalina

### DIFF
--- a/pkgs/development/python-modules/ansible-runner/default.nix
+++ b/pkgs/development/python-modules/ansible-runner/default.nix
@@ -34,7 +34,9 @@ buildPythonPackage rec {
   # test_process_isolation_settings is currently broken on Darwin Catalina
   # https://github.com/ansible/ansible-runner/issues/413
   checkPhase = ''
-    HOME=$(mktemp -d) pytest --ignore test/unit/test_runner.py -k "not test_prepare${lib.optionalString stdenv.isDarwin " and not test_process_isolation_settings"}"
+    HOME=$TMPDIR pytest \
+      --ignore test/unit/test_runner.py \
+      -k "not prepare ${lib.optionalString stdenv.isDarwin "and not process_isolation_settings"}"
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/ansible-runner/default.nix
+++ b/pkgs/development/python-modules/ansible-runner/default.nix
@@ -6,6 +6,7 @@
 , python-daemon
 , pyyaml
 , six
+, stdenv
 , ansible
 , pytest
 , mock
@@ -30,8 +31,10 @@ buildPythonPackage rec {
     six
   ];
 
+  # test_process_isolation_settings is currently broken on Darwin Catalina
+  # https://github.com/ansible/ansible-runner/issues/413
   checkPhase = ''
-    HOME=$(mktemp -d) pytest --ignore test/unit/test_runner.py -k "not test_prepare"
+    HOME=$(mktemp -d) pytest --ignore test/unit/test_runner.py -k "not test_prepare${lib.optionalString stdenv.isDarwin " and not test_process_isolation_settings"}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Catalina replaced the director /home with a symbolic link to `/System/Volumes/Data/home` and this test is looking for /home explicitly.

I filed https://github.com/ansible/ansible-runner/issues/413 to get this fix upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
