### PR TITLE
meson: 0.52.1 -> 0.53.1

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,6 +1,5 @@
 { lib
 , python3Packages
-, fetchpatch
 , stdenv
 , writeTextDir
 , substituteAll
@@ -20,11 +19,11 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "meson";
-  version = "0.52.1";
+  version = "0.53.2";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "02fnrk1fjf3yiix0ak0m9vgbpl4h97fafii5pmw7phmvnlv9fyan";
+    sha256 = "Po+DDzMYQ5fC6wtlHsUCrbY97LKJeL3ISzVY1xKEwh8=";
   };
 
   postFixup = ''
@@ -61,14 +60,6 @@ python3Packages.buildPythonApplication rec {
     (substituteAll {
       src = ./fix-rpath.patch;
       inherit (builtins) storeDir;
-    })
-
-    # Fix detecting incorrect compiler in the store path hash.
-    # https://github.com/NixOS/nixpkgs/issues/73417#issuecomment-554077964
-    # https://github.com/mesonbuild/meson/pull/6185
-    (fetchpatch {
-      url = "https://github.com/mesonbuild/meson/commit/972ede1d14fdf17fe5bb8fb99be220f9395c2392.patch";
-      sha256 = "19bfsylhpy0b2xv3ks8ac9x3q6vvvyj1wjcy971v9d5f1455xhbb";
     })
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Keep meson up-to-date.
In particular, 0.52.1 caused annoying warnings about value duplication in compilation flags, which has been fixed upstream.

###### Things done
- Removed a patch, as https://github.com/mesonbuild/meson/pull/6185 has been merged.
- Compiled and tested my programs that are built with meson, didn't see any problems with them.
  However, **I didn't build all the packages that depend on meson**.
  I tried a `nixpkgs-review wip` but the 10k+ packages involved scared me.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
