### PR TITLE
haskellPackages.stack: get building with ghc882

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1400,4 +1400,27 @@ self: super: {
   # https://github.com/bergmark/feed/issues/43
   feed = dontCheck super.feed;
 
+  pantry = appendPatches super.pantry [
+    # Pantry has been updated for ghc-8.8 upstream, but there hasn't been a
+    # release yet with this patch. This can probably be removed when a
+    # version of pantry is released after 0.2.0.0.
+    # https://github.com/commercialhaskell/pantry/pull/6
+    (pkgs.fetchpatch {
+      url = "https://github.com/commercialhaskell/pantry/pull/6.diff";
+      sha256 = "0aml06jshpjh3aiscs5av7y33m3d6s6x5pzdvh7pky476izfg87k";
+      excludes = [
+        ".azure/azure-linux-template.yml"
+        ".azure/azure-osx-template.yml"
+        ".azure/azure-windows-template.yml"
+        "package.yaml"
+        "pantry.cabal"
+        "stack-lts-11.yaml"
+        "stack-lts-12.yaml"
+        "stack-nightly.yaml"
+        "stack-windows.yaml"
+        "stack.yaml"
+      ];
+    })
+  ];
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1071,8 +1071,28 @@ self: super: {
 
   # Generate shell completion.
   cabal2nix = generateOptparseApplicativeCompletion "cabal2nix" super.cabal2nix;
-  stack = generateOptparseApplicativeCompletion "stack" (super.stack.overrideScope (self: super: {
-  }));
+
+  stack =
+    generateOptparseApplicativeCompletion
+      "stack"
+      (appendPatches super.stack [
+        # This PR fixes stack up to be able to build with Cabal-3.  This patch
+        # can probably be dropped when the next stack release is made after
+        # 2.1.3.1.
+        (pkgs.fetchpatch {
+          url = "https://github.com/commercialhaskell/stack/pull/5156.diff";
+          sha256 = "0knk6f9fh1b4fxkhvx5gfrwclal4vi2va4zy34gpmwnjr7knf42y";
+          excludes = [
+            "snapshot-lts-12.yaml"
+            "snapshot-nightly.yaml"
+            "snapshot.yaml"
+          ];
+        })
+        # This patch fixes stack up to be able to build various GHC-8.8 changes.
+        # This can hopefully be dropped when the next stack release is made
+        # after 2.1.3.1 (assuming the next stack release uses GHC-8.8).
+        ./patches/stack-ghc882-support.patch
+      ]);
 
   # musl fixes
   # dontCheck: use of non-standard strptime "%s" which musl doesn't support; only used in test

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8026,7 +8026,6 @@ broken-packages:
   - pangraph
   - panpipe
   - pansite
-  - pantry
   - pantry-tmp
   - papa
   - papa-base

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9572,7 +9572,6 @@ broken-packages:
   - stable-marriage
   - stable-memo
   - stable-tree
-  - stack
   - stack-bump
   - stack-fix
   - stack-hpc-coveralls

--- a/pkgs/development/haskell-modules/patches/stack-ghc882-support.patch
+++ b/pkgs/development/haskell-modules/patches/stack-ghc882-support.patch
@@ -1,0 +1,104 @@
+diff --git a/src/Stack/Coverage.hs b/src/Stack/Coverage.hs
+index d95fa332..f80e121a 100644
+--- a/src/Stack/Coverage.hs
++++ b/src/Stack/Coverage.hs
+@@ -235,7 +235,7 @@ generateHpcReportForTargets opts tixFiles targetNames = do
+                              case nc of
+                                  CTest testName ->
+                                      liftM (pkgPath </>) $ parseRelFile (T.unpack testName ++ "/" ++ T.unpack testName ++ ".tix")
+-                                 _ -> fail $
++                                 _ -> liftIO $ fail $
+                                      "Can't specify anything except test-suites as hpc report targets (" ++
+                                      packageNameString name ++
+                                      " is used with a non test-suite target)"
+diff --git a/src/Stack/Package.hs b/src/Stack/Package.hs
+index b69337ce..08eb9b9f 100644
+--- a/src/Stack/Package.hs
++++ b/src/Stack/Package.hs
+@@ -463,7 +463,7 @@ makeObjectFilePathFromC
+ makeObjectFilePathFromC cabalDir namedComponent distDir cFilePath = do
+     relCFilePath <- stripProperPrefix cabalDir cFilePath
+     relOFilePath <-
+-        parseRelFile (replaceExtension (toFilePath relCFilePath) "o")
++        parseRelFile (System.FilePath.replaceExtension (toFilePath relCFilePath) "o")
+     return (componentOutputDir namedComponent distDir </> relOFilePath)
+ 
+ -- | Make the global autogen dir if Cabal version is new enough.
+diff --git a/src/Stack/Script.hs b/src/Stack/Script.hs
+index c63c9f62..70257be1 100644
+--- a/src/Stack/Script.hs
++++ b/src/Stack/Script.hs
+@@ -172,8 +172,8 @@ scriptCmd opts = do
+ 
+   toExeName fp =
+     if osIsWindows
+-      then replaceExtension fp "exe"
+-      else dropExtension fp
++      then System.FilePath.replaceExtension fp "exe"
++      else System.FilePath.dropExtension fp
+ 
+ getPackagesFromImports
+   :: FilePath -- ^ script filename
+diff --git a/src/Stack/Setup.hs b/src/Stack/Setup.hs
+index 8bbfc45c..5c5b028c 100644
+--- a/src/Stack/Setup.hs
++++ b/src/Stack/Setup.hs
+@@ -876,7 +876,7 @@ buildGhcFromSource getSetupInfo' installed (CompilerRepository url) commitId fla
+          (_,files) <- listDir (cwd </> bindistPath)
+          let
+            isBindist p = "ghc-" `isPrefixOf` (toFilePath (filename p))
+-                         && fileExtension (filename p) == ".xz"
++                         && (maybe "" id (fileExtension (filename p))) == ".xz"
+            mbindist = filter isBindist files
+          case mbindist of
+            [bindist] -> do
+diff --git a/src/Stack/Storage/Project.hs b/src/Stack/Storage/Project.hs
+index dc5318d8..984e6259 100644
+--- a/src/Stack/Storage/Project.hs
++++ b/src/Stack/Storage/Project.hs
+@@ -12,6 +12,9 @@
+ {-# LANGUAGE UndecidableInstances #-}
+ {-# OPTIONS_GHC -Wno-unused-top-binds -Wno-identities #-}
+ 
++{-# LANGUAGE DerivingStrategies #-}
++{-# LANGUAGE StandaloneDeriving #-}
++
+ -- | Work with SQLite database used for caches across a single project.
+ module Stack.Storage.Project
+     ( initProjectStorage
+diff --git a/src/Stack/Storage/User.hs b/src/Stack/Storage/User.hs
+index 3845b094..09695344 100644
+--- a/src/Stack/Storage/User.hs
++++ b/src/Stack/Storage/User.hs
+@@ -12,6 +12,9 @@
+ {-# LANGUAGE UndecidableInstances #-}
+ {-# OPTIONS_GHC -Wno-unused-top-binds -Wno-identities #-}
+ 
++{-# LANGUAGE DerivingStrategies #-}
++{-# LANGUAGE StandaloneDeriving #-}
++
+ -- | Work with SQLite database used for caches across an entire user account.
+ module Stack.Storage.User
+     ( initUserStorage
+diff --git a/src/Stack/Types/Config.hs b/src/Stack/Types/Config.hs
+index a5cc22b5..a329d353 100644
+--- a/src/Stack/Types/Config.hs
++++ b/src/Stack/Types/Config.hs
+@@ -406,7 +406,7 @@ instance FromJSON CabalConfigKey where
+ instance FromJSONKey CabalConfigKey where
+   fromJSONKey = FromJSONKeyTextParser parseCabalConfigKey
+ 
+-parseCabalConfigKey :: Monad m => Text -> m CabalConfigKey
++parseCabalConfigKey :: MonadFail m => Text -> m CabalConfigKey
+ parseCabalConfigKey "$targets" = pure CCKTargets
+ parseCabalConfigKey "$locals" = pure CCKLocals
+ parseCabalConfigKey "$everything" = pure CCKEverything
+@@ -974,7 +974,7 @@ parseConfigMonoidObject rootDir obj = do
+ 
+     return ConfigMonoid {..}
+   where
+-    handleExplicitSetupDep :: Monad m => (Text, Bool) -> m (Maybe PackageName, Bool)
++    handleExplicitSetupDep :: MonadFail m => (Text, Bool) -> m (Maybe PackageName, Bool)
+     handleExplicitSetupDep (name', b) = do
+         name <-
+             if name' == "*"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This gets `haskellPackages.stack` building again after the update to ghc882.

Fixes #81338.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
