### PR TITLE
poetry2nix: fix typo fetchPyPi -> fetchPypi

### DIFF
--- a/pkgs/development/tools/poetry2nix/poetry2nix/lib.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/lib.nix
@@ -65,7 +65,7 @@ let
       else { pkg = []; str = null; };
 
   # Fetch the artifacts from the PyPI index. Since we get all
-  # info we need from the lock file we don't use nixpkgs' fetchPyPi
+  # info we need from the lock file we don't use nixpkgs' fetchPypi
   # as it modifies casing while not providing anything we don't already
   # have.
   #


### PR DESCRIPTION
nixpkgs' fetchPypi is called fetchPypi, not fetchPyPi.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
