### PR TITLE
clog-cli: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/clog-cli/default.nix
+++ b/pkgs/development/tools/clog-cli/default.nix
@@ -13,10 +13,7 @@ buildRustPackage rec {
     sha256 = "1wxglc4n1dar5qphhj5pab7ps34cjr7jy611fwn72lz0f6c7jp3z";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1i1aq7bwkx8sqrlpxq24ldh908j72lwi2r3sg9zaz5p8xq1xgq6p";
+  cargoSha256 = "1s7g9mcjyp0pjjxma1mb290fi7fk54qy2khh1zksxhr4d3mciv08";
 
   meta = {
     description = "Generate changelogs from local git metadata";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.