### PR TITLE
percona-server56: 5.6.43-84.3 -> 5.6.47-87.0 and add nixos test

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -9,6 +9,7 @@ let
   mysql = cfg.package;
 
   isMariaDB = lib.getName mysql == lib.getName pkgs.mariadb;
+  isPercona56 = lib.getName mysql == lib.getName pkgs.percona-server56;
 
   mysqldOptions =
     "--user=${cfg.user} --datadir=${cfg.dataDir} --basedir=${mysql}";
@@ -358,7 +359,7 @@ in
           pkgs.nettools
         ];
 
-        preStart = if isMariaDB then ''
+        preStart = if (isMariaDB || isPercona56) then ''
           if ! test -e ${cfg.dataDir}/mysql; then
             ${mysql}/bin/mysql_install_db --defaults-file=/etc/my.cnf ${mysqldOptions}
             touch /tmp/mysql_init

--- a/pkgs/servers/sql/percona/5.6.x.nix
+++ b/pkgs/servers/sql/percona/5.6.x.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "percona-server";
-  version = "5.6.43-84.3";
+  version = "5.6.47-87.0";
 
   src = fetchurl {
     url = "https://www.percona.com/downloads/Percona-Server-5.6/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
-    sha256 = "1cc0lfmpq4pw90bcsszsygw06vd4j4bh3ph5x0yn3z7wddvmjlpw";
+    sha256 = "0wqxs224594zz7rnsvi4gda3yfbqxmip2vw76a0xvj0q9i63h09p";
   };
 
   buildInputs = [ cmake bison ncurses openssl zlib libaio perl ];


### PR DESCRIPTION
ZHF: #80379
https://hydra.nixos.org/build/112819253
https://hydra.nixos.org/build/112816500

Updating percona-server fixed the build failure. 

Added percona-server to nixos/tests/mysql (needs virtualisation.memorySize=2048 to avoid oom)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
