### PR TITLE
WIP: mutt-ics: Init at 2020-02-26

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt-ics/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt-ics/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication rec {
+  pname   = "mutt-ics";
+  version = "2020-02-26";
+
+  src = fetchFromGitHub {
+    owner = "dmedvinsky";
+    repo = pname;
+    rev = "ac54116be429cb92230f03ec8d3cdbdceaf8f008";
+    sha256 = "1ppy94k87q7nfpxmajry1mn42c960n8zd9ka10g1jfjwkby2rmp8";
+  };
+
+  buildInputs = with python3Packages; [
+    icalendar
+    dateutil
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Simple viewer for ics in mutt";
+    homepage = https://github.com/dmedvinsky/mutt-ics;
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20557,6 +20557,8 @@ in
     withSidebar = true;
   };
 
+  mutt-ics = callPackage ../applications/networking/mailreaders/mutt-ics { };
+
   mwic = callPackage ../applications/misc/mwic {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

If someone with a bit more python packaging experience could have a look? The package builds, but execution fails with

```
$ ./result/bin/mutt-ics 
Traceback (most recent call last):
  File "/nix/store/jsm145nay5iy9sg3k1nrmz8yv4r8p1r8-mutt-ics-2020-02-26/bin/.mutt-ics-wrapped", line 6, in <module>
    from mutt_ics.mutt_ics import entry_point
  File "/nix/store/jsm145nay5iy9sg3k1nrmz8yv4r8p1r8-mutt-ics-2020-02-26/lib/python3.7/site-packages/mutt_ics/mutt_ics.py", line 8, in <module>
    from dateutil import tz
ModuleNotFoundError: No module named 'dateutil'
```