### PR TITLE
[20.03] GNOME 3.34.4 (minor rebuild)

### DIFF
--- a/pkgs/applications/graphics/gnome-photos/default.nix
+++ b/pkgs/applications/graphics/gnome-photos/default.nix
@@ -35,13 +35,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-photos";
-  version = "3.34.0";
+  version = "3.34.1";
 
   outputs = [ "out" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "12j455id5g616cn0nnj73v83aqgpavrsqszw1r5yhbpyc76lg03m";
+    sha256 = "1ifm8hmxpf9nnxddfcpkbc5wc5f5hz43yj83nnakzqr6x1mq7gdp";
   };
 
   patches = [

--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -5,11 +5,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meld";
-  version = "3.20.1";
+  version = "3.20.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0jdj7kd6vj1mdc16gvrj1kar88b2j5875ajq18fx7cbc9ny46j55";
+    sha256 = "0a0x156zr3w2yg0rnhwy39giy3xnfm6sqcfa4xcw4i6ahvwqa2dc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/apps/evolution/default.nix
@@ -43,11 +43,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.34.3";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1s4y29iszvd3zppgxx2qc2jr1lg7ipl3072jnn8g2l3bghcvq7xq";
+    sha256 = "136vpaq94ymyn8pf3a3z1w45xlk1xbvwjdnzasq0d7iwbac0jwks";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome-3/apps/file-roller/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "file-roller";
-  version = "3.32.3";
+  version = "3.32.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/file-roller/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0ap2hxvjljh4p6wsd9ikh2my3vsxp9r2nvjxxj3v87nwfyw1y4dy";
+    sha256 = "05s046br4fcli1d3wngh4jmwi0aikpfkl1px1cahskj4rfzjqfqv";
   };
 
   LANG = "en_US.UTF-8"; # postinstall.py

--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -51,11 +51,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-boxes";
-  version = "3.34.3";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-boxes/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1izhqgsb658lzrzj12dw06w47bjhqdpfl0j74aq7bzql7nqsb3wa";
+    sha256 = "1bqrl36nngbd8jpj31ipnywg2k0rg2j3bcgnyvn8r86ysh1gnm0f";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
@@ -29,13 +29,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "3.34.3";
+  version = "3.34.4";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0kp7r6l8hb8aq9j2fdiw49p7hyls4gllz258qy6fp3bbfzmbn4g7";
+    sha256 = "1l2jaf5jfdkqqpjxwahsjslb3sa2vlhjgpi1ib51is04ln729xb6";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
@@ -3,13 +3,13 @@
 
 let
   pname = "dconf-editor";
-  version = "3.34.3";
+  version = "3.34.4";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "12q2cjds5fbarc5zajmhbx9vrbfn28hrklrk1fbgdv1ykxm1ljcv";
+    sha256 = "129a2klywvnrj49rz6p5camwsamajldqpsfkl1rgpm6nw0q2lnyy";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome-3/core/epiphany/default.nix
@@ -34,11 +34,11 @@
 
 stdenv.mkDerivation rec {
   pname = "epiphany";
-  version = "3.34.3.1";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/epiphany/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0vga9bqcv792ivnlw6pbfz17zn0nh6wq01rp60c4px08l7xpkr00";
+    sha256 = "13ar3s40cds1rplwbzx0fzigf120w0rydiv05r3k6zpc0zy91qb0";
   };
 
   # Tests need an X display

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.34.3";
+  version = "3.34.4";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1af3f218i5h3df81xkjdij0n9knsw355fsmhzdrfh1bflxfarpyj";
+    sha256 = "1wz8mizblmvficxap6z9w62ymjwa8x99spnaljcwjl1wc55lnp4q";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -62,16 +62,17 @@
 , vino
 , gnome-user-share
 , gnome-remote-desktop
+, shadow
 , wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-control-center";
