### PR TITLE
nixos/mysql: split database provisioning into a separate systemd unit

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -83,6 +83,12 @@ in
         description = "User account under which MySQL runs";
       };
 
+      group = mkOption {
+        type = types.str;
+        default = "mysql";
+        description = "Group under which MySQL runs.";
+      };
+
       dataDir = mkOption {
         type = types.path;
         example = "/var/lib/mysql";
@@ -343,13 +349,17 @@ in
       })
     ];
 
-    users.users.mysql = {
-      description = "MySQL server user";
-      group = "mysql";
-      uid = config.ids.uids.mysql;
+    users.users = optionalAttrs (cfg.user == "mysql") {
+      mysql = {
+        description = "MySQL server user";
+        group = cfg.group;
+        uid = config.ids.uids.mysql;
+      };
     };
 
-    users.groups.mysql.gid = config.ids.gids.mysql;
+    users.groups = optionalAttrs (cfg.group == "mysql") {
+      mysql.gid = config.ids.gids.mysql;
+    };
 
     environment.systemPackages = [ cfg.package ];
 
@@ -401,7 +411,7 @@ in
           Restart = "on-abort";
           RestartSec = "5s";
           User = cfg.user;
-          Group = "mysql";
+          Group = cfg.group;
           RuntimeDirectory = "mysqld";
           RuntimeDirectoryMode = "0755";
           # Access write directories

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -44,7 +44,7 @@ in
 
 {
   imports = [
-    (mkRemovedOptionModule [ "services" "mysql" "pidDir" ] "Don't wait for pidfiles, describe dependencies through systemd")
+    (mkRemovedOptionModule [ "services" "mysql" "pidDir" ] "Don't wait for pidfiles, describe dependencies through systemd.")
     (mkRemovedOptionModule [ "services" "mysql" "rootPassword" ] "Use socket authentication or set the password outside of the nix store.")
   ];
 
@@ -59,40 +59,50 @@ in
       package = mkOption {
         type = types.package;
         example = literalExample "pkgs.mysql";
-        description = "
+        description = ''
           Which MySQL derivation to use. MariaDB packages are supported too.
-        ";
+        '';
       };
 
       bind = mkOption {
         type = types.nullOr types.str;
         default = null;
         example = literalExample "0.0.0.0";
-        description = "Address to bind to. The default is to bind to all addresses";
+        description = ''
+          Address to bind to. The default is to bind to all addresses.
+        '';
       };
 
       port = mkOption {
-        type = types.int;
+        type = types.port;
         default = 3306;
-        description = "Port of MySQL";
+        description = ''
+          Port of MySQL.
+        '';
       };
 
       user = mkOption {
         type = types.str;
         default = "mysql";
-        description = "User account under which MySQL runs";
+        description = ''
+          User account under which MySQL runs.
+        '';
       };
 
       group = mkOption {
         type = types.str;
         default = "mysql";
-        description = "Group under which MySQL runs.";
+        description = ''
+          Group under which MySQL runs.
+        '';
       };
 
       dataDir = mkOption {
         type = types.path;
         example = "/var/lib/mysql";
-        description = "Location where MySQL stores its table files";
+        description = ''
+          Location where MySQL stores its table files.
+        '';
       };
 
       configFile = mkOption {
@@ -199,7 +209,9 @@ in
       initialScript = mkOption {
         type = types.nullOr types.path;
         default = null;
-        description = "A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database";
+        description = ''
+          A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database.
+        '';
       };
 
       ensureDatabases = mkOption {
@@ -281,39 +293,53 @@ in
         role = mkOption {
           type = types.enum [ "master" "slave" "none" ];
           default = "none";
-          description = "Role of the MySQL server instance.";
+          description = ''
+            Role of the MySQL server instance.
+          '';
         };
 
         serverId = mkOption {
           type = types.int;
           default = 1;
-          description = "Id of the MySQL server instance. This number must be unique for each instance";
+          description = ''
+            Id of the MySQL server instance. This number must be unique for each instance.
+          '';
         };
 
         masterHost = mkOption {
           type = types.str;
-          description = "Hostname of the MySQL master server";
+          description = ''
+            Hostname of the MySQL master server.
+          '';
         };
 
         slaveHost = mkOption {
           type = types.str;
-          description = "Hostname of the MySQL slave server";
+          description = ''
+            Hostname of the MySQL slave server.
+          '';
         };
 
         masterUser = mkOption {
           type = types.str;
-          description = "Username of the MySQL replication user";
+          description = ''
+            Username of the MySQL replication user.
+          '';
         };
 
         masterPassword = mkOption {
           type = types.str;
-          description = "Password of the MySQL replication user";
+          description = ''
+            Password of the MySQL replication user.
+          '';
         };
 
         masterPort = mkOption {
-          type = types.int;
+          type = types.port;
           default = 3306;
-          description = "Port number on which the MySQL master server runs";
+          description = ''
+            Port number on which the MySQL master server runs.
+          '';
         };
       };
     };
@@ -384,7 +410,7 @@ in
 
       restartTriggers = [ cfg.configFile ];
 
-      unitConfig.RequiresMountsFor = "${cfg.dataDir}";
+      unitConfig.RequiresMountsFor = cfg.dataDir;
 
       path = [
         # Needed for the mysql_install_db command in the preStart script

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -18,6 +18,30 @@ let
     optionalString (cfg.extraOptions != null) "[mysqld]\n${cfg.extraOptions}"
   );
 
+  commonServiceConfig = {
+    # Capabilities
+    CapabilityBoundingSet = "";
+    # Security
+    NoNewPrivileges = true;
+    # Sandboxing
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    ProtectHostname = true;
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectControlGroups = true;
+    RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
+    LockPersonality = true;
+    MemoryDenyWriteExecute = true;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    PrivateMounts = true;
+    # System Call Filtering
+    SystemCallArchitectures = "native";
+  };
+
 in
 
 {
@@ -338,13 +362,20 @@ in
       "z '${cfg.dataDir}' 0700 ${cfg.user} mysql - -"
     ];
 
+    systemd.targets.mysql = {
+      description = "MySQL target";
+      wantedBy = [ "multi-user.target" ];
+    };
+
     systemd.services.mysql = let
       hasNotify = (cfg.package == pkgs.mariadb);
     in {
         description = "MySQL Server";
 
         after = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "mysql.target" ];
+        partOf = [ "mysql.target" ];
+
         restartTriggers = [ cfg.configFile ];
 
         unitConfig.RequiresMountsFor = "${cfg.dataDir}";
@@ -367,143 +398,144 @@ in
           fi
         '';
 
-        serviceConfig = {
-          Type = if hasNotify then "notify" else "simple";
-          Restart = "on-abort";
-          RestartSec = "5s";
-          # The last two environment variables are used for starting Galera clusters
-          ExecStart = "${mysql}/bin/mysqld --defaults-file=/etc/my.cnf ${mysqldOptions} $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION";
-          ExecStartPost =
-            let
-              setupScript = pkgs.writeScript "mysql-setup" ''
-                #!${pkgs.runtimeShell} -e
+        serviceConfig = mkMerge [
+          commonServiceConfig
+          {
+            Type = if hasNotify then "notify" else "simple";
+            Restart = "on-abort";
+            RestartSec = "5s";
+            User = cfg.user;
+            Group = "mysql";
+            RuntimeDirectory = "mysqld";
+            RuntimeDirectoryMode = "0755";
+            # Access write directories
+            ReadWritePaths = [ cfg.dataDir ];
 
-                ${optionalString (!hasNotify) ''
-                  # Wait until the MySQL server is available for use
-                  count=0
-                  while [ ! -e /run/mysqld/mysqld.sock ]
-                  do
-                      if [ $count -eq 30 ]
-                      then
-                          echo "Tried 30 times, giving up..."
-                          exit 1
-                      fi
+            # The last two environment variables are used for starting Galera clusters
+            ExecStart = "${mysql}/bin/mysqld --defaults-file=/etc/my.cnf ${mysqldOptions} $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION";
+            ExecStartPost =
+              let
+                setupScript = pkgs.writeScript "mysql-setup" ''
+                  #!${pkgs.runtimeShell} -e
 
-                      echo "MySQL daemon not yet started. Waiting for 1 second..."
-                      count=$((count++))
-                      sleep 1
-                  done
-                ''}
+                  ${optionalString (!hasNotify) ''
+                    # Wait until the MySQL server is available for use
+                    count=0
+                    while [ ! -e /run/mysqld/mysqld.sock ]
+                    do
+                        if [ $count -eq 30 ]
+                        then
+                            echo "Tried 30 times, giving up..."
+                            exit 1
+                        fi
 
-                if [ -f ${cfg.dataDir}/mysql_init ]
-                then
-                    ${concatMapStrings (database: ''
-                      # Create initial databases
-                      if ! test -e "${cfg.dataDir}/${database.name}"; then
-                          echo "Creating initial database: ${database.name}"
-                          ( echo 'create database `${database.name}`;'
+                        echo "MySQL daemon not yet started. Waiting for 1 second..."
+                        count=$((count++))
+                        sleep 1
+                    done
+                  ''}
 
-                            ${optionalString (database.schema != null) ''
-                            echo 'use `${database.name}`;'
+                  if [ -f ${cfg.dataDir}/mysql_init ]
+                  then
+                      ${concatMapStrings (database: ''
+                        # Create initial databases
+                        if ! test -e "${cfg.dataDir}/${database.name}"; then
+                            echo "Creating initial database: ${database.name}"
+                            ( echo 'create database `${database.name}`;'
 
-                            # TODO: this silently falls through if database.schema does not exist,
-                            # we should catch this somehow and exit, but can't do it here because we're in a subshell.
-                            if [ -f "${database.schema}" ]
-                            then
-                                cat ${database.schema}
-                            elif [ -d "${database.schema}" ]
-                            then
-                                cat ${database.schema}/mysql-databases/*.sql
-                            fi
-                            ''}
+                              ${optionalString (database.schema != null) ''
+                              echo 'use `${database.name}`;'
+
+                              # TODO: this silently falls through if database.schema does not exist,
+                              # we should catch this somehow and exit, but can't do it here because we're in a subshell.
+                              if [ -f "${database.schema}" ]
+                              then
+                                  cat ${database.schema}
+                              elif [ -d "${database.schema}" ]
+                              then
+                                  cat ${database.schema}/mysql-databases/*.sql
+                              fi
+                              ''}
+                            ) | ${mysql}/bin/mysql -u root -N
+                        fi
+                      '') cfg.initialDatabases}
+
+                      ${optionalString (cfg.replication.role == "master")
+                        ''
+                          # Set up the replication master
+
+                          ( echo "use mysql;"
+                            echo "CREATE USER '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' IDENTIFIED WITH mysql_native_password;"
+                            echo "SET PASSWORD FOR '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' = PASSWORD('${cfg.replication.masterPassword}');"
+                            echo "GRANT REPLICATION SLAVE ON *.* TO '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}';"
                           ) | ${mysql}/bin/mysql -u root -N
-                      fi
-                    '') cfg.initialDatabases}
+                        ''}
 
-                    ${optionalString (cfg.replication.role == "master")
-                      ''
-                        # Set up the replication master
+                      ${optionalString (cfg.replication.role == "slave")
+                        ''
+                          # Set up the replication slave
 
-                        ( echo "use mysql;"
-                          echo "CREATE USER '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' IDENTIFIED WITH mysql_native_password;"
-                          echo "SET PASSWORD FOR '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' = PASSWORD('${cfg.replication.masterPassword}');"
-                          echo "GRANT REPLICATION SLAVE ON *.* TO '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}';"
-                        ) | ${mysql}/bin/mysql -u root -N
-                      ''}
+                          ( echo "stop slave;"
+                            echo "change master to master_host='${cfg.replication.masterHost}', master_user='${cfg.replication.masterUser}', master_password='${cfg.replication.masterPassword}';"
+                            echo "start slave;"
+                          ) | ${mysql}/bin/mysql -u root -N
+                        ''}
 
-                    ${optionalString (cfg.replication.role == "slave")
-                      ''
-                        # Set up the replication slave
+                      ${optionalString (cfg.initialScript != null)
+                        ''
+                          # Execute initial script
+                          # using toString to avoid copying the file to nix store if given as path instead of string,
+                          # as it might contain credentials
+                          cat ${toString cfg.initialScript} | ${mysql}/bin/mysql -u root -N
+                        ''}
 
-                        ( echo "stop slave;"
-                          echo "change master to master_host='${cfg.replication.masterHost}', master_user='${cfg.replication.masterUser}', master_password='${cfg.replication.masterPassword}';"
-                          echo "start slave;"
-                        ) | ${mysql}/bin/mysql -u root -N
-                      ''}
-
-                    ${optionalString (cfg.initialScript != null)
-                      ''
-                        # Execute initial script
-                        # using toString to avoid copying the file to nix store if given as path instead of string,
-                        # as it might contain credentials
-                        cat ${toString cfg.initialScript} | ${mysql}/bin/mysql -u root -N
-                      ''}
-
-                    rm ${cfg.dataDir}/mysql_init
-                fi
-
-                ${optionalString (cfg.ensureDatabases != []) ''
-                  (
-                  ${concatMapStrings (database: ''
-                    echo "CREATE DATABASE IF NOT EXISTS \`${database}\`;"
-                  '') cfg.ensureDatabases}
-                  ) | ${mysql}/bin/mysql -u root -N
-                ''}
-
-                ${concatMapStrings (user:
-                  ''
-                    ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' IDENTIFIED WITH ${if isMariaDB then "unix_socket" else "auth_socket"};"
-                      ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
-                        echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
-                      '') user.ensurePermissions)}
-                    ) | ${mysql}/bin/mysql -u root -N
-                  '') cfg.ensureUsers}
-              '';
-            in
-              # ensureDatbases & ensureUsers depends on this script being run as root
-              # when the user has secured their mysql install
-              "+${setupScript}";
-          # User and group
-          User = cfg.user;
-          Group = "mysql";
-          # Runtime directory and mode
-          RuntimeDirectory = "mysqld";
-          RuntimeDirectoryMode = "0755";
-          # Access write directories
-          ReadWritePaths = [ cfg.dataDir ];
-          # Capabilities
-          CapabilityBoundingSet = "";
-          # Security
-          NoNewPrivileges = true;
-          # Sandboxing
-          ProtectSystem = "strict";
-          ProtectHome = true;
-          PrivateTmp = true;
-          PrivateDevices = true;
-          ProtectHostname = true;
-          ProtectKernelTunables = true;
-          ProtectKernelModules = true;
-          ProtectControlGroups = true;
-          RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          PrivateMounts = true;
-          # System Call Filtering
-          SystemCallArchitectures = "native";
-        };
+                      rm ${cfg.dataDir}/mysql_init
+                  fi
+                '';
+              in
+                # ensureDatbases & ensureUsers depends on this script being run as root
+                # when the user has secured their mysql install
+                "+${setupScript}";
+          }
+        ];
       };
+
+    systemd.services.mysql-init = {
+      description = "MySQL database and user provisioning";
+
+      after = [ "mysql.service" ];
+      wantedBy = [ "mysql.target" ];
+      partOf = [ "mysql.target" ];
+
+      # ensureDatbases & ensureUsers depends on this script being run as root
+      # when the user has secured their mysql install
+      script = ''
+        ${optionalString (cfg.ensureDatabases != []) ''
+          (
+          ${concatMapStrings (database: ''
+            echo "CREATE DATABASE IF NOT EXISTS \`${database}\`;"
+          '') cfg.ensureDatabases}
+          ) | ${mysql}/bin/mysql -u root -N
+        ''}
+
+        ${concatMapStrings (user:
+          ''
+            ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' IDENTIFIED WITH ${if isMariaDB then "unix_socket" else "auth_socket"};"
+              ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
+                echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
+              '') user.ensurePermissions)}
+            ) | ${mysql}/bin/mysql -u root -N
+          '') cfg.ensureUsers}
+      '';
+
+      serviceConfig = mkMerge [
+        commonServiceConfig
+        {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        }
+      ];
+    };
 
   };
 

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -372,7 +372,7 @@ in
 
     systemd.services.gitea = {
       description = "gitea";
-      after = [ "network.target" ] ++ lib.optional usePostgresql "postgresql.service" ++ lib.optional useMysql "mysql.service";
+      after = [ "network.target" ] ++ lib.optional usePostgresql "postgresql.service" ++ lib.optional useMysql "mysql.target";
       wantedBy = [ "multi-user.target" ];
       path = [ gitea pkgs.gitAndTools.git ];
 

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -289,7 +289,7 @@ in
     ];
 
     systemd.services.redmine = {
-      after = [ "network.target" ] ++ optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = [ "network.target" ] ++ optional mysqlLocal "mysql.target" ++ optional pgsqlLocal "postgresql.service";
       wantedBy = [ "multi-user.target" ];
       environment.RAILS_ENV = "production";
       environment.RAILS_CACHE = "${cfg.stateDir}/cache";

--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -316,7 +316,7 @@ in {
           procps
           psmisc
         ];
-        after = [ "nginx.service" ] ++ lib.optional cfg.database.createLocally "mysql.service";
+        after = [ "nginx.service" ] ++ lib.optional cfg.database.createLocally "mysql.target";
         wantedBy = [ "multi-user.target" ];
         restartTriggers = [ defaultsFile configFile ];
         preStart = lib.optionalString useCustomDir ''

--- a/nixos/modules/services/monitoring/zabbix-proxy.nix
+++ b/nixos/modules/services/monitoring/zabbix-proxy.nix
@@ -268,7 +268,7 @@ in
       description = "Zabbix Proxy";
 
       wantedBy = [ "multi-user.target" ];
-      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = optional mysqlLocal "mysql.target" ++ optional pgsqlLocal "postgresql.service";
 
       path = [ "/run/wrappers" ] ++ cfg.extraPackages;
       preStart = optionalString pgsqlLocal ''

--- a/nixos/modules/services/monitoring/zabbix-server.nix
+++ b/nixos/modules/services/monitoring/zabbix-server.nix
@@ -256,7 +256,7 @@ in
       description = "Zabbix Server";
 
       wantedBy = [ "multi-user.target" ];
-      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = optional mysqlLocal "mysql.target" ++ optional pgsqlLocal "postgresql.service";
 
       path = [ "/run/wrappers" ] ++ cfg.extraPackages;
       preStart = ''

--- a/nixos/modules/services/web-apps/limesurvey.nix
+++ b/nixos/modules/services/web-apps/limesurvey.nix
@@ -255,7 +255,7 @@ in
     systemd.services.limesurvey-init = {
       wantedBy = [ "multi-user.target" ];
       before = [ "phpfpm-limesurvey.service" ];
-      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = optional mysqlLocal "mysql.target" ++ optional pgsqlLocal "postgresql.service";
       environment.LIMESURVEY_CONFIG = limesurveyConfig;
       script = ''
         # update or install the database as required

--- a/nixos/modules/services/web-apps/mediawiki.nix
+++ b/nixos/modules/services/web-apps/mediawiki.nix
@@ -429,7 +429,7 @@ in
     systemd.services.mediawiki-init = {
       wantedBy = [ "multi-user.target" ];
       before = [ "phpfpm-mediawiki.service" ];
-      after = optional cfg.database.createLocally "mysql.service";
+      after = optional cfg.database.createLocally "mysql.target";
       script = ''
         if ! test -e "${stateDir}/secret.key"; then
           tr -dc A-Za-z0-9 </dev/urandom 2>/dev/null | head -c 64 > ${stateDir}/secret.key

--- a/nixos/modules/services/web-apps/moodle.nix
+++ b/nixos/modules/services/web-apps/moodle.nix
@@ -264,7 +264,7 @@ in
     systemd.services.moodle-init = {
       wantedBy = [ "multi-user.target" ];
       before = [ "phpfpm-moodle.service" ];
-      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = optional mysqlLocal "mysql.target" ++ optional pgsqlLocal "postgresql.service";
       environment.MOODLE_CONFIG = moodleConfig;
       script = ''
         ${phpExt}/bin/php ${cfg.package}/share/moodle/admin/cli/check_database_schema.php && rc=$? || rc=$?

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -641,7 +641,7 @@ let
 
         wantedBy = [ "multi-user.target" ];
         requires = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
-        after = [ "network.target" ] ++ optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+        after = [ "network.target" ] ++ optional mysqlLocal "mysql.target" ++ optional pgsqlLocal "postgresql.service";
     };
 
     services.mysql = mkIf mysqlLocal {

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -342,7 +342,7 @@ in
         nameValuePair "wordpress-init-${hostName}" {
           wantedBy = [ "multi-user.target" ];
           before = [ "phpfpm-wordpress-${hostName}.service" ];
-          after = optional cfg.database.createLocally "mysql.service";
+          after = optional cfg.database.createLocally "mysql.target";
           script = secretsScript (stateDir hostName);
 
           serviceConfig = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
- prevent `mysql/mariadb` server from restarting for no good reason when using `ensure*` options
- add a `mysql.target` so module authors have a `.target` to use for custom database scripts
- minor cleanup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @thorstenweber83 