### PR TITLE
luaPackages.luv: cleanup build

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -64,6 +64,7 @@ luautf8,,,,,pstn
 luazip,,,,,
 lua-yajl,,,,,pstn
 luuid,,,,,
+luv,,,,,
 markdown,,,,,
 mediator_lua,,,,,
 mpack,,,,,

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -64,7 +64,6 @@ luautf8,,,,,pstn
 luazip,,,,,
 lua-yajl,,,,,pstn
 luuid,,,,,
-luv,,,,,
 markdown,,,,,
 mediator_lua,,,,,
 mpack,,,,,

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -14,7 +14,7 @@ let
   neovimLuaEnv = lua.withPackages(ps:
     (with ps; [ lpeg luabitop mpack ]
     ++ optionals doCheck [
-        nvim-client luv coxpcall busted luafilesystem penlight inspect
+        nvim-client libluv coxpcall busted luafilesystem penlight inspect
       ]
     ));
 in
@@ -44,7 +44,7 @@ in
       libtermkey
       libuv
       libvterm-neovim
-      lua.pkgs.luv
+      lua.pkgs.libluv
       msgpack
       ncurses
       neovimLuaEnv

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -79,8 +79,6 @@ in
       "-DGPERF_PRG=${gperf}/bin/gperf"
       "-DLUA_PRG=${neovimLuaEnv.interpreter}"
     ]
-    # TODO: Check if that's needed on darwin
-    ++ optional (stdenv.isDarwin) "-DLIBLUV_LIBRARY=${lua.pkgs.luv}/lib/lua/${lua.luaversion}/libluv.dylib"
     ++ optional doCheck "-DBUSTED_PRG=${neovimLuaEnv}/bin/busted"
     ++ optional (!lua.pkgs.isLuaJIT) "-DPREFER_LUA=ON"
     ;

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -44,7 +44,7 @@ in
       libtermkey
       libuv
       libvterm-neovim
-      lua.pkgs.luv.libluv
+      lua.pkgs.luv
       msgpack
       ncurses
       neovimLuaEnv
@@ -79,9 +79,8 @@ in
       "-DGPERF_PRG=${gperf}/bin/gperf"
       "-DLUA_PRG=${neovimLuaEnv.interpreter}"
     ]
-    # FIXME: this is verry messy and strange.
-    ++ optional (!stdenv.isDarwin) "-DLIBLUV_LIBRARY=${lua.pkgs.luv}/lib/lua/${lua.luaversion}/luv.so"
-    ++ optional (stdenv.isDarwin) "-DLIBLUV_LIBRARY=${lua.pkgs.luv.libluv}/lib/lua/${lua.luaversion}/libluv.dylib"
+    # TODO: Check if that's needed on darwin
+    ++ optional (stdenv.isDarwin) "-DLIBLUV_LIBRARY=${lua.pkgs.luv}/lib/lua/${lua.luaversion}/libluv.dylib"
     ++ optional doCheck "-DBUSTED_PRG=${neovimLuaEnv}/bin/busted"
     ++ optional (!lua.pkgs.isLuaJIT) "-DPREFER_LUA=ON"
     ;

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1324,6 +1324,25 @@ luuid = buildLuarocksPackage {
     };
   };
 };
+luv = buildLuarocksPackage {
+  pname = "luv";
+  version = "1.34.2-0";
+
+  src = fetchurl {
+    url    = https://luarocks.org/luv-1.34.2-0.src.rock;
+    sha256 = "05c0s1a897yvk0qp31hra2b2qg6kr9fd4cib9hbrpxvzzn9a9cwc";
+  };
+  disabled = (luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/luvit/luv";
+    description = "Bare libuv bindings for lua";
+    license = {
+      fullName = "Apache 2.0";
+    };
+  };
+};
 markdown = buildLuarocksPackage {
   pname = "markdown";
   version = "0.33-1";

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1324,25 +1324,6 @@ luuid = buildLuarocksPackage {
     };
   };
 };
-luv = buildLuarocksPackage {
-  pname = "luv";
-  version = "1.34.1-1";
-
-  src = fetchurl {
-    url    = https://luarocks.org/luv-1.34.1-1.src.rock;
-    sha256 = "044cyp25xn35nj5qp1hx04lfkzrpa6adhqjshq2g7wvbga77p1q0";
-  };
-  disabled = (luaOlder "5.1");
-  propagatedBuildInputs = [ lua ];
-
-  meta = with stdenv.lib; {
-    homepage = "https://github.com/luvit/luv";
-    description = "Bare libuv bindings for lua";
-    license = {
-      fullName = "Apache 2.0";
-    };
-  };
-};
 markdown = buildLuarocksPackage {
   pname = "markdown";
   version = "0.33-1";

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -302,12 +302,7 @@ with super;
     nativeBuildInputs = [
       pkgs.cmake
       super.lua.pkgs.compat53
-    ]
-    # TODO: Check if that's needed on darwin
-    ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-      pkgs.fixDarwinDylibNames
-    ]
-    ;
+    ];
     # Fixup linking libluv.dylib, for some reason it's not linked against lua correctly.
     NIX_LDFLAGS = pkgs.lib.optionalString pkgs.stdenv.isDarwin
       (if isLuaJIT then "-lluajit-${lua.luaversion}" else "-llua");

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -309,7 +309,6 @@ with super;
     ]
     ;
     # Fixup linking libluv.dylib, for some reason it's not linked against lua correctly.
