### PR TITLE
acgtk: 1.5.0 → 1.5.1

### DIFF
--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation {
 
-  name = "acgtk-1.5.0";
+  name = "acgtk-1.5.1";
 
   src = fetchurl {
-    url = http://calligramme.loria.fr/acg/software/acg-1.5.0-20181019.tar.gz;
-    sha256 = "14n003gxzw5w79hlpw1ja4nq97jqf9zqyg00ihvpxw4bv9jlm8jm";
+    url = https://acg.loria.fr/software/acg-1.5.1-20191113.tar.gz;
+    sha256 = "17595qfwhzz5q091ak6i6bg5wlppbn8zfn58x3hmmmjvx2yfajn1";
   };
 
   buildInputs = [ dune ] ++ (with ocamlPackages; [
-    ocaml findlib ansiterminal cairo2 fmt logs menhir mtime ocf
+    ocaml findlib ansiterminal cairo2 cmdliner fmt logs menhir mtime yojson
   ]);
 
   buildPhase = "dune build";
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   inherit (dune) installPhase;
 
   meta = with stdenv.lib; {
-    homepage = http://calligramme.loria.fr/acg/;
+    homepage = https://acg.loria.fr/;
     description = "A toolkit for developing ACG signatures and lexicon";
     license = licenses.cecill20;
     inherit (ocamlPackages.ocaml.meta) platforms;

--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -2,7 +2,8 @@
 
 stdenv.mkDerivation {
 
-  name = "acgtk-1.5.1";
+  pname = "acgtk";
+  version = "1.5.1";
 
   src = fetchurl {
     url = https://acg.loria.fr/software/acg-1.5.1-20191113.tar.gz;


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
