### PR TITLE
nixos/acme: Must-Staple and extra flags

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -149,6 +149,14 @@ let
           </itemizedlist>
         '';
       };
+
+      extraLegoRenewFlags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Additional flags to pass to lego renew.
+        '';
+      };
     };
   };
 
@@ -305,7 +313,7 @@ in
                 runOpts = escapeShellArgs (globalOpts ++ [ "run" ] ++ certOpts);
                 renewOpts = escapeShellArgs (globalOpts ++
                   [ "renew" "--days" (toString cfg.validMinDays) ] ++
-                  certOpts);
+                  certOpts ++ data.extraLegoRenewFlags);
                 acmeService = {
                   description = "Renew ACME Certificate for ${cert}";
                   after = [ "network.target" "network-online.target" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Split out from #80856.

Responding to @m1cr0man from there:

> The first two look good to me! I probably need this on my own setup with the 28 certs I'm trying to validate there, to avoid rate limits stuck_out_tongue
> 
> As for the additionalLegoRenewFlags, I actually had something similar (`extraFlags`) before I made the PR for lego (#77578, actually it was [here](https://github.com/redbrick/nix-configs/blob/67a927d9bc3cf0507e8c06f637dbbb0b4a6d676f/services/certs/rbacme.nix#L120)) . I removed it because I felt it was too solution specific, and if we were to change acme clients again, this flag would have to be deprecated. With the other options like mustStaple and dnsPropagationCheck, at least if the next client has those features we can rewrite the arguments, but if people have random extra arguments then we can only break their configuration.
> 
> I am not against the idea either, for power users there is certainly desire to allow for custom flags to the service, but they run the above risk of it breaking some day. Would love to hear some other opinions on the matter. :slightly_smiling_face:

I personally think that it's better for `additionalLegoRenewFlags = ["--my-option"]` to break cleanly at a later date than it is for people to be unable to use the NixOS module if they need additional configuration, but I realize that this is a somewhat philosophical difference. I made sure to include the name of the command in the configuration option so that there's no clash with a possible later `additionalCertbotFlags` or similar.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).