### PR TITLE
lcov: Fix patch checksums

### DIFF
--- a/pkgs/development/tools/analysis/lcov/default.nix
+++ b/pkgs/development/tools/analysis/lcov/default.nix
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
   patches =
     [ (fetchpatch {
         url = https://github.com/linux-test-project/lcov/commit/ebfeb3e179e450c69c3532f98cd5ea1fbf6ccba7.patch;
-        sha256 = "1z9jfqpj34jnzdvmqr5fs8hl56bvbwd8xhlbg3chcswbjj97vk7l";
+        sha256 = "0dalkqbjb6a4vp1lcsxd39dpn5fzdf7ihsjbiviq285s15nxdj1j";
       })
       (fetchpatch {
         url = https://github.com/linux-test-project/lcov/commit/75fbae1cfc5027f818a0bb865bf6f96fab3202da.patch;
-        sha256 = "1wgd4y7vhvfnxyhdd0z2pi9ys6l0z88f14i69a7prb296m1zwg5j";
+        sha256 = "0v1hn0511dxqbf50ppwasc6vmg0m6rns7ydbdy2rdbn0j7gxw30x";
       })
     ];
 


### PR DESCRIPTION
###### Motivation for this change
The previously committed checksums seem to have been mistakenly taken
directly from fetchurl without fetchpatch normalization.
This unbreaks local lcov builds. cc: @vcunat (https://github.com/NixOS/nixpkgs/commit/74c82056c966b9e3cf39d427cd6ea99a887277ec#r37585339)


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
