### PR TITLE
ucx: init at 1.7.0

### DIFF
--- a/pkgs/development/libraries/ucx/default.nix
+++ b/pkgs/development/libraries/ucx/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, doxygen
+, numactl, rdma-core, libbfd, libiberty, perl, zlib
+}:
+
+let
+  version = "1.7.0";
+
+in stdenv.mkDerivation {
+  name = "ucx-${version}";
+
+  src = fetchFromGitHub {
+    owner = "openucx";
+    repo = "ucx";
+    rev = "v${version}";
+    sha256 = "149p8s7jrg7pbbq0hw0qm8va119bsl19q4scgk94vjqliyc1s33h";
+  };
+
+  nativeBuildInputs = [ autoreconfHook doxygen ];
+
+  buildInputs = [ numactl rdma-core libbfd libiberty perl zlib ];
+
+  configureFlags = [
+    "--with-rdmacm=${rdma-core}"
+    "--with-dc"
+    "--with-rc"
+    "--with-dm"
+    "--with-verbs=${rdma-core}"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Unified Communication X library";
+    homepage = http://www.openucx.org;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6007,6 +6007,8 @@ in
 
   openmpi = callPackage ../development/libraries/openmpi { };
 
+  ucx = callPackage ../development/libraries/ucx {};
+
   openmodelica = callPackage ../applications/science/misc/openmodelica { };
 
   qarte = libsForQt5.callPackage ../applications/video/qarte { };


### PR DESCRIPTION
###### Motivation for this change
split from https://github.com/NixOS/nixpkgs/pull/79771

###### Things done
took https://github.com/markuskowa/NixOS-QChem/blob/ucx/ucx/default.nix and went through it. the differences are:
1. the configure option `--with-verbs` seems to need the path of `rdma-core` passed to it (suggested by the configure log).
2. removal of the local optimization

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
