### PR TITLE
quickbms: init at 0.10.1

### DIFF
--- a/pkgs/development/tools/parsing/quickbms/default.nix
+++ b/pkgs/development/tools/parsing/quickbms/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, pkgconfig, unzip, lzo, bzip2, zlib, openssl }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  version = "0.10.1";
+  pname = "quickbms";
+
+  src = fetchurl {
+    url = "http://aluigi.zenhax.com/papers/quickbms-src-${version}.zip";
+    sha256 = "172588jc60irrafjwz4dhy0h08hc7s5c68mmq5v6140yv3f9ixc0";
+  };
+
+  nativeBuildInputs = [ unzip ];
+  buildInputs = [ lzo bzip2 zlib openssl ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "Files extractor and reimporter, archives and file formats parser";
+    homepage = "http://quickbms.com";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6012,6 +6012,8 @@ in
 
   qtikz = libsForQt5.callPackage ../applications/graphics/ktikz { };
 
+  quickbms = pkgsi686Linux.callPackage ../development/tools/parsing/quickbms { };
+
   quickjs = callPackage ../development/interpreters/quickjs { };
 
   quickserve = callPackage ../tools/networking/quickserve { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

need pkgsi686Linux for gnu/stubs-32.h.