### PR TITLE
tockloader: init at v1.4.0

### DIFF
--- a/pkgs/development/tools/misc/tockloader/default.nix
+++ b/pkgs/development/tools/misc/tockloader/default.nix
@@ -1,0 +1,27 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "tockloader";
+  version = "1.4.0";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0l8mvlqzyq2bfb6g5zhgv2ndgyyrmpww2l7f2snbli73g6x5j2g2";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    argcomplete
+    colorama
+    crcmod
+    pytoml
+    pyserial
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/tock/tockloader";
+    license = licenses.mit;
+    description = "Tool for programming Tock onto hardware boards.";
+    maintainers = with maintainers; [ hexa ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23939,6 +23939,8 @@ in
 
   tinyfugue = callPackage ../games/tinyfugue { };
 
+  tockloader = callPackage ../development/tools/misc/tockloader { };
+
   tome2 = callPackage ../games/tome2 { };
 
   tome4 = callPackage ../games/tome4 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Tockloader describes itself as a "Tool for programming Tock onto hardware boards."

Personally I'm trying to get OpenSK (https://github.com/google/OpenSK) running on a Nordic nRF52840 MDK and the deploy process requires among other things tockloader.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
