### PR TITLE
iterm2: 3.0.14 -> 3.3.9 & fix build

### DIFF
--- a/pkgs/applications/misc/iterm2/default.nix
+++ b/pkgs/applications/misc/iterm2/default.nix
@@ -4,8 +4,8 @@
  This derivation is impure: it relies on an Xcode toolchain being installed
  and available in the expected place. The values of sandboxProfile
  are copied pretty directly from the MacVim derivation, which
- is also impure. In order to build you at least need the `build-use-chroot`
- option set to `relaxed` or set the `sandbox` option to `false`.
+ is also impure. In order to build you at least need the `sandbox`
+ option set to `relaxed` or `false`.
  */
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/misc/iterm2/default.nix
+++ b/pkgs/applications/misc/iterm2/default.nix
@@ -1,31 +1,48 @@
 { stdenv, fetchFromGitHub }:
 
+ /*
+ This derivation is impure: it relies on an Xcode toolchain being installed
+ and available in the expected place. The values of sandboxProfile
+ are copied pretty directly from the MacVim derivation, which
+ is also impure. In order to build you at least need the `build-use-chroot`
+ option set to `relaxed` or set the `sandbox` option to `false`.
+ */
+
 stdenv.mkDerivation rec {
   pname = "iterm2";
-  version = "3.0.14";
+  version = "3.3.9";
 
   src = fetchFromGitHub {
     owner = "gnachman";
     repo = "iTerm2";
     rev = "v${version}";
-    sha256 = "03m0ja11w9910z96yi8fzq3436y8xl14q031rdb2w3sapjd54qrj";
+    sha256 = "06mq3gfjgy8jw2f3fzdsi3pbfkdijfzzlhlw6ixa5bfb4hbcgn5j";
   };
 
   patches = [ ./disable_updates.patch ];
   postPatch = ''
     sed -i -e 's/CODE_SIGN_IDENTITY = "Developer ID Application"/CODE_SIGN_IDENTITY = ""/g' ./iTerm2.xcodeproj/project.pbxproj
   '';
+
   preConfigure = "LD=$CC";
-  makeFlagsArray = ["Deployment"];
+  makeFlagsArray = ["Nix"];
   installPhase = ''
-    mkdir -p "$out/Applications"
-    mv "build/Deployment/iTerm2.app" "$out/Applications/iTerm.app"
+    mkdir -p $out/Applications
+    mv Build/Products/Deployment/iTerm2.app $out/Applications/iTerm.app
   '';
 
-  meta = {
+  sandboxProfile = ''
+     (allow file-read* file-write* process-exec mach-lookup)
+     ; block homebrew dependencies
+     (deny file-read* file-write* process-exec mach-lookup (subpath "/usr/local") (with no-log))
+  '';
+
+  meta = with stdenv.lib; {
     description = "A replacement for Terminal and the successor to iTerm";
     homepage = https://www.iterm2.com/;
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.darwin;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ tricktron ];
+    platforms = platforms.darwin;
+    hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes #80647 and builds iterm2 impurely. See this [pull request](https://github.com/gnachman/iTerm2/pull/407#issue-327914480) for the reasons.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
