### PR TITLE
gnomeExtensions.draw-on-your-screen: init at 6

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/draw-on-your-screen/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/draw-on-your-screen/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit, gettext, gnome3 }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-draw-on-your-screen";
+  version = "6";
+
+  src = fetchgit {
+    url = "https://framagit.org/abakkk/DrawOnYourScreen/";
+    rev = "v${version}";
+    sha256 = "05i20ii8lv6mg56rz8lng80dx35l6g45j8wr7jgbp591hg0spj1w";
+  };
+
+  uuid = "drawOnYourScreen@abakkk.framagit.org";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r . $out/share/gnome-shell/extensions/${uuid}
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A drawing extension for GNOME Shell";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ericdallo ];
+    platforms = gnome3.gnome-shell.meta.platforms;
+    homepage = "https://framagit.org/abakkk/DrawOnYourScreen";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23784,6 +23784,7 @@ in
     clipboard-indicator = callPackage ../desktops/gnome-3/extensions/clipboard-indicator { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
+    draw-on-your-screen = callPackage ../desktops/gnome-3/extensions/draw-on-your-screen { };
     drop-down-terminal = callPackage ../desktops/gnome-3/extensions/drop-down-terminal { };
     gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add gnome extension `draw-on-your-screen`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
