### PR TITLE
[20.03] go_1_14: init at 1.14 and switch to it (backport)

### DIFF
--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -1,0 +1,245 @@
+{ stdenv, fetchurl, tzdata, iana-etc, runCommand
+, perl, which, pkgconfig, patch, procps, pcre, cacert, Security, Foundation
+, mailcap, runtimeShell
+, buildPackages, pkgsTargetTarget
+}:
+
+let
+
+  inherit (stdenv.lib) optionals optionalString;
+
+  goBootstrap = runCommand "go-bootstrap" {} ''
+    mkdir $out
+    cp -rf ${buildPackages.go_bootstrap}/* $out/
+    chmod -R u+w $out
+    find $out -name "*.c" -delete
+    cp -rf $out/bin/* $out/share/go/bin/
+  '';
+
+  goarch = platform: {
+    "i686" = "386";
+    "x86_64" = "amd64";
+    "aarch64" = "arm64";
+    "arm" = "arm";
+    "armv5tel" = "arm";
+    "armv6l" = "arm";
+    "armv7l" = "arm";
+  }.${platform.parsed.cpu.name} or (throw "Unsupported system");
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "go";
+  version = "1.14";
+
+  src = fetchurl {
+    url = "https://dl.google.com/go/go${version}.src.tar.gz";
+    sha256 = "12a3nzj4k4p5ica447sjfva9pvvj84a03b4xlg3mhl2nmm33wr3d";
+  };
+
+  # perl is used for testing go vet
+  nativeBuildInputs = [ perl which pkgconfig patch procps ];
+  buildInputs = [ cacert pcre ]
+    ++ optionals stdenv.isLinux [ stdenv.cc.libc.out ]
+    ++ optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+
+  propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
+
+  hardeningDisable = [ "all" ];
+
+  prePatch = ''
+    patchShebangs ./ # replace /bin/bash
+
+    # This source produces shell script at run time,
+    # and thus it is not corrected by patchShebangs.
+    substituteInPlace misc/cgo/testcarchive/carchive_test.go \
+      --replace '#!/usr/bin/env bash' '#!${runtimeShell}'
+
+    # Patch the mimetype database location which is missing on NixOS.
+    # but also allow static binaries built with NixOS to run outside nix
+    sed -i 's,\"/etc/mime.types,"${mailcap}/etc/mime.types\"\,\n\t&,' src/mime/type_unix.go
+
+    # Disabling the 'os/http/net' tests (they want files not available in
+    # chroot builds)
+    rm src/net/{listen,parse}_test.go
+    rm src/syscall/exec_linux_test.go
+
+    # !!! substituteInPlace does not seems to be effective.
+    # The os test wants to read files in an existing path. Just don't let it be /usr/bin.
+    sed -i 's,/usr/bin,'"`pwd`", src/os/os_test.go
+    sed -i 's,/bin/pwd,'"`type -P pwd`", src/os/os_test.go
+    # Disable the unix socket test
+    sed -i '/TestShutdownUnix/aif true \{ return\; \}' src/net/net_test.go
+    # Disable the hostname test
+    sed -i '/TestHostname/aif true \{ return\; \}' src/os/os_test.go
+    # ParseInLocation fails the test
+    sed -i '/TestParseInSydney/aif true \{ return\; \}' src/time/format_test.go
+    # Remove the api check as it never worked
+    sed -i '/src\/cmd\/api\/run.go/ireturn nil' src/cmd/dist/test.go
+    # Remove the coverage test as we have removed this utility
+    sed -i '/TestCoverageWithCgo/aif true \{ return\; \}' src/cmd/go/go_test.go
+    # Remove the timezone naming test
+    sed -i '/TestLoadFixed/aif true \{ return\; \}' src/time/time_test.go
+    # Remove disable setgid test
+    sed -i '/TestRespectSetgidDir/aif true \{ return\; \}' src/cmd/go/internal/work/build_test.go
+    # Remove cert tests that conflict with NixOS's cert resolution
+    sed -i '/TestEnvVars/aif true \{ return\; \}' src/crypto/x509/root_unix_test.go
+    # TestWritevError hangs sometimes
+    sed -i '/TestWritevError/aif true \{ return\; \}' src/net/writev_test.go
+    # TestVariousDeadlines fails sometimes
+    sed -i '/TestVariousDeadlines/aif true \{ return\; \}' src/net/timeout_test.go
+
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
+
+    # Disable cgo lookup tests not works, they depend on resolver
+    rm src/net/cgo_unix_test.go
+
+  '' + optionalString stdenv.isLinux ''
+    # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
+    # that run outside a nix server
+    sed -i 's,\"/usr/share/zoneinfo/,"${tzdata}/share/zoneinfo/\"\,\n\t&,' src/time/zoneinfo_unix.go
+
+  '' + optionalString stdenv.isAarch32 ''
+    echo '#!${runtimeShell}' > misc/cgo/testplugin/test.bash
+  '' + optionalString stdenv.isDarwin ''
+    substituteInPlace src/race.bash --replace \
+      "sysctl machdep.cpu.extfeatures | grep -qv EM64T" true
+    sed -i 's,strings.Contains(.*sysctl.*,true {,' src/cmd/dist/util.go
+    sed -i 's,"/etc","'"$TMPDIR"'",' src/os/os_test.go
+    sed -i 's,/_go_os_test,'"$TMPDIR"'/_go_os_test,' src/os/path_test.go
+
+    sed -i '/TestChdirAndGetwd/aif true \{ return\; \}' src/os/os_test.go
+    sed -i '/TestCredentialNoSetGroups/aif true \{ return\; \}' src/os/exec/exec_posix_test.go
+    sed -i '/TestRead0/aif true \{ return\; \}' src/os/os_test.go
+    sed -i '/TestSystemRoots/aif true \{ return\; \}' src/crypto/x509/root_darwin_test.go
+
+    sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/aif true \{ return\; \}' src/cmd/go/go_test.go
+    sed -i '/TestBuildDashIInstallsDependencies/aif true \{ return\; \}' src/cmd/go/go_test.go
+
+    sed -i '/TestDisasmExtld/aif true \{ return\; \}' src/cmd/objdump/objdump_test.go
+
+    sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
+
+    # TestCurrent fails because Current is not implemented on Darwin
+    sed -i 's/TestCurrent/testCurrent/g' src/os/user/user_test.go
+    sed -i 's/TestLookup/testLookup/g' src/os/user/user_test.go
+
+    touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
+  '';
+
+  patches = [
+    ./remove-tools-1.11.patch
+    ./ssl-cert-file-1.13.patch
+    ./remove-test-pie-1.14.patch
+    ./creds-test.patch
+    ./go-1.9-skip-flaky-19608.patch
+    ./go-1.9-skip-flaky-20072.patch
+    ./skip-external-network-tests.patch
+    ./skip-nohup-tests.patch
+  ] ++ [
+    # breaks under load: https://github.com/golang/go/issues/25628
+    (if stdenv.isAarch32
+    then ./skip-test-extra-files-on-aarch32-1.14.patch
+    else ./skip-test-extra-files-on-386-1.14.patch)
+  ];
+
+  postPatch = ''
+    find . -name '*.orig' -exec rm {} ';'
+  '';
+
+  GOOS = stdenv.targetPlatform.parsed.kernel.name;
+  GOARCH = goarch stdenv.targetPlatform;
+  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+  # Go will nevertheless build a for host system that we will copy over in
+  # the install phase.
+  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
+  GOHOSTARCH = goarch stdenv.buildPlatform;
+
+  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+  # to be different from CC/CXX
+  CC_FOR_TARGET = if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc"
+    else
+      null;
+  CXX_FOR_TARGET = if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}c++"
+    else
+      null;
+
+  GOARM = toString (stdenv.lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
+  GO386 = 387; # from Arch: don't assume sse2 on i686
+  CGO_ENABLED = 1;
+  # Hopefully avoids test timeouts on Hydra
+  GO_TEST_TIMEOUT_SCALE = 3;
+
+  # Indicate that we are running on build infrastructure
+  # Some tests assume things like home directories and users exists
+  GO_BUILDER_NAME = "nix";
+
+  GOROOT_BOOTSTRAP="${goBootstrap}/share/go";
+
+  postConfigure = ''
+    export GOCACHE=$TMPDIR/go-cache
+    # this is compiled into the binary
+    export GOROOT_FINAL=$out/share/go
+
+    export PATH=$(pwd)/bin:$PATH
+
+    # Independent from host/target, CC should produce code for the building system.
+    export CC=${buildPackages.stdenv.cc}/bin/cc
+    ulimit -a
+  '';
+
+  postBuild = ''
+    (cd src && ./make.bash)
+  '';
+
+  doCheck = stdenv.hostPlatform == stdenv.targetPlatform && !stdenv.isDarwin;
+
+  checkPhase = ''
+    runHook preCheck
+    (cd src && HOME=$TMPDIR GOCACHE=$TMPDIR/go-cache ./run.bash --no-rebuild)
+    runHook postCheck
+  '';
+
+  preInstall = ''
+    rm -r pkg/obj
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  '' + (if (stdenv.buildPlatform != stdenv.hostPlatform) then ''
+    mv bin/*_*/* bin
+    rmdir bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOHOSTOS}_${GOHOSTARCH} pkg/tool/${GOHOSTOS}_${GOHOSTARCH}
+    ''}
+  '' else if (stdenv.hostPlatform != stdenv.targetPlatform) then ''
+    rm -rf bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOOS}_${GOARCH} pkg/tool/${GOOS}_${GOARCH}
+    ''}
+  '' else "");
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $GOROOT_FINAL
+    cp -a bin pkg src lib misc api doc $GOROOT_FINAL
+    ln -s $GOROOT_FINAL/bin $out/bin
+    runHook postInstall
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  disallowedReferences = [ goBootstrap ];
+
+  meta = with stdenv.lib; {
+    branch = "1.14";
+    homepage = http://golang.org/;
+    description = "The Go Programming language";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cstrahan orivej mic92 rvolosatovs kalbasit Frostman ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/compilers/go/remove-test-pie-1.14.patch
+++ b/pkgs/development/compilers/go/remove-test-pie-1.14.patch
@@ -1,0 +1,34 @@
+diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
+index 56bdfcac19..d7d67ab94d 100644
+--- a/src/cmd/dist/test.go
++++ b/src/cmd/dist/test.go
+@@ -580,29 +580,6 @@ func (t *tester) registerTests() {
+ 		})
+ 	}
+ 
+-	// Test internal linking of PIE binaries where it is supported.
+-	if goos == "linux" && (goarch == "amd64" || goarch == "arm64") {
+-		t.tests = append(t.tests, distTest{
+-			name:    "pie_internal",
+-			heading: "internal linking of -buildmode=pie",
+-			fn: func(dt *distTest) error {
+-				t.addCmd(dt, "src", t.goTest(), "reflect", "-buildmode=pie", "-ldflags=-linkmode=internal", t.timeout(60))
+-				return nil
+-			},
+-		})
+-		// Also test a cgo package.
+-		if t.cgoEnabled && t.internalLink() {
+-			t.tests = append(t.tests, distTest{
+-				name:    "pie_internal_cgo",
+-				heading: "internal linking of -buildmode=pie",
+-				fn: func(dt *distTest) error {
+-					t.addCmd(dt, "src", t.goTest(), "os/user", "-buildmode=pie", "-ldflags=-linkmode=internal", t.timeout(60))
+-					return nil
+-				},
+-			})
+-		}
+-	}
+-
+ 	// sync tests
+ 	if goos != "js" { // js doesn't support -cpu=10
+ 		t.tests = append(t.tests, distTest{

--- a/pkgs/development/compilers/go/skip-test-extra-files-on-386-1.14.patch
+++ b/pkgs/development/compilers/go/skip-test-extra-files-on-386-1.14.patch
@@ -1,0 +1,15 @@
+diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
+index dce66c5c2e..2532224376 100644
+--- a/src/os/exec/exec_test.go
++++ b/src/os/exec/exec_test.go
+@@ -627,6 +627,10 @@ func TestExtraFiles(t *testing.T) {
+ 		t.Skipf("skipping test on %q", runtime.GOOS)
+ 	}
+ 
++	if runtime.GOOS == "linux" && runtime.GOARCH  == "386" {
++		t.Skipf("skipping test on %q %q", runtime.GOARCH, runtime.GOOS)
++	}
++
+ 	// Force network usage, to verify the epoll (or whatever) fd
+ 	// doesn't leak to the child,
+ 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/pkgs/development/compilers/go/skip-test-extra-files-on-aarch32-1.14.patch
+++ b/pkgs/development/compilers/go/skip-test-extra-files-on-aarch32-1.14.patch
@@ -1,0 +1,15 @@
+diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
+index dce66c5c2e..2532224376 100644
+--- a/src/os/exec/exec_test.go
++++ b/src/os/exec/exec_test.go
+@@ -627,6 +627,10 @@ func TestExtraFiles(t *testing.T) {
+ 		t.Skipf("skipping test on %q", runtime.GOOS)
+ 	}
+ 
++	if runtime.GOOS == "linux" && runtime.GOARCH  == "arm" {
++		t.Skipf("skipping test on %q %q", runtime.GOARCH, runtime.GOOS)
++	}
++
+ 	// Force network usage, to verify the epoll (or whatever) fd
+ 	// doesn't leak to the child,
+ 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8344,7 +8344,14 @@ in
     buildPackages = buildPackages // { stdenv = gcc8Stdenv; };
   });
 
-  go = go_1_13;
+  go_1_14 = callPackage ../development/compilers/go/1.14.nix ({
+    inherit (darwin.apple_sdk.frameworks) Security Foundation;
+  } // lib.optionalAttrs stdenv.isAarch64 {
+    stdenv = gcc8Stdenv;
+    buildPackages = buildPackages // { stdenv = gcc8Stdenv; };
+  });
+
+  go = go_1_14;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };
 
