### PR TITLE
ipmitool: migrate to openssl 1.1

### DIFF
--- a/pkgs/tools/system/ipmitool/default.nix
+++ b/pkgs/tools/system/ipmitool/default.nix
@@ -19,19 +19,19 @@ stdenv.mkDerivation {
     })
   ];
 
-  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace src/plugins/ipmi_intf.c --replace "s6_addr16" "s6_addr"
-  '';
-
   buildInputs = [ openssl ];
 
-  preConfigure = ''
-    configureFlagsArray=(
-      --infodir=$out/share/info
-      --mandir=$out/share/man
-      ${if static then "LDFLAGS=-static --enable-static --disable-shared" else "--enable-shared"}
-    )
-  '';
+  configureFlags = [
+    "--infodir=${placeholder "out"}/share/info"
+    "--mandir=${placeholder "out"}/share/man"
+  ] ++ stdenv.lib.optionals static [
+    "LDFLAGS=-static"
+    "--enable-static"
+    "--disable-shared"
+  ] ++ stdenv.lib.optionals (!static) [
+    "--enable-shared"
+  ];
+
   makeFlags = stdenv.lib.optional static "AM_LDFLAGS=-all-static";
   dontDisableStatic = static;
 

--- a/pkgs/tools/system/ipmitool/default.nix
+++ b/pkgs/tools/system/ipmitool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, openssl, static ? false }:
+{ stdenv, lib, fetchurl, openssl, fetchpatch, static ? false }:
 
 let
   pkgname = "ipmitool";
@@ -12,7 +12,14 @@ stdenv.mkDerivation {
     sha256 = "0kfh8ny35rvwxwah4yv91a05qwpx74b5slq2lhrh71wz572va93m";
   };
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  patches = [
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/i/ipmitool/1.8.18-6/debian/patches/0120-openssl1.1.patch";
+      sha256 = "1xvsjxb782lzy72bnqqnsk3r5h4zl3na95s4pqn2qg7cic2mnbfk";
+    })
+  ];
+
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/plugins/ipmi_intf.c --replace "s6_addr16" "s6_addr"
   '';
 

--- a/pkgs/tools/system/ipmitool/default.nix
+++ b/pkgs/tools/system/ipmitool/default.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation {
       url = "https://sources.debian.org/data/main/i/ipmitool/1.8.18-6/debian/patches/0120-openssl1.1.patch";
       sha256 = "1xvsjxb782lzy72bnqqnsk3r5h4zl3na95s4pqn2qg7cic2mnbfk";
     })
+    # Fix build on non-linux systems
+    (fetchpatch {
+      url = "https://github.com/ipmitool/ipmitool/commit/5db314f694f75c575cd7c9ffe9ee57aaf3a88866.patch";
+      sha256 = "01niwrgajhrdhl441gzmw6v1r1yc3i8kn98db4b6smfn5fwdp1pa";
+    })
   ];
 
   buildInputs = [ openssl ];
@@ -39,7 +44,7 @@ stdenv.mkDerivation {
     description = ''Command-line interface to IPMI-enabled devices'';
     license = licenses.bsd3;
     homepage = https://sourceforge.net/projects/ipmitool/;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4261,9 +4261,7 @@ in
 
   ipget = callPackage ../applications/networking/ipget { };
 
-  ipmitool = callPackage ../tools/system/ipmitool {
-    openssl = openssl_1_0_2;
-  };
+  ipmitool = callPackage ../tools/system/ipmitool {};
 
   ipmiutil = callPackage ../tools/system/ipmiutil {};
 


### PR DESCRIPTION
##### Motivation for this change

This adds a patch from debian to switch ipmitool to openssl 1.1. Upstream seems to already carry a version of this but that is yet to be part of a release.

If this is accepted we should backport to 20.03.

cc #80746 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
