### PR TITLE
[20.03] pythonPackages.seaborn: use v0.9.1 for python 2

### DIFF
--- a/pkgs/development/python-modules/seaborn/0.9.1.nix
+++ b/pkgs/development/python-modules/seaborn/0.9.1.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     description = "Statisitical data visualization";
     homepage = "http://stanford.edu/~mwaskom/software/seaborn/";
     license = with lib.licenses; [ bsd3 ];
-    maintainers = with lib.maintainers; [ fridh ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/seaborn/0.9.1.nix
+++ b/pkgs/development/python-modules/seaborn/0.9.1.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, pandas
+, matplotlib
+}:
+
+buildPythonPackage rec {
+  pname = "seaborn";
+  version = "0.9.1";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "da33aa8c20a9a342ce73831d02831a10413f54a05471c7f31edf34f225d456ae";
+  };
+
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [ pandas matplotlib ];
+
+  checkPhase = ''
+    nosetests -v
+  '';
+
+  # Computationally very demanding tests
+  doCheck = false;
+
+  meta = {
+    description = "Statisitical data visualization";
+    homepage = "http://stanford.edu/~mwaskom/software/seaborn/";
+    license = with lib.licenses; [ bsd3 ];
+    maintainers = with lib.maintainers; [ fridh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5434,7 +5434,10 @@ in {
 
   scp = callPackage ../development/python-modules/scp {};
 
-  seaborn = callPackage ../development/python-modules/seaborn { };
+  seaborn = if isPy3k then
+    callPackage ../development/python-modules/seaborn { }
+  else
+    callPackage ../development/python-modules/seaborn/0.9.1.nix { };
 
   seabreeze = callPackage ../development/python-modules/seabreeze { };
 


### PR DESCRIPTION
required for poretools

(cherry picked from commit 7045c74cb2abb6285867a51438f5ef13851f7cf3)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backports #80832 
ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
