### PR TITLE
xv: 0.1.1 -> 0.1.2, rename to xxv

### DIFF
--- a/pkgs/tools/misc/xxv/default.nix
+++ b/pkgs/tools/misc/xxv/default.nix
@@ -7,20 +7,17 @@ let useNcurses = !stdenv.hostPlatform.isWindows; in
 assert useNcurses -> ncurses != null;
 
 rustPlatform.buildRustPackage rec {
-  pname   = "xv";
-  version = "0.1.1";
+  pname   = "xxv";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner  = "chrisvest";
     repo   = pname;
     rev    = version;
-    sha256 = "0x2yd21sr4wik3z22rknkx1fgb64j119ynjls919za8gd83zk81g";
+    sha256 = "0ppfsgdigza2jppbkg4qanjhlkpnq7p115c4471vc6vpikpfrlk3";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0m69pcmnx3c3q7lgvbhxc8dl6lavv5ch4r6wg2bhdmapcmb4p7jq";
+  cargoSha256 = "1gnyig87a0yqgkng52fpn6hv629vym6k7ydljnxrhb5phmj2qbqx";
 
   buildInputs = lib.optionals useNcurses [ ncurses ]
   ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security ])
@@ -33,10 +30,10 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "A visual hex viewer for the terminal";
     longDescription = ''
-      XV is a terminal hex viewer with a text user interface, written in 100% safe Rust.
+      XXV is a terminal hex viewer with a text user interface, written in 100% safe Rust.
     '';
-    homepage    = https://chrisvest.github.io/xv/;
-    license     = with licenses; [ asl20 ];
+    homepage    = "https://chrisvest.github.io/xxv/";
+    license     = with licenses; [ gpl3 ];
     maintainers = with maintainers; [ lilyball ];
     platforms   = platforms.all;
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -509,6 +509,7 @@ mapAliases ({
   xf86_input_multitouch = throw "xf86_input_multitouch has been removed from nixpkgs."; # added 2020-01-20
   xlibs = xorg; # added 2015-09
   xpraGtk3 = xpra; # added 2018-09-13
+  xv = xxv; # added 2020-02-22
   youtubeDL = youtube-dl;  # added 2014-10-26
   zdfmediathk = mediathekview; # added 2019-01-19
   gnome_user_docs = gnome-user-docs; # added 2019-11-20

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7576,7 +7576,7 @@ in
 
   xurls = callPackage ../tools/text/xurls {};
 
-  xv = callPackage ../tools/misc/xv {};
+  xxv = callPackage ../tools/misc/xxv {};
 
   xvfb_run = callPackage ../tools/misc/xvfb-run { inherit (texFunctions) fontsConf; };
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/chrisvest/xxv/releases/tag/0.1.2

The `xv` tool was renamed to `xxv` and the license was updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
