### PR TITLE
bazel: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -25,11 +25,11 @@
 }:
 
 let
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "1fvc7lakdczim1i99hrwhwx2w75afd3q9fgbhrx7i3pnav3a6kbj";
+    sha256 = "0ijz9lxralyw18r5ra2h79jnafk5521ncr3knaip74cqa28csw9k";
   };
 
   # Update with `eval $(nix-build -A bazel.updater)`,
@@ -51,9 +51,9 @@ let
       (if stdenv.hostPlatform.isDarwin
        then srcs."java_tools_javac11_darwin-v7.0.zip"
        else srcs."java_tools_javac11_linux-v7.0.zip")
-      srcs."coverage_output_generator-v2.0.zip"
+      srcs."coverage_output_generator-v2.1.zip"
       srcs.build_bazel_rules_nodejs
-      srcs."android_tools_pkg-0.12.tar.gz"
+      srcs."android_tools_pkg-0.13.tar.gz"
       srcs."0.28.3.tar.gz"
       srcs.rules_pkg
       srcs.rules_cc

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -106,6 +106,7 @@ let
   # and libraries path.
   # We prefetch it, patch it, and override it in a global bazelrc.
   system = if stdenv.hostPlatform.isDarwin then "darwin" else "linux";
+  arch = stdenv.hostPlatform.parsed.cpu.name;
 
   remote_java_tools = stdenv.mkDerivation {
     name = "remote_java_tools_${system}";
@@ -493,9 +494,11 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
 
     # official wrapper scripts that searches for $WORKSPACE_ROOT/tools/bazel
-    # if it can’t find something in tools, it calls $out/bin/bazel-real
+    # if it can’t find something in tools, it calls $out/bin/bazel-{version}-{os_arch}
+    # The binary _must_ exist with this naming if your project contains a .bazelversion
+    # file.
     cp ./bazel_src/scripts/packages/bazel.sh $out/bin/bazel
-    mv ./bazel_src/output/bazel $out/bin/bazel-real
+    mv ./bazel_src/output/bazel $out/bin/bazel-${version}-${system}-${arch}
 
     # shell completion files
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions
@@ -534,7 +537,7 @@ stdenv.mkDerivation rec {
     exec "$BAZEL_REAL" "$@"
     EOF
 
-    # second call succeeds because it defers to $out/bin/bazel-real
+    # second call succeeds because it defers to $out/bin/bazel-{version}-{os_arch}
     hello_test
   '';
 

--- a/pkgs/development/tools/build-managers/bazel/src-deps.json
+++ b/pkgs/development/tools/build-managers/bazel/src-deps.json
@@ -55,11 +55,11 @@
             "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz"
         ]
     },
-    "android_tools_pkg-0.12.tar.gz": {
-        "name": "android_tools_pkg-0.12.tar.gz",
-        "sha256": "96c4eef4d195dd95e43a4259cf5b82a1e34f67333439e91955bbdc0e1c8e7a31",
+    "android_tools_pkg-0.13.tar.gz": {
+        "name": "android_tools_pkg-0.13.tar.gz",
+        "sha256": "3ca6a5e6576a9cda7c59f5fd33b1fe096725730712057c5893589ac15b019407",
         "urls": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.12.tar.gz"
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.13.tar.gz"
         ]
     },
     "bazel_j2objc": {
@@ -115,11 +115,11 @@
             "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
         ]
     },
-    "coverage_output_generator-v2.0.zip": {
-        "name": "coverage_output_generator-v2.0.zip",
-        "sha256": "3a6951051272d51613ac4c77af6ce238a3db321bf06506fde1b8866eb18a89dd",
+    "coverage_output_generator-v2.1.zip": {
+        "name": "coverage_output_generator-v2.1.zip",
+        "sha256": "96ac6bc9b9fbc67b532bcae562da1642409791e6a4b8e522f04946ee5cc3ff8e",
         "urls": [
-            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.0.zip"
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.1.zip"
         ]
     },
     "desugar_jdk_libs": {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The official Bazel wrapper script included from version 2.0.0 onwards enforces the actual `bazel` binary (previously named `bazel-real` in this package) has the following naming convention, if the root of your Bazel project contains a `.bazelversion` file: `bazel-${version}-${os}-${arch}`.

This modifies output binary name and, while we're at it, upgrades Bazel to 2.1.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
