### PR TITLE
gsasl: export LOCALDOMAIN before running tests

### DIFF
--- a/pkgs/development/libraries/gsasl/default.nix
+++ b/pkgs/development/libraries/gsasl/default.nix
@@ -12,16 +12,19 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-gssapi-impl=mit" ];
 
+  preCheck = ''
+    export LOCALDOMAIN="dummydomain"
+  '';
   doCheck = !stdenv.hostPlatform.isDarwin;
 
   meta = {
     description = "GNU SASL, Simple Authentication and Security Layer library";
 
     longDescription =
-      '' GNU SASL is a library that implements the IETF Simple 
-         Authentication and Security Layer (SASL) framework and 
-         some SASL mechanisms. SASL is used in network servers 
-         (e.g. IMAP, SMTP, etc.) to authenticate peers. 
+      '' GNU SASL is a library that implements the IETF Simple
+         Authentication and Security Layer (SASL) framework and
+         some SASL mechanisms. SASL is used in network servers
+         (e.g. IMAP, SMTP, etc.) to authenticate peers.
        '';
 
     homepage = https://www.gnu.org/software/gsasl/;


### PR DESCRIPTION
##### Motivation for this change

Recently kerberos added a code path that relies on the local domain part
to be available. See [hydra] for the recent build failure and [github]
for a brief analysis of the error.

[hydra] https://hydra.nixos.org/build/113717403
[github]:
  - https://github.com/NixOS/nixpkgs/pull/81531#issuecomment-593840860
  - https://github.com/NixOS/nixpkgs/pull/81531#issuecomment-593853565

This unblocks nixos-unstable.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
