### PR TITLE
scaleft: Init at 1.41.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3580,6 +3580,12 @@
     githubId = 1058504;
     name = "José Luis Lafuente";
   };
+  jloyet = {
+    email = "ml@fatbsd.com";
+    github = "fatpat";
+    githubId = 822436;
+    name = "Jérôme Loyet";
+  };
   jluttine = {
     email = "jaakko.luttinen@iki.fi";
     github = "jluttine";

--- a/pkgs/applications/networking/scaleft/default.nix
+++ b/pkgs/applications/networking/scaleft/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, rpmextract, patchelf, bash }:
+
+stdenv.mkDerivation rec {
+  pname = "scaleft";
+  version = "1.41.0";
+
+  src =
+    fetchurl {
+      url = "http://pkg.scaleft.com/rpm/scaleft-client-tools-${version}-1.x86_64.rpm";
+      sha256 = "a9a2f60cc85167a1098f44b35efd755b8155f0b88da8572e96ace767e7933c4d";
+    };
+
+  nativeBuildInputs = [ patchelf rpmextract ];
+
+  libPath =
+    stdenv.lib.makeLibraryPath
+       [ stdenv.cc stdenv.cc.cc.lib ];
+
+  buildCommand = ''
+    mkdir -p $out/bin/
+    cd $out
+    rpmextract $src
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      usr/bin/sft
+    patchelf \
+      --set-rpath ${libPath} \
+      usr/bin/sft
+    ln -s $out/usr/bin/sft $out/bin/sft
+    chmod +x $out/bin/sft
+    patchShebangs $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "ScaleFT provides Zero Trust software which you can use to secure your internal servers and services";
+    homepage = "https://www.scaleft.com";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ jloyet ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23781,6 +23781,8 @@ in
 
   sauerbraten = callPackage ../games/sauerbraten {};
 
+  scaleft = callPackage ../applications/networking/scaleft { };
+
   scaleway-cli = callPackage ../tools/admin/scaleway-cli { };
 
   scid = callPackage ../games/scid {


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
