### PR TITLE
SDL_mixer: enable MikMod

### DIFF
--- a/pkgs/development/libraries/SDL_mixer/default.nix
+++ b/pkgs/development/libraries/SDL_mixer/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchurl, SDL, libogg, libvorbis, smpeg, enableNativeMidi ? false, fluidsynth ? null }:
+{ stdenv, lib, fetchurl, SDL, libogg, libvorbis, smpeg, libmikmod
+, enableNativeMidi ? false, fluidsynth ? null }:
 
 stdenv.mkDerivation rec {
   pname   = "SDL_mixer";
@@ -9,9 +10,9 @@ stdenv.mkDerivation rec {
     sha256 = "0alrhqgm40p4c92s26mimg9cm1y7rzr6m0p49687jxd9g6130i0n";
   };
 
-  buildInputs = [ SDL libogg libvorbis fluidsynth smpeg ];
+  buildInputs = [ SDL libogg libvorbis fluidsynth smpeg libmikmod ];
 
-  configureFlags = [ "--disable-music-ogg-shared" ]
+  configureFlags = [ "--disable-music-ogg-shared" "--disable-music-mod-shared" ]
     ++ lib.optional enableNativeMidi " --enable-music-native-midi-gpl"
     ++ lib.optionals stdenv.isDarwin [ "--disable-sdltest" "--disable-smpegtest" ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[pingus](https://github.com/NixOS/nixpkgs/tree/46420bbaa3f8f79ce7b9ee68e98eba1f7bce2db6/pkgs/games/pingus) fails to play music without MikMod support from [SDL_mixer](https://github.com/NixOS/nixpkgs/tree/46420bbaa3f8f79ce7b9ee68e98eba1f7bce2db6/pkgs/development/libraries/SDL_mixer).

With this change pingus plays music.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
    (no executable files)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    ~8 KiB increase
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).