### PR TITLE
ghq: 0.12.6 -> 1.1.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/ghq/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/ghq/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, buildGoModule, fetchFromGitHub, fetchpatch }:
+{ stdenv, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "ghq";
-  version = "0.12.6";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
-    owner = "motemen";
+    owner = "x-motemen";
     repo = "ghq";
     rev = "v${version}";
-    sha256 = "14rm7fvphr7r9x0ys10vhzjwhfhhscgr574n1i1z4lzw551lrnp4";
+    sha256 = "1i0q9lxdxbyj0l0510cbkwkbycawrx8cxlbdrhb2p2fnk0vqnyiv";
   };
 
-  modSha256 = "1y2v8ir7kc2avgri06nagfyaxqr3xrg4g5pxl9rwzq9dyzm6ci5z";
+  modSha256 = "0hlbhky3c6zva9khn73n6xgq57k5p8anskxy3g2m0wzhr72cyc41";
 
   buildFlagsArray = ''
     -ldflags=
@@ -19,20 +19,13 @@ buildGoModule rec {
   '';
 
   postInstall = ''
-    install -m 444 -D ${src}/zsh/_ghq $out/share/zsh/site-functions/_ghq
+    install -m 444 -D ${src}/misc/zsh/_ghq $out/share/zsh/site-functions/_ghq
+    install -m 444 -D ${src}/misc/bash/_ghq $out/share/bash-completion/completions/_ghq
   '';
-
-  patches = [
-    (fetchpatch {
-      # remove once the commit lands in a release.
-      url = "https://github.com/motemen/ghq/commit/38ac89e60e60182b5870108f9753c9fe8d00e4a6.patch";
-      sha256 = "1z8yvzmka3sh44my6jnwc39p8zs7mczxgvwc9z0pkqk4vgvaj8gj";
-    })
-  ];
 
   meta = {
     description = "Remote repository management made easy";
-    homepage = https://github.com/motemen/ghq;
+    homepage = https://github.com/x-motemen/ghq;
     maintainers = with stdenv.lib.maintainers; [ sigma ];
     license = stdenv.lib.licenses.mit;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update ghq.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
