### PR TITLE
poetry: 0.12.17 -> 1.0.3

### DIFF
--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, callPackage
-, isPy27, isPy34
+, isPy27, isPy34, pythonOlder
 , cleo
 , requests
 , cachy
@@ -7,7 +7,6 @@
 , pyrsistent
 , pyparsing
 , cachecontrol
-, lockfile
 , pkginfo
 , html5lib
 , shellingham
@@ -17,42 +16,43 @@
 , pathlib2
 , virtualenv
 , functools32
+, clikit
+, keyring
+, pexpect
+, importlib-metadata
 , pytest
 , jsonschema
+, intreehooks
+, lockfile
 }:
 
 let
-  cleo6 = cleo.overridePythonAttrs (oldAttrs: rec {
-    version = "0.6.8";
-    src = fetchPypi {
-      inherit (oldAttrs) pname;
-      inherit version;
-      sha256 = "06zp695hq835rkaq6irr1ds1dp2qfzyf32v60vxpd8rcnxv319l5";
-    };
-  });
   glob2 = callPackage ./glob2.nix { };
 
 in buildPythonPackage rec {
   pname = "poetry";
-  version = "0.12.17";
+  version = "1.0.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0gxwcd65qjmzqzppf53x51sic1rbcd9py6cdzx3aprppipimslvf";
+    sha256 = "0fx1ilgkrsqjjnpgv5zljsp0wpcsywdqvvi8im9z396qq6qpk830";
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace \
-      "requests-toolbelt>=0.8.0,<0.9.0" \
-      "requests-toolbelt>=0.8.0,<0.10.0" \
-      --replace 'pyrsistent>=0.14.2,<0.15.0' 'pyrsistent>=0.14.2,<0.16.0'
+    substituteInPlace pyproject.toml \
+     --replace "pyrsistent = \"^0.14.2\"" "pyrsistent = \"^0.15.0\"" \
+     --replace "requests-toolbelt = \"^0.8.0\"" "requests-toolbelt = \"^0.9.0\"" \
+     --replace "importlib-metadata = {version = \"~1.1.3\", python = \"<3.8\"}" \
+       "importlib-metadata = {version = \"~1.3.0\", python = \"<3.8\"}"
   '';
 
   format = "pyproject";
 
+  nativeBuildInputs = [ intreehooks ];
+
   propagatedBuildInputs = [
-    cachy
-    cleo6
+    cleo
+    clikit
     requests
     cachy
     requests-toolbelt
@@ -60,13 +60,16 @@ in buildPythonPackage rec {
     pyrsistent
     pyparsing
     cachecontrol
-    lockfile
     pkginfo
     html5lib
     shellingham
     tomlkit
+    pexpect
+    keyring
+    lockfile
   ] ++ lib.optionals (isPy27 || isPy34) [ typing pathlib2 glob2 ]
-    ++ lib.optionals isPy27 [ virtualenv functools32 subprocess32 ];
+    ++ lib.optionals isPy27 [ virtualenv functools32 subprocess32 ]
+    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   postInstall = ''
     mkdir -p "$out/share/bash-completion/completions"
@@ -85,7 +88,7 @@ in buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    homepage = https://github.com/sdispater/poetry;
+    homepage = "https://python-poetry.org/";
     description = "Python dependency management and packaging made easy";
     license = licenses.mit;
     maintainers = with maintainers; [ jakewaksbaum ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

 - ZHF: #80379
 - The current version is outdated by quite a bit and fails to build due to `substituteInPlace`'ing `setup.py` having no effect on the resulting wheel (anymore?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (exits with *No diff detected, stopping review...*, which I assume is good)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
