### PR TITLE
system-syzygy: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/games/system-syzygy/default.nix
+++ b/pkgs/games/system-syzygy/default.nix
@@ -23,10 +23,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ SDL2 ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "03724z33dqxbbrzpvz172qh45qrgnyb801algjdcm32v8xsx81qg";
+  cargoSha256 = "001cwdq8zxji56yahwfsydi7s0j7c5zsip60lxk3qmn078wcipdp";
 
   postInstall = ''
     mkdir -p $out/share/syzygy/


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.