### PR TITLE
ocamlPackages.owl: 0.7.2 -> 0.8.0

### DIFF
--- a/pkgs/development/ocaml-modules/eigen/default.nix
+++ b/pkgs/development/ocaml-modules/eigen/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, buildDunePackage, fetchFromGitHub, ctypes }:
+{ stdenv, buildDune2Package, fetchFromGitHub, ctypes }:
 
-buildDunePackage rec {
+buildDune2Package rec {
   pname = "eigen";
-  version = "0.1.5";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "owlbarn";
     repo   = pname;
     rev    = version;
-    sha256 = "0pbqd87i9h7qpx84hr8k4iw0rhmjgma4s3wihxh992jjvsrgdyfi";
+    sha256 = "1zaw03as14hyvfpyj6bjrfbcxp2ljdbqcqqgm53kms244mig425f";
   };
 
-  minimumOCamlVersion = "4.04";
+  minimumOCamlVersion = "4.02";
 
   propagatedBuildInputs = [ ctypes ];
 

--- a/pkgs/development/ocaml-modules/owl-base/default.nix
+++ b/pkgs/development/ocaml-modules/owl-base/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, buildDunePackage, fetchFromGitHub, stdlib-shims }:
+{ stdenv, buildDune2Package, fetchFromGitHub, stdlib-shims }:
 
-buildDunePackage rec {
+buildDune2Package rec {
   pname = "owl-base";
-  version = "0.7.2";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner  = "owlbarn";
     repo   = "owl";
     rev    = version;
-    sha256 = "1a2lbhywrb3bmm4k48wwbp6iszpd3aj1f23v10i78cbqm5slk6dj";
+    sha256 = "1j3xmr4izfznmv8lbn8vkx9c77py2xr6fqyn6ypjlf5k9b8g4mmw";
   };
 
   propagatedBuildInputs = [ stdlib-shims ];

--- a/pkgs/development/ocaml-modules/owl/default.nix
+++ b/pkgs/development/ocaml-modules/owl/default.nix
@@ -1,14 +1,26 @@
-{ stdenv, buildDunePackage, fetchFromGitHub, alcotest
-, eigen, stdio, stdlib-shims, openblasCompat, owl-base
+{ stdenv
+, buildDune2Package
+, dune-configurator
+, fetchFromGitHub
+, alcotest
+, eigen
+, stdio
+, stdlib-shims
+, openblasCompat
+, owl-base
+, npy
 }:
 
-buildDunePackage rec {
+buildDune2Package rec {
   pname = "owl";
 
   inherit (owl-base) version src meta;
 
   checkInputs = [ alcotest ];
-  propagatedBuildInputs = [ eigen stdio stdlib-shims openblasCompat owl-base ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [
+    eigen stdio stdlib-shims openblasCompat owl-base npy
+  ];
 
   doCheck = !stdenv.isDarwin;  # https://github.com/owlbarn/owl/issues/462
 }

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, buildDunePackage, fetchFromGitHub, ppx_deriving
+{ stdenv, buildDune2Package, fetchFromGitHub, ppx_deriving
 , alcotest, biocaml, gnuplot, lacaml, menhir, owl }:
 
-buildDunePackage rec {
+buildDune2Package rec {
   pname = "phylogenetics";
   version = "unstable-2019-11-15";
 
@@ -20,7 +20,7 @@ buildDunePackage rec {
   doCheck = false;  # many tests require bppsuite
 
   meta = with stdenv.lib; {
-    inherit (std.meta) homepage;
+    inherit (src.meta) homepage;
     description = "Bioinformatics library for Ocaml";
     maintainers = [ maintainers.bcdarwin ];
     license = licenses.cecill-b;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

Built the sole reverse dependency, `ocamlPackages_latest.phylogenetics`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
