### PR TITLE
vimix-gtk-themes: init at 2020-02-24

### DIFF
--- a/pkgs/data/themes/vimix/default.nix
+++ b/pkgs/data/themes/vimix/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, gtk_engines, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "vimix-gtk-themes";
+  version = "2020-02-24";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "18v7yhwzachjgy276rdhj5cg353f0qysa2kxk9gyc6s71q2gjzcv";
+  };
+
+  buildInputs = [ gtk_engines ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    patchShebangs .
+    mkdir -p $out/share/themes
+    name= ./install.sh -d $out/share/themes
+    rm $out/share/themes/*/{AUTHORS,LICENSE}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Flat Material Design theme for GTK based desktop environments";
+    homepage = "https://github.com/vinceliuice/vimix-gtk-themes";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18085,6 +18085,8 @@ in
 
   victor-mono = callPackage ../data/fonts/victor-mono { };
 
+  vimix-gtk-themes = callPackage ../data/themes/vimix {};
+
   vistafonts = callPackage ../data/fonts/vista-fonts { };
 
   vistafonts-chs = callPackage ../data/fonts/vista-fonts-chs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [vimix-gtk-themes](https://github.com/vinceliuice/vimix-gtk-themes), some flat Material Design themes for GTK 3, GTK 2 and Gnome-Shell which supports GTK 3 and GTK 2 based desktop environments like Gnome, Unity, Budgie, Pantheon, XFCE, Mate, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).