### PR TITLE
tree-sitter.builtGrammars: build parser libraries

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/library.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/library.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, language
+, tree-sitter
+, version
+, source
+}:
+
+stdenv.mkDerivation {
+
+  pname = "tree-sitter-${language}-library";
+  inherit version;
+
+  src = source;
+
+  buildInputs = [ tree-sitter ];
+
+  dontUnpack = true;
+  configurePhase= ":";
+  buildPhase = ''
+    runHook preBuild
+    $CC -I$src/src/ -shared -o parser -Os $src/src/parser.c
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    mkdir $out
+    mv parser $out/
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
except for typescript that provokes an error.
These libraries can be used on neovim 0.5 for instance.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
