### PR TITLE
appimage: refactoring extractType2 to avoid use of appimage packer

### DIFF
--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -13,7 +13,7 @@ rec {
           @sh "appimageSignature=\(.appimageSignature) appimageType=\(.appimageType)"')
 
       # check AppImage signature
-      if [[ $appimageSignature != "AI" ]]; then
+      if [[ "$appimageSignature" != "AI" ]]; then
         echo "Not an appimage."
         exit
       fi
@@ -25,14 +25,13 @@ rec {
           ;;
 
         2)
-          install $src ./appimage
-
           # multiarch offset one-liner using same method as AppImage
           # see https://gist.github.com/probonopd/a490ba3401b5ef7b881d5e603fa20c93
-          offset=$(r2 ./appimage -nn -Nqc "pfj.elf_header @ 0" |\
+          offset=$(r2 $src -nn -Nqc "pfj.elf_header @ 0" |\
             jq 'map({(.name): .value}) | add | .shoff + (.shnum * .shentsize)')
 
-          unsquashfs -q -d $out -o $offset ./appimage
+          unsquashfs -q -d $out -o $offset $src
+          chmod go-w $out
           ;;
 
         # 3) get ready, https://github.com/TheAssassin/type3-runtime


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

* avoid to use appimage packer intend to avoid to modify it (copy then patch it) or execute random unofficial packer, this method should work as non-native unpack  ...
* unify extract simplify code and prepare for next appimage type 3. 
both are steps to make appimage packaging fully automatic.

I let people merge the PR before continuing improvements on this topic.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @tilpner @jtojnar  @matthewbauer  @worldofpeace 