### PR TITLE
nixos/tlp: force necessary settings

### DIFF
--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -37,6 +37,21 @@ in
 
   ###### implementation
   config = mkIf cfg.enable {
+    warnings = with builtins.isNull;
+    if !isNull config.powerManagement.scsiLinkPolicy then
+      [ "You've set a non-null value for powerManagement.scsiLinkPolicy. The TLP module will override that decision." ]
+    else if !isNull config.powerManagement.cpuFreqGovernor then
+      [ "You've set a non-null value for powerManagement.cpuFreqGovernor. The TLP module will override that decision." ]
+    else if !isNull config.powerManagement.cpufreq.max then
+      [ "You've set a non-null value for powerManagement.cpufreq.max. The TLP module will override that decision." ]
+    else if !isNull config.powerManagement.cpufreq.min then
+      [ "You've set a non-null value for powerManagement.cpufreq.min. The TLP module will override that decision." ]
+    else if config.systemd.services.systemd-rfkill.enable == true then
+      [ "You've enabled systemd.services.systemd-rfkill. The TLP module will forcefully disable it." ]
+    else if config.systemd.sockets.systemd-rfkill.enable == true then
+      [ "You've enabled systemd.sockets.systemd-rfkill. The TLP module will forcefully disable it." ]
+    else [];
+
     boot.kernelModules = [ "msr" ];
 
     environment.etc = {
@@ -51,10 +66,10 @@ in
     # FIXME: When the config is parametrized we need to move these into a
     # conditional on the relevant options being enabled.
     powerManagement = {
-      scsiLinkPolicy = null;
-      cpuFreqGovernor = null;
-      cpufreq.max = null;
-      cpufreq.min = null;
+      scsiLinkPolicy = lib.mkForce null;
+      cpuFreqGovernor = lib.mkForce null;
+      cpufreq.max = lib.mkForce null;
+      cpufreq.min = lib.mkForce null;
     };
 
     services.udev.packages = [ tlp ];
@@ -64,8 +79,8 @@ in
       # XXX: These must always be disabled/masked according to [1].
       #
       # [1]: https://github.com/linrunner/TLP/blob/a9ada09e0821f275ce5f93dc80a4d81a7ff62ae4/tlp-stat.in#L319
-      sockets.systemd-rfkill.enable = false;
-      services.systemd-rfkill.enable = false;
+      sockets.systemd-rfkill.enable = lib.mkForce false;
+      services.systemd-rfkill.enable = lib.mkForce false;
 
       services.tlp = {
         # XXX: The service should reload whenever the configuration changes,


### PR DESCRIPTION
###### Motivation for this change
TLP is very sensitive to certain system settings that we take care to
disable/nullify in the module code. This takes the further step to
mkForce those options to ensure no insane behavior if the user attempts
to set them in disagreement with the module.

cc. @worldofpeace 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
