### PR TITLE
gsasl: don't check on linux either

### DIFF
--- a/pkgs/development/libraries/gsasl/default.nix
+++ b/pkgs/development/libraries/gsasl/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-gssapi-impl=mit" ];
 
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = false;
 
   meta = {
     description = "GNU SASL, Simple Authentication and Security Layer library";


### PR DESCRIPTION
Recently (https://hydra.nixos.org/build/113717403) something has caused the linux version to start segfaulting in its test suite:
```
Header version 1.8.0 library version 1.8.0
/nix/store/8gy2bmpz3qawxr3g8hqhfgkf32wb0wfl-bash-4.4-p23/bin/bash: line 5: 28803 Segmentation fault      (core dumped) SHISHI_KEYS=./gssapi.key SHISHI_TICKETS=./gssapi.tkt SHISHI_CONFIG=./shishi.conf SHISHI_HOME=. SHISHI_USER=ignore-this-warning THREADSAFETY_FILES=`ls ../lib/*/*.c | /nix/store/8z2qcxbl9kfqhqqjm04lzlvvlwli4bw7-gnugrep-3.4/bin/grep -v -e lib/gl/vasnprintf.c -e lib/gl/getdelim.c` MD5FILE=./cram-md5.pwd EGREP="/nix/store/8z2qcxbl9kfqhqqjm04lzlvvlwli4bw7-gnugrep-3.4/bin/grep -E" GNUGSS=`if grep 'HAVE_LIBGSS 1' ../lib/config.h > /dev/null; then echo yes; else echo no; fi` ${dir}$tst
FAIL: old-simple
```
This library has been marked as don't-check on darwin for more than a
year---unfortunately that commit message didn't mention *why*, so it's
hard to say if linux has started seeing the same issue or a different
one.

Regardless, this is just a stopgap; the real solution is probably to
upgrade at least to 1.8.1 (a new stable release made last year), or
perhaps even to the 1.9 betas---but that seems like something that
should be the decision of the maintainer, @shlevy.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Wanted to get `msmtp` working again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
