### PR TITLE
buildPythonApplication: added withPackages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8131,6 +8131,12 @@
     email = "ngerstle@gmail.com";
     github = "ngerstle";
   };
+  xavierzwirtz = {
+    email = "me@xavierzwirtz.com";
+    github = "xavierzwirtz";
+    githubId = 474343;
+    name = "Xavier Zwirtz";
+  };
 }
 
   

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -6,7 +6,7 @@
 let
   inherit (python3Packages) docutils dulwich python;
 
-in python3Packages.buildPythonApplication rec {
+in let self = python3Packages.buildPythonApplication rec {
   pname = "mercurial";
   version = "5.3";
 
@@ -63,4 +63,7 @@ in python3Packages.buildPythonApplication rec {
     updateWalker = true;
     platforms = stdenv.lib.platforms.unix;
   };
+};
+in self // {
+  withPackages = self.withPackages ["$out/bin/hg"];
 }

--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -17,7 +17,8 @@ let
     };
   });
 
-in python3Packages.buildPythonApplication {
+in 
+let self = python3Packages.buildPythonApplication {
     inherit (tortoisehgSrc.meta) name version;
     src = tortoisehgSrc;
 
@@ -49,4 +50,7 @@ in python3Packages.buildPythonApplication {
       platforms = lib.platforms.linux;
       maintainers = with lib.maintainers; [ danbst ];
     };
+};
+in self // {
+  withPackages = self.withPackages ["$out/bin/thg"];
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -50,6 +50,7 @@ let
   buildPythonApplication = makeOverridablePythonPackage ( makeOverridable (callPackage ../development/interpreters/python/mk-python-derivation.nix {
     namePrefix = "";        # Python applications should not have any prefix
     toPythonModule = x: x;  # Application does not provide modules.
+    includeWithPackages = true;
   }));
 
   # See build-setupcfg/default.nix for documentation.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
tortoisehg and mercurial need to be run with user specified python packages to support extensions like [hg-evolve](https://pypi.org/project/hg-evolve/).

###### Things done
* withPackages is added to the derivation created by buildPythonApplication, providing a way to inject python packages into an already created derivation.
* tortoisehg and mercurial pre-apply withPackages with their binaries.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
