### PR TITLE
icon-lang: 9.5.1 -> unstable-2020-02-05

### DIFF
--- a/pkgs/development/interpreters/icon-lang/default.nix
+++ b/pkgs/development/interpreters/icon-lang/default.nix
@@ -1,30 +1,34 @@
-{ stdenv, fetchFromGitHub
-, libX11, libXt
+{ stdenv
+, fetchFromGitHub
+, libX11
+, libXt
 , withGraphics ? true
 }:
 
 stdenv.mkDerivation rec {
   pname = "icon-lang";
-  version = "9.5.20i";
-
+  version = "unstable-2020-02-05";
   src = fetchFromGitHub {
     owner = "gtownsend";
     repo = "icon";
-    rev = "v${version}";
-    sha256 = "0072b3jk8mc94w818z8bklhjdf9rf0d9a7lkvw40pz3niy7zv84s";
+    rev = "829cff33de4a21546fb269de3ef5acd7b4f0c0c7";
+    sha256 = "1lj2f13pbaajcy4v3744bz46rghhw5sv4dwwfnzhsllbj5gnjsv2";
   };
 
   buildInputs = stdenv.lib.optionals withGraphics [ libX11 libXt ];
 
-  configurePhase = let
-    target = if withGraphics then "X-Configure" else "Configure";
-    platform = if stdenv.isLinux  then "linux"
-          else if stdenv.isDarwin then "macintosh"
-          else if stdenv.isBSD    then "bsd"
-          else if stdenv.isCygwin then "cygwin"
-          else if stdenv.isSunOS  then "solaris"
-          else throw "unsupported system";
-  in "make ${target} name=${platform}";
+  configurePhase =
+    let
+      target = if withGraphics then "X-Configure" else "Configure";
+      platform =
+        if stdenv.isLinux then "linux"
+        else if stdenv.isDarwin then "macintosh"
+        else if stdenv.isBSD then "bsd"
+        else if stdenv.isCygwin then "cygwin"
+        else if stdenv.isSunOS then "solaris"
+        else throw "unsupported system";
+    in
+    "make ${target} name=${platform}";
 
   installPhase = "make Install dest=$out";
 

--- a/pkgs/development/interpreters/icon-lang/default.nix
+++ b/pkgs/development/interpreters/icon-lang/default.nix
@@ -30,7 +30,12 @@ stdenv.mkDerivation rec {
     in
     "make ${target} name=${platform}";
 
-  installPhase = "make Install dest=$out";
+  installPhase = ''
+    make Install dest=$out
+    rm $out/README
+    mkdir -p $out/share/doc
+    mv $out/doc $out/share/doc/icon
+  '';
 
   meta = with stdenv.lib; {
     description = ''A very high level general-purpose programming language'';


### PR DESCRIPTION
Latest release (https://github.com/gtownsend/icon/releases/tag/ok2018j)
doesn't seem like a properly versioned release. Latest properly
versioned release
(https://github.com/gtownsend/icon/releases/tag/rel951) is from 2013. So
I have decided to use the unstable release, which works.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

(This was ZHF: #80379 but a different PR resolved that)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

   Not sure I have done this correctly, it doesn't seem to build e.g. `noweb`, which I know `noweb` depends on this (and is currently broken). Will try to make `noweb` work too, a `grep` doesn't indicate any other dependencies.

- [ ] Tested execution of all binary files (usually in `./result/bin/`)

    Not tested all binary files, but tested noweb (see PR #81042, which depends on this)

- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
