### PR TITLE
netpbm: fix typo on substituteInPlace parameters

### DIFF
--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   postPatch = /* CVE-2005-2471, from Arch */ ''
     substituteInPlace converter/other/pstopnm.c \
-      --replace '"-DSAFER"' '"-DPARANOIDSAFER"'
+      --replace '"-dSAFER"' '"-dPARANOIDSAFER"'
   '';
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change
It seems like originally `-dSAFER` should have been replaced with
`-dPARANOIDSAFER` instead of `-DSAFER` (capital D vs lower case d).

This was pointed out in #75153 (cc @caadar  @veprbl). This might now finally (properly?) fix
CVE-2005-2471.


cc @vcunat as you initially added that substitution.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
