### PR TITLE
libyamlcpp: don't use multiple outputs

### DIFF
--- a/pkgs/development/libraries/libyaml-cpp/default.nix
+++ b/pkgs/development/libraries/libyaml-cpp/default.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation rec {
     sha256 = "0ykkxzxcwwiv8l8r697gyqh1nl582krpvi7m7l6b40ijnk4pw30s";
   };
 
-  outputs = [ "out" "dev" ];
-
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" "-DYAML_CPP_BUILD_TESTS=OFF" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


This package uses CMake's `install(EXPORT ...)` command which assumes that libraries can be found relative to the CMake files. This results in the following error when this package is imported by another CMake package:

```
CMake Error at /nix/store/n77s62wwd9m7cjqd4hky91h2khkiy06n-libyaml-cpp-0.6.3-dev/lib/cmake/yaml-cpp/yaml-cpp-targets.cmake:74 (message):
  The imported target "yaml-cpp" references the file

     "/nix/store/n77s62wwd9m7cjqd4hky91h2khkiy06n-libyaml-cpp-0.6.3-dev/lib/libyaml-cpp.so.0.6.3"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/nix/store/n77s62wwd9m7cjqd4hky91h2khkiy06n-libyaml-cpp-0.6.3-dev/lib/cmake/yaml-cpp/yaml-cpp-targets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /nix/store/n77s62wwd9m7cjqd4hky91h2khkiy06n-libyaml-cpp-0.6.3-dev/lib/cmake/yaml-cpp/yaml-cpp-config.cmake:11 (include)
  src/rviz/CMakeLists.txt:1 (find_package)
```

Disabling multiple outputs only results in a small increase in closure size (936K -> 1.1M).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @andir 