### PR TITLE
pythonPackages.fluidasserts: disable because of dependency issues

### DIFF
--- a/pkgs/development/python-modules/fluidasserts/default.nix
+++ b/pkgs/development/python-modules/fluidasserts/default.nix
@@ -171,5 +171,6 @@ buildPythonPackage rec {
     maintainers = with maintainers; [
       kamadorueda
     ];
+    broken = true; # dependency breadth is making this unmanagable
   };
 }


### PR DESCRIPTION
###### Motivation for this change
```
Their version bounds are too restrictive on packages
that get bumped too often. Making this package broken
constantly.
```
dependency concerns have been expressed for a while:
#78111
#78401
#79765
#78301
#79038
#79612

mostly want to avoid the  noise of it on reviews
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
Nothing changed
https://github.com/NixOS/nixpkgs/pull/80822
$ nix-shell /home/jon/.cache/nixpkgs-review/pr-80822/shell.nix
```