### PR TITLE
pythonPackages.bravado-core: init at 5.16.1

### DIFF
--- a/pkgs/development/python-modules/bravado-core/default.nix
+++ b/pkgs/development/python-modules/bravado-core/default.nix
@@ -1,0 +1,52 @@
+{ lib, buildPythonPackage, fetchFromGitHub, python-dateutil, jsonref, jsonschema,
+  pyyaml, simplejson, six, pytz, msgpack, swagger-spec-validator, rfc3987,
+  strict-rfc3339, webcolors, mypy-extensions, jsonpointer, idna, pytest, mock,
+  pytest-benchmark, isPy27, enum34 }:
+
+buildPythonPackage rec {
+  pname = "bravado-core";
+  version = "5.16.1";
+
+  src = fetchFromGitHub {
+    owner = "Yelp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0r9gk5vkjbc407fjydms3ik3hnzajq54znyz58d8rm6pvqcvjjpl";
+  };
+
+  checkInputs = [
+    mypy-extensions
+    pytest
+    mock
+    pytest-benchmark
+  ];
+
+  checkPhase = ''pytest --benchmark-skip'';
+
+  propagatedBuildInputs = [
+    python-dateutil
+    jsonref
+    jsonschema
+    pyyaml
+    simplejson
+    six
+    pytz
+    msgpack
+    swagger-spec-validator
+
+    # the following 3 packages are included when jsonschema (3.2) is installed
+    # as jsonschema[format], which reflects what happens in setup.py
+    rfc3987
+    strict-rfc3339
+    webcolors
+    jsonpointer
+    idna
+  ] ++ lib.optionals isPy27 [ enum34 ];
+
+  meta = with lib; {
+    description = "Library for adding Swagger support to clients and servers";
+    homepage = "https://github.com/Yelp/bravado-core";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ vanschelven ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -506,6 +506,8 @@ in {
 
   django-sesame = callPackage ../development/python-modules/django-sesame { };
 
+  bravado-core = callPackage ../development/python-modules/bravado-core { };
+
   breathe = callPackage ../development/python-modules/breathe { };
 
   brotli = callPackage ../development/python-modules/brotli { };


### PR DESCRIPTION
###### Motivation for this change

Bravado is a python client library for Swagger 2.0 services

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
