### PR TITLE
iptables: switch from iptables-legacy to iptables-nftables-compat

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -17,6 +17,12 @@
     <itemizedlist>
       <listitem>
         <para>
+          <literal>iptables</literal> now uses
+          <literal>nf_tables</literal> backend.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           PHP now defaults to PHP 8.0, updated from 7.4.
         </para>
       </listitem>
@@ -326,6 +332,14 @@
           that before NixOS 21.11, specifying either setuid or setgid
           but not owner/group resulted in wrappers owned by
           nobody/nogroup, which is unsafe.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Since <literal>iptables</literal> now uses
+          <literal>nf_tables</literal> backend and
+          <literal>ipset</literal> doesn’t support it, some applications
+          (ferm, shorewall, firehol) may have limited functionality.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -6,6 +6,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 ## Highlights {#sec-release-21.11-highlights}
 
+- `iptables` now uses `nf_tables` backend.
+
 - PHP now defaults to PHP 8.0, updated from 7.4.
 
 - kOps now defaults to 1.21.1, which uses containerd as the default runtime.
@@ -102,6 +104,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `security.wrappers` option now requires to always specify an owner, group and whether the setuid/setgid bit should be set.
   This is motivated by the fact that before NixOS 21.11, specifying either setuid or setgid but not owner/group resulted in wrappers owned by nobody/nogroup, which is unsafe.
