### PR TITLE
faust2jaqt: make it work again

### DIFF
--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -20,13 +20,13 @@ with stdenv.lib.strings;
 
 let
 
-  version = "2.20.2";
+  version = "unstable-2020-02-28";
 
   src = fetchFromGitHub {
     owner = "grame-cncm";
     repo = "faust";
-    rev = version;
-    sha256 = "08hv8gyj6c83128z3si92r1ka5ckf9sdpn5jdnlhrqyzja4mrxsy";
+    rev = "c7da997f5f09931eca493eb8eef9defc27493002";
+    sha256 = "08yvxpwrwh9mn1sp1dnqknpbxnph6n7ks91z9rifijss7akf7g41";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/audio/faust/faust2jaqt.nix
+++ b/pkgs/applications/audio/faust/faust2jaqt.nix
@@ -3,6 +3,7 @@
 , opencv
 , qt4
 , libsndfile
+, which
 }:
 
 faust.wrapWithBuildEnv {
@@ -19,6 +20,7 @@ faust.wrapWithBuildEnv {
     opencv
     qt4
     libsndfile
+    which
   ];
 
 }

--- a/pkgs/applications/audio/faust/faust2lv2.nix
+++ b/pkgs/applications/audio/faust/faust2lv2.nix
@@ -2,6 +2,7 @@
 , faust
 , lv2
 , qt4
+, which
 
 }:
 
@@ -9,6 +10,6 @@ faust.wrapWithBuildEnv {
 
   baseName = "faust2lv2";
 
-  propagatedBuildInputs = [ boost lv2 qt4 ];
+  propagatedBuildInputs = [ boost lv2 qt4 which ];
 
 }

--- a/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''
+    echo "hack out autoComp.dsp due to https://github.com/grame-cncm/faust/issues/407 "
+    rm autoComp.dsp
     for f in *.dsp;
     do
       echo "compiling standalone from" $f


### PR DESCRIPTION
My [update from 2.5.23 to 2.20.2](https://github.com/NixOS/nixpkgs/pull/78613#event-3024003262) broke this pkg, this commit fixes it.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
