### PR TITLE
papermc: init at 1.15.2r121

### DIFF
--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, jre }:
+let
+  mcVersion = "1.15.2";
+  buildNum = "161";
+  jar = fetchurl {
+    url = "https://papermc.io/api/v1/paper/${mcVersion}/${buildNum}/download";
+    sha256 = "1jngj5djs1fjdj25wg9iszw0dsp56f386j8ydms7x4ky8s8kxyms";
+  };
+in stdenv.mkDerivation {
+  pname = "papermc";
+  version = "${mcVersion}r${buildNum}";
+
+  preferLocalBuild = true;
+
+  dontUnpack = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${jar} $out/papermc.jar
+    cat > $out/bin/minecraft-server << EOF
+    #!/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/papermc.jar nogui
+    EOF
+    chmod +x $out/bin/minecraft-server
+  '';
+
+  phases = "installPhase";
+
+  meta = {
+    description = "High-performance Minecraft Server";
+    homepage    = "https://papermc.io/";
+    license     = stdenv.lib.licenses.gpl3;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ aaronjanse ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23362,6 +23362,8 @@ in
 
   pacvim = callPackage ../games/pacvim { };
 
+  papermc = callPackage ../games/papermc { };
+
   pentobi = libsForQt5.callPackage ../games/pentobi { };
 
   performous = callPackage ../games/performous {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
PaperMC is a significantly faster Minecraft server implementation than the one provided by Mojang. I'm currently using `papermc` as the `services.minecraft-server.package` for a NixOS machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note that I borrowed the `preferLocalBuild` attribute from the vanilla `minecraft-server` package. I'm [not sure what this does](https://discourse.nixos.org/t/meaning-of-preferlocalbuild/6047).

Also, do I need both `dontUnpack` and `phases`? I thought the latter is discouraged?
