### PR TITLE
pythonPackages.gtts: init at 2.1.1

### DIFF
--- a/pkgs/development/python-modules/gtts/default.nix
+++ b/pkgs/development/python-modules/gtts/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, beautifulsoup4
+, click
+, gtts-token
+, mock
+, pytest
+, requests
+, six
+, testfixtures
+, twine
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "gtts";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "pndurette";
+    repo = "gTTS";
+    rev = "v${version}";
+    sha256 = "1d0r6dnb8xvgyvxz7nfj4q4xqmpmvcwcsjghxrh76m6p364lh1hj";
+  };
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    click
+    gtts-token
+    requests
+    six
+    urllib3
+    twine
+  ];
+
+  checkInputs = [ pytest mock testfixtures ];
+
+  # majority of tests just try to call out to Google's Translate API endpoint
+  doCheck = false;
+  checkPhase = ''
+    pytest
+  '';
+
+  pythonImportsCheck = [ "gtts" ];
+
+  meta = with lib; {
+    description = "A Python library and CLI tool to interface with Google Translate text-to-speech API";
+    homepage = "https://gtts.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ unode ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2763,6 +2763,8 @@ in {
 
   gtimelog = callPackage ../development/python-modules/gtimelog { };
 
+  gtts = callPackage ../development/python-modules/gtts { };
+
   gurobipy = if stdenv.hostPlatform.system == "x86_64-darwin"
   then callPackage ../development/python-modules/gurobipy/darwin.nix {
     inherit (pkgs.darwin) cctools insert_dylib;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This package is also needed to fix the `mnemosyne` runtime errors mentioned in #80924

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
