### PR TITLE
pythonPackages.chalice: disable pip version bounds

### DIFF
--- a/pkgs/development/python-modules/chalice/default.nix
+++ b/pkgs/development/python-modules/chalice/default.nix
@@ -44,8 +44,9 @@ buildPythonPackage rec {
   doCheck = false;
 
   postPatch = ''
+    sed -i setup.py -e "/pip>=/c\'pip',"
     substituteInPlace setup.py \
-      --replace 'pip>=9,<=18.1' 'pip' \
+      --replace 'pip>=9,<=19.4' 'pip' \
       --replace 'typing==3.6.4' 'typing' \
       --replace 'attrs==17.4.0' 'attrs' \
       --replace 'click>=6.6,<7.0' 'click'


### PR DESCRIPTION
###### Motivation for this change
to fix
```
on2.7/site-packages (from chalice==1.12.0) (7.0)
  ERROR: Could not find a version that satisfies the requirement pip<19.4,>=9 (from chalice==1.12.0) (from versions: none)
  ERROR: No matching distribution found for pip<19.4,>=9 (from chalice==1.12.0)
```

tests get ran, so versioning isn't a major concern

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[4 built, 2 copied (0.2 MiB), 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/80821
4 package built:
python27Packages.PyLTI python27Packages.chalice python37Packages.chalice python38Packages.chalice
```