### PR TITLE
ycmd: 2019-09-19 -> 2020-02-22

### DIFF
--- a/pkgs/development/tools/misc/ycmd/default.nix
+++ b/pkgs/development/tools/misc/ycmd/default.nix
@@ -8,12 +8,13 @@
 
 stdenv.mkDerivation {
   pname = "ycmd";
-  version = "2019-09-19";
+  version = "2020-02-22";
+  disabled = !python.isPy3k;
 
   src = fetchgit {
     url = "https://github.com/Valloric/ycmd.git";
-    rev = "c6d360775b0c5c82e2513dce7b625f8bf3812702";
-    sha256 = "19rxlval20gg65xc5p7q9cnzfm9zw2j0m6vxxk0vqlalcyh0rnzd";
+    rev = "9a6b86e3a156066335b678c328f226229746bae5";
+    sha256 = "1c5axdngxaxj5vc6lr8sxb99mr5adsm1dnjckaxc23kq78pc8cn7";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -61,12 +61,12 @@ let
 
   ale = buildVimPluginFrom2Nix {
     pname = "ale";
-    version = "2020-02-22";
+    version = "2020-02-25";
     src = fetchFromGitHub {
       owner = "w0rp";
       repo = "ale";
-      rev = "8012809c3f30a767db8395c5b8e3651cdb995635";
-      sha256 = "1g3zws7zi18plvwd6m7wrvj83siczsnwx0yr892v1m0gh7x2452y";
+      rev = "634c81fd465269f59e3db878fe8405828e6d2da9";
+      sha256 = "1lcqyj0yjdhm2kdk0p6pr8avjnb7gm4hg0dygm6fpjz3f078n9py";
     };
   };
 
@@ -160,12 +160,12 @@ let
 
   awesome-vim-colorschemes = buildVimPluginFrom2Nix {
     pname = "awesome-vim-colorschemes";
-    version = "2020-02-23";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "rafi";
       repo = "awesome-vim-colorschemes";
-      rev = "fc222a81de4734eeccd89e81d66319d4a2e8fee7";
-      sha256 = "08wk7i2p62zghvk7q22z6ac6qidpd58r1pkx5lbxg6l9zv7sb8j3";
+      rev = "b8bdaca805a059eed03a4f439578d373798c6d74";
+      sha256 = "1gmip6fggm5scbry9r1ggaq2fiy5xhwsj6ql24fa5jylyf1gfm26";
     };
   };
 
@@ -347,12 +347,12 @@ let
 
   coc-git = buildVimPluginFrom2Nix {
     pname = "coc-git";
-    version = "2020-02-19";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "neoclide";
       repo = "coc-git";
-      rev = "b0b6d913f2faaf02a79542c41cfa4db0c1d9b373";
-      sha256 = "0xg90a2h6g97m3wiakniqk60kdzi4ijgyc1p0bk1cxbj7gxvc7yg";
+      rev = "fc720742d1f7fed7a0737ee92235d743f2a86a12";
+      sha256 = "0qx3wsdnjnfxi6dg3z9pdcqnj2rhwnprz3ypch6ysyshlbvbs9ag";
     };
   };
 
@@ -402,12 +402,12 @@ let
 
   coc-java = buildVimPluginFrom2Nix {
     pname = "coc-java";
-    version = "2019-12-17";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "neoclide";
       repo = "coc-java";
-      rev = "4be4a57ad8f888ef92974ccb6e685358498863f1";
-      sha256 = "15175bphaiih5j63bigj5sblcyqjj68g3k81wn7dwgwdpglf1mwf";
+      rev = "4c5124b38f1b2a252bf4713cce67a1bb0cf04b5d";
+      sha256 = "1ygr4dpbjgy3872fc9kaivgbplkyc9l9wmifxkapp9s9ll11c7l0";
     };
   };
 