-  version = "3.34.2";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "054igagvmyzpaa5nwzz98gv7bk7l5dwp6g813707132si3szlpx8";
+    sha256 = "0bi7lsmr5hcf0v17brsa8j33p6i0wnh620bzwycmxryfp6s6vshp";
   };
 
   nativeBuildInputs = [
@@ -138,6 +139,7 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./paths.patch;
       gcm = gnome-color-manager;
+      usermod = "${shadow}/bin/usermod";
       gnome_desktop = gnome-desktop;
       inherit glibc libgnomekbd tzdata;
       inherit cups networkmanagerapplet;

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/paths.patch
@@ -55,7 +55,7 @@ index 96b25140c..1ad704d4a 100644
  typedef struct _TzDB TzDB;
  typedef struct _TzLocation TzLocation;
 diff --git a/panels/info/cc-info-overview-panel.c b/panels/info/cc-info-overview-panel.c
-index 4541986db..da7826bfe 100644
+index 7fce8691e..b839f8b69 100644
 --- a/panels/info/cc-info-overview-panel.c
 +++ b/panels/info/cc-info-overview-panel.c
 @@ -187,7 +187,7 @@ load_gnome_version (char **version,
@@ -84,10 +84,10 @@ index 9390a3308..d30b4a68e 100644
          }
  
 diff --git a/panels/network/net-device-wifi.c b/panels/network/net-device-wifi.c
-index 360fbfc72..870157a11 100644
+index dd99a7485..4baa88a4e 100644
 --- a/panels/network/net-device-wifi.c
 +++ b/panels/network/net-device-wifi.c
-@@ -1385,7 +1385,7 @@ device_wifi_edit (NetObject *object)
+@@ -1445,7 +1445,7 @@ device_wifi_edit (NetObject *object)
                  return;
          }
          uuid = nm_connection_get_uuid (NM_CONNECTION (connection));
@@ -123,10 +123,10 @@ index f53ba217e..d24bcaeb9 100644
  
    /* Use SNMP to get printer's informations */
 diff --git a/panels/region/cc-region-panel.c b/panels/region/cc-region-panel.c
-index 35859526d..21486c917 100644
+index e0604b8c3..fc323c1b2 100644
 --- a/panels/region/cc-region-panel.c
 +++ b/panels/region/cc-region-panel.c
