### PR TITLE
pythonPackages.locustio: 0.9.0 -> 0.14.4

### DIFF
--- a/pkgs/development/python-modules/locustio/default.nix
+++ b/pkgs/development/python-modules/locustio/default.nix
@@ -1,17 +1,18 @@
-{ buildPythonPackage
-, fetchFromGitHub
-, mock
-, unittest2
-, msgpack
-, requests
+{ buildPythonPackage, fetchFromGitHub, isPy38
 , flask
 , gevent
+, mock
+, msgpack
 , pyzmq
+, requests
+, unittest2
 }:
 
 buildPythonPackage rec {
   pname = "locustio";
-  version = "0.9.0";
+  version = "0.14.4";
+  # tests hang on python38
+  disabled = isPy38;
 
   src = fetchFromGitHub {
     owner = "locustio";
@@ -21,10 +22,14 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ msgpack requests flask gevent pyzmq ];
-  buildInputs = [ mock unittest2 ];
+  checkInputs = [ mock unittest2 ];
+  # remove file which attempts to do GET request
+  preCheck = ''
+    rm locust/test/test_stats.py
+  '';
 
   meta = {
-    homepage = https://locust.io/;
+    homepage = "https://locust.io/";
     description = "A load testing tool";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
while reviewing #80934 I noticed that the python38 version hangs.

Decided to bump the package  to see if it fixed the frozen tests, it didn't. So just left the bump and disabled py38

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


```
https://github.com/NixOS/nixpkgs/pull/80937
2 package built:
python27Packages.locustio python37Packages.locustio
```