### PR TITLE
click: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/applications/networking/cluster/click/default.nix
+++ b/pkgs/applications/networking/cluster/click/default.nix
@@ -13,10 +13,7 @@ buildRustPackage rec {
     sha256 = "18mpzvvww2g6y2d3m8wcfajzdshagihn59k03xvcknd5d8zxagl3";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0298x7wkr4j1l5flmv5vhl1ay8icvh4dlhsh4xi8fd3p8jl9jpqv";
+  cargoSha256 = "1f9yn4pvp58laylngdrfdkwygisnzkhkm7pndf6l33k3aqxhz5mm";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.