@@ -14928,18 +14935,23 @@ in
   buildGo113Package = callPackage ../development/go-packages/generic {
     go = buildPackages.go_1_13;
   };
+  buildGo114Package = callPackage ../development/go-packages/generic {
+    go = buildPackages.go_1_14;
+  };
 
-  buildGoPackage = buildGo113Package;
+  buildGoPackage = buildGo114Package;
 
   buildGo112Module = callPackage ../development/go-modules/generic {
     go = buildPackages.go_1_12;
   };
-
   buildGo113Module = callPackage ../development/go-modules/generic {
     go = buildPackages.go_1_13;
   };
+  buildGo114Module = callPackage ../development/go-modules/generic {
+    go = buildPackages.go_1_14;
+  };
 
-  buildGoModule = buildGo113Module;
+  buildGoModule = buildGo114Module;
 
   go2nix = callPackage ../development/tools/go2nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15260,9 +15260,7 @@ in
 
   gofish = callPackage ../servers/gopher/gofish { };
 
-  grafana = callPackage ../servers/monitoring/grafana {
-    buildGoPackage = buildGo113Package;
-  };
+  grafana = callPackage ../servers/monitoring/grafana { };
 
   grafana-loki = callPackage ../servers/monitoring/loki { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://golang.org/doc/go1.14

There are Go releases every half a year and we had 1.13 in 19.09, so, it’ll be great to have 1.14 in 20.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/81266)
<!-- Reviewable:end -->
