### PR TITLE
sonic-lineup: init at 1.0.1

### DIFF
--- a/pkgs/applications/audio/sonic-lineup/default.nix
+++ b/pkgs/applications/audio/sonic-lineup/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, alsaLib, boost, bzip2, fftw, fftwFloat, libfishsound
+, libid3tag, liblo, liblrdf, libmad, liboggz, libpulseaudio, libsamplerate
+, libsndfile, opusfile, portaudio, rubberband, serd, sord, vampSDK, capnproto
+, wrapQtAppsHook, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sonic-lineup";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://code.soundsoftware.ac.uk/attachments/download/2610/${pname}-${version}.tar.gz";
+    sha256 = "0w4v5zr81d8fh97y820r0vj1rrbl0kwgvhfkdnyl4hiabs97b1i7";
+  };
+
+  buildInputs =
+    [ alsaLib boost bzip2 fftw fftwFloat libfishsound libid3tag liblo liblrdf
+      libmad liboggz libpulseaudio libsamplerate libsndfile opusfile pkgconfig
+      portaudio rubberband serd sord capnproto
+    ];
+
+  nativeBuildInputs = [ pkgconfig wrapQtAppsHook ];
+
+  enableParallelBuilding = true;
+
+  # comment out the tests
+  preConfigure = ''
+    sed -i 's/sub_test_svcore_/#sub_test_svcore_/' sonic-lineup.pro
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Comparative visualisation of related audio recordings";
+    homepage = https://www.sonicvisualiser.org/sonic-lineup/;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.vandenoever ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21550,6 +21550,10 @@ in
 
   skanlite = libsForQt5.callPackage ../applications/office/skanlite { };
 
+  sonic-lineup = libsForQt5.callPackage ../applications/audio/sonic-lineup {
+    inherit (pkgs.vamp) vampSDK;
+  };
+
   sonic-visualiser = libsForQt5.callPackage ../applications/audio/sonic-visualiser {
     inherit (pkgs.vamp) vampSDK;
   };


### PR DESCRIPTION
###### Motivation for this change

@cillianderoiste @luzpaz @ttuegel

If you like sonic-visualiser, you'll probably like this app from the same family too.

https://www.sonicvisualiser.org/sonic-lineup/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
