### PR TITLE
lutris: Add metadata from lutris-unwrapped also to lutris

### DIFF
--- a/pkgs/applications/misc/lutris/chrootenv.nix
+++ b/pkgs/applications/misc/lutris/chrootenv.nix
@@ -12,7 +12,7 @@ let
   ];
 
 in buildFHSUserEnv {
-  name = "lutris";
+  name = "lutris-${lutris-unwrapped.version}";
 
   runScript = "lutris";
 
@@ -113,5 +113,13 @@ in buildFHSUserEnv {
     mkdir -p $out/share
     ln -sf ${lutris-unwrapped}/share/applications $out/share
     ln -sf ${lutris-unwrapped}/share/icons $out/share
+    ln -s $out/bin/lutris-${lutris-unwrapped.version} $out/bin/lutris
   '';
+
+  meta = with lutris-unwrapped.meta; {
+    homepage = homepage;
+    description = description;
+    license = license;
+    maintainers = maintainers;
+  };
 }


### PR DESCRIPTION
...and lutris-free, so that they can be found by repology.

###### Motivation for this change

Closes #72921



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
