### PR TITLE
nginx: add EECDH+AESGCM and EDH+AESGCM SSL ciphers

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -487,7 +487,7 @@ in
 
       sslCiphers = mkOption {
         type = types.str;
-        default = "EECDH+aRSA+AESGCM:EDH+aRSA:EECDH+aRSA:+AES256:+AES128:+SHA1:!CAMELLIA:!SEED:!3DES:!DES:!RC4:!eNULL";
+        default = "EECDH+AESGCM:EDH+AESGCM:EECDH+aRSA+AESGCM:EDH+aRSA:EECDH+aRSA:+AES256:+AES128:+SHA1:!CAMELLIA:!SEED:!3DES:!DES:!RC4:!eNULL";
         description = "Ciphers to choose from when negotiating tls handshakes.";
       };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

In short: Some browsers / apps weren't able to connect to my web sites/services because of cipher mismatch.

I have some web pages and services running behind nginx. I use SSL with:

```
        forceSSL = true;
        enableACME = true;
```

SSL works for most browsers I've used, but one browser on my Android device and some TinyTinyRSS clients on my Android device refuse to connect because of `ERR_SSL_VERSION_OR_CIPHER_MISMATCH`.

I got some help from `dminuoso` in IRC. He pointed this website: https://syslink.pl/cipherlist/

Based on that, I added this to my configuration:

```
config.services.nginx.sslCiphers = "EECDH+AESGCM:EDH+AESGCM:" + options.services.nginx.sslCiphers.default
```

After that change, all the browsers and RSS clients managed to connect. So, I decided to make a pull request that modifies the default value.

**Disclaimer: I'm not at all familiar with SSL cipher stuff. Someone should review if this change affects security badly.**

Do you think this makes sense?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
