### PR TITLE
certbot: 1.0.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/admin/certbot/0001-Don-t-use-distutils.StrictVersion-that-cannot-handle.patch
+++ b/pkgs/tools/admin/certbot/0001-Don-t-use-distutils.StrictVersion-that-cannot-handle.patch
@@ -22,18 +22,16 @@ ValueError: invalid version number '41.4.0.post20191022'
  1 file changed, 1 insertion(+), 14 deletions(-)
 
 diff --git a/certbot/setup.py b/certbot/setup.py
-index c1bf914..7456bf2 100644
+index d19327e5e..ac1524793 100644
 --- a/certbot/setup.py
 +++ b/certbot/setup.py
-@@ -3,7 +3,6 @@ import os
+@@ -1,5 +1,4 @@
+ import codecs
+-from distutils.version import StrictVersion
+ import os
  import re
  import sys
- 
--from distutils.version import StrictVersion
- from setuptools import find_packages, setup, __version__ as setuptools_version
- from setuptools.command.test import test as TestCommand
- 
-@@ -56,20 +55,8 @@ install_requires = [
+@@ -58,20 +57,8 @@ install_requires = [
  
  # Add pywin32 on Windows platforms to handle low-level system calls.
  # This dependency needs to be added using environment markers to avoid its installation on Linux.
@@ -54,7 +52,7 @@ index c1bf914..7456bf2 100644
 +install_requires.append(pywin32_req + " ; sys_platform == 'win32'")
  
  dev_extras = [
-     'astroid==1.6.5',
+     'coverage',
 -- 
 2.24.1
 

--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -1,22 +1,27 @@
-{ stdenv, python37Packages, fetchFromGitHub, fetchurl, dialog, autoPatchelfHook }:
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, ConfigArgParse, acme, configobj, cryptography, distro, josepy, parsedatetime, pyRFC3339, pyopenssl, pytz, requests, six, zope_component, zope_interface
+, dialog, mock, gnureadline
+, pytest_xdist, pytest, dateutil
+}:
 
-
-python37Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "certbot";
-  version = "1.0.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "180x7gcpfbrzw8k654s7b5nxdy2yg61lq513dykyn3wz4gssw465";
+    sha256 = "1nzp1l63f64qqp89y1vyd4lgfhykfp5dkr6iwfiyf273y7sjwpsa";
   };
 
   patches = [
     ./0001-Don-t-use-distutils.StrictVersion-that-cannot-handle.patch
   ];
 
-  propagatedBuildInputs = with python37Packages; [
+  propagatedBuildInputs = [
     ConfigArgParse
     acme
     configobj
@@ -24,26 +29,21 @@ python37Packages.buildPythonApplication rec {
     distro
     josepy
     parsedatetime
-    psutil
     pyRFC3339
     pyopenssl
     pytz
+    requests
     six
     zope_component
     zope_interface
   ];
 
-  buildInputs = [ dialog ] ++ (with python37Packages; [ mock gnureadline ]);
+  buildInputs = [ dialog mock gnureadline ];
 
-  checkInputs = with python37Packages; [
-    pytest_xdist
-    pytest
-    dateutil
-  ];
+  checkInputs = [ pytest_xdist pytest dateutil ];
 
-  postPatch = ''
+  preBuild = ''
     cd certbot
-    substituteInPlace certbot/_internal/notify.py --replace "/usr/sbin/sendmail" "/run/wrappers/bin/sendmail"
   '';
 
   postInstall = ''
@@ -55,11 +55,11 @@ python37Packages.buildPythonApplication rec {
 
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = src.meta.homepage;
     description = "ACME client that can obtain certs and extensibly update server configurations";
     platforms = platforms.unix;
-    maintainers = [ maintainers.domenkozar ];
-    license = licenses.asl20;
+    maintainers = with maintainers; [ domenkozar ];
+    license = with licenses; [ asl20 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11126,7 +11126,7 @@ in
     ogre = ogre1_10;
   };
 
-  certbot = callPackage ../tools/admin/certbot { };
+  certbot = python3Packages.callPackage ../tools/admin/certbot { };
 
   caf = callPackage ../development/libraries/caf {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version update. Fixes https://github.com/NixOS/nixpkgs/issues/81148

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
