### PR TITLE
svgcleaner: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/graphics/svgcleaner/default.nix
+++ b/pkgs/tools/graphics/svgcleaner/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1jpnqsln37kkxz98vj7gly3c2170v6zamd876nc9nfl9vns41s0f";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0kzrklw5nrzgvrfzq1mlnri06s19p4f3w38v39247baz2xd6j1n2";
+  cargoSha256 = "1xhwlsq9b6cnafbapm5jf48zqdx5k2vxlr701lh5f8nqvd7nxi6g";
 
   meta = with stdenv.lib; {
     description = "A tool for tidying and optimizing SVGs";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.