### PR TITLE
[20.03] pythonPackages.pyfribidi: fix build

### DIFF
--- a/pkgs/development/python-modules/pyfribidi/default.nix
+++ b/pkgs/development/python-modules/pyfribidi/default.nix
@@ -1,20 +1,22 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, isPy3k
 , isPyPy
+, six
 }:
 
 buildPythonPackage rec {
   version = "0.12.0";
   pname = "pyfribidi";
-  disabled = isPy3k || isPyPy;
+  disabled = isPyPy;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
     sha256 = "64726a4a56783acdc79c6b9b3a15f16e6071077c897a0b999f3b43f744bc621c";
   };
+
+  propagatedBuildInputs = [ six ];
 
   meta = with stdenv.lib; {
     description = "A simple wrapper around fribidi";

--- a/pkgs/development/python-modules/pyfribidi/default.nix
+++ b/pkgs/development/python-modules/pyfribidi/default.nix
@@ -16,6 +16,8 @@ buildPythonPackage rec {
     sha256 = "64726a4a56783acdc79c6b9b3a15f16e6071077c897a0b999f3b43f744bc621c";
   };
 
+  patches = stdenv.lib.optional stdenv.cc.isClang ./pyfribidi-clang.patch;
+
   propagatedBuildInputs = [ six ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pyfribidi/pyfribidi-clang.patch
+++ b/pkgs/development/python-modules/pyfribidi/pyfribidi-clang.patch
@@ -1,0 +1,17 @@
+diff --git a/pyfribidi.c b/pyfribidi.c
+index 9a0120d..238134a 100644
+--- a/pyfribidi.c
++++ b/pyfribidi.c
+@@ -148,10 +148,11 @@ init_pyfribidi (void)
+ {
+ #if PY_MAJOR_VERSION >= 3
+         PyObject *module = PyModule_Create (&pyfribidi_moduledef);
++        if (module == NULL) return NULL;
+ #else
+         PyObject *module = Py_InitModule ("_pyfribidi", PyfribidiMethods);
++        if (module == NULL) return;
+ #endif
+-	if (module == NULL) return NULL;
+ 
+ 	PyModule_AddIntConstant (module, "RTL", (long) FRIBIDI_TYPE_RTL);
+ 	PyModule_AddIntConstant (module, "LTR", (long) FRIBIDI_TYPE_LTR);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backports #80838 
ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
