### PR TITLE
pythonPackages.swagger-spec-validator 2.4.3 -> 2.5.0

### DIFF
--- a/pkgs/development/python-modules/swagger-spec-validator/default.nix
+++ b/pkgs/development/python-modules/swagger-spec-validator/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "swagger-spec-validator";
-  version = "2.4.3";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "Yelp";
     repo = "swagger_spec_validator";
     rev = "v" + version;
-    sha256 = "02f8amc6iq2clxxmrz8hirbb57sizaxijp0higqy16shk63ibalw";
+    sha256 = "0qlkiyncdh7cdyjvnwjpv9i7y75ghwnpyqkkpfaa8hg698na13pw";
   };
 
   checkInputs = [


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/81018 

Includes various upstream fixes of the tests, see

* https://github.com/Yelp/swagger_spec_validator/pull/117
* https://github.com/Yelp/swagger_spec_validator/pull/121

(cherry picked from commit efa25157e92af69d8871ecd1c3e7abeb4a2877c3)