### PR TITLE
cargo-audit: 0.10.0 -> 0.11.2

### DIFF
--- a/pkgs/tools/package-management/cargo-audit/default.nix
+++ b/pkgs/tools/package-management/cargo-audit/default.nix
@@ -1,16 +1,16 @@
 { stdenv, lib, rustPlatform, fetchFromGitHub, openssl, pkg-config, Security, libiconv }:
 rustPlatform.buildRustPackage rec {
   pname = "cargo-audit";
-  version = "0.10.0";
+  version = "0.11.2";
 
   src = fetchFromGitHub {
     owner = "RustSec";
     repo = "cargo-audit";
     rev = "v${version}";
-    sha256 = "1977ykablfi4mc6j2iil0bxc6diy07vi5hm56xmqj3n37ziavf1m";
+    sha256 = "0py4z50ld4vs0g7vh8ga6v5h11nz2yfcpr3xqzpihf4p7sg1mdf4";
   };
 
-  cargoSha256 = "0bpqsg8mv94ivwmbfxfcnd89yx5vry33395ynqrzhqq9s1jwq0dq";
+  cargoSha256 = "0n4q8767aby6fgq0z7wj966zgqydlwirrzgyahf234dz6arsxw2l";
 
   buildInputs = [ openssl libiconv ] ++ lib.optionals stdenv.isDarwin [ Security ];
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nixpkgs-update tools. This update was made based on information from https://repology.org/metapackage/cargo-audit/versions.



meta.description for cargo-audit is: '"Audit Cargo.lock files for crates with security vulnerabilities"'.


meta.homepage for cargo-audit is: '"https://rustsec.org"


[Compare changes on GitHub](https://github.com/RustSec/cargo-audit/compare/v0.10.0...v0.11.2)

<details>
<summary>
Checks done (click to expand)
</summary>

- built on NixOS
- The tests defined in `passthru.tests`, if any, passed

- 0 of 0 passed binary check by having a zero exit code.
- 0 of 0 passed binary check by having the new version present in output.
- found 0.11.2 with grep in /nix/store/cdwz3csrpj57m7bvv62xqx6niaxd44sp-cargo-audit-0.11.2

</details>
<details>
<summary>
Rebuild report (if merged into master) (click to expand)
</summary>

4 total rebuild path(s)

1 package rebuild(s)

1 x86_64-linux rebuild(s)
1 i686-linux rebuild(s)
1 x86_64-darwin rebuild(s)
1 aarch64-linux rebuild(s)


First fifty rebuilds by attrpath
cargo-audit

</details>

<details>
<summary>
Instructions to test this update (click to expand)
</summary>

Build yourself:
```
nix-build -A cargo-audit https://github.com/r-ryantm/nixpkgs/archive/1895236d373b227889b5dd64d162f80aa593eace.tar.gz
```

After you've downloaded or built it, look at the files and if there are any, run the binaries:
```
ls -la /nix/store/cdwz3csrpj57m7bvv62xqx6niaxd44sp-cargo-audit-0.11.2
ls -la /nix/store/cdwz3csrpj57m7bvv62xqx6niaxd44sp-cargo-audit-0.11.2/bin
```


</details>
<br/>




cc @basvandijk for testing.