### PR TITLE
s-tui: migrate to python3

### DIFF
--- a/pkgs/tools/system/s-tui/default.nix
+++ b/pkgs/tools/system/s-tui/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, pythonPackages }:
+{ stdenv, python3Packages }:
 
-pythonPackages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "s-tui";
   version = "1.0.0";
 
-  src = pythonPackages.fetchPypi {
+  src = python3Packages.fetchPypi {
     inherit pname version;
     sha256 = "0r5yhlsi5xiy7ii1w4kqkaxz9069v5bbfwi3x3xnxhk51yjfgr8n";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python3Packages; [
     urwid
     psutil
   ];
+
+  LC_ALL = "en_US.UTF-8";
 
   meta = with stdenv.lib; {
     homepage = https://amanusk.github.io/s-tui/;


### PR DESCRIPTION
Including glibcLocales in checkInputs resolves a locale.Error exception
during the check phase.

```py3tb
  File "/build/s-tui-1.0.0/s_tui/sensors_menu.py", line 27, in <module>
    import urwid
  File "/nix/store/xxhpq1kcjy0kimfwnwqlzh2pchkp9khi-python3.7-urwid-2.1.0/lib/python3.7/site-packages/urwid/__init__.py", line 26, in <module>
    from urwid.widget import (FLOW, BOX, FIXED, LEFT, RIGHT, CENTER, TOP, MIDDLE,
  File "/nix/store/xxhpq1kcjy0kimfwnwqlzh2pchkp9khi-python3.7-urwid-2.1.0/lib/python3.7/site-packages/urwid/widget.py", line 27, in <module>
    from urwid.util import (MetaSuper, decompose_tagmarkup, calc_width,
  File "/nix/store/xxhpq1kcjy0kimfwnwqlzh2pchkp9khi-python3.7-urwid-2.1.0/lib/python3.7/site-packages/urwid/util.py", line 61, in <module>
    detected_encoding = detect_encoding()
  File "/nix/store/xxhpq1kcjy0kimfwnwqlzh2pchkp9khi-python3.7-urwid-2.1.0/lib/python3.7/site-packages/urwid/util.py", line 58, in detect_encoding
    locale.setlocale(locale.LC_ALL, initial)
  File "/nix/store/ja04f3cmapzb3f2mvjrb883bfqclsirq-python3-3.7.6/lib/python3.7/locale.py", line 608, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
