### PR TITLE
python.pkgs.pybullet: 2.6.1 -> 2.6.6

### DIFF
--- a/pkgs/development/python-modules/pybullet/default.nix
+++ b/pkgs/development/python-modules/pybullet/default.nix
@@ -3,21 +3,24 @@
 , fetchPypi
 , libGLU, libGL
 , xorg
+, numpy
 }:
 
 buildPythonPackage rec {
   pname = "pybullet";
-  version = "2.6.1";
+  version = "2.6.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c6da064687ae481c73b744b9f3a62d8231349a6bf368d7a2e564f71ef73e9403";
+    sha256 = "1lsvjqij1vb9w8j6lvnq7lppflc7svz4cj37n74q67mb46gq3dxr";
   };
 
   buildInputs = [
     libGLU libGL
     xorg.libX11
   ];
+
+  propagatedBuildInputs =  [ numpy ];
 
   patches = [
     # make sure X11 and OpenGL can be found at runtime

--- a/pkgs/development/python-modules/pybullet/static-libs.patch
+++ b/pkgs/development/python-modules/pybullet/static-libs.patch
@@ -1,13 +1,13 @@
 diff --git a/setup.py b/setup.py
-index 98efabdbf..e69e79084 100644
+index 6f7bd7589..321fc6ab0 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -563,6 +563,8 @@ print("-----")
+@@ -465,6 +465,8 @@ print("-----")
  
  extensions = []
  
 +libraries += [ "X11", "GL" ] # statically link x11 and opengl
 +
- pybullet_ext = Extension("pybullet",
-         sources =  sources,
-         libraries = libraries,
+ pybullet_ext = Extension(
+     "pybullet",
+     sources=sources,


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
