### PR TITLE
patroni: init at 1.6.4

### DIFF
--- a/pkgs/servers/sql/patroni/default.nix
+++ b/pkgs/servers/sql/patroni/default.nix
@@ -1,0 +1,57 @@
+{ lib, pythonPackages, fetchFromGitHub }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "patroni";
+  version = "1.6.4";
+
+  src = fetchFromGitHub {
+    owner = "zalando";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0w0mz4a1cyxdsqmv7jrkw163jll8ir5zmf93zcidlqx13knrk80g";
+  };
+
+  # cdiff renamed to ydiff; remove when patroni source reflects this.
+  postPatch = ''
+    for i in requirements.txt patroni/ctl.py tests/test_ctl.py; do
+      substituteInPlace $i --replace cdiff ydiff
+    done
+  '';
+
+  propagatedBuildInputs = with pythonPackages; [
+    boto
+    click
+    consul
+    dns
+    kazoo
+    kubernetes
+    prettytable
+    psutil
+    psycopg2
+    python-dateutil
+    python-etcd
+    pyyaml
+    tzlocal
+    urllib3
+    ydiff
+  ];
+
+  checkInputs = with pythonPackages; [
+    flake8
+    mock
+    pytest
+    pytestcov
+    requests
+  ];
+
+  # Fix tests by preventing them from writing to /homeless-shelter.
+  preCheck = "export HOME=$(mktemp -d)";
+
+  meta = with lib; {
+    homepage = "https://patroni.readthedocs.io/en/latest/";
+    description = "A Template for PostgreSQL HA with ZooKeeper, etcd or Consul";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.limeytexan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15673,6 +15673,8 @@ in
 
   vmfs-tools = callPackage ../tools/filesystems/vmfs-tools { };
 
+  patroni = callPackage ../servers/sql/patroni { pythonPackages = python3Packages; };
+
   pgbouncer = callPackage ../servers/sql/pgbouncer { };
 
   pgpool = callPackage ../servers/sql/pgpool {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
