### PR TITLE
nixos/documentation: Allow specifying extraSources

### DIFF
--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -17,6 +17,7 @@ let
     inherit pkgs config;
     version = config.system.nixos.release;
     revision = "release-${version}";
+    extraSources = cfg.nixos.extraModuleSources;
     options =
       let
         scrubbedEval = evalModules {
@@ -160,6 +161,19 @@ in
           the options from all the NixOS modules included in the current
           <literal>configuration.nix</literal>. Disabling this will make the manual
           generator to ignore options defined outside of <literal>baseModules</literal>.
+        '';
+      };
+
+      nixos.extraModuleSources = mkOption {
+        type = types.listOf (types.either types.path types.str);
+        default = [ ];
+        description = ''
+          Which extra NixOS module paths the generated NixOS's documentation should strip
+          from options.
+        '';
+        example = literalExample ''
+          # e.g. with options from modules in ''${pkgs.customModules}/nix:
+          [ pkgs.customModules ]
         '';
       };
 


### PR DESCRIPTION
Because there was absolutely no way of setting this without rewriting parts of the module otherwise.

###### Motivation for this change

When using https://github.com/DBCDK/morph with NixOS machines specifying `documentation.nixos.includeAllModules = true;`, the manuals of NixOS instantations were impure & repeatedly rebuilding due to both morph's use of temporary directories & Nixpkgs modules and the normal location of the morph network's repository being in a user's home directory along with our definition of Nixpkgs modules. Some examples from these manual builds:

```xml
<attrs>
  <attr name="declarations">
    <list>
      <string value="/tmp/morph-974414533/options.nix" />
    </list>
  <attr name="default">
```

```xml
<attrs>
  <attr name="declarations">
    <list>
      <string value="/home/bb010g/Documents/sysadmin/contoso/modules/nix-substituters.nix" />
    </list>
  <attr name="default">
```

NixOS's documentation machinery has a configuration option to deal with this, `extraSources`, but it's not exposed, and the expressions aren't structured in a way to allow sneaky, underhanded configuration either. You can't get around this without patching Nixpkgs. (This PR has been tested so far on our repository via applying `pkgs.applyPatches { src = nixpkgs.outPath; patches = [ ./nixpkgs-nixos-expose-extrasources.patch ]; }` before importing Nixpkgs. (Whee.))

With this change in place, the repository-directory impurity demonstrated can be eliminated with `nixos.extraSources = [ ./. ];` from the repository root, and the morph impurity with an (approximate) patch to `/data/eval-machines.nix` of:
```patch
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -26,6 +26,8 @@ rec {
             [ ({ config, lib, options, ... }: {
                 key = "deploy-stuff";
                 imports = [ ./options.nix ];
+                # Make doc builds determinisitic, even with our tempdir module imports
+                documentation.nixos.extraSources = [ ../. ];
                 # Provide a default hostname and deployment target equal
                 # to the attribute name of the machine in the model.
                 networking.hostName = lib.mkDefault machineName;
```

Sorry for the delay on PRing this; I know this should have been in way earlier for 20.03's sake. If possible, I'd like to get this backported to 20.03 for sanity in situtations like morph when 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/81557)
<!-- Reviewable:end -->
