### PR TITLE
mumble: fix build

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -19,7 +19,9 @@ let
     pname = overrides.type;
     version = source.version;
 
-    patches = (source.patches or []) ++ optional jackSupport ./mumble-jack-support.patch;
+    patches = (source.patches or [])
+      ++ optional jackSupport ./mumble-jack-support.patch
+      ++ [ ./fix-rnnoise-argument.patch ];
 
     nativeBuildInputs = [ pkgconfig python qt5.qmake ]
       ++ (overrides.nativeBuildInputs or [ ]);

--- a/pkgs/applications/networking/mumble/fix-rnnoise-argument.patch
+++ b/pkgs/applications/networking/mumble/fix-rnnoise-argument.patch
@@ -1,0 +1,16 @@
+nixpkgs has a more recent rnnoise than the one used by mumble, and rnnoise
+changed the argument rnnoise_create[1],
+
+[1] https://github.com/xiph/rnnoise/commit/231b9c02d14a74cb449a98004cb7a2cf1bdeca2f
+
+--- old/src/mumble/AudioInput.cpp	2020-02-18 22:55:32.000000000 -0500
++++ new/src/mumble/AudioInput.cpp	2020-02-18 22:58:08.000000000 -0500
+@@ -106,7 +106,7 @@
+ #endif
+ 
+ #ifdef USE_RNNOISE
+-	denoiseState = rnnoise_create();
++	denoiseState = rnnoise_create(NULL);
+ #endif
+ 
+ 	qWarning("AudioInput: %d bits/s, %d hz, %d sample", iAudioQuality, iSampleRate, iFrameSize);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
FIxes https://github.com/NixOS/nixpkgs/issues/80491
cc: @ajs124 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
