### PR TITLE
cocotb: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "cocotb";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "091q63jcm87xggqgqi44lw2vjxhl1v4yl0mv2c76hgavb29w4w5y";
+    sha256 = "0gwd79zm7196fhnbzbdpyvgzsfjfzl3pmc5hh27h7hckfpxzj9yw";
   };
 
   propagatedBuildInputs = [
@@ -24,10 +24,10 @@ buildPythonPackage rec {
       cocotb/share/makefiles/simulators/Makefile.*
     do
       substituteInPlace $f --replace 'shell which' 'shell command -v'
-      # replace hardcoded gcc. Remove once https://github.com/cocotb/cocotb/pull/1137 gets merged
-      substituteInPlace $f --replace 'gcc' '$(CC)'
-      substituteInPlace $f --replace 'g++' '$(CXX)'
     done
+
+    # This can probably be removed in the next update after 1.3.0
+    substituteInPlace cocotb/share/makefiles/Makefile.inc --replace "-Werror" ""
   '';
 
   checkInputs = [ swig verilog ];
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python";
-    homepage = https://github.com/cocotb/cocotb;
+    homepage = "https://github.com/cocotb/cocotb";
     license = licenses.bsd3;
     maintainers = with maintainers; [ matthuszagh ];
   };


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New release of cocotb. Changelog: https://cocotb.readthedocs.io/en/latest/release_notes.html#cocotb-1-3-0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
