### PR TITLE
ausweisapp2: init at 1.20.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -271,6 +271,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "European Union Public License 1.1";
   };
 
+  eupl12 = spdx {
+    spdxId = "EUPL-1.2";
+    fullName = "European Union Public License 1.2";
+  };
+
   fdl12 = spdx {
     spdxId = "GFDL-1.2-only";
     fullName = "GNU Free Documentation License v1.2 only";

--- a/pkgs/applications/misc/ausweisapp2/default.nix
+++ b/pkgs/applications/misc/ausweisapp2/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, pcsclite, qtsvg, qttools, qtwebsockets
+, qtquickcontrols2, qtgraphicaleffects }:
+
+mkDerivation rec {
+  pname = "AusweisApp2";
+  version = "1.20.0";
+
+  src = fetchFromGitHub {
+    owner = "Governikus";
+    repo = "AusweisApp2";
+    rev = "${version}";
+    sha256 = "0qkwdaxhig4qjim7h20j6ln6w76ycppfc786nd8l69bd1qv46m40";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ qtsvg qttools qtwebsockets qtquickcontrols2 qtgraphicaleffects pcsclite ];
+
+  meta = with stdenv.lib; {
+    description = "Authentication software for the German ID card";
+    downloadPage = "https://github.com/Governikus/AusweisApp2/releases";
+    homepage = "https://www.ausweisapp.bund.de/ausweisapp2/";
+    license = licenses.eupl12;
+    maintainers = with maintainers; [ b4dm4n ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18538,6 +18538,8 @@ in
 
   aesop = callPackage ../applications/office/aesop { };
 
+  AusweisApp2 = libsForQt5.callPackage ../applications/misc/ausweisapp2 { };
+
   avidemux = libsForQt5.callPackage ../applications/video/avidemux { };
 
   avrdudess = callPackage ../applications/misc/avrdudess { };


### PR DESCRIPTION
###### Motivation for this change

Add a build for the `AusweisApp2` project.

Fixes #80415

###### Things done

Build and run successfully under NixOS. I couldn't get the macOS build running because of the required pcsc paths and the special cmake install handling for macOS.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
