### PR TITLE
pythonPackages.pytest-timeout: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -21,7 +21,10 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest pexpect ];
-  checkPhase = ''pytest -ra'';
+  checkPhase = ''
+    # test_suppresses_timeout_when_pdb_is_entered fails under heavy load
+    pytest -ra -k 'not test_suppresses_timeout_when_pdb_is_entered'
+  '';
 
   meta = with lib;{
     description = "py.test plugin to abort hanging tests";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #80379 

I could finally reproduce the failure on hydra by running the test in a i686-linux VM with `stress -c 5`. Only this test seems to fail reliably, so let's disable it!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox))
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
