### PR TITLE
dmenu-wayland: init at 2020-02-28

### DIFF
--- a/pkgs/applications/misc/dmenu/wayland.nix
+++ b/pkgs/applications/misc/dmenu/wayland.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, meson, ninja, cairo, pango, pkg-config, wayland-protocols
+, glib, wayland, libxkbcommon, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dmenu-wayland-unstable";
+  version = "2020-02-28";
+
+  src = fetchFromGitHub {
+    owner = "nyyManni";
+    repo = "dmenu-wayland";
+    rev = "68e08e8bcde10a10ac3290431f173c6c7fce4238";
+    sha256 = "10b1v2brgpgb6wkzn62haj56zmkf3aq6fs3p9rp6bxiw8bs2nvlm";
+  };
+
+  outputs = [ "out" "man" ];
+
+  nativeBuildInputs = [ meson ninja pkg-config makeWrapper ];
+  buildInputs = [ cairo pango wayland-protocols glib wayland libxkbcommon ];
+
+  postInstall = ''
+    wrapProgram $out/bin/dmenu-wl_run \
+      --prefix PATH : $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    platforms = platforms.linux;
+    description = "dmenu for wayland-compositors";
+    homepage = "https://github.com/nyyManni/dmenu-wayland";
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18752,6 +18752,7 @@ in
   djview4 = pkgs.djview;
 
   dmenu = callPackage ../applications/misc/dmenu { };
+  dmenu-wayland = callPackage ../applications/misc/dmenu/wayland.nix { };
 
   dmensamenu = callPackage ../applications/misc/dmensamenu {
     inherit (python3Packages) buildPythonApplication requests;


### PR DESCRIPTION

###### Motivation for this change

Although this one isn't feature-complete yet, it fixes the scaling
issues on Wayland I'm experiencing when using `pkgs.dmenu`
through XWayland.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
