### PR TITLE
viu: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/graphics/viu/default.nix
+++ b/pkgs/tools/graphics/viu/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0p4ibvv0qrflqdc2bi9rjn7yhn01ncxrpqpxmh8cbq67rbvm7jnx";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1h9dm2hhld2079dnx4x5nzkn3ivk6g5ijhv49jxnc200mx4mr1s5";
+  cargoSha256 = "1wvqln3xr192ml9gfzfv6qdv59g654xyaw15d790sysm82gd0inz";
 
   meta = with lib; {
     description = "A command-line application to view images from the terminal written in Rust";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.