### PR TITLE
qogir-theme: 2020-02-20 -> 2020-02-26

### DIFF
--- a/pkgs/data/themes/qogir/default.nix
+++ b/pkgs/data/themes/qogir/default.nix
@@ -19,6 +19,9 @@ stdenv.mkDerivation rec {
     patchShebangs .
     mkdir -p $out/share/themes
     name= ./install.sh -d $out/share/themes
+    mkdir -p $out/share/doc/${pname}
+    cp -a src/firefox $out/share/doc/${pname}
+    rm $out/share/themes/*/{AUTHORS,COPYING}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/data/themes/qogir/default.nix
+++ b/pkgs/data/themes/qogir/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qogir-theme";
-  version = "2020-02-20";
+  version = "2020-02-26";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    sha256 = "0f0fa13ql59j9zv24vnsai76i0qwawh3jxzj1p78yfvcfmg45jcn";
+    sha256 = "1s14knj0ral5a62ymwbg5k5g94v8cq0acq0kyam8ay0rfi7wycdm";
   };
 
   buildInputs = [ gdk-pixbuf librsvg ];

--- a/pkgs/data/themes/qogir/default.nix
+++ b/pkgs/data/themes/qogir/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Flat Design theme for GTK based desktop environments";
-    homepage = https://vinceliuice.github.io/Qogir-theme;
+    homepage = "https://vinceliuice.github.io/Qogir-theme";
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [2020-02-26](https://github.com/vinceliuice/Qogir-theme/releases/tag/2020-02-26)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).