### PR TITLE
poetry: Fix build with Python 3.8

### DIFF
--- a/pkgs/development/tools/poetry/default.nix
+++ b/pkgs/development/tools/poetry/default.nix
@@ -8,6 +8,12 @@ poetry2nix.mkPoetryApplication {
   pyproject = ./pyproject.toml;
   poetrylock = ./poetry.lock;
 
+  overrides = [ (poetry2nix.defaultPoetryOverrides.overrideOverlay (self: super: {
+    # Needed because poetry2nix currently doesn't handle pyproject.toml python bounds
+    # See https://github.com/nix-community/poetry2nix/issues/50
+    importlib-metadata = if python.pythonOlder "3.8" then super.importlib-metadata else null;
+  }))];
+
   src = fetchFromGitHub (lib.importJSON ./src.json);
 
   # "Vendor" dependencies (for build-system support)


### PR DESCRIPTION
###### Motivation for this change
Poetry build with python 3.8 was broken:
```
$ nix-build -E 'with import ./. {}; poetry.override { python = python38; }'
error: value is null while a set was expected, at /nix/store/24kjp6k6piq42jxvzx80imdx0ysz6grz-nixexprs.tar.xz
  /pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix:569:27 (use '--show-trace' to show detailed location information)
```

See https://github.com/nix-community/poetry2nix/issues/50 for further info. The proper fix might take a while to be implemented. This here is only a workaround until then.

Ping @adisbladis 

This PR is sponsored by [Niteo](https://niteo.co/) :sparkles: 

###### Things done

- [x] Checked that the normal Python 3.7 poetry still builds: `nix-build -A poetry`
- [x] Checked that now a Python 3.8 poetry builds with `nix-build -E 'with import ./. {}; poetry.override { python = python38; }'`
