### PR TITLE
python37Packages.fastapi: 0.45.0 -> 0.49.0

### DIFF
--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchurl
 , uvicorn
 , starlette
 , pydantic
@@ -10,11 +11,12 @@
 , pyjwt
 , passlib
 , aiosqlite
+, peewee
 }:
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.45.0";
+  version = "0.49.0";
   format = "flit";
   disabled = !isPy3k;
 
@@ -22,7 +24,7 @@ buildPythonPackage rec {
     owner = "tiangolo";
     repo = "fastapi";
     rev = version;
-    sha256 = "1qwh382ny6qa3zi64micdq4j7dc64zv4rfd8g91j0digd4rhs6i1";
+    sha256 = "1dw5f2xvn0fqqsy29ypba8v3444cy7dvc7gkpmnhshky0rmfni3n";
   };
 
   propagatedBuildInputs = [
@@ -37,15 +39,8 @@ buildPythonPackage rec {
     pyjwt
     passlib
     aiosqlite
+    peewee
   ];
-
-  # starlette pinning kept in place due to 0.12.9 being a hard
-  # dependency luckily fastapi is currently the only dependent on
-  # starlette. Please remove pinning when possible
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "pydantic >=0.32.2,<=0.32.2" "pydantic"
-  '';
 
   checkPhase = ''
     pytest --ignore=tests/test_default_response_class.py

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , aiofiles
 , graphene
 , itsdangerous
@@ -20,12 +20,20 @@
 
 buildPythonPackage rec {
   pname = "starlette";
-  version = "0.13.0";
+
+  # This is not the latest version of Starlette, however, later
+  # versions of Starlette break FastAPI due to
+  # https://github.com/tiangolo/fastapi/issues/683. Please update when
+  # possible. FastAPI is currently Starlette's only dependent.
+
+  version = "0.12.9";
   disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "6bd414152d40d000ccbf6aa40ed89718b40868366a0f69fb83034f416303acef";
+  src = fetchFromGitHub {
+    owner = "encode";
+    repo = pname;
+    rev = version;
+    sha256 = "0w44s8ynzy8w8dgm755c8jina9i4dd87vqkcv7jc1kwkg384w9i5";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

 - Pin Starlette to verion 0.12.9 due to tiangolo/fastapi#683 otherwise fails to build.

 - Add peewee to test environment as now required.

 - Remove pyproject.toml patching as no longer required.

First commit is part of #81304 so that needs to be merged first

These changes need to backported to release-20.03, #80379

This PR partially replaces #81055

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
