### PR TITLE
https-dns-proxy: init at unstable-20200419

### DIFF
--- a/pkgs/servers/dns/https-dns-proxy/default.nix
+++ b/pkgs/servers/dns/https-dns-proxy/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, gtest, c-ares, curl, libev }:
+
+stdenv.mkDerivation rec {
+  pname = "https-dns-proxy";
+  # there are no stable releases (yet?)
+  version = "unstable-20200419";
+
+  src = fetchFromGitHub {
+    owner = "aarond10";
+    repo = "https_dns_proxy";
+    rev = "79fc7b085e3b1ad64c8332f7115dfe2bf5f1f3e4";
+    sha256 = "1cdfswfjby4alp6gy7yyjm76kfyclh5ax0zadnqs2pyigg9plh0b";
+  };
+
+  nativeBuildInputs = [ cmake gtest ];
+
+  buildInputs = [ c-ares curl libev ];
+
+  installPhase = ''
+    install -Dm555 -t $out/bin https_dns_proxy
+    install -Dm444 -t $out/share/doc/${pname} ../{LICENSE,README}.*
+  '';
+
+  # upstream wants to add tests and the gtest framework is in place, so be ready
+  # for when that happens despite there being none as of right now
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "DNS to DNS over HTTPS (DoH) proxy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15356,6 +15356,8 @@ in
 
   home-assistant-cli = callPackage ../servers/home-assistant/cli.nix { };
 
+  https-dns-proxy = callPackage ../servers/dns/https-dns-proxy { };
+
   hydron = callPackage ../servers/hydron { };
 
   icingaweb2 = callPackage ../servers/icingaweb2 { };


### PR DESCRIPTION
###### Motivation for this change

Some applications support DNS over HTTPS but using the https-dns-proxy, it is
now available to all devices on a network.

This PR was opened on a machine that used a firewall that resolves everything
via https-dns-proxy, so it works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).