### PR TITLE
hg-evolve: init at 9.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8131,6 +8131,12 @@
     email = "ngerstle@gmail.com";
     github = "ngerstle";
   };
+  xavierzwirtz = {
+    email = "me@xavierzwirtz.com";
+    github = "xavierzwirtz";
+    githubId = 474343;
+    name = "Xavier Zwirtz";
+  };
 }
 
   

--- a/pkgs/development/python-modules/hg-evolve/default.nix
+++ b/pkgs/development/python-modules/hg-evolve/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "hg-evolve";
+  version = "9.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08bjrgxv8zrrz5xxydzkjl4a8cw3g62nmzfnvdzxxcrf1c96qw76";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Enables the “changeset evolution” feature of Mercurial core";
+    homepage = "https://www.mercurial-scm.org/doc/evolution/";
+    maintainers = with maintainers; [ xavierzwirtz ];
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3441,6 +3441,8 @@ in {
 
   hg-git = callPackage ../development/python-modules/hg-git { };
 
+  hg-evolve = callPackage ../development/python-modules/hg-evolve { };
+
   dtopt = callPackage ../development/python-modules/dtopt { };
 
   easywatch = callPackage ../development/python-modules/easywatch { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[Mercurial Evolve](https://www.mercurial-scm.org/doc/evolution/) enables safe mutable history for mercurial. 

###### Things done

hg-evolve: init at 9.2.2

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
