### PR TITLE
swappy: Init at 1.2.1

### DIFF
--- a/pkgs/applications/misc/swappy/default.nix
+++ b/pkgs/applications/misc/swappy/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub
+, meson
+, ninja
+, wayland
+, cairo
+, pango
+, gtk
+, pkgconfig
+, cmake
+, scdoc
+, libnotify
+, gio-sharp
+, glib
+}:
+
+stdenv.mkDerivation rec {
+  name = "swappy-${version}";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "jtheoof";
+    repo = "swappy";
+    rev = "v${version}";
+    sha256 = "14ac2jmnak7avcz0jhqjm30vk7pv3gq5aq5rdyh84k8c613kkicf";
+  };
+
+  nativeBuildInputs = [ glib meson ninja pkgconfig cmake scdoc ];
+
+  buildInputs = [ cairo pango gtk libnotify wayland glib ];
+
+  strictDeps = true;
+
+  mesonFlags = [
+    # TODO: https://github.com/NixOS/nixpkgs/issues/36468
+    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/jtheoof/swappy";
+    description = "A Wayland native snapshot editing tool, inspired by Snappy on macOS ";
+    license = licenses.mit;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2303,6 +2303,8 @@ in
 
   bash-supergenpass = callPackage ../tools/security/bash-supergenpass { };
 
+  swappy = callPackage ../applications/misc/swappy { gtk = gtk3; };
+
   sweep-visualizer = callPackage ../tools/misc/sweep-visualizer { };
 
   syscall_limiter = callPackage ../os-specific/linux/syscall_limiter {};


### PR DESCRIPTION
WIP because waiting for

* https://github.com/jtheoof/swappy/issues/10
* https://github.com/jtheoof/swappy/issues/11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
