### PR TITLE
tigervnc: fix compatibility with xorgserver 1.20.7

### DIFF
--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
 
   inherit fontDirectories;
 
+  patches = [ ./u_xorg-server-1.20.7-ddxInputThreadInit.patch ];
+
   postPatch = ''
     sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -xkbdir ${xkeyboard_config}/etc/X11/xkb";' unix/vncserver
     fontPath=

--- a/pkgs/tools/admin/tigervnc/u_xorg-server-1.20.7-ddxInputThreadInit.patch
+++ b/pkgs/tools/admin/tigervnc/u_xorg-server-1.20.7-ddxInputThreadInit.patch
@@ -1,0 +1,21 @@
+Origin: https://build.opensuse.org/package/view_file/X11:XOrg/tigervnc/u_xorg-server-1.20.7-ddxInputThreadInit.patch
+diff -u -p -r tigervnc-1.10.0.old/unix/xserver/hw/vnc/xvnc.c tigervnc-1.10.0/unix/xserver/hw/vnc/xvnc.c
+--- tigervnc-1.10.0.old/unix/xserver/hw/vnc/xvnc.c	2020-01-15 11:19:19.486731848 +0000
++++ tigervnc-1.10.0/unix/xserver/hw/vnc/xvnc.c	2020-01-15 11:37:33.275445409 +0000
+@@ -295,6 +295,15 @@ void ddxBeforeReset(void)
+ }
+ #endif
+ 
++#if INPUTTHREAD
++/** This function is called in Xserver/os/inputthread.c when starting
++    the input thread. */
++void
++ddxInputThreadInit(void)
++{
++}
++#endif
++
+ void ddxUseMsg(void)
+ {
+     vncPrintBanner();
+


### PR DESCRIPTION
(cherry picked from commit f216b03d5b01490aadc54e5e9d5e3cb607816262)

###### Motivation for this change
fix tigervnc build with nixos-20.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ZHF: #80379