### PR TITLE
plan9port: fix linker flags for macosx

### DIFF
--- a/pkgs/tools/system/plan9port/builder.sh
+++ b/pkgs/tools/system/plan9port/builder.sh
@@ -8,13 +8,20 @@ plan9portLinkFlags()
     local -a linkFlags=()
     eval set -- "$NIX_LDFLAGS"
     while (( $# > 0 )); do
-        if [[ $1 = -rpath ]]; then
-            linkFlags+=( "-Wl,-rpath,$2" )
+        case "$1" in
+        -rpath|-macosx_version_min|-sdk_version)
+            linkFlags+=( "-Wl,$1,$2" )
             shift 2
-        else
+            ;;
+        -no_uuid)
+            linkFlags+=( "-Wl,$1" )
+            shift
+            ;;
+        *)
             linkFlags+=( "$1" )
             shift
-        fi
+            ;;
+        esac
     done
     echo "${linkFlags[*]}"
 }

--- a/pkgs/tools/system/plan9port/builder.sh
+++ b/pkgs/tools/system/plan9port/builder.sh
@@ -5,25 +5,11 @@ export PLAN9_TARGET=$PLAN9
 
 plan9portLinkFlags()
 {
-    local -a linkFlags=()
     eval set -- "$NIX_LDFLAGS"
-    while (( $# > 0 )); do
-        case "$1" in
-        -rpath|-macosx_version_min|-sdk_version)
-            linkFlags+=( "-Wl,$1,$2" )
-            shift 2
-            ;;
-        -no_uuid)
-            linkFlags+=( "-Wl,$1" )
-            shift
-            ;;
-        *)
-            linkFlags+=( "$1" )
-            shift
-            ;;
-        esac
+    local flag
+    for flag in "$@"; do
+        printf ' -Wl,%s' "$flag"
     done
-    echo "${linkFlags[*]}"
 }
 
 configurePhase()


### PR DESCRIPTION
###### Motivation for this change

PR #77632 made Mac builds more reproducible by adding some linker
flags to `$NIX_LDFLAGS`; however, plan9port uses the C compiler
front end as a linker, requiring these new options to be wrapped
with `-Wl`.

This fixes the Mac build of plan9port.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @LnL7 @AndersonTorres @bbarker @ftrvxmtrx @kovirobi