### PR TITLE
Lammps

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -35,11 +35,13 @@ stdenv.mkDerivation rec {
     for pack in ${stdenv.lib.concatStringsSep " " packages}; do make "yes-$pack" SHELL=$SHELL; done
   '';
 
+  enableParallelBuilding = true;
+
   # Must do manual build due to LAMMPS requiring a seperate build for
   # the libraries and executable. Also non-typical make script
   buildPhase = ''
-    make mode=exe ${if withMPI then "mpi" else "serial"} SHELL=$SHELL LMP_INC="${lammps_includes}" FFT_PATH=-DFFT_FFTW3 FFT_LIB=-lfftw3 JPG_LIB=-lpng
-    make mode=shlib ${if withMPI then "mpi" else "serial"} SHELL=$SHELL LMP_INC="${lammps_includes}" FFT_PATH=-DFFT_FFTW3 FFT_LIB=-lfftw3 JPG_LIB=-lpng
+    make mode=exe ${if withMPI then "mpi" else "serial"} ${if enableParallelBuilding then "-j" else ""} SHELL=$SHELL LMP_INC="${lammps_includes}" FFT_PATH=-DFFT_FFTW3 FFT_LIB=-lfftw3 JPG_LIB=-lpng
+    make mode=shlib ${if withMPI then "mpi" else "serial"} ${if enableParallelBuilding then "-j" else ""} SHELL=$SHELL LMP_INC="${lammps_includes}" FFT_PATH=-DFFT_FFTW3 FFT_LIB=-lfftw3 JPG_LIB=-lpng
   '';
 
   installPhase = ''

--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -12,14 +12,14 @@ let packages = [
 in
 stdenv.mkDerivation rec {
   # LAMMPS has weird versioning converted to ISO 8601 format
-  version = "stable_22Aug2018";
+  version = "stable_7Aug2019";
   pname = "lammps";
 
   src = fetchFromGitHub {
     owner = "lammps";
     repo = "lammps";
     rev = version;
-    sha256 = "1dlifm9wm1jcw2zwal3fnzzl41ng08c7v48w6hx2mz84zljg1nsj";
+    sha256 = "0yddiyizmqip87jvg76pqa8g3nk4sm0xwzryp9bq276q20l6mamj";
   };
 
   passthru = {

--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -4,13 +4,16 @@
 , mpi ? null
 }:
 let
+  withMPI = (mpi != null);
+
   packages = [
     "asphere" "body" "class2" "colloid" "compress" "coreshell" "dipole"
-    "granular" "kspace" "manybody" "mc" "meam" "misc" "molecule" "mpiio" "opt"
+    "granular" "kspace" "manybody" "mc" "meam" "misc" "molecule" "opt"
     "peri" "poems" "qeq" "replica" "rigid" "shock" "snap" "srd" "user-atc"
     "user-fep" "user-manifold" "user-misc" "user-molfile" "user-reaxc"
     "kokkos" "python"
-  ];
+  ]
+  ++ stdenv.lib.optionals withMPI [ "mpiio" ];
 
   lammps_includes = [
     "-DLAMMPS_EXCEPTIONS=yes"
@@ -18,8 +21,6 @@ let
     "-DLAMMPS_MEMALIGN=64"
     "-DBUILD_LIB=yes"
   ];
-
-  withMPI = (mpi != null);
 
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change
Update to the latest stable release and make it compile with `cmake` instead of `gnumake`, as preferred by upstream.

Split from https://github.com/NixOS/nixpkgs/pull/79771

###### Things done
Update, change build system and enable more modules. Didn't test the modules' functionality, just startup.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
