### PR TITLE
[20.03] python3Packages.monosat: Fix Python 3.8 build

### DIFF
--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, zlib, gmp, jdk8,
+{ stdenv, fetchpatch, fetchFromGitHub, cmake, zlib, gmp, jdk8,
   # The JDK we use on Darwin currenly makes extensive use of rpaths which are
   # annoying and break the python library, so let's not bother for now
   includeJava ? !stdenv.hostPlatform.isDarwin, includeGplCode ? true }:
@@ -20,9 +20,17 @@ let
     inherit rev sha256;
   };
 
+  patches = [
+    # Python 3.8 compatibility
+    (fetchpatch {
+      url = https://github.com/sambayless/monosat/commit/a5079711d0df0451f9840f3a41248e56dbb03967.patch;
+      sha256 = "0fwsk67798dns7izdry19r7r3nmym4cbgxfpbjbnx4b4mlak65j8";
+    })
+  ];
+
   core = stdenv.mkDerivation {
     name = "${pname}-${version}";
-    inherit src;
+    inherit src patches;
     buildInputs = [ cmake zlib gmp jdk8 ];
 
     cmakeFlags = [
@@ -48,20 +56,22 @@ let
   };
 
   python = { buildPythonPackage, cython }: buildPythonPackage {
-    inherit pname version src;
-
-    # The top-level "source" is what fetchFromGitHub gives us. The rest is inside the repo
-    sourceRoot = "source/src/monosat/api/python/";
+    inherit pname version src patches;
 
     propagatedBuildInputs = [ core cython ];
 
     # This tells setup.py to use cython, which should produce faster bindings
     MONOSAT_CYTHON = true;
 
+    # After patching src, move to where the actually relevant source is. This could just be made
+    # the sourceRoot if it weren't for the patch.
+    postPatch = ''
+      cd src/monosat/api/python
+    '' +
     # The relative paths here don't make sense for our Nix build
     # TODO: do we want to just reference the core monosat library rather than copying the
     # shared lib? The current setup.py copies the .dylib/.so...
-    postPatch = ''
+    ''
       substituteInPlace setup.py \
         --replace 'library_dir = "../../../../"' 'library_dir = "${core}/lib/"'
     '';

--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -24,7 +24,7 @@ let
     # Python 3.8 compatibility
     (fetchpatch {
       url = https://github.com/sambayless/monosat/commit/a5079711d0df0451f9840f3a41248e56dbb03967.patch;
-      sha256 = "0fwsk67798dns7izdry19r7r3nmym4cbgxfpbjbnx4b4mlak65j8";
+      sha256 = "1p2y0jw8hb9c90nbffhn86k1dxd6f6hk5v70dfmpzka3y6g1ksal";
     })
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Backport: #81562 #81638
ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
