### PR TITLE
diffr: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/text/diffr/default.nix
+++ b/pkgs/tools/text/diffr/default.nix
@@ -14,10 +14,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1fpcyl4kc4djfl6a2jlj56xqra42334vygz8n7614zgjpyxz3zx2";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1dddb3a547qnpm1vvrgffb3v9m8sh19hmhy0fg6xjqpm032lqx3v";
+  cargoSha256 = "17xgjk8li29b8q8p2bi56klqg0v2q0j6ich438c4p06jrszccx1f";
 
   nativeBuildInputs = [];
   buildInputs = (stdenv.lib.optional stdenv.isDarwin Security);


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.