### PR TITLE
[20.03] amp: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/applications/editors/amp/default.nix
+++ b/pkgs/applications/editors/amp/default.nix
@@ -3,17 +3,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "amp";
-  # The latest release (0.5.2) does not compile, so we use a git snapshot instead.
-  version = "unstable-2019-06-09";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "jmacdonald";
     repo = pname;
-    rev = "2c88e82a88ada8a5fd2620ef225192395a4533a2";
-    sha256 = "0ha1xiabq31s687gkrnszf3zc7b3sfdl79iyg5ygbc49mzvarp8c";
+    rev = version;
+    sha256 = "0l1vpcfq6jrq2dkrmsa4ghwdpp7c54f46gz3n7nk0i41b12hnigw";
   };
 
-  cargoSha256 = "1bvj2zg19ak4vi47vjkqlybz011kn5zq1j7zznr76zrryacw4lz1";
+  cargoSha256 = "1rfpk3gaas1x0p2hx0cfhlpjh7yy2sw1pb4n6wly5h3vxzkmd214";
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ openssl python3 xorg.libxcb libgit2 ] ++ stdenv.lib.optionals stdenv.isDarwin


### PR DESCRIPTION
###### Motivation for this change

Fix hydra build.

Backport: #81462
ZHF: #80379

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
