### PR TITLE
gdb: Fix abort w/NIX_DEBUG_INFO_DIRS patch

### DIFF
--- a/pkgs/development/tools/misc/gdb/debug-info-from-env.patch
+++ b/pkgs/development/tools/misc/gdb/debug-info-from-env.patch
@@ -3,11 +3,13 @@ of directories with separate debugging information files.
 
 --- a/gdb/main.c
 +++ b/gdb/main.c
-@@ -551,3 +551,6 @@ captured_main_1 (struct captured_main_args *context)
+@@ -556,3 +556,8 @@ captured_main_1 (struct captured_main_args *context)
  
 -  debug_file_directory = relocate_gdb_directory (DEBUGDIR,
 +  debug_file_directory = getenv("NIX_DEBUG_INFO_DIRS");
 +
-+  if (debug_file_directory == NULL)
++  if (debug_file_directory != NULL)
++    debug_file_directory = xstrdup(debug_file_directory);
++  else
 +    debug_file_directory = relocate_gdb_directory (DEBUGDIR,
  						 DEBUGDIR_RELOCATABLE);


### PR DESCRIPTION
The current gdb patch to support NIX_DEBUG_INFO_DIRS fails if
the user attempts to change the debug file directory to a
value other than the default. For instance:

(gdb) set debug-file-directory /run/booted-system/sw/lib/debug

results in:

munmap_chunk(): invalid pointer
Aborted (core dumped)

To fix this issue, the debug_file_directory is allocated
with xstrdup so that a subsequent call to xfree will succeed.

NOTE: As a workaround, unset NIX_DEBUG_INFO_DIRS before running gdb.

This patch was tested on gdb 8.3.1. If merged, it can hopefully be included in 20.03. The gdb 9.1 upgrade in #79711 also appears to have the same issue. @lsix

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
