### PR TITLE
ocamlPackages.ocp-index: 1.1.9 → 1.2

### DIFF
--- a/pkgs/development/tools/ocaml/ocp-build/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-build/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ncurses }:
+{ stdenv, fetchpatch, fetchFromGitHub, ocaml, findlib, ncurses }:
 let
   version = "1.99.19-beta";
 in
@@ -12,6 +12,11 @@ stdenv.mkDerivation {
     rev = version;
     sha256 = "162k5l0cxyqanxlml5v8mqapdq5qbqc9m4b8wdjq7mf523b3h2zj";
   };
+
+  patches = stdenv.lib.optional (stdenv.lib.versionAtLeast ocaml.version "4.08") (fetchpatch {
+    url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/ocp-pp/ocp-pp.1.99.19-beta/files/0001-Fix-ocp-pp-for-changes-in-compiler-libs.patch";
+    sha256 = "0s0s2hh4d7cmwd6i7ixjgb79vij0r1v54m0vwwi26b3fips09qyn";
+  });
 
   buildInputs = [ ocaml findlib ];
   propagatedBuildInputs = [ ncurses ];

--- a/pkgs/development/tools/ocaml/ocp-index/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-index/default.nix
@@ -1,14 +1,12 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, ocp-build, ocp-indent, cmdliner, re,  }:
+{ lib, fetchurl, buildDunePackage, ocp-build, ocp-indent, cmdliner, re }:
 
 buildDunePackage rec {
   pname = "ocp-index";
-  version = "1.1.9";
+  version = "1.2";
 
-  src = fetchFromGitHub {
-    owner = "OCamlPro";
-    repo = pname;
-    rev = version;
-    sha256 = "0dq1kap16xfajc6gg9hbiadax782winpvxnr3dkm2ncznnxds37p";
+  src = fetchurl {
+    url = "https://github.com/OCamlPro/ocp-index/releases/download/${version}/ocp-index-${version}.tbz";
+    sha256 = "1lchw02sakjjppmzr0rzlarwbg1lc2bl7pwcfpsiycnaz46x6gmr";
   };
 
   buildInputs = [ ocp-build cmdliner re ];
@@ -18,7 +16,7 @@ buildDunePackage rec {
   meta = {
     homepage = http://typerex.ocamlpro.com/ocp-index.html;
     description = "A simple and light-weight documentation extractor for OCaml";
-    license = stdenv.lib.licenses.lgpl3;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml ≥ 4.08

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
