### PR TITLE
ocamlPackages.javalib: 3.1.1 → 3.2.1; ocamlPackages.sawja: 1.5.7 → 1.5.8

### DIFF
--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -8,11 +8,11 @@ else
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-javalib-${version}";
-  version = "3.1.1";
+  version = "3.2.1";
 
   src = fetchzip {
     url = "https://github.com/javalib-team/javalib/archive/v${version}.tar.gz";
-    sha256 = "1myrf7kw7pi04pmp0bi4747nj4h4vfxlla05sz2hp4w8k76iscld";
+    sha256 = "1fkdaiiza145yv0r1cm0n2hsrr0rbn6b27vs66njgv405zwn3vbn";
   };
 
   buildInputs = [ which ocaml findlib ];

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -1,19 +1,24 @@
-{stdenv, fetchurl, which, perl, ocaml, findlib, javalib }:
-
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12";
+{ stdenv, fetchFromGitHub, which, perl, ocaml, findlib, javalib }:
 
 let
   pname = "sawja";
-  version = "1.5.7";
+  version = "1.5.8";
   webpage = "http://sawja.inria.fr/";
 in
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.07"
+then throw "${pname} is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
 
   name = "ocaml${ocaml.version}-${pname}-${version}";
 
-  src = fetchurl {
-    url = https://gforge.inria.fr/frs/download.php/file/38117/sawja-1.5.7.tar.bz2;
-    sha256 = "08xv1bq4pragc1g93w4dnbn0mighcjwfp3ixj9jzmhka2vzqm4cc";
+  src = fetchFromGitHub {
+    owner = "javalib-team";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0rawr0jav33rvagm8sxc0arc7ya1fd9w5nng3lhfk8p02f9z8wrp";
   };
 
   buildInputs = [ which perl ocaml findlib ];


### PR DESCRIPTION
###### Motivation for this change

Fixes and improvements.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
