### PR TITLE
tiny: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/networking/irc/tiny/default.nix
+++ b/pkgs/applications/networking/irc/tiny/default.nix
@@ -19,10 +19,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1m57xsrc7lzkrm8k1wh3yx3in5bhd0qjzygxdwr8lvigpsiy5caa";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1vj6whnx8gd5r66zric9163ddlqc4al4azj0dvhv5sq0r33871kv";
+  cargoSha256 = "1s93zxk85wa7zw8745ba1sgipal75w1y18nc9vca6sig4pzvvj41";
 
   RUSTC_BOOTSTRAP = 1;
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.