### PR TITLE
hexyl: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/hexyl/default.nix
+++ b/pkgs/tools/misc/hexyl/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1n2q5a6697bxvl0askywhad2x560cajv456gxihdqqmmyq2vf63h";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1wcpbqlglf9r0xhfjmyym8bnd4pgrsf9lrmb14hn1ml5zlshpd7p";
+  cargoSha256 = "0dd7b6iibjmmriwi081pc65crq0y1j2pmbm1iq0lkqdd89c9f1yp";
 
   meta = with stdenv.lib; {
     description = "A command-line hex viewer";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.