### PR TITLE
gitAndTools.git-ignore: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
@@ -13,10 +13,7 @@ buildRustPackage rec {
     sha256 = "0krz50pw9bkyzl78bvppk6skbpjp8ga7bd34jya4ha1xfmd8p89c";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1ccipxifnm38315qigaq28hlzam2wr8q2p2dbcq96kar6pq377vf";
+  cargoSha256 = "0vcg2pl0s329fr8p23pwdx2jy7qahbr7n337ib61f69aaxi1xmq0";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ]


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.