### PR TITLE
nix: Patch config.nix.in to reference host platform binaries

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -66,17 +66,15 @@ common =
       preConfigure =
         # Copy libboost_context so we don't get all of Boost in our closure.
         # https://github.com/NixOS/nixpkgs/issues/45462
-        (if is20 then ''
-           mkdir -p $out/lib
-           cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
-           rm -f $out/lib/*.a
-           ${lib.optionalString stdenv.isLinux ''
-             chmod u+w $out/lib/*.so.*
-             patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
-           ''}
-         '' else ''
-           configureFlagsArray+=(BDW_GC_LIBS="-lgc -lgccpp")
-         '') +
+        lib.optionalString is20 ''
+          mkdir -p $out/lib
+          cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
+          rm -f $out/lib/*.a
+          ${lib.optionalString stdenv.isLinux ''
+            chmod u+w $out/lib/*.so.*
+            patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
+          ''}
+        '' +
         # For Nix-2.3, patch around an issue where the Nix configure step pulls in the
         # build system's bash and other utilities when cross-compiling
         lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform && isExactly23) ''
@@ -103,6 +101,7 @@ common =
           "--with-dbi=${perlPackages.DBI}/${perl.libPrefix}"
           "--with-dbd-sqlite=${perlPackages.DBDSQLite}/${perl.libPrefix}"
           "--with-www-curl=${perlPackages.WWWCurl}/${perl.libPrefix}"
+          "BDW_GC_LIBS=\"-lgc -lgccpp\""
         ] ++ lib.optionals (is20 && stdenv.isLinux) [
           "--with-sandbox-shell=${sh}/bin/busybox"
         ]

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -10,6 +10,7 @@ let
 
 common =
   { lib, stdenv, fetchpatch, perl, curl, bzip2, sqlite, openssl ? null, xz
+  , bash, coreutils, gzip, gnutar
   , pkgconfig, boehmgc, perlPackages, libsodium, brotli, boost, editline, nlohmann_json
   , jq, libarchive, rustc, cargo
   , busybox-sandbox-shell
@@ -30,6 +31,7 @@ common =
 
       is20 = lib.versionAtLeast version "2.0pre";
       is24 = lib.versionAtLeast version "2.4pre";
+      isExactly23 = lib.versionAtLeast version "2.3" && lib.versionOlder version "2.4";
 
       VERSION_SUFFIX = suffix;
 
@@ -64,17 +66,31 @@ common =
       preConfigure =
         # Copy libboost_context so we don't get all of Boost in our closure.
         # https://github.com/NixOS/nixpkgs/issues/45462
-        if is20 then ''
-          mkdir -p $out/lib
-          cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
-          rm -f $out/lib/*.a
-          ${lib.optionalString stdenv.isLinux ''
-            chmod u+w $out/lib/*.so.*
-            patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
-          ''}
-        '' else ''
-          configureFlagsArray+=(BDW_GC_LIBS="-lgc -lgccpp")
-        '';
+        (if is20 then ''
+           mkdir -p $out/lib
+           cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
+           rm -f $out/lib/*.a
+           ${lib.optionalString stdenv.isLinux ''
+             chmod u+w $out/lib/*.so.*
+             patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
+           ''}
+         '' else ''
+           configureFlagsArray+=(BDW_GC_LIBS="-lgc -lgccpp")
+         '') +
+        # For Nix-2.3, patch around an issue where the Nix configure step pulls in the
+        # build system's bash and other utilities when cross-compiling
+        lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform && isExactly23) ''
+          mkdir tmp/
+          substitute corepkgs/config.nix.in tmp/config.nix.in \
+            --subst-var-by bash ${bash}/bin/bash \
+            --subst-var-by coreutils ${coreutils}/bin \
+            --subst-var-by bzip2 ${bzip2}/bin/bzip2 \
+            --subst-var-by gzip ${gzip}/bin/gzip \
+            --subst-var-by xz ${xz}/bin/xz \
+            --subst-var-by tar ${gnutar}/bin/tar \
+            --subst-var-by tr ${coreutils}/bin/tr
+          mv tmp/config.nix.in corepkgs/config.nix.in
+          '';
 
       configureFlags =
         [ "--with-store-dir=${storeDir}"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Presently the stable version of nix (2.3.3), when cross-compiled from nixpkgs, will pull into its closure and attempt to invoke the build platform's version of bash. This works around some of the build system for nix to correct that, so that a cross-compiled nix binary can be used on the system it is compiled for.

See #81153 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
