### PR TITLE
[r20.03] Backport tigervnc fix

### DIFF
--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
 
   inherit fontDirectories;
 
+  patches = [ ./u_xorg-server-1.20.7-ddxInputThreadInit.patch ];
+
   postPatch = ''
     sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -xkbdir ${xkeyboard_config}/etc/X11/xkb";' unix/vncserver
     fontPath=

--- a/pkgs/tools/admin/tigervnc/u_xorg-server-1.20.7-ddxInputThreadInit.patch
+++ b/pkgs/tools/admin/tigervnc/u_xorg-server-1.20.7-ddxInputThreadInit.patch
@@ -1,0 +1,21 @@
+Origin: https://build.opensuse.org/package/view_file/X11:XOrg/tigervnc/u_xorg-server-1.20.7-ddxInputThreadInit.patch
+diff -u -p -r tigervnc-1.10.0.old/unix/xserver/hw/vnc/xvnc.c tigervnc-1.10.0/unix/xserver/hw/vnc/xvnc.c
+--- tigervnc-1.10.0.old/unix/xserver/hw/vnc/xvnc.c	2020-01-15 11:19:19.486731848 +0000
++++ tigervnc-1.10.0/unix/xserver/hw/vnc/xvnc.c	2020-01-15 11:37:33.275445409 +0000
+@@ -295,6 +295,15 @@ void ddxBeforeReset(void)
+ }
+ #endif
+ 
++#if INPUTTHREAD
++/** This function is called in Xserver/os/inputthread.c when starting
++    the input thread. */
++void
++ddxInputThreadInit(void)
++{
++}
++#endif
++
+ void ddxUseMsg(void)
+ {
+     vncPrintBanner();
+


### PR DESCRIPTION
(cherry picked from commit f216b03d5b01490aadc54e5e9d5e3cb607816262)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

ZHF: #80379

Original pull request I think is #78996, but it's not accessible for me (?). I can mouse over the pull request number however and learn the patch came from https://build.opensuse.org/package/view_file/X11:XOrg/tigervnc/u_xorg-server-1.20.7-ddxInputThreadInit.patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
