### PR TITLE
tree-wide: Fix with nixUnstable

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -102,6 +102,7 @@ if [[ -z $system ]]; then
     outLink="$tmpdir/system"
     nix build --out-link "$outLink" --store "$mountPoint" "${extraBuildFlags[@]}" \
         --extra-substituters "$sub" \
+        --option experimental-features nix-command \
         -f '<nixpkgs/nixos>' system -I "nixos-config=$NIXOS_CONFIG" ${verbosity[@]} ${buildLogs}
     system=$(readlink -f $outLink)
 fi

--- a/nixos/modules/installer/tools/nixos-option/nixos-option.cc
+++ b/nixos/modules/installer/tools/nixos-option/nixos-option.cc
@@ -588,13 +588,14 @@ int main(int argc, char ** argv)
     std::string optionsExpr = "(import <nixpkgs/nixos> {}).options";
     std::string configExpr = "(import <nixpkgs/nixos> {}).config";
     std::vector<std::string> args;
+    std::string_view pname = nix::baseNameOf(argv[0]);
 
     struct MyArgs : nix::LegacyArgs, nix::MixEvalArgs
     {
         using nix::LegacyArgs::LegacyArgs;
     };
 
-    MyArgs myArgs(nix::baseNameOf(argv[0]), [&](Strings::iterator & arg, const Strings::iterator & end) {
+    MyArgs myArgs(pname.data(), [&](Strings::iterator & arg, const Strings::iterator & end) {
         if (*arg == "--help") {
             nix::showManPage("nixos-option");
         } else if (*arg == "--version") {

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -452,7 +452,7 @@ in
     system.activationScripts.nix = stringAfter [ "etc" "users" ]
       ''
         # Create directories in /nix.
-        ${nix}/bin/nix ping-store --no-net
+        ${nix}/bin/nix --option experimental-features nix-command ping-store --no-net
 
         # Subscribe the root user to the NixOS channel by default.
         if [ ! -e "/root/.nix-channels" ]; then


### PR DESCRIPTION
###### Motivation for this change
It is great that the experimental commands are now gated but since we are dogfooding them, we need to open the gates.

I ran `nixos-rebuild switch` with the following in my config:

###### Things done

```nix
{
  nixpkgs.overlays = [
    (self: super: {
      nix = super.nixUnstable;
    })
  ];

  nix.package = pkgs.nixUnstable;
}
```

- [x] Verified that nixos-option builds
- [x] Verified that system is activated correctly
- Did not check nixos-install