### PR TITLE
Update mednafen and mednaffe

### DIFF
--- a/pkgs/misc/emulators/mednafen/default.nix
+++ b/pkgs/misc/emulators/mednafen/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pkgconfig, freeglut, libGLU, libGL, libcdio, libjack2
-, libsamplerate, libsndfile, libX11, SDL, SDL_net, zlib }:
+, libsamplerate, libsndfile, libX11, SDL2, SDL2_net, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "mednafen";
-  version = "0.9.48";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "https://mednafen.github.io/releases/files/${pname}-${version}.tar.xz";
-    sha256 = "00i12mywhp43274aq466fwavglk5b7d8z8bfdna12ra9iy1hrk6k";
+    sha256 = "159gvzrf4as1fp74czzc14vamhd6s3hlnvwglfgdd5j6d6n37m7s";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
     libsamplerate
     libsndfile
     libX11
-    SDL
-    SDL_net
+    SDL2
+    SDL2_net
     zlib
   ];
 
@@ -34,7 +34,38 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A portable, CLI-driven, SDL+OpenGL-based, multi-system emulator";
-    homepage = https://mednafen.github.io/;
+    longDescription = ''
+      Mednafen is a portable, utilizing OpenGL and SDL,
+      argument(command-line)-driven multi-system emulator. Mednafen has the
+      ability to remap hotkey functions and virtual system inputs to a keyboard,
+      a joystick, or both simultaneously. Save states are supported, as is
+      real-time game rewinding. Screen snapshots may be taken, in the PNG file
+      format, at the press of a button. Mednafen can record audiovisual movies
+      in the QuickTime file format, with several different lossless codecs
+      supported.
+
+      The following systems are supported (refer to the emulation module
+      documentation for more details):
+
+      - Apple II/II+
+      - Atari Lynx
+      - Neo Geo Pocket (Color)
+      - WonderSwan
+      - GameBoy (Color)
+      - GameBoy Advance
+      - Nintendo Entertainment System
+      - Super Nintendo Entertainment System/Super Famicom
+      - Virtual Boy
+      - PC Engine/TurboGrafx 16 (CD)
+      - SuperGrafx
+      - PC-FX
+      - Sega Game Gear
+      - Sega Genesis/Megadrive
+      - Sega Master System
+      - Sega Saturn (experimental, x86_64 only)
+      - Sony PlayStation
+    '';
+    homepage = "https://mednafen.github.io/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux;

--- a/pkgs/misc/emulators/mednafen/server.nix
+++ b/pkgs/misc/emulators/mednafen/server.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Netplay server for Mednafen";
-    homepage = https://mednafen.github.io/;
+    homepage = "https://mednafen.github.io/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux;

--- a/pkgs/misc/emulators/mednaffe/default.nix
+++ b/pkgs/misc/emulators/mednaffe/default.nix
@@ -5,13 +5,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "mednaffe";
-  version = "0.8.6";
+  version = "0.8.8";
 
   src = fetchFromGitHub {
     owner = "AmatCoder";
     repo = "mednaffe";
-    rev = "v${version}";
-    sha256 = "13l7gls430dcslpan39k0ymdnib2v6crdsmn6bs9k9g30nfnqi6m";
+    rev = "${version}";
+    sha256 = "15qk3a3l1phr8bap2ayh3c0vyvw2jwhny1iz1ajq2adyjpm9fhr7";
   };
 
   nativeBuildInputs = [ autoreconfHook makeWrapper pkgconfig wrapGAppsHook ];
@@ -22,9 +22,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "GTK-based frontend for mednafen emulator";
-    homepage = https://github.com/AmatCoder/mednaffe;
+    homepage = "https://github.com/AmatCoder/mednaffe";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ sheenobu yegortimoshenko ];
+    maintainers = with maintainers; [ sheenobu yegortimoshenko AndersonTorres ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New versions and adding myself as maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
