### PR TITLE
seasocks: remove unneeded patch

### DIFF
--- a/pkgs/development/libraries/seasocks/default.nix
+++ b/pkgs/development/libraries/seasocks/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, python, zlib, fetchpatch }:
+{ stdenv, fetchFromGitHub, cmake, python, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "seasocks";
@@ -10,13 +10,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1c2gc0k9wgbgn7y7wmq2ylp0gvdbmagc1x8c4jwbsncl1gy6x4g2";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/mattgodbolt/seasocks/commit/5753b50ce3b2232d166843450043f88a4a362422.patch";
-      sha256 = "1c20xjma8jdgcr5m321srpmys6b4jvqkazfqr668km3r2ck5xncl";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib python ];


### PR DESCRIPTION
###### Motivation for this change

Remove patch upstreamed in `v1.4.3`.

ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
