### PR TITLE
[wip] indicator-cpufreq: init at bzr 98

### DIFF
--- a/pkgs/os-specific/linux/indicator-cpufreq/default.nix
+++ b/pkgs/os-specific/linux/indicator-cpufreq/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, cpufrequtils, lib, fetchbzr, gobject-introspection
+  , intltool, glib, python3, wrapGAppsHook }:
+
+python3.pkgs.buildPythonApplication {
+  name = "indicator-cpufreq-98";
+  src = fetchbzr {
+    url = lp:indicator-cpufreq;
+    rev = "98";
+    sha256 = "0h54mxqy0xi73vn3q7vx99lhry38ysfhfd5rnbcyhf5lvm4xrj8i";
+  };
+
+  patchPhase = ''
+    substituteInPlace data/com.ubuntu.IndicatorCpufreqSelector.service \
+      --replace /usr $out
+    substituteInPlace indicator_cpufreq/cpufreq.py \
+      --replace find_library\(\"cpufreq\"\) \"$(realpath ${lib.makeLibraryPath [cpufrequtils]}/libcpufreq.so)\"
+  '';
+
+  nativeBuildInputs = with python3.pkgs;  [
+
+    distutils_extra
+    intltool
+    wrapGAppsHook
+    #wrapPython
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    dbus-python pygobject3 glib gobject-introspection ];
+
+  doCheck = false;
+
+  meta = {
+    homepage = https://launchpad.net/indicator-cpufreq;
+    description = "Indicator applet for displaying and changing CPU frequency on-the-fly";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ genesis ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16317,6 +16317,8 @@ in
     openssl = openssl_1_0_2;
   };
 
+  indicator-cpufreq = callPackage ../os-specific/linux/indicator-cpufreq { };
+
   intel2200BGFirmware = callPackage ../os-specific/linux/firmware/intel2200BGFirmware { };
 
   intel-compute-runtime = callPackage ../os-specific/linux/intel-compute-runtime { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I need some help here, need to fix a cadence dependencies ( see improvement here #81098 )
Issues : 
* dbus.exceptions.DBusException: org.freedesktop.DBus.Error.AccessDenied: Connection ":1.400" is not allowed to own the service "com.ubuntu.IndicatorCpufreqSelector" due to security policies in the configuration file

