### PR TITLE
ssh-import-id: init at 5.8

### DIFF
--- a/pkgs/tools/admin/ssh-import-id/default.nix
+++ b/pkgs/tools/admin/ssh-import-id/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, stdenv
+, fetchgit
+, requests
+, makeWrapper
+, extraHandlers ? []
+}:
+
+buildPythonPackage rec {
+  pname = "ssh-import-id";
+  version = "5.8";
+
+  src = fetchgit {
+    url = "https://git.launchpad.net/ssh-import-id";
+    rev = version;
+    sha256 = "0l9gya1hyf2qfidlmvg2cgfils1fp9rn5r8sihwvx4qfsfp5yaak";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ] ++ extraHandlers;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  # handlers require main bin, main bin requires handlers
+  makeWrapperArgs = [ "--prefix" ":" "$out/bin" ];
+
+  meta = with stdenv.lib; {
+    description = "Retrieves an SSH public key and installs it locally";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mkg20001 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1019,6 +1019,8 @@ in
 
   ssh-agents = callPackage ../tools/networking/ssh-agents { };
 
+  ssh-import-id = python3Packages.callPackage ../tools/admin/ssh-import-id { };
+
   titaniumenv = callPackage ../development/mobile/titaniumenv { };
 
   abootimg = callPackage ../development/mobile/abootimg {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Need this tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
