### PR TITLE
bup: 0.29.2 -> 0.29.3

### DIFF
--- a/pkgs/tools/backup/bup/default.nix
+++ b/pkgs/tools/backup/bup/default.nix
@@ -5,7 +5,7 @@
 
 assert par2Support -> par2cmdline != null;
 
-let version = "0.29.2"; in
+let version = "0.29.3"; in
 
 with stdenv.lib;
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     repo = "bup";
     owner = "bup";
     rev = version;
-    sha256 = "17lpbyhf43gcln5s43m2zzgichcx7jq6ragcawfklw6svg1vnj89";
+    sha256 = "1b5ynljd9gs1vzbsa0kggw32s3r4zhbprc2clvjm5qmvnx23hxh8";
   };
 
   buildInputs = [


### PR DESCRIPTION
(cherry picked from commit 219ddc54e498cb875b2dd7ac37036e5cb6bf8a3d)

###### Motivation for this change

bup-0.29.2 which is currently in release-19.09 can't be built from source due to source hash mismatch:

```
> nix-build -A bup '<nixpkgs>' --substituters ''
these derivations will be built:
  /nix/store/jf4gjiy8wrw6h55gprwjjf4ywp20s4ih-source.drv
  /nix/store/5j3zz2xmb9gcy6594bmnj85f87jmmjhx-bup-0.29.2.drv
building '/nix/store/jf4gjiy8wrw6h55gprwjjf4ywp20s4ih-source.drv'...
error checking the existence of http://tarballs.nixos.org/sha256/17lpbyhf43gcln5s43m2zzgichcx7jq6ragcawfklw6svg1vnj89:
curl: (28) Connection timed out after 15000 milliseconds

trying https://github.com/bup/bup/archive/0.29.2.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   115  100   115    0     0    218      0 --:--:-- --:--:-- --:--:--   217
100  380k    0  380k    0     0   176k      0 --:--:--  0:00:02 --:--:--  353k
unpacking source archive /build/0.29.2.tar.gz
hash mismatch in fixed-output derivation '/nix/store/78m4hkq1nca176ncjgjd3ylhcsgkj0pj-source':
  wanted: sha256:17lpbyhf43gcln5s43m2zzgichcx7jq6ragcawfklw6svg1vnj89
  got:    sha256:07bllb9gi6mrgs28v2jdlsz7aq3vhlv60g65n3k1sir0q3xi2q6v
cannot build derivation '/nix/store/5j3zz2xmb9gcy6594bmnj85f87jmmjhx-bup-0.29.2.drv': 1 dependencies couldn't be built
error: build of '/nix/store/5j3zz2xmb9gcy6594bmnj85f87jmmjhx-bup-0.29.2.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
