### PR TITLE
gitAndTools.git-gone: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-gone/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-gone/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "05wlng563p9iy0ky3z23a4jakcix887fb45r7j2mk0fp5ykdjmzh";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1s3v5p6qgz74sh34gvajf453fsgl13sds4v8hz8c6ivipz4hpby2";
+  cargoSha256 = "1scp9rzn59akxsf9p48j1zq6clbwdyasnyi4j28nj03ghvdv2i33";
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.