### PR TITLE
linux: add policy routing config flag

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -104,6 +104,7 @@ let
 
     networking = {
       NET                = yes;
+      IP_ADVANCED_ROUTER = yes;
       IP_PNP             = no;
       IP_VS_PROTO_TCP    = yes;
       IP_VS_PROTO_UDP    = yes;
@@ -126,6 +127,7 @@ let
       IP_ROUTE_VERBOSE            = yes;
       IP_MROUTE_MULTIPLE_TABLES   = yes;
       IP_MULTICAST                = yes;
+      IP_MULTIPLE_TABLES          = yes;
       IPV6_ROUTER_PREF            = yes;
       IPV6_ROUTE_INFO             = yes;
       IPV6_OPTIMISTIC_DAD         = yes;


### PR DESCRIPTION
###### Motivation for this change
Continuation of https://github.com/NixOS/nixpkgs/pull/81405#issuecomment-593000149

`CONFIG_IP_MULTIPLE_TABLES` is part of the default x86 kernel config but
absent from the Aarch64 one. Adding this flag on the aarch64 config to
align it with the x86.

I did not use any `option` guard here: it seem like this flag is supported since Linux 2.5.45 https://cateee.net/lkddb/web-lkddb/IP_MULTIPLE_TABLES.html

Disclaimer: I do not have access to a aarch64 machine to try this out + I don't really know what I'm doing.

CC @samueldr 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Fixes https://github.com/NixOS/nixpkgs/issues/61602
