### PR TITLE
tor: fix build

### DIFF
--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ libevent openssl zlib lzma zstd scrypt ] ++
     stdenv.lib.optionals stdenv.isLinux [ libseccomp systemd libcap ];
 
+  patches = [ ./disable-monotonic-timer-tests.patch ];
+
   NIX_CFLAGS_LINK = stdenv.lib.optionalString stdenv.cc.isGNU "-lgcc_s";
 
   postPatch = ''
@@ -39,7 +41,6 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
-  enableParallelChecking = false; # 4 tests fail randomly
 
   doCheck = true;
 

--- a/pkgs/tools/security/tor/disable-monotonic-timer-tests.patch
+++ b/pkgs/tools/security/tor/disable-monotonic-timer-tests.patch
@@ -1,0 +1,26 @@
+diff --git a/src/test/test_util.c b/src/test/test_util.c
+index 0d86a5ab5..e93c6ba89 100644
+--- a/src/test/test_util.c
++++ b/src/test/test_util.c
+@@ -5829,13 +5829,9 @@ test_util_monotonic_time(void *arg)
+   /* We need to be a little careful here since we don't know the system load.
+    */
+   tt_i64_op(monotime_diff_msec(&mt1, &mt2), OP_GE, 175);
+-  tt_i64_op(monotime_diff_msec(&mt1, &mt2), OP_LT, 1000);
+   tt_i64_op(monotime_coarse_diff_msec(&mtc1, &mtc2), OP_GE, 125);
+-  tt_i64_op(monotime_coarse_diff_msec(&mtc1, &mtc2), OP_LT, 1000);
+   tt_u64_op(nsec2-nsec1, OP_GE, 175000000);
+-  tt_u64_op(nsec2-nsec1, OP_LT, 1000000000);
+   tt_u64_op(nsecc2-nsecc1, OP_GE, 125000000);
+-  tt_u64_op(nsecc2-nsecc1, OP_LT, 1000000000);
+ 
+   tt_u64_op(msec1, OP_GE, nsec1 / 1000000);
+   tt_u64_op(usec1, OP_GE, nsec1 / 1000);
+@@ -5849,7 +5845,6 @@ test_util_monotonic_time(void *arg)
+   uint64_t coarse_stamp_diff =
+     monotime_coarse_stamp_units_to_approx_msec(stamp2-stamp1);
+   tt_u64_op(coarse_stamp_diff, OP_GE, 120);
+-  tt_u64_op(coarse_stamp_diff, OP_LE, 1200);
+ 
+   {
+     uint64_t units = monotime_msec_to_approx_coarse_stamp_units(5000);


### PR DESCRIPTION
Monotonic timer test expects sleep(200ms) to take at most 1s. On loaded systems like hydra, it's possible for such a test to take longer than 1 second.

Tests expecting sleep(200ms) to take at least 175ms weren't removed, because load shouldn't cause sleep to be shorter.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

ZHF: #80379


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
