### PR TITLE
libdmapsharing: init at 3.9.10

### DIFF
--- a/pkgs/development/libraries/libdmapsharing/default.nix
+++ b/pkgs/development/libraries/libdmapsharing/default.nix
@@ -1,0 +1,95 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, autoconf
+, automake
+, libtool
+, which
+, pkg-config
+, python3
+, vala
+, avahi
+, gdk-pixbuf
+, gst_all_1
+, glib
+, gtk3
+, libgee
+, check
+, gtk-doc
+, docbook-xsl-nons
+, docbook_xml_dtd_43
+, gobject-introspection
+, libsoup
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libdmapsharing";
+  version = "3.9.10";
+
+  outputs = [ "out" "dev" "devdoc" ];
+  outputBin = "dev";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = pname;
+    rev = "${lib.toUpper pname}_${lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "04y1wjwnbw4pzg05h383d83p6an6ylwy4b4g32jmjxpfi388x33g";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    which
+    pkg-config
+    python3
+    gobject-introspection
+    vala
+    gtk-doc
+    docbook-xsl-nons
+    docbook_xml_dtd_43
+  ];
+
+  buildInputs = [
+    avahi
+    gdk-pixbuf
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+  ];
+
+  propagatedBuildInputs = [
+    glib
+    libsoup
+  ];
+
+  checkInputs = [
+    libgee
+    check
+    gtk3
+  ];
+
+  configureFlags = [
+    "--enable-gtk-doc"
+  ];
+
+  # Cannot disable tests here or `check` from checkInputs would not be included.
+  # Cannot disable building the tests or docs will not build:
+  # https://gitlab.gnome.org/GNOME/libdmapsharing/-/issues/49
+  doCheck = true;
+
+  preConfigure = ''
+    NOCONFIGURE=1 ./autogen.sh
+  '';
+
+  # Tests require mDNS server.
+  checkPhase = ":";
+
+  meta = with lib; {
+    homepage = "https://www.flyn.org/projects/libdmapsharing/";
+    description = "Library that implements the DMAP family of protocols";
+    maintainers = teams.gnome.members;
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15061,6 +15061,8 @@ in
 
   libdmtx = callPackage ../development/libraries/libdmtx { };
 
+  libdmapsharing = callPackage ../development/libraries/libdmapsharing { };
+
   libdnet = callPackage ../development/libraries/libdnet { };
 
   libdnf = callPackage ../tools/package-management/libdnf { };


### PR DESCRIPTION
~~Currently failing to build: https://gitlab.gnome.org/GNOME/libdmapsharing/issues/11~~

###### Motivation for this change
Library that implements the DMAP family of protocols

https://gitlab.gnome.org/GNOME/libdmapsharing

One of the unpackaged backends for `grilo-plugins` library. The version in Nixpkgs depends on older version at the moment but GNOME 3.36 [will support](https://gitlab.gnome.org/GNOME/grilo-plugins/-/merge_requests/70) this one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
