### PR TITLE
pythonPackages.swagger-spec-validator 2.4.3 -> 2.5.0

### DIFF
--- a/pkgs/development/python-modules/swagger-spec-validator/default.nix
+++ b/pkgs/development/python-modules/swagger-spec-validator/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "swagger-spec-validator";
-  version = "2.4.3";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "Yelp";
     repo = "swagger_spec_validator";
     rev = "v" + version;
-    sha256 = "02f8amc6iq2clxxmrz8hirbb57sizaxijp0higqy16shk63ibalw";
+    sha256 = "0qlkiyncdh7cdyjvnwjpv9i7y75ghwnpyqkkpfaa8hg698na13pw";
   };
 
   checkInputs = [


### PR DESCRIPTION
#### Motivation for this change

Includes various upstream fixes of the tests, see

* https://github.com/Yelp/swagger_spec_validator/pull/117
* https://github.com/Yelp/swagger_spec_validator/pull/121

The associated breakage (now fixed) was also showing up in Hydra, in other words: ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
