### PR TITLE
nixos/version: obfuscate stateVersion to discourage modification

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -55,6 +55,8 @@ let
     # back-compat aliases
     platforms = systems.doubles;
 
+    nixos = callLibs ./nixos.nix;
+
     inherit (builtins) add addErrorContext attrNames concatLists
       deepSeq elem elemAt filter genericClosure genList getAttr
       hasAttr head isAttrs isBool isInt isList isString length

--- a/lib/nixos.nix
+++ b/lib/nixos.nix
@@ -1,0 +1,27 @@
+/* Collection of functions and constants specific to NixOS */
+{ lib }:
+let
+  inherit (lib) versions strings;
+in rec {
+  # arbitrarily chosen, needs to be >99
+  # needs to be != 100, that would defeat the point
+  stateVersionBase = 149;
+
+  encodeStateVersion = v:
+    let parts = versions.splitVersion v;
+        numbers = map strings.toInt parts;
+     in lib.foldl' (acc: digit: acc * stateVersionBase + digit) 0 numbers;
+
+  decodeStateVersion = v:
+    let parts = n: if n == 0 then [] else [ (lib.mod n stateVersionBase) ] ++ parts (n / stateVersionBase);
+        numbers = lib.reverseList (parts v);
+        version = lib.concatMapStringsSep "." (strings.fixedWidthNumber 2) numbers;
+    in version;
+
+  sanityCheckStateVersion = newestPossibleVersion: version:
+    let minor = versions.minor version;
+        validMinorVersions = [ "03" "09" ];
+        validMinor = lib.elem minor validMinorVersions;
+        notNewerThanNixpkgs = lib.versionAtLeast newestPossibleVersion version;
+    in validMinor && notNewerThanNixpkgs;
+}

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -90,7 +90,7 @@ in
       # your system.  Help is available in the configuration.nix(5) man page
       # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-      { config, pkgs, ... }:
+      { config, pkgs, lib, ... }:
 
       {
         imports =
@@ -174,7 +174,7 @@ in
         # this value at the release version of the first install of this system.
         # Before changing this value read the documentation for this option
         # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-        system.stateVersion = "${config.system.nixos.release}"; # Did you read the comment?
+        system.stateVersion = lib.nixos.decodeStateVersion ${toString (lib.nixos.encodeStateVersion config.system.nixos.release)}; # Did you read the comment?
 
       }
     '';

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -89,6 +89,10 @@ in
   };
 
   config = {
+    assertions = [ {
+      assertion = lib.nixos.sanityCheckStateVersion cfg.release config.system.stateVersion;
+      message = "system.stateVersion was set to an invalid version.";
+    } ];
 
     system.nixos = {
       # These defaults are set here rather than up there so that


### PR DESCRIPTION
###### Motivation for this change

Many users get the impression of having to update stateVersion when
upgrading their channel, and cause subtle or obvious breakage.

This happened repeatedly, despite nixos-generate-config adding
5 lines of comment around the definition.

Because the value of stateVersion is a NixOS version, e.g. "19.09",
people were tricked into believing this option sets the state ("system
version") of their system, when instead it sets the system version
of the state to stay compatible with.

This commit changes nothing about stateVersion itself, to ensure
backwards compatibility with uses of stateVersion inside and outside
of nixpkgs.

Instead, it now sets stateVersion to an expression that doesn't look
like a NixOS version, and should not invoke the notion of needing to be
updated.

Example configuration snippet:
system.stateVersion = lib.nixos.decodeStateVersion 2989;

Some effort is made to prevent decoding to invalid versions, but
those can still be set.

This is only for newly generated configurations, and the obfuscation
can be bypassed by just setting stateVersion to e.g. "20.03" directly,
without encoding/decoding.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Generated ISO and installed a new system
- [x] Tried a few encoded values, passed sanity check as expected
- [ ] Good error handling for values like "unstable" and "nixos-unstable"
- [ ] Revise the comment above it?

###### Things to question

- Do we never need a `stateVersion` newer than `config.system.nixos.release`?
- Do we want `lib.nixos`, or rather `utils`?
- Is this a good encoding scheme (it would be a permanent choice)?
- Is this still needed after c1d7850f85eaedbe8ebe13205f90865ca1361d31?
- Is this condescending to our users (this protects you from yourself, we know better, etc.)?

I only discovered the new comment when I was almost done. I'm okay with this being closed,
but I still wanted to bring it up.

###### Related contributors

@Infinisil @maralorn @nh2 @grahamc 