### PR TITLE
treewide: add a debug-output to a few packages

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "man" "doc" ];
+  separateDebugInfo = true;
 
   nativeBuildInputs = [ makeWrapper xorg.libXt ];
 

--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -62,6 +62,7 @@ buildPythonApplication rec {
   propagatedBuildInputs = stdenv.lib.optional stdenv.isLinux libGL;
 
   outputs = [ "out" "terminfo" ];
+  separateDebugInfo = true;
 
   patches = [
     ./fix-paths.patch

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     ./load-configuration-from-etc.patch
   ];
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     pkgconfig meson ninja scdoc
   ];

--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -28,7 +28,7 @@ in symlinkJoin {
   name = "sway-${sway-unwrapped.version}";
 
   paths = (optional withBaseWrapper baseWrapper)
-    ++ [ sway-unwrapped ];
+    ++ [ sway-unwrapped (sway-unwrapped.debug or null) ];
 
   nativeBuildInputs = [ makeWrapper ]
     ++ (optional withGtkWrapper wrapGAppsHook);

--- a/pkgs/development/tools/jq/default.nix
+++ b/pkgs/development/tools/jq/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "doc" "man" "dev" "lib" "out" ];
 
+  separateDebugInfo = true;
+
   buildInputs = [ oniguruma ];
 
   configureFlags =

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     sha256 = "09viyfv5j2rl6ly52b2xlc2zbmb6i22dv89jc6823bzdjjimkrg6";
   };
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     autoreconfHook
     docutils

--- a/pkgs/tools/graphics/wdisplays/default.nix
+++ b/pkgs/tools/graphics/wdisplays/default.nix
@@ -7,6 +7,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ gtk3 epoxy wayland ];
 
+  separateDebugInfo = true;
+
   src = fetchFromGitHub {
     owner = "cyclopsian";
     repo = "wdisplays";

--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0mrwpb3cpn3ai7ar33m31yklj64c3pp576vh1naqff6f21pq5mnr";
   };
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [ python3 ];
   buildInputs =
     [ ncurses ] ++


### PR DESCRIPTION
###### Motivation for this change

After learning about the optional [debug](https://nixos.wiki/wiki/Debug_Symbols)-output I realized that only a few packages provide debug symbols. This PR adds the `debug`-output to an arbitrary list of packages to spread the usage of this feature.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
