### PR TITLE
netdata: 1.19.0 -> 1.20.0

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -12,14 +12,14 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.19.0";
+  version = "1.20.0";
   pname = "netdata";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "netdata";
     rev = "v${version}";
-    sha256 = "1s6kzx4xh8b6v7ki8h2mfzprj5rxvlgx2md20cr8c0v81qpz3q3q";
+    sha256 = "0g7iv5w14wndl5iv2q81dppgwq09sm93vpnyq7p49nl7q1dsz1d6";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
+++ b/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
@@ -1,27 +1,8 @@
-diff --git a/Makefile.am b/Makefile.am
-index 2625dcc..1fdd645 100644
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -113,10 +113,10 @@ AM_CFLAGS = \
-     $(NULL)
- 
- sbin_PROGRAMS =
--dist_cache_DATA = packaging/installer/.keep
--dist_varlib_DATA = packaging/installer/.keep
--dist_registry_DATA = packaging/installer/.keep
--dist_log_DATA = packaging/installer/.keep
-+dist_cache_DATA =
-+dist_varlib_DATA =
-+dist_registry_DATA =
-+dist_log_DATA =
- plugins_PROGRAMS =
- 
- LIBNETDATA_FILES = \
 diff --git a/collectors/Makefile.am b/collectors/Makefile.am
-index 7431025..f62f8ac 100644
+index 9bb5295..36d9ee0 100644
 --- a/collectors/Makefile.am
 +++ b/collectors/Makefile.am
-@@ -30,11 +30,6 @@ SUBDIRS = \
+@@ -31,11 +31,6 @@ SUBDIRS = \
  usercustompluginsconfigdir=$(configdir)/custom-plugins.d
  usergoconfigdir=$(configdir)/go.d
  
@@ -34,14 +15,11 @@ index 7431025..f62f8ac 100644
      README.md \
      $(NULL)
 diff --git a/collectors/charts.d.plugin/Makefile.am b/collectors/charts.d.plugin/Makefile.am
-index b3b2fb9..68b768e 100644
+index 03c7f0a..93f6e3b 100644
 --- a/collectors/charts.d.plugin/Makefile.am
 +++ b/collectors/charts.d.plugin/Makefile.am
-@@ -31,13 +31,8 @@ dist_charts_DATA = \
- 
- userchartsconfigdir=$(configdir)/charts.d
+@@ -33,10 +33,6 @@ userchartsconfigdir=$(configdir)/charts.d
  dist_userchartsconfig_DATA = \
--    .keep \
      $(NULL)
  
 -# Explicitly install directories to avoid permission issues due to umask
@@ -52,14 +30,11 @@ index b3b2fb9..68b768e 100644
  dist_chartsconfig_DATA = \
      $(NULL)
 diff --git a/collectors/node.d.plugin/Makefile.am b/collectors/node.d.plugin/Makefile.am
-index 411bce9..ba60276 100644
+index c3142d4..ba60276 100644
 --- a/collectors/node.d.plugin/Makefile.am
 +++ b/collectors/node.d.plugin/Makefile.am
-@@ -23,13 +23,8 @@ dist_noinst_DATA = \
- 
- usernodeconfigdir=$(configdir)/node.d
+@@ -25,10 +25,6 @@ usernodeconfigdir=$(configdir)/node.d
  dist_usernodeconfig_DATA = \
--    .keep \
      $(NULL)
  
 -# Explicitly install directories to avoid permission issues due to umask
@@ -70,14 +45,11 @@ index 411bce9..ba60276 100644
  dist_nodeconfig_DATA = \
      $(NULL)
 diff --git a/collectors/python.d.plugin/Makefile.am b/collectors/python.d.plugin/Makefile.am
-index cb14e35..8a6c5a7 100644
+index e678f86..784a9f4 100644
 --- a/collectors/python.d.plugin/Makefile.am
 +++ b/collectors/python.d.plugin/Makefile.am
-@@ -29,13 +29,8 @@ dist_python_DATA = \
- 
- userpythonconfigdir=$(configdir)/python.d
+@@ -31,10 +31,6 @@ userpythonconfigdir=$(configdir)/python.d
  dist_userpythonconfig_DATA = \
--    .keep \
      $(NULL)
  
 -# Explicitly install directories to avoid permission issues due to umask
@@ -88,28 +60,22 @@ index cb14e35..8a6c5a7 100644
  dist_pythonconfig_DATA = \
      $(NULL)
 diff --git a/collectors/statsd.plugin/Makefile.am b/collectors/statsd.plugin/Makefile.am
-index 87b6ca7..9d010c7 100644
+index b01302d..c0d48e1 100644
 --- a/collectors/statsd.plugin/Makefile.am
 +++ b/collectors/statsd.plugin/Makefile.am
-@@ -14,9 +14,4 @@ dist_statsdconfig_DATA = \
- 
- userstatsdconfigdir=$(configdir)/statsd.d
+@@ -16,6 +16,3 @@ userstatsdconfigdir=$(configdir)/statsd.d
  dist_userstatsdconfig_DATA = \
--    .keep \
      $(NULL)
--
+ 
 -# Explicitly install directories to avoid permission issues due to umask
 -install-exec-local:
 -	$(INSTALL) -d $(DESTDIR)$(userstatsdconfigdir)
 diff --git a/health/Makefile.am b/health/Makefile.am
-index f63faa8..8912ef2 100644
+index 853ed0d..ae0bde3 100644
 --- a/health/Makefile.am
 +++ b/health/Makefile.am
-@@ -16,13 +16,8 @@ dist_noinst_DATA = \
- 
- userhealthconfigdir=$(configdir)/health.d
+@@ -18,10 +18,6 @@ userhealthconfigdir=$(configdir)/health.d
  dist_userhealthconfig_DATA = \
--    .keep \
      $(NULL)
  
 -# Explicitly install directories to avoid permission issues due to umask


### PR DESCRIPTION
###### Motivation for this change
Update netdata to version 1.20.0.
Changelog - https://docs.netdata.cloud/changelog/#v1200-2020-02-21

cc @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
