### PR TITLE
[ZHF] pythonPackages.astroquery 0.3.10 -> 0.4

### DIFF
--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -9,21 +9,26 @@
 , pytest
 , pytest-astropy
 , astropy-helpers
+, isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "astroquery";
-  version = "0.3.10";
+  version = "0.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ce57a8792c7d5d74206d797d379de6da35d56be433ea5840c41a49f202e2fab";
+    sha256 = "1ddwnj9vpvxkrfb45c4pwv5f5za9kn2q0040dpw2ymj2bwlpl61h";
   };
+
+  disabled = !isPy3k;
 
   propagatedBuildInputs = [ astropy requests keyring beautifulsoup4 html5lib ];
 
   nativeBuildInputs = [ astropy-helpers ];
 
+  # Tests disabled until pytest-astropy has been updated to include pytest-astropy-header
+  doCheck = false;
   checkInputs = [ pytest pytest-astropy ];
 
   # Disable automatic update of the astropy-helper module


### PR DESCRIPTION
###### Motivation for this change

Backport #80552 to the 20.03 release branch.

ZHF: #80379
cc @NixOS/nixos-release-managers 
