### PR TITLE
pythonPackages.psutil: 5.6.7 -> 5.7.0

### DIFF
--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -1,26 +1,41 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
+{ lib, stdenv, buildPythonPackage, fetchPypi, isPy27, python
 , darwin
+, pytest
+, mock
+, ipaddress
 }:
 
 buildPythonPackage rec {
   pname = "psutil";
-  version = "5.6.7";
+  version = "5.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa";
+    sha256 = "03jykdi3dgf1cdal9bv4fq9zjvzj9l9bs99gi5ar81sdl5nc2pk8";
   };
 
-  # No tests in archive
-  doCheck = false;
+  # arch doesn't report frequency is the same way
+  doCheck = stdenv.isx86_64;
+  checkInputs = [ pytest ]
+    ++ lib.optionals isPy27 [ mock ipaddress ];
+  # out must be referenced as test import paths are relative
+  # disable tests which don't work in sandbox
+  # cpu_times is flakey on darwin
+  checkPhase = ''
+    pytest $out/${python.sitePackages}/psutil/tests/test_system.py \
+      -k 'not user \
+          and not disk_io_counters and not sensors_battery \
+          and not cpu_times'
+  '';
 
-  buildInputs = [] ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.IOKit ];
+  buildInputs = lib.optionals stdenv.isDarwin [ darwin.IOKit ];
 
-  meta = {
+  pythonImportsCheck = [ "psutil" ];
+
+  meta = with lib; {
     description = "Process and system utilization information interface for python";
-    homepage = https://github.com/giampaolo/psutil;
-    license = stdenv.lib.licenses.bsd3;
+    homepage = "https://github.com/giampaolo/psutil";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jonringer ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
