### PR TITLE
rakudo: 2020.01.1 -> 2020.02

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "rakudo";
-  version = "2020.01";
+  version = "2020.02";
 
   src = fetchurl {
     url    = "https://github.com/rakudo/rakudo/releases/download/${version}/rakudo-${version}.tar.gz";
-    sha256 = "1c63ns90zy13gyj0l27k63q7dv08w4589w605nywd7pplbygq0if";
+    sha256 = "0yhld3ij4mfa42chkfph7lzcl5q9b613hdjmw9rv46appmxvvmrs";
   };
 
   buildInputs = [ icu zlib gmp perl ];

--- a/pkgs/development/interpreters/rakudo/moarvm.nix
+++ b/pkgs/development/interpreters/rakudo/moarvm.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   pname = "moarvm";
-  version = "2020.01.1";
+  version = "2020.02";
 
   src = fetchurl {
-    url    = "https://github.com/MoarVM/MoarVM/releases/download/${version}/MoarVM-${version}.tar.gz";
-    sha256 = "11rmlps6r3nqa9m2yyv9i2imahirsqmxbfay71f3gs4ql121xdnw";
-  };
+    url = "https://www.moarvm.org/releases/MoarVM-${version}.tar.gz";
+    sha256 = "1kz97yy357lax7xdz4mnnwswn7axhp14nq0dw3n6xbcpap6m82aw";
+   };
 
   buildInputs = [ perl ] ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];
   doCheck = false; # MoarVM does not come with its own test suite
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "VM with adaptive optimization and JIT compilation, built for Rakudo";
-    homepage    = "https://github.com/MoarVM/MoarVM";
+    homepage    = "https://www.moarvm.org/";
     license     = licenses.artistic2;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice vrthra sgo ];

--- a/pkgs/development/interpreters/rakudo/nqp.nix
+++ b/pkgs/development/interpreters/rakudo/nqp.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nqp";
-  version = "2020.01";
+  version = "2020.02";
 
   src = fetchurl {
     url    = "https://github.com/perl6/nqp/releases/download/${version}/nqp-${version}.tar.gz";
-    sha256 = "0nwn6a9i9akw1zmywhkn631gqy8l4dvy50d6id63zir28ccrrk2c";
+    sha256 = "0ik3fscywxjx1qxlbjf68msz83alpckzw3myj9jmkalvy8q5v0nk";
   };
 
   buildInputs = [ perl ];

--- a/pkgs/development/interpreters/rakudo/zef.nix
+++ b/pkgs/development/interpreters/rakudo/zef.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zef";
-  version = "0.8.2";
+  version = "0.8.3";
 
   src = fetchFromGitHub {
     owner = "ugexe";
     repo = "zef";
     rev = "v${version}";
-    sha256 = "064nbl2hz55mpxdcy9zi39s2z6bad3bj73xsna966a7hzkls0a70";
+    sha256 = "1fscv8fbaa5l8dcwclmq3hvg3c59l4dvyjqb316mgnc5anxpzy2f";
   };
 
   buildInputs = [ rakudo makeWrapper ];


### PR DESCRIPTION
dependencies:
moarvm: 2020.01.1 -> 2020.02
nqp: 2020.01 -> 2020.01

recommended:
zef: 0.8.2 -> 0.8.3

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
