### PR TITLE
vivid: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/vivid/default.nix
+++ b/pkgs/tools/misc/vivid/default.nix
@@ -15,10 +15,7 @@ rustPlatform.buildRustPackage rec {
     substituteInPlace src/main.rs --replace /usr/share $out/share
   '';
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "04xx26ngz7hx7bv5g01q9h6dqa96xkx0xm3jb0qk6c3hp6500zpn";
+  cargoSha256 = "1l34i7qalid9mlcbpqhbb2bxgn2ylb2lwki4c0hf4kkq646ql0n1";
 
   postInstall = ''
     mkdir -p $out/share/${pname}


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.