### PR TITLE
WIP gnomeExtensions.text-translator: init at unstable-2020-02-25

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/text-translator/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/text-translator/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, gnome3, gst_all_1, pkgs, substituteAll, translate-shell, clutter }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-text-translator";
+  version = "unstable-2020-02-25";
+
+  src = fetchFromGitHub {
+    owner = "gufoe";
+    repo = "text-translator";
+    rev = "991daadff538bd7acd15cf60415704e0215f2bf6";
+    sha256 = "098a967p1gr8g20nz0fdnlmpc6k40fh0ijqcdhp7ckfqr39imkhr";
+  };
+
+  uuid = "text_translator@awamper.gmail.com";
+
+  patches = [
+    (substituteAll {
+      src = ./fix-deps.patch;
+      trans = "${translate-shell}/bin/trans";
+      clutter = "${clutter}/lib/girepository-1.0";
+      gstBase = "${gst_all_1.gst-plugins-base}/lib/gstreamer-1.0";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r . $out/share/gnome-shell/extensions/${uuid}
+    runHook preInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A text translator extension for GNOME Shell";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ericdallo ];
+    platforms = gnome3.gnome-shell.meta.platforms;
+    homepage = "https://github.com/gufoe/text-translator";
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/text-translator/fix-deps.patch
+++ b/pkgs/desktops/gnome-3/extensions/text-translator/fix-deps.patch
@@ -1,0 +1,58 @@
+diff --git a/extension.js b/extension.js
+index 421a2aa..6b84ef9 100644
+--- a/extension.js
++++ b/extension.js
+@@ -6,6 +6,7 @@
+             GIRepository.Repository.prepend_search_path("/usr/lib/" + path);
+         }
+     );
++    GIRepository.Repository.prepend_search_path('@clutter@');
+ })();
+ 
+ const St = imports.gi.St;
+diff --git a/google_tts.js b/google_tts.js
+index 469e29d..0daaa1b 100644
+--- a/google_tts.js
++++ b/google_tts.js
+@@ -8,6 +8,8 @@ var GoogleTTS = class GoogleTTS {
+     constructor() {
+         Gst.init(null);
+ 
++        Gst.Registry.get().scan_path('@gstBase@');
++
+         this._player = Gst.ElementFactory.make("playbin", "player");
+         this._bus = this._player.get_bus();
+         this._bus.add_signal_watch();
+diff --git a/translation_provider_base.js b/translation_provider_base.js
+index cbb5c96..405bccc 100644
+--- a/translation_provider_base.js
++++ b/translation_provider_base.js
+@@ -259,7 +259,7 @@ var TranslationProviderBase = class TranslationProviderBase {
+ 
+     translate(source_lang, target_lang, text, callback) {
+         let command = [
+-            "trans",
++            "@trans@",
+             "-e",
+             this.engine,
+             "--show-original",
+diff --git a/utils.js b/utils.js
+index 1c3d179..22ea56d 100644
+--- a/utils.js
++++ b/utils.js
+@@ -7,7 +7,6 @@ const Gio = imports.gi.Gio;
+ const GLib = imports.gi.GLib;
+ const ExtensionUtils = imports.misc.extensionUtils;
+ const Soup = imports.gi.Soup;
+-const Clutter = imports.gi.Clutter;
+ 
+ var _httpSession = new Soup.SessionAsync();
+ Soup.Session.prototype.add_feature.call(
+@@ -127,6 +126,7 @@ function get_files_in_dir(path) {
+ }
+ 
+ function get_unichar(keyval) {
++    const Clutter = imports.gi.Clutter;
+     let ch = Clutter.keysym_to_unicode(keyval);
+ 
+     if (ch) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23794,6 +23794,7 @@ in
     sound-output-device-chooser = callPackage ../desktops/gnome-3/extensions/sound-output-device-chooser { };
     system-monitor = callPackage ../desktops/gnome-3/extensions/system-monitor { };
     taskwhisperer = callPackage ../desktops/gnome-3/extensions/taskwhisperer { };
+    text-translator = callPackage ../desktops/gnome-3/extensions/text-translator { };
     tilingnome = callPackage ../desktops/gnome-3/extensions/tilingnome { };
     timepp = callPackage ../desktops/gnome-3/extensions/timepp { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add gnome extension `text-translator`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