@@ -446,12 +446,12 @@ let
 
   coc-metals = buildVimPluginFrom2Nix {
     pname = "coc-metals";
-    version = "2020-02-19";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "ckipp01";
       repo = "coc-metals";
-      rev = "973360108311862d6b49711af20671329d22fef5";
-      sha256 = "0f1chb6f18bqzcrps1nl871k98i91833lp1d2ql2rpl7kk7bsl72";
+      rev = "4dd4685ef44f1a38ea20b373f2a20b82304d68e0";
+      sha256 = "1q165kh4k59ikivs9pwp6w9jla6li8hcln5zbpkxhis6sh9g3bn6";
     };
   };
 
@@ -854,12 +854,12 @@ let
 
   defx-nvim = buildVimPluginFrom2Nix {
     pname = "defx-nvim";
-    version = "2020-02-09";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "defx.nvim";
-      rev = "17c86251515e18a2791552d88d6142495fa78a69";
-      sha256 = "184mwc8iapjzdysc5fsabdm77kyvr2p2a1azsryji7b65h1pzdal";
+      rev = "f962b9908f48f823b817b7fd61ce9d706bbb41fd";
+      sha256 = "1sv2g6sx9ap71937ky8iysck9q32mracmanc0vnyvffvqy7jwksf";
     };
   };
 
@@ -887,12 +887,12 @@ let
 
   denite-git = buildVimPluginFrom2Nix {
     pname = "denite-git";
-    version = "2020-02-18";
+    version = "2020-02-26";
     src = fetchFromGitHub {
       owner = "chemzqm";
       repo = "denite-git";
-      rev = "52b47c249ba67bc089c9fdcbab5628fc1b767651";
-      sha256 = "000vv7jka1911b9sb8vbb6y25npqrw95nx6wmcj7vnm9pn64izdb";
+      rev = "0c7ffefa872ca19d61ecec6e014a797f0c25e98f";
+      sha256 = "11mz76x7pj2p3k3d8ycjvrwdjrabrdcssw5lr529r9dardkqchzl";
     };
   };
 
@@ -1077,12 +1077,12 @@ let
 
   deoplete-nvim = buildVimPluginFrom2Nix {
     pname = "deoplete-nvim";
-    version = "2020-02-23";
+    version = "2020-02-25";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "deoplete.nvim";
-      rev = "ebc9c155b0247314609e8d326e030adb3391f243";
-      sha256 = "1y51fn2lxal6kf7cls913kl51f67in08xhv2waqngv71bd377bjj";
+      rev = "3a8e68d09c6d1a62991c883279f6f647c9e23b7f";
+      sha256 = "0h87i51w0xll2nyib4fqhspdwzh4ynrv1zs74dz7a8nl1v3lzlnx";
     };
   };
 
@@ -1121,12 +1121,12 @@ let
 
   echodoc-vim = buildVimPluginFrom2Nix {
     pname = "echodoc-vim";
-    version = "2020-02-12";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "echodoc.vim";
-      rev = "42d0ac0f41601f5e09bd9d62d6c14a5de99f0964";
-      sha256 = "19mydl8r6cqmv2z93p7rww0bxvr7b1y1ag8qml5ajfcsfaz9r1i2";
+      rev = "577b7e7d083e37c0c15158cbd761de7cd831e682";
+      sha256 = "1cmp80s4k7sslj4vd919wwlinzmy0yghnczwzrwgk9yf0jclk4nv";
     };
   };
 
@@ -1189,12 +1189,12 @@ let
 
   falcon = buildVimPluginFrom2Nix {
     pname = "falcon";
-    version = "2020-02-07";
+    version = "2020-02-26";
     src = fetchFromGitHub {
       owner = "fenetikm";
       repo = "falcon";
-      rev = "b37f45f0a25dbbebe86470e72d735e110e193b4e";
-      sha256 = "148s39lm13m825ax48p0lrj2bg0i80lli8x18f3xnaqjad0lb1fk";
+      rev = "7128e3a6778347ff7848d9f8a423f63b94e6d9b9";
+      sha256 = "0s4sd982z3f8cppcz4hja788jgcm1gsh6qn8lw9535i6bmphn027";
     };
   };
 
