### PR TITLE
pantalaimon: 0.4 -> 0.5.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPythonApplication, fetchPypi, pythonOlder,
+{ lib, stdenv, buildPythonApplication, fetchFromGitHub, pythonOlder,
   attrs, aiohttp, appdirs, click, keyring, Logbook, peewee, janus,
   prompt_toolkit, matrix-nio, dbus-python, pydbus, notify2, pygobject3,
 
@@ -9,13 +9,16 @@
 
 buildPythonApplication rec {
   pname = "pantalaimon";
-  version = "0.4";
+  version = "0.5.1";
 
   disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1canj9w72wh1rcw6fivrvaahpxy13gb6gh1k8nss6bgixalvnq9m";
+  # pypi tarball miss tests
+  src = fetchFromGitHub {
+    owner = "matrix-org";
+    repo = pname;
+    rev = version;
+    sha256 = "18jihvqlfk8lx97hxcr36zdkp2sffg2l8mkg5lflylwcgwy1dx0y";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -20,13 +20,13 @@
 
 buildPythonPackage rec {
   pname = "nio";
-  version = "0.7.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "poljar";
     repo = "matrix-nio";
     rev = version;
-    sha256 = "05cggfhsfa0irvzc7x3fndv6n0zszxxhmlv89r5rkrl5wvrhbb2h";
+    sha256 = "151c59a913y6kx99g7g3mhpgbgavwic1mh21nfrr9x0rm98ilay9";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "luarocks";
-  version = "3.3.1";
+  version = "3.2.1";
 
   src = fetchFromGitHub {
     owner = "luarocks";
     repo = "luarocks";
     rev = "v${version}";
-    sha256 = "0859k2b9pihmcw45fdsbwx936npcj3vbp3hxi1v3j7n61dkw7r0s";
+    sha256 = "0viiafmb8binksda79ah828q1dfnb6jsqlk7vyndl2xvx9yfn4y2";
   };
 
   patches = [ ./darwin-3.1.3.patch ];


### PR DESCRIPTION

###### Motivation for this change

update pantalaimon

###### Things done

updated nio as a new version is required by pantalaimon.

Tested that pantalaimon is functional.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` <- nix-review OOMs on my machine.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
