### PR TITLE
libfido2: add macOS support

### DIFF
--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, fetchurl, cmake, pkgconfig, libcbor, libressl, udev }:
+{ stdenv, fetchurl, cmake, pkgconfig, libcbor, libressl, udev, IOKit }:
 
 stdenv.mkDerivation rec {
   pname = "libfido2";
-  version = "1.3.0";
+  version = "1.3.1";
   src = fetchurl {
     url = "https://developers.yubico.com/${pname}/Releases/${pname}-${version}.tar.gz";
-    sha256 = "1izyl3as9rn7zcxpsvgngjwr55gli5gy822ac3ajzm65qiqkcbhb";
+    sha256 = "0hdgxbmjbnm9kjwc07nrl2zy87qclvb3rzvdwr5iw35n2qhf4dds";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libcbor libressl ] ++ stdenv.lib.optionals stdenv.isLinux [ udev ];
+  buildInputs = [ libcbor libressl ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ udev ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
 
-  cmakeFlags = [ "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d" ];
+  patches = [ ./detect_apple_ld.patch ];
+
+  cmakeFlags = [ "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d"
+                 "-DCMAKE_INSTALL_LIBDIR=lib" ];
 
   meta = with stdenv.lib; {
     description = ''
@@ -20,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/Yubico/libfido2;
     license = licenses.bsd2;
     maintainers = with maintainers; [ dtzWill ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libfido2/detect_apple_ld.patch
+++ b/pkgs/development/libraries/libfido2/detect_apple_ld.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2020-02-19 17:21:59.000000000 +0000
++++ b/CMakeLists.txt	2020-02-23 15:57:34.241115306 +0000
+@@ -296,7 +296,7 @@
+ endif()
+ 
+ # export list
+-if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
++if(APPLE AND CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")	
+ 	# clang + lld
+ 	string(CONCAT CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS}
+ 	    " -exported_symbols_list ${CMAKE_CURRENT_SOURCE_DIR}/src/export.llvm")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12468,7 +12468,9 @@ in
 
   libfakekey = callPackage ../development/libraries/libfakekey { };
 
-  libfido2 = callPackage ../development/libraries/libfido2 { };
+  libfido2 = callPackage ../development/libraries/libfido2 {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
 
   libfilezilla = callPackage ../development/libraries/libfilezilla { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Currently, libfido2 does not support building on macOS. This means that OpenSSH 8.2 will be unable to support ecdsa-sk keys on macOS when running as an SSH client.

###### Things done

* pass IOKit to libfido2
* Add a patch so that cmake uses lld flags when linking
* Upgrade from 1.3.0 to 1.3.1 (based off #80781)
* Specify CMAKE_INSTALL_LIBDIR so that the demo binaries link
  correctly on macOS and libfido2.pc specifies correct arguments

I tested that FIDO keys were detected on both nixOS and macOS 10.13 (the newest mac I own).
I also built openssh 8.2p1 using the changes from #80196 with libfido2 and was able to generate an ecdsa-sk keypair on both nixOS and macOS.


Note that I do not have permission to build with ofborg on macOS, so someone else will have to do that for me.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
