### PR TITLE
fetchpatch: Allow using base64-encoded hash

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -11,9 +11,13 @@ let
 in
 { stripLen ? 0, extraPrefix ? null, excludes ? [], includes ? [], revert ? false, ... }@args:
 
+let
+  # Make base-64 encoded SRI hash filename-safe using RFC 4648 §5
+  tmpname = lib.replaceStrings [ "+" "/" "=" ] [ "-" "_" "" ] args.sha256;
+in
 fetchurl ({
   postFetch = ''
-    tmpfile="$TMPDIR/${args.sha256}"
+    tmpfile="$TMPDIR/${tmpname}"
     if [ ! -s "$out" ]; then
       echo "error: Fetched patch file '$out' is empty!" 1>&2
       exit 1


### PR DESCRIPTION
###### Motivation for this change
Nix now returns base64-encoded SRI hashes on hash mismatch. Usually, people copy the returned hashes in TOFU fashion but since base64-encoded strings can contain slashes, they often broke our use of them for temporary file name.

Escaping them should prevent the failures.

Partially supersedes https://github.com/NixOS/nixpkgs/pull/79987

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
