### PR TITLE
powershell: update supported platforms

### DIFF
--- a/pkgs/shells/powershell/default.nix
+++ b/pkgs/shells/powershell/default.nix
@@ -30,22 +30,23 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     mkdir -p $out/share/powershell
     cp -r * $out/share/powershell
-    makeWrapper $out/share/powershell/pwsh $out/bin/pwsh --prefix ${platformLdLibraryPath} : "${stdenv.lib.makeLibraryPath libraries}" \
-                                           --set TERM xterm --set POWERSHELL_TELEMETRY_OPTOUT 1 --set DOTNET_CLI_TELEMETRY_OPTOUT 1
+    makeWrapper $out/share/powershell/pwsh $out/bin/pwsh \
+      --prefix ${platformLdLibraryPath} : "${stdenv.lib.makeLibraryPath libraries}" \
+      --set TERM xterm --set POWERSHELL_TELEMETRY_OPTOUT 1 --set DOTNET_CLI_TELEMETRY_OPTOUT 1
   '';
 
   dontStrip = true;
 
   meta = with stdenv.lib; {
     description = "Cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework";
-    homepage = https://github.com/PowerShell/PowerShell;
+    homepage = "https://github.com/PowerShell/PowerShell";
     maintainers = [ maintainers.yrashk ];
-    platforms = platforms.unix;
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
     license = with licenses; [ mit ];
   };
 
-  passthru = { 
-    shellPath = "/bin/pwsh"; 
+  passthru = {
+    shellPath = "/bin/pwsh";
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
update platforms to reflect actual supported builds

related: #80523

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
