### PR TITLE
noweb: fix installation of manpages, use placeholders

### DIFF
--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -27,16 +27,19 @@ let noweb = stdenv.mkDerivation rec {
     "CC=clang"
   ];
 
+
   installFlags = [
-    "BIN=$(out)/bin"
-    "ELISP=$(out)/share/emacs/site-lisp"
-    "LIB=$(out)/lib/noweb"
-    "MAN=$(out)/share/man"
-    "TEXINPUTS=$(tex)/tex/latex/noweb"
   ];
 
   preInstall = ''
     mkdir -p "$tex/tex/latex/noweb"
+    installFlagsArray+=(                                   \
+        "BIN=${placeholder "out"}/bin"                     \
+        "ELISP=${placeholder "out"}/share/emacs/site-lisp" \
+        "LIB=${placeholder "out"}/lib/noweb"               \
+        "MAN=${placeholder "out"}/share/man"               \
+        "TEXINPUTS=${placeholder "tex"}/tex/latex/noweb"   \
+    )
   '';
 
   installTargets = [ "install-code" "install-tex" "install-elisp" ];
@@ -57,7 +60,7 @@ let noweb = stdenv.mkDerivation rec {
 
     # HACK: This is ugly, but functional.
     PATH=$out/bin:$PATH make -BC xdoc
-    make "''${installFlags[@]} install-man"
+    make "''${installFlagsArray[@]}" install-man
 
     ln -s "$tex" "$out/share/texmf"
   '';


### PR DESCRIPTION
The problem was that nix passes lists as space-separated strings not as
arrays of strings, so `"${foo[@]}"` doesn't work as intended because
it's not an array.

Also, using builtins.placeholder instead of passing "$(out)" to bash, as
that's not what we want to do. (As in bash "$(...)" is shell expansion, unsure if that worked at all.)


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

(This was ZHF: #80379 but a different PR resolved that, though it doesn't now install man-pages. This fixes that.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
