### PR TITLE
shell-hist: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/shell-hist/default.nix
+++ b/pkgs/tools/misc/shell-hist/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage {
     sha256 = "0kc128xnnp1d56if70vfv0w3qnwhljhbnvzwwb7hfm3x2m0vqrqf";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1nqnkzwqk879qy1261g1gds668xz6islhzq7chzhilaqpmvf6039";
+  cargoSha256 = "0mfgax937na351qvi5n6s1ql9136djqiydzyfyax4684sp3kp613";
 
   meta = with lib; {
     description = "Inspect your shell history";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.