### PR TITLE
cargo-fuzz: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/rust/cargo-fuzz/default.nix
+++ b/pkgs/development/tools/rust/cargo-fuzz/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0qy4xb7bxyw2x2ya7zmbkz48wxb69jcnvvj7021f1kyc6wdwcxs7";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1d42cmpg1yn1ql9isx26kxsxzf5rg6qw6j948skc5p054r0c9n3f";
+  cargoSha256 = "0d24crgx6wrb1p96w2yww7cs474x2pz4i6f26cry8pf5dwqfsqdm";
 
   meta = with stdenv.lib; {
     description = "Command line helpers for fuzzing";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.