### PR TITLE
nixos/version: validate system.stateVersion

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -89,6 +89,17 @@ in
   };
 
   config = {
+    assertions = [
+      { assertion = let
+          inherit (lib) versions length stringLength all elem elemAt versionAtLeast;
+          inherit (config.system) stateVersion;
+          parts = versions.splitVersion stateVersion;
+          isVersion = length parts == 2 && all (p: stringLength p == 2) parts;
+          correctMinorVersion = elem (elemAt parts 1) [ "03" "09" ];
+          notNewerThanNixpkgs = versionAtLeast cfg.release stateVersion;
+        in isVersion && correctMinorVersion && notNewerThanNixpkgs;
+        message = "system.stateVersion was not set to a valid NixOS version (e.g. 20.03)."; }
+    ];
 
     system.nixos = {
       # These defaults are set here rather than up there so that


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Stripped down #80907 to validate only.

###### Things done

Correctly invalid (on branch nixos-20.03):

- "19", "19.3"
- "unstable", "nixos-unstable", "nixos.unstable"
- "19.04"

Questionably invalid (on branch nixos-20.03):

- "20.09": future value, not used yet, but there might still be reason for setting this

Correctly valid:

- "19.03"
- "16.09"

Incorrectly valid:

- "xy.03"

###### Open questions

- Is this the right place to encode how NixOS versions look like?
- Should future NixOS versions be valid?