### PR TITLE
recursive: 1.030 -> 1.042

### DIFF
--- a/pkgs/data/fonts/recursive/default.nix
+++ b/pkgs/data/fonts/recursive/default.nix
@@ -1,24 +1,23 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
-stdenv.mkDerivation rec {
-  pname = "recursive";
-  version = "1.030";
+let
+  version = "1.042";
+in
+fetchzip {
+  name = "recursive-${version}";
 
-  src = fetchzip {
-    url = "https://github.com/arrowtype/recursive/releases/download/${version}/recursive-beta_1_030--statics.zip";
-    sha256 = "1clds4ljiqdf0zc3b7nlna1w7kc23pc9gxdd5vwbgmz9xfvkam0f";
-    stripRoot = false;
-  };
+  url = "https://github.com/arrowtype/recursive/releases/download/${version}/Recursive-Beta_${version}.zip";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,woff2}
-    find -name "*.otf" -exec cp "{}" $out/share/fonts/opentype \;
-    find -name "*.ttf" -exec cp "{}" $out/share/fonts/truetype \;
-    find -name "*.woff2" -exec cp "{}" $out/share/fonts/woff2 \;
+  postFetch = ''
+    mkdir -p $out/share/fonts/
+    unzip -j $downloadedFile \*.ttf   -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2
   '';
 
-  meta = with stdenv.lib; {
-    homepage = https://github.com/arrowtype/recursive;
+  sha256 = "1zcrvnzwd39fim2jxa3by6jgdrx7fdp64iw2bd181iwzinv1yqsa";
+
+  meta = with lib; {
+    homepage = "https://recursive.design/";
     description = "A variable font family for code & UI";
     license = licenses.ofl;
     maintainers = [ maintainers.eadwu ];


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/arrowtype/recursive/releases/tag/1.042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
