### PR TITLE
python.pkgs.httpretty: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/httpretty/default.nix
+++ b/pkgs/development/python-modules/httpretty/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
     "tests.functional.test_httplib2.test_callback_response"
     "tests.functional.test_requests.test_streaming_responses"
     "tests.functional.test_httplib2.test_callback_response"
+    "tests.functional.test_requests.test_httpretty_should_allow_adding_and_overwritting_by_kwargs_u2"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

The test fails intermittently as noted upstream: https://github.com/gabrielfalcao/HTTPretty/issues/376

(cherry picked from commit c597007cce813c7fa5afb8ed9866d6aa0694bae5)

See the PR to master: https://github.com/NixOS/nixpkgs/pull/80699

ZHF: #80379