### PR TITLE
fix node updater

### DIFF
--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -2,7 +2,7 @@
 #! nix-shell shell-generate.nix -i bash
 set -eu -o pipefail
 
-cd "$NODE_NIXPKGS_PATH/pkgs/development/node-packages"
+cd "$NODE_NIXPKGS_PATH"
 rm -f ./node-env.nix
 for version in 10 12 13; do
     tmpdir=$(mktemp -d)

--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -5,11 +5,6 @@ set -eu -o pipefail
 cd "$NODE_NIXPKGS_PATH"
 rm -f ./node-env.nix
 for version in 10 12 13; do
-    tmpdir=$(mktemp -d)
-    node2nix --nodejs-$version -i node-packages-v$version.json -o $tmpdir/node-packages-v$version.nix -c $tmpdir/composition-v$version.nix
-    if [ $? -eq 0 ]; then
-        mv $tmpdir/node-packages-v$version.nix .
-        mv $tmpdir/composition-v$version.nix .
-    fi
+    node2nix --nodejs-$version -i node-packages-v$version.json -o node-packages-v$version.nix -c composition-v$version.nix
 done
 cd -


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The following error since #70974 when running `./generate.sh`:
```
./generate.sh: line 5: cd: /home/user/src/nixpkgs/pkgs/development/node-packages/pkgs/development/node-packages: No such file or directory
```

`$NODE_NIXPKGS_PATH` already points to `/pkgs/development/node-packages`, appending it again makes the path erroneous.

###### Things done

removed duplicate trailing path.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