-    # TODO: Check if that's needed on darwin
     NIX_LDFLAGS = pkgs.lib.optionalString pkgs.stdenv.isDarwin
       (if isLuaJIT then "-lluajit-${lua.luaversion}" else "-llua");
     propagatedBuildInputs = [ lua ];

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -264,6 +264,13 @@ with super;
     disabled = luaOlder "5.1" || (luaAtLeast "5.4");
   });
 
+  compat53 = super.compat53.override (old: {
+    # needed for luv build
+    postInstall = ''
+      cp -r c-api $out/c-api
+    '';
+  });
+
   luv = pkgs.stdenv.mkDerivation rec {
 
     pname = super.luv.pname;

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -271,46 +271,6 @@ with super;
     '';
   });
 
-  luv = pkgs.stdenv.mkDerivation rec {
-
-    pname = super.luv.pname;
-    version = super.luv.version;
-
-    src = pkgs.fetchFromGitHub {
-      owner = "luvit";
-      repo = pname;
-      rev = version;
-      sha256 = "0lg3kncaka1mx18k0w4wsylsa6xnp7m11n68wgn38sph7f2nn1x9";
-    };
-
-    # So we can be sure no internal dependency is used from the repo and that
-    # everything is provided by us
-    postUnpack = ''
-     rm -rf deps
-    '';
-
-    cmakeFlags = [
-      "-DWITH_SHARED_LIBUV=ON"
-      "-DLUA_BUILD_TYPE=System"
-      "-DBUILD_MODULE=OFF"
-      "-DBUILD_SHARED_LIBS=ON"
-      "-DLUA_COMPAT53_DIR=${super.lua.pkgs.compat53}"
-    ];
-
-    buildInputs = [ pkgs.libuv ];
-
-    nativeBuildInputs = [
-      pkgs.cmake
-      super.lua.pkgs.compat53
-    ];
-    # Fixup linking libluv.dylib, for some reason it's not linked against lua correctly.
-    NIX_LDFLAGS = pkgs.lib.optionalString pkgs.stdenv.isDarwin
-      (if isLuaJIT then "-lluajit-${lua.luaversion}" else "-llua");
-    propagatedBuildInputs = [ lua ];
-
-    meta = super.luv.meta;
-  };
-
   rapidjson = super.rapidjson.override({
     preBuild = ''
       sed -i '/set(CMAKE_CXX_FLAGS/d' CMakeLists.txt

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -99,7 +99,19 @@ with self; {
 
   luarocks-nix = callPackage ../development/tools/misc/luarocks/luarocks-nix.nix { };
 
-  luv = pkgs.stdenv.mkDerivation rec {
+  # This package is very much like `lua.pkgs.luv`, but it's not defined as a
+  # module because it fails to install some files if we use
+  # `buildLuarocksPackage` instead of `mkDerivation`. However, if another
+  # package (e.g lua.pkgs.nvim-client) would require `luv =
+  # stdenv.mkDerivation`, it would not detect it and hence it would fail to
+  # build.
+
+  # The workaround implemented here is to create 2 versions of `libluv` while
+  # `luv` is still defined by lua's generated packages and still overriden as
+  # necessary in lua's overrides. This version is used in neovim and every
+  # other package that needs luv as a shared library (not as a mere lua
+  # module).
+  libluv = pkgs.stdenv.mkDerivation rec {
     pname = "luv";
     version = "1.34.2-0";
 

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -101,13 +101,13 @@ with self; {
 
   luv = pkgs.stdenv.mkDerivation rec {
     pname = "luv";
-    version = "1.34.1-1";
+    version = "1.34.2-0";
 
     src = pkgs.fetchFromGitHub {
       owner = "luvit";
       repo = pname;
       rev = version;
-      sha256 = "0lg3kncaka1mx18k0w4wsylsa6xnp7m11n68wgn38sph7f2nn1x9";
+      sha256 = "0iq272n7p0wkll4a7d880qyhdp65582cwc3b2zzrirpli93x3v87";
     };
     disabled = (luaOlder "5.1");
 
@@ -120,7 +120,7 @@ with self; {
     cmakeFlags = [
       "-DWITH_SHARED_LIBUV=ON"
       "-DLUA_BUILD_TYPE=System"
-      "-DBUILD_MODULE=OFF"
+      "-DBUILD_MODULE=ON"
       "-DBUILD_SHARED_LIBS=ON"
       "-DLUA_COMPAT53_DIR=${lua.pkgs.compat53}"
     ];


### PR DESCRIPTION
###### Motivation for this change

- Enable us to update Luarocks without breaking neovim as in https://github.com/NixOS/nixpkgs/issues/79870, https://github.com/NixOS/nixpkgs/issues/80704 & https://github.com/NixOS/nixpkgs/issues/81206.
- Make luv's build less hacky, clearer and more maintainable.

###### Things done

- Remove `passthru` of `libluv` which was always too confusing IMO - I think I understand the original motivation behind that but I don't think it's worth the maintenance / confusion burden it introduced.
- Make `luaPackages.compat53` install it's c-api files luv needs in order to build cleanly.
- Tested Neovim builds and runs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS - **Darwin users please see the `TODO`s I've left**.
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ccing people involved in https://github.com/NixOS/nixpkgs/issues/79870 :

- @manveru, @rvolosatovs and @Ma27 (Neovim maintainers)
- @teto
- @bjornfor
- @ArdaXi
- @mjlbach
- @jokogr
- @chkno