### PR TITLE
brotab: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/tools/misc/brotab/default.nix
+++ b/pkgs/tools/misc/brotab/default.nix
@@ -1,29 +1,32 @@
 { lib, fetchFromGitHub, glibcLocales, python }:
 
 python.pkgs.buildPythonApplication rec {
-  version = "1.1.0";
+  version = "1.2.1";
   pname = "brotab";
 
   src = fetchFromGitHub {
     owner = "balta2ar";
     repo = pname;
     rev = version;
-    sha256 = "17yj5i8p28a7zmixdfa1i4gfc7c2fmdkxlymazasar58dz8m68mw";
+    sha256 = "14yz0szwzdjvwkw24rma34y6iiwnw9qzsm89gkglc0xxa6msg6j3";
   };
 
   propagatedBuildInputs = with python.pkgs; [
     requests
     flask
-    requests
-    pytest
     psutil
+    setuptools
+  ];
+
+  checkBuildInputs = with python.pkgs; [
+    pytest
   ];
 
   # test_integration.py requires Chrome browser session
   checkPhase = ''
     ${python.interpreter} -m unittest brotab/tests/test_{brotab,utils}.py
   '';
-  
+
   meta = with lib; {
     homepage = "https://github.com/balta2ar/brotab";
     description = "Control your browser's tabs from the command line";


### PR DESCRIPTION
Cleanup deps a little bit.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