+
+- Since `iptables` now uses `nf_tables` backend and `ipset` doesn't support it, some applications (ferm, shorewall, firehol) may have limited functionality.
 
 - The `paperless` module and package have been removed. All users should migrate to the
   successor `paperless-ng` instead. The Paperless project [has been

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -167,7 +167,7 @@ in {
       etc."qemu/bridge.conf".text = lib.concatMapStringsSep "\n" (e:
         "allow ${e}") cfg.allowedBridges;
       systemPackages = with pkgs; [ libressl.nc iptables cfg.package cfg.qemuPackage ];
-      etc.ethertypes.source = "${pkgs.ebtables}/etc/ethertypes";
+      etc.ethertypes.source = "${pkgs.iptables}/etc/ethertypes";
     };
 
     boot.kernelModules = [ "tun" ];

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -13,7 +13,6 @@
 , pkg-config
 , ethtool
 , util-linux
-, ipset
 , fetchFromGitHub
 , fetchurl
 , fetchzip
@@ -254,7 +253,6 @@ stdenv.mkDerivation rec {
     bridge-utils
     ethtool
     util-linux # kubelet wants 'nsenter' from util-linux: https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-705994388
-    ipset
     conntrack-tools
   ];
 

--- a/pkgs/applications/networking/firehol/default.nix
+++ b/pkgs/applications/networking/firehol/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, pkgs
-, autoconf, automake, curl, iprange, iproute2, ipset, iptables, iputils
+, autoconf, automake, curl, iprange, iproute2, iptables, iputils
 , kmod, nettools, procps, tcpdump, traceroute, util-linux, whois
 
 # If true, just install FireQOS without FireHOL
@@ -35,13 +35,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoconf automake ];
   buildInputs = [
-    curl iprange iproute2 ipset iptables iputils kmod
+    curl iprange iproute2 iptables iputils kmod
     nettools procps tcpdump traceroute util-linux whois
   ];
 
   preConfigure = "./autogen.sh";
   configureFlags = [ "--localstatedir=/var"
-                     "--disable-doc" "--disable-man" ] ++
+                     "--disable-doc" "--disable-man"
+                     "--disable-update-ipsets" ] ++
                    lib.optional onlyQOS [ "--disable-firehol" ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/libvirt/5.9.0.nix
+++ b/pkgs/development/libraries/libvirt/5.9.0.nix
@@ -2,7 +2,7 @@
 , pkg-config, makeWrapper, libtool, autoconf, automake, fetchpatch
 , coreutils, libxml2, gnutls, perl, python2, attr
 , iproute2, iptables, readline, lvm2, util-linux, systemd, libpciaccess, gettext
-, libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
+, libtasn1, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
 , dnsmasq, libnl, libpcap, libxslt, xhtml1, numad, numactl, perlPackages
 , curl, libiconv, gmp, zfs, parted, bridge-utils, dmidecode, glib, rpcsvc-proto, libtirpc
 , enableXen ? false, xen ? null
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
 
   preConfigure = ''
     ${ optionalString (!buildFromTarball) "./bootstrap --no-git --gnulib-srcdir=$(pwd)/.gnulib" }
-    PATH=${lib.makeBinPath ([ dnsmasq ] ++ optionals stdenv.isLinux [ iproute2 iptables ebtables lvm2 systemd numad ] ++ optionals enableIscsi [ openiscsi ])}:$PATH
+    PATH=${lib.makeBinPath ([ dnsmasq ] ++ optionals stdenv.isLinux [ iproute2 iptables lvm2 systemd numad ] ++ optionals enableIscsi [ openiscsi ])}:$PATH
     # the path to qemu-kvm will be stored in VM's .xml and .save files
     # do not use "''${qemu_kvm}/bin/qemu-kvm" to avoid bound VMs to particular qemu derivations
     substituteInPlace src/lxc/lxc_conf.c \
@@ -75,7 +75,6 @@ in stdenv.mkDerivation rec {
   ] ++ optionals stdenv.isLinux [
     "QEMU_BRIDGE_HELPER=/run/wrappers/bin/qemu-bridge-helper"
     "QEMU_PR_HELPER=/run/libvirt/nix-helpers/qemu-pr-helper"
-    "EBTABLES_PATH=${ebtables}/bin/ebtables-legacy"
     "CFLAGS=-I${libtirpc.dev}/include/tirpc"
     "--with-attr"
     "--with-apparmor"
@@ -101,7 +100,7 @@ in stdenv.mkDerivation rec {
 
 
   postInstall = let
-    binPath = [ iptables iproute2 pmutils numad numactl bridge-utils dmidecode dnsmasq ebtables ] ++ optionals enableIscsi [ openiscsi ];
+    binPath = [ iptables iproute2 pmutils numad numactl bridge-utils dmidecode dnsmasq ] ++ optionals enableIscsi [ openiscsi ];
   in ''
     substituteInPlace $out/libexec/libvirt-guests.sh \
       --replace 'ON_BOOT=start'       'ON_BOOT=''${ON_BOOT:-start}' \

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -22,7 +22,6 @@
 , gettext
 , libtasn1
 , iptables
-, ebtables
 , libgcrypt
 , yajl
 , pmutils
@@ -68,19 +67,6 @@ with lib;
 # if you update, also bump <nixpkgs/pkgs/development/python-modules/libvirt/default.nix> and SysVirt in <nixpkgs/pkgs/top-level/perl-packages.nix>
 let
   buildFromTarball = stdenv.isDarwin;
-  # libvirt hardcodes the binary name 'ebtables', but in nixpkgs the ebtables
-  # binary we want to use is named 'ebtables-legacy'.
-  # Create a derivation to alias the binary name so that libvirt can find the right one, and use that below.
-  ebtables-compat = stdenv.mkDerivation {
-    pname = "ebtables-compat";
-    version = ebtables.version;
-    src = null;
-    buildInputs = [ ebtables ];
-    buildCommand = ''
-      mkdir -p $out/bin
-      ln -sf ${ebtables}/bin/ebtables-legacy $out/bin/ebtables
-    '';
-  };
 in
 stdenv.mkDerivation rec {
   pname = "libvirt";
@@ -178,7 +164,7 @@ stdenv.mkDerivation rec {
       '';
     in
     ''
-      PATH=${lib.makeBinPath ([ dnsmasq ] ++ optionals stdenv.isLinux [ iproute2 iptables ebtables-compat lvm2 systemd numad ] ++ optionals enableIscsi [ openiscsi ])}:$PATH
+      PATH=${lib.makeBinPath ([ dnsmasq ] ++ optionals stdenv.isLinux [ iproute2 iptables lvm2 systemd numad ] ++ optionals enableIscsi [ openiscsi ])}:$PATH
       # the path to qemu-kvm will be stored in VM's .xml and .save files
       # do not use "''${qemu_kvm}/bin/qemu-kvm" to avoid bound VMs to particular qemu derivations
       substituteInPlace src/lxc/lxc_conf.c \
@@ -226,8 +212,7 @@ stdenv.mkDerivation rec {
 
   postInstall =
     let
-      # Keep the legacy iptables binary for now for backwards compatibility (comment on #109332)
-      binPath = [ iptables ebtables-compat iproute2 pmutils numad numactl bridge-utils dmidecode dnsmasq ] ++ optionals enableIscsi [ openiscsi ];
+      binPath = [ iptables iproute2 pmutils numad numactl bridge-utils dmidecode dnsmasq ] ++ optionals enableIscsi [ openiscsi ];
     in
     ''
         substituteInPlace $out/libexec/libvirt-guests.sh \

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config, pruneLibtoolFiles, flex, bison
 , libmnl, libnetfilter_conntrack, libnfnetlink, libnftnl, libpcap
-, nftablesCompat ? false
+, nftablesCompat ? true
 }:
 
 with lib;

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -4,7 +4,7 @@
 , gmp, jansson, readline
 , withDebugSymbols ? false
 , withPython ? false , python3
-, withXtables ? false , iptables
+, withXtables ? true , iptables
 }:
 
 with lib;

--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -1,22 +1,14 @@
 { lib, hwdata, pkg-config, lxc, buildGoPackage, fetchurl
 , makeWrapper, acl, rsync, gnutar, xz, btrfs-progs, gzip, dnsmasq, attr
-, squashfsTools, iproute2, iptables, ebtables, iptables-nftables-compat, libcap
+, squashfsTools, iproute2, iptables, libcap
 , dqlite, raft-canonical, sqlite-replication, udev
 , writeShellScriptBin, apparmor-profiles, apparmor-parser
 , criu
 , bash
 , installShellFiles
-, nftablesSupport ? false
 , nixosTests
 }:
 
-let
-  networkPkgs = if nftablesSupport then
-    [ iptables-nftables-compat ]
-  else
-    [ iptables ebtables ];
-
-in
 buildGoPackage rec {
   pname = "lxd";
   version = "4.18";
@@ -45,7 +37,7 @@ buildGoPackage rec {
     rm $out/bin/{deps,macaroon-identity,generate}
 
     wrapProgram $out/bin/lxd --prefix PATH : ${lib.makeBinPath (
-      networkPkgs
+      [ iptables ]
       ++ [ acl rsync gnutar xz btrfs-progs gzip dnsmasq squashfsTools iproute2 bash criu attr ]
       ++ [ (writeShellScriptBin "apparmor_parser" ''
              exec '${apparmor-parser}/bin/apparmor_parser' -I '${apparmor-profiles}/etc/apparmor.d' "$@"

--- a/pkgs/tools/networking/ferm/default.nix
+++ b/pkgs/tools/networking/ferm/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, perl, ebtables, ipset, iptables, nixosTests }:
+{ lib, stdenv, fetchurl, makeWrapper, perl, iptables, nixosTests }:
 
 let
   inherit (lib.versions) majorMinor;
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
   postInstall = ''
     rm -r $out/lib/systemd
     for i in "$out/sbin/"*; do
-      wrapProgram "$i" --prefix PATH : "${lib.makeBinPath [ iptables ipset ebtables ]}"
+      wrapProgram "$i" --prefix PATH : "${lib.makeBinPath [ iptables ]}"
     done
   '';
 

--- a/pkgs/tools/networking/shorewall/default.nix
+++ b/pkgs/tools/networking/shorewall/default.nix
@@ -1,10 +1,8 @@
 { coreutils
-, ebtables
 , fetchurl
 , gnugrep
 , gnused
 , iproute2
-, ipset
 , iptables
 , perl
 , perlPackages
@@ -17,8 +15,6 @@ let
            [ "${coreutils}/bin"
              "${iproute2}/bin"
              "${iptables}/bin"
-             "${ipset}/bin"
-             "${ebtables}/bin"
              "${util-linux}/bin"
              "${gnugrep}/bin"
              "${gnused}/bin"
@@ -47,9 +43,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     coreutils
     iproute2
-    ipset
     iptables
-    ebtables
     util-linux
     gnugrep
     gnused

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21396,9 +21396,9 @@ with pkgs;
   iputils = hiPrio (callPackage ../os-specific/linux/iputils { });
   # hiPrio for collisions with inetutils (ping and tftpd.8.gz)
 
-  iptables = iptables-legacy;
-  iptables-legacy = callPackage ../os-specific/linux/iptables { };
-  iptables-nftables-compat = callPackage ../os-specific/linux/iptables { nftablesCompat = true; };
+  iptables = callPackage ../os-specific/linux/iptables { };
+  iptables-legacy = callPackage ../os-specific/linux/iptables { nftablesCompat = false; };
+  iptables-nftables-compat = iptables;
 
   iptstate = callPackage ../os-specific/linux/iptstate { } ;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
`iptables-nftables-compat` transparently converts `iptables` rules to `nft` rules. This should ease the migration to `nftables`.
[Debian](https://wiki.debian.org/nftables#Current_status) and [Fedora](https://fedoraproject.org/wiki/Changes/iptables-nft-default) already switched to `iptables-nftables-compat` by default.

Related: https://github.com/NixOS/nixpkgs/issues/23181
https://wiki.nftables.org/wiki-nftables/index.php/Moving_from_iptables_to_nftables
https://www.redhat.com/en/blog/using-iptables-nft-hybrid-linux-firewall

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   - [x] docker
   - [x] oci-containers
   - [x] firewall
   - [x] initrdNetwork
   - [x] ipv6
   - [x] nat
   - [x] networking.networkd
   - [x] networking.scripted
   - [x] wireguard
   - [x] ferm
   - [x] k3s
   - [x] kubernetes
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
