### PR TITLE
liblinear: use absolute install name on Darwin

### DIFF
--- a/pkgs/development/libraries/liblinear/default.nix
+++ b/pkgs/development/libraries/liblinear/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   pname = "liblinear";
@@ -14,14 +14,11 @@ stdenv.mkDerivation rec {
     make lib
   '';
 
-  installPhase = let
-    libSuff = stdenv.hostPlatform.extensions.sharedLibrary;
-  in ''
+  installPhase = ''
     mkdir -p $out/lib $out/bin $out/include
     ${if stdenv.isDarwin then ''
       cp liblinear.so.3 $out/lib/liblinear.3.dylib
       ln -s $out/lib/liblinear.3.dylib $out/lib/liblinear.dylib
-      install_name_tool -id liblinear.3.dylib $out/lib/liblinear.3.dylib
     '' else ''
       cp liblinear.so.3 $out/lib/liblinear.so.3
       ln -s $out/lib/liblinear.so.3 $out/lib/liblinear.so
@@ -30,6 +27,8 @@ stdenv.mkDerivation rec {
     cp predict $out/bin/liblinear-predict
     cp linear.h $out/include
   '';
+
+  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin [ fixDarwinDylibNames ];
 
   meta = with stdenv.lib; {
     description = "A library for large linear classification";


### PR DESCRIPTION
nixpkgs prefers absolute install names. Replace the manually specified
relative install name with the standard hook.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixing nmap on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
