### PR TITLE
kent: init at 394

### DIFF
--- a/pkgs/applications/science/biology/kent/default.nix
+++ b/pkgs/applications/science/biology/kent/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, libpng
+, libuuid
+, zlib
+, bzip2
+, lzma
+, openssl
+, curl
+, libmysqlclient
+, bash
+, fetchFromGitHub
+, which
+}:
+stdenv.mkDerivation rec {
+  pname = "kent";
+  version = "404";
+
+  src = fetchFromGitHub {
+    owner = "ucscGenomeBrowser";
+    repo = pname;
+    rev = "v${version}_base";
+    sha256 = "0l5lmqqc6sqkf4hyk3z4825ly0vdlj5xdfad6zd0708cb1v81nbx";
+  };
+
+  buildInputs = [ libpng libuuid zlib bzip2 lzma openssl curl libmysqlclient ];
+
+  patchPhase = ''
+    substituteInPlace ./src/checkUmask.sh \
+      --replace "/bin/bash" "${bash}/bin/bash"
+
+    substituteInPlace ./src/hg/sqlEnvTest.sh \
+      --replace "which mysql_config" "${which}/bin/which ${libmysqlclient}/bin/mysql_config"
+  '';
+
+  buildPhase = ''
+    export MACHTYPE=$(uname -m)
+    export CFLAGS="-fPIC"
+    export MYSQLINC=$(mysql_config --include | sed -e 's/^-I//g')
+    export MYSQLLIBS=$(mysql_config --libs)
+    export DESTBINDIR=$NIX_BUILD_TOP/bin
+    export HOME=$NIX_BUILD_TOP
+
+    cd ./src
+    chmod +x ./checkUmask.sh
+    ./checkUmask.sh
+
+    mkdir -p $NIX_BUILD_TOP/lib
+    mkdir -p $NIX_BUILD_TOP/bin/x86_64
+
+    make libs
+    cd jkOwnLib
+    make
+
+    cp ../lib/x86_64/jkOwnLib.a $NIX_BUILD_TOP/lib
+    cp ../lib/x86_64/jkweb.a $NIX_BUILD_TOP/lib
+
+    cd ../utils
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/lib
+    cp $NIX_BUILD_TOP/lib/jkOwnLib.a $out/lib
+    cp $NIX_BUILD_TOP/lib/jkweb.a $out/lib
+    cp $NIX_BUILD_TOP/bin/x86_64/* $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "UCSC Genome Bioinformatics Group's suite of biological analysis tools, i.e. the kent utilities";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ scalavision ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Kent utilities are a very versatile and fast suite of bioinformatic tools that has been available for a long time. It has some very nice tools to optimize for visualization of big data.

###### Things done

I have put the `mit` license, however some of these tools are not allowed to be used outside non-profit organizations. My understanding of nixpkgs is that it is completely non-profit. 

For `lib`, `inc` and `utils` the MIT wording has been used:

* <https://github.com/ucscGenomeBrowser/kent/blob/master/src/lib/LICENSE>
* <https://github.com/ucscGenomeBrowser/kent/blob/master/src/inc/LICENSE>
* <https://github.com/ucscGenomeBrowser/kent/blob/master/src/utils/LICENSE>

The licenses where there are exceptions from the `mit` license says this:

```
License hereby is granted for personal, academic and non-profit purposes
```

* <https://github.com/ucscGenomeBrowser/kent/blob/master/src/lib/README#L9>
* <https://github.com/ucscGenomeBrowser/kent/blob/master/src/jkOwnLib/README>

Should I choose something else than `mit`?

It is possible to build the ``utility suite`` without these libraries, but I am also working on adding `ensembl-vep`, where these libraries are required. Since there also are commercial binaries in nixpkgs, I don't think this should be a problem, but I am not a lawyer ..

I really hope these tools can be added to `nixpkgs`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x ] Ensured that relevant documentation is up to date
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
