### PR TITLE
pulseaudio-dlna: add missing setuptools dep

### DIFF
--- a/pkgs/applications/audio/pulseaudio-dlna/default.nix
+++ b/pkgs/applications/audio/pulseaudio-dlna/default.nix
@@ -16,10 +16,10 @@ assert vorbisSupport -> vorbisTools != null;
 
 let
   zeroconf = pythonPackages.callPackage ./zeroconf.nix { };
-
-in pythonPackages.buildPythonApplication {
+in
+pythonPackages.buildPythonApplication {
   pname = "pulseaudio-dlna";
-  version = "2017-11-01";
+  version = "unstable-2017-11-01";
 
   src = fetchFromGitHub {
     owner = "masmu";
@@ -28,12 +28,9 @@ in pythonPackages.buildPythonApplication {
     sha256 = "1dfn7036vrq49kxv4an7rayypnm5dlawsf02pfsldw877hzdamqk";
   };
 
-  # pulseaudio-dlna has no tests
-  doCheck = false;
-
   propagatedBuildInputs = with pythonPackages; [
     dbus-python docopt requests setproctitle protobuf psutil futures
-    chardet notify2 netifaces pyroute2 pygobject2 lxml ]
+    chardet notify2 netifaces pyroute2 pygobject2 lxml setuptools ]
     ++ [ zeroconf ]
     ++ stdenv.lib.optional mp3Support lame
     ++ stdenv.lib.optional opusSupport opusTools
@@ -42,12 +39,15 @@ in pythonPackages.buildPythonApplication {
     ++ stdenv.lib.optional soxSupport sox
     ++ stdenv.lib.optional vorbisSupport vorbisTools;
 
+  # upstream has no tests
+  checkPhase = ''
+    $out/bin/pulseaudio-dlna --help > /dev/null
+  '';
+
   meta = with stdenv.lib; {
     description = "A lightweight streaming server which brings DLNA / UPNP and Chromecast support to PulseAudio and Linux";
-    homepage = https://github.com/masmu/pulseaudio-dlna;
-
+    homepage = "https://github.com/masmu/pulseaudio-dlna";
     license = licenses.gpl3Plus;
-
     maintainers = with maintainers; [ mog ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
to fix:
```
$ ./results/pulseaudio-dlna/bin/pulseaudio-dlna --help
Traceback (most recent call last):
  File "/nix/store/sr9x9f05qka1pvchv6pr3c8rmak9128b-pulseaudio-dlna-2017-11-01/bin/.pulseaudio-dlna-wrapped", line 6, in <module>
    from pulseaudio_dlna.__main__ import main
  File "/nix/store/sr9x9f05qka1pvchv6pr3c8rmak9128b-pulseaudio-dlna-2017-11-01/lib/python2.7/site-packages/pulseaudio_dlna/__init__.py", line 21, in <module>
    import pkg_resources
ImportError: No module named pkg_resources
```

related PR: https://github.com/NixOS/nixpkgs/pull/80691
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/80693
1 package built:
pulseaudio-dlna
```