### PR TITLE
restic: fix cross compilation

### DIFF
--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub, nixosTests }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, nixosTests}:
 
 buildGoPackage rec {
   pname = "restic";
@@ -13,20 +13,19 @@ buildGoPackage rec {
     sha256 = "0lydll93n1lcn1fl669b9cikmzz9d6vfpc8ky3ng5fi8kj3v1dz7";
   };
 
-  buildPhase = ''
-    cd go/src/${goPackagePath}
-    go run build.go
-  '';
-
   passthru.tests.restic = nixosTests.restic;
 
+  # Use a custom install phase here as by default the
+  # build-release-binaries and prepare-releases binaries are
+  # installed.
   installPhase = ''
+    mkdir -p "$bin/bin"
+    cp go/bin/restic "$bin/bin"
+  '' + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     mkdir -p \
-      $bin/bin \
       $bin/etc/bash_completion.d \
       $bin/share/zsh/vendor-completions \
       $bin/share/man/man1
-    cp restic $bin/bin/
     $bin/bin/restic generate \
       --bash-completion $bin/etc/bash_completion.d/restic.sh \
       --zsh-completion $bin/share/zsh/vendor-completions/_restic \


### PR DESCRIPTION
Remove the custom build phase

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mbrgm
  - What was the reson for the custom build phase, it seems to work fine
  without this.
  - The custom install phase is staying as there are some unwanted
  binaries moved into the store otherwise (build-release-binaries and
  prepare-release). Was the custom build phase to prevent building
  these binaries in the first place?