### PR TITLE
[20.03] R: fix build on aarch64 by removing a failing test

### DIFF
--- a/pkgs/applications/science/math/R/0001-Disable-test-pending-upstream-fix.patch
+++ b/pkgs/applications/science/math/R/0001-Disable-test-pending-upstream-fix.patch
@@ -1,0 +1,26 @@
+From 85ede2cf452800710de136f4f864921d3bb9773c Mon Sep 17 00:00:00 2001
+From: Tom Hall <tahall256@protonmail.ch>
+Date: Fri, 21 Feb 2020 22:56:06 +0000
+Subject: [PATCH] Disable test pending upstream fix
+
+See https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17718
+---
+ tests/reg-tests-1d.R | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/reg-tests-1d.R b/tests/reg-tests-1d.R
+index 9b551a1fc8..18ce6027ed 100644
+--- a/tests/reg-tests-1d.R
++++ b/tests/reg-tests-1d.R
+@@ -3079,7 +3079,7 @@ stopifnot(exprs = {
+     x[1:52] %% 3 == 2:1
+    -x[1:52] %% 3 == 1:2
+ }) # larger x suffer from cancellation (well, warning too early now):
+-tools::assertWarning(x[60:68] %% 3)
++#tools::assertWarning(x[60:68] %% 3)
+ 
+ 
+ ## Hilmar Berger's on R-devel list: 'data.frame() == NULL' etc
+-- 
+2.24.1
+

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -7,7 +7,6 @@
 # R as of writing does not support outputting both .so and .a files; it outputs:
 #     --enable-R-static-lib conflicts with --enable-R-shlib and will be ignored
 , static ? false
-, javaSupport ? (!stdenv.hostPlatform.isAarch32 && !stdenv.hostPlatform.isAarch64)
 }:
 
 stdenv.mkDerivation rec {
@@ -23,9 +22,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     bzip2 gfortran libX11 libXmu libXt libXt libjpeg libpng libtiff ncurses
     pango pcre perl readline texLive xz zlib less texinfo graphviz icu
-    pkgconfig bison imake which openblas curl tcl tk
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa Foundation libobjc libcxx ]
-    ++ stdenv.lib.optional javaSupport jdk;
+    pkgconfig bison imake which openblas curl tcl tk jdk
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa Foundation libobjc libcxx ];
 
   patches = [
     ./no-usr-local-search-paths.patch
@@ -57,7 +55,7 @@ stdenv.mkDerivation rec {
       CC=$(type -p cc)
       CXX=$(type -p c++)
       FC="${gfortran}/bin/gfortran" F77="${gfortran}/bin/gfortran"
-      ${stdenv.lib.optionalString javaSupport "JAVA_HOME=\"${jdk}\""}
+      JAVA_HOME="${jdk}"
       RANLIB=$(type -p ranlib)
       R_SHELL="${stdenv.shell}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./no-usr-local-search-paths.patch
+  ] ++ stdenv.lib.optionals stdenv.hostPlatform.isAarch64 [
+    # Remove a test which fails on aarch64.
+    # See https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17718
+    ./0001-Disable-test-pending-upstream-fix.patch
   ];
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Motivation for this change
Fix R on aarch64 in 20.03

###### Things done
Backported changes from #80759 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc  @NixOS/nixos-release-managers