### PR TITLE
coqPackages.paco: enable for Coq 8.10 and 8.11

### DIFF
--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -19,13 +19,15 @@ let
     "8.7" = versions.post_8_6;
     "8.8" = versions.post_8_6;
     "8.9" = versions.post_8_6;
+    "8.10" = versions.post_8_6;
+    "8.11" = versions.post_8_6;
   };
   param = params.${coq.coq-version};
 in
 
 stdenv.mkDerivation rec {
   inherit (param) version;
-  name = "coq-paco-${coq.coq-version}-${version}";
+  name = "coq${coq.coq-version}-paco-${version}";
 
   src = fetchFromGitHub {
     inherit (param) rev sha256;
@@ -52,7 +54,7 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = stdenv.lib.flip builtins.hasAttr params;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Make this library available to recent versions of Coq.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
