### PR TITLE
stderred: init at unstable-2017-07-20

### DIFF
--- a/pkgs/tools/misc/stderred/default.nix
+++ b/pkgs/tools/misc/stderred/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "stderred";
+  version = "unstable-2017-07-20";
+
+  src = fetchFromGitHub {
+    owner = "sickill";
+    repo = "stderred";
+    rev = "399e3b199c6de0ac6fdda3c30fb845ff36a75b1f";
+    sha256 = "08wdmn49q115gppvgff9v14hhj2vddlrb6whl9sl7fsa43f5lmnx";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  sourceRoot = "${src.name}/src";
+
+  meta = with stdenv.lib; {
+    description = "stderr in red";
+    homepage = "https://github.com/sickill/stderred";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6565,6 +6565,8 @@ in
 
   stdman = callPackage ../data/documentation/stdman { };
 
+  stderred = callPackage ../tools/misc/stderred { };
+
   stenc = callPackage ../tools/backup/stenc { };
 
   stm32loader = with python3Packages; toPythonApplication stm32loader;


### PR DESCRIPTION
###### Motivation for this change
Tool for colouring stderr in red.

https://github.com/sickill/stderred

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
