### PR TITLE
platforms: add bigEndian and littleEndian

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -50,32 +50,35 @@ in {
 
   none = [];
 
-  arm     = filterDoubles predicates.isAarch32;
-  aarch64 = filterDoubles predicates.isAarch64;
-  x86     = filterDoubles predicates.isx86;
-  i686    = filterDoubles predicates.isi686;
-  x86_64  = filterDoubles predicates.isx86_64;
-  mips    = filterDoubles predicates.isMips;
-  riscv   = filterDoubles predicates.isRiscV;
-  vc4     = filterDoubles predicates.isVc4;
-  js      = filterDoubles predicates.isJavaScript;
+  arm           = filterDoubles predicates.isAarch32;
+  aarch64       = filterDoubles predicates.isAarch64;
+  x86           = filterDoubles predicates.isx86;
+  i686          = filterDoubles predicates.isi686;
+  x86_64        = filterDoubles predicates.isx86_64;
+  mips          = filterDoubles predicates.isMips;
+  riscv         = filterDoubles predicates.isRiscV;
+  vc4           = filterDoubles predicates.isVc4;
+  js            = filterDoubles predicates.isJavaScript;
 
-  cygwin  = filterDoubles predicates.isCygwin;
-  darwin  = filterDoubles predicates.isDarwin;
-  freebsd = filterDoubles predicates.isFreeBSD;
+  bigEndian     = filterDoubles predicates.isBigEndian;
+  littleEndian  = filterDoubles predicates.isLittleEndian;
+
+  cygwin        = filterDoubles predicates.isCygwin;
+  darwin        = filterDoubles predicates.isDarwin;
+  freebsd       = filterDoubles predicates.isFreeBSD;
   # Should be better, but MinGW is unclear.
-  gnu     = filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnu; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabi; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabihf; });
-  illumos = filterDoubles predicates.isSunOS;
-  linux   = filterDoubles predicates.isLinux;
-  netbsd  = filterDoubles predicates.isNetBSD;
-  openbsd = filterDoubles predicates.isOpenBSD;
-  unix    = filterDoubles predicates.isUnix;
-  wasi    = filterDoubles predicates.isWasi;
-  redox   = filterDoubles predicates.isRedox;
-  windows = filterDoubles predicates.isWindows;
-  genode  = filterDoubles predicates.isGenode;
+  gnu           = filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnu; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabi; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabihf; });
+  illumos       = filterDoubles predicates.isSunOS;
+  linux         = filterDoubles predicates.isLinux;
+  netbsd        = filterDoubles predicates.isNetBSD;
+  openbsd       = filterDoubles predicates.isOpenBSD;
+  unix          = filterDoubles predicates.isUnix;
+  wasi          = filterDoubles predicates.isWasi;
+  redox         = filterDoubles predicates.isRedox;
+  windows       = filterDoubles predicates.isWindows;
+  genode        = filterDoubles predicates.isGenode;
 
-  embedded = filterDoubles predicates.isNone;
+  embedded      = filterDoubles predicates.isNone;
 
   mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "armv7a-linux" "aarch64-linux" "powerpc64le-linux"];
 }


### PR DESCRIPTION
###### Motivation for this change

This would be useful for #80611 and #80612. The website for those programs advertises compatibility with little-endian systems only, and doing the system filtering in the package would be a bit ugly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
