### PR TITLE
rainloop: 1.13.0 -> 1.14.0

### DIFF
--- a/pkgs/servers/rainloop/default.nix
+++ b/pkgs/servers/rainloop/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, unzip, dataPath ? "/etc/rainloop" }: let
+{ stdenv, fetchurl, unzip, pkgs, dataPath ? "/var/lib/rainloop" }: let
   common = { edition, sha256 }:
     stdenv.mkDerivation (rec {
       pname = "rainloop${stdenv.lib.optionalString (edition != "") "-${edition}"}";
-      version = "1.13.0";
+      version = "1.14.0";
 
       buildInputs = [ unzip ];
 
@@ -16,11 +16,23 @@
         sha256 = sha256;
       };
 
+      includeScript = pkgs.writeText "include.php" ''
+        <?php
+
+        /**
+         * @return string
+         */
+        function __get_custom_data_full_path()
+        {
+          return '${dataPath}'; // custom data folder path
+        }
+      '';
+
       installPhase = ''
         mkdir $out
         cp -r rainloop/* $out
         rm -rf $out/data
-        ln -s ${dataPath} $out/data
+        cp ${includeScript} $out/include.php
       '';
 
       meta = with stdenv.lib; {
@@ -35,10 +47,10 @@
   in {
     rainloop-community = common {
       edition = "community";
-      sha256 = "1skwq6bn98142xf8r77b818fy00nb4x0s1ii3mw5849ih94spx40";
+      sha256 = "0a8qafm4khwj8cnaiaxvjb9073w6fr63vk1b89nks4hmfv10jn6y";
     };
     rainloop-standard = common {
       edition = "";
-      sha256 = "e3ec8209cb3b9f092938a89094e645ef27659763432bedbe7fad4fa650554222";
+      sha256 = "0961g4mci080f7y98zx9r4qw620l4z3na1ivvlyhhr1v4dywqvch";
     };
   }


### PR DESCRIPTION
- update version
- change mechanism to set the data folder outside the nix store

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update rainloop to latest available version, and also fix a problem on NixOS where the application would not work by simply creating a symlink for the `<derivation>/data` folder, as rainloop will complain the data directory is not writable.

The better way to set a data folder outside the rainloop folder is by creating a short `include.php` that is used as an override to data location (reference: https://github.com/RainLoop/rainloop-webmail/blob/master/_include.php).

The new location for the `data` folder will have to be created separately (e.g. through a module in NixOS or otherwise) with write access to the user under which the PHP scripts are executed.

Note that on NixOS, setting the rainloop data path under `/etc` will also cause errors, hence the change of the default to `/var/lib/rainloop`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
