### PR TITLE
swaylock-effects: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1085,6 +1085,12 @@
     githubId = 7716744;
     name = "Berno Strik";
   };
+  bram209 = {
+    email = "bram.hoendervangers@gmail.com";
+    github = "bram209";
+    githubId = 9047770;
+    name = "Bram Hoendervangers";
+  };
   brettlyons = {
     email = "blyons@fastmail.com";
     github = "brettlyons";

--- a/pkgs/applications/window-managers/sway/lock-effects.nix
+++ b/pkgs/applications/window-managers/sway/lock-effects.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation rec {
   pname = "swaylock-effects";
-  version = "1.6.0";
+  version = "1.6-0";
 
   src = fetchFromGitHub {
     owner = "mortie";

--- a/pkgs/applications/window-managers/sway/lock-effects.nix
+++ b/pkgs/applications/window-managers/sway/lock-effects.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkgconfig, scdoc
+, wayland, wayland-protocols, libxkbcommon, cairo, gdk-pixbuf, pam
+}:
+
+stdenv.mkDerivation rec {
+  pname = "swaylock-effects";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "mortie";
+    repo = "swaylock-effects";
+    rev = "v${version}";
+    sha256 = "11nap4xylq48pv7qaqxdcz3lbb2hyki8r996rzfzpw467mkxhsr5";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig scdoc ];
+  buildInputs = [ wayland wayland-protocols libxkbcommon cairo gdk-pixbuf pam ];
+
+  mesonFlags = [
+    "-Dpam=enabled" "-Dgdk-pixbuf=enabled" "-Dman-pages=enabled"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Screen locker with effects for Wayland";
+    longDescription = ''
+      swaylock-effects is a screen locking utility with built-in screenshots
+      and image manipulation effects for Wayland compositors.
+    '';
+    homepage = "https://github.com/mortie/swaylock-effects";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ bram209 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19710,6 +19710,8 @@ in
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
   swaylock = callPackage ../applications/window-managers/sway/lock.nix { };
 
+  swaylock-effects = callPackage ../applications/window-managers/sway/lock-effects.nix { };
+
   swaylock-fancy = callPackage ../applications/window-managers/sway/lock-fancy.nix { };
 
   waybar = callPackage ../applications/misc/waybar {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
