### PR TITLE
buildRustPackage: add support for non-default bins

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -73,6 +73,17 @@ pkgs.rustPlatform.buildRustPackage {
 }
 ```
 
+### Building another executable from the crate
+
+To build different executables from the crate's default, use the `buildBins` attribute:
+
+```nix
+pkgs.rustPlatform.buildRustPackage {
+  (...)
+  buildBins = [ "sccache-dist" ];
+}
+```
+
 ## Compiling Rust crates using Nix instead of Cargo
 
 ### Simple operation

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -19,6 +19,7 @@
   # section on the manual and ./README.md.
 , legacyCargoFetcher ? false
 , buildType ? "release"
+, buildBins ? []
 , meta ? {}
 , target ? null
 , cargoVendorDir ? null
@@ -151,6 +152,7 @@ stdenv.mkDerivation (filteredArgs // {
       cargo build \
         ${stdenv.lib.optionalString (buildType == "release") "--release"} \
         --target ${rustTarget} \
+        ${concatStringsSep " " (map (b: "--bin=${b}") buildBins)} \
         --frozen ${concatStringsSep " " cargoBuildFlags}
     )
 


### PR DESCRIPTION
###### Motivation for this change

In order to eventually package sccache-dist, I need to plumb through the `--bin` flag to `cargo build` (i.e. `cargo build --bin sccache-dist`).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
