### PR TITLE
ft2-clone: init at 1.09

### DIFF
--- a/pkgs/applications/audio/ft2-clone/default.nix
+++ b/pkgs/applications/audio/ft2-clone/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, alsaLib
+, SDL2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ft2-clone";
+  version = "1.09";
+
+  src = fetchFromGitHub {
+    owner = "8bitbubsy";
+    repo = "ft2-clone";
+    rev = "v${version}";
+    sha256 = "18my7fywaf66rq8phsly8lglxzpglran8rj27fvwgpni8098ic7d";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ SDL2 ] ++ stdenv.lib.optional stdenv.isLinux alsaLib;
+
+  meta = with stdenv.lib; {
+    description = "A highly accurate clone of the classic Fasttracker II software for MS-DOS";
+    homepage = "https://16-bits.org/ft2.php";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19031,6 +19031,8 @@ in
 
   fsv = callPackage ../applications/misc/fsv { };
 
+  ft2-clone = callPackage ../applications/audio/ft2-clone { };
+
   fvwm = callPackage ../applications/window-managers/fvwm { };
 
   ganttproject-bin = callPackage ../applications/misc/ganttproject-bin { };


### PR DESCRIPTION
##### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

If you review/merge this pr, please take a look at #80611 too (it's mostly the same)
