### PR TITLE
python2Packages.jinja2: disable tests on 32bit systems

### DIFF
--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -1,5 +1,9 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, pytest, markupsafe }:
+{ stdenv
+, buildPythonPackage
+, isPy3k
+, fetchPypi
+, pytest
+, markupsafe }:
 
 buildPythonPackage rec {
   pname = "Jinja2";
@@ -12,6 +16,10 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest ];
   propagatedBuildInputs = [ markupsafe ];
+
+  # Multiple tests run out of stack space on 32bit systems with python2.
+  # See https://github.com/pallets/jinja/issues/1158
+  doCheck = !stdenv.is32bit || isPy3k;
 
   checkPhase = ''
     pytest -v tests


### PR DESCRIPTION
###### Motivation for this change
ZHF: #80379 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox))
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested on aarch64, i686, x86_64
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
