### PR TITLE
kak-lsp: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/kak-lsp/default.nix
+++ b/pkgs/tools/misc/kak-lsp/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1b9v417g0z9q1sqgnms5vy740xggg4fcz0fdwbc4hfvfj6jkyaad";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0kzrrphlilnyl79yfmlvd6an8iyi8zcs0inwiq74z383lnbdpk7q";
+  cargoSha256 = "1cmms8kvh24sjb0w77i1bwl09wkx3x65p49pkg1j0lipwic3apm3";
 
   buildInputs = lib.optional stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.