### PR TITLE
rl-2003: mention python driver

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -75,6 +75,24 @@ services.xserver.displayManager.defaultSession = "xfce+icewm";
 </programlisting>
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The testing driver implementation in NixOS is now in Python <filename>make-test-python.nix</filename>.
+     This was done by Jacek Galowicz (<link xlink:href="https://github.com/tfc">@tfc</link>), and with the
+     collaboration of Julian Stecklina (<link xlink:href="https://github.com/blitz">@blitz</link>) and
+     Jana Traue (<link xlink:href="https://github.com/jtraue">@jtraue</link>). All documentation has been updated to use this
+     testing driver, and a vast majority of the 286 tests in NixOS were ported to python driver. In 20.09 the Perl driver implementation,
+     <filename>make-test.nix</filename>, is slated for removal. This should give users of the NixOS integration framework
+     a transitory period to rewrite their tests to use the Python implementation. Users of the Perl driver will see
+     this warning everytime they use it:
+<screen>
+<prompt>$ </prompt>warning: Perl VM tests are deprecated and will be removed for 20.09.
+Please update your tests to use the python test driver.
+See https://github.com/NixOS/nixpkgs/pull/71684 for details.
+</screen>
+     API compatibility is planned to be kept for at least the next release with the perl driver.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Trying to cover https://github.com/NixOS/nixpkgs/issues/72828 https://github.com/NixOS/nixpkgs/pull/79335 and the plans for removal on the perl driver.

Don't merge just yet, because I need a hand with calculating how many tests were ported in 20.03.
(ref the [how_many_tests_were_ported] placeholder).

- [ ] figure how many tests were ported in 20.03

cc @tfc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
