### PR TITLE
zsh-powerlevel10k: 1.0 → 1.2.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -1,14 +1,14 @@
-{callPackage, stdenv, fetchFromGitHub, ...}:
+{ callPackage, stdenv, fetchFromGitHub, ...}:
 
 stdenv.mkDerivation {
   pname = "gitstatus";
-  version = "unstable-2020-01-28";
+  version = "unstable-2020-02-26";
 
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "gitstatus";
-    rev = "edb99aa7b86d10ad0a1cfe25135b57c8031d82ad";
-    sha256 = "1nys74qswwc7hn9cv0j7syvbpnw0f15chc9pi11him4d6lsflrfd";
+    rev = "c0e5a24299c1a1a71434dac1de6ea650e80fbe49";
+    sha256 = "0fj84cvr5a895jqgg86raakx6lqyyhahf1dgzgx05y2gfvnxxh8m";
   };
 
   buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];

--- a/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub, libgit2, ...}:
+{ fetchFromGitHub, libgit2, ...}:
 
 libgit2.overrideAttrs (oldAttrs: {
   cmakeFlags = oldAttrs.cmakeFlags ++ [
@@ -13,7 +13,7 @@ libgit2.overrideAttrs (oldAttrs: {
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "libgit2";
-    rev = "75be63625a0de418ec3551306362ee1e21034039";
-    sha256 = "1bwr1ahfxn1nn2f78ri91icxpv8xhpmgypcvg042cmcpm2qrahz9";
+    rev = "bb77509f4436901f3958e30272026f63d2247d7d";
+    sha256 = "06iypr0sc6g11xipwfbgm6f039d4qy9krmwb3zww8k4y004s5jcv";
   };
 })

--- a/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
@@ -3,14 +3,15 @@
 # To make use of this derivation, use
 # `programs.zsh.promptInit = "source ${pkgs.zsh-powerlevel10k}/share/zsh-powerlevel10k/powerlevel10k.zsh-theme";`
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "powerlevel10k";
-  version = "1.1";
+  version = "1.2.0";
+
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "powerlevel10k";
-    rev = "9d9c50611da19044370ee759e593ccadbad32a6a";
-    sha256 = "0jl4jamh7i8w7lp3qbbakh1wsyrrmslsrjwh9jgyvw50a83hp6fj";
+    rev = "v${version}";
+    sha256 = "1hvhql7564j6n6xwg4wckzvzs4fk5zlrdxkx5nd9i3g2d477nbac";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

New upstream release. Also updates gitstatusd and its internally used libgit2 fork.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@mmlb @flokli @andir @maralorn 