### PR TITLE
netpbm: 10.82.01 → 10.89.1

### DIFF
--- a/pkgs/applications/editors/texmacs/darwin.nix
+++ b/pkgs/applications/editors/texmacs/darwin.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
     "${ghostscript}/bin:" +
     (if aspell == null then "" else "${aspell}/bin:") +
     (if tex == null then "" else "${tex}/bin:") +
-    (if netpbm == null then "" else "${netpbm}/bin:") +
+    (if netpbm == null then "" else "${stdenv.lib.getBin netpbm}/bin:") +
     (if imagemagick == null then "" else "${imagemagick}/bin:");
 
   enableParallelBuilding = true;

--- a/pkgs/applications/science/electronics/fped/default.nix
+++ b/pkgs/applications/science/electronics/fped/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "LEX=flex"
-    "RGBDEF=${netpbm}/share/netpbm/misc/rgb.txt"
+    "RGBDEF=${netpbm.out}/share/netpbm/misc/rgb.txt"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -46,6 +46,8 @@ stdenv.mkDerivation {
   ] ++ lib.optional enableX11 libX11;
 
   configurePhase = ''
+    runHook preConfigure
+
     cp config.mk.in config.mk
     echo "STATICLIB_TOO = n" >> config.mk
     substituteInPlace "config.mk" \
