### PR TITLE
nixos/modprobe: Fix modprobe configuration manpage link

### DIFF
--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -28,7 +28,7 @@ with lib;
         Any additional configuration to be appended to the generated
         <filename>modprobe.conf</filename>.  This is typically used to
         specify module options.  See
-        <citerefentry><refentrytitle>modprobe.conf</refentrytitle>
+        <citerefentry><refentrytitle>modprobe.d</refentrytitle>
         <manvolnum>5</manvolnum></citerefentry> for details.
       '';
       type = types.lines;


### PR DESCRIPTION
###### Motivation for this change
When the option description says "run `man ____` for details", that should work.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
