### PR TITLE
pyradio: init at 0.8.7.1

### DIFF
--- a/pkgs/applications/radio/pyradio/default.nix
+++ b/pkgs/applications/radio/pyradio/default.nix
@@ -1,0 +1,24 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pyradio";
+  version = "0.8.7.1";
+
+  src = fetchFromGitHub {
+    owner = "coderholic";
+    repo = pname;
+    rev = version;
+    sha256 = "1f1dch5vrx2armrff19rh9gpqydspn3nvzc9p9j2jfi6gsxhppyb";
+  };
+
+  checkPhase = ''
+    $out/bin/pyradio --help
+  '';
+
+  meta = with lib; {
+    homepage = "http://www.coderholic.com/pyradio/";
+    description = "Curses based internet radio player";
+    license = licenses.mit;
+    maintainers = with maintainers; [ contrun ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9445,6 +9445,8 @@ in
 
   pipewire = callPackage ../development/libraries/pipewire {};
 
+  pyradio = callPackage ../applications/radio/pyradio {};
+
   pyrex = pyrex095;
 
   pyrex095 = callPackage ../development/interpreters/pyrex/0.9.5.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
