### PR TITLE
ruby-modules: eliminate BUNDLE_PATH

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -123,6 +123,7 @@ let
             makeWrapper "$i" $out/bin/$(basename "$i") \
               --set BUNDLE_GEMFILE ${confFiles}/Gemfile \
               --set BUNDLE_FROZEN 1 \
+              --unset BUNDLE_PATH \
               --set GEM_HOME ${basicEnv}/${ruby.gemPath} \
               --set GEM_PATH ${basicEnv}/${ruby.gemPath}
           done

--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -122,7 +122,6 @@ let
           for i in ${ruby}/bin/*; do
             makeWrapper "$i" $out/bin/$(basename "$i") \
               --set BUNDLE_GEMFILE ${confFiles}/Gemfile \
-              --set BUNDLE_PATH ${basicEnv}/${ruby.gemPath} \
               --set BUNDLE_FROZEN 1 \
               --set GEM_HOME ${basicEnv}/${ruby.gemPath} \
               --set GEM_PATH ${basicEnv}/${ruby.gemPath}

--- a/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
+++ b/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
@@ -32,8 +32,9 @@ paths.each do |path|
 #
 
 ENV["BUNDLE_GEMFILE"] = #{gemfile.dump}
-ENV["BUNDLE_PATH"] = #{bundle_path.dump}
 ENV['BUNDLE_FROZEN'] = '1'
+ENV["GEM_HOME"] = #{bundle_path.dump}
+ENV["GEM_PATH"] = #{bundle_path.dump}
 
 $LOAD_PATH.unshift #{bundler_path.dump} + "/lib"
 

--- a/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
+++ b/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
@@ -33,6 +33,7 @@ paths.each do |path|
 
 ENV["BUNDLE_GEMFILE"] = #{gemfile.dump}
 ENV['BUNDLE_FROZEN'] = '1'
+ENV.delete('BUNDLE_PATH')
 ENV["GEM_HOME"] = #{bundle_path.dump}
 ENV["GEM_PATH"] = #{bundle_path.dump}
 

--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -53,7 +53,6 @@ in
     ${(lib.concatMapStrings (x: "ln -s '${basicEnv}/bin/${x}' $out/bin/${x};\n") exes)}
     ${(lib.concatMapStrings (s: "makeWrapper $out/bin/$(basename ${s}) $srcdir/${s} " +
                                 "--set BUNDLE_GEMFILE ${basicEnv.confFiles}/Gemfile "+
-                                "--set BUNDLE_PATH ${basicEnv}/${ruby.gemPath} "+
                                 "--set BUNDLE_FROZEN 1 "+
                                 "--set GEM_HOME ${basicEnv}/${ruby.gemPath} "+
                                 "--set GEM_PATH ${basicEnv}/${ruby.gemPath} "+

--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -54,6 +54,7 @@ in
     ${(lib.concatMapStrings (s: "makeWrapper $out/bin/$(basename ${s}) $srcdir/${s} " +
                                 "--set BUNDLE_GEMFILE ${basicEnv.confFiles}/Gemfile "+
                                 "--set BUNDLE_FROZEN 1 "+
+                                "--unset BUNDLE_PATH "+
                                 "--set GEM_HOME ${basicEnv}/${ruby.gemPath} "+
                                 "--set GEM_PATH ${basicEnv}/${ruby.gemPath} "+
                                 "--run \"cd $srcdir\";\n") scripts)}


### PR DESCRIPTION
Newer versions of bundler use a "ruby scope" when installing into a
custom path (set via BUNDLE_PATH). For example, ruby 2.7 with bundler
2 will install gems into "$BUNDLE_PATH/ruby/2.7.0". This is not
compatible with setting bundler's path to $GEM_HOME, which contains
gems directly.

The ruby infrastructure doesn't need to direct bundler where to
install gems, only where to find already installed gems. The simplest
configuration that works with all current versions of ruby and bundler
is to stop using bundler's `path`, and rely on GEM_HOME and GEM_PATH.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Make the ruby infrastructure nixpkgs compatible with bundler 2.

Related PRs and issues: #81442, #78242

**I have not tested this beyond a few simple tests.**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
