### PR TITLE
goattracker: init at 2.75

### DIFF
--- a/pkgs/applications/audio/goattracker/default.nix
+++ b/pkgs/applications/audio/goattracker/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, fetchurl
+, unzip
+, makeDesktopItem
+, imagemagick
+, SDL
+, isStereo ? false
+}:
+
+with stdenv.lib;
+let
+  pname = "goattracker" + optionalString isStereo "-stereo";
+  desktopItem = makeDesktopItem {
+    type = "Application";
+    name = pname;
+    desktopName = "GoatTracker 2" + optionalString isStereo " Stereo";
+    genericName = "Music Tracker";
+    exec = if isStereo
+      then "gt2stereo"
+      else "goattrk2";
+    icon = "goattracker";
+    categories = "AudioVideo;AudioVideoEditing;";
+    extraEntries = "Keywords=tracker;music;";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname;
+  version = if isStereo
+    then "2.76"  # stereo
+    else "2.75"; # normal
+
+  src = fetchurl {
+    url = "mirror://sourceforge/goattracker2/GoatTracker_${version}${optionalString isStereo "_Stereo"}.zip";
+    sha256 = if isStereo
+      then "12cz3780x5k047jqdv69n6rjgbfiwv67z850kfl4i37lxja432l7"  # stereo
+      else "1km97nl7qvk6qc5l5j69wncbm76hf86j47sgzgr968423g0bxxlk"; # normal
+  };
+  sourceRoot = (if isStereo then "gt2stereo/trunk" else "goattrk2") + "/src";
+
+  nativeBuildInputs = [ unzip imagemagick ];
+  buildInputs = [ SDL ];
+
+  # PREFIX gets treated as BINDIR.
+  makeFlags = [ "PREFIX=$(out)/bin/" ];
+
+  # The zip contains some build artifacts.
+  prePatch = "make clean";
+
+  # The destination does not get created automatically.
+  preBuild = "mkdir -p $out/bin";
+
+  # Other files get installed during the build phase.
+  installPhase = ''
+    convert goattrk2.bmp goattracker.png
+    install -Dm644 goattracker.png $out/share/icons/hicolor/32x32/apps/goattracker.png
+    ${desktopItem.buildCommand}
+  '';
+
+  meta = {
+    description = "A crossplatform music editor for creating Commodore 64 music. Uses reSID library by Dag Lem and supports alternatively HardSID & CatWeasel devices"
+      + optionalString isStereo " - Stereo version";
+    homepage = "https://cadaver.github.io/tools.html";
+    downloadPage = "https://sourceforge.net/projects/goattracker2/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3730,6 +3730,12 @@ in
   # rename to upower-notify?
   go-upower-notify = callPackage ../tools/misc/upower-notify { };
 
+  goattracker = callPackage ../applications/audio/goattracker { };
+
+  goattracker-stereo = callPackage ../applications/audio/goattracker {
+    isStereo = true;
+  };
+
   google-app-engine-go-sdk = callPackage ../development/tools/google-app-engine-go-sdk { };
 
   google-authenticator = callPackage ../os-specific/linux/google-authenticator { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
