### PR TITLE
chicken: 5.1.0 -> 5.2.0

### DIFF
--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper, bootstrap-chicken ? null }:
 
 let
-  version = "5.1.0";
+  version = "5.2.0";
   platform = with stdenv;
     if isDarwin then "macosx"
     else if isCygwin then "cygwin"
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://code.call-cc.org/releases/${version}/chicken-${version}.tar.gz";
-    sha256 = "0jsbp3kp0134f318j3wpd1n85gf8qzh034fn198gvazsv2l024aw";
+    sha256 = "1yl0hxm9cirgcp8jgxp6vv29lpswfvaw3zfkh6rsj0vkrv44k4c1";
   };
 
   setupHook = lib.ifEnable (bootstrap-chicken != null) ./setup-hook.sh;

--- a/pkgs/development/compilers/chicken/5/eggDerivation.nix
+++ b/pkgs/development/compilers/chicken/5/eggDerivation.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation ({
     for f in $out/bin/*
     do
       wrapProgram $f \
-        --prefix CHICKEN_REPOSITORY_PATH : "$out/lib/chicken/${toString chicken.binaryVersion}/:$CHICKEN_REPOSITORY_PATH" \
-        --prefix CHICKEN_INCLUDE_PATH : "$CHICKEN_INCLUDE_PATH:$out/share/" \
+        --prefix CHICKEN_REPOSITORY_PATH : "$out/lib/chicken/${toString chicken.binaryVersion}:$CHICKEN_REPOSITORY_PATH" \
+        --prefix CHICKEN_INCLUDE_PATH : "$CHICKEN_INCLUDE_PATH:$out/share" \
         --prefix PATH : "$out/bin:${chicken}/bin:$CHICKEN_REPOSITORY_PATH"
     done
 

--- a/pkgs/development/compilers/chicken/5/eggs.nix
+++ b/pkgs/development/compilers/chicken/5/eggs.nix
@@ -19,12 +19,12 @@ rec {
   };
 
   matchable = eggDerivation {
-    name = "matchable-1.0";
+    name = "matchable-1.1";
 
     src = fetchegg {
       name = "matchable";
-      version = "1.0";
-      sha256 = "01vy2ppq3sq0wirvsvl3dh0bwa5jqs1i6rdjdd7pnwj4nncxd1ga";
+      version = "1.1";
+      sha256 = "084hm5dvbvgnpb32ispkp3hjili8z02hamln860r99jx68jx6j2v";
     };
 
     buildInputs = [

--- a/pkgs/development/compilers/chicken/5/setup-hook.sh
+++ b/pkgs/development/compilers/chicken/5/setup-hook.sh
@@ -1,6 +1,6 @@
 addChickenRepositoryPath() {
-    addToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_PATH "$1/lib/chicken/11/"
-    addToSearchPathWithCustomDelimiter : CHICKEN_INCLUDE_PATH "$1/share/"
+    addToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_PATH "$1/lib/chicken/11"
+    addToSearchPathWithCustomDelimiter : CHICKEN_INCLUDE_PATH "$1/share"
 }
 
 addEnvHooks "$targetOffset" addChickenRepositoryPath


### PR DESCRIPTION
Updates CHICKEN 5.x to the latest stable version.

Also updates the matchable egg (used by egg2nix) from 1.0 -> 1.1 and removes trailing slashes from the path prefix variables passed to wrapProgram (they're unnecessary and only result in doubled-up slashes in the values).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
New minor version available ([release announcement](https://lists.nongnu.org/archive/html/chicken-announce/2020-02/msg00001.html)).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
