### PR TITLE
libfido2: build only Linux

### DIFF
--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/Yubico/libfido2;
     license = licenses.bsd2;
     maintainers = with maintainers; [ dtzWill ];
-
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
#### Motivation for this change

An attempt to fix the failed evaluation in https://github.com/NixOS/nixpkgs/pull/80196.

We should build libfido2 with systemd only on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
