### PR TITLE
Tony: init at 2.1.1

### DIFF
--- a/pkgs/applications/audio/tony/default.nix
+++ b/pkgs/applications/audio/tony/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, alsaLib, boost, bzip2, fftw, fftwFloat, libfishsound
+, libid3tag, liblo, liblrdf, libmad, liboggz, libpulseaudio, libsamplerate
+, libsndfile, opusfile, portaudio, rubberband, serd, sord, vampSDK
+, wrapQtAppsHook, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tony";
+  version = "2.1.1";
+
+  src = fetchurl {
+    url = "https://code.soundsoftware.ac.uk/attachments/download/2616/${pname}-${version}.tar.gz";
+    sha256 = "03g2bmlj08lmgvh54dyd635xccjn730g4wwlhpvsw04bffz8b7fp";
+  };
+
+  buildInputs =
+    [ alsaLib boost bzip2 fftw fftwFloat libfishsound libid3tag liblo liblrdf
+      libmad liboggz libpulseaudio libsamplerate libsndfile opusfile pkgconfig
+      portaudio rubberband serd sord
+    ];
+
+  nativeBuildInputs = [ pkgconfig wrapQtAppsHook ];
+
+  enableParallelBuilding = true;
+
+  # comment out the tests
+  preConfigure = ''
+    sed -i 's/sub_test_svcore_/#sub_test_svcore_/' tony.pro
+  '';
+
+  meta = with stdenv.lib; {
+    description = "High quality melody transcription";
+    homepage = https://www.sonicvisualiser.org/tony/;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.vandenoever ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/audio/vamp/default.nix
+++ b/pkgs/development/libraries/audio/vamp/default.nix
@@ -6,13 +6,12 @@
 {
 
   vampSDK = stdenv.mkDerivation {
-    name = "vamp-sdk-2.7.1";
-    # version = "2.7.1";
+    name = "vamp-sdk-2.9.0";
 
     src = fetchFromGitHub {
       owner = "c4dm";
       repo = "vamp-plugin-sdk";
-      rev = "vamp-plugin-sdk-v2.7.1";
+      rev = "vamp-plugin-sdk-v2.9.0";
       sha256 = "1ifd6l6b89pg83ss4gld5i72fr0cczjnl2by44z5jnndsg3sklw4";
     };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21839,6 +21839,10 @@ in
 
   toggldesktop = libsForQt5.callPackage ../applications/misc/toggldesktop { };
 
+  tony = libsForQt5.callPackage ../applications/audio/tony {
+    inherit (pkgs.vamp) vampSDK;
+  };
+
   topydo = callPackage ../applications/misc/topydo {};
 
   torchPackages = recurseIntoAttrs ( callPackage ../applications/science/machine-learning/torch {


### PR DESCRIPTION
###### Motivation for this change

Add new tool for musicians from the same suite of applications as sonic-visualiser.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
