### PR TITLE
openssl_1_0_2: mark as insecure; fixes #77503 (kinda)

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -7,7 +7,8 @@
 with stdenv.lib;
 
 let
-  common = { version, sha256, patches ? [], withDocs ? false }: stdenv.mkDerivation rec {
+  common = { version, sha256, patches ? [], withDocs ? false, extraMeta ? {} }:
+   stdenv.mkDerivation rec {
     pname = "openssl";
     inherit version;
 
@@ -130,7 +131,7 @@ let
       license = licenses.openssl;
       platforms = platforms.all;
       maintainers = [ maintainers.peti ];
-    };
+    } // extraMeta;
   };
 
 in {
@@ -145,6 +146,7 @@ in {
        then ./1.0.2/use-etc-ssl-certs-darwin.patch
        else ./1.0.2/use-etc-ssl-certs.patch)
     ];
+    extraMeta.knownVulnerabilities = [ "Support for OpenSSL 1.0.2 ended with 2019." ];
   };
 
   openssl_1_1 = common {


### PR DESCRIPTION
No vulnerabilities are know so far (to me), but still I'd go this way.  Especially for 20.03 it seems better to deprecate it before official release happens.

Current casualties:
```
$ ./maintainers/scripts/rebuild-amount.sh --print HEAD HEAD^
Estimating rebuild amount by counting changed Hydra jobs.
     87 x86_64-darwin
    161 x86_64-linux
```
<details><pre>
almanah.x86_64-linux                                                          /nix/store/gjwfikg9cgbl9b9s8q0d13vlp874qly5-almanah-0.12.0
ameba.x86_64-linux                                                            /nix/store/yqn3v41sgrhf56lj6q6kdvvi43wwqd1b-ameba-0.11.0
apeClex.x86_64-darwin                                                         /nix/store/9rawn25dszla1x6dv5h1pcxhp62pn3kp-ape-clex-2019-08-10
apeClex.x86_64-linux                                                          /nix/store/5bfi88lckh061z2px8rby4qy61hx5pk6-ape-clex-2019-08-10
ape.x86_64-darwin                                                             /nix/store/xlc5g6797kg3sq47z4sijs2sj0g8ywv4-ape-2019-08-10
ape.x86_64-linux                                                              /nix/store/bdvnphg1qgnm9hwyzf0gcsa6qd1zhlh7-ape-2019-08-10
aqemu.x86_64-linux                                                            /nix/store/0lcvc3rwdp5l717sr4ddhq19ayllknic-aqemu-0.9.2
arachne-pnr.x86_64-linux                                                      /nix/store/rfjd8rkp5gdyyvdjfll02ihs3kgcz7wi-arachne-pnr-2019.07.29
botan.x86_64-darwin                                                           /nix/store/zq0lhyivzpmzf43rjh1idrk18jn3w1nn-botan-1.10.17
botan.x86_64-linux                                                            /nix/store/6i4cj6fqzpdg1cd5l0z8gknz1wzzrr94-botan-1.10.17
bully.x86_64-linux                                                            /nix/store/qg9fx8mjn3pw2d8c9b5h6yyxiqbgxv07-bully-1.1
cadaver.x86_64-linux                                                          /nix/store/mvg2ig818m3l3xhm0g1cjln2mfrqa4vv-cadaver-0.23.3
ccrtp.x86_64-linux                                                            /nix/store/bw403pi3ggwlsa2jy0zw456jyb92syjc-ccrtp-2.1.2
cloud-init.x86_64-linux                                                       /nix/store/w6qxmcwdvhzpgmvrivc8av55p79qbb4h-cloud-init-0.7.9
cloud-utils.x86_64-linux                                                      /nix/store/lv5p9v18s3is1blnd329wbyhz0afqxd4-cloud-utils-0.30
couchdb.x86_64-linux                                                          /nix/store/n3wlj06msm4wq0g500zcbkckihimcfk6-couchdb-1.7.1
crystal_0_27.x86_64-darwin                                                    bin=/nix/store/6i9dsm67qfn2fdqvwhfvxniq24f3micg-crystal-0.27.2-bin;lib=/nix/store/nf4zrhnw82hpp8zkif33vc21zmln4jxw-crystal-0.27.2-lib;/nix/store/76zxxl5ag48j4nv274s6bjzvhzldk0fx-crystal-0.27.2
crystal_0_27.x86_64-linux                                                     bin=/nix/store/l7yf08h629p5wj3p6i6fkiadmmb437rm-crystal-0.27.2-bin;lib=/nix/store/nzba0xvkpgcc6h28bca0lw19bc1sq80q-crystal-0.27.2-lib;/nix/store/dbzsim1flpg7lz0yadvkqvaiy2r7vf88-crystal-0.27.2
crystal_0_29.x86_64-darwin                                                    bin=/nix/store/1z0rss7wg6k3is7irsma71k32v14xz2c-crystal-0.29.0-bin;lib=/nix/store/qlq8v5788f4v0iirxw8ia9dj0448cszj-crystal-0.29.0-lib;/nix/store/ngnz5xzj2a67332paf5yhqq2ynhmb794-crystal-0.29.0
crystal_0_29.x86_64-linux                                                     bin=/nix/store/j53318zj8smp9fsj6ygrrhivphm23rsl-crystal-0.29.0-bin;lib=/nix/store/2gjpsdk57qc0gq1pxhzfmd8bm3d5rxqv-crystal-0.29.0-lib;/nix/store/0xi1d8fv37dfj7vpa8ic2cr2m6s38h81-crystal-0.29.0
crystal_0_30.x86_64-darwin                                                    bin=/nix/store/p6rj5m4sp4vkyipg821pd0kmf3nhlvim-crystal-0.30.1-bin;lib=/nix/store/gamis3w5b3vyxvgg4d5l5qf4shjz50nk-crystal-0.30.1-lib;/nix/store/w6lgrylqz5l67h7yj47h6gri7cb6y56w-crystal-0.30.1
crystal_0_30.x86_64-linux                                                     bin=/nix/store/2xshvry5iraf0mmi149080ssa1847cnk-crystal-0.30.1-bin;lib=/nix/store/gmjr673nrhd6zh7j0g8zpynhp6hvpx6d-crystal-0.30.1-lib;/nix/store/dxgl2pbsps4jl474x7sas1fqjpqp62v2-crystal-0.30.1
crystal_0_31.x86_64-darwin                                                    bin=/nix/store/1nmbf3inqv4kifbf8bzkp1r4pknnrnci-crystal-0.31.1-bin;lib=/nix/store/mg6b8awiscsyqq9i8zj3mrcab0x7askv-crystal-0.31.1-lib;/nix/store/0c0ijxzd5c84rjq1anwk8acpfghwybk3-crystal-0.31.1
crystal_0_31.x86_64-linux                                                     bin=/nix/store/3ilqfnmf024kvk9l3rqjigai1cjqqnfa-crystal-0.31.1-bin;lib=/nix/store/xgnk28r7c5gnzq1if60x8kdgi5ycy898-crystal-0.31.1-lib;/nix/store/7416awh65n4vla2dj2346zkv91pwmjh6-crystal-0.31.1
crystal_0_32.x86_64-darwin                                                    bin=/nix/store/93snhnz19frlhvq0p1bhgl1ldfn1byc0-crystal-0.32.1-bin;lib=/nix/store/srs5xym2cg5saaawp7aiz4bqd6gxzcdn-crystal-0.32.1-lib;/nix/store/bl1vjk7hz99l4c3pysa893kgkaw417zz-crystal-0.32.1
crystal_0_32.x86_64-linux                                                     bin=/nix/store/r8kyl8wcd37xzyc2y57cb3fq124rbfdk-crystal-0.32.1-bin;lib=/nix/store/6n3nxicws8j0r93b4kmqcl3zwjmvi4wq-crystal-0.32.1-lib;/nix/store/fmnpbqcl1c06yw7zga7njyxkrascsg8p-crystal-0.32.1
crystal2nix.x86_64-darwin                                                     /nix/store/7i6jx6bcjd46gma4v79n85qzkc6jmm52-crystal2nix-unstable-2018-07-31
crystal2nix.x86_64-linux                                                      /nix/store/5gz0j3cahx0qalylb35fyd9d1qzwz8ji-crystal2nix-unstable-2018-07-31
crystal.x86_64-darwin                                                         bin=/nix/store/93snhnz19frlhvq0p1bhgl1ldfn1byc0-crystal-0.32.1-bin;lib=/nix/store/srs5xym2cg5saaawp7aiz4bqd6gxzcdn-crystal-0.32.1-lib;/nix/store/bl1vjk7hz99l4c3pysa893kgkaw417zz-crystal-0.32.1
crystal.x86_64-linux                                                          bin=/nix/store/r8kyl8wcd37xzyc2y57cb3fq124rbfdk-crystal-0.32.1-bin;lib=/nix/store/6n3nxicws8j0r93b4kmqcl3zwjmvi4wq-crystal-0.32.1-lib;/nix/store/fmnpbqcl1c06yw7zga7njyxkrascsg8p-crystal-0.32.1
cuter.x86_64-darwin                                                           /nix/store/9crjy63bma6ldbkc0fpskddzm14sv0bf-cuter-0.1
cuter.x86_64-linux                                                            /nix/store/zqwggvzn4wldsfsb7jbknly3mgrq6i9i-cuter-0.1
darwin.iproute2mac.x86_64-darwin                                              /nix/store/hhzjn9yh655rd7c9jjd4pws6bq2j71pr-iproute2mac-1.2.1
darwin.network_cmds.x86_64-darwin                                             /nix/store/298xqjscwz8nwh48rp1miyqsg6y0vb91-network_cmds-osx-10.11.6
debian-devscripts.x86_64-linux                                                /nix/store/3qc0chbghjkxqsj73yamhkjnx4wxn5ax-debian-devscripts-2.16.8
dkimproxy.x86_64-darwin                                                       /nix/store/gsl957g6sf0dd6m17zjkb892m2h4fdc2-dkimproxy-1.4.1
dkimproxy.x86_64-linux                                                        /nix/store/lgbzdl042a6fxab6j096xa08cl5frsyj-dkimproxy-1.4.1
dmg2img.x86_64-darwin                                                         /nix/store/b6fivfd2v6x0klb7y0aj4g4bgc4f00wg-dmg2img-1.6.7
dmg2img.x86_64-linux                                                          /nix/store/0ri4hb6lpr62nv6gjcb2df8qw6n5q756-dmg2img-1.6.7
elinks.x86_64-linux                                                           /nix/store/lq8wb5i620fg6ns6nm6msk46c79a5bvm-elinks-0.12pre6
erlangR18.x86_64-darwin                                                       /nix/store/a586mifs6hjkys8pimva03x2ssgmnk8k-erlang-18.3.4.8
erlangR18.x86_64-linux                                                        /nix/store/v7xx825bqpj3yz6p1l5in0lr5l2cp1kp-erlang-18.3.4.8
erlangR19.x86_64-darwin                                                       /nix/store/kc2sxrvkgvba6wlxvbr7jqsx9j54r3rm-erlang-19.3.6.11
erlangR19.x86_64-linux                                                        /nix/store/5qzvggil2c8pfzml1sb4j8pql7pzy4i3-erlang-19.3.6.11
ettercap.x86_64-darwin                                                        /nix/store/k37sl8yv0863863y4f9day5phlpm4638-ettercap-0.8.3
ettercap.x86_64-linux                                                         /nix/store/rz917v8hy1ykfxxqz883w9spx1xyx4s4-ettercap-0.8.3
fetchmail.x86_64-darwin                                                       /nix/store/1g499mdkyzr0dfx622ma9cabhwws8nnn-fetchmail-6.3.26
fetchmail.x86_64-linux                                                        /nix/store/60ggx5cvrh97w75yc6yb6j622x4wpq08-fetchmail-6.3.26
fribid.x86_64-linux                                                           /nix/store/j4bigs4cnwy2x11xx5fagcl9zb8chrzz-fribid-1.0.4
gitAndTools.git-dit.x86_64-darwin                                             /nix/store/skwmnfn5z9vk0p1d75qg9m6fxi8bskhk-git-dit-0.4.0
gitAndTools.git-dit.x86_64-linux                                              /nix/store/y8i86qb4hxmgvgrj23xcxvzqr9zaxm1y-git-dit-0.4.0
gitAndTools.thicket.x86_64-darwin                                             /nix/store/r22zqjaxk1caczh5aqivyjwzndfcf7ah-thicket-0.1.3
gitAndTools.thicket.x86_64-linux                                              /nix/store/fz2dj789qzajp234c26y4xx2nxp8q0bj-thicket-0.1.3
gitolite.x86_64-darwin                                                        /nix/store/pkgnp5qrfxaw5bva03bv0aj44skrm2ib-gitolite-3.6.11
glasgow.x86_64-linux                                                          /nix/store/dv4746hwd0f88c5ll7zbr3y3w9n6zkqv-python3.7-glasgow-unstable-2020-02-08
globalplatform.x86_64-linux                                                   /nix/store/f76a0sair18af89q853k36fbg5csh3wq-globalplatform-6.0.0
gnome3.evolution.x86_64-linux                                                 /nix/store/i7bzyjzvanjcy71kdjk051l21i3d7dsp-evolution-3.34.4
gogoclient.x86_64-linux                                                       /nix/store/k9vb2v0f5nf5fpaavjfjdjzx349i1q4n-gogoclient-1.2
gppcscconnectionplugin.x86_64-linux                                           /nix/store/z8ri30lv7r17m2p1i6wswyrmmyh4yank-gppcscconnectionplugin-1.1.0
gpshell.x86_64-linux                                                          /nix/store/z4gp2jrq9phgfkbvd88lmql3nkg00hv5-gpshell-1.4.4
gtmess.x86_64-linux                                                           /nix/store/qqk2andj9w27js4gk6k3hh6f2fqy5028-gtmess-0.97
guitone.x86_64-linux                                                          /nix/store/28l6clm77zs9k9xr31mw5j5q8m3la4pm-guitone-1.0-mtn-head
gvpe.x86_64-linux                                                             /nix/store/cj5xxfln6vx7j1q1gr1kxj2yn8n0hpi3-gvpe-3.0
hadoop_2_7.x86_64-linux                                                       /nix/store/ck5ddi0ibs198z43x7r7c8pbx0046cc0-hadoop-2.7.7
hadoop_2_8.x86_64-linux                                                       /nix/store/viajhifwnqgwb64hbg5siza52m9llq15-hadoop-2.8.4
hadoop_2_9.x86_64-linux                                                       /nix/store/i3zvb7shx8kys8bczan6rzlwlrbchvv5-hadoop-2.9.1
hadoop.x86_64-linux                                                           /nix/store/ck5ddi0ibs198z43x7r7c8pbx0046cc0-hadoop-2.7.7
icestorm.x86_64-linux                                                         /nix/store/jyd0c3i69lfvnil87g9r7l60kip73vip-icestorm-2019.09.13
icr.x86_64-linux                                                              /nix/store/pxpf5r8zp05gbjgvzaybdfy0p4p5aifd-icr-0.6.0
ikiwiki.x86_64-linux                                                          /nix/store/y44fcii1w9f3zfynj4kkh0snnl071hin-ikiwiki-3.20190228
ima-evm-utils.x86_64-linux                                                    /nix/store/s4d430gyyzgfxcfin12i83x7z00dcfx7-ima-evm-utils-1.1
imapproxy.x86_64-darwin                                                       /nix/store/lrkf7722zvm105kssa1v3wh2dvajp9z1-imapproxy-1.2.7
imapproxy.x86_64-linux                                                        /nix/store/ysyzjy4whrdlpvb45p19nini3n37kff9-imapproxy-1.2.7
imapsync.x86_64-linux                                                         /nix/store/xlg9hiw74ilccx7z77j7hq8p0asjjibc-imapsync-1.727
intecture-cli.x86_64-darwin                                                   /nix/store/rl8j25y94l1j93b573rxvqqilggjgpg1-intecture-cli-0.3.4
intecture-cli.x86_64-linux                                                    /nix/store/wz1098zxrg0a5qg6dd7wr0gcsw8g6imf-intecture-cli-0.3.4
iodine.x86_64-darwin                                                          /nix/store/pszbrc40gsfivcqh2ihx4bgny32k9cv5-iodine-0.7.0
ipmitool.x86_64-linux                                                         /nix/store/glqka9w5878bw4jwl5127rx0nafw87si-ipmitool-1.8.18
ipsecTools.x86_64-linux                                                       /nix/store/la5cfbnj7g9675zpa22pn0kba6r911nz-ipsec-tools-0.8.2
kinetic-cpp-client.x86_64-darwin                                              /nix/store/whskpb3k5wfzs5nzrjzd4bi9bb9l3h3w-kinetic-cpp-client-2015-04-14
kinetic-cpp-client.x86_64-linux                                               /nix/store/671l8jki3dmddv79cmszgv3ziq6kajni-kinetic-cpp-client-2015-04-14
lfe_1_2.x86_64-darwin                                                         /nix/store/zg5rsgdsgyqn4brngwvxa8aaws0yba5n-lfe-1.2.1
lfe_1_2.x86_64-linux                                                          /nix/store/dr7pvj8klq1hx7rlzx7bg1r7msl48zp4-lfe-1.2.1
libguestfs-with-appliance.x86_64-linux                                        /nix/store/32ki4xkppqsxw2sbp39i5q52rdd6bp3r-libguestfs-1.40.2
libguestfs.x86_64-linux                                                       /nix/store/zk9f3977g7py9lk9280kbhndg32h5avl-libguestfs-1.40.2
libksi.x86_64-darwin                                                          /nix/store/3x0h17awy2zp4m04qj7pdb0f0kmw1kfn-libksi-3.20.3025
libksi.x86_64-linux                                                           /nix/store/4p7f9pk5h8162k3ls11f1z2mrwz015z1-libksi-3.20.3025
libnats-c.x86_64-darwin                                                       dev=/nix/store/mdra8sdcfzzkklgayb7r1qz564iziqff-libnats-2.1.0-dev;/nix/store/4zq3vvgf3bz7daa9x1h90rgwj1jsav55-libnats-2.1.0
libnats-c.x86_64-linux                                                        debug=/nix/store/d25h8gw6xk9abgs9bn8z83lgcpgvdn7l-libnats-2.1.0-debug;dev=/nix/store/zv9bb2v0r12vg6349zn9sbajihvw0r0c-libnats-2.1.0-dev;/nix/store/awbr5zhim0fxb8i3y8dji28lqh28rwqj-libnats-2.1.0
longview.x86_64-linux                                                         /nix/store/mch8smhgsgqnby4kv0b6gn3sbncx6ba4-longview-1.1.5
magic-wormhole.x86_64-darwin                                                  /nix/store/841x6mmws9g6nns6yx9cs67nccd9imhd-python3.7-magic-wormhole-0.11.2
minikube.x86_64-linux                                                         /nix/store/zhisbizl698q9cs1qck5fqkb4y7xz12x-minikube-1.2.0
mint.x86_64-darwin                                                            /nix/store/5mvnr9yzrigfi93ncyyspabcl8ha2s8x-mint-0.7.1
mint.x86_64-linux                                                             /nix/store/yb4cdz22grirbh2zwhcw2y0kny8gkg6p-mint-0.7.1
mongodb.x86_64-darwin                                                         /nix/store/m27q9b45qnfydq3fvj3avyi8csywyrw3-mongodb-3.4.10
mongodb.x86_64-linux                                                          /nix/store/4bbpmb5sxmlc8dnr7z493ylqhb5g4c45-mongodb-3.4.10
monkeysphere.x86_64-linux                                                     /nix/store/88swf3gcvfg8lzz6n9mnmswqp58a5a6j-monkeysphere-0.44
monotone.x86_64-darwin                                                        /nix/store/dhk0kmxcy07g75g2d8khzciwjd06xp88-monotone-1.1
monotone.x86_64-linux                                                         /nix/store/wms3dx92lvd158dx21s0si8cp8qhn0cp-monotone-1.1
mysocketw.x86_64-darwin                                                       /nix/store/fdim1nba7xym22sqwzb9ml3yz7b7vqw0-mysocketw-031026
mysocketw.x86_64-linux                                                        /nix/store/v82li1w3l4gfvmc1irlayn6jkhyxmwb0-mysocketw-031026
neon_0_29.x86_64-darwin                                                       /nix/store/7754jm84zhcf69zi9fdrf2adg3hd6ay1-neon-0.29.6
neon_0_29.x86_64-linux                                                        /nix/store/45xfd1zs4xm9xvp5r2wc1an6za6cxbl6-neon-0.29.6
nextpnr.x86_64-linux                                                          /nix/store/gl6k6i4lxnz2ap5vk23syxcnls2fnv9r-nextpnr-2020.02.04
openssl_1_0_2.x86_64-darwin                                                   bin=/nix/store/b52d3q7iv14h5dswa53fv9fhidbkv77a-openssl-1.0.2u-bin;dev=/nix/store/6js61scnnns7l0dslv50m3zbzlb5gc10-openssl-1.0.2u-dev;man=/nix/store/gl5i9ik77grln95kh6ixi6d3cad6230v-openssl-1.0.2u-man;/nix/store/ndyin0ca6n2khwgy9dwq9w8lhixjvcwy-openssl-1.0.2u
openssl_1_0_2.x86_64-linux                                                    bin=/nix/store/dpfpvn8phv5b6x3q5dj5fdm6ccad3qkd-openssl-1.0.2u-bin;debug=/nix/store/f2d3izrxq9kivkh0yljwa17n0w5jx6hy-openssl-1.0.2u-debug;dev=/nix/store/ayj29jb18ddcd0z42abf7nww5sni1mwj-openssl-1.0.2u-dev;man=/nix/store/lvywg2crmm8l9k0nxp156r9gj1jvqwq7-openssl-1.0.2u-man;/nix/store/vg37azxslig2ysv6pnm3x3pfsbdld0ln-openssl-1.0.2u
out-of-tree.x86_64-darwin                                                     bin=/nix/store/kk1n7hhf2n3klxfhahcgrlvk0xk34iq8-out-of-tree-1.2.1-bin;/nix/store/baqwmj4yy4h4qp2zkgvvlbxdmi73z8zc-out-of-tree-1.2.1
out-of-tree.x86_64-linux                                                      bin=/nix/store/7j3v81b5560xbsj1f83jr97vygh4rfay-out-of-tree-1.2.1-bin;/nix/store/j7ij1wqjp0k1i6wrcw7njabj6x027g19-out-of-tree-1.2.1
pakcs.x86_64-linux                                                            /nix/store/88gzhyk89l3dknnpqxkz5w7rpp8c21fa-pakcs-2.2.0
pam_ssh_agent_auth.x86_64-linux                                               /nix/store/dnpbmv7s5kn8rkbimi0i2gxalhpakbz4-pam_ssh_agent_auth-0.10.3
pbis-open.x86_64-linux                                                        /nix/store/8ssks1i2zl8hing96dyv2d8kbssqgws7-pbis-open-9.1.0;sys=/nix/store/viz4r2y22j9y5afas1f1qmqrri7agprh-pbis-open-9.1.0-sys
perl528Packages.CryptOpenSSLAES.x86_64-darwin                                 devdoc=/nix/store/lj1il4w46ixz1pzgv41gk7fqrsxngamn-perl5.28.2-Crypt-OpenSSL-AES-0.02-devdoc;/nix/store/zmfp1x2rm2rs00gijaxj3i3zgazclp1q-perl5.28.2-Crypt-OpenSSL-AES-0.02
perl528Packages.CryptOpenSSLAES.x86_64-linux                                  devdoc=/nix/store/l9ly745wg1a0bl2dm52i3a5m8p7ffp0f-perl5.28.2-Crypt-OpenSSL-AES-0.02-devdoc;/nix/store/945qjmnha45w83ncgy4105a44sdd22bl-perl5.28.2-Crypt-OpenSSL-AES-0.02
perl528Packages.CryptOpenSSLBignum.x86_64-darwin                              devdoc=/nix/store/yvf1fm6h9lphvr6xmzyxhd9wlr0jcd77-perl5.28.2-Crypt-OpenSSL-Bignum-0.09-devdoc;/nix/store/1ax64v1s30zg5wbw3ky29bf7yqd4bmv0-perl5.28.2-Crypt-OpenSSL-Bignum-0.09
perl528Packages.CryptOpenSSLBignum.x86_64-linux                               devdoc=/nix/store/03lim4clxc0g09ia893x6ci97gx9ib3r-perl5.28.2-Crypt-OpenSSL-Bignum-0.09-devdoc;/nix/store/8b80mfxvjpb9j1yh4aiqkadj67lkl412-perl5.28.2-Crypt-OpenSSL-Bignum-0.09
perl528Packages.CryptOpenSSLRSA.x86_64-darwin                                 devdoc=/nix/store/3rkj8vjkz7pna218qcdzbh2slgzj6mx3-perl5.28.2-Crypt-OpenSSL-RSA-0.31-devdoc;/nix/store/36g4gyvf72v0n7saqwpcjq0vk9ms5p53-perl5.28.2-Crypt-OpenSSL-RSA-0.31
perl528Packages.CryptOpenSSLRSA.x86_64-linux                                  devdoc=/nix/store/g457z3pprlgylpyw9c3spi898d2qkhfm-perl5.28.2-Crypt-OpenSSL-RSA-0.31-devdoc;/nix/store/ks3xlp4m8hknqzq1bzry401qvklsk353-perl5.28.2-Crypt-OpenSSL-RSA-0.31
perl528Packages.CryptSSLeay.x86_64-darwin                                     devdoc=/nix/store/dhp2lpn7rm42ggvxarwvb598yfbfzni2-perl5.28.2-Crypt-SSLeay-0.72-devdoc;/nix/store/9xb4pvva5x9q9wrppivwx3mqsipk92j9-perl5.28.2-Crypt-SSLeay-0.72
perl528Packages.CryptSSLeay.x86_64-linux                                      devdoc=/nix/store/9hhbz2zm68blvf5l55msgjdi0kjnk94g-perl5.28.2-Crypt-SSLeay-0.72-devdoc;/nix/store/244vhlry4kldfy79k0ill7v7mpynla10-perl5.28.2-Crypt-SSLeay-0.72
perl528Packages.MailDKIM.x86_64-darwin                                        devdoc=/nix/store/cpqns8ylzg9fyli44izgdk3iwx7dw4s1-perl5.28.2-Mail-DKIM-0.58-devdoc;/nix/store/2vxgi8gvnva77gj70lcksn1k5sjdnrd5-perl5.28.2-Mail-DKIM-0.58
perl528Packages.MailDKIM.x86_64-linux                                         devdoc=/nix/store/zpkpr63qkc0a8b3a30gbhfc0mm9y0bg3-perl5.28.2-Mail-DKIM-0.58-devdoc;/nix/store/2923y18k4ix09p5kql1p33zawznpc16g-perl5.28.2-Mail-DKIM-0.58
perl530Packages.CryptOpenSSLAES.x86_64-darwin                                 devdoc=/nix/store/lr2b3k7ihxlflh36lhv64rzxxj98aqw5-perl5.30.1-Crypt-OpenSSL-AES-0.02-devdoc;/nix/store/nsp0rcbpifhqhjx5cmwfwy0qacbb81d2-perl5.30.1-Crypt-OpenSSL-AES-0.02
perl530Packages.CryptOpenSSLAES.x86_64-linux                                  devdoc=/nix/store/c8q3rp5n5z10fm7bx2qxybbdhgwgg4j4-perl5.30.1-Crypt-OpenSSL-AES-0.02-devdoc;/nix/store/5y00n8svai73p21nykj02x7gl3pgm6k6-perl5.30.1-Crypt-OpenSSL-AES-0.02
perl530Packages.CryptOpenSSLBignum.x86_64-darwin                              devdoc=/nix/store/86ijkssdrm7nan5r69hxq5zv3chg2knw-perl5.30.1-Crypt-OpenSSL-Bignum-0.09-devdoc;/nix/store/ljgd6m27mwvfk8907pyczmzzqa8k2hdd-perl5.30.1-Crypt-OpenSSL-Bignum-0.09
perl530Packages.CryptOpenSSLBignum.x86_64-linux                               devdoc=/nix/store/d0qmrq19s1q19p078pa69w0v8xp4kggk-perl5.30.1-Crypt-OpenSSL-Bignum-0.09-devdoc;/nix/store/8hng5azkmvs0md5ivvzfbmsrhzb6adrh-perl5.30.1-Crypt-OpenSSL-Bignum-0.09
perl530Packages.CryptOpenSSLRSA.x86_64-darwin                                 devdoc=/nix/store/s2xl86grl2bynxcmdslc38nxch4xmabi-perl5.30.1-Crypt-OpenSSL-RSA-0.31-devdoc;/nix/store/f70c5ji0akl5x6nsbm1bzg9fqyxh5xis-perl5.30.1-Crypt-OpenSSL-RSA-0.31
perl530Packages.CryptOpenSSLRSA.x86_64-linux                                  devdoc=/nix/store/y7s51pzk13z1zah11jc7y41bi2q1ks5x-perl5.30.1-Crypt-OpenSSL-RSA-0.31-devdoc;/nix/store/01qbi7zry3w4im2q517aw5qjd8qwlraj-perl5.30.1-Crypt-OpenSSL-RSA-0.31
perl530Packages.CryptSSLeay.x86_64-darwin                                     devdoc=/nix/store/jpmdzpx5hljzzbgi36pkk6b5lp56jgkz-perl5.30.1-Crypt-SSLeay-0.72-devdoc;/nix/store/p0gn49vlis7zdq1ndxagb7939n0yf6h8-perl5.30.1-Crypt-SSLeay-0.72
perl530Packages.CryptSSLeay.x86_64-linux                                      devdoc=/nix/store/3wrlvv1cgy267yy2v131hc945v4s9p15-perl5.30.1-Crypt-SSLeay-0.72-devdoc;/nix/store/hgnfp8arrx4myg2n9cqja32jq03cyzyi-perl5.30.1-Crypt-SSLeay-0.72
perl530Packages.MailDKIM.x86_64-darwin                                        devdoc=/nix/store/hldhds5jlmv25n2hydx5jhqhghsiznqr-perl5.30.1-Mail-DKIM-0.58-devdoc;/nix/store/0zhqkpsa914rh7n1gmsfdami3wdgmfh3-perl5.30.1-Mail-DKIM-0.58
perl530Packages.MailDKIM.x86_64-linux                                         devdoc=/nix/store/njwmbgq7b3hbfrndf49j0ri9kjzpk531-perl5.30.1-Mail-DKIM-0.58-devdoc;/nix/store/awq6rqqzah9wl2prvm435x5pggmzpf53-perl5.30.1-Mail-DKIM-0.58
pgadmin.x86_64-linux                                                          /nix/store/3kakw0i1mj3jrb8d56l28j20kydi60kw-pgadmin3-1.22.2
pig.x86_64-linux                                                              /nix/store/gvr0rp0k44rs9rw4v5lghrjb22qjnbmd-pig-0.17.0
pivxd.x86_64-darwin                                                           /nix/store/yxdgvsqcd63w1xwf5wfxrvpz3q315zg1-pivx-4.0.2
pivxd.x86_64-linux                                                            /nix/store/570bi5r3xw13932lrmd07m5bzk4694yr-pivx-4.0.2
pivx.x86_64-darwin                                                            /nix/store/72spq9426cl0sdw7cdghlg3lcayga9b7-pivx-4.0.2
pivx.x86_64-linux                                                             /nix/store/indjmjvny4gzfsl0wn16aj7gfj9542qv-pivx-4.0.2
powershell.x86_64-darwin                                                      /nix/store/2p8qb01r5v000m68w0jmrfqf5hhc2qc4-powershell-6.2.3
powershell.x86_64-linux                                                       /nix/store/m7hlf3xqkv3xx9d067ssc7f2kf8s6sz8-powershell-6.2.3
proxytunnel.x86_64-linux                                                      /nix/store/63ixnb334cizm7jw0gl9d4609b9ixa5q-proxytunnel-1.9.0
pypy27.x86_64-darwin                                                          /nix/store/2mkizaixq16r7l05vjappkp4wjlkin80-pypy-7.1.1
pypy27.x86_64-linux                                                           /nix/store/dj5c6x27pdij6cd95ncsfw7cfj66wni0-pypy-7.1.1
pypy2.x86_64-darwin                                                           /nix/store/2mkizaixq16r7l05vjappkp4wjlkin80-pypy-7.1.1
pypy2.x86_64-linux                                                            /nix/store/dj5c6x27pdij6cd95ncsfw7cfj66wni0-pypy-7.1.1
pypy36.x86_64-darwin                                                          /nix/store/17scawd0yaijq57cr2n9irm7paaslkhn-pypy3-7.1.1
pypy36.x86_64-linux                                                           /nix/store/6y9iah6jgy92n2r700r5mwdrbm3lsgq5-pypy3-7.1.1
pypy3.x86_64-darwin                                                           /nix/store/17scawd0yaijq57cr2n9irm7paaslkhn-pypy3-7.1.1
pypy3.x86_64-linux                                                            /nix/store/6y9iah6jgy92n2r700r5mwdrbm3lsgq5-pypy3-7.1.1
pypy.x86_64-darwin                                                            /nix/store/2mkizaixq16r7l05vjappkp4wjlkin80-pypy-7.1.1
pypy.x86_64-linux                                                             /nix/store/dj5c6x27pdij6cd95ncsfw7cfj66wni0-pypy-7.1.1
python27Packages.guestfs.x86_64-linux                                         /nix/store/4f5bwbcybxb3szhm0fvv09dxn7fmn8d1-python2.7-guestfs-1.40.1
python37Packages.arviz.x86_64-darwin                                          /nix/store/3df7ql5mjlfpd9csww11jw56dymqm7mi-python3.7-arviz-0.6.1
python37Packages.arviz.x86_64-linux                                           /nix/store/qvzn2a9apnywf4z6y5nm8v30zjk53jgq-python3.7-arviz-0.6.1
python37Packages.baselines.x86_64-linux                                       /nix/store/2pr359iqsa5l8viy5y9mmi83mwsz22as-python3.7-baselines-0.1.6
python37Packages.dm-sonnet.x86_64-linux                                       /nix/store/k2ngyxnw7sdz8zaijry8x0gmwl4ly2m6-python3.7-dm-sonnet-1.33
python37Packages.edward.x86_64-darwin                                         /nix/store/qybqp9l1jsvx0lsjq37nil44drjbzic5-python3.7-edward-1.3.5
python37Packages.edward.x86_64-linux                                          /nix/store/bdq7jlibn5jqw4c81nrfsg73r07r4xp6-python3.7-edward-1.3.5
python37Packages.glasgow.x86_64-linux                                         /nix/store/dv4746hwd0f88c5ll7zbr3y3w9n6zkqv-python3.7-glasgow-unstable-2020-02-08
python37Packages.graph_nets.x86_64-linux                                      /nix/store/ip0cr1nci3bqw7iwx23wfskah7v21fhw-python3.7-graph_nets-1.0.5
python37Packages.guestfs.x86_64-linux                                         /nix/store/zqdq2lkc5ap7kbbj6l50hc93f25gnplm-python3.7-guestfs-1.40.1
python37Packages.magic-wormhole.x86_64-darwin                                 /nix/store/841x6mmws9g6nns6yx9cs67nccd9imhd-python3.7-magic-wormhole-0.11.2
python37Packages.optuna.x86_64-linux                                          /nix/store/k52ns11ijg7hqbl5gwnvwyrabv0bvgc7-python3.7-optuna-0.19.0
python37Packages.rl-coach.x86_64-linux                                        /nix/store/sc1vidq441nd35cwym1dfyz7jlj90rxd-python3.7-rl-coach-1.0.1
python37Packages.tensorflow-build.x86_64-darwin                               /nix/store/2hs4c1n7dvscj6857n8caq5c8jvbf0y4-python3.7-tensorflow-1.15.0
python37Packages.tensorflow-build.x86_64-linux                                /nix/store/aq4am0dq6b49s0j4cx4d99pcjyrf5fj1-python3.7-tensorflow-1.15.0
python37Packages.tensorflow-probability.x86_64-darwin                         /nix/store/rcv0r9b0vlbrx7crq1qyqc4g790ql2fd-python3.7-tensorflow_probability-0.7
python37Packages.tensorflow-probability.x86_64-linux                          /nix/store/ms7nim58qw19xya7pkah4mrai6nsjnj7-python3.7-tensorflow_probability-0.7
python37Packages.tensorflowWithoutCuda.x86_64-darwin                          /nix/store/2hs4c1n7dvscj6857n8caq5c8jvbf0y4-python3.7-tensorflow-1.15.0
python37Packages.tensorflowWithoutCuda.x86_64-linux                           /nix/store/aq4am0dq6b49s0j4cx4d99pcjyrf5fj1-python3.7-tensorflow-1.15.0
python37Packages.tensorflow.x86_64-darwin                                     /nix/store/2hs4c1n7dvscj6857n8caq5c8jvbf0y4-python3.7-tensorflow-1.15.0
python37Packages.tensorflow.x86_64-linux                                      /nix/store/aq4am0dq6b49s0j4cx4d99pcjyrf5fj1-python3.7-tensorflow-1.15.0
python37Packages.tflearn.x86_64-darwin                                        /nix/store/k6cgw5ill69f9cazzaflmvl8ckbwfiky-python3.7-tflearn-0.3.2
python37Packages.tflearn.x86_64-linux                                         /nix/store/sxd4m448gc1am7zciyiafx320qbsxydz-python3.7-tflearn-0.3.2
python38Packages.arviz.x86_64-darwin                                          /nix/store/dcfg7146mz9kvp0q3afm20xj3g3zg9hs-python3.8-arviz-0.6.1
python38Packages.arviz.x86_64-linux                                           /nix/store/vj2im8m4jjpk4mv6pdzr3bmmgqmaa8y2-python3.8-arviz-0.6.1
python38Packages.baselines.x86_64-linux                                       /nix/store/3m4rw3nzxsbi3dajkfbf5kfcfz3lr1l2-python3.8-baselines-0.1.6
python38Packages.dm-sonnet.x86_64-linux                                       /nix/store/phscyzvrls2najwzppgp8lyqz8yv73fd-python3.8-dm-sonnet-1.33
python38Packages.edward.x86_64-darwin                                         /nix/store/cd6zldny562k229sainqv2kdazk4w8ls-python3.8-edward-1.3.5
python38Packages.edward.x86_64-linux                                          /nix/store/x550wiizwc5ldqpy2s564l9jrpdvv5r6-python3.8-edward-1.3.5
python38Packages.graph_nets.x86_64-linux                                      /nix/store/0lvlkrmgdwmj2prixxn3024xjfdva8lb-python3.8-graph_nets-1.0.5
python38Packages.guestfs.x86_64-linux                                         /nix/store/806s9iqfmvq95znd757q1k5z6iy7jh4l-python3.8-guestfs-1.40.1
python38Packages.magic-wormhole.x86_64-darwin                                 /nix/store/6y24y0csmkq0fn5d5fbkb3a0v3xzwz5x-python3.8-magic-wormhole-0.11.2
python38Packages.optuna.x86_64-linux                                          /nix/store/xn16piqlkfwghw9smg7720lxfipm8b98-python3.8-optuna-0.19.0
python38Packages.rl-coach.x86_64-linux                                        /nix/store/7dy4jzwib6c7llqw2fc89n1i6fxbjcd9-python3.8-rl-coach-1.0.1
python38Packages.tensorflow-build.x86_64-darwin                               /nix/store/flzxjqkx6ymn6h3pgxg1ax2ss9xpj2vk-python3.8-tensorflow-1.15.0
python38Packages.tensorflow-build.x86_64-linux                                /nix/store/nsf5psnaivscxxb58lq7q14rr2j67p0k-python3.8-tensorflow-1.15.0
python38Packages.tensorflow-probability.x86_64-darwin                         /nix/store/0lwg16aa2xnqpi5rnl6sly86qmhxngj8-python3.8-tensorflow_probability-0.7
python38Packages.tensorflow-probability.x86_64-linux                          /nix/store/cbvs6mmi9wqrrab6czp92zvap6dnijvn-python3.8-tensorflow_probability-0.7
python38Packages.tensorflowWithoutCuda.x86_64-darwin                          /nix/store/flzxjqkx6ymn6h3pgxg1ax2ss9xpj2vk-python3.8-tensorflow-1.15.0
python38Packages.tensorflowWithoutCuda.x86_64-linux                           /nix/store/nsf5psnaivscxxb58lq7q14rr2j67p0k-python3.8-tensorflow-1.15.0
python38Packages.tensorflow.x86_64-darwin                                     /nix/store/flzxjqkx6ymn6h3pgxg1ax2ss9xpj2vk-python3.8-tensorflow-1.15.0
python38Packages.tensorflow.x86_64-linux                                      /nix/store/nsf5psnaivscxxb58lq7q14rr2j67p0k-python3.8-tensorflow-1.15.0
python38Packages.tflearn.x86_64-darwin                                        /nix/store/x5n5sj40bqm76aijjwv3gc0qnpghd1mq-python3.8-tflearn-0.3.2
python38Packages.tflearn.x86_64-linux                                         /nix/store/s6d8wyc2bkh239niqkx30w43jmyg32ax-python3.8-tflearn-0.3.2
qemu_kvm.x86_64-darwin                                                        ga=/nix/store/jhdn9lhjbw2q0yzlhgi1c46k9ndvipbi-qemu-host-cpu-only-4.2.0-ga;/nix/store/60b0rb0vsg5cmcqqc5vk535ca0gc5nn7-qemu-host-cpu-only-4.2.0
qemu_kvm.x86_64-linux                                                         ga=/nix/store/qyq5xz042p3f9wp31q1xygcbx595py8n-qemu-host-cpu-only-4.2.0-ga;/nix/store/ncmfjv6pxxghl76nmc9w53fwm8cvhzh5-qemu-host-cpu-only-4.2.0
qemu_test.x86_64-darwin                                                       ga=/nix/store/qgs2yv0zjd8q7if5h8x4sjdczm1yd0mj-qemu-host-cpu-only-for-vm-tests-4.2.0-ga;/nix/store/dbm4vng53amhwwj9x4hf6520v425973a-qemu-host-cpu-only-for-vm-tests-4.2.0
qemu_test.x86_64-linux                                                        ga=/nix/store/26xrid63a4y0n214mg9vms4jik69zmf7-qemu-host-cpu-only-for-vm-tests-4.2.0-ga;/nix/store/9nxvdkx3cs4z2cmb45dbwc0da0l8zmrc-qemu-host-cpu-only-for-vm-tests-4.2.0
qemu-utils.x86_64-linux                                                       /nix/store/287m1cpqlpybc4hf991f5ggxsn7nw6w3-qemu-utils-4.2.0
qemu.x86_64-darwin                                                            ga=/nix/store/91ch1ws5ni649lfw0wmxs88ywq5v9nfj-qemu-4.2.0-ga;/nix/store/z7mdqczvgmg0kwl2vsnmcsl5nrwns26v-qemu-4.2.0
qemu.x86_64-linux                                                             ga=/nix/store/xl63h8lz4ls9gx86rjgdh59jkmrd4g3h-qemu-4.2.0-ga;/nix/store/p6mhrlyp43grvjnc8zn0nill3nfrbakc-qemu-4.2.0
qemu_xen_4_10-light.x86_64-linux                                              ga=/nix/store/82slv8arga78cjv1axz5p08kbkvps1p5-qemu-xen-host-cpu-only-4.2.0-ga;/nix/store/4q4cjy60gnxcrsw8346pizym2fpyyaj3-qemu-xen-host-cpu-only-4.2.0
qemu_xen_4_10.x86_64-linux                                                    ga=/nix/store/2y1jin071l28w6g0j2nv37ldnf0fmajv-qemu-xen-host-cpu-only-4.2.0-ga;/nix/store/d51kajzbm55kj3hbc765mspcdyvq055x-qemu-xen-host-cpu-only-4.2.0
qemu_xen_4_8-light.x86_64-linux                                               ga=/nix/store/26aac9xa743jmvlmpxy3bjrmcm1a95db-qemu-xen-host-cpu-only-4.2.0-ga;/nix/store/nay8cxj8slb34k8jkzy35hgs72ifh1dg-qemu-xen-host-cpu-only-4.2.0
qemu_xen_4_8.x86_64-linux                                                     ga=/nix/store/jjfb93j6n49sgbr7d5lilj6yx98dbq37-qemu-xen-host-cpu-only-4.2.0-ga;/nix/store/aqhjaqz6lksq9xc46p7rpxcbxxq63509-qemu-xen-host-cpu-only-4.2.0
qemu_xen-light.x86_64-linux                                                   ga=/nix/store/26aac9xa743jmvlmpxy3bjrmcm1a95db-qemu-xen-host-cpu-only-4.2.0-ga;/nix/store/nay8cxj8slb34k8jkzy35hgs72ifh1dg-qemu-xen-host-cpu-only-4.2.0
qemu_xen.x86_64-linux                                                         ga=/nix/store/jjfb93j6n49sgbr7d5lilj6yx98dbq37-qemu-xen-host-cpu-only-4.2.0-ga;/nix/store/aqhjaqz6lksq9xc46p7rpxcbxxq63509-qemu-xen-host-cpu-only-4.2.0
reposurgeon.x86_64-darwin                                                     /nix/store/0p220j8v27cpnzklnjmrk89vy1bd42n0-reposurgeon-3.44
reposurgeon.x86_64-linux                                                      /nix/store/f6azapi2vb9b0my560vfd4ci3rbagn97-reposurgeon-3.44
rsyslog.x86_64-linux                                                          /nix/store/d90lmr4c92jzvgzzsj5n3fc6iccgvlav-rsyslog-8.2001.0
rt.x86_64-darwin                                                              /nix/store/7i9gwy243cknvkdhk8hcirdr7h4i90cz-rt-4.4.4
rt.x86_64-linux                                                               /nix/store/d45pl6w6mbjdxypsnhc9l68bvpyq1bil-rt-4.4.4
scry.x86_64-darwin                                                            /nix/store/p6ym1zb9rbs7wh4imp6l0k4i8cmwlz51-scry-0.8.1
scry.x86_64-linux                                                             /nix/store/7g8sa7f608k6kfcylhsmy3fq1289pnb5-scry-0.8.1
shards.x86_64-darwin                                                          /nix/store/i9ww8fgc60rypamnmg6amyf2hn40pf8w-shards-0.9.0
shards.x86_64-linux                                                           /nix/store/zyiy3mhdg67l8sfhy98b0dd8044k7zk0-shards-0.9.0
shellinabox.x86_64-linux                                                      /nix/store/80v0s4vpkmm29v50jvfqk4pqdhzmf47c-shellinabox-2.20
sipwitch.x86_64-linux                                                         /nix/store/14c4bqmg1qp7fa3lii5lxmsgcjddskyx-sipwitch-1.9.15
softether_4_25.x86_64-linux                                                   /nix/store/573i8mfhgqjlmj0gp0jwfvczx3aywy7w-softether-4.25
softhsm.x86_64-darwin                                                         /nix/store/d165wrihnl0d21k2s7jh719kar1kz7jr-softhsm-2.5.0
softhsm.x86_64-linux                                                          /nix/store/fgr2axcxbh81631m9pnvirl9x2c3yk20-softhsm-2.5.0
spamassassin.x86_64-darwin                                                    devdoc=/nix/store/1zg2dms4fq9sgi91kgq2wqzsb95d0b1m-perl5.30.1-SpamAssassin-3.4.3-devdoc;/nix/store/5qr0icn0dw44hgdymaazzvg1x8yf7qhy-perl5.30.1-SpamAssassin-3.4.3
spamassassin.x86_64-linux                                                     devdoc=/nix/store/a86vdkjpy01mxd4rswk6wwhhbqajb8xk-perl5.30.1-SpamAssassin-3.4.3-devdoc;/nix/store/47lrs5s0ggx3l315n6j3x2dixbz2pvnl-perl5.30.1-SpamAssassin-3.4.3
spark.x86_64-linux                                                            /nix/store/n60f2275dpyy1glf4c835azrq9lawmxf-spark-2.4.4
sshuttle.x86_64-darwin                                                        /nix/store/nn0bn6k5q7ysv7jhf7gadqcdrgk7pmrh-sshuttle-0.78.5
sslscan.x86_64-darwin                                                         /nix/store/xsyy3qcr2hx1s2pdxz9mn2sqa0z1rkky-sslscan-1.11.13
sslscan.x86_64-linux                                                          /nix/store/2763xm8nih609s09dz6msi4qs1qgwg0k-sslscan-1.11.13
swiPrologWithGui.x86_64-linux                                                 /nix/store/h6c25gc2i6348lvbmkkng4568cjhv270-swi-prolog-8.1.15
swiProlog.x86_64-darwin                                                       /nix/store/qhxxhxk9hfln5wgswp32yymwyaf5aggj-swi-prolog-8.1.15
swiProlog.x86_64-linux                                                        /nix/store/ix34r4pcwqhl1mihpkq3ssmvi7ya32nw-swi-prolog-8.1.15
sympa.x86_64-darwin                                                           /nix/store/i9m2hf7j1iwy55nnj7m00pinzspfj484-sympa-6.2.52
sympa.x86_64-linux                                                            /nix/store/yxjmy9s4dqf5g3p74lfl0h1rmrdv3869-sympa-6.2.52
tcltls.x86_64-darwin                                                          /nix/store/i0xv9qf71l44dalvxbw8di23fnbipxrc-tcltls-1.6.7
tcltls.x86_64-linux                                                           /nix/store/qjjjvgk9s11564fzis7cy1h4pgaas2kf-tcltls-1.6.7
tests.nixos-functions.nixosTest-test.x86_64-linux                             /nix/store/6ysniriibs7dsl93i33nfigfgpqrmzgl-vm-test-run-nixosTest-test
tor-arm.x86_64-darwin                                                         man=/nix/store/2yfscr0gsliy9fapk2692rqpj58qww5g-tor-arm-1.4.5.0-man;/nix/store/27vpckxi5kjnkyy5ggs81cx7md0aqcd8-tor-arm-1.4.5.0
twinkle.x86_64-linux                                                          /nix/store/5mx5kimdyfqp3ipqkzfdjrg8pl53dyxz-twinkle-1.10.2
ucommon_openssl.x86_64-linux                                                  /nix/store/44nim8280qnhhsyac39zhivbjzqjk892-ucommon-7.0.0
ucommon.x86_64-linux                                                          /nix/store/44nim8280qnhhsyac39zhivbjzqjk892-ucommon-7.0.0
vagrant.x86_64-linux                                                          /nix/store/zg6li6j47lc8nwq36gk7hk12lyhkjvkp-vagrant-2.2.7
vde2.x86_64-darwin                                                            /nix/store/ga8fwm74aa9n16cpni8iapwkmri4qm3w-vde2-2.3.2
vde2.x86_64-linux                                                             /nix/store/psad66prfdn96q0sz3m83jgq0ijq3gwl-vde2-2.3.2
virtuoso6.x86_64-linux                                                        dev=/nix/store/bs0b8zbylfgmg27sqgrx9ccrvphal97f-virtuoso-opensource-6.1.6-dev;doc=/nix/store/bcyry8fyxpbxdbp6svms0vylpykdl9lm-virtuoso-opensource-6.1.6-doc;/nix/store/dbwazkf2f1wlf26wavmxz2czsmryanaw-virtuoso-opensource-6.1.6
virtuoso7.x86_64-linux                                                        /nix/store/r0dh7k0rbawa7m0nvj4mmax9x4d4izkr-virtuoso-opensource-7.2.4.2
virtuoso.x86_64-linux                                                         dev=/nix/store/bs0b8zbylfgmg27sqgrx9ccrvphal97f-virtuoso-opensource-6.1.6-dev;doc=/nix/store/bcyry8fyxpbxdbp6svms0vylpykdl9lm-virtuoso-opensource-6.1.6-doc;/nix/store/dbwazkf2f1wlf26wavmxz2czsmryanaw-virtuoso-opensource-6.1.6
vtun.x86_64-linux                                                             /nix/store/iq7mc62bd1r2163rwvgr630r2l0aiapr-vtun-3.0.4
wraith.x86_64-linux                                                           /nix/store/hbvfkza5x49ixggclxqyyv0xnj416d9y-wraith-1.4.7
yaws.x86_64-linux                                                             /nix/store/06d4wh60c2yrgalnaxbr44s2kdvhlmb9-yaws-2.0.6
</pre></details>


See also the discussion thread on https://github.com/NixOS/nixpkgs/issues/77503

20.03: /cc @NixOS/nixos-release-managers.  19.09: hopefully there won't be any notable vulnerabilities before 19.09 support ends :-)