@@ -1586,12 +1586,12 @@ let
 
   jedi-vim = buildVimPluginFrom2Nix {
     pname = "jedi-vim";
-    version = "2020-02-03";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "davidhalter";
       repo = "jedi-vim";
-      rev = "8d24b837547688f19f3184d99e96a430b3c3722e";
-      sha256 = "1xbk0d4r02hmxj7y33jjazr0ri5a4bw7v29fl5qll3dgqjbijmjm";
+      rev = "686f39ac002ca31acd663ae8749982144484ff95";
+      sha256 = "0ll0rnw00kl58a3dpvcx85dmd5j2figg6cc87qld2mn169qcx354";
       fetchSubmodules = true;
     };
   };
@@ -2027,12 +2027,12 @@ let
 
   neosnippet-snippets = buildVimPluginFrom2Nix {
     pname = "neosnippet-snippets";
-    version = "2020-01-26";
+    version = "2020-02-24";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "neosnippet-snippets";
-      rev = "0d7f506538a82b594e3527c58f7b2bccd44d9a85";
-      sha256 = "0clb394pkxwrh14rbll4ffpx45sqgvmlbrr9bl3q58q7b5qhg54d";
+      rev = "aed6074642363d0c97da5cd86e1b23027479df84";
+      sha256 = "1smfyghn7sxdqx867145xyjranvrjaa8s9fp1wvyzb3s3jfwh3mk";
     };
   };
 
@@ -2225,12 +2225,12 @@ let
 
   nvim-lsp = buildVimPluginFrom2Nix {
     pname = "nvim-lsp";
-    version = "2020-02-23";
+    version = "2020-02-25";
     src = fetchFromGitHub {
       owner = "neovim";
       repo = "nvim-lsp";
-      rev = "2dc39ef00bedde68aa7fab7023646a5ff8ca9986";
-      sha256 = "0l6blvqj2fh942farbwk02gfl2skqr59m6zz1kn4drybvr0sdw8k";
+      rev = "1739274e24087565760b35a789a28bc217308ecf";
+      sha256 = "08lmpagkxqgn06375bib8z9k3hm7b6q139vbkzc2hxpbg3xd4jfs";
     };
   };
 
@@ -2632,12 +2632,12 @@ let
 
   seoul256-vim = buildVimPluginFrom2Nix {
     pname = "seoul256-vim";
-    version = "2019-12-13";
+    version = "2020-02-25";
     src = fetchFromGitHub {
       owner = "junegunn";
       repo = "seoul256.vim";
-      rev = "b68f4032c49b64065072b449dc0f0f1f30616d8d";
-      sha256 = "0bxw0ks5gndzrgixa6xqhnf78b7n75w2jnc3s6bv75lz0fn0gypx";
+      rev = "fb0607ff91ac3b2fb2fa226be12bec1ccef4f1e1";
+      sha256 = "1d2rsxb8ag42ba0bqj9g7ax56v36vch6x2q768q73plagiwr4jzy";
     };
   };
 
@@ -2702,8 +2702,8 @@ let
     src = fetchFromGitHub {
       owner = "jaredgorski";
       repo = "SpaceCamp";
-      rev = "44d2e55286bc04588b35b356e36c56ae15e78ad2";
-      sha256 = "1qzlcp46x4pm6dyf2k4n2rrdh27zj7j719gh853gvhdbvjk650yr";
+      rev = "c35ee8509a9f690366b7d8c04cded9d9f07d8a86";
+      sha256 = "18y7z79469lkcn293zyly306hm7dr1sq9dvnl69nc4a82cdpaha8";
     };
   };
 