-@@ -755,10 +755,10 @@ row_layout_cb (CcRegionPanel *self,
+@@ -763,10 +763,10 @@ row_layout_cb (CcRegionPanel *self,
          layout_variant = cc_input_source_get_layout_variant (source);
  
          if (layout_variant && layout_variant[0])
@@ -140,7 +140,7 @@ index 35859526d..21486c917 100644
  
          g_spawn_command_line_async (commandline, NULL);
 diff --git a/panels/user-accounts/run-passwd.c b/panels/user-accounts/run-passwd.c
-index 00239ce0f..617c98870 100644
+index 19934f186..9f41a9620 100644
 --- a/panels/user-accounts/run-passwd.c
 +++ b/panels/user-accounts/run-passwd.c
 @@ -150,7 +150,7 @@ spawn_passwd (PasswdHandler *passwd_handler, GError **error)
@@ -152,6 +152,19 @@ index 00239ce0f..617c98870 100644
          argv[1] = NULL;
  
          envp = g_get_environ ();
+diff --git a/panels/user-accounts/user-utils.c b/panels/user-accounts/user-utils.c
+index 83d4cd091..e8784c722 100644
+--- a/panels/user-accounts/user-utils.c
++++ b/panels/user-accounts/user-utils.c
+@@ -486,7 +486,7 @@ is_valid_username_async (const gchar *username,
+          * future, so it would be nice to have some official way for this
+          * instead of relying on the current "--login" implementation.
+          */
+-        argv[0] = "/usr/sbin/usermod";
++        argv[0] = "@usermod@";
+         argv[1] = "--login";
+         argv[2] = data->username;
+         argv[3] = "--";
 diff --git a/tests/datetime/test-endianess.c b/tests/datetime/test-endianess.c
 index 9cb92007a..84d2f0fa3 100644
 --- a/tests/datetime/test-endianess.c

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-desktop";
-  version = "3.34.2";
+  version = "3.34.4";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-desktop/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1v983xirwp1y6ggz97bh742ak6gff0hxb359dgn37nikjxhvm0a0";
+    sha256 = "1g0cvsx0gk65kfa91knkqg7l2isrnlpvqwjbzpr3a5f2girp4gn5";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-disk-utility";
-  version = "3.34.0";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-disk-utility/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1mb7q90lnlp97dhxhnadhjagcfd12dfqzp0vj9h6b1r61pzhy97y";
+    sha256 = "0p7pifmihg1vpsvym4qabdjqdp96yx9b4cbc6cnmf5i055js7i8y";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -15,11 +15,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "gnome-shell";
-  version = "3.34.3";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "12mxavjf83d96qd5m8k0z2jnpi1587i25al5w9xpv965hvrvwx14";
+    sha256 = "0rm32h7lv4vyadi9x32sb6fwxslarwk70yzmvzjxbq872cazp779";
   };
 
   LANG = "en_US.UTF-8";

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -42,13 +42,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mutter";
-  version = "3.34.3";
+  version = "3.34.4";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "12aaxmclg3aw7qkk3pzpw8f5vrk0cxwprdrjnx9bjpf31gfpvxfd";
+    sha256 = "18hbw98p4h3d4qz57415smwmfg72s9a0nk8mb04ds1gn2lsm2d01";
   };
 
   mesonFlags = [

--- a/pkgs/desktops/gnome-3/core/simple-scan/default.nix
+++ b/pkgs/desktops/gnome-3/core/simple-scan/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "simple-scan";
-  version = "3.34.2";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/simple-scan/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1fk3g4f9slckqfwm576jrjq1d1qihw0dlgzdf00ns7qbhzb0kxsp";
+    sha256 = "0xvy672zyl6jsdlnxma8nc2aqsx9k92jhp6wfxs0msj9ppp1nd3z";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/games/four-in-a-row/default.nix
+++ b/pkgs/desktops/gnome-3/games/four-in-a-row/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "four-in-a-row";
-  version = "3.34.3";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/four-in-a-row/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1agdjg9kcfcfaq3d2w4s4ksci6is1jzfnxanp3f84zqdq55s0k1y";
+    sha256 = "1gw54llbmbv4w2rxmmkzq2wq6sacnpj99maw06zpn071cga0g4z5";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "gnome-klotski";
-  version = "3.34.3";
+  version = "3.34.4";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0swbyjlgrkd1hgcmp23h7p8fpjm2rpmnn87n6is0jx1x4cl8ab18";
+    sha256 = "1bg7hl64lmjryzvp51qfak5jqs7vbqfmj0s7h1g3c7snscca7rx6";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/games/gnome-taquin/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-taquin/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-taquin";
-  version = "3.34.3";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-taquin/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0njlcqb316qbi0dm2j39s42ca8gc2fqmk5aqill5gpb57znb4d81";
+    sha256 = "0s8gsgaj1mxldg5yaq6k9anfha9bc4n16wms66kbbpqi8k5hcm40";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/games/gnome-tetravex/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-tetravex/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-tetravex";
-  version = "3.34.1";
+  version = "3.34.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-tetravex/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "05i9y6x9ai7fay0khr4zb4ji92qs49v88p3lqx9lac8hz04dnvg0";
+    sha256 = "1sm90nkpig02hwk7bh5bnf65awgssxl63bvvh2a7gmlaln8x99iy";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/games/iagno/default.nix
+++ b/pkgs/desktops/gnome-3/games/iagno/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "iagno";
-  version = "3.34.4";
+  version = "3.34.5";
 
   src = fetchurl {
     url = "mirror://gnome/sources/iagno/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0v0x2dmgcgfcjmbx21arnrwdx9xwa5q05wrm8a9sgrjjzqx6ynwb";
+    sha256 = "05qywjcar29vk29yvbxwlddxhwlrvllgjw7srmlz5811hc5m0a1m";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "geary";
-  version = "3.34.1";
+  version = "3.34.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1bx57g8199pcqh1p90dlnca2g1kpyrifr6g8m1rdjmpm2a1r993v";
+    sha256 = "1a6j70pzr57ga7m4nypqdkqwlzk2dablpz93yaympgrlqpf5zkvm";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Backports https://github.com/NixOS/nixpkgs/pull/80334.
This is a stable update https://mail.gnome.org/archives/devel-announce-list/2020-February/msg00003.html.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
