### PR TITLE
Codebraid: init at 0.5.0-unstable-2019-12-11

### DIFF
--- a/pkgs/development/python-modules/bespon/default.nix
+++ b/pkgs/development/python-modules/bespon/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  version = "0.3.0";
+  pname = "BespON";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0698vx1kh8c84f5qfhl4grdlyn1lljvdih8yczdz0pql8wkn8i7v";
+  };
+
+  propagatedBuildInputs = [ ];
+  # upstream doesn't contain tests
+  doCheck = false;
+  
+  pythonImportsCheck = [ "bespon" ];
+  meta = with stdenv.lib; {
+    description = "Encodes and decodes data in the BespON format.";
+    homepage = "https://github.com/gpoore/bespon_py";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ synthetica ];
+  };
+
+}

--- a/pkgs/tools/misc/codebraid/default.nix
+++ b/pkgs/tools/misc/codebraid/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "codebraid";
+  version = "0.5.0-unstable-2019-12-11";
+
+  src = fetchFromGitHub {
+    owner = "gpoore";
+    repo = pname;
+    rev = "fac1b29";
+    sha256 = "0ldfrkkip7i1fdyz1iydyik3mhm0xv0jvxnl37r7g707dl38vf3h";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ bespon ];
+  # unfortunately upstream doesn't contain tests
+  checkPhase = ''
+    $out/bin/codebraid --help > /dev/null
+  '';
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/gpoore/codebraid";
+    description = ''
+      Live code in Pandoc Markdown.
+
+      Codebraid is a Python program that enables executable code in Pandoc
+      Markdown documents. Using Codebraid can be as simple as adding a class to
+      your code blocks' attributes, and then running codebraid rather than
+      pandoc to convert your document from Markdown to another format.
+      codebraid supports almost all of pandoc's options and passes them to
+      pandoc internally.
+
+      Codebraid provides two options for executing code. It includes a built-in
+      code execution system that currently supports Python 3.5+, Julia, Rust,
+      R, Bash, and JavaScript. Code can also be executed using Jupyter kernels,
+      with support for rich output like plots.
+    '';
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ synthetica ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2622,6 +2622,8 @@ in
 
   cocoapods-beta = lowPrio (callPackage ../development/mobile/cocoapods { beta = true; });
 
+  codebraid = callPackage ../tools/misc/codebraid { };
+
   compass = callPackage ../development/tools/compass { };
 
   conda = callPackage ../tools/package-management/conda { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1770,6 +1770,8 @@ in {
 
   beaker = callPackage ../development/python-modules/beaker { };
 
+  bespon = callPackage ../development/python-modules/bespon { };
+
   betamax = callPackage ../development/python-modules/betamax {};
 
   betamax-matchers = callPackage ../development/python-modules/betamax-matchers { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

As to why I'm specifically using an unstable version: after 0.4.0 a few nice new features were introduced, like:

- [SageMath Support](https://github.com/gpoore/codebraid/commit/911e10325e36ca880af2bb3ae7d7227fba7ed55a)
- [Pandoc-Citeproc compatibility](https://github.com/gpoore/codebraid/commit/911e10325e36ca880af2bb3ae7d7227fba7ed55a)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
