### PR TITLE
buildBazelPackage: poison all the fixed output derivations

### DIFF
--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -76,7 +76,7 @@ in buildBazelPackage rec {
       rm -f "$bazelOut"/java.log "$bazelOut"/java.log.*
     '';
 
-    sha256 = "122qk6iv8hd7g2a84y9aqqhij4r0m47vpxzbqhhh6k5livc73qd6";
+    sha256 = "1bn7nhv5pag8fdm8l8nvgg3fzvhpy2yv9yl2slrb16lckxzha3v6";
   };
 
   buildAttrs = {

--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -122,6 +122,8 @@ in stdenv.mkDerivation (fBuildAttrs // {
 
       cp -r $bazelOut/external $out
 
+      echo '${bazel.name}' > $out/.nix-bazel-version
+
       runHook postInstall
     '';
 
@@ -143,6 +145,14 @@ in stdenv.mkDerivation (fBuildAttrs // {
 
   preConfigure = ''
     mkdir -p "$bazelOut"
+
+    test "${bazel.name}" = "$(<$deps/.nix-bazel-version)" || {
+      echo "fixed output derivation was built for a different bazel version" >&2
+      echo "     got: $(<$deps/.nix-bazel-version)" >&2
+      echo "expected: ${bazel.name}" >&2
+      exit 1
+    }
+
     cp -r $deps $bazelOut/external
     chmod -R +w $bazelOut
     find $bazelOut -type l | while read symlink; do

--- a/pkgs/development/python-modules/dm-sonnet/default.nix
+++ b/pkgs/development/python-modules/dm-sonnet/default.nix
@@ -36,7 +36,7 @@ let
     bazelTarget = ":install";
 
     fetchAttrs = {
-      sha256 = "0mxma7jajm42v1hv6agl909xra0azihj588032ivhlmmh403x6wg";
+      sha256 = "0wb2gh9ji8bgq4s9ci9x017dybxqzjhncpw33b1wjksm2yhbkvlz";
     };
 
     bazelFlags = [

--- a/pkgs/development/python-modules/tensorflow-estimator/1_15_1.nix
+++ b/pkgs/development/python-modules/tensorflow-estimator/1_15_1.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, numpy
+, absl-py
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "tensorflow-estimator";
+  version = "1.15.1";
+  format = "wheel";
+
+  src = fetchPypi {
+    pname = "tensorflow_estimator";
+    inherit version format;
+    sha256 = "1fc61wmc0w22frs79j2x4g6wnv5g21xc6rix1g4bsvy9qfvvylw8";
+  };
+
+  propagatedBuildInputs = [ mock numpy absl-py ];
+
+  meta = with stdenv.lib; {
+    description = "TensorFlow Estimator is a high-level API that encapsulates model training, evaluation, prediction, and exporting.";
+    homepage = http://tensorflow.org;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jyp ];
+  };
+}
+

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -42,7 +42,7 @@ let
     bazelTarget = ":pip_pkg";
 
     fetchAttrs = {
-      sha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+      sha256 = "0135nxxvkmjzpd80r1g9fdkk9h62g0xlvp32g5zgk0hkma5kq0bx";
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -296,10 +296,12 @@ let
       TF_SYSTEM_LIBS = null;
 
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
+      # FIXME: can't (re)produce this output with current bazel.
+      # FIXME: build log: https://gist.github.com/andir/eff3e9c8eda5b56c8ea84903aed9cc35
       sha256 = if cudaSupport then
-        "1p544yk7jcspgc4qr4amw11ds16c2an5yxvagx5pmwawz0s083pf"
+        "0gyhjvzshgj59mbns8njlfl9qpz4sdg4j0xs2dva0w2nql7cr7im"
       else
-        "1dqbw3k3avqiy9xpgs44l6z65ab5rjjlxwig8z7gcl7fw9h6sbq9";
+        "04jvg3mc2si4xdbszc1vnw1rmf22p7snbjphmnklp7bc39jxkcrz";
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -7,7 +7,7 @@
 , future, setuptools, wheel, keras-preprocessing, keras-applications, google-pasta
 , functools32
 , opt-einsum
-, termcolor, grpcio, six, wrapt, protobuf, tensorflow-estimator
+, termcolor, grpcio, six, wrapt, protobuf, tensorflow-estimator_1_15_1
 # Common deps
 , git, swig, which, binutils, glibcLocales, cython
 # Common libraries
@@ -374,7 +374,7 @@ in buildPythonPackage {
     numpy
     six
     protobuf
-    tensorflow-estimator
+    tensorflow-estimator_1_15_1
     termcolor
     wrapt
     grpcio

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -62,7 +62,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "0g2y283glx2ykxxqc3vsg520a6s2w5d937wndhgpfajc5yjgiz43";
+    sha256 = "0cmj186n2y1g9kkdhcivmh2qvigvpnbp03m575b7hgsxi1cp3ssj";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -64,7 +64,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "1n66hg1w5jv2rc8q4sjlaf0agvxr713aa40mbkhgjv57x9j7bgn0";
+    sha256 = "0lnwc7ya6sjlx6jk5dwws166vli1lzdfc256f9g6dy1fci3sc17y";
   };
 
   buildAttrs = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6657,6 +6657,7 @@ in {
   zerobin = callPackage ../development/python-modules/zerobin { };
 
   tensorflow-estimator = callPackage ../development/python-modules/tensorflow-estimator { };
+  tensorflow-estimator_1_15_1 = callPackage ../development/python-modules/tensorflow-estimator/1_15_1.nix { };
 
   tensorflow-probability = callPackage ../development/python-modules/tensorflow-probability { };
 


### PR DESCRIPTION
###### Motivation for this change

This is an attempt at solving a long annoyance with `buildBazelPackage`.

Currently each fixed output derivation can happily be used throughout many different bazel versions. That might be good as the fetched containt might not have changed betwen (minor) bazel version changes. The risk here is that we update bazel, rebuild everything but are not longer able to actually reproduce the fixed output. This is currently the case with the Tensorflow expression.

We did update TF and/or bazel and right now (on master) it still builds but if you try to reproduce the fixed output content it doesn't work anymore.

With this PR I attempt to mitigate some of the issues with those fetchers. Each of the fixed output derivations will contain the `name` string of the `bazel` package that was used to build them. On the consuming end within `buildBazelPackage` that version string is compared against the current bazel name. If those do not match the build fails. This will avoid silently loosing the ability to reproduce the fixed output paths (in some cases).

I also added the ability to override the Bazel package that should be used for each build. This will be use in some future work.

Currently the TF build does not produce a valid fixed output (anymore?). This will likely require another Bazel version or yet another patch to make it work with the newer Bazel version. I would prefer investing time into having another Bazel version within Nixpkgs.

Opinions?


Previous discussions on this topic were in https://github.com/NixOS/nixpkgs/pull/76851


###### Future work

- We should verify that all the store paths that are being referenced from within the fixed output derivation are still valid. If they are not valid we should fail the build.
This is feasible and very naïve but would fail basically the day (after) the updated derivation hit Nixpkgs as something along the dependency path has been changed and thus invalidated all the store paths.

- Another line of work is to have multiple versions of bazel within nixpkgs. This avoid us having to patch upstream sources to work with our always changing version of Bazel. It shouldn't harm anyone if we support multiple Bazel versions. We are doing this with compilers and various other things already.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
