### PR TITLE
pythonPackages.acoustics: disable

### DIFF
--- a/pkgs/development/python-modules/acoustics/default.nix
+++ b/pkgs/development/python-modules/acoustics/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage rec {
     description = "A package for acousticians";
     maintainers = with maintainers; [ fridh ];
     license = with licenses; [ bsd3 ];
-    homepage = https://github.com/python-acoustics/python-acoustics;
+    homepage = "https://github.com/python-acoustics/python-acoustics";
+    broken = true; # no longer compatible with pandas>=1
   };
 }


### PR DESCRIPTION
###### Motivation for this change
no longer compatible with pandas>=1

probably also applicable to ZHF

```
builder for '/nix/store/790sq5wi9fp7ci3pwdabdcnnprxbfqxg-python3.7-acoustics-0.2.3.drv' failed with exit code 1; last 10 log lines:
  E                       ValueError: Length of passed values is 1, index implies 4.

  /nix/store/nqxwx13rn7253jif95nh84ypv7arr6ks-python3.7-pandas-1.0.1/lib/python3.7/site-packages/pandas/core/series.py:292: ValueError
  =============================== warnings summary ===============================
  standards/test_iec_61672_1_2013.py:30
    /build/acoustics-0.2.3/tests/standards/test_iec_61672_1_2013.py:30: DeprecationWarning: invalid escape sequence \c
      """

  -- Docs: https://docs.pytest.org/en/latest/warnings.html
  ================== 1 failed, 503 passed, 1 warning in 16.30s ===================
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
