### PR TITLE
various: use qt5's mkDerivation

### DIFF
--- a/pkgs/applications/graphics/qview/default.nix
+++ b/pkgs/applications/graphics/qview/default.nix
@@ -1,18 +1,27 @@
-{stdenv, fetchFromGitHub, qmake}:
-stdenv.mkDerivation rec {
+{ mkDerivation, lib, fetchFromGitHub, qmake, qtbase }:
+
+mkDerivation rec {
   pname = "qview";
   version = "3.0";
+
   src = fetchFromGitHub {
     owner = "jurplel";
     repo = "qView";
     rev = version;
     sha256 = "15a91bs3wcqhgf76wzigbn10hayg628j84pq4j2vaxar94ak0vk7";
   };
+
   nativeBuildInputs = [ qmake ];
+
+  buildInputs = [
+    qtbase
+  ];
+
   patchPhase = ''
     sed "s|/usr/|$out/|g" -i qView.pro
   '';
-  meta = with stdenv.lib; {
+
+  meta = with lib; {
     description = "Practical and minimal image viewer";
     homepage = "https://interversehq.com/qview/";
     license = licenses.gpl3;

--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools
+{ mkDerivation, lib, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools
 , seafile-shared, ccnet, jansson, libsearpc
 , withShibboleth ? true, qtwebengine }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "seafile-client";
   version = "7.0.5";
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional withShibboleth "-DBUILD_SHIBBOLETH_SUPPORT=ON";
 
   qtWrapperArgs = [
-    "--suffix PATH : ${stdenv.lib.makeBinPath [ ccnet seafile-shared ]}"
+    "--suffix PATH : ${lib.makeBinPath [ ccnet seafile-shared ]}"
   ];
 
   meta = with lib; {

--- a/pkgs/games/qgo/default.nix
+++ b/pkgs/games/qgo/default.nix
@@ -1,17 +1,17 @@
-{ stdenv
+{ lib
+, mkDerivation
 , fetchFromGitHub
-, makeWrapper
 , qmake
 , qtbase
 , qtmultimedia
 , qttranslations
 }:
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "qgo";
   version = "unstable-2017-12-18";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A Go client based on Qt5";
     longDescription = ''
       qGo is a Go Client based on Qt 5. It supports playing online at
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
   postPatch = ''
     sed -i 's|@out@|'"''${out}"'|g' src/src.pro src/defines.h
   '';
-  nativeBuildInputs = [ makeWrapper qmake ];
+  nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase qtmultimedia qttranslations ];
   enableParallelBuilding = true;
 

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qmake, qttools, qtbase, libsForQt5, flex, bison }:
+{ stdenv, mkDerivation, fetchFromGitHub, qmake, qttools, qtbase, poppler, flex, bison }:
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "tikzit";
   version = "2.1.4";
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ qmake qttools flex bison ];
-  buildInputs = [ qtbase libsForQt5.poppler ];
+  buildInputs = [ qtbase poppler ];
 
   # src/data/tikzlexer.l:29:10: fatal error: tikzparser.parser.hpp: No such file or directory
   enableParallelBuilding = false;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done
Made sure the binaries at $out/bin were wrappers.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
