### PR TITLE
[20.03] whitebox-tools: 0.16.0 -> 1.2.0

### DIFF
--- a/pkgs/applications/gis/whitebox-tools/default.nix
+++ b/pkgs/applications/gis/whitebox-tools/default.nix
@@ -1,18 +1,18 @@
 { stdenv, rustPlatform , fetchFromGitHub, Security }:
 rustPlatform.buildRustPackage rec {
   pname = "whitebox_tools";
-  version = "0.16.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "jblindsay";
     repo = "whitebox-tools";
     rev = "v${version}";
-    sha256 = "1vs4hf2x3qjnffs9kjx56rzl67kpcy8xvng6p0r9fp9mfnblxg6j";
+    sha256 = "0zi32d0wrbl2763dcllv2g0liwacsfiza5lkx52620prjjbhby8i";
   };
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 
-  cargoSha256 = "1y3vk8bzsaisx7wrncjxcqdh355f2wk4n59vq5qgj37fph2zpy7f";
+  cargoSha256 = "0zn4b4md3pn1rvb15rnz3zcx9a359x26nfy7zcfp7nx27ais13n5";
 
   # failures: structures::polyline::test::test_polyline_split
   doCheck = false;


### PR DESCRIPTION
(cherry picked from commit bba9b7fe6e51482be4a9ba4287e3b6b1558a3c71)

whitebox-tools is broken with newer Rust compiler. Updated it to the latest version.

Test `structures::polyline::test::test_polyline_split` still fails.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backports #80787 
ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
