### PR TITLE
pythonPackages.qiskit-aer: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -1,0 +1,99 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, cvxpy
+, cython
+, numpy
+, openblas
+, pybind11
+, scikit-build
+, spdlog
+  # Check Inputs
+, qiskit-terra
+, pytestCheckHook
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-aer";
+  version = "0.4.1";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = pname;
+    rev = version;
+    fetchSubmodules = true; # fetch muparserx and other required libraries
+    sha256 = "1j2pv6jx5dlzanjp1qnf32s53d8jrlpv96nvymznkcnjvqn60gv9";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    scikit-build
+  ];
+
+  buildInputs = [
+    openblas
+    spdlog
+  ];
+
+  propagatedBuildInputs = [
+    cvxpy
+    cython  # generates some cython files at runtime that need to be cython-ized
+    numpy
+    pybind11
+  ];
+
+  prePatch = ''
+    # remove dependency on PyPi cmake package, which isn't in Nixpkgs
+    substituteInPlace setup.py --replace "'cmake'" ""
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  cmakeFlags = [
+    "-DBUILD_TESTS=True"
+    "-DAER_THRUST_BACKEND=OMP"
+  ];
+
+  # Needed to find qiskit.providers.aer modules in cython. This exists in GitHub, don't know why it isn't copied by default
+  postFixup = ''
+    touch $out/${python.sitePackages}/qiskit/__init__.pxd
+  '';
+
+  # *** Testing ***
+
+  pythonImportsCheck = [
+    "qiskit.providers.aer"
+    "qiskit.providers.aer.backends.qasm_simulator"
+    "qiskit.providers.aer.backends.controller_wrappers" # Checks C++ files built correctly. Only exists if built & moved to output
+  ];
+  checkInputs = [
+    qiskit-terra
+    pytestCheckHook
+  ];
+  dontUseSetuptoolsCheck = true;  # Otherwise runs tests twice
+
+  preCheck = ''
+    # Tests include a compiled "circuit" which is auto-built in $HOME
+    export HOME=$(mktemp -d)
+    # move tests b/c by default try to find (missing) cython-ized code in /build/source dir
+    cp -r test $HOME
+
+    # Add qiskit-aer compiled files to cython include search
+    pushd $HOME
+  '';
+  postCheck = ''
+    popd
+  '';
+
+  meta = with lib; {
+    description = "High performance simulators for Qiskit";
+    homepage = "https://github.com/QISKit/qiskit-aer";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7058,6 +7058,8 @@ in {
 
   qiskit = callPackage ../development/python-modules/qiskit { };
 
+  qiskit-aer = callPackage ../development/python-modules/qiskit-aer { };
+
   qiskit-ibmq-provider = callPackage ../development/python-modules/qiskit-ibmq-provider { };
 
   qiskit-terra = callPackage ../development/python-modules/qiskit-terra { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update qiskit according to new upstream package structure (collection of subpackages). This is broken out of #78772. Would like to get it into 20.03 if at all possible. Has out-of-tree dependencies: qiskit-terra #80464 and cvxpy (#78898). I will rebase & remove commits when each is approved.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
