### PR TITLE
python.pkgs.slackclient: 1.2.1 -> 2.5.0

### DIFF
--- a/pkgs/applications/networking/errbot/default.nix
+++ b/pkgs/applications/networking/errbot/default.nix
@@ -70,6 +70,7 @@ py.pkgs.buildPythonApplication rec {
     homepage = http://errbot.io/;
     maintainers = with maintainers; [ fpletz globin ];
     license = licenses.gpl3;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
+    # flaky on darwin, "RuntimeError: can't start new thread"
   };
 }

--- a/pkgs/applications/networking/errbot/default.nix
+++ b/pkgs/applications/networking/errbot/default.nix
@@ -1,9 +1,9 @@
 { lib, fetchFromGitHub, python, glibcLocales }:
 
 let
-  # errbot requires markdown<3, and is not compatible with it either.
   py = python.override {
     packageOverrides = self: super: {
+      # errbot requires markdown<3, and is not compatible with it either.
       markdown = super.markdown.overridePythonAttrs (oldAttrs: rec {
         version = "2.6.11";
         src = super.fetchPypi {
@@ -11,6 +11,28 @@ let
           inherit version;
           sha256 = "108g80ryzykh8bj0i7jfp71510wrcixdi771lf2asyghgyf8cmm8";
         };
+      });
+
+      # errbot requires slackclient 1.x, see https://github.com/errbotio/errbot/pull/1367
+      # latest 1.x release would be 1.3.2, but it requires an older websocket_client than the one in nixpkgs
+      # so let's just vendor the known-working version until they've migrated to 2.x.
+      slackclient = super.slackclient.overridePythonAttrs (oldAttrs: rec {
+        version = "1.2.1";
+        pname = "slackclient";
+        src = fetchFromGitHub {
+          owner  = "slackapi";
+          repo   = "python-slackclient";
+          rev    = version;
+          sha256 = "073fwf6fm2sqdp5ms3vm1v3ljh0pldi69k048404rp6iy3cfwkp0";
+        };
+
+        propagatedBuildInputs = with self; [ websocket_client requests six ];
+
+        checkInputs = with self; [ pytest codecov coverage mock pytestcov pytest-mock responses flake8 ];
+        # test_server.py fails because it needs connection (I think);
+        checkPhase = ''
+          py.test --cov-report= --cov=slackclient tests --ignore=tests/test_server.py
+        '';
       });
     };
   };

--- a/pkgs/development/python-modules/slackclient/default.nix
+++ b/pkgs/development/python-modules/slackclient/default.nix
@@ -1,29 +1,58 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, websocket_client, requests, six, pytest, codecov, coverage, mock, pytestcov, pytest-mock, responses, flake8 }:
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, black
+, codecov
+, flake8
+, isPy3k
+, mock
+, pytest-mock
+, pytestCheckHook
+, pytestcov
+, pytestrunner
+, requests
+, responses
+, six
+, websocket_client
+}:
 
 buildPythonPackage rec {
   pname = "python-slackclient";
-  version = "1.2.1";
+  version = "2.5.0";
+
+  disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner  = "slackapi";
     repo   = pname;
     rev    = version;
-    sha256 = "073fwf6fm2sqdp5ms3vm1v3ljh0pldi69k048404rp6iy3cfwkp0";
+    sha256 = "1ngj1mivbln19546195k400w9yaw69g0w6is7c75rqwyxr8wgzsk";
   };
 
-  propagatedBuildInputs = [ websocket_client requests six ];
+  propagatedBuildInputs = [
+    aiohttp
+    websocket_client
+    requests
+    six
+  ];
 
-  checkInputs = [ pytest codecov coverage mock pytestcov pytest-mock responses flake8 ];
-  # test_server.py fails because it needs connection (I think);
-  checkPhase = ''
-    py.test --cov-report= --cov=slackclient tests --ignore=tests/test_server.py
-  '';
+  checkInputs = [
+    black
+    codecov
+    flake8
+    mock
+    pytest-mock
+    pytestCheckHook
+    pytestcov
+    pytestrunner
+    responses
+  ];
 
   meta = with stdenv.lib; {
     description = "A client for Slack, which supports the Slack Web API and Real Time Messaging (RTM) API";
-    homepage = https://github.com/slackapi/python-slackclient;
+    homepage = "https://github.com/slackapi/python-slackclient";
     license = licenses.mit;
-    maintainers = with maintainers; [ psyanticy ];
+    maintainers = with maintainers; [ flokli psyanticy ];
   };
 }
-


### PR DESCRIPTION
This bumps `slackclient` to the latest PyPi release, and uses
pytestCheckHook to run pytest tests.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
