### PR TITLE
lbzip2: 2.5 -> 2.5+git20180127

### DIFF
--- a/pkgs/tools/compression/lbzip2/default.nix
+++ b/pkgs/tools/compression/lbzip2/default.nix
@@ -1,12 +1,22 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub, perl, gnulib, autoconf, automake }:
 
 stdenv.mkDerivation rec {
-  name = "lbzip2-2.5";
+  pname = "lbzip2";
+  version = "2.5+git20180127";
 
-  src = fetchurl {
-    url = "http://archive.lbzip2.org/${name}.tar.gz";
-    sha256 = "1sahaqc5bw4i0iyri05syfza4ncf5cml89an033fspn97klmxis6";
+  src = fetchFromGitHub {
+    owner = "kjn";
+    repo = "lbzip2";
+    rev = "b6dc48a7b9bfe6b340ed1f6d72133608ad57144b";
+    sha256 = "140xp00dmjsr6c3dwb4dwf0pzlgf159igri321inbinsjiclkngy";
   };
+
+  preConfigure = ''
+    substituteInPlace build-aux/autogen.sh --replace gnulib-tool 'gnulib-tool --symlink --more-symlink'
+    build-aux/autogen.sh
+  '';
+
+  nativeBuildInputs = [ perl gnulib autoconf automake ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/kjn/lbzip2"; # Formerly http://lbzip2.org/


### PR DESCRIPTION
The build fails with newer glibc due to vendored gnulib.

###### Motivation for this change

* ZHF: #80379 (will backport once this one is merged)
* updated to newer version because the original tarball does not exist anymore

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @abbradar 