### PR TITLE
[ZHF] polyml: fix with new libffi

### DIFF
--- a/pkgs/development/compilers/polyml/5.7-new-libffi-FFI_SYSV.patch
+++ b/pkgs/development/compilers/polyml/5.7-new-libffi-FFI_SYSV.patch
@@ -1,0 +1,34 @@
+For 5.7 the copyright header is different.
+
+From ad32de7f181acaffaba78d5c3d9e5aa6b84a741c Mon Sep 17 00:00:00 2001
+From: David Matthews <dm@prolingua.co.uk>
+Date: Sun, 7 Apr 2019 13:41:33 +0100
+Subject: [PATCH] Remove FFI_SYSV from abi table for X86/64 Unix.  It appears
+ that this has been removed in upstream versions of libffi and causes problems
+ when building using the system libffi.
+
+---
+ libpolyml/polyffi.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/libpolyml/polyffi.cpp b/libpolyml/polyffi.cpp
+index 5424dd84..3dc9cc7c 100644
+--- a/libpolyml/polyffi.cpp
++++ b/libpolyml/polyffi.cpp
+@@ -1,7 +1,7 @@
+ /*
+     Title:  New Foreign Function Interface
+
+-    Copyright (c) 2015  David C.J. Matthews
++    Copyright (c) 2015, 2019  David C.J. Matthews
+
+     This library is free software; you can redistribute it and/or
+     modify it under the terms of the GNU Lesser General Public
+@@ -109,7 +109,6 @@ static struct _abiTable { const char *abiName; ffi_abi abiCode; } abiTable[] =
+ #elif defined(X86_WIN64)
+     {"win64", FFI_WIN64},
+ #elif defined(X86_ANY)
+-    {"sysv", FFI_SYSV},
+     {"unix64", FFI_UNIX64},
+ #endif
+     { "default", FFI_DEFAULT_ABI}

--- a/pkgs/development/compilers/polyml/5.7.nix
+++ b/pkgs/development/compilers/polyml/5.7.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     substituteInPlace configure.ac --replace stdc++ c++
   '';
 
+  patches = [ ./5.7-new-libffi-FFI_SYSV.patch ];
+
   buildInputs = [ libffi gmp ];
 
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin autoreconfHook;

--- a/pkgs/development/compilers/polyml/5.7.nix
+++ b/pkgs/development/compilers/polyml/5.7.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.polyml.org/;
     license = licenses.lgpl21;
     platforms = with platforms; (linux ++ darwin);
-    maintainers = with maintainers; [ maggesi yurrriq ];
+    maintainers = with maintainers; [ maggesi ];
   };
 }

--- a/pkgs/development/compilers/polyml/default.nix
+++ b/pkgs/development/compilers/polyml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, gmp, libffi }:
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, gmp, libffi }:
 
 stdenv.mkDerivation rec {
   pname = "polyml";
@@ -7,6 +7,14 @@ stdenv.mkDerivation rec {
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure.ac --replace stdc++ c++
   '';
+
+  patches = [
+    (fetchpatch {
+      name = "new-libffi-FFI_SYSV.patch";
+      url = "https://github.com/polyml/polyml/commit/ad32de7f181acaffaba78d5c3d9e5aa6b84a741c.patch";
+      sha256 = "007q3r2h9kfh3c1nv0dyhipmak44q468ab9bwnz4kk4a2dq76n8v";
+    })
+  ];
 
   buildInputs = [ libffi gmp ];
 

--- a/pkgs/development/compilers/polyml/default.nix
+++ b/pkgs/development/compilers/polyml/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.polyml.org/;
     license = licenses.lgpl21;
     platforms = with platforms; (linux ++ darwin);
-    maintainers = with maintainers; [ maggesi yurrriq ];
+    maintainers = with maintainers; [ maggesi kovirobi ];
   };
 }


### PR DESCRIPTION
New libffi doesn't have FFI_SYSV for x86/64 unix, this pulls in the
commit for the upstream version which fixes it, and ports that patch to
the 5.7 version. The 5.6 version is unchanged.

For ZHF: #80379

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
