### PR TITLE
cmigemo: init at 1.3e

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1641,6 +1641,12 @@
     githubId = 5561189;
     name = "Cody Opel";
   };
+  cohei = {
+    email = "a.d.xvii.kal.mai@gmail.com";
+    github = "cohei";
+    githubId = 3477497;
+    name = "TANIGUCHI Kohei";
+  };
   cohencyril = {
     email = "cyril.cohen@inria.fr";
     github = "CohenCyril";

--- a/pkgs/tools/text/cmigemo/default.nix
+++ b/pkgs/tools/text/cmigemo/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, fetchurl, gzip, libiconv, nkf, perl, skk-dicts, which }:
+
+stdenv.mkDerivation {
+  pname = "cmigemo";
+  version = "1.3e";
+
+  src = fetchFromGitHub {
+    owner = "koron";
+    repo = "cmigemo";
+    rev = "5c014a885972c77e67d0d17d367d05017c5873f7";
+    sha256 = "0xrblwhaf70m0knkd5584iahaq84rlk0926bhdsrzmakpw77hils";
+  };
+
+  nativeBuildInputs = [ gzip libiconv nkf perl which ];
+
+  postUnpack = ''
+    cp ${skk-dicts}/share/SKK-JISYO.L source/dict/
+  '';
+
+  patches = [ ./no-http-tool-check.patch ];
+
+  makeFlags = [ "INSTALL=install" ];
+
+  buildPhase = if stdenv.isDarwin then "make osx-all" else "make gcc-all";
+
+  installTargets = [ (if stdenv.isDarwin then "osx-install" else "gcc-install") ];
+
+  meta = with stdenv.lib; {
+    description = "A tool that supports Japanese incremental search with Romaji";
+    homepage = "https://www.kaoriya.net/software/cmigemo";
+    license = licenses.mit;
+    maintainers = [ maintainers.cohei ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/text/cmigemo/no-http-tool-check.patch
+++ b/pkgs/tools/text/cmigemo/no-http-tool-check.patch
@@ -1,0 +1,23 @@
+diff --git a/configure b/configure
+index 4480261..2fb9b34 100755
+--- a/configure
++++ b/configure
+@@ -28,18 +28,6 @@ do
+   esac
+ done
+ 
+-# Check HTTP access tool
+-if CHECK_COMMAND curl ; then
+-  PROGRAM_HTTP="curl -O"
+-elif CHECK_COMMAND wget ; then
+-  PROGRAM_HTTP="wget"
+-elif CHECK_COMMAND fetch ; then
+-  PROGRAM_HTTP="fetch"
+-else
+-  echo "ERROR: Require one of HTTP access tools (curl, wget or fetch)."
+-  exit 1
+-fi
+-
+ # Check encoding filter
+ if CHECK_COMMAND qkc ; then
+   PROGRAM_ENCODEFILTER="qkc -q -u"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2702,6 +2702,8 @@ in
 
   citra = libsForQt5.callPackage ../misc/emulators/citra { };
 
+  cmigemo = callPackage ../tools/text/cmigemo { };
+
   cmst = libsForQt5.callPackage ../tools/networking/cmst { };
 
   cmt = callPackage ../applications/audio/cmt {};


### PR DESCRIPTION
cmigemo is a tool that supports Japanese incremental search with Romaji.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
