### PR TITLE
megasync: fix build with glibc 2.30

### DIFF
--- a/pkgs/applications/misc/megasync/default.nix
+++ b/pkgs/applications/misc/megasync/default.nix
@@ -68,6 +68,9 @@ mkDerivation rec {
     ./noinstall-distro-version.patch
     # megasync target is not part of the install rule thanks to a commented block
     ./install-megasync.patch
+    # https://github.com/meganz/MEGAsync/issues/366
+    # https://chromium.googlesource.com/breakpad/breakpad/+/7e3c165000d44fa153a3270870ed500bc8bbb461%5E%21/#F0
+    ./fix-breakpad.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/misc/megasync/fix-breakpad.patch
+++ b/pkgs/applications/misc/megasync/fix-breakpad.patch
@@ -1,0 +1,25 @@
+diff -ur source-a/src/MEGASync/google_breakpad/client/linux/handler/exception_handler.cc source-b/src/MEGASync/google_breakpad/client/linux/handler/exception_handler.cc
+--- source-a/src/MEGASync/google_breakpad/client/linux/handler/exception_handler.cc	1970-01-01 09:00:01.000000000 +0900
++++ source-b/src/MEGASync/google_breakpad/client/linux/handler/exception_handler.cc	2020-03-01 18:18:09.142104648 +0900
+@@ -103,12 +103,6 @@
+ #define PR_SET_PTRACER 0x59616d61
+ #endif
+ 
+-// A wrapper for the tgkill syscall: send a signal to a specific thread.
+-static int tgkill(pid_t tgid, pid_t tid, int sig) {
+-  return syscall(__NR_tgkill, tgid, tid, sig);
+-  return 0;
+-}
+-
+ namespace google_breakpad {
+ 
+ namespace {
+@@ -347,7 +341,7 @@
+     // In order to retrigger it, we have to queue a new signal by calling
+     // kill() ourselves.  The special case (si_pid == 0 && sig == SIGABRT) is
+     // due to the kernel sending a SIGABRT from a user request via SysRQ.
+-    if (tgkill(getpid(), syscall(__NR_gettid), sig) < 0) {
++    if (sys_tgkill(getpid(), syscall(__NR_gettid), sig) < 0) {
+       // If we failed to kill ourselves (e.g. because a sandbox disallows us
+       // to do so), we instead resort to terminating our process. This will
+       // result in an incorrect exit code.


### PR DESCRIPTION
###### Motivation for this change

Fixes #81387

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
