### PR TITLE
aws-vault: 4.5.1 to 5.3.2

### DIFF
--- a/pkgs/tools/admin/aws-vault/default.nix
+++ b/pkgs/tools/admin/aws-vault/default.nix
@@ -1,16 +1,17 @@
-{ buildGoPackage, lib, fetchFromGitHub }:
-buildGoPackage rec {
+{ buildGoModule, lib, fetchFromGitHub }:
+buildGoModule rec {
   pname = "aws-vault";
-  version = "4.5.1";
-
-  goPackagePath = "github.com/99designs/${pname}";
+  version = "5.3.2";
 
   src = fetchFromGitHub {
     owner = "99designs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0y64fx15p9ls829lif7c0jaxyclzpnr8l5cyw25q545878dzmcs5";
+    sha256 = "04dyibcaijv5011laycf39m4gvprvvsn5zkxslyih1kqd170w3wg";
   };
+
+  modSha256 = "1d3hjfmfmlpw2scfyn597zkzz864w97p0wrsxjp49m9mi0pgmhq9";
+  subPackages = [ "." ];
 
   # set the version. see: aws-vault's Makefile
   buildFlagsArray = ''
@@ -19,10 +20,10 @@ buildGoPackage rec {
   '';
 
   meta = with lib; {
-    description = "A vault for securely storing and accessing AWS credentials in development environments";
+    description =
+      "A vault for securely storing and accessing AWS credentials in development environments";
     homepage = "https://github.com/99designs/aws-vault";
     license = licenses.mit;
     maintainers = with maintainers; [ zimbatm ];
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change
The aws-vault development has switched to using go modules. Therefore this package has also been updated to use `buildGoModule` helper.

###### Things done

- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
