### PR TITLE
ocamlPackages.pgocaml_ppx: init at 4.0

### DIFF
--- a/pkgs/development/ocaml-modules/pgocaml/ppx.nix
+++ b/pkgs/development/ocaml-modules/pgocaml/ppx.nix
@@ -1,0 +1,8 @@
+{ buildDunePackage, pgocaml, ppx_tools, ppx_tools_versioned, rresult }:
+
+buildDunePackage {
+  pname = "pgocaml_ppx";
+  inherit (pgocaml) src version meta;
+
+  propagatedBuildInputs = [ pgocaml ppx_tools ppx_tools_versioned rresult ];
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -623,6 +623,8 @@ let
 
     pgocaml = callPackage ../development/ocaml-modules/pgocaml {};
 
+    pgocaml_ppx = callPackage ../development/ocaml-modules/pgocaml/ppx.nix {};
+
     ocaml-sat-solvers = callPackage ../development/ocaml-modules/ocaml-sat-solvers { };
 
     ocamlscript = callPackage ../development/tools/ocaml/ocamlscript { };


### PR DESCRIPTION
###### Motivation for this change

Required to update `ocsigen-start`.

cc #75766 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
