### PR TITLE
pythonPackages.isort: Add explicit setuptools dep and bin test

### DIFF
--- a/pkgs/development/python-modules/isort/default.nix
+++ b/pkgs/development/python-modules/isort/default.nix
@@ -1,4 +1,6 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, futures, backports_functools_lru_cache, mock, pytest }:
+{ lib, buildPythonPackage, fetchPypi, setuptools, isPy27, futures
+, backports_functools_lru_cache, mock, pytest
+}:
 
 let
   skipTests = [ "test_requirements_finder" "test_pipfile_finder" ] ++ lib.optional isPy27 "test_standard_library_deprecates_user_issue_778";
@@ -12,13 +14,24 @@ in buildPythonPackage rec {
     sha256 = "c40744b6bc5162bbb39c1257fe298b7a393861d50978b565f3ccd9cb9de0182a";
   };
 
-  propagatedBuildInputs = lib.optionals isPy27 [ futures backports_functools_lru_cache ];
+  propagatedBuildInputs = [
+    setuptools
+  ] ++ lib.optionals isPy27 [ futures backports_functools_lru_cache ];
 
   checkInputs = [ mock pytest ];
 
-  # isort excludes paths that contain /build/, so test fixtures don't work with TMPDIR=/build/
   checkPhase = ''
+    # isort excludes paths that contain /build/, so test fixtures don't work
+    # with TMPDIR=/build/
     PATH=$out/bin:$PATH TMPDIR=/tmp/ pytest ${testOpts}
+
+    # Confirm that the produced executable script is wrapped correctly and runs
+    # OK, by launching it in a subshell without PYTHONPATH
+    (
+      unset PYTHONPATH
+      echo "Testing that `isort --version-number` returns OK..."
+      $out/bin/isort --version-number
+    )
   '';
 
   meta = with lib; {


### PR DESCRIPTION
(cherry picked from commit 94a80621ac1d12671593074de88f1ee8012a7f82)

Backported as per discussion on https://github.com/NixOS/nixpkgs/pull/72204/