### PR TITLE
pythonPackages.msgpack: 0.6.2 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/msgpack/1.0.0.nix
+++ b/pkgs/development/python-modules/msgpack/1.0.0.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, fetchPypi
+, pytest
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "msgpack";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1h5mxh84rcw04dvxy1qbfn2hisavfqgilh9k09rgyjhd936dad4m";
+  };
+
+  checkPhase = ''
+    py.test
+  '';
+
+  checkInputs = [ pytest ];
+
+  meta = {
+    homepage = https://github.com/msgpack/msgpack-python;
+    description = "MessagePack serializer implementation for Python";
+    license = lib.licenses.asl20;
+    # maintainers =  ?? ;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4346,6 +4346,8 @@ in {
 
   msgpack = callPackage ../development/python-modules/msgpack {};
 
+  msgpack_1_0_0 = callPackage ../development/python-modules/msgpack/1.0.0.nix {};
+
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy {};
 
   msrplib = callPackage ../development/python-modules/msrplib { };
@@ -6468,7 +6470,9 @@ in {
 
   trollius = callPackage ../development/python-modules/trollius {};
 
-  pynvim = callPackage ../development/python-modules/pynvim {};
+  pynvim = callPackage ../development/python-modules/pynvim {
+    msgpack = self.msgpack_1_0_0;
+  };
 
   typogrify = callPackage ../development/python-modules/typogrify { };
 


### PR DESCRIPTION
###### Motivation for this change

Needed by vimPlugins.deoplete.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
