### PR TITLE
connman: 1.37 -> 1.38

### DIFF
--- a/pkgs/tools/networking/connman/connman.nix
+++ b/pkgs/tools/networking/connman/connman.nix
@@ -73,9 +73,6 @@ stdenv.mkDerivation rec {
     pkgconfig
     file
   ]
-    ++ optionals (enableOpenvpn) [ openvpn ]
-    ++ optionals (enableOpenconnect) [ openconnect ]
-    ++ optionals (enableVpnc) [ vpnc ]
     ++ optionals (enablePolkit) [ polkit ]
     ++ optionals (enablePptp) [ pptp ppp ]
     ++ optionals (firewallType == "iptables") [ iptables ]

--- a/pkgs/tools/networking/connman/connman.nix
+++ b/pkgs/tools/networking/connman/connman.nix
@@ -42,7 +42,6 @@
 , enableDatafiles ? true
 # optional features which are turned *off* by default
 , enableNetworkManager ? false
-, networkmanager ? null
 , enableHh2serialGps ? false
 , enableL2tp ? false
 , enableIospm ? false

--- a/pkgs/tools/networking/connman/connman.nix
+++ b/pkgs/tools/networking/connman/connman.nix
@@ -84,10 +84,8 @@ stdenv.mkDerivation rec {
   ;
 
   # fix invalid path to 'file'
-  patchPhase = ''
-    runHook prePatch
+  postPatch = ''
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
-    runHook postPatch
   '';
 
   configureFlags = [

--- a/pkgs/tools/networking/connman/connman.nix
+++ b/pkgs/tools/networking/connman/connman.nix
@@ -1,0 +1,177 @@
+{ stdenv
+, fetchurl
+, pkgconfig
+, file
+, glib
+# always required runtime dependencies
+, dbus
+, libmnl
+, gnutls
+, readline
+# configureable options
+, firewallType ? "iptables" # or "nftables"
+, iptables ? null
+, libnftnl ? null # for nftables
+, dnsType ? "internal" # or "systemd-resolved"
+# optional features which are turned *on* by default
+, enableOpenconnect ? true
+, openconnect ? null
+, enableOpenvpn ? true
+, openvpn ? null
+, enableVpnc ? true
+, vpnc ? true
+, enablePolkit ? true
+, polkit ? null
+, enablePptp ? true
+, pptp ? null
+, ppp ? null
+, enableLoopback ? true
+, enableEthernet ? true
+, enableWireguard ? true
+, enableGadget ? true
+, enableWifi ? true
+, enableBluetooth ? true
+, enableOfono ? true
+, enableDundee ? true
+, enablePacrunner ? true
+, enableNeard ? true
+, enableWispr ? true
+, enableTools ? true
+, enableStats ? true
+, enableClient ? true
+, enableDatafiles ? true
+# optional features which are turned *off* by default
+, enableNetworkManager ? false
+, networkmanager ? null
+, enableHh2serialGps ? false
+, enableL2tp ? false
+, enableIospm ? false
+, enableTist ? false
+}:
+
+assert stdenv.lib.asserts.assertOneOf "firewallType" firewallType [ "iptables" "nftables" ];
+assert stdenv.lib.asserts.assertOneOf "dnsType" dnsType [ "internal" "systemd-resolved" ];
+
+let inherit (stdenv.lib) optionals; in
+
+stdenv.mkDerivation rec {
+  pname = "connman";
+  version = "1.38";
+  src = fetchurl {
+    url = "mirror://kernel/linux/network/connman/${pname}-${version}.tar.xz";
+    sha256 = "0awkqigvhwwxiapw0x6yd4whl465ka8a4al0v2pcqy9ggjlsqc6b";
+  };
+
+  buildInputs = [
+    glib
+    dbus
+    libmnl
+    gnutls
+    readline
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    file
+  ]
+    ++ optionals (enableOpenvpn) [ openvpn ]
+    ++ optionals (enableOpenconnect) [ openconnect ]
+    ++ optionals (enableVpnc) [ vpnc ]
+    ++ optionals (enablePolkit) [ polkit ]
+    ++ optionals (enablePptp) [ pptp ppp ]
+    ++ optionals (firewallType == "iptables") [ iptables ]
+    ++ optionals (firewallType == "nftables") [ libnftnl ]
+  ;
+
+  # fix invalid path to 'file'
+  patchPhase = ''
+    runHook prePatch
+    sed -i "s/\/usr\/bin\/file/file/g" ./configure
+    runHook postPatch
+  '';
+
+  configureFlags = [
+    # directories flags
+    "--sysconfdir=${placeholder "out"}/etc"
+    "--localstatedir=/var"
+    "--with-dbusconfdir=${placeholder "out"}/share"
+    "--with-dbusdatadir=${placeholder "out"}/share"
+    "--with-tmpfilesdir=${placeholder "out"}/lib/tmpfiles.d"
+    "--with-systemdunitdir=${placeholder "out"}/lib/systemd/system"
+    "--with-dns-backend=${dnsType}"
+    "--with-firewall=${firewallType}"
+    # production build flags
+    "--disable-maintainer-mode"
+    "--enable-session-policy-local=builtin"
+    # for building and running tests
+    # "--enable-tests" # installs the tests, we don't want that
+    "--enable-tools"
+  ]
+    ++ optionals (!enableLoopback) [ "--disable-loopback" ]
+    ++ optionals (!enableEthernet) [ "--disable-ethernet" ]
+    ++ optionals (!enableWireguard) [ "--disable-wireguard" ]
+    ++ optionals (!enableGadget) [ "--disable-gadget" ]
+    ++ optionals (!enableWifi) [ "--disable-wifi" ]
+    # enable IWD support for wifi as it doesn't require any new dependencies
+    # and it's easier for the NixOS module to use only one connman package when
+    # IWD is requested
+    ++ optionals (enableWifi) [ "--enable-iwd" ]
+    ++ optionals (!enableBluetooth) [ "--disable-bluetooth" ]
+    ++ optionals (!enableOfono) [ "--disable-ofono" ]
+    ++ optionals (!enableDundee) [ "--disable-dundee" ]
+    ++ optionals (!enablePacrunner) [ "--disable-pacrunner" ]
+    ++ optionals (!enableNeard) [ "--disable-neard" ]
+    ++ optionals (!enableWispr) [ "--disable-wispr" ]
+    ++ optionals (!enableTools) [ "--disable-tools" ]
+    ++ optionals (!enableStats) [ "--disable-stats" ]
+    ++ optionals (!enableClient) [ "--disable-client" ]
+    ++ optionals (!enableDatafiles) [ "--disable-datafiles" ]
+    ++ optionals (enableOpenconnect) [
+      "--enable-openconnect=builtin"
+      "--with-openconnect=${openconnect}/sbin/openconnect"
+    ]
+    ++ optionals (enableOpenvpn) [
+      "--enable-openvpn=builtin"
+      "--with-openvpn=${openvpn}/sbin/openvpn"
+    ]
+    ++ optionals (enableVpnc) [
+      "--enable-vpnc=builtin"
+      "--with-vpnc=${vpnc}/sbin/vpnc"
+    ]
+    ++ optionals (enablePolkit) [
+      "--enable-polkit"
+    ]
+    ++ optionals (enablePptp) [
+      "--enable-pptp"
+      "--with-pptp=${pptp}/sbin/pptp"
+    ]
+    ++ optionals (!enableWireguard) [
+      "--disable-wireguard"
+    ]
+    ++ optionals (enableNetworkManager) [
+      "--enable-nmcompat"
+    ]
+    ++ optionals (enableHh2serialGps) [
+      "--enable-hh2serial-gps"
+    ]
+    ++ optionals (enableL2tp) [
+      "--enable-l2tp"
+    ]
+    ++ optionals (enableIospm) [
+      "--enable-iospm"
+    ]
+    ++ optionals (enableTist) [
+      "--enable-tist"
+    ]
+  ;
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "A daemon for managing internet connections";
+    homepage = "https://01.org/connman";
+    maintainers = [ maintainers.matejc ];
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -84,8 +84,10 @@ stdenv.mkDerivation rec {
   ;
 
   # fix invalid path to 'file'
-  preConfigure = ''
+  patchPhase = ''
+    runHook prePatch
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
+    runHook postPatch
   '';
 
   configureFlags = [

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -3,7 +3,6 @@
 , pkgconfig
 , openconnect
 , file
-, gawk,
   openvpn
 , vpnc
 , glib
@@ -11,7 +10,6 @@
 , iptables
 , gnutls
 , polkit,
-  wpa_supplicant
 , readline6
 , pptp
 , ppp
@@ -34,7 +32,6 @@ stdenv.mkDerivation rec {
     dbus
     iptables
     gnutls
-    wpa_supplicant
     readline6
     pptp
     ppp
@@ -43,13 +40,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig
     file
-    gawk
   ];
 
   preConfigure = ''
-    export WPASUPPLICANT=${wpa_supplicant}/sbin/wpa_supplicant
     export PPPD=${ppp}/sbin/pppd
-    export AWK=${gawk}/bin/gawk
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
   '';
 

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--sysconfdir=\${out}/etc"
+    "--sysconfdir=${placeholder "out"}/etc"
     "--localstatedir=/var"
     "--with-dbusconfdir=${placeholder "out"}/share"
     "--with-dbusdatadir=${placeholder "out"}/share"

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -19,10 +19,10 @@
 
 stdenv.mkDerivation rec {
   pname = "connman";
-  version = "1.37";
+  version = "1.38";
   src = fetchurl {
     url = "mirror://kernel/linux/network/connman/${pname}-${version}.tar.xz";
-    sha256 = "05kfjiqhqfmbbwc4snnyvi5hc4zxanac62f6gcwaf5mvn0z9pqkc";
+    sha256 = "0awkqigvhwwxiapw0x6yd4whl465ka8a4al0v2pcqy9ggjlsqc6b";
   };
 
   buildInputs = [

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A daemon for managing internet connections";
-    homepage = https://01.org/connman;
+    homepage = "https://01.org/connman";
     maintainers = [ maintainers.matejc ];
     platforms = platforms.linux;
     license = licenses.gpl2;

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -52,6 +52,8 @@
 assert stdenv.lib.asserts.assertOneOf "firewallType" firewallType [ "iptables" "nftables" ];
 assert stdenv.lib.asserts.assertOneOf "dnsType" dnsType [ "internal" "systemd-resolved" ];
 
+let inherit (stdenv.lib) optionals; 
+
 stdenv.mkDerivation rec {
   pname = "connman";
   version = "1.38";
@@ -72,13 +74,13 @@ stdenv.mkDerivation rec {
     pkgconfig
     file
   ]
-    ++ stdenv.lib.optionals (enableOpenvpn) [ openvpn ]
-    ++ stdenv.lib.optionals (enableOpenconnect) [ openconnect ]
-    ++ stdenv.lib.optionals (enableVpnc) [ vpnc ]
-    ++ stdenv.lib.optionals (enablePolkit) [ polkit ]
-    ++ stdenv.lib.optionals (enablePptp) [ pptp ppp ]
-    ++ stdenv.lib.optionals (firewallType == "iptables") [ iptables ]
-    ++ stdenv.lib.optionals (firewallType == "nftables") [ libnftnl ]
+    ++ optionals (enableOpenvpn) [ openvpn ]
+    ++ optionals (enableOpenconnect) [ openconnect ]
+    ++ optionals (enableVpnc) [ vpnc ]
+    ++ optionals (enablePolkit) [ polkit ]
+    ++ optionals (enablePptp) [ pptp ppp ]
+    ++ optionals (firewallType == "iptables") [ iptables ]
+    ++ optionals (firewallType == "nftables") [ libnftnl ]
   ;
 
   # fix invalid path to 'file'
@@ -103,60 +105,60 @@ stdenv.mkDerivation rec {
     # --enable-tests # installs the tests, we don't want that
     "--enable-tools"
   ]
-    ++ stdenv.lib.optionals (!enableLoopback) [ "--disable-loopback" ]
-    ++ stdenv.lib.optionals (!enableEthernet) [ "--disable-ethernet" ]
-    ++ stdenv.lib.optionals (!enableWireguard) [ "--disable-wireguard" ]
-    ++ stdenv.lib.optionals (!enableGadget) [ "--disable-gadget" ]
-    ++ stdenv.lib.optionals (!enableWifi) [ "--disable-wifi" ]
+    ++ optionals (!enableLoopback) [ "--disable-loopback" ]
+    ++ optionals (!enableEthernet) [ "--disable-ethernet" ]
+    ++ optionals (!enableWireguard) [ "--disable-wireguard" ]
+    ++ optionals (!enableGadget) [ "--disable-gadget" ]
+    ++ optionals (!enableWifi) [ "--disable-wifi" ]
     # enable IWD support for wifi as it doesn't require any new dependencies
     # and it's easier for the NixOS module to use only one connman package when
     # IWD is requested
-    ++ stdenv.lib.optionals (enableWifi) [ "--enable-iwd" ]
-    ++ stdenv.lib.optionals (!enableBluetooth) [ "--disable-bluetooth" ]
-    ++ stdenv.lib.optionals (!enableOfono) [ "--disable-ofono" ]
-    ++ stdenv.lib.optionals (!enableDundee) [ "--disable-dundee" ]
-    ++ stdenv.lib.optionals (!enablePacrunner) [ "--disable-pacrunner" ]
-    ++ stdenv.lib.optionals (!enableNeard) [ "--disable-neard" ]
-    ++ stdenv.lib.optionals (!enableWispr) [ "--disable-wispr" ]
-    ++ stdenv.lib.optionals (!enableTools) [ "--disable-tools" ]
-    ++ stdenv.lib.optionals (!enableStats) [ "--disable-stats" ]
-    ++ stdenv.lib.optionals (!enableClient) [ "--disable-client" ]
-    ++ stdenv.lib.optionals (!enableDatafiles) [ "--disable-datafiles" ]
-    ++ stdenv.lib.optionals (enableOpenconnect) [
+    ++ optionals (enableWifi) [ "--enable-iwd" ]
+    ++ optionals (!enableBluetooth) [ "--disable-bluetooth" ]
+    ++ optionals (!enableOfono) [ "--disable-ofono" ]
+    ++ optionals (!enableDundee) [ "--disable-dundee" ]
+    ++ optionals (!enablePacrunner) [ "--disable-pacrunner" ]
+    ++ optionals (!enableNeard) [ "--disable-neard" ]
+    ++ optionals (!enableWispr) [ "--disable-wispr" ]
+    ++ optionals (!enableTools) [ "--disable-tools" ]
+    ++ optionals (!enableStats) [ "--disable-stats" ]
+    ++ optionals (!enableClient) [ "--disable-client" ]
+    ++ optionals (!enableDatafiles) [ "--disable-datafiles" ]
+    ++ optionals (enableOpenconnect) [
       "--enable-openconnect=builtin"
       "--with-openconnect=${openconnect}/sbin/openconnect"
     ]
-    ++ stdenv.lib.optionals (enableOpenvpn) [
+    ++ optionals (enableOpenvpn) [
       "--enable-openvpn=builtin"
       "--with-openvpn=${openvpn}/sbin/openvpn"
     ]
-    ++ stdenv.lib.optionals (enableVpnc) [
+    ++ optionals (enableVpnc) [
       "--enable-vpnc=builtin"
       "--with-vpnc=${vpnc}/sbin/vpnc"
     ]
-    ++ stdenv.lib.optionals (enablePolkit) [
+    ++ optionals (enablePolkit) [
       "--enable-polkit"
     ]
-    ++ stdenv.lib.optionals (enablePptp) [
+    ++ optionals (enablePptp) [
       "--enable-pptp"
       "--with-pptp=${pptp}/sbin/pptp"
     ]
-    ++ stdenv.lib.optionals (!enableWireguard) [
+    ++ optionals (!enableWireguard) [
       "--disable-wireguard"
     ]
-    ++ stdenv.lib.optionals (enableNetworkManager) [
+    ++ optionals (enableNetworkManager) [
       "--enable-nmcompat"
     ]
-    ++ stdenv.lib.optionals (enableHh2serialGps) [
+    ++ optionals (enableHh2serialGps) [
       "--enable-hh2serial-gps"
     ]
-    ++ stdenv.lib.optionals (enableL2tp) [
+    ++ optionals (enableL2tp) [
       "--enable-l2tp"
     ]
-    ++ stdenv.lib.optionals (enableIospm) [
+    ++ optionals (enableIospm) [
       "--enable-iospm"
     ]
-    ++ stdenv.lib.optionals (enableTist) [
+    ++ optionals (enableTist) [
       "--enable-tist"
     ]
   ;

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     vpnc
     glib
     dbus
+    libmnl
     iptables
     gnutls
     readline
@@ -69,6 +70,9 @@ stdenv.mkDerivation rec {
     "--with-pptp=${pptp}/sbin/pptp"
     "--enable-iwd"
   ];
+  doCheck = true;
+
+  outputs = [ "out" "dev" ];
 
   meta = with stdenv.lib; {
     description = "A daemon for managing internet connections";

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    export PPPD=${ppp}/sbin/pppd
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
   '';
 
@@ -70,10 +69,6 @@ stdenv.mkDerivation rec {
     "--with-pptp=${pptp}/sbin/pptp"
     "--enable-iwd"
   ];
-
-  postInstall = ''
-    cp ./client/connmanctl $out/sbin/connmanctl
-  '';
 
   meta = with stdenv.lib; {
     description = "A daemon for managing internet connections";

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,6 +1,9 @@
 { callPackage }:
 
 {
+  # All the defaults
+  connman = callPackage ./connman.nix { };
+
   connmanFull = callPackage ./connman.nix {
     enableNetworkManager = true;
     enableHh2serialGps = true;
@@ -32,7 +35,4 @@
     enableClient = false;
     # enableDatafiles = false; # If disabled, configuration and data files are not installed
   };
-
-  # All the defaults
-  connman = callPackage ./connman.nix { };
 }

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,177 +1,38 @@
-{ stdenv
-, fetchurl
-, pkgconfig
-, file
-, glib
-# always required runtime dependencies
-, dbus
-, libmnl
-, gnutls
-, readline
-# configureable options
-, firewallType ? "iptables" # or "nftables"
-, iptables ? null
-, libnftnl ? null # for nftables
-, dnsType ? "internal" # or "systemd-resolved"
-# optional features which are turned *on* by default
-, enableOpenconnect ? true
-, openconnect ? null
-, enableOpenvpn ? true
-, openvpn ? null
-, enableVpnc ? true
-, vpnc ? true
-, enablePolkit ? true
-, polkit ? null
-, enablePptp ? true
-, pptp ? null
-, ppp ? null
-, enableLoopback ? true
-, enableEthernet ? true
-, enableWireguard ? true
-, enableGadget ? true
-, enableWifi ? true
-, enableBluetooth ? true
-, enableOfono ? true
-, enableDundee ? true
-, enablePacrunner ? true
-, enableNeard ? true
-, enableWispr ? true
-, enableTools ? true
-, enableStats ? true
-, enableClient ? true
-, enableDatafiles ? true
-# optional features which are turned *off* by default
-, enableNetworkManager ? false
-, networkmanager ? null
-, enableHh2serialGps ? false
-, enableL2tp ? false
-, enableIospm ? false
-, enableTist ? false
-}:
+{ callPackage, lowPrio }:
 
-assert stdenv.lib.asserts.assertOneOf "firewallType" firewallType [ "iptables" "nftables" ];
-assert stdenv.lib.asserts.assertOneOf "dnsType" dnsType [ "internal" "systemd-resolved" ];
-
-let inherit (stdenv.lib) optionals; 
-
-stdenv.mkDerivation rec {
-  pname = "connman";
-  version = "1.38";
-  src = fetchurl {
-    url = "mirror://kernel/linux/network/connman/${pname}-${version}.tar.xz";
-    sha256 = "0awkqigvhwwxiapw0x6yd4whl465ka8a4al0v2pcqy9ggjlsqc6b";
+{
+  connmanFull = callPackage ./connman.nix {
+    enableNetworkManager = true;
+    enableHh2serialGps = true;
+    enableL2tp = true;
+    enableIospm = true;
+    enableTist = true;
   };
 
-  buildInputs = [
-    glib
-    dbus
-    libmnl
-    gnutls
-    readline
-  ];
+  connmanMinimal = lowPrio (callPackage ./connman.nix {
+    enableOpenconnect = false;
+    enableOpenvpn = false;
+    enableVpnc = false;
+    vpnc = false;
+    enablePolkit = false;
+    enablePptp = false;
+    enableLoopback = false;
+    # enableEthernet = false; # If disabled no ethernet connection can be performed
+    enableWireguard = false;
+    enableGadget = false;
+    # enableWifi = false; # If disabled no WiFi connection can be performed
+    enableBluetooth = false;
+    enableOfono = false;
+    enableDundee = false;
+    enablePacrunner = false;
+    enableNeard = false;
+    enableWispr = false;
+    enableTools = false;
+    enableStats = false;
+    enableClient = false;
+    # enableDatafiles = false; # If disabled, configuration and data files are not installed
+  });
 
-  nativeBuildInputs = [
-    pkgconfig
-    file
-  ]
-    ++ optionals (enableOpenvpn) [ openvpn ]
-    ++ optionals (enableOpenconnect) [ openconnect ]
-    ++ optionals (enableVpnc) [ vpnc ]
-    ++ optionals (enablePolkit) [ polkit ]
-    ++ optionals (enablePptp) [ pptp ppp ]
-    ++ optionals (firewallType == "iptables") [ iptables ]
-    ++ optionals (firewallType == "nftables") [ libnftnl ]
-  ;
-
-  # fix invalid path to 'file'
-  patchPhase = ''
-    runHook prePatch
-    sed -i "s/\/usr\/bin\/file/file/g" ./configure
-    runHook postPatch
-  '';
-
-  configureFlags = [
-    # directories flags
-    "--sysconfdir=${placeholder "out"}/etc"
-    "--localstatedir=/var"
-    "--with-dbusconfdir=${placeholder "out"}/share"
-    "--with-dbusdatadir=${placeholder "out"}/share"
-    "--with-tmpfilesdir=${placeholder "out"}/lib/tmpfiles.d"
-    "--with-systemdunitdir=${placeholder "out"}/lib/systemd/system"
-    "--with-dns-backend=${dnsType}"
-    "--with-firewall=${firewallType}"
-    # production build flags
-    "--disable-maintainer-mode"
-    "--enable-session-policy-local=builtin"
-    # for building and running tests
-    # --enable-tests # installs the tests, we don't want that
-    "--enable-tools"
-  ]
-    ++ optionals (!enableLoopback) [ "--disable-loopback" ]
-    ++ optionals (!enableEthernet) [ "--disable-ethernet" ]
-    ++ optionals (!enableWireguard) [ "--disable-wireguard" ]
-    ++ optionals (!enableGadget) [ "--disable-gadget" ]
-    ++ optionals (!enableWifi) [ "--disable-wifi" ]
-    # enable IWD support for wifi as it doesn't require any new dependencies
-    # and it's easier for the NixOS module to use only one connman package when
-    # IWD is requested
-    ++ optionals (enableWifi) [ "--enable-iwd" ]
-    ++ optionals (!enableBluetooth) [ "--disable-bluetooth" ]
-    ++ optionals (!enableOfono) [ "--disable-ofono" ]
-    ++ optionals (!enableDundee) [ "--disable-dundee" ]
-    ++ optionals (!enablePacrunner) [ "--disable-pacrunner" ]
-    ++ optionals (!enableNeard) [ "--disable-neard" ]
-    ++ optionals (!enableWispr) [ "--disable-wispr" ]
-    ++ optionals (!enableTools) [ "--disable-tools" ]
-    ++ optionals (!enableStats) [ "--disable-stats" ]
-    ++ optionals (!enableClient) [ "--disable-client" ]
-    ++ optionals (!enableDatafiles) [ "--disable-datafiles" ]
-    ++ optionals (enableOpenconnect) [
-      "--enable-openconnect=builtin"
-      "--with-openconnect=${openconnect}/sbin/openconnect"
-    ]
-    ++ optionals (enableOpenvpn) [
-      "--enable-openvpn=builtin"
-      "--with-openvpn=${openvpn}/sbin/openvpn"
-    ]
-    ++ optionals (enableVpnc) [
-      "--enable-vpnc=builtin"
-      "--with-vpnc=${vpnc}/sbin/vpnc"
-    ]
-    ++ optionals (enablePolkit) [
-      "--enable-polkit"
-    ]
-    ++ optionals (enablePptp) [
-      "--enable-pptp"
-      "--with-pptp=${pptp}/sbin/pptp"
-    ]
-    ++ optionals (!enableWireguard) [
-      "--disable-wireguard"
-    ]
-    ++ optionals (enableNetworkManager) [
-      "--enable-nmcompat"
-    ]
-    ++ optionals (enableHh2serialGps) [
-      "--enable-hh2serial-gps"
-    ]
-    ++ optionals (enableL2tp) [
-      "--enable-l2tp"
-    ]
-    ++ optionals (enableIospm) [
-      "--enable-iospm"
-    ]
-    ++ optionals (enableTist) [
-      "--enable-tist"
-    ]
-  ;
-
-  doCheck = true;
-
-  meta = with stdenv.lib; {
-    description = "A daemon for managing internet connections";
-    homepage = "https://01.org/connman";
-    maintainers = [ maintainers.matejc ];
-    platforms = platforms.linux;
-    license = licenses.gpl2;
-  };
+  # All the defaults
+  connman = callPackage ./connman.nix { };
 }

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, lowPrio }:
+{ callPackage }:
 
 {
   connmanFull = callPackage ./connman.nix {
@@ -9,7 +9,7 @@
     enableTist = true;
   };
 
-  connmanMinimal = lowPrio (callPackage ./connman.nix {
+  connmanMinimal = callPackage ./connman.nix {
     enableOpenconnect = false;
     enableOpenvpn = false;
     enableVpnc = false;
@@ -31,7 +31,7 @@
     enableStats = false;
     enableClient = false;
     # enableDatafiles = false; # If disabled, configuration and data files are not installed
-  });
+  };
 
   # All the defaults
   connman = callPackage ./connman.nix { };

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -8,7 +8,7 @@
 , libmnl
 , gnutls
 , readline
-# Choices one has to decide
+# configureable options
 , firewallType ? "iptables" # or "nftables"
 , iptables ? null
 , libnftnl ? null # for nftables
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals (firewallType == "nftables") [ libnftnl ]
   ;
 
-  # Fix file program not found
+  # fix invalid path to 'file'
   preConfigure = ''
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
   '';
@@ -99,8 +99,8 @@ stdenv.mkDerivation rec {
     # production build flags
     "--disable-maintainer-mode"
     "--enable-session-policy-local=builtin"
-    # This is for building and running tests (probably enabled by default),
-    # --enable-tests installs the tests as well
+    # for building and running tests
+    # --enable-tests # installs the tests, we don't want that
     "--enable-tools"
   ]
     ++ stdenv.lib.optionals (!enableLoopback) [ "--disable-loopback" ]
@@ -108,8 +108,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals (!enableWireguard) [ "--disable-wireguard" ]
     ++ stdenv.lib.optionals (!enableGadget) [ "--disable-gadget" ]
     ++ stdenv.lib.optionals (!enableWifi) [ "--disable-wifi" ]
-    # We (almost) always turn on IWD support as it doesn't require any new dependencies
-    # and it's easier for the NixOS module to use only 1 connmand package when
+    # enable IWD support for wifi as it doesn't require any new dependencies
+    # and it's easier for the NixOS module to use only one connman package when
     # IWD is requested
     ++ stdenv.lib.optionals (enableWifi) [ "--enable-iwd" ]
     ++ stdenv.lib.optionals (!enableBluetooth) [ "--disable-bluetooth" ]

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -10,7 +10,7 @@
 , iptables
 , gnutls
 , polkit,
-, readline6
+, readline
 , pptp
 , ppp
 }:
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     dbus
     iptables
     gnutls
-    readline6
+    readline
     pptp
     ppp
   ];

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,19 +1,56 @@
 { stdenv
 , fetchurl
 , pkgconfig
-, openconnect
 , file
-  openvpn
-, vpnc
 , glib
+# always required runtime dependencies
 , dbus
-, iptables
+, libmnl
 , gnutls
-, polkit,
 , readline
-, pptp
-, ppp
+# Choices one has to decide
+, firewallType ? "iptables" # or "nftables"
+, iptables ? null
+, libnftnl ? null # for nftables
+, dnsType ? "internal" # or "systemd-resolved"
+# optional features which are turned *on* by default
+, enableOpenconnect ? true
+, openconnect ? null
+, enableOpenvpn ? true
+, openvpn ? null
+, enableVpnc ? true
+, vpnc ? true
+, enablePolkit ? true
+, polkit ? null
+, enablePptp ? true
+, pptp ? null
+, ppp ? null
+, enableLoopback ? true
+, enableEthernet ? true
+, enableWireguard ? true
+, enableGadget ? true
+, enableWifi ? true
+, enableBluetooth ? true
+, enableOfono ? true
+, enableDundee ? true
+, enablePacrunner ? true
+, enableNeard ? true
+, enableWispr ? true
+, enableTools ? true
+, enableStats ? true
+, enableClient ? true
+, enableDatafiles ? true
+# optional features which are turned *off* by default
+, enableNetworkManager ? false
+, networkmanager ? null
+, enableHh2serialGps ? false
+, enableL2tp ? false
+, enableIospm ? false
+, enableTist ? false
 }:
+
+assert stdenv.lib.asserts.assertOneOf "firewallType" firewallType [ "iptables" "nftables" ];
+assert stdenv.lib.asserts.assertOneOf "dnsType" dnsType [ "internal" "systemd-resolved" ];
 
 stdenv.mkDerivation rec {
   pname = "connman";
@@ -24,55 +61,107 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    openconnect
-    polkit
-    openvpn
-    vpnc
     glib
     dbus
     libmnl
-    iptables
     gnutls
     readline
-    pptp
-    ppp
   ];
 
   nativeBuildInputs = [
     pkgconfig
     file
-  ];
+  ]
+    ++ stdenv.lib.optionals (enableOpenvpn) [ openvpn ]
+    ++ stdenv.lib.optionals (enableOpenconnect) [ openconnect ]
+    ++ stdenv.lib.optionals (enableVpnc) [ vpnc ]
+    ++ stdenv.lib.optionals (enablePolkit) [ polkit ]
+    ++ stdenv.lib.optionals (enablePptp) [ pptp ppp ]
+    ++ stdenv.lib.optionals (firewallType == "iptables") [ iptables ]
+    ++ stdenv.lib.optionals (firewallType == "nftables") [ libnftnl ]
+  ;
 
+  # Fix file program not found
   preConfigure = ''
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
   '';
 
   configureFlags = [
+    # directories flags
     "--sysconfdir=${placeholder "out"}/etc"
     "--localstatedir=/var"
     "--with-dbusconfdir=${placeholder "out"}/share"
     "--with-dbusdatadir=${placeholder "out"}/share"
+    "--with-tmpfilesdir=${placeholder "out"}/lib/tmpfiles.d"
+    "--with-systemdunitdir=${placeholder "out"}/lib/systemd/system"
+    "--with-dns-backend=${dnsType}"
+    "--with-firewall=${firewallType}"
+    # production build flags
     "--disable-maintainer-mode"
-    "--enable-openconnect=builtin"
-    "--with-openconnect=${openconnect}/sbin/openconnect"
-    "--enable-openvpn=builtin"
-    "--with-openvpn=${openvpn}/sbin/openvpn"
-    "--enable-vpnc=builtin"
-    "--with-vpnc=${vpnc}/sbin/vpnc"
     "--enable-session-policy-local=builtin"
-    "--enable-client"
-    "--enable-bluetooth"
-    "--enable-wifi"
-    "--enable-polkit"
+    # This is for building and running tests (probably enabled by default),
+    # --enable-tests installs the tests as well
     "--enable-tools"
-    "--enable-datafiles"
-    "--enable-pptp"
-    "--with-pptp=${pptp}/sbin/pptp"
-    "--enable-iwd"
-  ];
-  doCheck = true;
+  ]
+    ++ stdenv.lib.optionals (!enableLoopback) [ "--disable-loopback" ]
+    ++ stdenv.lib.optionals (!enableEthernet) [ "--disable-ethernet" ]
+    ++ stdenv.lib.optionals (!enableWireguard) [ "--disable-wireguard" ]
+    ++ stdenv.lib.optionals (!enableGadget) [ "--disable-gadget" ]
+    ++ stdenv.lib.optionals (!enableWifi) [ "--disable-wifi" ]
+    # We (almost) always turn on IWD support as it doesn't require any new dependencies
+    # and it's easier for the NixOS module to use only 1 connmand package when
+    # IWD is requested
+    ++ stdenv.lib.optionals (enableWifi) [ "--enable-iwd" ]
+    ++ stdenv.lib.optionals (!enableBluetooth) [ "--disable-bluetooth" ]
+    ++ stdenv.lib.optionals (!enableOfono) [ "--disable-ofono" ]
+    ++ stdenv.lib.optionals (!enableDundee) [ "--disable-dundee" ]
+    ++ stdenv.lib.optionals (!enablePacrunner) [ "--disable-pacrunner" ]
+    ++ stdenv.lib.optionals (!enableNeard) [ "--disable-neard" ]
+    ++ stdenv.lib.optionals (!enableWispr) [ "--disable-wispr" ]
+    ++ stdenv.lib.optionals (!enableTools) [ "--disable-tools" ]
+    ++ stdenv.lib.optionals (!enableStats) [ "--disable-stats" ]
+    ++ stdenv.lib.optionals (!enableClient) [ "--disable-client" ]
+    ++ stdenv.lib.optionals (!enableDatafiles) [ "--disable-datafiles" ]
+    ++ stdenv.lib.optionals (enableOpenconnect) [
+      "--enable-openconnect=builtin"
+      "--with-openconnect=${openconnect}/sbin/openconnect"
+    ]
+    ++ stdenv.lib.optionals (enableOpenvpn) [
+      "--enable-openvpn=builtin"
+      "--with-openvpn=${openvpn}/sbin/openvpn"
+    ]
+    ++ stdenv.lib.optionals (enableVpnc) [
+      "--enable-vpnc=builtin"
+      "--with-vpnc=${vpnc}/sbin/vpnc"
+    ]
+    ++ stdenv.lib.optionals (enablePolkit) [
+      "--enable-polkit"
+    ]
+    ++ stdenv.lib.optionals (enablePptp) [
+      "--enable-pptp"
+      "--with-pptp=${pptp}/sbin/pptp"
+    ]
+    ++ stdenv.lib.optionals (!enableWireguard) [
+      "--disable-wireguard"
+    ]
+    ++ stdenv.lib.optionals (enableNetworkManager) [
+      "--enable-nmcompat"
+    ]
+    ++ stdenv.lib.optionals (enableHh2serialGps) [
+      "--enable-hh2serial-gps"
+    ]
+    ++ stdenv.lib.optionals (enableL2tp) [
+      "--enable-l2tp"
+    ]
+    ++ stdenv.lib.optionals (enableIospm) [
+      "--enable-iospm"
+    ]
+    ++ stdenv.lib.optionals (enableTist) [
+      "--enable-tist"
+    ]
+  ;
 
-  outputs = [ "out" "dev" ];
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "A daemon for managing internet connections";

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,6 +1,21 @@
-{ stdenv, fetchurl, pkgconfig, openconnect, file, gawk,
-  openvpn, vpnc, glib, dbus, iptables, gnutls, polkit,
-  wpa_supplicant, readline6, pptp, ppp }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, openconnect
+, file
+, gawk,
+  openvpn
+, vpnc
+, glib
+, dbus
+, iptables
+, gnutls
+, polkit,
+  wpa_supplicant
+, readline6
+, pptp
+, ppp
+}:
 
 stdenv.mkDerivation rec {
   pname = "connman";
@@ -10,11 +25,26 @@ stdenv.mkDerivation rec {
     sha256 = "05kfjiqhqfmbbwc4snnyvi5hc4zxanac62f6gcwaf5mvn0z9pqkc";
   };
 
-  buildInputs = [ openconnect polkit
-                  openvpn vpnc glib dbus iptables gnutls
-                  wpa_supplicant readline6 pptp ppp ];
+  buildInputs = [
+    openconnect
+    polkit
+    openvpn
+    vpnc
+    glib
+    dbus
+    iptables
+    gnutls
+    wpa_supplicant
+    readline6
+    pptp
+    ppp
+  ];
 
-  nativeBuildInputs = [ pkgconfig file gawk ];
+  nativeBuildInputs = [
+    pkgconfig
+    file
+    gawk
+  ];
 
   preConfigure = ''
     export WPASUPPLICANT=${wpa_supplicant}/sbin/wpa_supplicant

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2550,37 +2550,11 @@ in
 
   conspy = callPackage ../os-specific/linux/conspy {};
 
-  connman = callPackage ../tools/networking/connman { };
-  connmanThin = callPackage ../tools/networking/connman {
-    enableOpenconnect = false;
-    enableOpenvpn = false;
-    enableVpnc = false;
-    vpnc = false;
-    enablePolkit = false;
-    enablePptp = false;
-    enableLoopback = false;
-    # enableEthernet = false; # If disabled no ethernet connection can be performed
-    enableWireguard = false;
-    enableGadget = false;
-    # enableWifi = false; # If disabled no WiFi connection can be performed
-    enableBluetooth = false;
-    enableOfono = false;
-    enableDundee = false;
-    enablePacrunner = false;
-    enableNeard = false;
-    enableWispr = false;
-    enableTools = false;
-    enableStats = false;
-    enableClient = false;
-    # enableDatafiles = false; # If disabled, configuration and data files are not installed
-  };
-  connmanFull = callPackage ../tools/networking/connman {
-    enableNetworkManager = true;
-    enableHh2serialGps = true;
-    enableL2tp = true;
-    enableIospm = true;
-    enableTist = true;
-  };
+  inherit (callPackage ../tools/networking/connman {})
+    connmanFull
+    connmanMinimal
+    connman
+  ;
 
   connman-gtk = callPackage ../tools/networking/connman/connman-gtk { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2559,10 +2559,10 @@ in
     enablePolkit = false;
     enablePptp = false;
     enableLoopback = false;
-    # enableEthernet = false;
+    # enableEthernet = false; # If disabled no ethernet connection can be performed
     enableWireguard = false;
     enableGadget = false;
-    # enableWifi = false;
+    # enableWifi = false; # If disabled no WiFi connection can be performed
     enableBluetooth = false;
     enableOfono = false;
     enableDundee = false;
@@ -2572,7 +2572,7 @@ in
     enableTools = false;
     enableStats = false;
     enableClient = false;
-    # enableDatafiles = false;
+    # enableDatafiles = false; # If disabled, configuration and data files are not installed
   };
   connmanFull = callPackage ../tools/networking/connman {
     enableNetworkManager = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2551,9 +2551,9 @@ in
   conspy = callPackage ../os-specific/linux/conspy {};
 
   inherit (callPackage ../tools/networking/connman {})
+    connman
     connmanFull
     connmanMinimal
-    connman
   ;
 
   connman-gtk = callPackage ../tools/networking/connman/connman-gtk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2551,6 +2551,36 @@ in
   conspy = callPackage ../os-specific/linux/conspy {};
 
   connman = callPackage ../tools/networking/connman { };
+  connmanThin = callPackage ../tools/networking/connman {
+    enableOpenconnect = false;
+    enableOpenvpn = false;
+    enableVpnc = false;
+    vpnc = false;
+    enablePolkit = false;
+    enablePptp = false;
+    enableLoopback = false;
+    # enableEthernet = false;
+    enableWireguard = false;
+    enableGadget = false;
+    # enableWifi = false;
+    enableBluetooth = false;
+    enableOfono = false;
+    enableDundee = false;
+    enablePacrunner = false;
+    enableNeard = false;
+    enableWispr = false;
+    enableTools = false;
+    enableStats = false;
+    enableClient = false;
+    # enableDatafiles = false;
+  };
+  connmanFull = callPackage ../tools/networking/connman {
+    enableNetworkManager = true;
+    enableHh2serialGps = true;
+    enableL2tp = true;
+    enableIospm = true;
+    enableTist = true;
+  };
 
   connman-gtk = callPackage ../tools/networking/connman/connman-gtk { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Update connman 1.38, see [change log](https://git.kernel.org/pub/scm/network/connman/connman.git/commit/?id=1ee420ace2b8edb0d4025f469aaa3d00d220dc98).
- Cleanup build for easy enable / disable of features.

###### Things done

- [X] Rewrite all features' enable / disable flags.
- [X] Cleaned up dependencies, including unneeded ones.
- [X] Added 2 new build flavors - `connmanFull` and `connmanThin` with several more / less features enabled / disabled.
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @matejc 