### PR TITLE
treewide Drop unneeded go 1.12 overrides

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -2,7 +2,6 @@
 , buildGoPackage
 , fetchFromGitHub
 , callPackage
-, buildGo112Module
 , Security
 }:
 let
@@ -26,11 +25,7 @@ let
 in
   {
     elasticsearch = callPackage ./elasticsearch {
-      # Version 0.7.0 fails to build with go 1.13 due to dependencies:
-      #   verifying git.apache.org/thrift.git@v0.12.0/go.mod: git.apache.org/thrift.git@v0.12.0/go.mod: Get https://sum.golang.org/lookup/git.apache.org/thrift.git@v0.12.0: dial tcp: lookup sum.golang.org on [::1]:53: read udp [::1]:52968->[::1]:53: read: connection refused
-      #   verifying github.com/hashicorp/terraform@v0.12.0/go.mod: github.com/hashicorp/terraform@v0.12.0/go.mod: Get https://sum.golang.org/lookup/github.com/hashicorp/terraform@v0.12.0: dial tcp: lookup sum.golang.org on [::1]:53: read udp [::1]:52968->[::1]:53: read: connection refused
-      buildGoModule = buildGo112Module;
-      inherit Security;
+     inherit Security;
     };
     gandi = callPackage ./gandi {};
     ibm = callPackage ./ibm {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25996,7 +25996,6 @@ in
 
   terraform-providers = recurseIntoAttrs (
     callPackage ../applications/networking/cluster/terraform-providers {
-      inherit buildGo112Module;
       inherit (darwin.apple_sdk.frameworks) Security;
     }
   );


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Cleaning up some go1.12 overrides that don't work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
