### PR TITLE
pythonPackages.dash*: bump

### DIFF
--- a/pkgs/development/python-modules/dash-core-components/default.nix
+++ b/pkgs/development/python-modules/dash-core-components/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "dash_core_components";
-  version = "1.7.0";
+  version = "1.8.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "16jjanq4glj6c2cwyw94954hrqqv49fknisbxj03lfmflg61j32k";
+    sha256 = "0qqf51mphv1pqqc2ff50rkbw44sp9liifg0mg7xkh41sgnv032cs";
   };
 
   # No tests in archive
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A dash component starter pack";
-    homepage = https://dash.plot.ly/dash-core-components;
+    homepage = "https://dash.plot.ly/dash-core-components";
     license = licenses.mit;
     maintainers = [ maintainers.antoinerg ];
   };

--- a/pkgs/development/python-modules/dash-renderer/default.nix
+++ b/pkgs/development/python-modules/dash-renderer/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "dash_renderer";
-  version = "1.2.3";
+  version = "1.2.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ccsykv24dz9xj24106aaj7f0w7x7sv7mamjbx0m6k0wyhh58vw1";
+    sha256 = "1w6mpmvfj6nv5rdzikwc7wwhrgscbh50d0azzydhsa9jccxvkakl";
   };
 
   # No tests in archive
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Renderer for the Dash framework";
-    homepage = https://dash.plot.ly/;
+    homepage = "https://dash.plot.ly/";
     license = licenses.mit;
     maintainers = [ maintainers.antoinerg ];
   };

--- a/pkgs/development/python-modules/dash-table/default.nix
+++ b/pkgs/development/python-modules/dash-table/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "dash_table";
-  version = "4.6.0";
+  version = "4.6.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "01wzac09ac6nr27if1liaxafzdf67x00vw1iq5vaad1147rdh36k";
+    sha256 = "0xwwkp7zsmrcnl3fswm5f319cxk7hk4dzacvfsarll2b47rmm434";
   };
 
   # No tests in archive
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A First-Class Interactive DataTable for Dash";
-    homepage = https://dash.plot.ly/datatable;
+    homepage = "https://dash.plot.ly/datatable";
     license = licenses.mit;
     maintainers = [ maintainers.antoinerg ];
   };

--- a/pkgs/development/python-modules/dash/default.nix
+++ b/pkgs/development/python-modules/dash/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "dash";
-  version = "1.8.0";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "plotly";
     repo = pname;
     rev = "v${version}";
-    sha256 = "11skbvjlj93aw1pqx6j56h73sy9r06jwq7z5h64fd1a3d4z2gsvy";
+    sha256 = "0lqvcq7xaw5l1mwmgfdhr9jspq8jzkxf77862k0ca4d9zglkqp4z";
   };
 
   propagatedBuildInputs = [
@@ -43,11 +43,8 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
-    pytest tests/unit/test_configs.py
-    pytest tests/unit/test_fingerprint.py
-    pytest tests/unit/test_import.py
-    pytest tests/unit/test_resources.py
-    pytest tests/unit/dash/
+    pytest tests/unit/test_{configs,fingerprint,import,resources}.py \
+      tests/unit/dash/
   '';
 
   pythonImportsCheck = [
@@ -56,7 +53,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python framework for building analytical web applications";
-    homepage = https://dash.plot.ly/;
+    homepage = "https://dash.plot.ly/";
     license = licenses.mit;
     maintainers = [ maintainers.antoinerg ];
   };


### PR DESCRIPTION
###### Motivation for this change
noticed some failures with #81144, so i bumped the entire package set

closes #81144

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[13 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/81489
5 package marked as broken and skipped:
python27Packages.dask-glm python27Packages.dask-image python27Packages.dask-jobqueue python27Packages.dask-mpi python27Packages.dask-xgboost

12 package built:
python27Packages.dash python27Packages.dash-core-components python27Packages.dash-renderer python27Packages.dash-table python37Packages.dash python37Packages.dash-core-components python37Packages.dash-renderer python37Packages.dash-table python38Packages.dash python38Packages.dash-core-components python38Packages.dash-renderer python38Packages.dash-table
```