### PR TITLE
Add J-Link binary package for embedded debugging

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6428,6 +6428,12 @@
     githubId = 1973389;
     name = "Reuben D'Netto";
   };
+  reardencode = {
+    email = "freedom@reardencode.com";
+    github = "reardencode";
+    githubId = 730881;
+    name = "Brandon Black";
+  };
   redbaron = {
     email = "ivanov.maxim@gmail.com";
     github = "redbaron";

--- a/pkgs/development/tools/jlink/default.nix
+++ b/pkgs/development/tools/jlink/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, requireFile, autoPatchelfHook, substituteAll,
+  qt4, fontconfig, freetype, libusb, libICE, libSM, ncurses5, udev,
+  libX11, libXext, libXcursor, libXfixes, libXrender, libXrandr }:
+
+let
+  architecture = {
+    x86_64-linux = "x86_64";
+    i686-linux   = "i386";
+    armv7l-linux = "arm";
+  }.${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
+
+  sha256 = {
+    x86_64-linux = "0vc7x6kjs92p6qdsn2lazmvlw7npz1z7r9ipj85wd123m7hgwnmg";
+    i686-linux   = "01qm56jyac3mzjny1z5lynik8y4hqrfq93n8119mvj6d4xiknv8y";
+    armv7l-linux = "03l2zkfjw7z6j6nsdw6j4nxxzh8mgby8qrc179qjcajbdr3hmbr7";
+  }.${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
+in
+
+stdenv.mkDerivation rec {
+  pname = "jlink";
+  version = "V662d";
+
+  src = requireFile {
+    name = "JLink_Linux_${version}_${architecture}.tgz";
+    url = "https://www.segger.com/downloads/jlink#J-LinkSoftwareAndDocumentationPack";
+    sha256 = sha256;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [
+    qt4 fontconfig freetype libusb libICE libSM ncurses5
+    libX11 libXext libXcursor libXfixes libXrender libXrandr
+  ];
+
+  runtimeDependencies = [ udev ];
+
+  installPhase = ''
+    mkdir -p $out/{JLink,bin}
+    cp -R * $out/JLink
+    ln -s $out/JLink/J* $out/bin/
+    rm -r $out/bin/JLinkDevices.xml $out/JLink/libQt*
+    install -D -t $out/lib/udev/rules.d 99-jlink.rules
+  '';
+
+  preFixup = ''
+    patchelf --add-needed libudev.so.1 $out/JLink/libjlinkarm.so
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.segger.com/downloads/jlink";
+    description = "SEGGER J-Link";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ reardencode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26714,4 +26714,6 @@ in
   vpsfree-client = callPackage ../tools/virtualization/vpsfree-client {};
 
   gpio-utils = callPackage ../os-specific/linux/kernel/gpio-utils.nix { };
+
+  jlink = callPackage ../development/tools/jlink {};
 }


### PR DESCRIPTION
###### Motivation for this change
J-Link is a common tool used in embedded development. It'd be great to be able to use it on NixOS

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
