### PR TITLE
terraform-providers.libvirt: 0.5.1 -> 0.6.1

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
@@ -19,7 +19,7 @@
 
 buildGoPackage rec {
   pname = "terraform-provider-libvirt";
-  version = "0.5.1";
+  version = "0.6.1";
 
   goPackagePath = "github.com/dmacvicar/terraform-provider-libvirt";
 
@@ -27,7 +27,7 @@ buildGoPackage rec {
     owner = "dmacvicar";
     repo = "terraform-provider-libvirt";
     rev = "v${version}";
-    sha256 = "0shnj5byqj3qzyqniiy1dcygd8xw1h2bx9z6mgcydw8k64fkm4bw";
+    sha256 = "1l2n97nj6g44n7bhnbjwmv36xi6754p4iq2qnpkdh39x4384a0zz";
   };
 
   buildInputs = [ libvirt pkgconfig makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

The current version of the plugin does not work with nixpkgs-unstable as the libvirt daemon is to new for the old plugin

###### Things done

Updated the plugin and terraformed away. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
