### PR TITLE
ulauncher: 4.4.0.r1 -> 5.6.1

### DIFF
--- a/pkgs/applications/misc/ulauncher/0001-Adjust-get_data_path-for-NixOS.patch
+++ b/pkgs/applications/misc/ulauncher/0001-Adjust-get_data_path-for-NixOS.patch
@@ -1,0 +1,55 @@
+From 86cc27022015697a61d1ec1b13e52f9dbe7f6c57 Mon Sep 17 00:00:00 2001
+From: worldofpeace <worldofpeace@protonmail.ch>
+Date: Mon, 23 Mar 2020 18:34:00 -0400
+Subject: [PATCH] Adjust get_data_path for NixOS
+
+We construct the ulauncher data path from xdg_data_dirs
+and prevent it from being a nix store path or being xdg_data_home.
+We do this to prevent /nix/store paths being hardcoded to shortcuts.json.
+On NixOS this path will either be /run/current-system/sw/share/ulauncher
+or $HOME/.nix-profile/share/ulauncher if the user used nix-env.
+---
+ ulauncher/config.py | 27 ++++++++++++++++++---------
+ 1 file changed, 18 insertions(+), 9 deletions(-)
+
+diff --git a/ulauncher/config.py b/ulauncher/config.py
+index f21014e..cc636e1 100644
+--- a/ulauncher/config.py
++++ b/ulauncher/config.py
+@@ -50,15 +50,24 @@ def get_data_path():
+     is specified at installation time.
+     """
+ 
+-    # Get pathname absolute or relative.
+-    path = os.path.join(
+-        os.path.dirname(__file__), __ulauncher_data_directory__)
+-
+-    abs_data_path = os.path.abspath(path)
+-    if not os.path.exists(abs_data_path):
+-        raise ProjectPathNotFoundError(abs_data_path)
+-
+-    return abs_data_path
++    paths = list(
++        filter(
++            os.path.exists,
++            [
++                os.path.join(dir, "ulauncher")
++                for dir in xdg_data_dirs
++                # Get path that isn't in the /nix/store so they don't get hardcoded into configs
++                if not dir.startswith("/nix/store/")
++                # Exclude .local/share/ulauncher which isn't what we want
++                if not dir.startswith(xdg_data_home)
++            ],
++        )
++    )
++
++    try:
++        return paths[0]
++    except:
++        raise ProjectPathNotFoundError()
+ 
+ 
+ def is_wayland():
+-- 
+2.25.1
+

--- a/pkgs/applications/misc/ulauncher/default.nix
+++ b/pkgs/applications/misc/ulauncher/default.nix
@@ -1,8 +1,11 @@
 { stdenv
 , fetchurl
-, python27Packages
+, python3Packages
+, gdk-pixbuf
+, glib
 , gnome3
 , gobject-introspection
+, gtk3
 , wrapGAppsHook
 , webkitgtk
 , libnotify
@@ -11,49 +14,54 @@
 , intltool
 , wmctrl
 , xvfb_run
+, librsvg
 }:
 
-python27Packages.buildPythonApplication rec  {
+python3Packages.buildPythonApplication rec  {
   pname = "ulauncher";
-  version = "4.4.0.r1";
+  version = "5.6.1";
 
-  # Python 3 support is currently in development
-  # on the dev branch and 5.x.x releases
-  disabled = ! python27Packages.isPy27;
+  disabled = python3Packages.isPy27;
 
   src = fetchurl {
     url = "https://github.com/Ulauncher/Ulauncher/releases/download/${version}/ulauncher_${version}.tar.gz";
-    sha256 = "12v7qpjhf0842ivsfflsl2zlvhiaw25f9ffv7vhnkvrhrmksim9f";
+    sha256 = "14k68lp58wldldhaq4cf0ffkhi81czv4ps9xa86iw1j5b1gd2vbl";
   };
 
-  nativeBuildInputs = with python27Packages;  [
+  nativeBuildInputs = with python3Packages;  [
     distutils_extra
     intltool
     wrapGAppsHook
   ];
 
   buildInputs = [
+    gdk-pixbuf
+    glib
     gnome3.adwaita-icon-theme
     gobject-introspection
+    gtk3
     keybinder3
     libappindicator
     libnotify
+    librsvg
     webkitgtk
     wmctrl
   ];
 
-  propagatedBuildInputs = with python27Packages; [
+  propagatedBuildInputs = with python3Packages; [
+    mock
+    mypy
+    mypy-extensions
     dbus-python
-    notify
     pygobject3
     pyinotify
-    pysqlite
     python-Levenshtein
     pyxdg
+    requests
     websocket_client
   ];
 
-  checkInputs = with python27Packages; [
+  checkInputs = with python3Packages; [
     mock
     pytest
     pytest-mock
@@ -63,6 +71,9 @@ python27Packages.buildPythonApplication rec  {
 
   patches = [
     ./fix-path.patch
+    ./fix-permissions.patch # ulauncher PR #523
+    ./0001-Adjust-get_data_path-for-NixOS.patch
+    ./fix-extensions.patch
   ];
 
   postPatch = ''
@@ -73,7 +84,7 @@ python27Packages.buildPythonApplication rec  {
   doCheck = false;
 
   preCheck = ''
-    export PYTHONPATH=$PYTHONPATH:$out/${python27Packages.python.sitePackages}
+    export PYTHONPATH=$PYTHONPATH:$out/${python3Packages.python.sitePackages}
   '';
 
   # Simple translation of

--- a/pkgs/applications/misc/ulauncher/fix-extensions.patch
+++ b/pkgs/applications/misc/ulauncher/fix-extensions.patch
@@ -1,0 +1,13 @@
+diff --git a/ulauncher/api/server/ExtensionRunner.py b/ulauncher/api/server/ExtensionRunner.py
+index 22042bf..f7b31c8 100644
+--- a/ulauncher/api/server/ExtensionRunner.py
++++ b/ulauncher/api/server/ExtensionRunner.py
+@@ -79,7 +79,7 @@ class ExtensionRunner:
+         cmd = [sys.executable, os.path.join(self.extensions_dir, extension_id, 'main.py')]
+         env = os.environ.copy()
+         env['ULAUNCHER_WS_API'] = self.extension_server.generate_ws_url(extension_id)
+-        env['PYTHONPATH'] = ':'.join(filter(bool, [ULAUNCHER_APP_DIR, os.getenv('PYTHONPATH')]))
++        env['PYTHONPATH'] = ':'.join([ULAUNCHER_APP_DIR] + sys.path)
+ 
+         if self.verbose:
+             env['VERBOSE'] = '1'

--- a/pkgs/applications/misc/ulauncher/fix-permissions.patch
+++ b/pkgs/applications/misc/ulauncher/fix-permissions.patch
@@ -1,0 +1,12 @@
+diff --git a/ulauncher/utils/Theme.py b/ulauncher/utils/Theme.py
+index 9cde624..4e36c4f 100644
+--- a/ulauncher/utils/Theme.py
++++ b/ulauncher/utils/Theme.py
+@@ -138,6 +138,9 @@ class Theme:
+         rmtree(new_theme_dir)
+         copytree(self.path, new_theme_dir)
+ 
++        # change file permissions (because Nix store is read-only)
++        os.chmod(new_theme_dir, 0o755)
++
+         return os.path.join(new_theme_dir, 'generated.css')


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Package update request https://github.com/NixOS/nixpkgs/issues/81178
> The actual version is outdated and almost no extension work on it. I'm not skilled enough to mage the derivation (even if I'm currently trying :p).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

For some reason, I got the following non-fatal error upon first run (or `rm -rf ~/.cache/ulauncher_cache ~/.config/ulauncher`), which didn't seem to break anything:
```
2020-02-27 13:07:53,504 | ERROR | ulauncher: except_hook() | Uncaught exception
Traceback (most recent call last):
  File "/nix/store/xky23w5sd8mbm9rpgjl1b8iqz70kjc77-ulauncher-5.6.1/lib/python3.6/site-packages/ulauncher/ui/windows/UlauncherWindow.py", line 298, in bind_show_app_hotkey
    self.notify_hotkey_change(accel_name)
  File "/nix/store/xky23w5sd8mbm9rpgjl1b8iqz70kjc77-ulauncher-5.6.1/lib/python3.6/site-packages/ulauncher/ui/windows/UlauncherWindow.py", line 307, in notify_hotkey_change
    show_notification("Ulauncher", "Hotkey is set to %s" % display_name)
  File "/nix/store/xky23w5sd8mbm9rpgjl1b8iqz70kjc77-ulauncher-5.6.1/lib/python3.6/site-packages/ulauncher/utils/desktop/notification.py", line 13, in show_notification
    Notify.Notification.new(summary, body, icon).show()
gi.repository.GLib.GError: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.Notifications was not provided by any .service files (2)
```

Also, when changing the theme, I get a permission error for a cache file. This is fixed by running with `sudo`, but, of course, running as root doesn't sound like a good idea.
```
2020-02-27 13:11:26,641 | ERROR | ulauncher: except_hook() | Uncaught exception
Traceback (most recent call last):
  File "/nix/store/xky23w5sd8mbm9rpgjl1b8iqz70kjc77-ulauncher-5.6.1/lib/python3.6/site-packages/ulauncher/ui/windows/PreferencesUlauncherDialog.py", line 307, in prefs_set_theme_name
    ulauncher_window.init_theme()
  File "/nix/store/xky23w5sd8mbm9rpgjl1b8iqz70kjc77-ulauncher-5.6.1/lib/python3.6/site-packages/ulauncher/ui/windows/UlauncherWindow.py", line 227, in init_theme
    self.init_styles(theme.compile_css())
  File "/nix/store/xky23w5sd8mbm9rpgjl1b8iqz70kjc77-ulauncher-5.6.1/lib/python3.6/site-packages/ulauncher/utils/Theme.py", line 120, in compile_css
    with open(generated_css, 'w') as new_css_file:
PermissionError: [Errno 13] Permission denied: '/home/ajanse/.cache/ulauncher_cache/themes/ubuntu/generated.css'
```

Other than the issues listed above, Ulauncher seems to work fine.

I don't know what to do about the test in the derivation and the `disabled` attribute.