### PR TITLE
cargo-generate: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/rust/cargo-generate/default.nix
+++ b/pkgs/development/tools/rust/cargo-generate/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "07hklya22ixklb44f3qp6yyh5d03a7rjcn0g76icqr36hvcjyjjh";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1rsk9j1ij53dz4gakxwdppgmv12lmyj0ihh9qypdbgskvyq3a2j9";
+  cargoSha256 = "133n8j4d0j0rasns3a4kkflhrvmvkqfggcrfj4sp79am19pr146b";
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.