@@ -3018,12 +3018,12 @@ let
 
   ultisnips = buildVimPluginFrom2Nix {
     pname = "ultisnips";
-    version = "2020-02-12";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "SirVer";
       repo = "ultisnips";
-      rev = "a6c9d4fd1b23e1480b973e7cee1fe20c79248b75";
-      sha256 = "1imqxb04gmqf5v4rd3pb26g5px3sd2pgvb6s0l0bg0qxhg8ksq0p";
+      rev = "129d33fc34a72ced857f3cfb72ff10caf10f0020";
+      sha256 = "1hf6d4rr2y4msjxqh0pjpdh6237992497wfj8jy0jalnp2j8icbx";
     };
   };
 
@@ -3040,12 +3040,12 @@ let
 
   unicode-vim = buildVimPluginFrom2Nix {
     pname = "unicode-vim";
-    version = "2020-02-07";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "chrisbra";
       repo = "unicode.vim";
-      rev = "749a38330c5cfb2557636137a3ab8183004173e6";
-      sha256 = "1lzp691a7q9hvc6vg0gl2v871sgryki3yifza7rdfwaxiam4yy0k";
+      rev = "582b715562c953ea9a1f043443f98793cfbc0d47";
+      sha256 = "1wjmdjn129d8p6nrx69xdrrzg05l930a5lfbrvhyic3aiqn5x1mf";
     };
   };
 
@@ -3337,12 +3337,12 @@ let
 
   vim-airline = buildVimPluginFrom2Nix {
     pname = "vim-airline";
-    version = "2020-02-21";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "vim-airline";
       repo = "vim-airline";
-      rev = "0b2683464877c1e39d0c67427c7fdc4bc6697d15";
-      sha256 = "010cqvszgfvwci1iw8w0kwjdy4284i16yarfcsq5zcd0786sn8s6";
+      rev = "774cd8b08ff1569f86cba78e24ee06e448f86b4f";
+      sha256 = "09hhgsbg5nnmzdpz4wclwgjnkxg2l1rvizhmv0wd7g6sshs9i83w";
     };
   };
 
@@ -3524,12 +3524,12 @@ let
 
   vim-codefmt = buildVimPluginFrom2Nix {
     pname = "vim-codefmt";
-    version = "2020-01-13";
+    version = "2020-02-26";
     src = fetchFromGitHub {
       owner = "google";
       repo = "vim-codefmt";
-      rev = "af796cf4084a3d32b85313ccc82675d626d40b59";
-      sha256 = "0pbwirsh8nx0dgf82w1sy6az6mpwdnxzy0ycqrx6qxs6bbf1kf74";
+      rev = "6d69f933f243ed3d7797641bd41c0e65d245c931";
+      sha256 = "0vzzyz7v03ihky3vx12rji4l1r6vbxgslvc1fvi4dznfqn5m9gfn";
     };
   };
 
@@ -3722,12 +3722,12 @@ let
 
   vim-dirvish = buildVimPluginFrom2Nix {
     pname = "vim-dirvish";
-    version = "2020-01-26";
+    version = "2020-02-24";
     src = fetchFromGitHub {
       owner = "justinmk";
       repo = "vim-dirvish";
-      rev = "5d84cb9ce7fdf7d3fd729a9d3f59060ca5ab3a6e";
-      sha256 = "0jsssvh1h4kzs51fcgd1gyrkrx6ldf5z3dcnllc26qz4fki1ds89";
+      rev = "0a53fadc22ab6df6aed9cc580c9e498715870522";
+      sha256 = "09q5xpc4xbskzxppp66ypzd5mnic5bcwxahmhb259ch9xs8qmrc6";
     };
   };
 
@@ -4001,8 +4001,8 @@ let
     src = fetchFromGitHub {
       owner = "tpope";
       repo = "vim-fugitive";
-      rev = "31629d8bd18ddb5db6d9c55585d1eeb325a6bb43";
-      sha256 = "1qvhdxha29wj7fw88i72n16m05hd9apfqwf16g6wi6v2nfqfwpnp";
+      rev = "c452181975761f8b055b88eb1c98f736323510fd";
+      sha256 = "0zx9p9y45h26imrzw9nm5balxw7dmv94ynd7cn8mvml29v0awv2g";
     };
   };
 
