### PR TITLE
pythonPackages.pysaml2: fix tests on 32bit systems

### DIFF
--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -36,6 +36,11 @@ buildPythonPackage rec {
     })
   ];
 
+  postPatch = ''
+    # fix failing tests on systems with 32bit time_t
+    sed -i 's/2999\(-.*T\)/2029\1/g' tests/*.xml
+  '';
+
   propagatedBuildInputs = [ cryptography defusedxml future pyopenssl dateutil pytz requests six ];
 
   checkInputs = [ mock pyasn1 pymongo pytest responses ];


### PR DESCRIPTION
###### Motivation for this change
ZHF: #80379 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox))
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested on i686, x86_64
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
