### PR TITLE
azuredatastudio: init at 1.17.1

### DIFF
--- a/pkgs/applications/misc/azuredatastudio/default.nix
+++ b/pkgs/applications/misc/azuredatastudio/default.nix
@@ -1,0 +1,115 @@
+{ stdenv
+, lib
+, fetchurl
+, makeWrapper
+, libuuid
+, libunwind
+, icu
+, openssl
+, zlib
+, curl
+, at-spi2-core
+, at-spi2-atk
+, gnutar
+, atomEnv
+, kerberos
+}:
+
+# from justinwoo/azuredatastudio-nix
+# https://github.com/justinwoo/azuredatastudio-nix/blob/537c48aa3981cd1a82d5d6e508ab7e7393b3d7c8/default.nix
+
+stdenv.mkDerivation rec {
+
+  pname = "azuredatastudio";
+  version = "1.17.1";
+
+  src = fetchurl {
+    url = "https://azuredatastudiobuilds.blob.core.windows.net/releases/${version}/azuredatastudio-linux-${version}.tar.gz";
+    sha256 = "0px9n9vyjvyddca4x7d0zindd0dim7350vkjg5dd0506fm8dc38k";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libuuid
+    at-spi2-core
+    at-spi2-atk
+  ];
+
+  phases = "unpackPhase fixupPhase";
+
+  # change this to azuredatastudio-insiders for insiders releases
+  edition = "azuredatastudio";
+  targetPath = "$out/${edition}";
+
+  unpackPhase = ''
+    mkdir -p ${targetPath}
+    ${gnutar}/bin/tar xf $src --strip 1 -C ${targetPath}
+  '';
+
+  sqltoolsserviceRpath = stdenv.lib.makeLibraryPath [
+    stdenv.cc.cc
+    libunwind
+    libuuid
+    icu
+    openssl
+    zlib
+    curl
+  ];
+
+  # this will most likely need to be updated when azuredatastudio's version changes
+  sqltoolsservicePath = "${targetPath}/resources/app/extensions/mssql/sqltoolsservice/Linux/2.0.0-release.56";
+
+  rpath = stdenv.lib.concatStringsSep ":" [
+    atomEnv.libPath
+    (
+      stdenv.lib.makeLibraryPath [
+        libuuid
+        at-spi2-core
+        at-spi2-atk
+        stdenv.cc.cc.lib
+        kerberos
+      ]
+    )
+    targetPath
+    sqltoolsserviceRpath
+  ];
+
+  fixupPhase = ''
+    fix_sqltoolsservice()
+    {
+      mv ${sqltoolsservicePath}/$1 ${sqltoolsservicePath}/$1_old
+      patchelf \
+        --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" \
+        ${sqltoolsservicePath}/$1_old
+
+      makeWrapper \
+        ${sqltoolsservicePath}/$1_old \
+        ${sqltoolsservicePath}/$1 \
+        --set LD_LIBRARY_PATH ${sqltoolsserviceRpath}
+    }
+
+    fix_sqltoolsservice MicrosoftSqlToolsServiceLayer
+    fix_sqltoolsservice MicrosoftSqlToolsCredentials
+    fix_sqltoolsservice SqlToolsResourceProviderService
+
+    patchelf \
+      --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" \
+      ${targetPath}/${edition}
+
+    mkdir -p $out/bin
+    makeWrapper \
+      ${targetPath}/bin/${edition} \
+      $out/bin/azuredatastudio \
+      --set LD_LIBRARY_PATH ${rpath}
+  '';
+
+  meta = {
+    maintainers = with stdenv.lib.maintainers; [ xavierzwirtz ];
+    description = "A data management tool that enables working with SQL Server, Azure SQL DB and SQL DW";
+    homepage = "https://docs.microsoft.com/en-us/sql/azure-data-studio/download-azure-data-studio";
+    license = lib.licenses.unfreeRedistributable;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15947,6 +15947,8 @@ in
 
   mssql_jdbc = callPackage ../servers/sql/mssql/jdbc { };
 
+  azuredatastudio = callPackage ../applications/misc/azuredatastudio { };
+
   miniflux = callPackage ../servers/miniflux { };
 
   nagios = callPackage ../servers/monitoring/nagios { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packages azuredatastudio for NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
