### PR TITLE
parallel-rust: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/parallel-rust/default.nix
+++ b/pkgs/tools/misc/parallel-rust/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1bb1m3ckkrxlnw9w24ig70bd1zwyrbaw914q3xz5yv43c0l6pn9c";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0ssawp06fidsppvfzk0balf4fink2vym9688r7k7x7pb2z7cvyqc";
+  cargoSha256 = "1r5chjhmy6ivhsvgqf75ph1qxa4x7n20f7rb3b6maqpbsc64km9n";
 
   patches = [ ./fix_cargo_lock_version.patch ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.