### PR TITLE
snowblind: init at 2020-02-26

### DIFF
--- a/pkgs/data/themes/snowblind/default.nix
+++ b/pkgs/data/themes/snowblind/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitLab, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "snowblind";
+  version = "2020-02-26";
+
+  src = fetchFromGitLab {
+    domain = "www.opencode.net";
+    owner = "ju1464";
+    repo = pname;
+    rev = "94c35410be5cccc142c9cd6be9dff973ce0761c4";
+    sha256 = "1aqmpg1vyqwp6s6iikp5c5yfrvdkzq75jdr9mmv2ijcam1g0jhnv";
+  };
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    cp -a Snowblind* $out/share/themes
+    rm $out/share/themes/*/{COPYING,CREDITS}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Smooth blue theme based on Materia Design";
+    homepage = "https://www.opencode.net/ju1464/Snowblind";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17924,6 +17924,8 @@ in
 
   sierra-gtk-theme = callPackage ../data/themes/sierra { };
 
+  snowblind = callPackage ../data/themes/snowblind { };
+
   solarc-gtk-theme = callPackage ../data/themes/solarc { };
 
   soundfont-fluid = callPackage ../data/soundfonts/fluid { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [Snowblind](https://www.pling.com/p/1333145), a smooth blue theme based on Materia Design. Easy on eyes, perfect for winter, but also for summer.

Includes theme for Gtk2, Gtk3, Gnome Shell, Cinnamon, Metacity, Unity and Xfwm4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).