### PR TITLE
igv: 2.4.19 -> 2.8.0

### DIFF
--- a/pkgs/applications/science/biology/igv/default.nix
+++ b/pkgs/applications/science/biology/igv/default.nix
@@ -1,32 +1,34 @@
-{ stdenv, fetchurl, unzip, jre }:
+{ stdenv, fetchzip, jdk11 }:
 
 stdenv.mkDerivation rec {
   pname = "igv";
-  version = "2.4.19";
-
-  src = fetchurl {
-    url = "https://data.broadinstitute.org/igv/projects/downloads/2.4/IGV_${version}.zip";
-    sha256 = "048dgrhxcb854d24kyjkqz12bw04bsv49i5jawb75yzkswwfkb0z";
+  version = "2.8.9";
+  src = fetchzip {
+    url = "https://data.broadinstitute.org/igv/projects/downloads/2.8/IGV_${version}.zip";
+    sha256 = "1874w1xprv91caz1ymfxilq6inhj36xzx8j9m0mcyp0qfvfvyjp7";
   };
-
-  buildInputs = [ unzip jre ];
 
   installPhase = ''
     mkdir -pv $out/{share,bin}
     cp -Rv * $out/share/
 
     sed -i "s#prefix=.*#prefix=$out/share#g" $out/share/igv.sh
-    sed -i 's#java#${jre}/bin/java#g' $out/share/igv.sh
+    sed -i 's#java#${jdk11}/bin/java#g' $out/share/igv.sh
+
+    sed -i "s#prefix=.*#prefix=$out/share#g" $out/share/igvtools
+    sed -i 's#java#${jdk11}/bin/java#g' $out/share/igvtools
 
     ln -s $out/share/igv.sh $out/bin/igv
+    ln -s $out/share/igvtools $out/bin/igvtools
 
     chmod +x $out/bin/igv
+    chmod +x $out/bin/igvtools
   '';
 
   meta = with stdenv.lib; {
     homepage = https://www.broadinstitute.org/igv/;
     description = "A visualization tool for interactive exploration of genomic datasets";
-    license = licenses.lgpl21;
+    license = licenses.mit;
     platforms = platforms.unix;
     maintainers = [ maintainers.mimame ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding igvtools, lot's of new features.

The license has been changed to `mit`:

https://software.broadinstitute.org/software/igv/download

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x ] Ensured that relevant documentation is up to date
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I have tested it locally, both `igv` itself and `igvtools` for the `count` tool. Everything seems to work fine without any issues.

I've used openjdk11 because I didn't find a `jre` for 11. Don't know what has changed on the jvm side with respect to this.