### PR TITLE
elinks: build with openssl 1.1

### DIFF
--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -18,7 +18,10 @@ stdenv.mkDerivation {
     sha256 = "1nnakbi01g7yd3zqwprchh5yp45br8086b0kbbpmnclabcvlcdiq";
   };
 
-  patches = [ ./gc-init.patch ];
+  patches = [
+    ./gc-init.patch
+    ./openssl-1.1.patch
+  ];
 
   buildInputs = [ ncurses xlibsWrapper bzip2 zlib openssl spidermonkey gpm ]
     ++ stdenv.lib.optional enableGuile guile

--- a/pkgs/applications/networking/browsers/elinks/openssl-1.1.patch
+++ b/pkgs/applications/networking/browsers/elinks/openssl-1.1.patch
@@ -1,0 +1,51 @@
+diff --git a/src/network/ssl/socket.c b/src/network/ssl/socket.c
+index 45b4b4a8..0385a431 100644
+--- a/src/network/ssl/socket.c
++++ b/src/network/ssl/socket.c
+@@ -67,7 +67,9 @@ static void
+ ssl_set_no_tls(struct socket *socket)
+ {
+ #ifdef CONFIG_OPENSSL
+-	((ssl_t *) socket->ssl)->options |= SSL_OP_NO_TLSv1;
++#ifdef SSL_OP_NO_TLSv1
++	SSL_set_options((ssl_t *)socket->ssl, SSL_OP_NO_TLSv1);
++#endif
+ #elif defined(CONFIG_GNUTLS)
+ 	{
+ 		/* GnuTLS does not support SSLv2 because it is "insecure".
+@@ -145,9 +147,11 @@ ssl_connect(struct socket *socket)
+ 		}
+ 
+ 		if (client_cert) {
+-			SSL_CTX *ctx = ((SSL *) socket->ssl)->ctx;
++			SSL_CTX *ctx = SSL_get_SSL_CTX((SSL *) socket->ssl);
+ 
+-			SSL_CTX_use_certificate_chain_file(ctx, client_cert);
++			SSL_CTX_use_certificate_chain_file(
++					(SSL *) socket->ssl,
++					client_cert);
+ 			SSL_CTX_use_PrivateKey_file(ctx, client_cert,
+ 						    SSL_FILETYPE_PEM);
+ 		}
+diff --git a/src/network/ssl/ssl.c b/src/network/ssl/ssl.c
+index c008121d..c06a80a7 100644
+--- a/src/network/ssl/ssl.c
++++ b/src/network/ssl/ssl.c
+@@ -50,11 +50,16 @@ init_openssl(struct module *module)
+ 	 * cannot initialize the PRNG and so every attempt to use SSL fails.
+ 	 * It's actually an OpenSSL FAQ, and according to them, it's up to the
+ 	 * application coders to seed the RNG. -- William Yodlowsky */
+-	if (RAND_egd(RAND_file_name(f_randfile, sizeof(f_randfile))) < 0) {
++	RAND_file_name(f_randfile, sizeof(f_randfile));
++#ifdef HAVE_RAND_EGD
++	if (RAND_egd(f_randfile) < 0) {
+ 		/* Not an EGD, so read and write to it */
++#endif
+ 		if (RAND_load_file(f_randfile, -1))
+ 			RAND_write_file(f_randfile);
++#ifdef HAVE_RAND_EGD
+ 	}
++#endif
+ 
+ 	SSLeay_add_ssl_algorithms();
+ 	context = SSL_CTX_new(SSLv23_client_method());

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18859,9 +18859,7 @@ in
 
   elementary-planner = callPackage ../applications/office/elementary-planner { };
 
-  elinks = callPackage ../applications/networking/browsers/elinks {
-    openssl = openssl_1_0_2;
-  };
+  elinks = callPackage ../applications/networking/browsers/elinks { };
 
   elvis = callPackage ../applications/editors/elvis { };
 


### PR DESCRIPTION
###### Motivation for this change

#80746 reasons. Patch is a combination of [f4a58ba](https://repo.or.cz/elinks.git/commit/f4a58ba3b574a478fd5954ba2c5b29e8b809ff9b) and [54ebe36](https://repo.or.cz/elinks.git/commit/54ebe365b752f8969a67279d0d29552ab638e025).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
