### PR TITLE
weechatScripts.weechat-autosort: 3.4 -> 3.8

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "weechat-autosort";
-  version = "3.4";
+  version = "3.8";
 
   src = fetchFromGitHub {
     owner = "de-vri-es";
     repo = pname;
     rev = version;
-    sha256 = "1sbr6ga9krrfgqznvsxjd3hdxzkvslh41ls5xrj7l2p4ws4gwlkn";
+    sha256 = "0a2gc8nhklvlivradhqy2pkymsqyy01pvzrmwg60cln8snmcqpd5";
   };
 
   passthru.scripts = [ "autosort.py" ];
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = "Autosort is a weechat script to automatically or manually keep your buffers sorted";
     homepage = https://github.com/de-vri-es/weechat-autosort;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ma27 emily ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New upstream release(s).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).