### PR TITLE
 sphinxsearch: Add support for MySQL & xmlpipe2

### DIFF
--- a/pkgs/servers/search/sphinxsearch/default.nix
+++ b/pkgs/servers/search/sphinxsearch/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1aa1mh32y019j8s3sjzn4vwi0xn83dwgl685jnbgh51k16gh6qk6";
   };
 
+  enableParallelBuilding = true;
+
   configureFlags = [
     "--program-prefix=sphinxsearch-"
     "--enable-id64"

--- a/pkgs/servers/search/sphinxsearch/default.nix
+++ b/pkgs/servers/search/sphinxsearch/default.nix
@@ -31,6 +31,14 @@ stdenv.mkDerivation rec {
     expat
   ];
 
+  CXXFLAGS = with stdenv.lib; concatStringsSep " " (optionals stdenv.isDarwin [
+    # see upstream bug: http://sphinxsearch.com/bugs/view.php?id=2578
+    # workaround for "error: invalid suffix on literal
+    "-Wno-reserved-user-defined-literal"
+    # workaround for "error: non-constant-expression cannot be narrowed from type 'long' to 'int'"
+    "-Wno-c++11-narrowing"
+  ]);
+
   meta = {
     description = "An open source full text search server";
     homepage    = http://sphinxsearch.com;

--- a/pkgs/servers/search/sphinxsearch/default.nix
+++ b/pkgs/servers/search/sphinxsearch/default.nix
@@ -1,24 +1,29 @@
-{ stdenv, fetchurl, pkgconfig,
-  version ? "2.2.11",
-  mainSrc ? fetchurl {
-    url = "http://sphinxsearch.com/files/sphinx-${version}-release.tar.gz";
-    sha256 = "1aa1mh32y019j8s3sjzn4vwi0xn83dwgl685jnbgh51k16gh6qk6";
-  }
+{ stdenv, fetchurl, pkg-config, libmysqlclient,
+  enableMysql ? true
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "sphinxsearch";
-  inherit version;
-  src = mainSrc;
+  version = "2.2.11";
+
+  src = fetchurl {
+    url = "http://sphinxsearch.com/files/sphinx-${version}-release.tar.gz";
+    sha256 = "1aa1mh32y019j8s3sjzn4vwi0xn83dwgl685jnbgh51k16gh6qk6";
+  };
 
   configureFlags = [
     "--program-prefix=sphinxsearch-"
-    "--without-mysql"
     "--enable-id64"
+  ] ++ stdenv.lib.optionals (!enableMysql) [
+    "--without-mysql"
   ];
 
   nativeBuildInputs = [
-    pkgconfig
+    pkg-config
+  ];
+
+  buildInputs = stdenv.lib.optionals enableMysql [
+    libmysqlclient
   ];
 
   meta = {

--- a/pkgs/servers/search/sphinxsearch/default.nix
+++ b/pkgs/servers/search/sphinxsearch/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation {
     homepage    = http://sphinxsearch.com;
     license     = stdenv.lib.licenses.gpl2;
     platforms   = stdenv.lib.platforms.all;
-    maintainers = with stdenv.lib.maintainers; [ ederoyd46 ];
+    maintainers = with stdenv.lib.maintainers; [ ederoyd46 valodim ];
   };
 }

--- a/pkgs/servers/search/sphinxsearch/default.nix
+++ b/pkgs/servers/search/sphinxsearch/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, pkg-config, libmysqlclient,
+{ stdenv, fetchurl, pkg-config, expat, libmysqlclient,
+  enableXmlpipe2 ? false,
   enableMysql ? true
 }:
 
@@ -24,6 +25,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = stdenv.lib.optionals enableMysql [
     libmysqlclient
+  ] ++ stdenv.lib.optionals enableXmlpipe2 [
+    expat
   ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

This PR obsoletes #79032.

I added support for MySQL sources, and optionally xmlpipe2. I don't use xmlpipe2 myself, so I didn't test that. I'll test MySQL source in the next few days in a small production environment. :)

The version and main source were pulled in as arguments? Not sure what that was about, overriding those should be done with `overrideAttrs`. I also enabled parallel builds (works fine for me), and added myself as maintainer. The 2.X branch of sphinxsearch isn't actively supported anymore though, so I don't expect any updates. The 3.X line isn't open source (yet), and has enough incompatibilities to go into its own sphinxsearch3 package anyways.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`~~ no packages depend on this
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
