### PR TITLE
elm-format: 0.8.2 -> 0.8.3

### DIFF
--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -6,11 +6,11 @@
 }:
 mkDerivation {
   pname = "elm-format";
-  version = "0.8.2";
+  version = "0.8.3";
   src = fetchgit {
     url = "https://github.com/avh4/elm-format";
-    sha256 = "0ly37fszrfviwqgrww57ikdcr7i8lcpczhqm8xqp5s7mrlpdxv7z";
-    rev = "ab3627cce01e5556b3fe8c2b5e3d92b80bfc74af";
+    sha256 = "0n6lrqj6mq044hdyraj3ss5cg74dn8k4z05xmwn2apjpm146iaw8";
+    rev = "b97e3593d564a1e069c0a022da8cbd98ca2c5a4b";
   };
   postPatch = ''
     mkdir -p ./generated
@@ -18,7 +18,7 @@ mkDerivation {
     module Build_elm_format where
 
     gitDescribe :: String
-    gitDescribe = "0.8.2"
+    gitDescribe = "0.8.3"
     EOHS
   '';
   isLibrary = false;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New release of elm-format.  https://github.com/avh4/elm-format/releases/tag/0.8.3 Changelog:

Bug fixes:

- performance is improved, allowing excessively long lists to be formatted without crashing


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
