### PR TITLE
qimgv: init at 0.8.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1461,6 +1461,16 @@
     githubId = 5684605;
     name = "Cole Scott";
   };
+  cole-h = {
+    name = "Cole Helbling";
+    email = "cole.e.helbling@outlook.com";
+    github = "cole-h";
+    githubId = 28582702;
+    keys = [{
+      longkeyid = "rsa4096/0xB37E0F2371016A4C";
+      fingerprint = "68B8 0D57 B2E5 4AC3 EC1F  49B0 B37E 0F23 7101 6A4C";
+    }];
+  };
   copumpkin = {
     email = "pumpkingod@gmail.com";
     github = "copumpkin";

--- a/pkgs/applications/graphics/qimgv/default.nix
+++ b/pkgs/applications/graphics/qimgv/default.nix
@@ -1,0 +1,49 @@
+{ mkDerivation, fetchFromGitHub, lib
+, pkgconfig, cmake
+, exiv2, qtbase, qtimageformats, qtsvg
+}:
+
+mkDerivation rec {
+  pname = "qimgv";
+  version = "0.8.9";
+
+  src = fetchFromGitHub {
+    owner = "easymodo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0cmya06j466v0pirhxbzbj1vbz0346y7rbc1gbv4n9xcp6c6bln6";
+  };
+
+  cmakeFlags = [
+    # Video support appears to be broken; the following gets printed upon
+    # attempting to view an mp4, webm, or mkv (and probably all video formats):
+    #
+    #   [VideoPlayerInitProxy] Error - could not load player library
+    #   "qimgv_player_mpv"
+    #
+    # GIFs are unaffected. If this ever gets addressed, all that is necessary is
+    # to add `mpv` to the arguments list and to `buildInputs`, and to remove
+    # `cmakeFlags`.
+    "-DVIDEO_SUPPORT=OFF"
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    cmake
+  ];
+
+  buildInputs = [
+    exiv2
+    qtbase
+    qtimageformats
+    qtsvg
+  ];
+
+  meta = with lib; {
+    description = "Qt5 image viewer with optional video support";
+    homepage = "https://github.com/easymodo/qimgv";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cole-h ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21172,6 +21172,8 @@ in
 
   qjackctl = libsForQt5.callPackage ../applications/audio/qjackctl { };
 
+  qimgv = libsForQt5.callPackage ../applications/graphics/qimgv { };
+
   qlandkartegt = libsForQt5.callPackage ../applications/misc/qlandkartegt {};
 
   garmindev = callPackage ../applications/misc/qlandkartegt/garmindev.nix {};


### PR DESCRIPTION
A few notes:

* I only run Linux, so that is what I set `meta.platforms` to. It may or may not build/work on `darwin`.
* Video support is broken in both Nix and Arch builds.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I use `qimgv` all the time. Now I can use it via Nix :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
