### PR TITLE
gitAndTools.gh: fix authentication

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gh/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gh/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildGoModule, installShellFiles }:
+{ lib, fetchFromGitHub, buildGoModule, installShellFiles, fetchpatch }:
 
 buildGoModule rec {
   pname = "gh";
@@ -26,6 +26,16 @@ buildGoModule rec {
       installShellCompletion gh.$shell
     done
   '';
+
+  # should be in the next release
+  # https://github.com/cli/cli/issues/401#issuecomment-586918622
+  # https://github.com/cli/cli/issues/401#issuecomment-588261787
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/cli/cli/commit/213f4a5333c21020da030012979bd326a34fb28c.patch";
+      sha256 = "0sp52khbbq8cfxgqs77qzxrmi7zwb12dnqps5z8sk063y30i97zp";
+    })
+  ];
 
   meta = with lib; {
     description = "GitHub CLI tool";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes an authentication issue with this package vs the official pre-compiled binary that had a different token applied during the build (and is now embedded in the source on master.)

I didn't notice this when submitting the package as I initially tried the pre-complied package and re-used the correctly generated token.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
