### PR TITLE
nixos/rdma-core: 27.0 -> 28.0, update RXE module

### DIFF
--- a/nixos/modules/services/networking/rxe.nix
+++ b/nixos/modules/services/networking/rxe.nix
@@ -5,20 +5,6 @@ with lib;
 let
   cfg = config.networking.rxe;
 
-  runRxeCmd = cmd: ifcs:
-    concatStrings ( map (x: "${pkgs.rdma-core}/bin/rxe_cfg -n ${cmd} ${x};") ifcs);
-
-  startScript = pkgs.writeShellScriptBin "rxe-start" ''
-    ${pkgs.rdma-core}/bin/rxe_cfg -n start
-    ${runRxeCmd "add" cfg.interfaces}
-    ${pkgs.rdma-core}/bin/rxe_cfg
-  '';
-
-  stopScript = pkgs.writeShellScriptBin "rxe-stop" ''
-    ${runRxeCmd "remove" cfg.interfaces }
-    ${pkgs.rdma-core}/bin/rxe_cfg -n stop
-  '';
-
 in {
   ###### interface
 
@@ -31,9 +17,8 @@ in {
         example = [ "eth0" ];
         description = ''
           Enable RDMA on the listed interfaces. The corresponding virtual
-          RDMA interfaces will be named rxe0 ... rxeN where the ordering
-          will be as they are named in the list. UDP port 4791 must be
-          open on the respective ethernet interfaces.
+          RDMA interfaces will be named rxe_<interface>.
+          UDP port 4791 must be open on the respective ethernet interfaces.
         '';
       };
     };
@@ -44,7 +29,6 @@ in {
   config = mkIf cfg.enable {
 
     systemd.services.rxe = {
-      path = with pkgs; [ kmod rdma-core ];
       description = "RoCE interfaces";
 
       wantedBy = [ "multi-user.target" ];
@@ -54,8 +38,13 @@ in {
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStart = "${startScript}/bin/rxe-start";
-        ExecStop = "${stopScript}/bin/rxe-stop";
+        ExecStart = map ( x:
+          "${pkgs.iproute}/bin/rdma link add rxe_${x} type rxe netdev ${x}"
+          ) cfg.interfaces;
+
+        ExecStop = map ( x:
+          "${pkgs.iproute}/bin/rdma link delete rxe_${x}"
+          ) cfg.interfaces;
       };
     };
   };

--- a/nixos/tests/rxe.nix
+++ b/nixos/tests/rxe.nix
@@ -28,7 +28,7 @@ in {
     # Test if rxe interface comes up
     server.wait_for_unit("default.target")
     server.succeed("systemctl status rxe.service")
-    server.succeed("ibv_devices | grep rxe0")
+    server.succeed("ibv_devices | grep rxe_eth1")
 
     client.wait_for_unit("default.target")
 

--- a/pkgs/os-specific/linux/iproute/default.nix
+++ b/pkgs/os-specific/linux/iproute/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, flex, bash, bison, db, iptables, pkgconfig, libelf }:
+{ fetchurl, stdenv, flex, bash, bison, db, iptables, pkgconfig, libelf, libmnl }:
 
 stdenv.mkDerivation rec {
   pname = "iproute2";
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     "CONFDIR=$(out)/etc/iproute2"
   ];
 
-  buildInputs = [ db iptables libelf ];
+  buildInputs = [ db iptables libelf libmnl ];
   nativeBuildInputs = [ bison flex pkgconfig ];
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -4,7 +4,7 @@
 } :
 
 let
-  version = "27.0";
+  version = "28.0";
 
 in stdenv.mkDerivation {
   pname = "rdma-core";
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
     owner = "linux-rdma";
     repo = "rdma-core";
     rev = "v${version}";
-    sha256 = "04mhcrcmbwxcjhswlkhnr6m5nl2389jgjv6aqhd4v0x555cwnfvw";
+    sha256 = "0az2is6p5gkyphi2b978kwn7knry60y33kn6p7cxz49ca79a42cy";
   };
 
   nativeBuildInputs = [ cmake pkgconfig pandoc docutils makeWrapper ];
@@ -26,11 +26,6 @@ in stdenv.mkDerivation {
   ];
 
   postPatch = ''
-    substituteInPlace providers/rxe/rxe_cfg.in \
-      --replace ethtool "${ethtool}/bin/ethtool" \
-      --replace 'ip addr' "${iproute}/bin/ip addr" \
-      --replace 'ip link' "${iproute}/bin/ip link"
-
     substituteInPlace srp_daemon/srp_daemon.sh.in \
       --replace /bin/rm rm
   '';


### PR DESCRIPTION
###### Motivation for this change
Update package and NixOS module

###### Things done
* rdma-core: 27.0 -> 28.0
* update rxe module, replace `rxe_cfg` with `rdma`
* build `iproute` with `libmnl` to enable build of `rmda` utility
* update rxe test

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
