### PR TITLE
satallax: fix build with GCC 9

### DIFF
--- a/pkgs/applications/science/logic/satallax/default.nix
+++ b/pkgs/applications/science/logic/satallax/default.nix
@@ -35,6 +35,9 @@ stdenv.mkDerivation rec {
     )
   '';
 
+  # Fix build with GCC 9
+  NIX_CFLAGS_COMPILE = "-fpermissive";
+
   postBuild = "echo testing; ! (bash ./test | grep ERROR)";
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

It does not build with gcc9

ZHF: #80379

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Ping @NixOS/nixos-release-managers