### PR TITLE
gnomeExtensions.switcher: init at 26

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/switcher/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/switcher/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-switcher";
+  version = "26";
+
+  src = fetchFromGitHub {
+    owner = "daniellandau";
+    repo = "switcher";
+    rev = "b707bdfcfaac9bf6e73e162ab75b871eb920ae41";
+    sha256 = "1hx078w8mzaflwk8kd7s8np4041mbgca86rg7iyb9g8wbrbb0nzv";
+  };
+
+  uuid = "switcher@landau.fi";
+
+  nativeBuildInputs = [ glib ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r * $out/share/gnome-shell/extensions/${uuid}/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gnome Shell extension for switching windows by typing";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ danieldk ];
+    homepage = "https://github.com/daniellandau/switcher";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23813,6 +23813,7 @@ in
     pidgin-im-integration = callPackage ../desktops/gnome-3/extensions/pidgin-im-integration { };
     remove-dropdown-arrows = callPackage ../desktops/gnome-3/extensions/remove-dropdown-arrows { };
     sound-output-device-chooser = callPackage ../desktops/gnome-3/extensions/sound-output-device-chooser { };
+    switcher = callPackage ../desktops/gnome-3/extensions/switcher { };
     system-monitor = callPackage ../desktops/gnome-3/extensions/system-monitor { };
     taskwhisperer = callPackage ../desktops/gnome-3/extensions/taskwhisperer { };
     tilingnome = callPackage ../desktops/gnome-3/extensions/tilingnome { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is a nice extension for quickly finding a window among gazillions of other windows.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
