### PR TITLE
icon-lang: fix build

### DIFF
--- a/pkgs/development/interpreters/icon-lang/default.nix
+++ b/pkgs/development/interpreters/icon-lang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libX11, libXt , withGraphics ? true }:
+{ stdenv, fetchFromGitHub, fetchpatch, libX11, libXt, withGraphics ? true }:
 
 stdenv.mkDerivation rec {
   pname = "icon-lang";
@@ -11,6 +11,18 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = stdenv.lib.optionals withGraphics [ libX11 libXt ];
+
+  patches = [
+    # Patch on git master, likely won't be necessary in future release
+    (fetchpatch {
+      url = "https://github.com/gtownsend/icon/commit/bfc4a6004d0d3984c8066289b8d8e563640c4ddd.patch";
+      sha256 = "1pqapjghk10rb73a1mfflki2wipjy4kvnravhmrilkqzb9hd6v8m";
+      excludes = [
+        "doc/relnotes.htm"
+        "src/h/version.h"
+      ];
+    })
+  ];
 
   configurePhase =
     let

--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -57,7 +57,7 @@ let noweb = stdenv.mkDerivation rec {
 
     # HACK: This is ugly, but functional.
     PATH=$out/bin:$PATH make -BC xdoc
-    make "''${installFlags[@]}" install-man
+    make "''${installFlags[@]} install-man"
 
     ln -s "$tex" "$out/share/texmf"
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

ZHF: #80379

@NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
