### PR TITLE
pythonPackages.sfepy: 2019.2 -> 2019.4

### DIFF
--- a/pkgs/development/python-modules/sfepy/default.nix
+++ b/pkgs/development/python-modules/sfepy/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   name = "sfepy_${version}";
-  version = "2019.2";
+  version = "2019.4";
 
   src = fetchurl {
     url="https://github.com/sfepy/sfepy/archive/release_${version}.tar.gz";
-    sha256 = "17dj0wbchcfa6x27yx4d4jix4z4nk6r2640xkqcsw0mf62x5l1pj";
+    sha256 = "1l9vgcw09l6bwhgfzlbn68fzpvns25r6nkd1pcp7hz5165hs6zzn";
   };
 
   propagatedBuildInputs = [
@@ -33,6 +33,7 @@ buildPythonPackage rec {
   postPatch = ''
     # broken test
     rm tests/test_homogenization_perfusion.py
+    rm tests/test_splinebox.py
 
     # slow tests
     rm tests/test_input_*.py


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

 - Bump the version number to fix incompatibility with Numpy 1.18.1
 - Remove broken test to fix incompatibility with Numpy 1.18.1

This change was mistakenly merged into release-20.03 first with https://github.com/NixOS/nixpkgs/pull/81043. The changes should have gone to master first and then been cherry picked to release-20.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
