### PR TITLE
heatseeker: 1.5.1 -> 1.7.1

### DIFF
--- a/pkgs/tools/misc/heatseeker/default.nix
+++ b/pkgs/tools/misc/heatseeker/default.nix
@@ -1,30 +1,36 @@
-{ stdenv, fetchFromGitHub, rustPlatform }:
+{ lib, fetchFromGitHub, rustPlatform, coreutils }:
 
 with rustPlatform;
 
 buildRustPackage rec {
   pname = "heatseeker";
-  version = "1.5.1";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "rschmitt";
     repo = "heatseeker";
     rev = "v${version}";
-    sha256 = "1fcrbjwnhcz71i70ppy0rcgk5crwwmbkm9nrk1kapvks33pv0az7";
+    sha256 = "1x7mdyf1m17s55f6yjdr1j510kb7a8f3zkd7lb2kzdc7nd3vgaxg";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
+  buildDepends = [ coreutils ];
 
-  cargoSha256 = "0m3sxbz1iii31s30cnv1970i1mwfhl6gm19k8wv0n7zji30ayx07";
+  # https://github.com/rschmitt/heatseeker/issues/42
+  # I've suggested using `/usr/bin/env stty`, but doing that isn't quite as simple
+  # as a substitution, and this works since we have the path to coreutils stty.
+  patchPhase = ''
+    substituteInPlace src/screen/unix.rs --replace "/bin/stty" "${coreutils}/bin/stty" 
+  '';
+
+  cargoSha256 = "0jnlcm7v29m4nc318qgf7r7jvs80s7n04fw83imm506vwr9rxbx9";
 
   # some tests require a tty, this variable turns them off for Travis CI,
   # which we can also make use of
   TRAVIS = "true";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A general-purpose fuzzy selector";
-    homepage = https://github.com/rschmitt/heatseeker;
+    homepage = "https://github.com/rschmitt/heatseeker";
     license = licenses.mit;
     maintainers = [ maintainers.michaelpj ];
     platforms = platforms.unix;


### PR DESCRIPTION
The old version is broken on our version of Rust.

Needed patching to fix https://github.com/rschmitt/heatseeker/issues/42.

Also get rid of `legacyCargoFetcher` as desired by
https://github.com/NixOS/nixpkgs/issues/79975.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)https://github.com/NixOS/nixpkgs/issues/79975
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
