### PR TITLE
peruse: 1.2.20180618 -> 1.2.20200208

### DIFF
--- a/pkgs/tools/misc/peruse/default.nix
+++ b/pkgs/tools/misc/peruse/default.nix
@@ -1,33 +1,55 @@
-{
-  mkDerivation, fetchFromGitHub, lib,
-  extra-cmake-modules, kdoctools, wrapGAppsHook,
-  baloo, karchive, kconfig, kcrash, kfilemetadata, kinit, kirigami2, knewstuff, plasma-framework
+{ mkDerivation
+, fetchFromGitHub
+, lib
+, extra-cmake-modules
+, kdoctools
+, wrapGAppsHook
+, baloo
+, karchive
+, kconfig
+, kcrash
+, kfilemetadata
+, kinit
+, kirigami2
+, knewstuff
+, plasma-framework
 }:
 
-let
+mkDerivation rec {
   pname = "peruse";
-  version = "1.2.20180816";
-
-in mkDerivation {
-  name = "${pname}-${version}";
+  version = "1.2.20200208";
 
   # The last formal release from 2016 uses kirigami1 which is deprecated
   src = fetchFromGitHub {
-    owner  = "KDE";
-    repo   = pname;
-    rev    = "f50027c6c9c680c4e2ce1dba4ec43364e661e7a3";
-    sha256 = "1217fa6w9ryh499agcc67mnp8k9dah4r0sw74qzsbk4p154jbgch";
+    owner = "KDE";
+    repo = pname;
+    rev = "4a1b3f954d2fe7e4919c0c5dbee1917776da582e";
+    sha256 = "1s5yy240x4cvrk93acygnrp5m10xp7ln013gdfbm0r5xvd8xy19k";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    wrapGAppsHook
+  ];
 
-  propagatedBuildInputs = [ baloo karchive kconfig kcrash kfilemetadata kinit kirigami2 knewstuff plasma-framework ];
+  propagatedBuildInputs = [
+    baloo
+    karchive
+    kconfig
+    kcrash
+    kfilemetadata
+    kinit
+    kirigami2
+    knewstuff
+    plasma-framework
+  ];
 
-  pathsToLink = [ "/etc/xdg/peruse.knsrc"];
+  pathsToLink = [ "/etc/xdg/peruse.knsrc" ];
 
   meta = with lib; {
-    homepage = "https://peruse.kde.org";
     description = "A comic book reader";
+    homepage = "https://peruse.kde.org";
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
   };


### PR DESCRIPTION
###### Motivation for this change

The version in master was not actually working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).