### PR TITLE
marvin: 20.4.0 -> 20.5.0

### DIFF
--- a/pkgs/applications/science/chemistry/marvin/default.nix
+++ b/pkgs/applications/science/chemistry/marvin/default.nix
@@ -4,12 +4,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "marvin";
-  version = "20.4.0";
+  version = "20.5.0";
 
   src = fetchurl {
     name = "marvin-${version}.deb";
     url = "http://dl.chemaxon.com/marvin/${version}/marvin_linux_${versions.majorMinor version}.deb";
-    sha256 = "12kygxq24in7hbp7shkx1baqig8rwmzvv0d3kc3ld9sj9hb0a2n1";
+    sha256 = "0hv4jwjb2ihr2h7099ymd70qypci4spxxijwqkn5xcaf5vczzgh3";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Marvin is outdated, it should be updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
