### PR TITLE
houdini: 17.5.327 -> 18.0.391

### DIFF
--- a/pkgs/applications/misc/houdini/default.nix
+++ b/pkgs/applications/misc/houdini/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, buildFHSUserEnv, undaemonize }:
+{ callPackage, buildFHSUserEnv, undaemonize, unwrapped ? callPackage ./runtime.nix {} }:
 
 let
   houdini-runtime = callPackage ./runtime.nix { };
@@ -8,6 +8,10 @@ in buildFHSUserEnv {
   extraBuildCommands = ''
     mkdir -p $out/usr/lib/sesi
   '';
+
+  passthru = {
+    unwrapped = houdini-runtime;
+  };
 
   runScript = "${undaemonize}/bin/undaemonize ${houdini-runtime}/bin/houdini";
 }

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -1,6 +1,7 @@
-{ lib, stdenv, requireFile, zlib, libpng, libSM, libICE, fontconfig, xorg, libGLU, libGL, alsa-lib, dbus, xkeyboardconfig, bc, addOpenGLRunpath }:
+{ lib, stdenv, requireFile, zlib, libpng, libSM, libICE, fontconfig, xorg, libGLU, libGL, alsa-lib, dbus, xkeyboardconfig, nss, nspr, expat, pciutils, libxkbcommon, bc, addOpenGLRunpath }:
 
 let
+  # NOTE: Some dependencies only show in errors when run with QT_DEBUG_PLUGINS=1
   ld_library_path = builtins.concatStringsSep ":" [
     "${stdenv.cc.cc.lib}/lib64"
     (lib.makeLibraryPath [
@@ -17,6 +18,8 @@ let
       xorg.libXcomposite
       xorg.libXdamage
       xorg.libXtst
+      xorg.libxcb
+      xorg.libXScrnSaver
       alsa-lib
       fontconfig
       libSM
@@ -25,16 +28,21 @@ let
       libpng
       dbus
       addOpenGLRunpath.driverLink
+      nss
+      nspr
+      expat
+      pciutils
+      libxkbcommon
     ])
   ];
   license_dir = "~/.config/houdini";
 in
 stdenv.mkDerivation rec {
-  version = "17.5.460";
+  version = "18.0.391";
   pname = "houdini-runtime";
   src = requireFile rec {
     name = "houdini-${version}-linux_x86_64_gcc6.3.tar.gz";
-    sha256 = "1w3i7pscxnqfp5ya6cwh5r357z2dqdg5pjadcy9pb6rs0mjc4vky";
+    sha256 = "0bcbw8hjrg180wlw34bl085d3vx666j2pzsfdbsxwgrf3lzkx7wk";
     url = meta.homepage;
   };
 

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -30,21 +30,12 @@ let
   license_dir = "~/.config/houdini";
 in
 stdenv.mkDerivation rec {
-  version = "17.5.327";
+  version = "17.5.460";
   pname = "houdini-runtime";
   src = requireFile rec {
     name = "houdini-${version}-linux_x86_64_gcc6.3.tar.gz";
-    sha256 = "1byigmhmby8lgi2vmgxy9jlrrqk7jyr507zqkihq5bv8kfsanv1x";
-    message = ''
-      This nix expression requires that ${name} is already part of the store.
-      Download it from https://www.sidefx.com and add it to the nix store with:
-
-          nix-prefetch-url <URL>
-
-      This can't be done automatically because you need to create an account on
-      their website and agree to their license terms before you can download
-      it. That's what you get for using proprietary software.
-    '';
+    sha256 = "1w3i7pscxnqfp5ya6cwh5r357z2dqdg5pjadcy9pb6rs0mjc4vky";
+    url = meta.homepage;
   };
 
   buildInputs = [ bc ];

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ]; # requireFile src's should be excluded
-    maintainers = [ lib.maintainers.canndrew ];
+    maintainers = with lib.maintainers; [ canndrew kwohlfahrt ];
   };
 }
 

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, requireFile, zlib, libpng, libSM, libICE, fontconfig, xorg, libGLU, libGL, alsa-lib, dbus, xkeyboardconfig, nss, nspr, expat, pciutils, libxkbcommon, bc, addOpenGLRunpath }:
+{ lib, stdenv, requireFile, zlib, libpng, libSM, libICE, fontconfig, xorg, libGLU, libGL, alsa-lib
+, dbus, xkeyboardconfig, nss, nspr, expat, pciutils, libxkbcommon, bc, addOpenGLRunpath
+}:
 
 let
   # NOTE: Some dependencies only show in errors when run with QT_DEBUG_PLUGINS=1
@@ -84,4 +86,3 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ canndrew kwohlfahrt ];
   };
 }
-

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -38,11 +38,11 @@ let
   license_dir = "~/.config/houdini";
 in
 stdenv.mkDerivation rec {
-  version = "18.0.391";
+  version = "18.0.460";
   pname = "houdini-runtime";
   src = requireFile rec {
     name = "houdini-${version}-linux_x86_64_gcc6.3.tar.gz";
-    sha256 = "0bcbw8hjrg180wlw34bl085d3vx666j2pzsfdbsxwgrf3lzkx7wk";
+    sha256 = "18rbwszcks2zfn9zbax62rxmq50z9mc3h39b13jpd39qjqdd3jsd";
     url = meta.homepage;
   };
 


### PR DESCRIPTION
##### Motivation for this change

Upstream package is no longer available for download, also new version is released.

Due to the first part (`17.5.327` no longer available for download) at least the first commit should be backported to stable I think?

I'm happy to add myself as a maintainer if @canndrew has no objections?

@emptyflask and @PlumpMath were working on the v18.0 update, so they might also be interested in this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
