### PR TITLE
allow to run luarocks test

### DIFF
--- a/pkgs/development/interpreters/lua-5/build-lua-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-lua-package.nix
@@ -230,6 +230,13 @@ builtins.removeAttrs attrs ["disabled" "checkInputs" "externalDeps" "extraVariab
     runHook postInstall
   '';
 
+
+  checkPhase = attrs.checkPhase or ''
+    runHook preCheck
+    $LUAROCKS test
+    runHook postCheck
+  '';
+
   passthru = {
     inherit lua; # The lua interpreter
     inherit externalDeps;

--- a/pkgs/development/interpreters/lua-5/build-lua-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-lua-package.nix
@@ -199,8 +199,6 @@ builtins.removeAttrs attrs ["disabled" "checkInputs" "externalDeps"] // {
         LUAROCKS="$LUAROCKS --verbose"
     fi
 
-    patchShebangs .
-
     runHook postBuild
   '';
 

--- a/pkgs/development/interpreters/lua-5/build-lua-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-lua-package.nix
@@ -56,7 +56,7 @@ name ? "${attrs.pname}-${attrs.version}"
 # Appended to the generated luarocks config
 , extraConfig ? ""
 # Inserted into the generated luarocks config in the "variables" table
-, extraVariables ? ""
+, extraVariables ? {}
 # The two above arguments have access to builder variables -- e.g. to $out
 
 # relative to srcRoot, path to the rockspec to use when using rocks
@@ -77,7 +77,10 @@ let
   # luarocks only looks for rockspecs in the default/system tree instead of all
   # configured trees)
   luarocks_config = "luarocks-config.lua";
-  luarocks_content = ''
+  luarocks_content = let
+    extraVariablesStr = lib.concatStringsSep "\n "
+      (lib.mapAttrsToList (k: v: "${k}='${v}';") extraVariables);
+  in ''
     local_cache = ""
     -- To prevent collisions when creating environments, we install the rock
     -- files into per-package subdirectories
@@ -105,8 +108,8 @@ let
       -- Some needed machinery to handle multiple-output external dependencies,
       -- as per https://github.com/luarocks/luarocks/issues/766
       ${lib.optionalString (lib.length depVariables > 0) ''
-      ${lib.concatStringsSep "\n  " depVariables}''}
-      ${extraVariables}
+        ${lib.concatStringsSep "\n  " depVariables}''}
+      ${extraVariablesStr}
     }
     ${extraConfig}
   '';
@@ -139,7 +142,7 @@ let
   externalDeps' = lib.filter (dep: !lib.isDerivation dep) externalDeps;
 in
 toLuaModule ( lua.stdenv.mkDerivation (
-builtins.removeAttrs attrs ["disabled" "checkInputs" "externalDeps"] // {
+builtins.removeAttrs attrs ["disabled" "checkInputs" "externalDeps" "extraVariables"] // {
 
   name = namePrefix + name;
 

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -153,11 +153,11 @@ with super;
   });
 
   luadbi-mysql = super.luadbi-mysql.override({
-    extraVariables = ''
-      -- Can't just be /include and /lib, unfortunately needs the trailing 'mysql'
-      MYSQL_INCDIR='${pkgs.libmysqlclient}/include/mysql';
-      MYSQL_LIBDIR='${pkgs.libmysqlclient}/lib/mysql';
-    '';
+    extraVariables = {
+      # Can't just be /include and /lib, unfortunately needs the trailing 'mysql'
+      MYSQL_INCDIR="${pkgs.libmysqlclient}/include/mysql";
+      MYSQL_LIBDIR="${pkgs.libmysqlclient}/lib/mysql";
+    };
     buildInputs = [
       pkgs.mysql.client
       pkgs.libmysqlclient


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

3 changes:
- luarocks 3.X introduced a testing infra. Almost no package support it and I've had issues with the few that have, thus tests default to off. I managed today to find the issues in argparse for instance so I hope to be able to turn the flag on in a future release.

- Patchshebangs posed problem when overriding some sources since it tried to write on readonly folders. Also it slows the install as it goes through the folder structure. I am not sure why I put it there in the first place but that looks bad and packages should be responsible for calling it I believe. I am afraid it may create some regressions but I don't have the necessary space to run a nixpkgs-review

- When looking at https://github.com/NixOS/nixpkgs/pull/80528, I noticed the lua infra doesn't work well with the cmake based lua packages. This isnot mandatory per se but having a structured attrset instead of a string looks better.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
