### PR TITLE
[20.03] openssh: 8.1p1 -> 8.2p1

### DIFF
--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libcbor libressl udev ];
+  buildInputs = [ libcbor libressl ] ++ stdenv.lib.optionals stdenv.isLinux [ udev ];
 
   cmakeFlags = [ "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d" ];
 

--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/Yubico/libfido2;
     license = licenses.bsd2;
     maintainers = with maintainers; [ dtzWill ];
-
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, fetchurl, cmake, pkgconfig, libcbor, libressl, udev }:
+{ stdenv, fetchurl, cmake, pkgconfig, libcbor, libressl, udev, IOKit }:
 
 stdenv.mkDerivation rec {
   pname = "libfido2";
-  version = "1.3.0";
+  version = "1.3.1";
   src = fetchurl {
     url = "https://developers.yubico.com/${pname}/Releases/${pname}-${version}.tar.gz";
-    sha256 = "1izyl3as9rn7zcxpsvgngjwr55gli5gy822ac3ajzm65qiqkcbhb";
+    sha256 = "0hdgxbmjbnm9kjwc07nrl2zy87qclvb3rzvdwr5iw35n2qhf4dds";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libcbor libressl ] ++ stdenv.lib.optionals stdenv.isLinux [ udev ];
+  buildInputs = [ libcbor libressl ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ udev ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
 
-  cmakeFlags = [ "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d" ];
+  patches = [ ./detect_apple_ld.patch ];
+
+  cmakeFlags = [ "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d"
+                 "-DCMAKE_INSTALL_LIBDIR=lib" ];
 
   meta = with stdenv.lib; {
     description = ''
@@ -20,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/Yubico/libfido2;
     license = licenses.bsd2;
     maintainers = with maintainers; [ dtzWill ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libfido2/detect_apple_ld.patch
+++ b/pkgs/development/libraries/libfido2/detect_apple_ld.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2020-02-19 17:21:59.000000000 +0000
++++ b/CMakeLists.txt	2020-02-23 15:57:34.241115306 +0000
+@@ -296,7 +296,7 @@
+ endif()
+ 
+ # export list
+-if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
++if(APPLE AND CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")	
+ 	# clang + lld
+ 	string(CONCAT CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS}
+ 	    " -exported_symbols_list ${CMAKE_CURRENT_SOURCE_DIR}/src/export.llvm")

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -22,12 +22,12 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "openssh";
-  version = if hpnSupport then "7.8p1" else "8.2p1";
+  version = if hpnSupport then "8.1p1" else "8.2p1";
 
   src = if hpnSupport then
       fetchurl {
-        url = "https://github.com/rapier1/openssh-portable/archive/hpn-KitchenSink-7_8_P1.tar.gz";
-        sha256 = "05q5hxx7fzcgd8a5i0zk4fwvmnz4xqk04j489irnwm7cka7xdqxw";
+        url = "https://github.com/rapier1/openssh-portable/archive/hpn-KitchenSink-8_1_P1.tar.gz";
+        sha256 = "1xiv28df9c15h44fv1i93fq8rvkyapjj9vj985ndnw3xk1nvqjyd";
       }
     else
       fetchurl {
@@ -43,15 +43,7 @@ stdenv.mkDerivation rec {
       ./dont_create_privsep_path.patch
 
       ./ssh-keysign.patch
-    ] ++ optional hpnSupport
-      # CVE-2018-20685, can probably be dropped with next version bump
-      # See https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
-      # for details
-      (fetchpatch {
-        name = "CVE-2018-20685.patch";
-        url = https://github.com/openssh/openssh-portable/commit/6010c0303a422a9c5fa8860c061bf7105eb7f8b2.patch;
-        sha256 = "0q27i9ymr97yb628y44qi4m11hk5qikb1ji1vhvax8hp18lwskds";
-      })
+    ]
     ++ optional withGssapiPatches (assert withKerberos; gssapiPatch);
 
   postPatch =
@@ -112,6 +104,5 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.bsd2;
     platforms = platforms.unix ++ platforms.windows;
     maintainers = with maintainers; [ eelco aneeshusa ];
-    broken = hpnSupport;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12414,7 +12414,9 @@ in
 
   libfakekey = callPackage ../development/libraries/libfakekey { };
 
-  libfido2 = callPackage ../development/libraries/libfido2 { };
+  libfido2 = callPackage ../development/libraries/libfido2 {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
 
   libfilezilla = callPackage ../development/libraries/libfilezilla { };
 


### PR DESCRIPTION
###### Motivation for this change

Backport of OpenSSH 8.2p1 as discussed in https://github.com/NixOS/nixpkgs/pull/80196

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
