### PR TITLE
nix-query-tree-viewer: init at 0.2.0

### DIFF
--- a/pkgs/tools/nix/nix-query-tree-viewer/default.nix
+++ b/pkgs/tools/nix/nix-query-tree-viewer/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, rustPlatform, glib, gtk3, wrapGAppsHook }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nix-query-tree-viewer";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "cdepillabout";
+    repo  = "nix-query-tree-viewer";
+    rev = "v${version}";
+    sha256 = "0vjcllhgq64n7mwxvyhmbqd6fpa9lwrpsnggc1kdlgd14ggq6jj6";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+  ];
+
+  cargoSha256 = "1pbyi7knqmqxbpi3jhl492is9zkaxdpdnmbm11nqwc1nvvbjblzc";
+
+  meta = with stdenv.lib; {
+    description = "GTK viewer for the output of `nix store --query --tree`";
+    homepage    = "https://github.com/cdepillabout/nix-query-tree-viewer";
+    license     = with licenses; [ mit ];
+    maintainers = with maintainers; [ cdepillabout ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25217,6 +25217,8 @@ in
     nix-prefetch-svn
     nix-prefetch-scripts;
 
+  nix-query-tree-viewer = callPackage ../tools/nix/nix-query-tree-viewer { };
+
   nix-update-source = callPackage ../tools/package-management/nix-update-source {};
 
   nix-script = callPackage ../tools/nix/nix-script {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds [`nix-query-tree-viewer`](https://github.com/cdepillabout/nix-query-tree-viewer).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
