### PR TITLE
vmfs-tools: minor cleanup

### DIFF
--- a/pkgs/tools/filesystems/vmfs-tools/default.nix
+++ b/pkgs/tools/filesystems/vmfs-tools/default.nix
@@ -1,25 +1,39 @@
-{ stdenv, fetchFromGitHub, pkgconfig
-, asciidoc, docbook_xsl, fuse, libuuid, libxslt }:
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, asciidoc
+, docbook_xsl
+, fuse
+, libuuid
+, libxslt
+}:
 
-stdenv.mkDerivation {
-  name = "vmfs-tools";
+stdenv.mkDerivation rec {
+  pname = "vmfs-tools";
+  version = "0.2.5.20160116";
 
   src = fetchFromGitHub {
-    owner  = "glandium";
-    repo   = "vmfs-tools";
-    rev    = "4ab76ef5b074bdf06e4b518ff6d50439de05ae7f";
+    owner = "glandium";
+    repo = pname;
+    rev = "4ab76ef5b074bdf06e4b518ff6d50439de05ae7f";
     sha256 = "14y412ww5hxk336ils62s3fwykfh6mx1j0iiaa5cwc615pi6qvi4";
   };
 
-  nativeBuildInputs = [ asciidoc docbook_xsl fuse libuuid libxslt pkgconfig ];
+  nativeBuildInputs = [ asciidoc docbook_xsl libxslt pkgconfig ];
+
+  buildInputs = [ fuse libuuid ];
 
   enableParallelBuilding = true;
 
+  postInstall = ''
+    install -Dm444 -t $out/share/doc/${pname} AUTHORS LICENSE README TODO
+  '';
+
   meta = with stdenv.lib; {
-    homepage = https://github.com/glandium/vmfs-tools;
-    description = "FUSE-based VMFS (vmware) mounting tools";
+    description = "FUSE-based VMFS (vmware) file system tools";
     maintainers = with maintainers; [ peterhoeg ];
-    platforms = platforms.linux;
     license = licenses.gpl2;
+    platforms = platforms.linux;
+    inherit (src.meta) homepage;
   };
 }


### PR DESCRIPTION
Move a few things to buildInputs where they belong and install documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).