### PR TITLE
teensy-loader-cli: 2.1 -> 2.1.20191110

### DIFF
--- a/pkgs/development/tools/misc/teensy-loader-cli/default.nix
+++ b/pkgs/development/tools/misc/teensy-loader-cli/default.nix
@@ -1,26 +1,31 @@
-{ stdenv, libusb, fetchgit }:
-let
-  version = "2.1";
-in
-stdenv.mkDerivation {
+{ stdenv, fetchFromGitHub, go-md2man, installShellFiles, libusb }:
+
+stdenv.mkDerivation rec {
   pname = "teensy-loader-cli";
-  inherit version;
-  src = fetchgit {
-    url = "git://github.com/PaulStoffregen/teensy_loader_cli.git";
-    rev = "f5b6d7aafda9a8b014b4bb08660833ca45c136d2";
-    sha256 = "1a663bv3lvm7bsf2wcaj2c0vpmniak7w5hwix5qgz608bvm2v781";
+  version = "2.1.20191110";
+
+  src = fetchFromGitHub {
+    owner = "PaulStoffregen";
+    repo = "teensy_loader_cli";
+    rev = "e98b5065cdb9f04aa4dde3f2e6e6e6f12dd97592";
+    sha256 = "1yx8vsh6b29pqr4zb6sx47429i9x51hj9psn8zksfz75j5ivfd5i";
   };
 
   buildInputs = [ libusb ];
 
+  nativeBuildInputs = [ go-md2man installShellFiles ];
+
   installPhase = ''
-    install -Dm755 teensy_loader_cli $out/bin/teensy-loader-cli
+    install -Dm555 teensy_loader_cli $out/bin/teensy-loader-cli
+    install -Dm444 -t $out/share/doc/${pname} *.md *.txt
+    go-md2man -in README.md -out ${pname}.1
+    installManPage *.1
   '';
 
   meta = with stdenv.lib; {
-    license = licenses.gpl3;
     description = "Firmware uploader for the Teensy microcontroller boards";
-    homepage = https://www.pjrc.com/teensy/;
+    homepage = "https://www.pjrc.com/teensy/";
+    license = licenses.gpl3;
     maintainers = with maintainers; [ the-kenny ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
Add manpages and documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).