### PR TITLE
gnulib:  20190811 -> 20200223  and simplify usage

### DIFF
--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "gnulib";
-  version = "20190811";
+  version = "20200223";
 
   src = fetchgit {
     url = https://git.savannah.gnu.org/r/gnulib.git;
-    rev = "6430babe47ece6953cf18ef07c1d8642c8588e89";
-    sha256 = "14kgykbjly03dlb25sllcfcrpk7zkypa449gr3zbqv4rhpmnzizg";
+    rev = "292fd5d6ff5ecce81ec3c648f353732a9ece83c0";
+    sha256 = "0hkg3nql8nsll0vrqk4ifda0v4kpi67xz42r8daqsql6c4rciqnw";
   };
 
   dontFixup = true;

--- a/pkgs/tools/X11/xprintidle-ng/default.nix
+++ b/pkgs/tools/X11/xprintidle-ng/default.nix
@@ -19,20 +19,18 @@ stdenv.mkDerivation rec {
       --replace "AC_PREREQ([2.62])" "AC_PREREQ([2.63])"
   '';
 
-  nativeBuildInputs = [ 
+  nativeBuildInputs = [
     autoconf automake gettext git gnulib
     help2man libtool perl pkgconfig texinfo
   ];
 
   configurePhase = ''
-    cp -r "${gnulib}" gnulib
-    chmod a+rX,u+w -R gnulib
-    ./bootstrap --gnulib-srcdir=gnulib
+    ./bootstrap --gnulib-srcdir=${gnulib}
     ./configure --prefix="$out"
   '';
 
   buildInputs = [
-    libX11 libXScrnSaver libXext  
+    libX11 libXScrnSaver libXext
   ];
 
   meta = {

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -83,12 +83,9 @@ stdenv.mkDerivation rec {
 
       unset CPP # setting CPP intereferes with dependency calculation
 
-      cp -r ${gnulib} $PWD/gnulib
-      chmod u+w -R $PWD/gnulib
-
       patchShebangs .
 
-      ./bootstrap --no-git --gnulib-srcdir=$PWD/gnulib
+      ./bootstrap --no-git --gnulib-srcdir=${gnulib}
 
       substituteInPlace ./configure --replace '/usr/share/fonts/unifont' '${unifont}/share/fonts'
     '';


### PR DESCRIPTION
###### Motivation for this change 

Update gnulib, which allows it to work correctly if installed to readonly location. We don't need to copy the gnulib sources in each build anymore.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).