### PR TITLE
wayvnc, neatvnc: init at 0.1.0

### DIFF
--- a/pkgs/applications/networking/remote/wayvnc/default.nix
+++ b/pkgs/applications/networking/remote/wayvnc/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, meson, pkg-config, ninja
+, pixman, libuv, libGL, libxkbcommon, wayland, neatvnc, libdrm, libX11
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wayvnc";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "any1";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "17c30c33zzhhlqzc4a5dd1y74ch7c8gsm98wvcn4n1fv50fbmpbd";
+  };
+
+  nativeBuildInputs = [ meson pkg-config ninja ];
+  buildInputs = [ pixman libuv libGL libxkbcommon wayland neatvnc libdrm libX11 ];
+
+  meta = with stdenv.lib; {
+    description = "A VNC server for wlroots based Wayland compositors";
+    longDescription = ''
+      This is a VNC server for wlroots based Wayland compositors. It attaches
+      to a running Wayland session, creates virtual input devices and exposes a
+      single display via the RFB protocol. The Wayland session may be a
+      headless one, so it is also possible to run wayvnc without a physical
+      display attached.
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/development/libraries/neatvnc/default.nix
+++ b/pkgs/development/libraries/neatvnc/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, meson, pkg-config, ninja
 , pixman, libuv, gnutls, libdrm
 # libjpeg_turbo: Optional, for tight encoding (disabled because experimental)
+, enableCpuAcceleration ? false # Whether to use CPU extensions (e.g. AVX)
 }:
 
 stdenv.mkDerivation rec {
@@ -16,6 +17,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson pkg-config ninja ];
   buildInputs = [ pixman libuv gnutls libdrm ];
+
+  patches = stdenv.lib.optional (!enableCpuAcceleration) ./disable-cpu-acceleration.patch;
 
   meta = with stdenv.lib; {
     description = "A VNC server library";

--- a/pkgs/development/libraries/neatvnc/default.nix
+++ b/pkgs/development/libraries/neatvnc/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, meson, pkg-config, ninja
+, pixman, libuv, gnutls, libdrm
+# libjpeg_turbo: Optional, for tight encoding (disabled because experimental)
+}:
+
+stdenv.mkDerivation rec {
+  pname = "neatvnc";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "any1";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04wcpwxlcf0bczcs97j21346mn6finfj7xgc2dsrwrw9xq8qa7wc";
+  };
+
+  nativeBuildInputs = [ meson pkg-config ninja ];
+  buildInputs = [ pixman libuv gnutls libdrm ];
+
+  meta = with stdenv.lib; {
+    description = "A VNC server library";
+    longDescription = ''
+      This is a liberally licensed VNC server library that's intended to be
+      fast and neat. Goals:
+      - Speed
+      - Clean interface
+      - Interoperability with the Freedesktop.org ecosystem
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/development/libraries/neatvnc/disable-cpu-acceleration.patch
+++ b/pkgs/development/libraries/neatvnc/disable-cpu-acceleration.patch
@@ -1,0 +1,17 @@
+diff --git a/meson.build b/meson.build
+index 31dd8b8..8761087 100644
+--- a/meson.build
++++ b/meson.build
+@@ -21,12 +21,6 @@ endif
+ 
+ cpu = host_machine.cpu_family()
+ 
+-if cpu == 'x86_64'
+-	c_args += '-mavx'
+-elif cpu == 'arm'
+-	c_args += '-mfpu=neon'
+-endif
+-
+ add_project_arguments(c_args, language: 'c')
+ 
+ cc = meson.get_compiler('c')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22166,6 +22166,8 @@ in
 
   wayv = callPackage ../tools/X11/wayv {};
 
+  wayvnc = callPackage ../applications/networking/remote/wayvnc { };
+
   webmacs = libsForQt5.callPackage ../applications/networking/browsers/webmacs {};
 
   webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13465,6 +13465,8 @@ in
 
   neardal = callPackage ../development/libraries/neardal { };
 
+  neatvnc = callPackage ../development/libraries/neatvnc { };
+
   neon = callPackage ../development/libraries/neon { };
 
   neon_0_29 = callPackage ../development/libraries/neon/0.29.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

~~Status: Theoretically it should work, but unfortunately `wayvnc` does crash inside my test VM after receiving SIGILL. Details regarding my crash are here: https://github.com/any1/neatvnc/issues/21~~
~~Works, but if we don't override the default configuration it requires AVX on x86_64 CPUs.~~
I decided to disable the usage of CPU extensions for performance by default (should be appropriate for Nixpkgs).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
