### PR TITLE
khronos: init at 1.0.5

### DIFF
--- a/pkgs/applications/office/khronos/default.nix
+++ b/pkgs/applications/office/khronos/default.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, vala
+, pkg-config
+, desktop-file-utils
+, pantheon
+, python3
+, glib
+, gtk3
+, json-glib
+, libgee
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "khronos";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "lainsce";
+    repo = pname;
+    rev = version;
+    sha256 = "0dk1b2d82gli3z35dn5p002lfkgq326janql0vn1z5hs8jvjakqh";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    meson
+    ninja
+    vala
+    pkg-config
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    json-glib
+    libgee
+    pantheon.granite
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  passthru = {
+    updateScript = pantheon.updateScript {
+      attrPath = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Track each task's time in a simple inobtrusive way";
+    homepage = "https://github.com/lainsce/khronos";
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15384,7 +15384,7 @@ in
   miniHttpd = callPackage ../servers/http/mini-httpd {};
 
   mlflow-server = callPackage ../servers/mlflow-server { };
-  
+
   mlmmj = callPackage ../servers/mail/mlmmj { };
 
   moodle = callPackage ../servers/web-apps/moodle { };
@@ -19902,6 +19902,8 @@ in
   kermit = callPackage ../tools/misc/kermit { };
 
   kexi = libsForQt5.callPackage ../applications/office/kexi { };
+
+  khronos = callPackage ../applications/office/khronos { };
 
   keyfinder = libsForQt5.callPackage ../applications/audio/keyfinder { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add more curated app from Elementary App Center to NixOS.

I started this derivation a while back and I just saw that a Nix file (https://github.com/lainsce/khronos/commit/5a7b28814e39a4f29621f0f6c09e3fc4d1e3735d) has been added to the app repository, which reminded me that mine still wasn't a PR :smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
