### PR TITLE
update telegraf 1.13.3 => 1.13.4

### DIFF
--- a/pkgs/servers/monitoring/telegraf/default.nix
+++ b/pkgs/servers/monitoring/telegraf/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "telegraf";
-  version = "1.13.3";
+  version = "1.13.4";
 
   goPackagePath = "github.com/influxdata/telegraf";
 
@@ -14,7 +14,7 @@ buildGoPackage rec {
     owner = "influxdata";
     repo = "telegraf";
     rev = version;
-    sha256 = "093695n83m1ywy4l7nswjh1xc0gkg7pxilxav7jjxkgl4p15yf28";
+    sha256 = "031hq9dg87cqj4am7qkbgfan2s6bqc2hf48h0gnrv78hbz8icxa1";
   };
 
   buildFlagsArray = [ ''-ldflags=

--- a/pkgs/servers/monitoring/telegraf/deps.nix
+++ b/pkgs/servers/monitoring/telegraf/deps.nix
@@ -932,8 +932,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/safchain/ethtool";
-      rev =  "ef7e7c9c27639f149a3c4bfae07a9c0fc3a1691a";
-      sha256 = "140bd01ngh2jgqhr2av3d4xmwk71c2mq5crg8gy89al76dwrjb7b";
+      rev =  "f459e2d136648a780248aba0fcac44740fe3b500";
+      sha256 = "0zhxq588vkicxy4cbjjd20l4n1pzpi7q734595y6zz4zljsp24cs";
     };
   }
   {
@@ -1013,8 +1013,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/stretchr/testify";
-      rev =  "f35b8ab0b5a2cef36673838d662e249dd9c94686";
-      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+      rev =  "3ebf1ddaeb260c4b1ae502a01c7844fa8c1fa0e9";
+      sha256 = "09r89m1wy4cjv2nps1ykp00qjpi0531r07q3s34hr7m6njk4srkl";
     };
   }
   {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Arch Linux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
