### PR TITLE
pykms: fix/enhance logging

### DIFF
--- a/nixos/modules/services/misc/pykms.nix
+++ b/nixos/modules/services/misc/pykms.nix
@@ -82,6 +82,7 @@ in {
         ]);
         ProtectHome = "tmpfs";
         WorkingDirectory = libDir;
+        SyslogIdentifier = "pykms";
         Restart = "on-failure";
         MemoryLimit = cfg.memoryLimit;
       };

--- a/pkgs/tools/networking/pykms/default.nix
+++ b/pkgs/tools/networking/pykms/default.nix
@@ -44,16 +44,14 @@ in buildPythonApplication rec {
 
   propagatedBuildInputs = [ systemd pytz tzlocal ];
 
+  # Fix https://github.com/SystemRage/py-kms/issues/64 :
+  patches = [ ./log-to-current-directory-by-default.patch ];
+
   postPatch = ''
     siteDir=$out/${python3.sitePackages}
 
     substituteInPlace pykms_DB2Dict.py \
       --replace "'KmsDataBase.xml'" "'$siteDir/KmsDataBase.xml'"
-
-    # we are logging to journal
-    sed -i pykms_Misc.py \
-      -e '6ifrom systemd import journal' \
-      -e 's/log_obj.addHandler(log_handler)/log_obj.addHandler(journal.JournalHandler())/'
   '';
 
   format = "other";

--- a/pkgs/tools/networking/pykms/log-to-current-directory-by-default.patch
+++ b/pkgs/tools/networking/pykms/log-to-current-directory-by-default.patch
@@ -1,0 +1,20 @@
+# By default, create log files in current directory, instead of the script directory.
+--- ../original/py-kms/pykms_Client.py
++++ py-kms/pykms_Client.py
+@@ -48,5 +48,5 @@
+                     'choi' : ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "MINI"]},
+         'lfile' : {'help' : 'Use this option to set an output log file. The default is \"pykms_logclient.log\" or type \"STDOUT\" to view log info on stdout.',
+-                   'def' : os.path.dirname(os.path.abspath( __file__ )) + "/pykms_logclient.log", 'des' : "logfile"},
++                   'def' : "pykms_logclient.log", 'des' : "logfile"},
+         'lsize' : {'help' : 'Use this flag to set a maximum size (in MB) to the output log file. Desactivated by default.', 'def' : 0, 'des': "logsize"},
+         }
+--- ../original/py-kms/pykms_Server.py
++++ py-kms/pykms_Server.py
+@@ -85,5 +85,5 @@
+                     'choi' : ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "MINI"]},
+         'lfile' : {'help' : 'Use this option to set or not an output log file. The default is \"pykms_logserver.log\" or type \"STDOUT\" to view log info on stdout.',
+-                   'def' : os.path.dirname(os.path.abspath( __file__ )) + "/pykms_logserver.log", 'des' : "logfile"},
++                   'def' : "pykms_logserver.log", 'des' : "logfile"},
+         'lsize' : {'help' : 'Use this flag to set a maximum size (in MB) to the output log file. Desactivated by default.', 'def' : 0, 'des': "logsize"},
+         }
+    '');


### PR DESCRIPTION
###### Motivation for this change

The current `pykms` package (version 20190611, introduced at https://github.com/NixOS/nixpkgs/commit/bf9cecf28d97b9cbcef5fc65cd8cbd297d405137) does logging in a problematic way: it is sed-patched to log to the systemd journal, but at the same time it still creates a log file inside Nix store by default (if the `--logfile` option is not specified). This prevents this package's binaries from being used without specifying the `--logfile` option. Also, the journal logs are prefixed with a long full path to the python file in Nix store, which make it quite inconvenient to look at them.

So I replaced the current "sed-patch" with another patch which changes the default location of the log file to be in the current directory, and doesn't involve the systemd journal. This way, the binaries can be used without the `--logfile` option.

Also, I added the `SyslogIdentifier` systemd unit option for better identification of pykms' logs.

The result is tested and works as intended.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
