### PR TITLE
keycloak: init 9.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8102,4 +8102,9 @@
     githubId = 3674056;
     name = "Asad Saeeduddin";
   };
+  ngerstle = {
+    name  = "Nicholas Gerstle";
+    email = "ngerstle@gmail.com";
+    github = "ngerstle";
+  };
 }

--- a/pkgs/servers/keycloak/default.nix
+++ b/pkgs/servers/keycloak/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchzip, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  pname   = "keycloak";
+  version = "9.0.0";
+
+  src = fetchzip {
+    url    = "https://downloads.jboss.org/keycloak/${version}/keycloak-${version}.zip";
+    sha256 = "1w2d76v1rjghvdks1w32qi08gh88cd37vbf6vx0kq9a2gnhn7hip";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir $out
+    cp -r * $out
+
+    rm -rf $out/bin/*.{ps1,bat}
+    rm -rf $out/bin/add-user-keycloak.sh
+    rm -rf $out/bin/jconsole.sh
+
+    chmod +x $out/bin/standalone.sh
+    wrapProgram $out/bin/standalone.sh \
+      --prefix PATH ":" ${jre}/bin ;
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = "https://www.keycloak.org/";
+    description = "Open Source Identity and Access Management For Modern Applications and Services";
+    license     = licenses.asl20;
+    maintainers = [ maintainers.ngerstle ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15349,6 +15349,8 @@ in
 
   jetty = callPackage ../servers/http/jetty { };
 
+  keycloak = callPackage ../servers/keycloak { };
+
   knot-dns = callPackage ../servers/dns/knot-dns { };
   knot-resolver = callPackage ../servers/dns/knot-resolver { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Keycloak is a common opensource IdP for both home and business use, and is missing from the nixpkg repos. While this does not build from source (which involves a complex maven build), it does grab a build jar and make it available for use.

Running `JBOSS_BASE_DIR=/some/mutable/folder standalone.sh` allows running keycloak in standalone mode (assuming the folder has necessary configuration files).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
