### PR TITLE
gitAndTools.git-codeowners: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-codeowners/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-codeowners/default.nix
@@ -10,10 +10,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0bzq4ridzb4l1zqrj1r0vlzkjpgfaqwky5jf49cwjhz4ybwrfpkq";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1k5gxbjv4a8l5y9rm0n4vwzlwp4hk1rb59v0wvcirmj0p7hpw9x9";
+  cargoSha256 = "0r0hyp15knbbs4l9rcn395pzrx2vbibmwvs4pmga363irmi8mcy5";
 
   meta = with lib; {
     homepage = "https://github.com/softprops/git-codeowners";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.