### PR TITLE
libeatmydata: fix launcher script - find shell library properly

### DIFF
--- a/pkgs/development/libraries/libeatmydata/default.nix
+++ b/pkgs/development/libraries/libeatmydata/default.nix
@@ -2,17 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "libeatmydata-105";
-  
+
   src = fetchurl {
     url = "https://www.flamingspork.com/projects/libeatmydata/${name}.tar.gz";
     sha256 = "1pd8sc73cgc41ldsvq6g8ics1m5k8gdcb91as9yg8z5jnrld1lmx";
   };
 
-  buildInputs = [ makeWrapper ];
-
-  postInstall = ''
-    wrapProgram $out/bin/eatmydata \
-      --prefix PATH : $out/bin
+  patches = [ ./find-shell-lib.patch ];
+  patchFlags = "-p0";
+  postPatch = ''
+    substituteInPlace eatmydata.in --replace NIX_OUT_DIR $out
   '';
 
   meta = {

--- a/pkgs/development/libraries/libeatmydata/find-shell-lib.patch
+++ b/pkgs/development/libraries/libeatmydata/find-shell-lib.patch
@@ -1,0 +1,20 @@
+--- eatmydata.in	2020-02-01 18:10:59.618679823 -0800
++++ eatmydata.in.new	2020-02-01 18:08:25.092620247 -0800
+@@ -15,15 +15,8 @@
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+-export `dpkg-architecture|grep DEB_BUILD_MULTIARCH`
+-
+-shlib="/usr/lib/$DEB_BUILD_MULTIARCH/eatmydata.sh"
+-if [ -f "$shlib" ]; then
+-    . "$shlib"
+-else
+-    echo "Unable to locate eatmydata shell library, it was not enabled" >&2
+-    exec "$@"
+-fi
++shlib="NIX_OUT_DIR/libexec/eatmydata.sh"
++. "$shlib"
+ 
+ usage()
+ {


### PR DESCRIPTION
The new version of the launcher script in version 105 doesn't have the #8665
bug, but it does try to find the shell library using Debian tools, which
obviously doesn't work on Nix. Removed the now-unnecessary makeWrapper and
patched out the Debian bits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
