### PR TITLE
[20.03] pythonPackages.mysql-connector: fix build for python != python3

### DIFF
--- a/pkgs/development/python-modules/mysql-connector/default.nix
+++ b/pkgs/development/python-modules/mysql-connector/default.nix
@@ -1,9 +1,7 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, python3, protobuf3_6
-}:
+{ lib, buildPythonPackage, fetchFromGitHub, python, protobuf3_6 }:
 
 let
-  python = python3.override {
+  py = python.override {
     packageOverrides = self: super: {
       protobuf = super.protobuf.override {
         protobuf = protobuf3_6;
@@ -21,7 +19,7 @@ in buildPythonPackage rec {
     sha256 = "1jscmc5s7mwx43gvxjlqc30ylp5jjpmkqx7s3b9nllbh926p3ixg";
   };
 
-  propagatedBuildInputs = with python.pkgs; [ protobuf dnspython ];
+  propagatedBuildInputs = with py.pkgs; [ protobuf dnspython ];
 
   # Tests are failing (TODO: unknown reason)
   # TypeError: __init__() missing 1 required positional argument: 'string'


### PR DESCRIPTION
###### Motivation for this change

Backport #80959

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
