### PR TITLE
wf-recorder: 0.1 -> 0.2

### DIFF
--- a/pkgs/applications/video/wf-recorder/default.nix
+++ b/pkgs/applications/video/wf-recorder/default.nix
@@ -1,26 +1,29 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, wayland, wayland-protocols
-, ffmpeg, x264, libpulseaudio
+{ stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland, scdoc
+, wayland-protocols, ffmpeg_4, x264, libpulseaudio, ocl-icd, opencl-headers
 }:
 
 stdenv.mkDerivation rec {
   pname = "wf-recorder";
-  version = "0.1";
+  version = "0.2";
 
   src = fetchFromGitHub {
     owner = "ammen99";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1rl75r87ijja9mfyrwrsz8r4zvjnhm0103qmgyhq2phlrdpkks5d";
+    sha256 = "1772hrd7j8b32y65x5c392kdijlcn13iqg9hrlagfar92102vsbf";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig ];
-  buildInputs = [ wayland wayland-protocols ffmpeg x264 libpulseaudio ];
+  nativeBuildInputs = [ meson ninja pkg-config wayland scdoc ];
+  buildInputs = [
+    wayland-protocols ffmpeg_4 x264 libpulseaudio ocl-icd opencl-headers
+  ];
 
   meta = with stdenv.lib; {
     description = "Utility program for screen recording of wlroots-based compositors";
-    homepage = https://github.com/ammen99/wf-recorder;
+    inherit (src.meta) homepage;
+    changelog = "https://github.com/ammen99/wf-recorder/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ CrazedProgrammer ];
+    maintainers = with maintainers; [ primeos CrazedProgrammer ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

@CrazedProgrammer I noticed that `wf-recorder` is outdated for a while now. Should I take care of updates or are you still actively using/maintaining it?
**Update:** I'll follow the release feed then.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
