### PR TITLE
Pipewire 0.3.0

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,15 +1,35 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, doxygen, graphviz, valgrind
-, glib, dbus, gst_all_1, alsaLib, ffmpeg, libjack2, udev, libva, xorg
-, sbc, SDL2, makeFontsConf
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkgconfig
+, doxygen
+, graphviz
+, valgrind
+, glib
+, dbus
+, gst_all_1
+, alsaLib
+, ffmpeg
+, libjack2
+, udev
+, libva
+, xorg
+, sbc
+, SDL2
+, makeFontsConf
 }:
 
 let
   fontsConf = makeFontsConf {
-    fontDirectories = [ ];
+    fontDirectories = [];
   };
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "pipewire";
   version = "0.2.7";
+
+  outputs = [ "out" "lib" "dev" "doc" ];
 
   src = fetchFromGitHub {
     owner = "PipeWire";
@@ -18,14 +38,28 @@ in stdenv.mkDerivation rec {
     sha256 = "1q5wrqnhhs6r49p8yvkw1pl0cnsd4rndxy4h5lvdydwgf1civcwc";
   };
 
-  outputs = [ "out" "lib" "dev" "doc" ];
-
   nativeBuildInputs = [
-    meson ninja pkgconfig doxygen graphviz valgrind
+    doxygen
+    graphviz
+    meson
+    ninja
+    pkgconfig
+    valgrind
   ];
+
   buildInputs = [
-    glib dbus gst_all_1.gst-plugins-base gst_all_1.gstreamer
-    alsaLib ffmpeg libjack2 udev libva xorg.libX11 sbc SDL2
+    SDL2
+    alsaLib
+    dbus
+    ffmpeg
+    glib
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    libjack2
+    libva
+    sbc
+    udev
+    xorg.libX11
   ];
 
   mesonFlags = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Mutter 3.36 will depend on this https://gitlab.gnome.org/GNOME/mutter/-/blob/84275688f32b1a15a2cb60447ecbf75b526c164a/meson.build#L53

This is a draft because **merging this will break stuff** until other releases have been made.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
