### PR TITLE
malcontent: 0.4.0 → 0.6.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -297,6 +297,7 @@
   ./services/desktops/geoclue2.nix
   ./services/desktops/gsignond.nix
   ./services/desktops/gvfs.nix
+  ./services/desktops/malcontent.nix
   ./services/desktops/pipewire.nix
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/chrome-gnome-shell.nix

--- a/nixos/modules/services/desktops/malcontent.nix
+++ b/nixos/modules/services/desktops/malcontent.nix
@@ -1,0 +1,32 @@
+# Malcontent daemon.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.malcontent = {
+
+      enable = mkEnableOption "Malcontent";
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.malcontent.enable {
+
+    environment.systemPackages = [ pkgs.malcontent ];
+
+    services.dbus.packages = [ pkgs.malcontent ];
+
+  };
+
+}

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -36,7 +36,6 @@
 , desktop-file-utils
 , gtk3
 , fuse
-, malcontent
 , nixosTests
 , libsoup
 , lzma
@@ -140,7 +139,6 @@ stdenv.mkDerivation rec {
     systemd
     xorg.libXau
     fuse
-    malcontent
     gsettings-desktop-schemas
     glib-networking
     librsvg # for flatpak-validate-icon

--- a/pkgs/development/libraries/malcontent/default.nix
+++ b/pkgs/development/libraries/malcontent/default.nix
@@ -7,7 +7,12 @@
 , wrapGAppsHook
 , glib
 , coreutils
+, accountsservice
 , dbus
+, flatpak
+, gtk3
+, pam
+, desktop-file-utils
 , polkit
 , glib-testing
 , python3
@@ -16,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "malcontent";
-  version = "0.4.0";
+  version = "0.6.0";
 
   outputs = [ "bin" "out" "dev" "man" "installedTests" ];
 
@@ -25,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "pwithnall";
     repo = pname;
     rev = version;
-    sha256 = "0d703r20djvrgy711jvn90i8dwbb0p7qj4j43z101afpkiizq810";
+    sha256 = "COh6N3CmLIcxx6tW4jcP0m6TZv0Z1YJUM/nlG0RzYHQ=";
   };
 
   patches = [
@@ -42,11 +47,16 @@ stdenv.mkDerivation rec {
     ninja
     pkgconfig
     gobject-introspection
+    desktop-file-utils
     wrapGAppsHook
   ];
 
   buildInputs = [
+    accountsservice
     dbus
+    flatpak
+    gtk3
+    pam
     polkit
     glib-testing
     (python3.withPackages (pp: with pp; [

--- a/pkgs/development/libraries/malcontent/installed-tests-path.patch
+++ b/pkgs/development/libraries/malcontent/installed-tests-path.patch
@@ -1,8 +1,8 @@
 diff --git a/libmalcontent/tests/meson.build b/libmalcontent/tests/meson.build
-index a8a815a..0b1d242 100644
+index 610bc35..13e0713 100644
 --- a/libmalcontent/tests/meson.build
 +++ b/libmalcontent/tests/meson.build
-@@ -61,9 +61,9 @@ test_programs = [
+@@ -72,9 +72,9 @@ test_programs = [
    ], deps],
  ]
  
@@ -14,7 +14,7 @@ index a8a815a..0b1d242 100644
                                       'libmalcontent-' + libmalcontent_api_version)
  
  foreach program: test_programs
-@@ -94,4 +94,4 @@ foreach program: test_programs
+@@ -105,4 +105,4 @@ foreach program: test_programs
      env: envs,
      args: ['--tap'],
    )
@@ -22,14 +22,32 @@ index a8a815a..0b1d242 100644
 \ No newline at end of file
 +endforeach
 diff --git a/meson_options.txt b/meson_options.txt
-index 96a517d..7cb1ee8 100644
+index 06329d4..72aa505 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -3,4 +3,5 @@ option(
-   type: 'boolean',
-   value: false,
-   description: 'enable installed tests'
--)
-\ No newline at end of file
+@@ -9,3 +9,9 @@ option(
+   type: 'string',
+   description: 'directory for PAM modules'
+ )
++option(
++  'installed_test_prefix',
++  type: 'string',
++  value: '',
++  description: 'Prefix for installed tests'
 +)
-+option('installed_test_prefix', type: 'string', value: '', description: 'Prefix for installed tests')
+diff --git a/pam/tests/meson.build b/pam/tests/meson.build
+index 0560dcb..a74dab2 100644
+--- a/pam/tests/meson.build
++++ b/pam/tests/meson.build
+@@ -12,9 +12,9 @@ test_programs = [
+   ['pam_malcontent', [], deps],
+ ]
+ 
+-installed_tests_metadir = join_paths(datadir, 'installed-tests',
++installed_tests_metadir = join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests',
+                                      'libmalcontent-' + libmalcontent_api_version)
+-installed_tests_execdir = join_paths(libexecdir, 'installed-tests',
++installed_tests_execdir = join_paths(get_option('installed_test_prefix'), 'libexec', 'installed-tests',
+                                      'libmalcontent-' + libmalcontent_api_version)
+ 
+ foreach program: test_programs

--- a/pkgs/development/libraries/malcontent/use-system-dependencies.patch
+++ b/pkgs/development/libraries/malcontent/use-system-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index f4a05ba..dd31537 100644
+index 3575224..0abea63 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -33,9 +33,8 @@ polkit_gobject = dependency('polkit-gobject-1')
+@@ -40,9 +40,8 @@ polkit_gobject = dependency('polkit-gobject-1')
  polkitpolicydir = polkit_gobject.get_pkgconfig_variable('policydir',
    define_variable: ['prefix', prefix])
  
@@ -13,10 +13,3 @@ index f4a05ba..dd31537 100644
    fallback: ['libglib-testing', 'libglib_testing_dep'],
  )
  
-@@ -120,4 +119,4 @@ test_env = [
- 
- subdir('accounts-service')
- subdir('malcontent-client')
--subdir('libmalcontent')
-\ No newline at end of file
-+subdir('libmalcontent')


### PR DESCRIPTION
At the moment fails due to cyclic dependency https://gitlab.freedesktop.org/pwithnall/malcontent/issues/16

###### Motivation for this change
* https://gitlab.freedesktop.org/pwithnall/malcontent/-/tags/0.5.0
* https://gitlab.freedesktop.org/pwithnall/malcontent/-/tags/0.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
