### PR TITLE
swift: Fix build for glibc 2.30

### DIFF
--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -26,6 +26,7 @@
 , git
 , libgit2
 , fetchFromGitHub
+, fetchpatch
 , findutils
 , makeWrapper
 , gnumake
@@ -223,6 +224,15 @@ stdenv.mkDerivation {
     sed -i 's/curses/ncurses/' llbuild/*/*/CMakeLists.txt
     # uuid.h is not part of glibc, but of libuuid
     sed -i 's|''${GLIBC_INCLUDE_PATH}/uuid/uuid.h|${libuuid.dev}/include/uuid/uuid.h|' swift/stdlib/public/Platform/glibc.modulemap.gyb
+
+    # Compatibility with glibc 2.30
+    # Adapted from https://github.com/apple/swift-package-manager/pull/2408
+    patch -p1 -d swiftpm -i ${./patches/swift-package-manager-glibc-2.30.patch}
+    # https://github.com/apple/swift/pull/27288
+    patch -p1 -d swift -i ${fetchpatch {
+      url = "https://github.com/apple/swift/commit/f968f4282d53f487b29cf456415df46f9adf8748.patch";
+      sha256 = "1aa7l66wlgip63i4r0zvi9072392bnj03s4cn12p706hbpq0k37c";
+    }}
 
     PREFIX=''${out/#\/}
     substituteInPlace indexstore-db/Utilities/build-script-helper.py \

--- a/pkgs/development/compilers/swift/patches/swift-package-manager-glibc-2.30.patch
+++ b/pkgs/development/compilers/swift/patches/swift-package-manager-glibc-2.30.patch
@@ -1,0 +1,25 @@
+diff --git a/Sources/Basic/Process.swift b/Sources/Basic/Process.swift
+index f388c769..8f208691 100644
+--- a/Sources/Basic/Process.swift
++++ b/Sources/Basic/Process.swift
+@@ -322,7 +322,10 @@ public final class Process: ObjectIdentifierProtocol {
+         defer { posix_spawn_file_actions_destroy(&fileActions) }
+ 
+         // Workaround for https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=89e435f3559c53084498e9baad22172b64429362
+-        let devNull = strdup("/dev/null")
++        // Change allowing for newer version of glibc
++        guard let devNull = strdup("/dev/null") else {
++            throw SystemError.posix_spawn(0, arguments)
++        }
+         defer { free(devNull) }
+         // Open /dev/null as stdin.
+         posix_spawn_file_actions_addopen(&fileActions, 0, devNull, O_RDONLY, 0)
+@@ -348,7 +351,7 @@ public final class Process: ObjectIdentifierProtocol {
+ 
+         let argv = CStringArray(arguments)
+         let env = CStringArray(environment.map({ "\($0.0)=\($0.1)" }))
+-        let rv = posix_spawnp(&processID, argv.cArray[0], &fileActions, &attributes, argv.cArray, env.cArray)
++        let rv = posix_spawnp(&processID, argv.cArray[0]!, &fileActions, &attributes, argv.cArray, env.cArray)
+ 
+         guard rv == 0 else {
+             throw SystemError.posix_spawn(rv, arguments)


### PR DESCRIPTION
###### Motivation for this change
ZHF #80379, so needs backport

Was broken since https://github.com/NixOS/nixpkgs/pull/66528

Fixes for glibc 2.30 in https://github.com/apple/swift/pull/27288 (well I think this is because of it, not sure, but I needed this to fix the build) and https://github.com/apple/swift-package-manager/pull/2408

Ping @mroi 

###### Things done

- [x] Tested this patch on the release-20.03 branch with a successful build of swift on NixOS