### PR TITLE
[19.09] chromium: 80.0.3987.106 -> 80.0.3987.116 (backport)

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -11,8 +11,8 @@
     version = "81.0.4044.17";
   };
   stable = {
-    sha256 = "10myihiyrgnm0ly41k4h8ayl3vv3cpshs3pshpqaba0l8i5r5b9f";
-    sha256bin64 = "0pd4ygmyinaq22lmaqjqi1gs3svnb863mkhcf85dzm1354iz1g9k";
-    version = "80.0.3987.106";
+    sha256 = "00c9czjyk1h3i40lvmh2rshp1mq7pcxwsfh1qrq22w8ba6ydkib5";
+    sha256bin64 = "0sydv69hnssbvkrl1zc3qpb1czmfxv9kq6qs9gdiy2i3zskfvhkx";
+    version = "80.0.3987.116";
   };
 }


### PR DESCRIPTION
(cherry picked from commit 3e9d2f80a43858713584847ffbe0e7ee438036d1)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/80615.

| platform | attribute | status | tester |
| --- | --- | --- | --- |
| x86_64 | chromium | :heavy_check_mark: | @Frostman |
| x86_64 | nixosTests.chromium | :heavy_check_mark: | @Frostman |
| x86_64 | google-chrome | :heavy_check_mark: | @primeos |

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
