### PR TITLE
go_1_12, go_1_13: remove velovix from maintainers

### DIFF
--- a/pkgs/development/compilers/go/1.12.nix
+++ b/pkgs/development/compilers/go/1.12.nix
@@ -242,7 +242,7 @@ stdenv.mkDerivation rec {
     homepage = http://golang.org/;
     description = "The Go Programming language";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ cstrahan orivej velovix mic92 rvolosatovs Frostman ];
+    maintainers = with maintainers; [ cstrahan orivej mic92 rvolosatovs Frostman ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -239,7 +239,7 @@ stdenv.mkDerivation rec {
     homepage = http://golang.org/;
     description = "The Go Programming language";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ cstrahan orivej velovix mic92 rvolosatovs kalbasit Frostman ];
+    maintainers = with maintainers; [ cstrahan orivej mic92 rvolosatovs kalbasit Frostman ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

When I originally added myself as a maintainer it seemed like there wasn't as much momentum behind Go on NixOS, but these days there are plenty of talented people making and approving PRs for Go. I don't have the expertise to maintain this package properly, but I sure am thankful for those of you that do!

###### Things done

I have removed myself as a maintainer for the Go packages.

I'm assuming that a change like this does not actually affect downstream packages so I haven't done any testing. Please correct me if I'm wrong and I'll do whatever's necessary.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
