### PR TITLE
EVDI: 2019-01-16 -> 2019-02-25

### DIFF
--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -2,25 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "evdi";
-  version = "-unstable-20190116";
+  version = "unstable-20200222";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = pname;
-    rev = "391f1f71e4c86fc18de27947c78e02b5e3e9f128";
-    sha256 = "147cwmk57ldchvzr06lila6av7jvcdggs9jgifqscklp9x6dc4ny";
+    rev = "bb3038c1b10aae99feddc7354c74a5bf22341246";
+    sha256 = "058f8gdma6fndg2w512l08mwl79h4hffacx4rnfkjxrb2ard3gd1";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   buildInputs = [ kernel libdrm ];
-
-  patches = [
-    (fetchpatch {
-      url    = "https://crazy.dev.frugalware.org/evdi-all-in-one-fixes.patch";
-      sha256 = "03hs68v8c2akf8a4rc02m15fzyp14ay70rcx8kwg2y98qkqh7w30";
-    })
-  ];
 
   makeFlags = [
     "KVER=${kernel.modDirVersion}"


### PR DESCRIPTION
##### Motivation for this change

Support for kernel 5.5, see https://github.com/DisplayLink/evdi/issues/185#issuecomment-586108568

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
