### PR TITLE
gzip: Don't depend on gzip being in $PATH

### DIFF
--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -17,6 +17,15 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "SHELL=/bin/sh" "GREP=grep" ];
 
+  # Many gzip executables are shell scripts that depend upon other gzip
+  # executables being in $PATH.  Rather than try to re-write all the
+  # internal cross-references, just add $out/bin to PATH at the top of
+  # all the executables that are shell scripts.
+  preFixup = ''
+    sed -i '1{;/#!\/bin\/sh/aPATH="'$out'/bin:$PATH"
+    }' $out/bin/*
+  '';
+
   meta = {
     homepage = "https://www.gnu.org/software/gzip/";
     description = "GNU zip compression program";


### PR DESCRIPTION
###### Motivation for this change
Direct references to `gunzip` & `zcat` ought to work in minimal environments like systemd scripts without having to ensure than `gzip` is added to PATH.

(This only addresses gzip's executables referencing each other -- it does not fix `zgrep` expecting `grep` to be in PATH or `zdiff` expecting `diff` to be in PATH.   I think fixing those would need to be done with care to avoid introducing circular dependencies, since gzip is used to extract sources when grep's source is fetched.)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
