### PR TITLE
poetry: 0.12.17 -> 1.0.3 (20.03 Backport)

### DIFF
--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, callPackage
-, isPy27, isPy34
+, isPy27, isPy34, pythonOlder
 , cleo
 , requests
 , cachy
@@ -7,7 +7,6 @@
 , pyrsistent
 , pyparsing
 , cachecontrol
-, lockfile
 , pkginfo
 , html5lib
 , shellingham
@@ -17,42 +16,43 @@
 , pathlib2
 , virtualenv
 , functools32
+, clikit
+, keyring
+, pexpect
+, importlib-metadata
 , pytest
 , jsonschema
+, intreehooks
+, lockfile
 }:
 
 let
-  cleo6 = cleo.overridePythonAttrs (oldAttrs: rec {
-    version = "0.6.8";
-    src = fetchPypi {
-      inherit (oldAttrs) pname;
-      inherit version;
-      sha256 = "06zp695hq835rkaq6irr1ds1dp2qfzyf32v60vxpd8rcnxv319l5";
-    };
-  });
   glob2 = callPackage ./glob2.nix { };
 
 in buildPythonPackage rec {
   pname = "poetry";
-  version = "0.12.17";
+  version = "1.0.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0gxwcd65qjmzqzppf53x51sic1rbcd9py6cdzx3aprppipimslvf";
+    sha256 = "0fx1ilgkrsqjjnpgv5zljsp0wpcsywdqvvi8im9z396qq6qpk830";
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace \
-      "requests-toolbelt>=0.8.0,<0.9.0" \
-      "requests-toolbelt>=0.8.0,<0.10.0" \
-      --replace 'pyrsistent>=0.14.2,<0.15.0' 'pyrsistent>=0.14.2,<0.16.0'
+    substituteInPlace pyproject.toml \
+     --replace "pyrsistent = \"^0.14.2\"" "pyrsistent = \"^0.15.0\"" \
+     --replace "requests-toolbelt = \"^0.8.0\"" "requests-toolbelt = \"^0.9.0\"" \
+     --replace "importlib-metadata = {version = \"~1.1.3\", python = \"<3.8\"}" \
+       "importlib-metadata = {version = \"~1.3.0\", python = \"<3.8\"}"
   '';
 
   format = "pyproject";
 
+  nativeBuildInputs = [ intreehooks ];
+
   propagatedBuildInputs = [
-    cachy
-    cleo6
+    cleo
+    clikit
     requests
     cachy
     requests-toolbelt
@@ -60,13 +60,16 @@ in buildPythonPackage rec {
     pyrsistent
     pyparsing
     cachecontrol
-    lockfile
     pkginfo
     html5lib
     shellingham
     tomlkit
+    pexpect
+    keyring
+    lockfile
   ] ++ lib.optionals (isPy27 || isPy34) [ typing pathlib2 glob2 ]
-    ++ lib.optionals isPy27 [ virtualenv functools32 subprocess32 ];
+    ++ lib.optionals isPy27 [ virtualenv functools32 subprocess32 ]
+    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   postInstall = ''
     mkdir -p "$out/share/bash-completion/completions"
@@ -85,7 +88,7 @@ in buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    homepage = https://github.com/sdispater/poetry;
+    homepage = "https://python-poetry.org/";
     description = "Python dependency management and packaging made easy";
     license = licenses.mit;
     maintainers = with maintainers; [ jakewaksbaum ];


### PR DESCRIPTION
Cherry picked from commit 011e2d3a2dee4318b5e1c994f617b40263ef5828/#80819

And a ping to @worldofpeace and @disassembler each, manually because I don't seem to be able to actually ping the group.

###### Motivation for this change

Needs backporting for #80379 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
