### PR TITLE
git-backup: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/version-management/git-backup/default.nix
+++ b/pkgs/applications/version-management/git-backup/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0h31j8clvk4gkw4mgva9p0ypf26zhf7f0y564fdmzyw6rsz9wzcj";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1vfyhfdy5ks9zs9sy61ck9459w86hn9v6jqcar7rib82bclzr1mx";
+  cargoSha256 = "09nfvzvgpdl5glzjays4lm50iwvjzbz364y6agya1a94qqwkaj7f";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.