### PR TITLE
gitaly: fix build

### DIFF
--- a/pkgs/applications/version-management/gitlab/gitaly/deps.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/deps.nix
@@ -842,8 +842,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/libgit2/git2go";
-      rev = "ecaeb7a21d47";
-      sha256 = "14r7ryff93r49g94f6kg66xc0y6rwb31lj22s3qmzmlgywk0pgvr";
+      rev = "v0.28.5";
+      sha256 = "1cbs3y53xklr5j580s76lpgv7rvjc2j6jwm7f7nw56wjq5vx5zyk";
     };
   }
   {


### PR DESCRIPTION
Updated dep git2go ecaeb7a21d47 -> v0.28.5 to fix build problem.
```
go/src/github.com/libgit2/git2go/git_dynamic.go:10:3: error: #error "Invalid libgit2 version; this git2go supports libgit2 v0.27"
   10 | # error "Invalid libgit2 version; this git2go supports libgit2 v0.27"
      |   ^~~~~
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
