### PR TITLE
sentencepiece: split into multiple outputs, optional gperftools

### DIFF
--- a/pkgs/development/libraries/sentencepiece/default.nix
+++ b/pkgs/development/libraries/sentencepiece/default.nix
@@ -1,9 +1,10 @@
-{ config
+{ lib
 , fetchFromGitHub
 , stdenv
-, lib
 , cmake
 , gperftools
+
+, withGPerfTools ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +18,9 @@ stdenv.mkDerivation rec {
     sha256 = "1ncvyw9ar0z7nd47cysxg5xrjm01y1shdlhp8l2pdpx059p3yx3w";
   };
 
-  nativeBuildInputs = [ cmake gperftools ];
+  nativeBuildInputs = [ cmake ] ++ lib.optional withGPerfTools gperftools;
+
+  outputs = [ "bin" "dev" "out" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/google/sentencepiece";

--- a/pkgs/development/libraries/sentencepiece/default.nix
+++ b/pkgs/development/libraries/sentencepiece/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     description = "Unsupervised text tokenizer for Neural Network-based text generation";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ pashashocky ];
+    maintainers = with maintainers; [ danieldk pashashocky ];
   };
 }

--- a/pkgs/development/python-modules/sentencepiece/default.nix
+++ b/pkgs/development/python-modules/sentencepiece/default.nix
@@ -6,10 +6,13 @@
 
 buildPythonPackage rec {
   pname = "sentencepiece";
-  inherit (sentencepiece) version src meta;
+  inherit (sentencepiece) version src;
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ sentencepiece ];
+  buildInputs = [ sentencepiece.dev ];
 
   sourceRoot = "source/python";
+
+  # sentencepiece installs 'bin' output.
+  meta = builtins.removeAttrs sentencepiece.meta [ "outputsToInstall" ];
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I am using sentencepiece in a downstream application where I want to
minimize the resulting closures. This commit makes changes to make
sentencepiece a leaner dependency:

- Split the outputs, so that the binaries/headers do not end up in the
  transitive closure in a library dependency.

- Add the `withGPerfTools` option, which is enabled by default, to
  make it possible to disable the gperftools dependency. According to
  the sentencepiece README, this dependency gives a 10-40% performance
  improvement. But in many cases this is overshadowed by the neural
  networks that use piece identifiers as input anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
