### PR TITLE
pazi: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/pazi/default.nix
+++ b/pkgs/tools/misc/pazi/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0nqcp54nwv4ic5jc3cgg15rh8dgkixfgkwb5q47rv8ding4cd0j5";
+  cargoSha256 = "0sja0q9i0b1zb3a0a6z561yg9lqykylwr3iwin4r6cmi7j2sw5j6";
 
   meta = with stdenv.lib; {
     description = "An autojump \"zap to directory\" helper";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.