### PR TITLE
sgt-puzzles: fix desktop files and add desktop sgt-puzzles.menu

### DIFF
--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -12,41 +12,49 @@ stdenv.mkDerivation rec {
     sha256 = "01fi2f3w71bfbgcfr6gxdp5a9cxh4dshbflv83q2j5rxxs2ll870";
   };
 
+  sgt-puzzles-menu = fetchurl {
+    url = "https://raw.githubusercontent.com/Oleh-Kravchenko/portage/master/games-puzzle/sgt-puzzles/files/sgt-puzzles.menu";
+    sha256 = "088w0x9g3j8pn725ix8ny8knhdsfgjr3hpswsh9fvfkz5vlg2xkm";
+  };
+
   nativeBuildInputs = [ autoreconfHook desktop-file-utils makeWrapper
     pkgconfig perl wrapGAppsHook ];
 
   buildInputs = [ gtk3 libX11 ];
 
-  makeFlags = ["prefix=$(out)" "gamesdir=$(out)/bin"];
+  makeFlags = [ "prefix=$(out)" "gamesdir=$(out)/bin"];
 
   preInstall = ''
-    mkdir -p "$out"/{bin,share/doc/sgtpuzzles,share/icons/hicolor/48x48/apps}
+    mkdir -p "$out"/{bin,share/doc/sgtpuzzles}
     cp gamedesc.txt LICENCE README "$out/share/doc/sgtpuzzles"
   '';
-  # SGT Puzzles use generic names like net, map, etc.
-  # Create symlinks with sgt-puzzle- prefix for possibility of
-  # disambiguation
+
   postInstall = ''
-    (
-      currentSrc=$PWD
-      cd "$out"/bin ;
-      for i in *; do
-        ln -s "$i" "sgt-puzzle-$i"
+    for i in  $(basename -s $out/bin/*); do
 
-        install -Dm644 $currentSrc/icons/$i-48d24.png $out/share/icons/hicolor/48x48/apps/
+      ln -s $out/bin/$i $out/bin/sgt-puzzle-$i
+      install -Dm644 icons/$i-48d24.png -t $out/share/icons/hicolor/48x48/apps/
 
-        # Generate/validate/install .desktop files.
-        echo "[Desktop Entry]" > $i.desktop
-        desktop-file-install --dir $out/share/applications \
-          --set-key Type --set-value Application \
-          --set-key Exec --set-value $i \
-          --set-key Name --set-value $i \
-          --set-key Comment --set-value "${meta.description}" \
-          --set-key Categories --set-value LogicGame \
-          --set-key Icon --set-value $i-48d24 $i.desktop
-        rm $i.desktop
-      done
-    )
+      # Generate/validate/install .desktop files.
+      echo "[Desktop Entry]" > $i.desktop
+      desktop-file-install --dir $out/share/applications \
+        --set-key Type --set-value Application \
+        --set-key Exec --set-value $i \
+        --set-key Name --set-value $i \
+        --set-key Comment --set-value "${meta.description}" \
+        --set-key Categories --set-value "Game;LogicGame;X-sgt-puzzles;" \
+        --set-key Icon --set-value $out/share/icons/hicolor/48x48/apps/$i-48d24 \
+        $i.desktop
+    done
+
+    echo "[Desktop Entry]" > sgt-puzzles.directory
+    desktop-file-install --dir $out/share/desktop-directories \
+      --set-key Type --set-value Directory \
+      --set-key Name --set-value Puzzles \
+      --set-key Icon --set-value $out/share/icons/hicolor/48x48/apps/sgt-puzzles_map \
+      sgt-puzzles.directory
+
+    install -Dm644 ${sgt-puzzles-menu} -t $out/etc/xdg/menus/applications-merged/
   '';
 
   preConfigure = ''
@@ -58,7 +66,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Simon Tatham's portable puzzle collection";
     license = licenses.mit;
-    maintainers = [ maintainers.raskin ];
+    maintainers = [ maintainers.raskin maintainers.genesis ];
     platforms = platforms.linux;
     homepage = https://www.chiark.greenend.org.uk/~sgtatham/puzzles/;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @7c6f434c