### PR TITLE
perlPackages.CPAN: fix build, patch url content has changed

### DIFF
--- a/pkgs/development/perl-modules/perl-CPAN-YAML-modules-default-for-LoadBlessed.patch
+++ b/pkgs/development/perl-modules/perl-CPAN-YAML-modules-default-for-LoadBlessed.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/CPAN.pm b/lib/CPAN.pm
+index 2d87f47f..2e28c9fc 100644
+--- a/lib/CPAN.pm
++++ b/lib/CPAN.pm
+@@ -558,7 +558,9 @@ sub _yaml_loadfile {
+         # 5.6.2 could not do the local() with the reference
+         # so we do it manually instead
+         my $old_loadcode = ${"$yaml_module\::LoadCode"};
++        my $old_loadblessed = ${"$yaml_module\::LoadBlessed"};
+         ${ "$yaml_module\::LoadCode" } = $CPAN::Config->{yaml_load_code} || 0;
++        ${ "$yaml_module\::LoadBlessed" } = 1;
+ 
+         my ($code, @yaml);
+         if ($code = UNIVERSAL::can($yaml_module, "LoadFile")) {
+@@ -582,6 +584,7 @@ sub _yaml_loadfile {
+             }
+         }
+         ${"$yaml_module\::LoadCode"} = $old_loadcode;
++        ${"$yaml_module\::LoadBlessed"} = $old_loadblessed;
+         return \@yaml;
+     } else {
+         # this shall not be done by the frontend

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3295,11 +3295,7 @@ let
       sha256 = "b4b1471a2881e2d616f59e723879b4110ae485b79d5962f115119c28cf69e07f";
     };
     patches = [
-      (fetchpatch {
-        url = "https://patch-diff.githubusercontent.com/raw/andk/cpanpm/pull/133.diff";
-        name = "patch-YAML-modules-default-for-LoadBlessed-was-changed-to-false";
-        sha256 = "0i8648cwshzzd0b34gyfn68s1vs85d8336ggk2kl99awah1ydsfr";
-      })
+      ../development/perl-modules/perl-CPAN-YAML-modules-default-for-LoadBlessed.patch
     ];
     propagatedBuildInputs = [ ArchiveZip CPANChecksums CPANPerlReleases Expect FileHomeDir LWP LogLog4perl ModuleBuild TermReadKey YAML YAMLLibYAML YAMLSyck ];
     meta = {


### PR DESCRIPTION
ZHF: #80379 

The LoadBlessed patch in https://github.com/NixOS/nixpkgs/pull/80471 was included from a GitHub PR without a commit reference, and the contents have changed.

Updated the patch from the merged PR, and stored as a file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
