### PR TITLE
ocaml-ng.ocamlPackages_4_10.ocaml: 4.10.0+rc2 → 4.10.0

### DIFF
--- a/pkgs/development/compilers/ocaml/4.10.nix
+++ b/pkgs/development/compilers/ocaml/4.10.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "10";
-  patch_version = "0+rc2";
-  sha256 = "1iv8x9xr4k2s1x1p4rj4fqdh2iwzhgi56lyshvh6gg224i14rkbz";
+  patch_version = "0";
+  sha256 = "1dzy7lbdapcmwn1wg8k87419khi54f8hb6n314bdv7v0gfqlswrh";
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1246,7 +1246,7 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_4_10 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.10.nix { });
 
-  ocamlPackages_latest = ocamlPackages_4_09;
+  ocamlPackages_latest = ocamlPackages_4_10;
 
   ocamlPackages = ocamlPackages_4_07;
 }


### PR DESCRIPTION
###### Motivation for this change

Major release: https://inbox.ocaml.org/caml-list/247215ad-3bb1-501a-93e2-3bacb8cc3d0a@inria.fr/T/#u

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