@@ -4041,12 +4041,12 @@ let
 
   vim-gitgutter = buildVimPluginFrom2Nix {
     pname = "vim-gitgutter";
-    version = "2020-02-13";
+    version = "2020-02-24";
     src = fetchFromGitHub {
       owner = "airblade";
       repo = "vim-gitgutter";
-      rev = "da2c785221810b3d57479bb4b3678aabf32f3b88";
-      sha256 = "1kgyzraz48c4zlpkz4qxlvzqzmh6dy7qwlq7gz8n8pbpr7kahmhb";
+      rev = "c337eef1b735906411577f488e977be69506ef08";
+      sha256 = "10sz744djns1qn9lh7npzvnmkqbr34zgk78cag6ss45bnczqx1h7";
     };
   };
 
@@ -4074,12 +4074,12 @@ let
 
   vim-go = buildVimPluginFrom2Nix {
     pname = "vim-go";
-    version = "2020-02-23";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "fatih";
       repo = "vim-go";
-      rev = "dc02b2192ff2f652379f94791b7c7e311c946068";
-      sha256 = "1h6hb870zqx7wdk49wpcp7rrd70nvvb4wk311j8439z4f6ibfsdq";
+      rev = "1bf0d57e01f930ccc1db3dacb3c169d6dc78d2cb";
+      sha256 = "18imfrn948c20y7ymgh1xqsd82939dswj7hkf0b0fnsi0w9ydddk";
     };
   };
 
@@ -4548,12 +4548,12 @@ let
 
   vim-localvimrc = buildVimPluginFrom2Nix {
     pname = "vim-localvimrc";
-    version = "2020-02-17";
+    version = "2020-02-25";
     src = fetchFromGitHub {
       owner = "embear";
       repo = "vim-localvimrc";
-      rev = "1e3238470d833c8622453245694ba107eca46133";
-      sha256 = "1agiyycrjkh1ajfpfj4vzl9sd3xpxv68c7jrqkxqq0rfg74rksbc";
+      rev = "fc2f789ce7afa4bbdefbbb4599a802b39b7e7596";
+      sha256 = "19drgnsn4rb9kv30ykndwjgflsfs328dhm44a9hcp8f8faqpim3d";
     };
   };
 
@@ -5252,12 +5252,12 @@ let
 
   vim-slime = buildVimPluginFrom2Nix {
     pname = "vim-slime";
-    version = "2020-02-16";
+    version = "2020-02-26";
     src = fetchFromGitHub {
       owner = "jpalardy";
       repo = "vim-slime";
-      rev = "80c04d49b8d3c2a182e5cd745c52153de6ae272c";
-      sha256 = "12k1xq8xmwb7v7i8yx55mpg7fzin0ag2rvxvz77kdiwwni4vdrii";
+      rev = "73449cc1bf3375ce6f92a1018821cdd0ae91959d";
+      sha256 = "1wsrgchjxhircgdvwphvswnl7jq5b63l360wnjjlmcff6nvwhm77";
     };
   };
 
@@ -5307,12 +5307,12 @@ let
 
   vim-snippets = buildVimPluginFrom2Nix {
     pname = "vim-snippets";
-    version = "2020-02-20";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "honza";
       repo = "vim-snippets";
-      rev = "35067caeca1c17fa5d38d5de031b26610e939cba";
-      sha256 = "00y608jfrw72wfvzyl82f8m1qxmb1m3c5micncca8qvyjyya07y7";
+      rev = "66975121c7c824cb7c4fa8f2ea53f824e538e3cb";
+      sha256 = "0m1pw3iq29jpp439yzkaszjg1jiz5qkd16vfkskmk2kkg84y3kqn";
     };
   };
 
