### PR TITLE
webdis: init at 0.1.9

### DIFF
--- a/pkgs/development/tools/database/webdis/default.nix
+++ b/pkgs/development/tools/database/webdis/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, hiredis, http-parser, jansson, libevent, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  pname = "webdis";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "nicolasff";
+    repo = pname;
+    rev = version;
+    sha256 = "1kglzbs1sw3w05i678qr3lv4pxia20k2a8s3pjhfcxdlnlcy23sk";
+  };
+
+  patches = [
+    # Do not use DESTDIR. See: https://github.com/nicolasff/webdis/pull/172
+    (fetchpatch {
+      url = "https://github.com/nicolasff/webdis/commit/a44a2964a59f2e583f4945eeb65cd19235059270.patch";
+      sha256 = "0i41p98gc201vpp5ppjc9gxdyb1bpimr0qrvibaf3iq3sy4jr1gb";
+    })
+  ];
+
+  buildInputs = [ hiredis http-parser jansson libevent ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "CONFDIR=${placeholder "out"}/share/webdis"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A Redis HTTP interface with JSON output";
+    homepage = "https://webd.is/";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ wucke13 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10855,6 +10855,8 @@ in
 
   watson-ruby = callPackage ../development/tools/misc/watson-ruby {};
 
+  webdis = callPackage ../development/tools/database/webdis { };
+
   xc3sprog = callPackage ../development/tools/misc/xc3sprog { };
 
   xcodebuild = callPackage ../development/tools/xcbuild/wrapper.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Having a thin HTTP abstraction layer for Redis

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
