### PR TITLE
glibc: provide fallback for kernels with missing prlimit64

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -89,6 +89,18 @@ stdenv.mkDerivation ({
         less linux-*?/arch/x86/kernel/syscall_table_32.S
        */
       ./allow-kernel-2.6.32.patch
+
+      /* Provide a fallback for missing prlimit64 syscall on RHEL 6 -like
+         kernels.
+
+         This patch is maintained by @veprbl. If it gives you trouble, feel
+         free to ping me, I'd be happy to help.
+       */
+      (fetchurl {
+        url = "https://git.savannah.gnu.org/cgit/guix.git/plain/gnu/packages/patches/glibc-reinstate-prlimit64-fallback.patch?id=eab07e78b691ae7866267fc04d31c7c3ad6b0eeb";
+        sha256 = "091bk3kyrx1gc380gryrxjzgcmh1ajcj8s2rjhp2d2yzd5mpd5ps";
+      })
+
       /* Provide utf-8 locales by default, so we can use it in stdenv without depending on our large locale-archive. */
       (fetchurl {
         url = "https://salsa.debian.org/glibc-team/glibc/raw/49767c9f7de4828220b691b29de0baf60d8a54ec/debian/patches/localedata/locale-C.diff";


### PR DESCRIPTION
The current version of glibc implements support for kernels down to
3.2.0 (and we make sure to enable such support with apporopriate
--enable-kernel setting). The current RHEL6 operating system is based on
a maintained kernel based on 2.6.32 with lots of backports. We provide
basic support for this specific kernel by patching glibc to provide an
exception for this specific version of kernel. This allows for nixpkgs
software distribution to work on RHEL6 and it does so quite well with
almost no problems. There are, however, a few syscalls that are missing
in the 2.6.32 kernel, one of which is prlimit64. This commit provides a
fallback that uses an older {get,set}rlimit syscalls in cases when
prlimit64 is not available. This should streamline the experience for
nixpkgs users wanting to run it on RHEL6, namely, this fixes one of the
tests in findutils.

See also discussion in guix:
https://lists.gnu.org/archive/html/guix-devel/2018-03/msg00356.html

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Closes: #80352

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
