### PR TITLE
nixosTests.networking: disable virtual test with networkd

### DIFF
--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -463,7 +463,9 @@ let
         };
       };
 
-      testScript = ''
+      # The test is disabled for systemd-networkd.
+      # See the commit message of a3a441c.
+      testScript = optionalString (!networkd) ''
         targetList = """
         tap0: tap persist user 0
         tun0: tun persist user 0


### PR DESCRIPTION
###### Motivation for this change
ZHF: #80379 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via `nixosTests.networking.networkd.virtual` `nixosTests.networking.scripted.virtual`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't know how to disable the build of a test. This will effectively silence the failure but the test will be built anyway, which is probably misleading.