### PR TITLE
gnulib: 20190811 -> 20200222

### DIFF
--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "gnulib";
-  version = "20190811";
+  version = "20200222";
 
   src = fetchgit {
     url = https://git.savannah.gnu.org/r/gnulib.git;
-    rev = "6430babe47ece6953cf18ef07c1d8642c8588e89";
-    sha256 = "14kgykbjly03dlb25sllcfcrpk7zkypa449gr3zbqv4rhpmnzizg";
+    rev = "d571f0dca66b9347251d78b4c9085fefb78eddb3";
+    sha256 = "06mn7cwhq3k1jg49gqnv1sf248mji05h0fjhnrzrfhp9n7p26axp";
   };
 
   dontFixup = true;


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
ZHF: #80379

This fixes xprintidle-ng which allows the packages that depend on it: super-productivity, surf-display, and safeeyes to build.

###### Things done
I updated gnulib to the latest commit. This version includes updated files for using gettext version 0.20 instead of 0.19. As a reminder we moved from 0.19.8.1 to 0.20.1 in #72946.

I tested the built version of xprintidle-ng and it appeared to work.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
