### PR TITLE
common-updater-scripts: Handle errors in src hashing

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -2,6 +2,7 @@
 , maintainer ? null
 , path ? null
 , max-workers ? null
+, include-overlays ? false
 , keep-going ? null
 }:
 
@@ -20,9 +21,7 @@ let
       in
         [x] ++ nubOn f xs;
 
-  pkgs = import ./../../default.nix {
-    overlays = [];
-  };
+  pkgs = import ./../../default.nix (if include-overlays then { } else { overlays = []; });
 
   packagesWith = cond: return: set:
     nubOn (pkg: pkg.updateScript)

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -168,12 +168,12 @@ fi
 if [[ -z "$newHash" ]]; then
     nix-build $systemArg --no-out-link -A "$attr.src" 2>"$attr.fetchlog" >/dev/null || true
     # FIXME: use nix-build --hash here once https://github.com/NixOS/nix/issues/1172 is fixed
-    newHash=$(grep --extended-regexp --invert-match "killing process|dependencies couldn't be built|wanted: " "$attr.fetchlog" | tail -n2 | sed "s~output path .* has .* hash ‘\(.*\)’ when .* was expected\|fixed-output derivation produced path '.*' with .* hash '\(.*\)' instead of the expected hash '.*'\|  got:    .*:\(.*\)~\1\2\3~" | head -n1)
-fi
+    newHash=$(sed '1,/hash mismatch in fixed-output derivation/d' "$attr.fetchlog" | grep --perl-regexp --only-matching 'got: +.+[:-]\K.+')
 
-if [[ -n "$sri" ]]; then
-    # nix-build preserves the hashing scheme so we can just convert the result to SRI using the old type
-    newHash="$(nix to-sri --type "$oldHashAlgo" "$newHash")"
+    if [[ -n "$sri" ]]; then
+        # nix-build preserves the hashing scheme so we can just convert the result to SRI using the old type
+        newHash="$(nix to-sri --type "$oldHashAlgo" "$newHash")"
+    fi
 fi
 
 if [[ -z "$newHash" ]]; then

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -144,6 +144,10 @@ if [[ -n "$sri" ]]; then
     tempHash="$(nix to-sri --type "$oldHashAlgo" "$tempHash")"
 fi
 
+# Escape regex metacharacter that are allowed in hashes (+)
+oldHashEscaped=$(echo "$oldHash" | sed -re 's|[+]|\\&|g')
+tempHashEscaped=$(echo "$tempHash" | sed -re 's|[+]|\\&|g')
+
 # Replace new version
 sed -i.bak "$nixFile" -re "$pattern"
 if cmp -s "$nixFile" "$nixFile.bak"; then
@@ -159,7 +163,7 @@ if [[ -n "$newUrl" ]]; then
     fi
 fi
 
-sed -i "$nixFile" -re "s|\"$oldHash\"|\"$tempHash\"|"
+sed -i "$nixFile" -re "s|\"$oldHashEscaped\"|\"$tempHash\"|"
 if cmp -s "$nixFile" "$nixFile.bak"; then
     die "Failed to replace source hash of '$attr' to a temporary hash!"
 fi
@@ -186,7 +190,7 @@ if [[ -z "${ignoreSameHash}" && "$oldVersion" != "$newVersion" && "$oldHash" = "
     die "Both the old and new source hashes of '$attr.src' were equivalent. Please fix the package's source URL to be dependent on '\${version}'!"
 fi
 
-sed -i "$nixFile" -re "s|\"$tempHash\"|\"$newHash\"|"
+sed -i "$nixFile" -re "s|\"$tempHashEscaped\"|\"$newHash\"|"
 if cmp -s "$nixFile" "$nixFile.bak"; then
     die "Failed to replace temporary source hash of '$attr' to the final source hash!"
 fi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Previously, when downloading src failed for other reason than hash mismatch, the error ended up in newHash. This made evaluation fail since the error message is not valid hash. Now the failure will make newHash empty.

It is also much cleaner than previously since \K is very cool thing and we no longer grep for legacy messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
