### PR TITLE
[20.03] pythonPackages.fipy: 3.3 -> 3.4.1

### DIFF
--- a/pkgs/development/python-modules/fipy/default.nix
+++ b/pkgs/development/python-modules/fipy/default.nix
@@ -14,6 +14,8 @@
 , gmsh
 , python
 , stdenv
+, openssh
+, fetchurl
 }:
 
 let
@@ -21,12 +23,11 @@ let
 in
   buildPythonPackage rec {
     pname = "fipy";
-    version = "3.3";
+    version = "3.4.1";
 
-    src = fetchPypi {
-      pname = "FiPy";
-      inherit version;
-      sha256 = "11agpg3d6yrns8igkpml1mxy3mkqkjq2yrw1mw12y07dkk12ii19";
+    src = fetchurl {
+      url = "https://github.com/usnistgov/fipy/releases/download/${version}/FiPy-${version}.tar.gz";
+      sha256 = "0078yg96fknqhywn1v26ryc5z47c0j0c1qwz6p8wsjn0wmzggaqk";
     };
 
     propagatedBuildInputs = [
@@ -38,11 +39,13 @@ in
       mpi4py
       future
       scikit-fmm
+      openssh
     ] ++ lib.optionals isPy27 [ pysparse ] ++ not_darwin_inputs;
 
     checkInputs = not_darwin_inputs;
 
     checkPhase = ''
+      export OMPI_MCA_plm_rsh_agent=${openssh}/bin/ssh
       ${python.interpreter} setup.py test --modules
     '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix fipy, which is breaking in [Hydra](https://hydra.nixos.org/eval/1572384?filter=fipy&compare=1572343&full=#tabs-still-fail)

 - Required a version bump to fix compatibility with Numpy version
 - Required openssh to fix tests.
 - Using `fetchurl` rather than `fetchPypi`, which is preferred now

For ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
