### PR TITLE
python3Packages.sapi-python-client: init at 0.13.1

### DIFF
--- a/pkgs/development/python-modules/sapi-python-client/default.nix
+++ b/pkgs/development/python-modules/sapi-python-client/default.nix
@@ -11,6 +11,10 @@ buildPythonPackage rec {
         sha256 = "1xja4v5d30hy26lfys21vcz1lcs88v8mvjxwl2dc3wxx2pzdvcf6";
     };
 
+    postPatch = ''
+        sed -i 's|use_scm_version=True|version="${version}"|' setup.py
+    '';
+
     doCheck = false; # requires API token and an active keboola bucket
 
     nativeBuildInputs = [ git setuptools_scm ]; 

--- a/pkgs/development/python-modules/sapi-python-client/default.nix
+++ b/pkgs/development/python-modules/sapi-python-client/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, git, setuptools, setuptools_scm, fetchgit, requests, boto3, buildPythonPackage, responses }: 
+
+buildPythonPackage rec { 
+    pname = "sapi-python-client"; 
+    version = "0.1.3"; 
+
+    src = fetchgit { 
+        url = "https://github.com/keboola/sapi-python-client.git"; 
+        sha256 = "1zfxz9066ddpdmyxrwvns2v8kjn5dyyqgbiaai05k4ksrrf3zv22"; 
+        rev = "0.1.3"; 
+    }; 
+
+    doCheck = false; # requires API token and an active keboola bucket
+
+    nativeBuildInputs = [ git ]; 
+
+    propagatedBuildInputs = [ setuptools setuptools_scm ]; 
+
+    buildInputs = [ requests boto3 responses ];
+
+    meta = with stdenv.lib; { 
+        description = "Keboola Connection Storage API client"; 
+        homepage = "https://github.com/keboola/sapi-python-client"; 
+        maintainers = with maintainers; [ mrmebelman ];
+        license = licenses.mit; 
+    }; 
+}
+

--- a/pkgs/development/python-modules/sapi-python-client/default.nix
+++ b/pkgs/development/python-modules/sapi-python-client/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, git, setuptools, setuptools_scm, fetchgit, requests, boto3, buildPythonPackage, responses }: 
+{ stdenv, git, setuptools, setuptools_scm, fetchFromGitHub, requests, boto3, buildPythonPackage, responses }: 
 
 buildPythonPackage rec { 
     pname = "sapi-python-client"; 
     version = "0.1.3"; 
 
-    src = fetchgit { 
-        url = "https://github.com/keboola/sapi-python-client.git"; 
-        sha256 = "1zfxz9066ddpdmyxrwvns2v8kjn5dyyqgbiaai05k4ksrrf3zv22"; 
-        rev = "0.1.3"; 
-    }; 
+    src = fetchFromGitHub {
+        owner = "keboola";
+        repo = pname;
+        rev  = version;
+        sha256 = "1xja4v5d30hy26lfys21vcz1lcs88v8mvjxwl2dc3wxx2pzdvcf6";
+    };
 
     doCheck = false; # requires API token and an active keboola bucket
 
-    nativeBuildInputs = [ git ]; 
+    nativeBuildInputs = [ git setuptools_scm ]; 
 
-    propagatedBuildInputs = [ setuptools setuptools_scm ]; 
-
-    buildInputs = [ requests boto3 responses ];
+    propagatedBuildInputs = [ setuptools requests boto3 responses ]; 
 
     meta = with stdenv.lib; { 
         description = "Keboola Connection Storage API client"; 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1377,6 +1377,8 @@ in {
 
   sanic-auth = callPackage ../development/python-modules/sanic-auth { };
 
+  sapi-python-client = callPackage ../development/python-modules/sapi-python-client { };
+
   seekpath = callPackage ../development/python-modules/seekpath { };
 
   selectors2 = callPackage ../development/python-modules/selectors2 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
