### PR TITLE
ebtables: restore legacy commands

### DIFF
--- a/pkgs/os-specific/linux/ebtables/default.nix
+++ b/pkgs/os-specific/linux/ebtables/default.nix
@@ -9,15 +9,21 @@ stdenv.mkDerivation rec {
     sha256 = "0apxgmkhsk3vxn9q3libxn3dgrdljrxyy4mli2gk49m7hi3na7xp";
   };
 
-  makeFlags =
-    [ "LIBDIR=$(out)/lib" "BINDIR=$(out)/sbin" "MANDIR=$(out)/share/man"
-      "ETCDIR=$(out)/etc" "INITDIR=$(TMPDIR)" "SYSCONFIGDIR=$(out)/etc/sysconfig"
-      "LOCALSTATEDIR=/var"
-    ];
+  makeFlags = [
+    "LIBDIR=$(out)/lib" "BINDIR=$(out)/sbin" "MANDIR=$(out)/share/man"
+    "ETCDIR=$(out)/etc" "INITDIR=$(TMPDIR)" "SYSCONFIGDIR=$(out)/etc/sysconfig"
+    "LOCALSTATEDIR=/var"
+  ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
   preInstall = "mkdir -p $out/etc/sysconfig";
+
+  postInstall = ''
+    ln -s $out/sbin/ebtables-legacy          $out/sbin/ebtables
+    ln -s $out/sbin/ebtables-legacy-restore  $out/sbin/ebtables-restore
+    ln -s $out/sbin/ebtables-legacy-save     $out/sbin/ebtables-save
+  '';
 
   meta = with lib; {
     description = "A filtering tool for Linux-based bridging firewalls";


### PR DESCRIPTION
ebtables 2.0.11 renamed the ebtables commands from "ebtables*" to "ebtables-legacy-*".

Of course this breaks legacy packages and scripts that depends on the ebtables commands.

The idea behind this upstream change appears to be that ebtables-nft replaces ebtables and distributions should rename either the ebtables-legacy or ebtables-nft commands to provide the ebtables commands.

For nix a better fit is for packages to specify either the ebtables or the ebtables-nft package, while both packages provide the same commands.

This patch restores the ebtables package so it functions again.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
