### PR TITLE
cadence: fix dbus,libjack and missing dependancies

### DIFF
--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -7,7 +7,7 @@
 , fetchzip
 , jack_capture
 , pkgconfig
-, pulseaudio
+, pulseaudioFull
 , qtbase
 , makeWrapper
 , mkDerivation
@@ -38,7 +38,7 @@ mkDerivation rec {
       libjackso=$(realpath ${lib.makeLibraryPath [libjack2]}/libjack.so.0);
       substituteInPlace ./src/jacklib.py --replace libjack.so.0 $libjackso
       substituteInPlace ./src/cadence.py --replace "/usr/bin/pulseaudio" \
-        "${lib.makeBinPath[pulseaudio]}/pulseaudio"
+        "${lib.makeBinPath[pulseaudioFull]}/pulseaudio"
       substituteInPlace ./c++/jackbridge/JackBridge.cpp --replace libjack.so.0 $libjackso
   '';
 
@@ -49,6 +49,7 @@ mkDerivation rec {
   buildInputs = [
     qtbase
     jack_capture
+    pulseaudioFull
     ((python3.withPackages (ps: with ps; [
           pyqt5
           dbus-python
@@ -83,7 +84,10 @@ mkDerivation rec {
   in lib.mapAttrsToList (script: source: ''
     rm -f ${script}
     makeQtWrapper ${source} ${script} \
-      --prefix PATH : "${lib.makeBinPath [jack_capture]}"
+      --prefix PATH : "${lib.makeBinPath [
+        jack_capture # cadence-render
+        pulseaudioFull # cadence, cadence-session-start
+        ]}"
   '') scriptAndSource;
 
   meta = {

--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -1,15 +1,23 @@
 { stdenv
-, mkDerivation
+, a2jmidid
+, coreutils
 , lib
+, libjack2
 , fetchpatch
 , fetchzip
+, jack_capture
 , pkgconfig
+, pulseaudio
 , qtbase
 , makeWrapper
-, python3Packages
+, mkDerivation
+, python3
 }:
+#ladish missing, claudia can't work.
+#pulseaudio needs fixes (patchShebangs .pa ...)
+#desktop needs icons and exec fixing.
 
- mkDerivation rec {
+mkDerivation rec {
   version = "0.9.1";
   pname = "cadence";
 
@@ -26,21 +34,30 @@
     })
   ];
 
+  postPatch = ''
+      libjackso=$(realpath ${lib.makeLibraryPath [libjack2]}/libjack.so.0);
+      substituteInPlace ./src/jacklib.py --replace libjack.so.0 $libjackso
+      substituteInPlace ./src/cadence.py --replace "/usr/bin/pulseaudio" \
+        "${lib.makeBinPath[pulseaudio]}/pulseaudio"
+      substituteInPlace ./c++/jackbridge/JackBridge.cpp --replace libjack.so.0 $libjackso
+  '';
+
   nativeBuildInputs = [
     pkgconfig
   ];
 
   buildInputs = [
     qtbase
+    jack_capture
+    ((python3.withPackages (ps: with ps; [
+          pyqt5
+          dbus-python
+        ])))
   ];
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "SYSCONFDIR=${placeholder "out"}/etc"
-  ];
-
-  propagatedBuildInputs = with python3Packages; [
-    pyqt5_with_qtwebkit
   ];
 
   dontWrapQtApps = true;
@@ -65,10 +82,8 @@
     };
   in lib.mapAttrsToList (script: source: ''
     rm -f ${script}
-    makeWrapper ${python3Packages.python.interpreter} ${script} \
-      --set PYTHONPATH "$PYTHONPATH:${outRef}/share/cadence" \
-      ''${qtWrapperArgs[@]} \
-      --add-flags "-O ${source}"
+    makeQtWrapper ${source} ${script} \
+      --prefix PATH : "${lib.makeBinPath [jack_capture]}"
   '') scriptAndSource;
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18286,7 +18286,7 @@ in
 
   azpainter = callPackage ../applications/graphics/azpainter { };
 
-  cadence =  libsForQt5.callPackage ../applications/audio/cadence { };
+  cadence =  qt5.callPackage ../applications/audio/cadence { };
 
   milkytracker = callPackage ../applications/audio/milkytracker { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This should fix #55574