### PR TITLE
gnomeExtensions.hibernate-status: init at 1.5

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/hibernate-status/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/hibernate-status/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, glib, gnome3 }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-hibernate-status";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "arelange";
+    repo = "gnome-shell-extension-hibernate-status";
+    rev = "v${version}";
+    sha256 = "0418zcm9khgr7y5al51ffq0wbnajb8717589ci4207aaizgwipp8";
+  };
+
+  uuid = "hibernate-status@dromi";
+
+  nativeBuildInputs = [
+    glib
+  ];
+
+  buildPhase = ''
+    glib-compile-schemas --strict --targetdir=schemas/ schemas
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp *.js $out/share/gnome-shell/extensions/${uuid}
+    cp -r schemas $out/share/gnome-shell/extensions/${uuid}
+    cp metadata.json $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A hibernate/hybrid suspend button in status menu";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ericdallo ];
+    platforms = gnome3.gnome-shell.meta.platforms;
+    homepage = https://github.com/arelange/gnome-shell-extension-hibernate-status;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23786,6 +23786,7 @@ in
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
     drop-down-terminal = callPackage ../desktops/gnome-3/extensions/drop-down-terminal { };
     gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };
+    hibernate-status = callPackage ../desktops/gnome-3/extensions/hibernate-status { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     impatience = callPackage ../desktops/gnome-3/extensions/impatience.nix { };
     mpris-indicator-button = callPackage ../desktops/gnome-3/extensions/mpris-indicator-button { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add gnome extension `hibernate-status` button

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
