### PR TITLE
nixos/activation: propagate system to nested configurations

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -41,6 +41,12 @@ let
       # default to the argument. That way this new default could propagate all
       # they way through, but has the last priority behind everything else.
       nixpkgs.system = lib.mkDefault system;
+
+      # Stash the value of the `system` argument. When using `nesting.children`
+      # we want to have the same default value behavior (immediately above)
+      # without any interference from the user's configuration.
+      nixpkgs.initialSystem = system;
+
       _module.args.pkgs = lib.mkIf (pkgs_ != null) (lib.mkForce pkgs_);
     };
   };

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -216,6 +216,14 @@ in
         Ignored when <code>nixpkgs.pkgs</code> is set.
       '';
     };
+
+    initialSystem = mkOption {
+      type = types.str;
+      internal = true;
+      description = ''
+        Preserved value of <literal>system</literal> passed to <literal>eval-config.nix</literal>.
+      '';
+    };
   };
 
   config = {

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -15,6 +15,7 @@ let
     map (childConfig:
       (import ../../../lib/eval-config.nix {
         inherit baseModules;
+        system = config.nixpkgs.system;
         modules =
            (optionals inheritParent modules)
         ++ [ ./no-clone.nix ]

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -15,7 +15,7 @@ let
     map (childConfig:
       (import ../../../lib/eval-config.nix {
         inherit baseModules;
-        system = config.nixpkgs.system;
+        system = config.nixpkgs.initialSystem;
         modules =
            (optionals inheritParent modules)
         ++ [ ./no-clone.nix ]

--- a/nixos/tests/nesting.nix
+++ b/nixos/tests/nesting.nix
@@ -29,10 +29,10 @@ import ./make-test-python.nix {
         )
         clone.succeed("cowsay hey")
         clone.succeed("hello")
-    
-        children.wait_for_unit("default.target")
-        children.succeed("cowsay hey")
-        children.fail("hello")
+
+    children.wait_for_unit("default.target")
+    children.succeed("cowsay hey")
+    children.fail("hello")
 
     with subtest("Nested children do not inherit from parent"):
         children.succeed(


### PR DESCRIPTION
###### Motivation for this change

Fix the nesting tests for non-x86_64 on hydra, and the other tests that depend on nesting like nginx.

I'm not confident that this composes correctly with `nixpkgs.localSystem` and `nixpkgs.crossSystem`, so reviews and tests appreciated.

Fixes #80806

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