@@ -57,6 +59,8 @@ stdenv.mkDerivation {
     echo "LDSHLIB=-dynamiclib -install_name $out/lib/libnetpbm.\$(MAJ).dylib" >> config.mk
     echo "NETPBMLIBTYPE = dylib" >> config.mk
     echo "NETPBMLIBSUFFIX = dylib" >> config.mk
+
+    runHook postConfigure
   '';
 
   preBuild = ''
@@ -71,6 +75,8 @@ stdenv.mkDerivation {
   enableParallelBuilding = false;
 
   installPhase = ''
+    runHook preInstall
+
     make package pkgdir=$out
 
     rm -rf $out/link $out/*_template $out/{pkginfo,README,VERSION} $out/man/web
@@ -82,6 +88,8 @@ stdenv.mkDerivation {
     for prog in ppmquant; do
         wrapProgram "$out/bin/$prog" --prefix PATH : "$out/bin"
     done
+
+    runHook postInstall
   '';
 
   passthru.updateScript = ./update.sh;

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation {
     substituteInPlace "config.mk" \
         --replace "TIFFLIB = NONE" "TIFFLIB = ${libtiff.out}/lib/libtiff.so" \
         --replace "TIFFHDR_DIR =" "TIFFHDR_DIR = ${libtiff.dev}/include" \
+        --replace "TIFFLIB_NEEDS_JPEG = Y" "TIFFLIB_NEEDS_JPEG = N" \
+        --replace "TIFFLIB_NEEDS_Z = Y" "TIFFLIB_NEEDS_Z = N" \
         --replace "JPEGLIB = NONE" "JPEGLIB = ${libjpeg.out}/lib/libjpeg.so" \
         --replace "JPEGHDR_DIR =" "JPEGHDR_DIR = ${libjpeg.dev}/include"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -17,17 +17,22 @@
 stdenv.mkDerivation {
   # Determine version and revision from:
   # https://sourceforge.net/p/netpbm/code/HEAD/log/?path=/advanced
-  name = "netpbm-10.82.01";
+  name = "netpbm-10.89.1";
 
   src = fetchsvn {
     url = "https://svn.code.sf.net/p/netpbm/code/advanced";
-    rev = "3264";
-    sha256 = "17fmyjbxp1l18rma7gb0m8wd9kx2iwhqs8dd6fpalsn2cr8mf8hf";
+    rev = "3735";
+    sha256 = "hRepEUBlf83p77Amjze+Qz7XTHhCuPdV01K/UabR89Q=";
   };
 
-  postPatch = /* CVE-2005-2471, from Arch */ ''
+  postPatch = ''
+    # CVE-2005-2471, from Arch
     substituteInPlace converter/other/pstopnm.c \
       --replace '"-dSAFER"' '"-dPARANOIDSAFER"'
+
+    # Install libnetpbm.so symlink to correct destination
+    substituteInPlace lib/Makefile \
+      --replace '/sharedlink' '/lib'
   '';
 
   nativeBuildInputs = [
@@ -79,7 +84,7 @@ stdenv.mkDerivation {
 
     make package pkgdir=$out
 
-    rm -rf $out/link $out/*_template $out/{pkginfo,README,VERSION} $out/man/web
+    rm -rf $out/*_template $out/{pkginfo,README,VERSION} $out/man/web
 
     mkdir -p $out/share/netpbm
     mv $out/misc $out/share/netpbm/

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -1,6 +1,18 @@
-{ lib, stdenv, fetchsvn, pkgconfig, libjpeg, libpng, flex, zlib, perl, libxml2
-, makeWrapper, libtiff
-, enableX11 ? false, libX11 }:
+{ lib
+, stdenv
+, fetchsvn
+, pkgconfig
+, libjpeg
+, libpng
+, flex
+, zlib
+, perl
+, libxml2
+, makeWrapper
+, libtiff
+, enableX11 ? false
+, libX11
+}:
 
 stdenv.mkDerivation {
   # Determine version and revision from:
@@ -18,9 +30,20 @@ stdenv.mkDerivation {
       --replace '"-dSAFER"' '"-dPARANOIDSAFER"'
   '';
 
-  buildInputs =
-    [ pkgconfig flex zlib perl libpng libjpeg libxml2 makeWrapper libtiff ]
-    ++ lib.optional enableX11 libX11;
+  nativeBuildInputs = [
+    pkgconfig
+    flex
+    makeWrapper
+  ];
+
+  buildInputs = [
+    zlib
+    perl
+    libpng
+    libjpeg
+    libxml2
+    libtiff
+  ] ++ lib.optional enableX11 libX11;
 
   configurePhase = ''
     cp config.mk.in config.mk
@@ -30,7 +53,7 @@ stdenv.mkDerivation {
         --replace "TIFFHDR_DIR =" "TIFFHDR_DIR = ${libtiff.dev}/include" \
         --replace "JPEGLIB = NONE" "JPEGLIB = ${libjpeg.out}/lib/libjpeg.so" \
         --replace "JPEGHDR_DIR =" "JPEGHDR_DIR = ${libjpeg.dev}/include"
-   '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
     echo "LDSHLIB=-dynamiclib -install_name $out/lib/libnetpbm.\$(MAJ).dylib" >> config.mk
     echo "NETPBMLIBTYPE = dylib" >> config.mk
     echo "NETPBMLIBSUFFIX = dylib" >> config.mk
@@ -64,9 +87,9 @@ stdenv.mkDerivation {
   passthru.updateScript = ./update.sh;
 
   meta = {
-    homepage = http://netpbm.sourceforge.net/;
+    homepage = "http://netpbm.sourceforge.net/";
     description = "Toolkit for manipulation of graphic images";
-    license = "GPL,free";
+    license = lib.licenses.free; # http://netpbm.svn.code.sourceforge.net/p/netpbm/code/trunk/doc/copyright_summary
     platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -61,6 +61,8 @@ stdenv.mkDerivation {
     done
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     homepage = http://netpbm.sourceforge.net/;
     description = "Toolkit for manipulation of graphic images";

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation {
   # https://sourceforge.net/p/netpbm/code/HEAD/log/?path=/advanced
   name = "netpbm-10.89.1";
 
+  outputs = [ "bin" "out" "dev" ];
+
   src = fetchsvn {
     url = "https://svn.code.sf.net/p/netpbm/code/advanced";
     rev = "3735";
@@ -95,6 +97,8 @@ stdenv.mkDerivation {
     for prog in ppmquant; do
         wrapProgram "$out/bin/$prog" --prefix PATH : "$out/bin"
     done
+
+    moveToOutput bin "''${!outputBin}"
 
     runHook postInstall
   '';

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -56,29 +56,21 @@ stdenv.mkDerivation {
     runHook preConfigure
 
     cp config.mk.in config.mk
-    echo "STATICLIB_TOO = n" >> config.mk
-    substituteInPlace "config.mk" \
-        --replace "TIFFLIB = NONE" "TIFFLIB = ${libtiff.out}/lib/libtiff.so" \
-        --replace "TIFFHDR_DIR =" "TIFFHDR_DIR = ${libtiff.dev}/include" \
-        --replace "TIFFLIB_NEEDS_JPEG = Y" "TIFFLIB_NEEDS_JPEG = N" \
-        --replace "TIFFLIB_NEEDS_Z = Y" "TIFFLIB_NEEDS_Z = N" \
-        --replace "JPEGLIB = NONE" "JPEGLIB = ${libjpeg.out}/lib/libjpeg.so" \
-        --replace "JPEGHDR_DIR =" "JPEGHDR_DIR = ${libjpeg.dev}/include"
+
+    # Disable building static library
+    echo "STATICLIB_TOO = N" >> config.mk
+
+    # Use libraries from Nixpkgs
+    echo "TIFFLIB = libtiff.so" >> config.mk
+    echo "TIFFLIB_NEEDS_JPEG = N" >> config.mk
+    echo "TIFFLIB_NEEDS_Z = N" >> config.mk
+    echo "JPEGLIB = libjpeg.so" >> config.mk
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     echo "LDSHLIB=-dynamiclib -install_name $out/lib/libnetpbm.\$(MAJ).dylib" >> config.mk
     echo "NETPBMLIBTYPE = dylib" >> config.mk
     echo "NETPBMLIBSUFFIX = dylib" >> config.mk
 
     runHook postConfigure
-  '';
-
-  preBuild = ''
-    export LDFLAGS="-lz"
-    substituteInPlace "pm_config.in.h" \
-        --subst-var-by "rgbPath1" "$out/lib/rgb.txt" \
-        --subst-var-by "rgbPath2" "/var/empty/rgb.txt" \
-        --subst-var-by "rgbPath3" "/var/empty/rgb.txt"
-    touch lib/standardppmdfont.c
   '';
 
   enableParallelBuilding = false;

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation {
     runHook postConfigure
   '';
 
-  enableParallelBuilding = false;
+  enableParallelBuilding = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -65,6 +65,9 @@ stdenv.mkDerivation {
     echo "TIFFLIB_NEEDS_JPEG = N" >> config.mk
     echo "TIFFLIB_NEEDS_Z = N" >> config.mk
     echo "JPEGLIB = libjpeg.so" >> config.mk
+
+    # Fix path to rgb.txt
+    echo "RGB_DB_PATH = $out/share/netpbm/misc/rgb.txt" >> config.mk
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     echo "LDSHLIB=-dynamiclib -install_name $out/lib/libnetpbm.\$(MAJ).dylib" >> config.mk
     echo "NETPBMLIBTYPE = dylib" >> config.mk

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -28,10 +28,6 @@ stdenv.mkDerivation {
   };
 
   postPatch = ''
-    # CVE-2005-2471, from Arch
-    substituteInPlace converter/other/pstopnm.c \
-      --replace '"-dSAFER"' '"-dPARANOIDSAFER"'
-
     # Install libnetpbm.so symlink to correct destination
     substituteInPlace lib/Makefile \
       --replace '/sharedlink' '/lib'

--- a/pkgs/tools/graphics/netpbm/update.sh
+++ b/pkgs/tools/graphics/netpbm/update.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p bash -p subversion -p common-updater-scripts -i bash
+
+die() {
+    echo "error: $1" >&2
+    exit 1
+}
+
+attr=netpbm
+svnRoot=https://svn.code.sf.net/p/netpbm/code/advanced
+
+oldRev=$(nix-instantiate --eval -E "with import ./. {}; $attr.src.rev" | tr -d '"')
+if [[ -z "$oldRev" ]]; then
+    die "Could not extract old revision."
+fi
+
+latestRev=$(svn info --show-item "last-changed-revision" "$svnRoot")
+if [[ -z "$latestRev" ]]; then
+    die "Could not find out last changed revision."
+fi
+
+versionInfo=$(svn cat -r "$latestRev" "$svnRoot/version.mk")
+if [[ -z "$versionInfo" ]]; then
+    die "Could not get version info."
+fi
+
+nixFile=$(nix-instantiate --eval --strict -A "$attr.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
+if [[ ! -f "$nixFile" ]]; then
+    die "Could not evaluate '$attr.meta.position' to locate the .nix file!"
+fi
+
+# h remembers if we found the pattern; on the last line, if a pattern was previously found, we exit with 1
+# https://stackoverflow.com/a/12145797/160386
+sed -i "$nixFile" -re '/(\brev\b\s*=\s*)"'"$oldRev"'"/{ s||\1"'"$latestRev"'"|; h }; ${x; /./{x; q1}; x}' && die "Unable to update revision."
+
+majorRelease=$(grep --perl-regex --only-matching 'NETPBM_MAJOR_RELEASE = \K.+' <<< "$versionInfo")
+minorRelease=$(grep --perl-regex --only-matching 'NETPBM_MINOR_RELEASE = \K.+' <<< "$versionInfo")
+pointRelease=$(grep --perl-regex --only-matching 'NETPBM_POINT_RELEASE = \K.+' <<< "$versionInfo")
+
+update-source-version "$attr" "$majorRelease.$minorRelease.$pointRelease"

--- a/pkgs/tools/graphics/pfstools/default.nix
+++ b/pkgs/tools/graphics/pfstools/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     rm cmake/FindNETPBM.cmake
-    echo "SET(NETPBM_LIBRARY `find ${netpbm} -name "*.${stdenv.hostPlatform.extensions.sharedLibrary}*" -type f`)" >> cmake/FindNETPBM.cmake
-    echo "SET(NETPBM_LIBRARIES `find ${netpbm} -name "*.${stdenv.hostPlatform.extensions.sharedLibrary}*" -type f`)" >> cmake/FindNETPBM.cmake
-    echo "SET(NETPBM_INCLUDE_DIR ${netpbm}/include/netpbm)" >> cmake/FindNETPBM.cmake
+    echo "SET(NETPBM_LIBRARY `find ${stdenv.lib.getLib netpbm} -name "*.${stdenv.hostPlatform.extensions.sharedLibrary}*" -type f`)" >> cmake/FindNETPBM.cmake
+    echo "SET(NETPBM_LIBRARIES `find ${stdenv.lib.getLib netpbm} -name "*.${stdenv.hostPlatform.extensions.sharedLibrary}*" -type f`)" >> cmake/FindNETPBM.cmake
+    echo "SET(NETPBM_INCLUDE_DIR ${stdenv.lib.getDev netpbm}/include/netpbm)" >> cmake/FindNETPBM.cmake
     echo "INCLUDE(FindPackageHandleStandardArgs)" >> cmake/FindNETPBM.cmake
     echo "FIND_PACKAGE_HANDLE_STANDARD_ARGS(NETPBM DEFAULT_MSG NETPBM_LIBRARY NETPBM_INCLUDE_DIR)" >> cmake/FindNETPBM.cmake
   '';

--- a/pkgs/tools/graphics/sng/default.nix
+++ b/pkgs/tools/graphics/sng/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpng ];
 
   configureFlags = [
-    "--with-rgbtxt=${netpbm}/share/netpbm/misc/rgb.txt"
+    "--with-rgbtxt=${netpbm.out}/share/netpbm/misc/rgb.txt"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/yad/default.nix
+++ b/pkgs/tools/misc/yad/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     sed -i src/form.c -e '21i#include <stdlib.h>'
 
     # there is no point to bring in the whole netpbm package just for this file
-    install -Dm644 ${netpbm}/share/netpbm/misc/rgb.txt $out/share/yad/rgb.txt
+    install -Dm644 ${netpbm.out}/share/netpbm/misc/rgb.txt $out/share/yad/rgb.txt
   '';
 
   postAutoreconf = ''

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -29,13 +29,13 @@ stdenv.mkDerivation rec {
       --replace "psselect" "${psutils}/bin/psselect"
   '' + stdenv.lib.optionalString (netpbm != null) ''
     substituteInPlace src/preproc/html/pre-html.cpp \
-      --replace "pnmcut" "${netpbm}/bin/pnmcut" \
-      --replace "pnmcrop" "${netpbm}/bin/pnmcrop" \
-      --replace "pnmtopng" "${netpbm}/bin/pnmtopng"
+      --replace "pnmcut" "${stdenv.lib.getBin netpbm}/bin/pnmcut" \
+      --replace "pnmcrop" "${stdenv.lib.getBin netpbm}/bin/pnmcrop" \
+      --replace "pnmtopng" "${stdenv.lib.getBin netpbm}/bin/pnmtopng"
     substituteInPlace tmac/www.tmac \
-      --replace "pnmcrop" "${netpbm}/bin/pnmcrop" \
-      --replace "pngtopnm" "${netpbm}/bin/pngtopnm" \
-      --replace "@PNMTOPS_NOSETPAGE@" "${netpbm}/bin/pnmtops -nosetpage"
+      --replace "pnmcrop" "${stdenv.lib.getBin netpbm}/bin/pnmcrop" \
+      --replace "pngtopnm" "${stdenv.lib.getBin netpbm}/bin/pngtopnm" \
+      --replace "@PNMTOPS_NOSETPAGE@" "${stdenv.lib.getBin netpbm}/bin/pnmtops -nosetpage"
   '';
 
   buildInputs = [ ghostscript psutils netpbm perl ];


### PR DESCRIPTION
###### Motivation for this change

https://sourceforge.net/p/netpbm/code/3735/tree//advanced/doc/HISTORY

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size: 95.9M → 103.0M (31.7M just `${!outputLib}`)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
