### PR TITLE
ocamlPackages.dum: cleaning

### DIFF
--- a/pkgs/development/ocaml-modules/dum/default.nix
+++ b/pkgs/development/ocaml-modules/dum/default.nix
@@ -1,25 +1,24 @@
-{ lib, fetchFromGitHub, buildOcaml, ocaml
+{ stdenv, fetchFromGitHub, ocaml, findlib
 , easy-format
 }:
 
-buildOcaml rec {
-  name = "dum";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-dum-${version}";
   version = "1.0.1";
-
-  minimumOCamlVersion = "4.06";
 
   src = fetchFromGitHub {
     owner = "mjambon";
-    repo = name;
+    repo = "dum";
     rev = "v${version}";
     sha256 = "0yrxl97szjc0s2ghngs346x3y0xszx2chidgzxk93frjjpsr1mlr";
   };
 
-  buildInputs = [ easy-format ];
+  buildInputs = [ ocaml findlib ];
+  propagatedBuildInputs = [ easy-format ];
 
-  doCheck = true;
+  createFindlibDestdir = true;
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     homepage = https://github.com/mjambon/dum;
     description = "Inspect the runtime representation of arbitrary OCaml values";
     license = licenses.lgpl21Plus;


### PR DESCRIPTION
Propagate the `easy-format` dependency.

Fix build with OCaml ≥ 4.09.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @alexfmpe maintainer