### PR TITLE
travis: 1.8.10 -> 1.8.11

### DIFF
--- a/pkgs/development/tools/misc/travis/Gemfile.lock
+++ b/pkgs/development/tools/misc/travis/Gemfile.lock
@@ -2,15 +2,15 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    backports (3.15.0)
+    backports (3.16.1)
     coderay (1.1.2)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    faraday (0.17.0)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.13.1)
+    faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.11.2)
+    ffi (1.12.2)
     gh (0.15.1)
       addressable (~> 2.4.0)
       backports
@@ -19,7 +19,7 @@ GEM
       net-http-persistent (~> 2.9)
       net-http-pipeline
     highline (1.7.10)
-    json (2.2.0)
+    json (2.3.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     method_source (0.9.2)
@@ -33,7 +33,7 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    travis (1.8.10)
+    travis (1.8.11)
       backports
       faraday (~> 0.9)
       faraday_middleware (~> 0.9, >= 0.9.1)
@@ -54,4 +54,4 @@ DEPENDENCIES
   travis
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/pkgs/development/tools/misc/travis/gemset.nix
+++ b/pkgs/development/tools/misc/travis/gemset.nix
@@ -8,12 +8,14 @@
     version = "2.4.0";
   };
   backports = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0cczfi1yp7a68bg7ipzi4lvrmi4xsi36n9a19krr4yb3nfwd8fn2";
+      sha256 = "0sp3l5wa77klj34sqib95ppxyam53x3p57xk0y6gy2c3z29z6hs5";
       type = "gem";
     };
-    version = "3.15.0";
+    version = "3.16.1";
   };
   coderay = {
     groups = ["default"];
@@ -40,29 +42,31 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0jk2bar4x6miq2cr73lv0lsbmw4cymiljvp29xb85jifsb3ba6az";
+      sha256 = "13aghksmni2sl15y7wfpx6k5l3lfd8j9gdyqi6cbw6jgc7bqyyn2";
       type = "gem";
     };
-    version = "0.17.0";
+    version = "0.17.3";
   };
   faraday_middleware = {
     dependencies = ["faraday"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1a93rs58bakqck7bcihasz66a1riy22h2zpwrpmb13gp8mw3wkmr";
+      sha256 = "1x7jgvpzl1nm7hqcnc8carq6yj1lijq74jv8pph4sb3bcpfpvcsc";
       type = "gem";
     };
-    version = "0.13.1";
+    version = "0.14.0";
   };
   ffi = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0cbads5da12lb3j0mg2hjrd57s5qkkairxh2y6r9bqyblb5b8xbw";
+      sha256 = "10lfhahnnc91v63xpvk65apn61pib086zha3z5sp1xk9acfx12h4";
       type = "gem";
     };
-    version = "1.11.2";
+    version = "1.12.2";
   };
   gh = {
     dependencies = ["addressable" "backports" "faraday" "multi_json" "net-http-persistent" "net-http-pipeline"];
@@ -82,12 +86,14 @@
     version = "1.7.10";
   };
   json = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0sx97bm9by389rbzv8r1f43h06xcz8vwi3h5jv074gvparql7lcx";
+      sha256 = "0nrmw2r4nfxlfgprfgki3hjifgrcrs3l5zvm3ca3gb4743yr25mn";
       type = "gem";
     };
-    version = "2.2.0";
+    version = "2.3.0";
   };
   launchy = {
     dependencies = ["addressable"];
@@ -164,12 +170,14 @@
   };
   travis = {
     dependencies = ["backports" "faraday" "faraday_middleware" "gh" "highline" "launchy" "pusher-client" "typhoeus"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0ggdksipvnkl7s0g84l4wfpm9v70x9id8xvb9jmn3l0hhlk54dsk";
+      sha256 = "18zbi46as4d2wn83safawciyny0g2sk7yz5fvjvqmfk4ywpfrwrr";
       type = "gem";
     };
-    version = "1.8.10";
+    version = "1.8.11";
   };
   typhoeus = {
     dependencies = ["ethon"];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version bump.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
