### PR TITLE
weechatScripts.weechat-matrix: enable on darwin

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
@@ -64,7 +64,7 @@ in buildPythonPackage {
       --replace '/usr/bin/env -S python3' '${scriptPython}/bin/python'
     substituteInPlace $out/bin/matrix_decrypt \
       --replace '/usr/bin/env python3' '${scriptPython}/bin/python'
-   
+
     mkdir -p $out/${python.sitePackages}
     cp -r $src/matrix $out/${python.sitePackages}/matrix
   '';
@@ -75,7 +75,7 @@ in buildPythonPackage {
     description = "A Python plugin for Weechat that lets Weechat communicate over the Matrix protocol";
     homepage = "https://github.com/poljar/weechat-matrix";
     license = licenses.isc;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ tilpner emily ];
   };
 }


### PR DESCRIPTION
##### Motivation for this change

According to @Feliix42 this works fine on Mac.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
