### PR TITLE
google-cloud-sdk: fix Darwin build by only stripping local symbols

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -30,6 +30,8 @@ let
     };
   }.${system};
 
+  strip = if stdenv.isDarwin then "strip -x" else "strip";
+
 in stdenv.mkDerivation rec {
   pname = "google-cloud-sdk";
   version = "268.0.0";
@@ -93,7 +95,7 @@ in stdenv.mkDerivation rec {
     done
 
     # strip the Cython gRPC library
-    strip $out/google-cloud-sdk/lib/third_party/grpc/_cython/cygrpc.so
+    ${strip} $out/google-cloud-sdk/lib/third_party/grpc/_cython/cygrpc.so
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Darwin won't strip relocatable symbols, so strip only local symbols from `cygrpc.so`

From the man page for strip(1):

> For  dynamic  shared libraries, the maximum level of stripping is usually -x (to remove all non-global symbols).

###### Motivation for this change

Mainly to fix the build on macOS. See also https://github.com/NixOS/nixpkgs/commit/6ceebc441c43c0fd0ef5c61058c1c8ec3b93bc02#commitcomment-37355193

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<hr>

Please let me know if there's any other testing I should do. I don't have access to a Linux/NixOS machine right now so I couldn't test on that platform, but Hydra should check this, right?