### PR TITLE
mariadb-connector-c: add mysqlclient.pc pkgconfig symlink

### DIFF
--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation {
     ln -sv mariadb $out/lib/mysql
     ln -sv mariadb $out/include/mysql
     ln -sv mariadb_version.h $out/include/mariadb/mysql_version.h
+    ln -sv libmariadb.pc $out/lib/pkgconfig/mysqlclient.pc
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Some projects, like the [mysqlclient-sys](https://crates.io/crates/mysqlclient-sys) rust crate, use `pkg-config` to locate the `mysqlclient` library.

The `mariadb-connector-c` package only provides compatibility links for the mysql libs and includes. Adding the `mysqlclient.pc` link increases the compatibility with the build expecting the alternative name.

This fixes the currently failing build of `bitwarden_rs-mysql` in `master` and `release-20.03`.

ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @globin 