### PR TITLE
pam_ssh_agent_auth: fix dependency on insecure openssl

### DIFF
--- a/pkgs/os-specific/linux/pam_ssh_agent_auth/default.nix
+++ b/pkgs/os-specific/linux/pam_ssh_agent_auth/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pam, openssl, perl }:
+{ stdenv, fetchpatch, fetchurl, pam, openssl, perl }:
 
 stdenv.mkDerivation rec {
   name = "pam_ssh_agent_auth-0.10.3";
@@ -12,9 +12,30 @@ stdenv.mkDerivation rec {
     [ # Allow multiple colon-separated authorized keys files to be
       # specified in the file= option.
       ./multiple-key-files.patch
+      (fetchpatch {
+        name = "openssl-1.1.1-1.patch";
+        url = "https://sources.debian.org/data/main/p/pam-ssh-agent-auth/0.10.3-3/debian/patches/openssl-1.1.1-1.patch";
+        sha256 = "1ndp5j4xfhzshhnl345gb4mkldx6vjfa7284xgng6ikhzpc6y7pf";
+      })
+      (fetchpatch {
+        name = "openssl-1.1.1-2.patch";
+        url = "https://sources.debian.org/data/main/p/pam-ssh-agent-auth/0.10.3-3/debian/patches/openssl-1.1.1-2.patch";
+        sha256 = "0ksrs4xr417by8klf7862n3dircvnw30an1akq4pnsd3ichscmww";
+      })
     ];
 
   buildInputs = [ pam openssl perl ];
+
+  # It's not clear to me why this is necessary, but without it, you see:
+  #
+  # checking OpenSSL header version... 1010104f (OpenSSL 1.1.1d  10 Sep 2019)
+  # checking OpenSSL library version... 1010104f (OpenSSL 1.1.1d  10 Sep 2019)
+  # checking whether OpenSSL's headers match the library... no
+  # configure: WARNING: Your OpenSSL headers do not match your
+  # library. Check config.log for details.
+  #
+  # ...despite the fact that clearly the values match
+  configureFlags = [ "--without-openssl-header-check" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17067,9 +17067,7 @@ in
 
   pam_pgsql = callPackage ../os-specific/linux/pam_pgsql { };
 
-  pam_ssh_agent_auth = callPackage ../os-specific/linux/pam_ssh_agent_auth {
-    openssl = openssl_1_0_2;
-  };
+  pam_ssh_agent_auth = callPackage ../os-specific/linux/pam_ssh_agent_auth { };
 
   pam_u2f = callPackage ../os-specific/linux/pam_u2f { };
 


### PR DESCRIPTION
There have been a couple of patches floating around for about the last
18 months.  While they originated with FreeBSD, but they've been
adopted by Gentoo and Debian as well---and the most straightforward
way to get access to them was from the Debian repository.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Enable the package to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
