### PR TITLE
vaultenv: 0.8.0 -> 0.13.0

### DIFF
--- a/pkgs/development/tools/haskell/vaultenv/default.nix
+++ b/pkgs/development/tools/haskell/vaultenv/default.nix
@@ -2,15 +2,15 @@
 , directory, hpack, hspec, hspec-discover, hspec-expectations
 , http-client, http-conduit, lens, lens-aeson, megaparsec, mtl
 , optparse-applicative, parser-combinators, retry, stdenv, text
-, unix, unordered-containers, utf8-string, fetchzip
+, unix, unordered-containers, utf8-string, fetchzip, dotenv
 }:
 mkDerivation rec {
   pname = "vaultenv";
-  version = "0.8.0";
+  version = "0.13.0";
 
   src = fetchzip {
     url = "https://github.com/channable/vaultenv/archive/v${version}.tar.gz";
-    sha256 = "04hrwyy7gsybdwljrks4ym3pshqk1i43f8wpirjx7b0dfjgsd2l5";
+    sha256 = "0kz5p57fq855mhbqrpb737sqrax9cdcyh2g57460hc8fyvs97lq0";
   };
 
   buildTools = [ hpack ];
@@ -21,6 +21,7 @@ mkDerivation rec {
     async base bytestring connection containers http-client
     http-conduit lens lens-aeson megaparsec mtl optparse-applicative
     parser-combinators retry text unix unordered-containers utf8-string
+    dotenv
   ];
   testHaskellDepends = [
     async base bytestring connection containers directory hspec
@@ -32,7 +33,5 @@ mkDerivation rec {
   homepage = "https://github.com/channable/vaultenv#readme";
   description = "Runs processes with secrets from HashiCorp Vault";
   license = stdenv.lib.licenses.bsd3;
-  maintainers = with stdenv.lib.maintainers; [ lnl7 ];
-  hydraPlatforms = [];
-  broken = true;  # does not compile any longer
+  maintainers = with stdenv.lib.maintainers; [ lnl7 manveru ];
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This package was marked as broken and pretty old. Updated to latest and added the missing dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@LnL7 