### PR TITLE
vimPlugins.fruzzy: init at 2019-10-28

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -1320,6 +1320,17 @@ let
     };
   };
 
+  fruzzy = buildVimPluginFrom2Nix {
+    pname = "fruzzy";
+    version = "2019-10-28";
+    src = fetchFromGitHub {
+      owner = "raghur";
+      repo = "fruzzy";
+      rev = "b312ae79db98cf6939c8319f2511efa06889e8e3";
+      sha256 = "01iisbawq2w7yw866qvv109amnvyaymzyz9nqal3cjrrcwk6mmdk";
+    };
+  };
+
   fugitive-gitlab-vim = buildVimPluginFrom2Nix {
     pname = "fugitive-gitlab-vim";
     version = "2019-10-24";

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -28,6 +28,9 @@
 
 # vCoolor dependency
 , gnome3
+
+# fruzzy dependency
+, nim
 }:
 
 self: super: {
@@ -209,6 +212,38 @@ self: super: {
 
   forms = super.forms.overrideAttrs(old: {
     dependencies = with super; [ super.self ];
+  });
+
+  fruzzy = let # until https://github.com/NixOS/nixpkgs/pull/67878 is merged, there's no better way to install nim libraries with nix
+    nimpy = fetchFromGitHub {
+      owner = "yglukhov";
+      repo = "nimpy";
+      rev = "4840d1e438985af759ddf0923e7a9250fd8ea0da";
+      sha256 = "0qqklvaajjqnlqm3rkk36pwwnn7x942mbca7nf2cvryh36yg4q5k";
+    };
+    binaryheap = fetchFromGitHub {
+      owner = "bluenote10";
+      repo = "nim-heap";
+      rev = "c38039309cb11391112571aa332df9c55f625b54";
+      sha256 = "05xdy13vm5n8dw2i366ppbznc4cfhq23rdcklisbaklz2jhdx352";
+    };
+  in super.fruzzy.overrideAttrs(old: {
+    buildInputs = [ nim ];
+    patches = [
+      (substituteAll {
+        src = ./patches/fruzzy/get_version.patch;
+        version = old.version;
+      })
+    ];
+    configurePhase = ''
+      substituteInPlace Makefile \
+        --replace \
+          "nim c" \
+          "nim c --nimcache:$TMP --path:${nimpy} --path:${binaryheap}"
+    '';
+    buildPhase = ''
+      make build
+    '';
   });
 
   ghcid = super.ghcid.overrideAttrs(old: {

--- a/pkgs/misc/vim-plugins/patches/fruzzy/get_version.patch
+++ b/pkgs/misc/vim-plugins/patches/fruzzy/get_version.patch
@@ -1,0 +1,25 @@
+diff --git a/rplugin/python3/fruzzy_mod.nim b/rplugin/python3/fruzzy_mod.nim
+index dba0689..0109285 100644
+--- a/rplugin/python3/fruzzy_mod.nim
++++ b/rplugin/python3/fruzzy_mod.nim
+@@ -12,9 +12,7 @@ when defined(profile):
+     import nimprof
+
+ proc getVersion(): string {.compileTime.}=
+-    let ver = staticExec("git describe --tags --always --dirty").strip()
+-    # let cTime = format(times.now(), "yyyy-MM-dd hh:mm:ss")
+-    let branch = staticExec("git rev-parse --abbrev-ref HEAD").strip()
++    let ver = "@version@"
+     var options:seq[string] = newSeq[string]()
+     if not defined(removelogger):
+         options.add("info")
+@@ -26,7 +24,7 @@ proc getVersion(): string {.compileTime.}=
+         options.add("release")
+     let optionsStr = options.join(",")
+
+-    return &"rev: {ver} on branch: {branch} with options: {optionsStr}"
++    return &"version: {ver} with options: {optionsStr}"
+
+ let L = newConsoleLogger(levelThreshold = logging.Level.lvlDebug)
+ addHandler(L)
+

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -369,6 +369,7 @@ Quramy/tsuquyomi
 racer-rust/vim-racer
 rafaqz/ranger.vim
 rafi/awesome-vim-colorschemes
+raghur/fruzzy
 raghur/vim-ghost
 raichoo/purescript-vim
 Raimondi/delimitMate


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This adds the vim plugin [fruzzy](https://github.com/raghur/fruzzy/). Note that this plugin has a 'native' component (fuzzy searcher implemented in Nim), so I bootstrapped the Nim dependencies in a little bit of a hackey way (could be made neater if https://github.com/NixOS/nixpkgs/pull/67878 ever gets merged).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
