### PR TITLE
pythonPackages.aria2p: inherit poetry from python-modules

### DIFF
--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -32,6 +32,7 @@ let
 in buildPythonPackage rec {
   pname = "poetry";
   version = "1.0.3";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
@@ -42,11 +43,9 @@ in buildPythonPackage rec {
     substituteInPlace pyproject.toml \
      --replace "pyrsistent = \"^0.14.2\"" "pyrsistent = \"^0.15.0\"" \
      --replace "requests-toolbelt = \"^0.8.0\"" "requests-toolbelt = \"^0.9.0\"" \
-     --replace "importlib-metadata = {version = \"~1.1.3\", python = \"<3.8\"}" \
-       "importlib-metadata = {version = \"~1.3.0\", python = \"<3.8\"}"
+     --replace 'importlib-metadata = {version = "~1.1.3", python = "<3.8"}' \
+       'importlib-metadata = {version = ">=1.3,<2", python = "<3.8"}'
   '';
-
-  format = "pyproject";
 
   nativeBuildInputs = [ intreehooks ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -187,7 +187,7 @@ in {
 
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
-  aria2p = callPackage ../development/python-modules/aria2p { inherit (pkgs) aria2 poetry; };
+  aria2p = callPackage ../development/python-modules/aria2p { inherit (pkgs) aria2; };
 
   arviz = callPackage ../development/python-modules/arviz { };
 


### PR DESCRIPTION
###### Motivation for this change
noticed failure reviewing #81536

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[4 built, 21 copied (3.1 MiB), 0.6 MiB DL]
https://github.com/NixOS/nixpkgs/pull/81548
5 package built:
python27Packages.poetry python37Packages.aria2p python37Packages.poetry python38Packages.aria2p python38Packages.poetry
```