### PR TITLE
cargo-udeps: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/rust/cargo-udeps/default.nix
+++ b/pkgs/development/tools/rust/cargo-udeps/default.nix
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1wh8w5p9rb9cqgpmclaywfsz3ckfi9mw38hhg31w7hkgjmqalyj9";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0vb2qr03qv66mmxgs1d5fvs63cdfxaldlg7pilhmdzha1kgy7ib0";
+  cargoSha256 = "0g56rvan0p57hkl00warx4ig7a54g0qw6p2gkwn9yxi6p3p2wddj";
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.