### PR TITLE
fx_cast_bridge: 0.0.5 -> 0.0.6

### DIFF
--- a/pkgs/tools/misc/fx_cast/default.nix
+++ b/pkgs/tools/misc/fx_cast/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "fx_cast_bridge";
-  version = "0.0.5";
+  version = "0.0.6";
 
   src = fetchurl {
      url = "https://github.com/hensm/fx_cast/releases/download/v${version}/${pname}-${version}-x64.deb";
-     sha256 = "1qmp1d7miq7c2q8i4bhfp5ywxdngvyi7rjl6i82is2g5nhr7gbvv";
+     sha256 = "1mjpwd27b0cpigz4cc2mdl97d78rj5ikn2bqfdic50lqjciaqi1b";
   };
 
   nativeBuildInputs = [ dpkg ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/hensm/fx_cast/releases/tag/v0.0.6

Notably, fixes to work with youtube before "old site" is removed.
(youtube started showing a banner indicating this would happen soon...)

Other goodies too, see the notes :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).