### PR TITLE
libfido2: change dependency from libressl to openssl

### DIFF
--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, libcbor, libressl, udev, IOKit }:
+{ stdenv, fetchurl, cmake, pkgconfig, libcbor, openssl, udev, IOKit }:
 
 stdenv.mkDerivation rec {
   pname = "libfido2";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libcbor libressl ]
+  buildInputs = [ libcbor openssl ]
     ++ stdenv.lib.optionals stdenv.isLinux [ udev ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/Yubico/libfido2;
     license = licenses.bsd2;
-    maintainers = with maintainers; [ dtzWill ];
+    maintainers = with maintainers; [ dtzWill prusnak ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -1,4 +1,12 @@
-{ stdenv, fetchurl, cmake, pkgconfig, libcbor, openssl, udev, IOKit }:
+{ stdenv
+, fetchurl
+, fetchpatch
+, cmake
+, pkgconfig
+, libcbor
+, openssl
+, udev
+, IOKit }:
 
 stdenv.mkDerivation rec {
   pname = "libfido2";
@@ -9,14 +17,33 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
+
   buildInputs = [ libcbor openssl ]
     ++ stdenv.lib.optionals stdenv.isLinux [ udev ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
 
-  patches = [ ./detect_apple_ld.patch ];
+  patches = [
+    # fix build on darwin
+    (fetchpatch {
+      url = "https://github.com/Yubico/libfido2/commit/916ebd18a89e4028de203d603726805339be7a5b.patch";
+      sha256 = "07f0xpxnq02cccmqcric87b6pms7k7ssvdw722zr970a6qs8p6i7";
+    })
+    # allow attestation using any supported algorithm
+    (fetchpatch {
+      url = "https://github.com/Yubico/libfido2/commit/f7a9471fa0588cb91cbefffb13c1e4d06c2179b7.patch";
+      sha256 = "02qbw9bqy3sixvwig6az7v3vimgznxnfikn9p1jczm3d7mn8asw2";
+    })
+    # fix EdDSA attestation signature verification bug
+    (fetchpatch {
+      url = "https://github.com/Yubico/libfido2/commit/95126eea52294419515e6540dfd7220f35664c48.patch";
+      sha256 = "076mwpl9xndjhy359jdv2drrwyq7wd3pampkn28mn1rlwxfgf0d0";
+    })
+  ];
 
-  cmakeFlags = [ "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d"
-                 "-DCMAKE_INSTALL_LIBDIR=lib" ];
+  cmakeFlags = [
+    "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
 
   meta = with stdenv.lib; {
     description = ''


### PR DESCRIPTION
#### Motivation for this change

libressl does not enable EdDSA functionality in libfido2
see https://github.com/Yubico/libfido2/issues/144

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
