### PR TITLE
tox-node: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/networking/tox-node/default.nix
+++ b/pkgs/tools/networking/tox-node/default.nix
@@ -31,10 +31,7 @@ buildRustPackage rec {
 
   doCheck = false;
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1nv0630yb8k857n7km4bbgf41j747xdxv7xnc6a9746qpggmdbkh";
+  cargoSha256 = "1ka22krw8s05vpamg9naqqf7vv5h8dkpfdik0wy8nispkrxzgb92";
 
   meta = with stdenv.lib; {
     description = "A server application to run tox node written in pure Rust";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.