### PR TITLE
gimp: 2.10.14 → 2.10.16

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -50,13 +50,13 @@ let
   inherit (python2Packages) pygtk wrapPython python;
 in stdenv.mkDerivation rec {
   pname = "gimp";
-  version = "2.10.14";
+  version = "2.10.16";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "http://download.gimp.org/pub/gimp/v${lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
-    sha256 = "0m6wdnfvsxyhimdd4v3351g4r1fklllnbipbwcfym3h7q88hz6yz";
+    sha256 = "1sybf1yilw272lr8qbyx3zbvysf5rc89gk80gd4aj4xr6jazxyfb";
   };
 
   nativeBuildInputs = [
@@ -155,6 +155,7 @@ in stdenv.mkDerivation rec {
 
   configureFlags = [
     "--without-webkit" # old version is required
+    "--disable-check-update"
     "--with-bug-report-url=https://github.com/NixOS/nixpkgs/issues/new"
     "--with-icc-directory=/run/current-system/sw/share/color/icc"
     # fix libdir in pc files (${exec_prefix} needs to be passed verbatim)

--- a/pkgs/applications/graphics/gimp/remove-cc-reference.patch
+++ b/pkgs/applications/graphics/gimp/remove-cc-reference.patch
@@ -1,13 +1,15 @@
 diff --git a/app/gimp-version.c b/app/gimp-version.c
-index 12605c6..a9083da 100644
+index 0f7bfb9bf9..1679624b8e 100644
 --- a/app/gimp-version.c
 +++ b/app/gimp-version.c
-@@ -203,7 +203,7 @@ gimp_version (gboolean be_verbose,
-       lib_versions = gimp_library_versions (localized);
-       verbose_info = g_strdup_printf ("git-describe: %s\n"
-                                       "C compiler:\n%s\n%s",
--                                      GIMP_GIT_VERSION, CC_VERSION,
-+                                      GIMP_GIT_VERSION, "@cc_version@",
+@@ -228,9 +228,9 @@
+                                       "# Libraries #\n%s",
+                                       GIMP_GIT_VERSION,
+                                       GIMP_BUILD_ID,
+                                       gimp_version_get_revision (),
+                                       GIMP_BUILD_PLATFORM,
+-                                      CC_VERSION,
++                                      "@cc_version@",
                                        lib_versions);
        g_free (lib_versions);
  

--- a/pkgs/development/libraries/gegl/4.0.nix
+++ b/pkgs/development/libraries/gegl/4.0.nix
@@ -18,6 +18,7 @@
 , netsurf
 , pango
 , poly2tri-c
+, poppler
 , bzip2
 , json-glib
 , gettext
@@ -34,14 +35,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gegl";
-  version = "0.4.20";
+  version = "0.4.22";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
   src = fetchurl {
     url = "https://download.gimp.org/pub/gegl/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1zrxnxlhn0jmshg4n2m2xlgi886w059ynkiiihm7rpi05fs8pg93";
+    sha256 = "0q9cckf90fb82qc5d496fjz459f1xw4j4p3rff1f57yivx0yr20q";
   };
 
   patches = [
@@ -71,6 +72,7 @@ stdenv.mkDerivation rec {
     netsurf.libnsgif
     pango
     poly2tri-c
+    poppler
     bzip2
     libraw
     libwebp

--- a/pkgs/development/libraries/mypaint-brushes/1.0.nix
+++ b/pkgs/development/libraries/mypaint-brushes/1.0.nix
@@ -1,5 +1,4 @@
 { stdenv
-, fetchpatch
 , autoconf
 , automake
 , fetchFromGitHub
@@ -8,22 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mypaint-brushes";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "mypaint";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1iz89z6v2mp8j1lrf942k561s8311i3s34ap36wh4rybb2lq15m0";
+    sha256 = "1c95l1vfz7sbrdlzrbz7h1p6s1k113kyjfd9wfnxlm0p6562cz3j";
   };
-
-  patches = [
-    # build with automake 1.16
-    (fetchpatch {
-      url = https://github.com/Jehan/mypaint-brushes/commit/1e9109dde3bffd416ed351c3f30ecd6ffd0ca2cd.patch;
-      sha256 = "0mi8rwbirl0ib22f2hz7kdlgi4hw8s3ab29b003dsshdyzn5iha9";
-    })
-  ];
 
   nativeBuildInputs = [
     autoconf


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
