### PR TITLE
du-dust: 0.4.4 -> 0.5.0

### DIFF
--- a/pkgs/tools/misc/dust/default.nix
+++ b/pkgs/tools/misc/dust/default.nix
@@ -2,25 +2,25 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "dust";
-  version = "0.4.4";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "bootandy";
     repo = "dust";
     rev = "v${version}";
-    sha256 = "1qbh9vgdh0xmh4c78fm0rd1sgb01n656p3cr4my7ymsy81ypx9y7";
+    sha256 = "1qf24fqz6l71f6i6sv6sssmpds202313dp47phblg3qsvipp1w5y";
   };
 
   # Delete this on next update; see #79975 for details
   legacyCargoFetcher = true;
 
-  cargoSha256 = "07ynz6y1z3rz84662d4rfl2sw1sx46a3k48z8dckr0b3fqs2zj6a";
+  cargoSha256 = "0rbk99k96pczmpvgvba7hvkjgcpjgy2j2clbib8q8v4wjryzmnyn";
 
   doCheck = false;
 
   meta = with stdenv.lib; {
     description = "du + rust = dust. Like du but more intuitive";
-    homepage = https://github.com/bootandy/dust;
+    homepage = "https://github.com/bootandy/dust";
     license = licenses.asl20;
     maintainers = [ maintainers.infinisil ];
     platforms = platforms.all;


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nixpkgs-update tools. This update was made based on information from https://repology.org/metapackage/dust/versions.



meta.description for du-dust is: '"du + rust = dust. Like du but more intuitive"'.


meta.homepage for du-dust is: '"https://github.com/bootandy/dust"

[Release on GitHub](https://github.com/bootandy/dust/releases/tag/v0.5.0)


[Compare changes on GitHub](https://github.com/bootandy/dust/compare/v0.4.4...v0.5.0)

<details>
<summary>
Checks done (click to expand)
</summary>

- built on NixOS
- The tests defined in `passthru.tests`, if any, passed

- 0 of 0 passed binary check by having a zero exit code.
- 0 of 0 passed binary check by having the new version present in output.
- found 0.5.0 with grep in /nix/store/lq92bhs4hzmp06d0fh0z30xs6sfa41m0-dust-0.5.0

</details>
<details>
<summary>
Rebuild report (if merged into master) (click to expand)
</summary>

4 total rebuild path(s)

1 package rebuild(s)

1 x86_64-linux rebuild(s)
1 i686-linux rebuild(s)
1 x86_64-darwin rebuild(s)
1 aarch64-linux rebuild(s)


First fifty rebuilds by attrpath
du-dust

</details>

<details>
<summary>
Instructions to test this update (click to expand)
</summary>

Build yourself:
```
nix-build -A du-dust https://github.com/r-ryantm/nixpkgs/archive/31e69007f2c8b7aba571e2e6ef3e7713aa61df6c.tar.gz
```

After you've downloaded or built it, look at the files and if there are any, run the binaries:
```
ls -la /nix/store/lq92bhs4hzmp06d0fh0z30xs6sfa41m0-dust-0.5.0
ls -la /nix/store/lq92bhs4hzmp06d0fh0z30xs6sfa41m0-dust-0.5.0/bin
```


</details>
<br/>




cc @infinisil for testing.