### PR TITLE
python-mapnik: 3.0.16 -> unstable-2020-02-24

### DIFF
--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -18,13 +18,13 @@ let
 
 in buildPythonPackage rec {
   pname = "python-mapnik";
-  version = "3.0.16";
+  version = "unstable-2020-02-24";
 
   src = pkgs.fetchFromGitHub {
     owner = "mapnik";
     repo = "python-mapnik";
-    rev = "v${version}";
-    sha256 = "1gqs4kvmjawdgl80j0ab5r8y0va9kw0rvwix3093xsv4hwd00lcc";
+    rev = "7da019cf9eb12af8f8aa88b7d75789dfcd1e901b";
+    sha256 = "0snn7q7w1ab90311q8wgd1z64kw1svm5w831q0xd6glqhah86qc8";
   };
 
   disabled = isPyPy;


### PR DESCRIPTION
Update to fix build errors with mapnik 3.0.23, along with other pending
upstream commits.

Upstream has not tagged a python-mapnik release since 2017. This
unstable commit, however, is also the basis for the python-mapnik
package in Debian testing.

NOTE: This PR is dependent on #81537 (or other fix to GDAL build).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

nixpkgs-review was run on this PR on top of #81537:
Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>

  - gdata-sharp
</details>
<details>
  <summary>1 package failed to build:</summary>

  - mysqlWorkbench (mysql-workbench)
</details>
<details>
  <summary>27 package built:</summary>

  - gdal (python37Packages.gdal)
  - grass
  - libLAS
  - mapnik
  - mapproxy
  - merkaartor
  - openorienteering-mapper
  - perl528Packages.Tirex
  - perl530Packages.Tirex
  - postgis (postgresql11Packages.postgis)
  - python27Packages.cartopy
  - python27Packages.gdal
  - python27Packages.python-mapnik
  - python27Packages.tilestache
  - python27Packages.worldengine
  - python37Packages.cartopy
  - python37Packages.python-mapnik
  - python37Packages.worldengine
  - python38Packages.cartopy
  - python38Packages.gdal
  - python38Packages.python-mapnik
  - python38Packages.worldengine
  - qgis
  - qgis-unwrapped
  - qlandkartegt
  - qmapshack
  - saga
</details>

NOTE: The mysql-workbench package that failed to build has not built successfully since 2019-09-30 on hydra and the reason appears unrelated, see: https://hydra.nixos.org/build/113768418