### PR TITLE
haskellPackages.taffybar: Fix compilation with ghc882

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5284,7 +5284,6 @@ broken-packages:
   - gtfs-realtime
   - gtk-jsinput
   - gtk-serialized-event
-  - gtk-sni-tray
   - gtk-toy
   - gtk2hs-hello
   - gtk2hs-rpn
@@ -9622,7 +9621,6 @@ broken-packages:
   - statsd
   - statsd-client
   - statsdi
-  - status-notifier-item
   - statvfs
   - stb-image-redux
   - stc-lang
@@ -9810,7 +9808,6 @@ broken-packages:
   - Tablify
   - tabloid
   - tabs
-  - taffybar
   - tag-bits
   - tag-stream
   - tagged-exception-core
@@ -10697,7 +10694,6 @@ broken-packages:
   - xchat-plugin
   - xcp
   - xdcc
-  - xdg-desktop-entry
   - xdot
   - Xec
   - xenstore


### PR DESCRIPTION
@cdepillabout I saw your post here: https://discourse.nixos.org/t/call-to-action-for-updating-haskell-packages-after-bump-to-lts-15/6071

and was inspired to try to get taffybar building, but in this case, I actually need to regenerate hackage-packages.nix to actually test if everything is working because some dependencies have changed around, and I need new versions of certain packages.

I watched the video that you linked in there from @peti but I still don't understand what the appropriate way to actually do this is. Can you help?