### PR TITLE
elixir_1_10: 1.10.1 -> 1.10.2

### DIFF
--- a/pkgs/development/interpreters/elixir/1.10.nix
+++ b/pkgs/development/interpreters/elixir/1.10.nix
@@ -3,7 +3,7 @@
 # How to obtain `sha256`:
 # nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
 mkDerivation {
-  version = "1.10.1";
-  sha256 = "07iccn90yp11ms58mwkwd9ixd9vma0025l9zm6l7y0jjzrj3vycy";
+  version = "1.10.2";
+  sha256 = "04yi1hljq7ii9flh6pmb5411z7q1bdq9f9sq8323k9hm1f5jwkx6";
   minimumOTPVersion = "21";
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/elixir-lang/elixir/releases/tag/v1.10.2


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
