### PR TITLE
Httpie docs

### DIFF
--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -25,6 +25,14 @@ python3Packages.buildPythonApplication rec {
   ];
 
   postInstall = ''
+    # install completions
+    install -Dm555 \
+      extras/httpie-completion.bash \
+      $out/share/bash-completion/completions/http.bash
+    install -Dm555 \
+      extras/httpie-completion.fish \
+      $out/share/fish/vendor_completions.d/http.fish
+
     mkdir -p $man/share/man/man1
 
     docdir=$doc/share/doc/httpie

--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -11,6 +11,8 @@ python3Packages.buildPythonApplication rec {
     sha256 = "0d0rsn5i973l9y0ws3xmnzaw4jwxdlryyjbasnlddph5mvkf7dq0";
   };
 
+  outputs = [ "out" "doc" "man" ];
+
   propagatedBuildInputs = with python3Packages; [ pygments requests setuptools ];
   dontUseSetuptoolsCheck = true;
   patches = [ ./strip-venv.patch ];
@@ -21,6 +23,54 @@ python3Packages.buildPythonApplication rec {
     pytest-httpbin
     pytestCheckHook
   ];
+
+  postInstall = ''
+    mkdir -p $man/share/man/man1
+
+    docdir=$doc/share/doc/httpie
+    mkdir -p $docdir/html
+
+    cp AUTHORS.rst CHANGELOG.rst CONTRIBUTING.rst $docdir
+
+    # helpfully, the readme has a `no-web` class to exclude
+    # the parts that are not relevant for offline docs
+
+    # this one build link was not marked however
+    sed -e 's/^|build|//g' -i README.rst
+
+    toHtml() {
+      ${docutils}/bin/rst2html5 \
+        --strip-elements-with-class=no-web \
+        --title=http \
+        --no-generator \
+        --no-datestamp \
+        --no-source-link \
+        "$1" \
+        "$2"
+    }
+
+    toHtml README.rst $docdir/html/index.html
+    toHtml CHANGELOG.rst $docdir/html/CHANGELOG.html
+    toHtml CONTRIBUTING.rst $docdir/html/CONTRIBUTING.html
+
+    # change a few links to the local files
+    substituteInPlace $docdir/html/index.html \
+      --replace \
+        'https://github.com/jakubroztocil/httpie/blob/master/CHANGELOG.rst' \
+        "CHANGELOG.html" \
+      --replace \
+        'https://github.com/jakubroztocil/httpie/blob/master/CONTRIBUTING.rst' \
+        "CONTRIBUTING.html"
+
+    ${docutils}/bin/rst2man \
+      --strip-elements-with-class=no-web \
+      --title=http \
+      --no-generator \
+      --no-datestamp \
+      --no-source-link \
+      README.rst \
+      $man/share/man/man1/http.1
+  '';
 
   # the tests call rst2pseudoxml.py from docutils
   preCheck = ''


### PR DESCRIPTION
Adds htmp docs and a manpage to `http`, sets up the shell completions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @antono 