### PR TITLE
Fix FreeBSD support

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -62,6 +62,7 @@ let
     else if targetPlatform.system == "powerpc-linux"  then "${libc_lib}/lib/ld.so.1"
     else if targetPlatform.isMips                     then "${libc_lib}/lib/ld.so.1"
     else if targetPlatform.isDarwin                   then "/usr/lib/dyld"
+    else if targetPlatform.isFreeBSD                  then "/libexec/ld-elf.so.1"
     else if stdenv.lib.hasSuffix "pc-gnu" targetPlatform.config then "ld.so.1"
     else null;
 

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -243,6 +243,9 @@ in
         nativePrefix = "/usr";
         nativeLibc   = true;
         stdenvNoCC = prevStage.stdenv;
+        buildPackages = {
+          inherit (prevStage) stdenv;
+        };
         cc           = {
           name    = "clang-9.9.9";
           cc      = "/usr";

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -1,11 +1,170 @@
 { lib
-, localSystem, crossSystem, config, overlays
+, localSystem, crossSystem, config, overlays, crossOverlays ? []
 }:
 
 assert crossSystem == localSystem;
-let inherit (localSystem) system; in
-
-
+let inherit (localSystem) system;
+    fetchURL = import <nix/fetchurl.nix>;
+    trivialBuilder = (import ./trivial-builder.nix);
+    make = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "make";
+      ver = "4.3";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.gz";
+      sha256 = "06cfqzpqsvdnsxbysl5p2fgdgxgl9y4p7scpnrfa8z2zgkjdspz0";
+      configureArgs = [ "--disable-nls"
+                        "--without-libintl-prefix"
+                        "--without-libiconv-prefix"
+                      ];
+    };
+    bash = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "bash";
+      ver = "4.4.18";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.gz";
+      sha256 = "08vz660768mnnax7n8d4d85jxafwdmsxsi7fh0hzvmafbvn9wkb0";
+      configureArgs = [ "--disable-nls"
+                        "--without-libintl-prefix"
+                        "--without-libiconv-prefix"
+                      ];
+    };
+    coreutils = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "coreutils";
+      ver = "8.31";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.xz";
+      sha256 = "1zg9m79x1i2nifj4kb0waf9x3i5h6ydkypkjnbsb9rnwis8rqypz";
+      configureArgs = [ "--disable-nls"
+                        "--without-libintl-prefix"
+                        "--without-libiconv-prefix"
+                        "--without-gmp"
+                        "--without-libpth-prefix"
+                      ];
+    };
+    findutils = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "findutils";
+      ver = "4.7.0";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.xz";
+      sha256 = "16kqz9yz98dasmj70jwf5py7jk558w96w0vgp3zf9xsqk3gzpzn5";
+      configureArgs = [ "--disable-nls"
+                        "--without-libintl-prefix"
+                        "--without-libiconv-prefix"
+                        "--without-gmp"
+                        "--without-libpth-prefix"
+                      ];
+    };
+    diffutils = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "diffutils";
+      ver = "3.7";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.xz";
+      sha256 = "09isrg0isjinv8c535nxsi1s86wfdfzml80dbw41dj9x3hiad9xk";
+      configureArgs = [ "--disable-nls"
+                        "--without-libintl-prefix"
+                        "--without-libiconv-prefix"
+                        "--without-libsigsegv-prefix"
+                      ];
+    };
+    grep = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "grep";
+      ver = "3.4";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.xz";
+      sha256 = "1yy33kiwrxrwj2nxa4fg15bvmwyghqbs8qwkdvy5phm784f7brjq";
+      configureArgs = [ "--disable-nls"
+                        "--without-libintl-prefix"
+                        "--without-libiconv-prefix"
+                        "--disable-perl-regexp"
+                        "--without-libsegsegv-prefix"
+                      ];
+    };
+    patch = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "patch";
+      ver = "2.7.6";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.xz";
+      sha256 = "1zfqy4rdcy279vwn2z1kbv19dcfw25d2aqy9nzvdkq5bjzd0nqdc";
+    };
+    gawk = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "gawk";
+      ver = "5.0.1";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.xz";
+      sha256 = "15570p7g2x54asvr2fsc56sxzmm08fbk4mzpcs5n92fp9vq8cklf";
+      configureArgs = [ "--disable-nls"
+                        "--disable-mpfr"
+                        "--without-libintl-prefix"
+                        "--without-libiconv-prefix"
+                        "--without-libsegsegv-prefix"
+                      ];
+    };
+    cpio = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "cpio";
+      ver = "2.13";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.gz";
+      sha256 = "126vyg4a8wcdwh6npgvxy6gq433bzgz3ph37hmjpycc4r7cp0x78";
+      configureArgs = [ "--disable-nls"
+                        "--without-libintl-prefix"
+                        "--without-libiconv-prefix"
+                      ];
+    };
+    sed = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "sed";
+      ver = "4.8";
+      url = "https://ftp.gnu.org/gnu/${name}/${name}-${ver}.tar.xz";
+      sha256 = "0cznxw73fzv1n3nj2zsq6nf73rvsbxndp444xkpahdqvlzz0r6zp";
+      configureArgs = [ "--disable-nls"
+                        "--without-libintl-prefix"
+                        "--without-libiconv-prefix"
+                      ];
+    };
+    cacert = fetchURL rec {
+      url = "https://curl.haxx.se/ca/cacert-2020-01-01.pem";
+      sha256 = "07q808n307gzaga93abpf6an7c3rd35p18psdc1dd83lspgp1xxd";
+      executable = false;
+    };
+    curl = trivialBuilder rec {
+      inherit (localSystem) system;
+      name = "curl";
+      ver = "7.68.0";
+      url = "https://curl.haxx.se/download/${name}-${ver}.tar.xz";
+      sha256 = "0nh3j90w6b97wqcgxjfq55qhkz9s38955fbhwzv2fsi7483j895p";
+      configureArgs = [ "--disable-nls"
+                        "--disable-ares"
+                        "--disable-debug"
+                        "--disable-ldap"
+                        "--disable-ldaps"
+                        "--disable-rtsp"
+                        "--disable-dict"
+                        "--disable-telnet"
+                        "--disable-tftp"
+                        "--disable-pop3"
+                        "--disable-imap"
+                        "--disable-smb"
+                        "--disable-smtp"
+                        "--disable-gopher"
+                        "--disable-manual"
+                        "--disable-verbose"
+                        "--disable-sspi"
+                        "--disable-tls-srp"
+                        "--disable-unix-sockets"
+                        "--without-brotli"
+                        "--without-gnutls"
+                        "--without-mbedtls"
+                        "--without-wolfssl"
+                        "--without-bearssl"
+                        "--without-libidn2"
+                        "--without-librtmp"
+                        "--without-nghttp2"
+                        "--with-ssl=/usr"
+                        "--with-ca-bundle=${cacert}"
+                      ];
+    };
+    bashExe = "${bash}/bin/bash";
+in
 [
 
   ({}: {
@@ -13,11 +172,14 @@ let inherit (localSystem) system; in
 
     bootstrapTools = derivation {
       inherit system;
+      inherit make bash coreutils findutils
+        diffutils grep patch gawk cpio sed
+        curl;
 
       name = "trivial-bootstrap-tools";
-      builder = "/usr/local/bin/bash";
+      builder = bashExe;
       args = [ ./trivial-bootstrap.sh ];
-
+      buildInputs = [ make ];
       mkdir = "/bin/mkdir";
       ln = "/bin/ln";
     };
@@ -52,6 +214,8 @@ let inherit (localSystem) system; in
   (prevStage: {
     __raw = true;
 
+    inherit (prevStage) bootstrapTools;
+
     stdenv = import ../generic {
       name = "stdenv-freebsd-boot-0";
       inherit config;
@@ -66,7 +230,7 @@ let inherit (localSystem) system; in
 
   (prevStage: {
     inherit config overlays;
-    stdenv = import ../generic {
+    stdenv = import ../generic rec {
       name = "stdenv-freebsd-boot-3";
       inherit config;
 
@@ -82,9 +246,19 @@ let inherit (localSystem) system; in
         cc           = {
           name    = "clang-9.9.9";
           cc      = "/usr";
-          outPath = "/usr";
+          outPath = prevStage.bootstrapTools;
         };
         isClang      = true;
+        bintools = import ../../build-support/bintools-wrapper {
+
+          stdenvNoCC = prevStage.stdenv;
+          nativeTools  = true;
+          nativeLibc   = true;
+          propagateDoc = false;
+          nativePrefix = "/usr";
+          bintools     = { name = "${name}-binutils";
+                           outPath = prevStage.bootstrapTools; };
+        };
       };
 
       preHook = ''export NIX_NO_SELF_RPATH=1'';

--- a/pkgs/stdenv/freebsd/trivial-bootstrap.sh
+++ b/pkgs/stdenv/freebsd/trivial-bootstrap.sh
@@ -3,9 +3,9 @@ set -o nounset
 set -o pipefail
 
 echo Building the trivial bootstrap environment...
-echo
-echo Needed FreeBSD packages:
-echo findutils gcpio gawk gnugrep coreutils bash gsed gtar gmake xar binutils gpatch lbzip2 diffutils
+#echo
+#echo Needed FreeBSD packages:
+#echo findutils gcpio gawk gnugrep coreutils bash gsed gtar gmake xar binutils gpatch lbzip2 diffutils
 
 $mkdir -p $out/bin
 
@@ -28,14 +28,36 @@ ln () {
   fi
 }
 
-ln /usr/local/bin/bash
+ln $bash/bin/bash
+ln $make/bin/make
+
 ln /bin/sh
 
-ln /usr/local/bin/gmake make
+for i in b2sum base32 base64 basename basenc cat chcon chgrp chmod \
+    chown chroot cksum comm cp csplit cut date dd df dir dircolors \
+    dirname du echo env expand expr factor false fmt fold install \
+    groups head hostid id join kill link ln logname ls md5sum mkdir \
+    mkfifo mknod mktemp mv nice nl nohup nproc numfmt od paste pathchk \
+    pinky pr printenv printf ptx pwd readlink realpath rm rmdir runcon \
+    seq sha1sum sha224sum sha256sum sha384sum sha512sum shred shuf \
+    sleep sort split stat stdbuf stty sum sync tac tee test timeout \
+    touch tr true truncate tsort tty uname unexpand uniq unlink uptime \
+    users vdir wc who whoami yes
+do
+    ln "$coreutils/bin/$i" "$i"
+done
 
-ln /usr/local/bin/lbzip2
+for i in find xargs; do
+    ln "$findutils/bin/$i" "$i"
+done
 
-ln /usr/local/bin/gdiff diff
+for i in diff diff3 sdiff; do
+    ln "$diffutils/bin/$i" "$i"
+done
+
+for i in grep egrep fgrep; do
+    ln "$grep/bin/$i" "$i"
+done
 
 ln /usr/bin/locale
 
@@ -45,160 +67,52 @@ ln /usr/bin/hexdump # for bitcoin
 
 ln /usr/bin/bzip2
 ln /usr/bin/bunzip2
-ln /usr/bin/bzcat
 ln /usr/bin/bzip2recover
 
 ln /usr/bin/xz
 ln /usr/bin/unxz
-ln /usr/bin/xzcat
 ln /usr/bin/lzma
 ln /usr/bin/unlzma
-ln /usr/bin/lzcat
 
-ln /usr/local/bin/gcp cp
-ln /usr/local/bin/gdd dd
-ln /usr/local/bin/gmv mv
-ln /usr/local/bin/grm rm
-ln /usr/local/bin/gls ls
-ln /bin/ps ps
-ln /usr/local/bin/gcat cat
-ln /usr/local/bin/gecho echo
-ln /usr/local/bin/gexpr expr
-ln /usr/local/bin/gtest test
-ln /usr/local/bin/gdate date
-ln /usr/local/bin/gchmod chmod
-ln /usr/local/bin/grmdir rmdir
-ln /usr/local/bin/gsleep sleep
-ln /bin/hostname hostname
-
-ln /usr/local/bin/gid id
-ln /usr/local/bin/god od
-ln /usr/local/bin/gtr tr
-ln /usr/local/bin/gwc wc
-ln /usr/local/bin/gcut cut
-ln /usr/bin/cmp cmp
-ln /usr/local/bin/gsed sed
-ln /usr/local/bin/gtar tar
-ln /usr/local/bin/xar xar
-ln /usr/local/bin/gawk awk
-ln /usr/local/bin/genv env
-ln /usr/local/bin/gtee tee
-ln /usr/local/bin/gcomm comm
-ln /usr/local/bin/gcpio cpio
-ln /usr/local/bin/curl curl
-ln /usr/local/bin/gfind find
-ln /usr/local/bin/grep grep # other grep is in /usr/bin
+ln /bin/ps
+ln /bin/hostname
+ln /usr/bin/cmp
+ln $sed/bin/sed
+ln /usr/bin/tar tar
+ln $gawk/bin/gawk
+ln $gawk/bin/gawk awk
+ln $cpio/bin/cpio
+ln $curl/bin/curl curl
 ln /usr/bin/gzip
 ln /usr/bin/gunzip
-ln /usr/bin/zcat
-ln /usr/local/bin/ghead head
 ln /usr/bin/tail tail # note that we are not using gtail!!!
-ln /usr/local/bin/guniq uniq
 ln /usr/bin/less less
-ln /usr/local/bin/gtrue true
-# ln /usr/bin/diff diff # we are using gdiff (see above)
-ln /usr/local/bin/egrep egrep
-ln /usr/local/bin/fgrep fgrep
-ln /usr/local/bin/gpatch patch
-ln /usr/local/bin/guname uname
-ln /usr/local/bin/gtouch touch
-ln /usr/local/bin/gsplit split
-ln /usr/local/bin/gxargs xargs
+ln $patch/bin/patch patch
 ln /usr/bin/which which
-ln /usr/local/bin/ginstall install
-ln /usr/local/bin/gbasename basename
-ln /usr/local/bin/gdirname dirname
-ln /usr/local/bin/greadlink readlink
 
-ln /usr/local/bin/gln ln
-ln /usr/local/bin/gyes yes
-ln /usr/local/bin/gwhoami whoami
-ln /usr/local/bin/gvdir vdir
-ln /usr/local/bin/gusers users
-ln /usr/local/bin/guptime uptime
-ln /usr/local/bin/gunlink unlink
-ln /usr/local/bin/gtty tty
-ln /usr/local/bin/gunexpand unexpand
-ln /usr/local/bin/gtsort tsort
-ln /usr/local/bin/gtruncate truncate
-ln /usr/local/bin/gtimeout timeout
-ln /usr/local/bin/gtac tac
-ln /usr/local/bin/gsync sync
-ln /usr/local/bin/gsum sum
-ln /usr/local/bin/gstty stty
-ln /usr/local/bin/gstdbuf stdbuf
-ln /usr/local/bin/gsort sort
-ln /usr/local/bin/gruncon runcon
-ln /usr/local/bin/gseq seq
-ln /usr/local/bin/gsha1sum sha1sum
-ln /usr/local/bin/gsha224sum sha224sum
-ln /usr/local/bin/gsha256sum sha256sum
-ln /usr/local/bin/gsha384sum sha384sum
-ln /usr/local/bin/gsha512sum sha512sum
-ln /usr/local/bin/gshred shred
-ln /usr/local/bin/gshuf shuf
-ln /usr/local/bin/grealpath realpath
-ln "/usr/local/bin/g[" "["
-ln /usr/local/bin/gbase64 base64
-ln /usr/local/bin/gchcon chcon
-ln /usr/local/bin/gchgrp chgrp
-ln /usr/local/bin/gchown chown
-ln /usr/local/bin/gchroot chroot
-ln /usr/local/bin/gcksum cksum
-ln /usr/local/bin/gcsplit csplit
-ln /usr/local/bin/gdf df
-ln /usr/local/bin/gdircolors dircolors
-ln /usr/local/bin/gdu du
-ln /usr/local/bin/gexpand expand
-ln /usr/local/bin/gfactor factor
-ln /usr/local/bin/gfalse false
-ln /usr/local/bin/gfmt fmt
-ln /usr/local/bin/gfold fold
-ln /usr/local/bin/ggroups groups
-ln /usr/local/bin/ghostid hostid
-ln /usr/local/bin/gjoin join
-ln /usr/local/bin/gkill kill
-ln /usr/local/bin/glink link
-ln /usr/local/bin/glogname logname
-ln /usr/local/bin/gmd5sum md5sum
-ln /usr/local/bin/gmkdir mkdir
-ln /usr/local/bin/gmkfifo mkfifo
-ln /usr/local/bin/gmknod mknod
-ln /usr/local/bin/gmktemp mktemp
-ln /usr/local/bin/gnice nice
-ln /usr/local/bin/gnl nl
-ln /usr/local/bin/gnohup nohup
-ln /usr/local/bin/gnproc nproc
-ln /usr/local/bin/gnumfmt numfmt
-ln /usr/local/bin/gnustat nustat
-ln /usr/local/bin/gpaste paste
-ln /usr/local/bin/gpathchk pathchk
-ln /usr/local/bin/gpinky pinky
-ln /usr/local/bin/gpr pr
-ln /usr/local/bin/gprintenv printenv
-ln /usr/local/bin/gprintf printf
-ln /usr/local/bin/gptx ptx
-ln /usr/local/bin/gpwd pwd
-
-# binutils
+## binutils
 # pkg info -l binutils | grep usr/local/bin
-ln /usr/local/bin/addr2line
-ln /usr/local/bin/ar
-ln /usr/local/bin/as
-ln /usr/local/bin/c++filt
-ln /usr/local/bin/dwp
-ln /usr/local/bin/elfedit
-ln /usr/local/bin/gprof
-ln /usr/local/bin/ld
-ln /usr/local/bin/ld.bfd
-ln /usr/local/bin/ld.gold
-ln /usr/local/bin/nm
-ln /usr/local/bin/objcopy
-ln /usr/local/bin/objdump
-ln /usr/local/bin/ranlib
-ln /usr/local/bin/readelf
-ln /usr/local/bin/size
-ln /usr/local/bin/strings
-ln /usr/local/bin/strip
+ln /usr/bin/addr2line
+ln /usr/bin/ar
+ln /usr/bin/as
+ln /usr/bin/c++filt
+#ln /usr/bin/dwp
+#ln /usr/bin/elfedit
+ln /usr/bin/gprof
+ln /usr/bin/ld
+#ln /usr/bin/ld.bfd
+#ln /usr/bin/ld.gold
+ln /usr/bin/nm
+ln /usr/bin/objcopy
+ln /usr/bin/objdump
+ln /usr/bin/ranlib
+ln /usr/bin/readelf
+ln /usr/bin/size
+ln /usr/bin/strings
+ln /usr/bin/strip
+
+ln /usr/bin/cc
+ln /usr/bin/cpp
+ln /usr/bin/c++
 
 #pkg info -l llvm37 | grep usr/local/bin

--- a/pkgs/stdenv/freebsd/trivial-builder.nix
+++ b/pkgs/stdenv/freebsd/trivial-builder.nix
@@ -1,0 +1,13 @@
+{ system, name, ver, url, sha256, configureArgs ? [], executable ? false } :
+
+let fetchURL = import <nix/fetchurl.nix>;
+
+in derivation {
+  inherit system configureArgs;
+  name = "trivial-bootstrap-${name}-${ver}";
+  dname = "${name}-${ver}";
+  src = fetchURL {
+    inherit url sha256 executable;
+  };
+  builder = ./trivial-builder.sh;
+}

--- a/pkgs/stdenv/freebsd/trivial-builder.sh
+++ b/pkgs/stdenv/freebsd/trivial-builder.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+tar -zxvf $src
+cd $dname
+mkdir -p $out/bin
+./configure --prefix=$out $configureArgs
+make
+make install


### PR DESCRIPTION
###### Motivation for this change

I'm trying to make `nixpkgs` work on FreeBSD, similar to `nix-darwin`. For that, I attempted to fix FreeBSD stdenv. I'm not super familiar with `stdenv`, or internals of `nixpkgs`, so I would appreciate review.

Following is the output from `FreeBSD 12.1 amd64` trying to build `curl`:

https://pastebin.com/0b7cJeHF

For those interested in trying out `nix` on FreeBSD, there is a FreeBSD port in progress, https://github.com/0mp/freebsd-ports-nix which is how I got it  running.

Thanks in advance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
