### PR TITLE
edid-generator: init at unstable-2018-03-15

### DIFF
--- a/pkgs/tools/misc/edid-generator/default.nix
+++ b/pkgs/tools/misc/edid-generator/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, dos2unix
+, edid-decode
+, hexdump
+, zsh
+, modelines ? [] # Modeline "1280x800"   83.50  1280 1352 1480 1680  800 803 809 831 -hsync +vsync
+}:
+let
+  version = "unstable-2018-03-15";
+in stdenv.mkDerivation {
+  pname = "edid-generator";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "akatrevorjay";
+    repo = "edid-generator";
+    rev = "31a6f80784d289d2faa8c4ca4788409c83b3ea14";
+    sha256 = "0j6wqzx5frca8b5i6812vvr5iwk7440fka70bmqn00k0vfhsc2x3";
+  };
+
+  nativeBuildInputs = [ dos2unix edid-decode hexdump zsh ];
+
+  postPatch = ''
+    patchShebangs modeline2edid
+  '';
+
+  configurePhase = (stdenv.lib.concatMapStringsSep "\n" (m: "echo \"${m}\" | ./modeline2edid -") modelines);
+
+  installPhase = ''
+    install -Dm 444 *.bin -t "$out/lib/firmware/edid"
+  '';
+
+  meta = {
+    description = "Hackerswork to generate an EDID blob from given Xorg Modelines";
+    homepage = "https://github.com/akatrevorjay/edid-generator";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.flokli ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2984,6 +2984,8 @@ in
 
   edid-decode = callPackage ../tools/misc/edid-decode { };
 
+  edid-generator = callPackage ../tools/misc/edid-generator { };
+
   editres = callPackage ../tools/graphics/editres { };
 
   edit = callPackage ../applications/editors/edit { };


### PR DESCRIPTION
###### Motivation for this change
I'd like to generate custom edids to drive display with custom modes on wayland.

This derivation exposes a `modelines` argument, which can be used to add arbitrary modelines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
