### PR TITLE
docker-slim: 1.26.1 -> 1.27.0

### DIFF
--- a/pkgs/applications/virtualization/docker-slim/default.nix
+++ b/pkgs/applications/virtualization/docker-slim/default.nix
@@ -4,26 +4,17 @@
 , makeWrapper
 }:
 
-let
-
-  version = "1.26.1";
-  rev = "2ec04e169b12a87c5286aa09ef44eac1cea2c7a1";
-
-in buildGoPackage rec {
+buildGoPackage rec {
   pname = "docker-slim";
-  inherit version;
+  version = "1.27.0";
 
   goPackagePath = "github.com/docker-slim/docker-slim";
 
   src = fetchFromGitHub {
     owner = "docker-slim";
     repo = "docker-slim";
-    inherit rev;
-    # fetchzip yields a different hash on Darwin because `use-case-hack`
-    sha256 =
-      if stdenv.isDarwin
-      then "0j72rn6qap78qparrnslxm3yv83mzy1yc7ha0crb4frwkzmspyvf"
-      else "01bjb14z7yblm7qdqrx1j2pw5x5da7a6np4rkzay931gly739gbh";
+    rev = version;
+    sha256 = "1pd9sz981qgr5lx6ikrhdp0n21nyrnpjpnyl8i4r2jx35zr8b5q8";
   };
 
   subPackages = [ "cmd/docker-slim" "cmd/docker-slim-sensor" ];
@@ -32,20 +23,12 @@ in buildGoPackage rec {
     makeWrapper
   ];
 
-  # docker-slim vendorized logrus files in different directories, which
-  # conflicts on case-sensitive filesystems
-  preBuild = stdenv.lib.optionalString stdenv.isLinux ''
-    mv go/src/${goPackagePath}/vendor/github.com/Sirupsen/logrus/* \
-      go/src/${goPackagePath}/vendor/github.com/sirupsen/logrus/
-  '';
-
-  buildFlagsArray =
-    let
-      ldflags = "-ldflags=-s -w " +
-                "-X ${goPackagePath}/pkg/version.appVersionTag=${version} " +
-                "-X ${goPackagePath}/pkg/version.appVersionRev=${rev}";
-    in
-      [ ldflags ];
+  buildFlagsArray = [
+    ''-ldflags=
+        -s -w -X ${goPackagePath}/pkg/version.appVersionTag=${version}
+              -X ${goPackagePath}/pkg/version.appVersionRev=${src.rev}
+    ''
+  ];
 
   # docker-slim tries to create its state dir next to the binary (inside the nix
   # store), so we set it to use the working directory at the time of invocation


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/docker-slim/docker-slim/releases/tag/1.27.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
