### PR TITLE
pythonPackages.mask-rcnn: init at 2.1

### DIFF
--- a/pkgs/development/python-modules/mask-rcnn/default.nix
+++ b/pkgs/development/python-modules/mask-rcnn/default.nix
@@ -1,0 +1,52 @@
+{ buildPythonPackage
+, cython
+, fetchFromGitHub
+, h5py
+, imgaug
+, ipython
+, Keras
+, lib
+, matplotlib
+, numpy
+, opencv3
+, pillow
+, scikitimage
+, scipy
+, tensorflow
+}:
+
+buildPythonPackage rec {
+  pname = "mask-rcnn";
+  version = "2.1";
+  
+  src = fetchFromGitHub {
+    owner = "matterport";
+    repo = "Mask_RCNN";
+    rev = "3deaec5d902d16e1daf56b62d5971d428dc920bc";
+    sha256 = "13s3q9yh2q9m9vyksd269mww3bni4q2w7q5l419q70ca075qp8zp";
+  };
+
+  nativeBuildInputs = [ cython ];
+
+  propagatedBuildInputs = [
+    h5py
+    imgaug
+    ipython
+    Keras
+    matplotlib
+    numpy
+    opencv3
+    pillow
+    scikitimage
+    scipy
+    tensorflow
+  ];
+
+  meta = with lib; {
+    description = "Mask R-CNN for object detection and instance segmentation on Keras and TensorFlow";
+    homepage = "https://github.com/matterport/Mask_RCNN";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rakesh4g ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -878,6 +878,8 @@ in {
 
   markerlib = callPackage ../development/python-modules/markerlib { };
 
+  mask-rcnn = callPackage ../development/python-modules/mask-rcnn { };
+
   matchpy = callPackage ../development/python-modules/matchpy { };
 
   maxminddb = callPackage ../development/python-modules/maxminddb { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
pythonPackages.mask-rcnn: init at 2.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
@CMCDragonkai 