### PR TITLE
gitAndTools.git-absorb: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-absorb/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-absorb/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ libiconv Security ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1khplyglavsidh13nnq9y5rxd5w89ail08wgzn29a5m03zir1yfd";
+  cargoSha256 = "13gikjswbb0kkpvb5zhj88qq5l667624gkfb7hd3zygh4qyhsy05";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/tummychow/git-absorb";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.