### PR TITLE
vale: install documentation and example styles

### DIFF
--- a/pkgs/tools/text/vale/default.nix
+++ b/pkgs/tools/text/vale/default.nix
@@ -5,7 +5,7 @@ buildGoModule rec {
   version = "2.2.2";
 
   subPackages = [ "." ];
-  outputs = ["out" "doc"];
+  outputs = ["out" "doc" "data"];
 
   src = fetchFromGitHub {
     owner  = "errata-ai";
@@ -21,7 +21,9 @@ buildGoModule rec {
   goPackagePath = "github.com/errata-ai/vale";
   postInstall = ''
     mkdir -p $doc/share/doc/vale
+    mkdir -p $data/share/vale
     cp -r docs/* $doc/share/doc/vale
+    cp -r styles $data/share/vale
   '';
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];

--- a/pkgs/tools/text/vale/default.nix
+++ b/pkgs/tools/text/vale/default.nix
@@ -5,6 +5,7 @@ buildGoModule rec {
   version = "2.2.2";
 
   subPackages = [ "." ];
+  outputs = ["out" "doc"];
 
   src = fetchFromGitHub {
     owner  = "errata-ai";
@@ -18,6 +19,10 @@ buildGoModule rec {
   vendorSha256 = "150pvy94vfjvn74d63az917szixw1nhl60y1adixg8xqpcjnv9hj";
 
   goPackagePath = "github.com/errata-ai/vale";
+  postInstall = ''
+    mkdir -p $doc/share/doc/vale
+    cp -r docs/* $doc/share/doc/vale
+  '';
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
 

--- a/pkgs/tools/text/vale/default.nix
+++ b/pkgs/tools/text/vale/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "vale";
-  version = "2.0.0";
+  version = "2.2.2";
 
   subPackages = [ "." ];
 
@@ -10,8 +10,12 @@ buildGoPackage rec {
     owner  = "errata-ai";
     repo   = "vale";
     rev    = "v${version}";
-    sha256 = "068973ayd883kzkxl60lpammf3icjz090nw07kfccvhcf24x07bh";
+    sha256 = "11pgszm9cb65liczpnq04l1rx0v68jgmkzrw7ax5kln5hgnrh4kb";
   };
+
+  deleteVendor = true;
+
+  vendorSha256 = "150pvy94vfjvn74d63az917szixw1nhl60y1adixg8xqpcjnv9hj";
 
   goPackagePath = "github.com/errata-ai/vale";
 


### PR DESCRIPTION
"vale" is style checker for natural language. Currently, derivation only
installs binary, without any documentation on how to use it.  To
actually have "vale" to generate suggestions, config file with
specification of location of style files must be written.

This changeset adds "doc" output, which contains instructions on writing
config file and "data" output which contains style files.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).