@@ -5472,23 +5472,23 @@ let
 
   vim-terraform = buildVimPluginFrom2Nix {
     pname = "vim-terraform";
-    version = "2020-02-07";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "hashivim";
       repo = "vim-terraform";
-      rev = "c8c9bbd70da65e2c0bcba2947c4061a7c3e24e69";
-      sha256 = "0mpzy2y8k5kyz7pvg41pqy88g15mqay8lxhribi288smmbyswsyl";
+      rev = "a0046044670c412bcccc44aa80e5642785fb57a2";
+      sha256 = "0c1qzc3ds7gvsp2vk7cszy11x57angmjwq1skfsk1zz7vgzhcj2i";
     };
   };
 
   vim-test = buildVimPluginFrom2Nix {
     pname = "vim-test";
-    version = "2020-02-19";
+    version = "2020-02-24";
     src = fetchFromGitHub {
       owner = "janko-m";
       repo = "vim-test";
-      rev = "3ffaea971fe579c028242e79d7823dd8e8dbeebd";
-      sha256 = "0f3sn7zkwmdj3adxvclm8yqwkhxlbjzph8jmlr6kyx8xk8axdin8";
+      rev = "1dba5d0328b2d632a418dfc7b417ae83455cc342";
+      sha256 = "0rm1ckriwajhskyybnq83m027lhki8p7c5cykzl5f05ax9rfiva6";
     };
   };
 
@@ -5692,12 +5692,12 @@ let
 
   vim-visual-multi = buildVimPluginFrom2Nix {
     pname = "vim-visual-multi";
-    version = "2020-02-18";
+    version = "2020-02-26";
     src = fetchFromGitHub {
       owner = "mg979";
       repo = "vim-visual-multi";
-      rev = "7417eaf7349db2c904f1ff85e69b14122a1c07ae";
-      sha256 = "14cxpwq0r0c8aq3n6vk5b9rqlazvvjszm9fdlbsrggx52llkpq3z";
+      rev = "32fa278c458d8790a2604a71f3ac3d2500112040";
+      sha256 = "0v7asrgbqz70jq4avpi72338fcrs81bgapyvar18l43k6vgb867a";
     };
   };
 
@@ -5901,12 +5901,12 @@ let
 
   vimtex = buildVimPluginFrom2Nix {
     pname = "vimtex";
-    version = "2020-02-18";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "lervag";
       repo = "vimtex";
-      rev = "20f47baff2a981d6d72a8404adfd878c8736e4ee";
-      sha256 = "1bw4fh1c9xi1hfa3c3dpk605zkmg1hr4qnxrl02jlpiy631lalq2";
+      rev = "63593e05440bde5f1f4dbcd30447f410940f94c3";
+      sha256 = "19fxcqbvxx2b60cj03qcaawwi88b7y4wamw9fk278d7q64933h2z";
     };
   };
 
@@ -5945,12 +5945,12 @@ let
 
   vista-vim = buildVimPluginFrom2Nix {
     pname = "vista-vim";
-    version = "2020-02-19";
+    version = "2020-02-27";
     src = fetchFromGitHub {
       owner = "liuchengxu";
       repo = "vista.vim";
-      rev = "73ce1d884987910f3c219a99cf659ae4146e6bf4";
-      sha256 = "0815pjnzf3pgvf45y801bzigjq79dscl7xdcs3p7qj4b8afazygg";
+      rev = "6c8173a10633541fe99d54cc693874806e08858c";
+      sha256 = "08p4xkrgzfb9b3r738lnsp4hrly9p5bbzcv446qcflbxmbmy3fw4";
     };
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
It seems YCMD was left behind (from YCM) with #80218.
This normally might not make a difference, but this time, they came out of sync with commits that dropped python2 support.

The commits mentioned are https://github.com/ycm-core/YouCompleteMe/pull/3566 and https://github.com/ycm-core/ycmd/pull/1382, both of which were merged within the last month.

This broke YouCompleteMe, throwing the message:
`YouCompleteMe unavailable: No module named 'future'`

###### Things done
This PR updates YCMD and disables python2 support for both YCM and YCMD.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
