### PR TITLE
Remove vimPlugins.notational-fzf-vim

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2157,17 +2157,6 @@ let
     };
   };
 
-  notational-fzf-vim = buildVimPluginFrom2Nix {
-    pname = "notational-fzf-vim";
-    version = "2019-12-03";
-    src = fetchFromGitHub {
-      owner = "alok";
-      repo = "notational-fzf-vim";
-      rev = "16ea3477c8dbf3167f15246a29bd1d1fcc18c914";
-      sha256 = "1j1nfb297rqmg2h96hx4bmgxq55z179fh4f1ak79d6v815mr72bi";
-    };
-  };
-
   NrrwRgn = buildVimPluginFrom2Nix {
     pname = "NrrwRgn";
     version = "2019-12-12";

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -28,9 +28,6 @@
 
 # vCoolor dependency
 , gnome3
-
-# notational-fzf-vim dependencies
-, ripgrep
 }:
 
 self: super: {
@@ -251,17 +248,6 @@ self: super: {
 
   ncm2-ultisnips = super.ncm2-ultisnips.overrideAttrs(old: {
     dependencies = with super; [ ultisnips ];
-  });
-  
-  notational-fzf-vim = super.notational-fzf-vim.overrideAttrs(old: {
-    dependencies = with self; [ fzf-vim ];
-    patchPhase = ''
-      substituteInPlace plugin/notational_fzf.vim \
-        --replace "'rg'" "'${ripgrep}/bin/rg'" \
-        --replace \
-        "let s:python_executable = executable('pypy3') ? 'pypy3' : 'python3'" \
-        "let s:python_executable = '${python3}/bin/python3'"
-    '';
   });
 
   fzf-vim = super.fzf-vim.overrideAttrs(old: {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -4,7 +4,6 @@ airblade/vim-rooter
 ajh17/Spacegray.vim
 aklt/plantuml-syntax
 albfan/nerdtree-git-plugin
-alok/notational-fzf-vim
 altercation/vim-colors-solarized
 alvan/vim-closetag
 alx741/vim-hindent


### PR DESCRIPTION
vimPlugins.notational-fzf-vim as it is in nixos-unstable currently doesn't build.  This PR removes it.

This plugin requires two patches to the plugin to set up a hardcoded search path for what is a more limited version of a duplicated feature that vimPlugins.fzf-vim already has available.

I became aware of that after i made these commits and pr's, so, reverting.

