### PR TITLE
runInLinuxVM: Ensure tools requiring /etc/passwd work

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -126,6 +126,10 @@ rec {
     mkdir -p /fs/etc
     ln -sf /proc/mounts /fs/etc/mtab
     echo "127.0.0.1 localhost" > /fs/etc/hosts
+    # Ensures tools requiring /etc/passwd will work (e.g. nix)
+    if [ ! -e /fs/etc/passwd ]; then
+      echo "root:x:0:0:System administrator:/root:/bin/sh" > /fs/etc/passwd
+    fi
 
     echo "starting stage 2 ($command)"
     exec switch_root /fs $command $out


### PR DESCRIPTION
This includes, but is not limited to:

 * whoami
 * nix >= 2.3.1

See

 * https://github.com/NixOS/nixpkgs/issues/71157
 * https://github.com/NixOS/nixops/issues/1216
 * https://github.com/nix-community/nixops-libvirtd/issues/5

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix a *system* regression in 19.09, where nixops will not work using libvirtd, as pointed out personally to me by @JoeDupuis.

This fix, though, is a much broader fix, and could fix any tool that tries to identify the user in this step.

###### Things done

Tested using this:

```nix
let
  pkgs = import <nixpkgs> {};
  script = name: cmd: pkgs.runCommand "runInLinuxVM--lack-of-user--${name}" {
    buildInputs = with pkgs; [
      utillinux
      shadow
    ];
  } ''
    (PS4=" $ "; set -x
      ${cmd}
    )
  '';
  test = name: cmd: pkgs.vmTools.runInLinuxVM (script name cmd);
in
  [
    (test "id" "id | grep root")
    (test "whoami" "whoami")
    # https://github.com/NixOS/nixpkgs/issues/71157
    (test "nix" "${pkgs.nix.out}/bin/nix-store --version")
  ]
```

You can verify that without this fix, both on unstable, and 19.09 this fails in three different, but coherent ways. With this fix applied, it works.

This should be backported to 19.09, in my opinion, as this is a system breakage from a minor bump from nix in the nixops ecosystem.

This **has** to be backported to 20.03 if accepted in master.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
