### PR TITLE
sudo-font: 0.41 -> 0.42

### DIFF
--- a/pkgs/data/fonts/sudo/default.nix
+++ b/pkgs/data/fonts/sudo/default.nix
@@ -1,19 +1,21 @@
 { lib, fetchzip }:
 
 let
-  version = "0.41";
+  version = "0.42";
 in fetchzip {
   name = "sudo-font-${version}";
   url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
-  sha256 = "055sz9jg3fg7ypk9nia4dl9haaaq3w8zx5c2cdi3iq9kj8k5gg53";
+  sha256 = "1rqpwihf2sakrhkaw041r3xc9fhafaqn22n79haqkmwv4vmnspch";
 
   postFetch = ''
-    mkdir -p $out/share/fonts/truetype/
+    mkdir -p $out/share/fonts/
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
+    unzip -j $downloadedFile \*.woff -d $out/share/fonts/woff/
+    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2/
   '';
   meta = with lib; {
     description = "Font for programmers and command line users";
-    homepage = https://www.kutilek.de/sudo-font/;
+    homepage = "https://www.kutilek.de/sudo-font/";
     license = licenses.ofl;
     maintainers = with maintainers; [ dtzWill ];
     platforms = platforms.all;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
