### PR TITLE
nix-build-gc: init at nix-build-gc-2020-01-20

### DIFF
--- a/pkgs/tools/package-management/nix-build-gc/default.nix
+++ b/pkgs/tools/package-management/nix-build-gc/default.nix
@@ -1,0 +1,38 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, makeWrapper
+, coreutils
+, findutils
+, nix
+, stdenv
+}:
+
+stdenvNoCC.mkDerivation rec {
+  name = "nix-build-gc-2020-01-20";
+
+  src = fetchFromGitHub {
+    owner = "MatrixAI";
+    repo = "nix-build-gc";
+    rev = "52df0daba11bea6380e7eceb31617263f1314f5c";
+    sha256 = "05x624h1mb4lmm37z1xvr6bsvspdfxpiy007j4pw3i4jx4wm5nsn";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -D -m755 nix-build-gc $out/bin/nix-build-gc
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/nix-build-gc --set PATH ${lib.makeBinPath [ coreutils findutils nix ]}
+  '';
+  meta = with stdenv.lib; {
+    description = "Given a directory, this command will delete all symlinks that point to the /nix/store
+     and garbage collect the associated objects in the store`";
+    homepage    = "https://github.com/MatrixAI/nix-build-gc";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rakesh4g ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25219,6 +25219,8 @@ in
   nix-deploy = haskell.lib.justStaticExecutables haskellPackages.nix-deploy;
   nix-diff = haskell.lib.justStaticExecutables haskellPackages.nix-diff;
 
+  nix-build-gc = callPackage ../tools/package-management/nix-build-gc { };
+
   nix-du = callPackage ../tools/package-management/nix-du { };
 
   nix-info = callPackage ../tools/nix/info { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
nix-build-gc: init at nix-build-gc-2020-01-20

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
@CMCDragonkai 