### PR TITLE
mssql-server: init at 15.0.4003.23-3

### DIFF
--- a/pkgs/servers/sql/mssql/server/default.nix
+++ b/pkgs/servers/sql/mssql/server/default.nix
@@ -1,0 +1,148 @@
+{ stdenv
+, fetchurl
+, lib
+, rpmextract
+, makeWrapper
+, bash
+, python2
+, numactl
+, kerberos
+, e2fsprogs
+, sssd
+, libuuid
+, pam
+, openldap
+, systemd
+, libunwind
+, libredirect
+}:
+
+with lib;
+
+let
+  pname = "mssql-server";
+  version = "15.0.4003.23-3";
+  fetch-package = { pname, version, sha256 }:
+    fetchurl {
+      inherit sha256;
+      url =
+        "https://packages.microsoft.com/rhel/7/mssql-server-2019/${pname}-${version}.x86_64.rpm";
+    };
+  packages = {
+    mssql-server = fetch-package {
+      inherit pname version;
+      sha256 = "2c617e905b553e32b37b48f2d3cbce9bc6274e1e2f56172ff9efd696d264bbbc";
+    };
+    mssql-server-fts = fetch-package {
+      inherit version;
+      pname = "${pname}-fts";
+      sha256 = "1sd789sy30x92c8cj3lwb93w1fjx4w3vglh49sgdpr6dsm01l9yd";
+    };
+  };
+
+  withPackages = mssql-pkgs:
+
+    stdenv.mkDerivation rec {
+
+      inherit pname version;
+      dontUnpack = true;
+      nativeBuildInputs = [
+        makeWrapper
+        rpmextract
+      ];
+
+      ldLibraryPath = stdenv.lib.makeLibraryPath [
+        stdenv.cc.cc
+        numactl
+        kerberos
+        e2fsprogs
+        sssd
+        libuuid
+        pam
+        openldap
+        systemd.lib
+        libunwind
+      ];
+
+      installPhase = ''
+        runHook preInstall
+        rpmextract ${builtins.concatStringsSep " " mssql-pkgs}
+        mkdir -p $out/bin
+        mv opt $out
+        mv usr $out
+
+        fix_bash()
+        {
+          for x in $@; do
+            substituteInPlace "$x" \
+              --replace '/bin/bash' "${bash}/bin/bash"
+          done
+        }
+
+        fix_bash \
+          $out/opt/mssql/bin/mssql-conf \
+          $out/opt/mssql/lib/mssql-conf/{invokesqlservr,checkinstall}.sh
+
+        fix_python()
+        {
+          for x in $@; do
+            substituteInPlace "$x" \
+              --replace '/usr/bin/python2' "${python2}/bin/python"
+          done
+        }
+
+        fix_python $out/opt/mssql/lib/mssql-conf/{mssqlsettingsmanager,mssql-conf,mssqlconfhelper,mssqlsettings}.py
+
+        fix_sqlserver()
+        {
+          for x in $@; do
+            substituteInPlace "$x" \
+              --replace '/opt/mssql/bin/sqlservr' "$out/opt/mssql/bin/sqlservr"
+          done
+        }
+
+        fix_sqlserver \
+          $out/opt/mssql/lib/mssql-conf/{set-collation,invokesqlservr}.sh \
+          $out/usr/lib/systemd/system/mssql-server.service
+
+        chmod +x $out/opt/mssql/bin/sqlservr
+
+        fix_interpreter()
+        {
+          for x in $@; do
+            patchelf \
+              --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+              "$x"
+          done
+        }
+
+        fix_interpreter $out/opt/mssql/bin/{paldumper,sqlservr}
+
+        wrap()
+        {
+          for x in $@; do
+            wrapProgram $out/opt/mssql/bin/$x \
+              --suffix LD_LIBRARY_PATH : ${ldLibraryPath}
+            ln -s $out/opt/mssql/bin/$x $out/bin/
+          done
+        }
+
+        wrap paldumper sqlservr
+
+        runHook postInstall
+      '';
+
+      dontStrip = true;
+
+      meta = {
+        maintainers = with stdenv.lib.maintainers; [ xavierzwirtz ];
+        description = "A relational database management system developed by Microsoft";
+        homepage = https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-overview;
+        license = licenses.unfreeRedistributable;
+      };
+    };
+in
+
+withPackages [ packages.mssql-server ] // {
+  inherit withPackages packages;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15821,6 +15821,8 @@ in
 
   mssql_jdbc = callPackage ../servers/sql/mssql/jdbc { };
 
+  mssql-server = callPackage ../servers/sql/mssql/server { };
+  
   miniflux = callPackage ../servers/miniflux { };
 
   nagios = callPackage ../servers/monitoring/nagios { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packages mssql-server for NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
