### PR TITLE
qcad: init at v3.24.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8144,6 +8144,11 @@
       fingerprint = "85F8 E850 F8F2 F823 F934  535B EC50 6589 9AEA AF4C";
     }];
   };
+  yvesf = {
+    email = "yvesf+nix@xapek.org";
+    github = "yvesf";
+    name = "Yves Fischer";
+  };
   yvt = {
     email = "i@yvt.jp";
     github = "yvt";

--- a/pkgs/applications/misc/qcad/application-dir.patch
+++ b/pkgs/applications/misc/qcad/application-dir.patch
@@ -1,0 +1,35 @@
+diff --git a/src/core/RS.cpp b/src/core/RS.cpp
+index d8a135d6f..659795dbb 100644
+--- a/src/core/RS.cpp
++++ b/src/core/RS.cpp
+@@ -151,7 +151,7 @@ QStringList RS::getDirectoryList(const QString& subDirectory) {
+     dirList.append(appDir + "/../../../" + subDirectory);
+     dirList.append(QDir::currentPath() + "/" + subDirectory);
+ #else
+-    dirList.append(appDir + "/" + subDirectory);
++    dirList.append(appDir + "/../lib/" + subDirectory);
+ #endif
+ 
+     /*
+diff --git a/src/core/RSettings.cpp b/src/core/RSettings.cpp
+index c6c31cbf5..c51b59ce6 100644
+--- a/src/core/RSettings.cpp
++++ b/src/core/RSettings.cpp
+@@ -367,6 +367,8 @@ QString RSettings::getApplicationPath() {
+         ret.cdUp();
+     }
+ 
++    ret.cd("../lib");
++
+     return ret.path();
+ }
+ 
+@@ -1268,7 +1270,7 @@ QString RSettings::getRevisionString() {
+ }
+ 
+ QString RSettings::getReleaseDate() {
+-    return __DATE__;
++    return "";
+ }
+ 
+ int RSettings::getSnapRange() {

--- a/pkgs/applications/misc/qcad/default.nix
+++ b/pkgs/applications/misc/qcad/default.nix
@@ -1,0 +1,92 @@
+{ boost
+, fetchFromGitHub
+, mkDerivationWith
+, muparser
+, pkgconfig
+, qmake
+, qt5
+, stdenv
+, libGLU
+}:
+
+mkDerivationWith stdenv.mkDerivation rec {
+  pname = "qcad";
+  version = "v3.24.2.1";
+
+  src = fetchFromGitHub {
+    owner = "qcad";
+    repo = "qcad";
+    rev = version;
+    sha256 = "1g295gljq051x09f4d8k586bkg3vs8z22dn3rxj6xrm6803z8zw2";
+  };
+
+  patches = [
+    ./application-dir.patch
+  ];
+
+  postPatch = ''
+    mkdir src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version}
+    cp \
+      src/3rdparty/qt-labs-qtscriptgenerator-5.12.3/qt-labs-qtscriptgenerator-5.12.3.pro \
+      src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version}/qt-labs-qtscriptgenerator-${qt5.qtbase.version}.pro
+  '';
+
+  qmakeFlags = [
+    "MUPARSER_DIR=${muparser}"
+    "INSTALLROOT=$(out)"
+    "BOOST_DIR=${boost.dev}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 -t $out/bin release/qcad-bin
+    install -Dm555 -t $out/lib release/libspatialindexnavel.so
+    install -Dm555 -t $out/lib release/libqcadcore.so
+    install -Dm555 -t $out/lib release/libqcadentity.so
+    install -Dm555 -t $out/lib release/libqcadgrid.so
+    install -Dm555 -t $out/lib release/libqcadsnap.so
+    install -Dm555 -t $out/lib release/libqcadoperations.so
+    install -Dm555 -t $out/lib release/libqcadstemmer.so
+    install -Dm555 -t $out/lib release/libqcadspatialindex.so
+    install -Dm555 -t $out/lib release/libqcadgui.so
+    install -Dm555 -t $out/lib release/libqcadecmaapi.so
+
+    install -Dm444 -t $out/share/applications qcad.desktop
+    install -Dm644 -t $out/share/pixmaps      scripts/qcad_icon.png
+
+    cp -r scripts $out/lib
+    cp -r plugins $out/lib/plugins
+    cp -r patterns $out/lib/patterns
+
+    install -Dm644 scripts/qcad_icon.svg $out/share/icons/hicolor/scalable/apps/qcad.svg
+
+    runHook postInstall
+    '';
+
+  buildInputs = [
+    boost
+    muparser
+    libGLU
+    qt5.qtbase
+    qt5.qtscript
+    qt5.qtsvg
+    qt5.qtxmlpatterns
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    qt5.qmake
+    qt5.qttools
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "2D CAD package based on Qt";
+    homepage = "https://qcad.org";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ yvesf ];
+    platforms = qt5.qtbase.meta.platforms;
+  };
+}

--- a/pkgs/applications/misc/qcad/default.nix
+++ b/pkgs/applications/misc/qcad/default.nix
@@ -11,7 +11,7 @@
 
 mkDerivationWith stdenv.mkDerivation rec {
   pname = "qcad";
-  version = "v3.24.2.1";
+  version = "3.24.2.1";
 
   src = fetchFromGitHub {
     owner = "qcad";

--- a/pkgs/applications/misc/qcad/default.nix
+++ b/pkgs/applications/misc/qcad/default.nix
@@ -16,7 +16,7 @@ mkDerivationWith stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "qcad";
     repo = "qcad";
-    rev = version;
+    rev = "v${version}";
     sha256 = "1g295gljq051x09f4d8k586bkg3vs8z22dn3rxj6xrm6803z8zw2";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21333,6 +21333,8 @@ in
     guiSupport = false;
   };
 
+  qcad = libsForQt5.callPackage ../applications/misc/qcad { };
+
   qcomicbook = libsForQt5.callPackage ../applications/graphics/qcomicbook { };
 
   eiskaltdcpp = callPackage ../applications/networking/p2p/eiskaltdcpp {


### PR DESCRIPTION
###### Motivation for this change
Provide packaging for [qcad](https://qcad.org/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
