### PR TITLE
ffsend: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/ffsend/default.nix
+++ b/pkgs/tools/misc/ffsend/default.nix
@@ -25,10 +25,7 @@ buildRustPackage rec {
     sha256 = "0yqigqh5vldzmp7wc1mxi5a4bxzm81xycx5h0ghak74vbjibps49";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1wwdnm6a5g4gpd1f89qii8v4f6mcfc1bif1v6mdlcbrpwax5skh4";
+  cargoSha256 = "0m2931fmc8jczjpb08077cpz9klhhf3aq15j2h76sb254qndagzy";
 
   nativeBuildInputs = [ cmake pkgconfig installShellFiles ];
   buildInputs = [ openssl ]


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.