### PR TITLE
libvmaf: 1.3.15 -> 1.5.1

### DIFF
--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -1,31 +1,26 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, intltool, libtool, pkgconfig }:
+{ stdenv, fetchFromGitHub, meson, ninja }:
 
 stdenv.mkDerivation rec {
   pname = "libvmaf";
-  version = "1.3.15";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "netflix";
     repo = "vmaf";
     rev = "v${version}";
-    sha256="10kgcdf06hzhbl5r7zsllq88bxbyn282hfqx5i3hkp66fpq896d2";
+    sha256 = "10fw53k9k4aq4p2qi5qkfjfnhldw4p5bbmxggf8220gfa95nvyl3";
   };
 
-  nativeBuildInputs = [ autoconf automake intltool libtool pkgconfig ];
+  sourceRoot = "source/libvmaf";
+
+  nativeBuildInputs = [ meson ninja ];
   outputs = [ "out" "dev" ];
   doCheck = true;
-
-  postFixup = ''
-    substituteInPlace "$dev/lib/pkgconfig/libvmaf.pc" \
-      --replace "includedir=/usr/local/include" "includedir=$dev"
-  '';
-
-  makeFlags = [ "INSTALL_PREFIX=${placeholder "out"}" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/Netflix/vmaf";
     description = "Perceptual video quality assessment based on multi-method fusion (VMAF)";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.asl20;
     maintainers = [ maintainers.cfsmp3 ];
   };

--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     description = "Perceptual video quality assessment based on multi-method fusion (VMAF)";
     platforms = platforms.unix;
     license = licenses.asl20;
-    maintainers = [ maintainers.cfsmp3 ];
+    maintainers = [ maintainers.cfsmp3 maintainers.marsam ];
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11376,7 +11376,6 @@ in
     frei0r = if stdenv.isDarwin then null else frei0r;
     game-music-emu = if stdenv.isDarwin then null else game-music-emu;
     libjack2 = if stdenv.isDarwin then null else libjack2;
-    libvmaf = if stdenv.isDarwin then null else libvmaf;
     libmodplug = if stdenv.isDarwin then null else libmodplug;
     openal = if stdenv.isDarwin then null else openal;
     libmfx = if stdenv.isDarwin then null else intel-media-sdk;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/Netflix/vmaf/releases/tag/v1.5.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
