### PR TITLE
bluez: 5.52 -> 5.53

### DIFF
--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bluez";
-  version = "5.52";
+  version = "5.53";
 
   src = fetchurl {
     url = "mirror://kernel/linux/bluetooth/${pname}-${version}.tar.xz";
-    sha256 = "02jng21lp6fb3c2bh6vf9y7cj4gaxwk29dfc32ncy0lj0gi4q57p";
+    sha256 = "1g1qg6dz6hl3csrmz75ixr12lwv836hq3ckb259svvrg62l2vaiq";
   };
 
   pythonPath = with python3.pkgs; [
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Bluetooth support for Linux";
-    homepage = http://www.bluez.org/;
+    homepage = "http://www.bluez.org/";
     license = with licenses; [ gpl2 lgpl21 ];
     platforms = platforms.linux;
     repositories.git = https://git.kernel.org/pub/scm/bluetooth/bluez.git;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nixpkgs-update tools. This update was made based on information from https://repology.org/metapackage/bluez/versions.



meta.description for bluez is: '"Bluetooth support for Linux"'.


meta.homepage for bluez is: '"http://www.bluez.org/"


<details>
<summary>
Checks done (click to expand)
</summary>

- built on NixOS
- The tests defined in `passthru.tests`, if any, passed

- 0 of 0 passed binary check by having a zero exit code.
- 0 of 0 passed binary check by having the new version present in output.
- found 5.53 with grep in /nix/store/3w2n3dq7jydq43msqm7vawkliz0hmspb-bluez-5.53

</details>
<details>
<summary>
Rebuild report (if merged into master) (click to expand)
</summary>

1759 total rebuild path(s)

609 package rebuild(s)

609 x86_64-linux rebuild(s)
570 i686-linux rebuild(s)
27 x86_64-darwin rebuild(s)
553 aarch64-linux rebuild(s)


First fifty rebuilds by attrpath
adapta-gtk-theme
almanah
aravis
areca
astroid
audio-recorder
azureus
balsa
baresip
birdfont
blueman
bluez
bluez-alsa
bluez5
bolt
bomi
bookworm
brasero
brasero-original
brltty
bt-fw-converter
byzanz
calls
cawbird
chrome-gnome-shell
cinnamon.cinnamon-control-center
cinnamon.cjs
claws-mail
clight
cwiid
deepin.dde-control-center
deepin.dde-daemon
deepin.dde-dock
deepin.dde-file-manager
deepin.dde-kwin
deepin.dde-launcher
deepin.dde-session-ui
deepin.startdde
deja-dup
denemo
dino
discover
dolphin
dolphinEmu
dolphinEmuMaster
dragon
dropbox-cli
eclipses.eclipse-cpp
eclipses.eclipse-java
eclipses.eclipse-modeling

</details>

<details>
<summary>
Instructions to test this update (click to expand)
</summary>

Build yourself:
```
nix-build -A bluez https://github.com/r-ryantm/nixpkgs/archive/8f8b6459e9f38bc21df4976265f96b4541b917ec.tar.gz
```

After you've downloaded or built it, look at the files and if there are any, run the binaries:
```
ls -la /nix/store/3w2n3dq7jydq43msqm7vawkliz0hmspb-bluez-5.53
ls -la /nix/store/3w2n3dq7jydq43msqm7vawkliz0hmspb-bluez-5.53/bin
```


</details>
<br/>