### PR TITLE
pythonPackages.ansible-lint: disable for python2

### DIFF
--- a/pkgs/development/python-modules/ansible-lint/default.nix
+++ b/pkgs/development/python-modules/ansible-lint/default.nix
@@ -1,17 +1,21 @@
 { lib
 , fetchPypi
 , buildPythonPackage
+, isPy27
 , ansible
 , pyyaml
 , six
 , nose
 , setuptools_scm
 , ruamel_yaml
+, pathlib2
 }:
 
 buildPythonPackage rec {
   pname = "ansible-lint";
   version = "4.2.0";
+  # pip is not able to import version info on raumel.yaml
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
@@ -21,7 +25,8 @@ buildPythonPackage rec {
   format = "pyproject";
 
   nativeBuildInputs = [ setuptools_scm ];
-  propagatedBuildInputs = [ pyyaml six ansible ruamel_yaml ];
+  propagatedBuildInputs = [ pyyaml six ansible ruamel_yaml ]
+    ++ lib.optionals isPy27 [ pathlib2 ];
   checkInputs = [ nose ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
