### PR TITLE
perlPackages.MozillaCA: replace outdated cacert.pem with pkgs.cacert

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13120,6 +13120,11 @@ let
       url = mirror://cpan/authors/id/A/AB/ABH/Mozilla-CA-20180117.tar.gz;
       sha256 = "f2cc9fbe119f756313f321e0d9f1fac0859f8f154ac9d75b1a264c1afdf4e406";
     };
+
+    postPatch = ''
+      ln -s --force ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt lib/Mozilla/CA/cacert.pem
+    '';
+
     meta = {
       description = "Mozilla's CA cert bundle in PEM format";
       license = stdenv.lib.licenses.mpl20;


### PR DESCRIPTION
Mozilla::CA returns a path to a bundled cacert.pem file, this commit replaces
the bundled certificates with `pkgs.cacert`.

###### Motivation for this change

Mozilla::CA should return updated ca certs. 

Somewhat similar approach taken by Fedora: https://src.fedoraproject.org/rpms/perl-Mozilla-CA/c/df77aa9a2659c1d3fba630fc0f7ddd92a7fd1bc4?branch=master

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>

  - imatix_gsl
</details>
<details>
  <summary>1 package failed to build:</summary>

  - rt
</details>
<details>
  <summary>125 package built:</summary>

  - almanah
  - amtterm
  - biber
  - ddclient
  - debian-devscripts (debian_devscripts)
  - fusionInventory
  - get_iplayer
  - gitAndTools.gitFull
  - gnome3.evolution
  - gnucash
  - hydra
  - ikiwiki
  - imapsync
  - linode-cli
  - longview
  - lumail
  - lumina.lumina
  - manim
  - perl528Packages.AlienWxWidgets
  - perl528Packages.CPANUploader
  - perl528Packages.CacheKyotoTycoon
  - perl528Packages.CryptSSLeay
  - perl528Packages.DistZilla
  - perl528Packages.DistZillaPluginBundleTestingMania
  - perl528Packages.DistZillaPluginCheckChangeLog
  - perl528Packages.DistZillaPluginMojibakeTests
  - perl528Packages.DistZillaPluginNoTabsTests
  - perl528Packages.DistZillaPluginPodWeaver
  - perl528Packages.DistZillaPluginReadmeAnyFromPod
  - perl528Packages.DistZillaPluginReadmeMarkdownFromPod
  - perl528Packages.DistZillaPluginTestCPANChanges
  - perl528Packages.DistZillaPluginTestCPANMetaJSON
  - perl528Packages.DistZillaPluginTestCompile
  - perl528Packages.DistZillaPluginTestDistManifest
  - perl528Packages.DistZillaPluginTestEOL
  - perl528Packages.DistZillaPluginTestKwalitee
  - perl528Packages.DistZillaPluginTestMinimumVersion
  - perl528Packages.DistZillaPluginTestPerlCritic
  - perl528Packages.DistZillaPluginTestPodLinkCheck
  - perl528Packages.DistZillaPluginTestPortability
  - perl528Packages.DistZillaPluginTestSynopsis
  - perl528Packages.DistZillaPluginTestUnusedVars
  - perl528Packages.DistZillaPluginTestVersion
  - perl528Packages.DistZillaRoleFileWatcher
  - perl528Packages.FinanceQuote
  - perl528Packages.Furl
  - perl528Packages.GeoIP2
  - perl528Packages.IOSocketSSL
  - perl528Packages.LWPProtocolConnect
  - perl528Packages.LWPProtocolHttps
  - perl528Packages.MozillaCA
  - perl528Packages.NetAmazonEC2
  - perl528Packages.NetAmazonMechanicalTurk
  - perl528Packages.NetIMAPClient
  - perl528Packages.NetSMTPSSL
  - perl528Packages.NetSMTPTLS
  - perl528Packages.NetSMTPTLSButMaintained
  - perl528Packages.NetTwitterLite
  - perl528Packages.PerconaToolkit
  - perl528Packages.RESTClient
  - perl528Packages.SOAPLite
  - perl528Packages.WWWYoutubeViewer
  - perl528Packages.WebServiceLinode
  - perl528Packages.Wx
  - perl528Packages.WxGLCanvas
  - perl530Packages.AlienWxWidgets
  - perl530Packages.CPANUploader
  - perl530Packages.CacheKyotoTycoon
  - perl530Packages.CryptSSLeay
  - perl530Packages.DistZilla
  - perl530Packages.DistZillaPluginBundleTestingMania
  - perl530Packages.DistZillaPluginCheckChangeLog
  - perl530Packages.DistZillaPluginMojibakeTests
  - perl530Packages.DistZillaPluginNoTabsTests
  - perl530Packages.DistZillaPluginPodWeaver
  - perl530Packages.DistZillaPluginReadmeAnyFromPod
  - perl530Packages.DistZillaPluginReadmeMarkdownFromPod
  - perl530Packages.DistZillaPluginTestCPANChanges
  - perl530Packages.DistZillaPluginTestCPANMetaJSON
  - perl530Packages.DistZillaPluginTestCompile
  - perl530Packages.DistZillaPluginTestDistManifest
  - perl530Packages.DistZillaPluginTestEOL
  - perl530Packages.DistZillaPluginTestKwalitee
  - perl530Packages.DistZillaPluginTestMinimumVersion
  - perl530Packages.DistZillaPluginTestPerlCritic
  - perl530Packages.DistZillaPluginTestPodLinkCheck
  - perl530Packages.DistZillaPluginTestPortability
  - perl530Packages.DistZillaPluginTestSynopsis
  - perl530Packages.DistZillaPluginTestUnusedVars
  - perl530Packages.DistZillaPluginTestVersion
  - perl530Packages.DistZillaRoleFileWatcher
  - perl530Packages.FinanceQuote
  - perl530Packages.Furl
  - perl530Packages.GeoIP2
  - perl530Packages.IOSocketSSL
  - perl530Packages.LWPProtocolConnect
  - perl530Packages.LWPProtocolHttps
  - perl530Packages.MozillaCA
  - perl530Packages.NetAmazonEC2
  - perl530Packages.NetAmazonMechanicalTurk
  - perl530Packages.NetIMAPClient
  - perl530Packages.NetSMTPSSL
  - perl530Packages.NetSMTPTLS
  - perl530Packages.NetSMTPTLSButMaintained
  - perl530Packages.NetTwitterLite
  - perl530Packages.PerconaToolkit
  - perl530Packages.RESTClient
  - perl530Packages.SOAPLite
  - perl530Packages.WWWYoutubeViewer
  - perl530Packages.WebServiceLinode
  - perl530Packages.Wx
  - perl530Packages.WxGLCanvas
  - popfile
  - public-inbox
  - remotebox
  - shelldap
  - sieve-connect
  - slic3r
  - slimserver
  - spamassassin
  - sympa
  - texlive.combined.scheme-full
  - xscreensaver
  - xsecurelock
  - zoneminder
</details>


rt build error is fixed in https://github.com/NixOS/nixpkgs/pull/80677

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
