### PR TITLE
mutt-trim: Init at 2020-02-26

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt-trim/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt-trim/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, perl, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "mutt-trim";
+  version = "2020-02-26";
+
+  src = fetchFromGitHub {
+    owner  = "Konfekt";
+    repo   = "mutt-trim";
+    rev    = "eeaacb886f78b00e704cb06faec7fd7d2dbb7caa";
+    sha256 = "0bl6msck0skys0vaaajax1ghbsidi6yvqzz8ns0vry41gmbyd176";
+  };
+
+  propagatedBuildInputs = [ perl ];
+
+  buildPhase = null;
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    cp -v mutt-trim $out/bin/
+    chmod +x $out/bin/mutt-trim
+  '';
+
+  postFixup = ''
+    patchShebangs $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "unclutter and normalize quoted text in an e-mail";
+    # no license yet
+    #license = ;
+    homepage = "https://github.com/Konfekt/mutt-trim";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20814,6 +20814,8 @@ in
     withSidebar = true;
   };
 
+  mutt-trim = callPackage ../applications/networking/mailreaders/mutt-trim { };
+
   mwic = callPackage ../applications/misc/mwic {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Remains to be tested.
