### PR TITLE
google-cloud-sdk: 268.0.0 -> 281.0.0

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -32,7 +32,7 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "google-cloud-sdk";
-  version = "268.0.0";
+  version = "281.0.0";
 
   src = fetchurl (sources "${pname}-${version}" stdenv.hostPlatform.system);
 


### PR DESCRIPTION
###### Motivation for this change

Bring in GCP fix for python error in `bq` tool.
