### PR TITLE
python3Packages.ipykernel: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -16,7 +16,6 @@
 buildPythonPackage rec {
   pname = "ipykernel";
   version = "5.1.4";
-  disabled = pythonOlder "3.4";
 
   src = fetchPypi {
     inherit pname version;
@@ -38,12 +37,23 @@ buildPythonPackage rec {
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
-  disabledTests = lib.optionals stdenv.isDarwin [
+  disabledTests = lib.optionals stdenv.isDarwin ([
     # see https://github.com/NixOS/nixpkgs/issues/76197
     "test_subprocess_print"
     "test_subprocess_error"
     "test_ipython_start_kernel_no_userns"
-  ];
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    # flaky test https://github.com/ipython/ipykernel/issues/485
+    "test_shutdown"
+
+    # test regression https://github.com/ipython/ipykernel/issues/486
+    "test_sys_path_profile_dir"
+    "test_save_history"
+    "test_help_output"
+    "test_write_kernel_spec"
+    "test_ipython_start_kernel_userns"
+    "ZMQDisplayPublisherTests"
+  ]);
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
