### PR TITLE
rust 1.41: Fix build with no_std only target

### DIFF
--- a/pkgs/development/compilers/rust/1_41_0.nix
+++ b/pkgs/development/compilers/rust/1_41_0.nix
@@ -6,6 +6,16 @@
 #    request review, in case platforms cannot be covered.
 # 2. The LLVM version used for building should match with rust upstream.
 # 3. Firefox and Thunderbird should still build on x86_64-linux.
+
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, pkgsBuildTarget, pkgsBuildBuild
+, fetchpatch
+} @ args:
+
 import ./default.nix {
   rustcVersion = "1.41.0";
   rustcSha256 = "0jypz2mrzac41sj0zh07yd1z36g2s2rvgsb8g624sk4l14n84ijm";
@@ -26,4 +36,13 @@ import ./default.nix {
   };
 
   selectRustPackage = pkgs: pkgs.rust_1_41_0;
+
+  rustcPatches = [
+    (fetchpatch {
+      url = "https://github.com/QuiltOS/rust/commit/f1803452b9e95bfdbc3b8763138b9f92c7d12b46.diff";
+      sha256 = "1mzxaj46bq7ll617wg0mqnbnwr1da3hd4pbap8bjwhs3kfqnr7kk";
+    })
+  ];
 }
+
+(builtins.removeAttrs args [ "fetchpatch" ])

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -4,6 +4,7 @@
 , bootstrapVersion
 , bootstrapHashes
 , selectRustPackage
+, rustcPatches ? []
 }:
 { stdenv, lib
 , buildPackages
@@ -72,6 +73,8 @@
         version = rustcVersion;
         sha256 = rustcSha256;
         inherit enableRustcDev;
+
+        patches = rustcPatches;
 
         # Use boot package set to break cycle
         rustPlatform = bootRustPlatform;

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -7,6 +7,7 @@
 , enableRustcDev ? true
 , version
 , sha256
+, patches ? []
 }:
 
 let
@@ -103,6 +104,8 @@ in stdenv.mkDerivation rec {
 
   # the rust build system complains that nix alters the checksums
   dontFixLibtool = true;
+
+  inherit patches;
 
   postPatch = ''
     patchShebangs src/etc


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/rust-lang/rust/pull/69381. We always pass a config, and this was messing it up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
