### PR TITLE
Add Emacs packages: apheleia, isearch-prop, isearch-plus

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/apheleia/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/apheleia/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "apheleia";
+  version = "2021-05-23";
+
+  src = fetchFromGitHub {
+    owner = "raxod502";
+    repo = "apheleia";
+    rev = "f865c165dac606187a66b2b25a57d5099b452120";
+    sha256 = "sha256-n37jJsNOGhSjUtQysG3NVIjjayhbOa52iTXBc8SyKXE=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Reformat buffer stably";
+    homepage = "https://github.com/raxod502/apheleia";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/evil-markdown/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/evil-markdown/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, emacs, emacsPackages, lib }:
+
+let
+  runtimeDeps = with emacsPackages; [
+    evil
+    markdown-mode
+  ];
+in
+stdenv.mkDerivation {
+  pname = "evil-markdown";
+  version = "2020-06-01";
+
+  src = fetchFromGitHub {
+    owner = "Somelauw";
+    repo = "evil-markdown";
+    rev = "064fe9b4767470472356d20bdd08e2f30ebbc9ac";
+    sha256 = "sha256-Kt2wxG1XCFowavVWtj0urM/yURKegonpZcxTy/+CrJY=";
+  };
+
+  buildInputs = [
+    emacs
+  ] ++ runtimeDeps;
+
+  propagatedUserEnvPkgs = runtimeDeps;
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Vim-like keybindings for markdown-mode";
+    homepage = "https://github.com/Somelauw/evil-markdown";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/git-undo/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/git-undo/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "git-undo";
+  version = "2019-10-13";
+
+  src = fetchFromGitHub {
+    owner = "jwiegley";
+    repo = "git-undo-el";
+    rev = "cf31e38e7889e6ade7d2d2b9f8719fd44f52feb5";
+    sha256 = "sha256-cVkK9EF6qQyVV3uVqnBEjF8e9nEx/8ixnM8PvxqCyYE=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Revert region to most recent Git-historical version";
+    homepage = "https://github.com/jwiegley/git-undo-el";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/isearch-plus/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/isearch-plus/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "isearch-plus";
+  version = "2021-01-01";
+
+  src = fetchFromGitHub {
+    owner = "emacsmirror";
+    repo = "isearch-plus";
+    rev = "376a8f9f8a9666d7e61d125abcdb645847cb8619";
+    sha256 = "sha256-Kd5vpu+mI1tJPcsu7EpnnBcPVdVAijkAeTz+bLB3WlQ=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Extensions to isearch";
+    homepage = "https://www.emacswiki.org/emacs/download/isearch%2b.el";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/isearch-prop/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/isearch-prop/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "isearch-prop";
+  version = "2019-05-01";
+
+  src = fetchFromGitHub {
+    owner = "emacsmirror";
+    repo = "isearch-prop";
+    rev = "4a2765f835dd115d472142da05215c4c748809f4";
+    sha256 = "sha256-A1Kt4nm7iRV9J5yaLupwiNL5g7ddZvQs79dggmqZ7Rk=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Search text- or overlay-property contexts";
+    homepage = "https://www.emacswiki.org/emacs/download/isearch-prop.el";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -185,6 +185,8 @@
 
   };
 
+  mu4e-patch = callPackage ./mu4e-patch { };
+
   org-mac-link =
     callPackage ./org-mac-link { };
 

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -111,6 +111,8 @@
 
   helm-words = callPackage ./helm-words { };
 
+  isearch-plus = callPackage ./isearch-plus { };
+
   jam-mode = callPackage ./jam-mode { };
 
   llvm-mode = trivialBuild {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -65,6 +65,8 @@
     };
   };
 
+  apheleia = callPackage ./apheleia {};
+
   emacspeak = callPackage ./emacspeak {};
 
   ess-R-object-popup =

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -212,6 +212,8 @@
 
   tramp = callPackage ./tramp { };
 
+  youtube-dl = callPackage ./youtube-dl { };
+
   zeitgeist = callPackage ./zeitgeist { };
 
   # From old emacsPackages (pre emacsPackagesNg)

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -70,6 +70,8 @@
   ess-R-object-popup =
     callPackage ./ess-R-object-popup { };
 
+  evil-markdown = callPackage ./evil-markdown { };
+
   font-lock-plus = callPackage ./font-lock-plus { };
 
   ghc-mod = melpaBuild {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -113,6 +113,8 @@
 
   isearch-plus = callPackage ./isearch-plus { };
 
+  isearch-prop = callPackage ./isearch-prop { };
+
   jam-mode = callPackage ./jam-mode { };
 
   llvm-mode = trivialBuild {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -88,6 +88,8 @@
     };
   };
 
+  git-undo = callPackage ./git-undo { };
+
   haskell-unicode-input-method = melpaBuild {
     pname = "emacs-haskell-unicode-input-method";
     version = "20110905.2307";

--- a/pkgs/applications/editors/emacs/elisp-packages/mu4e-patch/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/mu4e-patch/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "mu4e-patch";
+  version = "2019-05-09";
+
+  src = fetchFromGitHub {
+    owner = "seanfarley";
+    repo = "mu4e-patch";
+    rev = "522da46c1653b1cacc79cde91d6534da7ae9517d";
+    sha256 = "sha256-1lV4dDuCdyCUXi/In2DzYJPEHuAc9Jfbz2ZecNZwn4I=";
+  };
+
+  buildInputs = [
+    emacs
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Colorize patch emails in mu4e";
+    homepage = "https://github.com/seanfarley/mu4e-patch";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/youtube-dl/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/youtube-dl/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "youtube-dl";
+  version = "2018-10-12";
+
+  src = fetchFromGitHub {
+    owner = "skeeto";
+    repo = "youtube-dl-emacs";
+    rev = "af877b5bc4f01c04fccfa7d47a2c328926f20ef4";
+    sha256 = "sha256-Etl95rcoRACDPjcTPQqYK2L+w8OZbOrTrRT0JadMdH4=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Emacs frontend to the youtube-dl utility";
+    homepage = "https://github.com/skeeto/youtube-dl-emacs";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Adding Emacs packages not in Melpa

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
