### PR TITLE
teensyduino: add missing dependencies for teensy-loader

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -3,7 +3,8 @@
 , withGui ? false, gtk2 ? null, withTeensyduino ? false
   /* Packages needed for Teensyduino */
 , upx, fontconfig, xorg, gcc
-, atk, glib, pango, gdk-pixbuf, libpng12, expat, freetype,
+, atk, glib, pango, gdk-pixbuf, libpng12, expat, freetype
+, cairo, udev
 }:
 
 assert withGui -> gtk2 != null;
@@ -32,6 +33,7 @@ let
 
   teensy_libpath = stdenv.lib.makeLibraryPath [
     atk
+    cairo
     expat
     fontconfig
     freetype
@@ -42,11 +44,13 @@ let
     libpng12
     libusb
     pango
+    udev
     xorg.libSM
     xorg.libX11
     xorg.libXext
     xorg.libXft
     xorg.libXinerama
+    xorg.libXxf86vm
     zlib
   ];
   teensy_architecture =


### PR DESCRIPTION

###### Motivation for this change

This is a fixed version of https://github.com/NixOS/nixpkgs/pull/75560 that adds the missing package arguments (`cairo` and `udev`) at the top of the file.


###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
