### PR TITLE
orca-c: init at git-2020-02-12

### DIFF
--- a/pkgs/applications/audio/orca-c/default.nix
+++ b/pkgs/applications/audio/orca-c/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "Orca is an esoteric programming language designed to quickly create procedural sequencers.";
+    description = "An esoteric programming language designed to quickly create procedural sequencers.";
     homepage = "https://github.com/hundredrabbits/Orca-c";
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/applications/audio/orca-c/default.nix
+++ b/pkgs/applications/audio/orca-c/default.nix
@@ -2,13 +2,13 @@
 stdenv.mkDerivation {
   pname = "orca-c";
 
-  version = "git-2020-02-12";
+  version = "git-2020-05-01";
 
   src = fetchFromGitHub {
     owner = "hundredrabbits";
     repo = "Orca-c";
-    rev = "c6d981d35bb7b93b9b43e1920d45a71f00328dd3";
-    sha256 = "00hmjcadv4w0y4ixbys8c6w43lcma48arjhikjr55grz9krlvwqa";
+    rev = "d7a3b169c5ed0b06a9ad0fdb3057704da9a0b6ce";
+    sha256 = "101y617a295hzwr98ykvza1sycxlk29kzxn2ybjwc718r0alkbzz";
   };
 
   buildInputs = [ ncurses portmidi ];

--- a/pkgs/applications/audio/orca-c/default.nix
+++ b/pkgs/applications/audio/orca-c/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, ncurses, portmidi }:
+stdenv.mkDerivation {
+  pname = "orca-c";
+
+  version = "git-2020-02-12";
+
+  src = fetchFromGitHub {
+    owner = "hundredrabbits";
+    repo = "Orca-c";
+    rev = "c6d981d35bb7b93b9b43e1920d45a71f00328dd3";
+    sha256 = "00hmjcadv4w0y4ixbys8c6w43lcma48arjhikjr55grz9krlvwqa";
+  };
+
+  buildInputs = [ ncurses portmidi ];
+
+  patchPhase = ''
+    patchShebangs tool
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install build/orca $out/bin/orca
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Orca is an esoteric programming language designed to quickly create procedural sequencers.";
+    homepage = "https://github.com/hundredrabbits/Orca-c";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20896,6 +20896,8 @@ in
     inherit (pkgs) pkgconfig;
   };
 
+  orca-c = callPackage ../applications/audio/orca-c {};
+
   osm2xmap = callPackage ../applications/misc/osm2xmap {
     libyamlcpp = libyamlcpp_0_3;
   };


### PR DESCRIPTION
##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
