### PR TITLE
pythonPackages.digital-ocean: 1.13.2 -> 1.15.0

### DIFF
--- a/pkgs/development/python-modules/digitalocean/default.nix
+++ b/pkgs/development/python-modules/digitalocean/default.nix
@@ -1,23 +1,53 @@
-{ stdenv, buildPythonPackage, fetchPypi, requests, jsonpickle }:
+{ buildPythonPackage
+, fetchFromGitHub
+, fetchPypi
+, isPy3k
+, jsonpickle
+, mock
+, pytest
+, pytestCheckHook
+, requests
+, responses
+, stdenv
+}:
 
 buildPythonPackage rec {
   pname = "python-digitalocean";
-  version = "1.13.2";
+  version = "1.15.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0h4drpdsmk0b3rlvg6q6cz11k23w0swj1iddk7xdcw4m7r7c52kw";
+  src = fetchFromGitHub {
+    owner = "koalalorenzo";
+    repo = "python-digitalocean";
+    rev = "v${version}";
+    sha256 = "1pz15mh72i992p63grwzqn2bbp6sm37zcp4f0fy1z7rsargwsbcz";
   };
 
-  propagatedBuildInputs = [ requests jsonpickle ];
+  propagatedBuildInputs = [
+    jsonpickle
+    requests
+  ];
 
-  # Package doesn't distribute tests.
-  doCheck = false;
+  dontUseSetuptoolsCheck = true;
+
+  checkInputs = [
+    pytest
+    pytestCheckHook
+    responses
+  ] ++ stdenv.lib.optionals (!isPy3k) [
+    mock
+  ];
+
+  preCheck = ''
+    cd digitalocean
+  '';
 
   meta = with stdenv.lib; {
     description = "digitalocean.com API to manage Droplets and Images";
-    homepage = https://pypi.python.org/pypi/python-digitalocean;
+    homepage = "https://pypi.python.org/pypi/python-digitalocean";
     license = licenses.lgpl3;
-    maintainers = with maintainers; [ teh ];
+    maintainers = with maintainers; [
+      kiwi
+      teh
+    ];
   };
 }


### PR DESCRIPTION
updated to newest version (1.13.2 was released ~2.25 years ago). switched to fetchFromGitHub to enable tests. added kiwi to maintainers. formatted with nixpkgs-fmt

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
it was old. and i think i need it updated for work i want to do on https://github.com/Kiwi/nixops-digitalocean/tree/digitalocean

###### Things done
i tested it (the python2Packages one at least) with my nixops-digitalocean successfully and the tests are now enabled and pass for both python2Packages and python3Packages. doing a nixpkgs-review pr 81217 right now... it might take a while.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
