### PR TITLE
clingcon: init at 3.3.0

### DIFF
--- a/pkgs/applications/science/logic/potassco/clingcon.nix
+++ b/pkgs/applications/science/logic/potassco/clingcon.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, bison
+, re2c
+}:
+
+stdenv.mkDerivation rec {
+  pname = "clingcon";
+  version = "3.3.0";
+
+  src = fetchFromGitHub {
+    owner = "potassco";
+    repo = "${pname}";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "1q7517h10jfvjdk2czq8d6y57r8kr1j1jj2k2ip2qxkpyfigk4rs";
+   };
+
+  # deal with clingcon through git submodules recursively importing
+  # an outdated version of libpotassco which uses deprecated <xlocale.h> header in .cpp files
+  postPatch = ''
+    find ./ -type f -exec sed -i 's/<xlocale.h>/<locale.h>/g' {} \;
+  '';
+
+  nativeBuildInputs = [ cmake bison re2c ];
+
+  cmakeFlags = [
+    "-DCLINGCON_MANAGE_RPATH=ON"
+    "-DCLINGO_BUILD_WITH_PYTHON=OFF"
+    "-DCLINGO_BUILD_WITH_LUA=OFF"
+  ];
+
+  meta = {
+    inherit version;
+    description = "Extension of clingo to handle constraints over integers";
+    license = stdenv.lib.licenses.gpl3; # for now GPL3, next version MIT!
+    platforms = stdenv.lib.platforms.unix;
+    homepage = "https://potassco.org/";
+    downloadPage = "https://github.com/potassco/clingcon/releases/";
+    changelog = "https://github.com/potassco/clingcon/releases/tag/v${version}";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1451,6 +1451,8 @@ in
 
   clingo = callPackage ../applications/science/logic/potassco/clingo.nix { };
 
+  clingcon = callPackage ../applications/science/logic/potassco/clingcon.nix { };
+
   clprover = callPackage ../applications/science/logic/clprover/clprover.nix { };
 
   coloredlogs = with python3Packages; toPythonApplication coloredlogs;


### PR DESCRIPTION
###### Motivation for this change

[Clingcon](https://potassco.org/clingcon/) is an answer set solver for constraint logic programs, building upon the answer set solver clingo. It extends the high-level modeling language of ASP with constraint solving capacities.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
   - Tested using `nix-build . --option build-use-chroot true -A clingcon`
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions

- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   - Not a nixos-level package, no virtual environment test necessary

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
   - No package depends on this newly introduced package, nor does this change introduce any modifications to existing packages
   - Running this command throws an error for me
```sh
$ nix-shell -p nixpkgs-review --run "nixpkgs-review wip" --show-trace
error: while evaluating the attribute 'buildInputs' of the derivation 'shell' at /nix/store/sj4in86dg5bij894jywp4zygr31w0dv1-nixos-18.03.133402.cb0e20d6db9/nixos/pkgs/stdenv/generic/make-derivation.nix:148:11:
while evaluating 'chooseDevOutputs' at /nix/store/sj4in86dg5bij894jywp4zygr31w0dv1-nixos-18.03.133402.cb0e20d6db9/nixos/lib/attrsets.nix:460:22, called from undefined position:
undefined variable 'nixpkgs-review' at (string):1:94
```
   - Running a similar command `nix-shell -I nixpkgs=. -p nixpkgs-review --run "nixpkgs-review wip"` returns `No diff detected, stopping review`

- [x] Tested execution of all binary files (usually in `./result/bin/`)
   - Tested also using runtime-sandboxing (`nix-shell -I nixpkgs=. --pure -p clingcon`)

- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
   - This throws an error for me
```sh
error: Please be informed that this pseudo-package is not the only part of
Nixpkgs that fails to evaluate. You should not evaluate entire Nixpkgs
without some special measures to handle failing packages, like those taken
by Hydra.
```

- [ ] Ensured that relevant documentation is up to date
   - Which documentation is meant here?

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
   - Everything fulfilled, except the `maintainers` field. While I'm happy to contribute and update the package version here and there I can not commit myself to maintaining this package.
