### PR TITLE
python3Packages.nitime: init at 0.8.1

### DIFF
--- a/pkgs/development/python-modules/nitime/default.nix
+++ b/pkgs/development/python-modules/nitime/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, python
+, fetchPypi
+, pytest
+, cython
+, numpy
+, scipy
+, matplotlib
+, networkx
+, nibabel
+}:
+
+buildPythonPackage rec {
+  pname = "nitime";
+  version = "0.8.1";
+  disabled = python.pythonVersion != "3.7";  # gcc error when running Cython with Python 3.8
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hb3x5196z2zaawb8s7lhja0vd3n983ncaynqfl9qg315x9ax7i6";
+  };
+
+  checkInputs = [ pytest ];
+  buildInputs = [ cython ];
+  propagatedBuildInputs = [ numpy scipy matplotlib networkx nibabel ];
+
+  checkPhase = "pytest nitime/tests";
+
+  meta = with lib; {
+    homepage = https://nipy.org/nitime;
+    description = "Algorithms and containers for time-series analysis in time and spectral domains";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4458,6 +4458,8 @@ in {
     inherit (pkgs) which;
   };
 
+  nitime = callPackage ../development/python-modules/nitime { };
+
   nixpkgs = callPackage ../development/python-modules/nixpkgs { };
 
   nixpkgs-pytools = callPackage ../development/python-modules/nixpkgs-pytools { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
