### PR TITLE
deadbeef: 1.8.0 -> 1.8.2

### DIFF
--- a/pkgs/applications/audio/deadbeef/default.nix
+++ b/pkgs/applications/audio/deadbeef/default.nix
@@ -68,13 +68,6 @@ stdenv.mkDerivation rec {
     sha256 = "016wwnh5jqdcfxn1ff6in5dz73c3gdhh3fva8inq7sc3vzdz5khj";
   };
 
-  #patches = [
-    # Fix broken symbol name
-    # https://github.com/NixOS/nixpkgs/pull/59187#issuecomment-480977993
-    # will be fixed in deadbeef 1.8.1
-  #  ./fix-wildmidi.patch
-  #];
-
   buildInputs = with stdenv.lib; [ jansson ]
     ++ optional gtk2Support gtk2
     ++ optionals gtk3Support [ gtk3 gsettings-desktop-schemas ]

--- a/pkgs/applications/audio/deadbeef/default.nix
+++ b/pkgs/applications/audio/deadbeef/default.nix
@@ -59,21 +59,21 @@ assert remoteSupport -> curl != null;
 
 stdenv.mkDerivation rec {
   pname = "deadbeef";
-  version = "1.8.0";
+  version = "1.8.2";
 
   src = fetchFromGitHub {
     owner = "DeaDBeeF-Player";
     repo = "deadbeef";
     rev = version;
-    sha256 = "126i5qlkpv7pvi1mmc9y0jhqs6jjspsj7j615n2ddvsb2jsps81c";
+    sha256 = "016wwnh5jqdcfxn1ff6in5dz73c3gdhh3fva8inq7sc3vzdz5khj";
   };
 
-  patches = [
+  #patches = [
     # Fix broken symbol name
     # https://github.com/NixOS/nixpkgs/pull/59187#issuecomment-480977993
     # will be fixed in deadbeef 1.8.1
-    ./fix-wildmidi.patch
-  ];
+  #  ./fix-wildmidi.patch
+  #];
 
   buildInputs = with stdenv.lib; [ jansson ]
     ++ optional gtk2Support gtk2


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New release : https://github.com/DeaDBeeF-Player/deadbeef/releases/tag/1.8.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
