### PR TITLE
thinkpad-scripts: init at 4.12.0

### DIFF
--- a/pkgs/tools/misc/thinkpad-scripts/default.nix
+++ b/pkgs/tools/misc/thinkpad-scripts/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchFromGitHub, python3Packages }:
+
+buildPythonPackage rec {
+  pname = "thinkpad-scripts";
+  version = "4.12.0";
+
+  src = fetchFromGitHub {
+    owner = "martin-ueding";
+    repo = "thinkpad-scripts";
+    rev = "v${version}";
+    sha256 = "08adx8r5pwwazbnfahay42l5f203mmvcn2ipz5hg8myqc9jxm2ky";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ setuptools ];
+
+  meta = {
+    description = "Screen rotation, docking and other scripts for ThinkPad® X220 and X230 Tablet";
+    homepage = "https://github.com/martin-ueding/thinkpad-scripts";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ dawidsowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6653,6 +6653,8 @@ in
 
   thin-provisioning-tools = callPackage ../tools/misc/thin-provisioning-tools {  };
 
+  thinkpad-scripts = python3.pkgs.callPackage ../tools/misc/thinkpad-scripts { };
+
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };
 
   tiledb = callPackage ../development/libraries/tiledb { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add [thinkpad-scripts](https://github.com/martin-ueding/thinkpad-scripts)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
