### PR TITLE
programs/chromium: allow extensions outside chrome web store

### DIFF
--- a/nixos/modules/programs/chromium.nix
+++ b/nixos/modules/programs/chromium.nix
@@ -9,9 +9,7 @@ let
     HomepageLocation = cfg.homepageLocation;
     DefaultSearchProviderSearchURL = cfg.defaultSearchProviderSearchURL;
     DefaultSearchProviderSuggestURL = cfg.defaultSearchProviderSuggestURL;
-    ExtensionInstallForcelist = map (extension:
-      "${extension};https://clients2.google.com/service/update2/crx"
-    ) cfg.extensions;
+    ExtensionInstallForcelist = cfg.extensions;
   };
 in
 
@@ -28,7 +26,11 @@ in
           List of chromium extensions to install.
           For list of plugins ids see id in url of extensions on
           <link xlink:href="https://chrome.google.com/webstore/category/extensions">chrome web store</link>
-          page.
+          page. To install a chromium extension not included in the chrome web
+          store, append to the extension id a semicolon ";" followed by a URL
+          pointing to an Update Manifest XML file. See
+          <link xlink:href="https://www.chromium.org/administrators/policy-list-3#ExtensionInstallForcelist">ExtensionInstallForcelist</link>
+          for additional details.
         '';
         default = [];
         example = literalExample ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The `programs.chromium.extensions` option currently appends the chrome web store update URL to the extension ID for the [ExtensionInstallForcelist](https://www.chromium.org/administrators/policy-list-3#ExtensionInstallForcelist) option. As indicated by the documentation for [ExtensionInstallForcelist](https://www.chromium.org/administrators/policy-list-3#ExtensionInstallForcelist) this is not necessary as it is already the default.

Removing this implicit default would allow a user to more easily install extensions not in the chrome web store by setting the update URL themselves.  An example was also added to the documentation.

If an alternative schema for this option is desired, I am open to it. Maybe a list of `{ id= "..."; updateURL = "..."; }` attrsets? I tried to just do a minimal change that wouldn't break any existing configs.

Also relevant to this PR is https://github.com/NixOS/nixpkgs/issues/76863 which would be nicer but probably requires a lot more work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
