### PR TITLE
vips: general clean-ups

### DIFF
--- a/pkgs/development/node-packages/default-v10.nix
+++ b/pkgs/development/node-packages/default-v10.nix
@@ -115,12 +115,9 @@ nodePackages // {
   joplin = nodePackages.joplin.override {
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = with pkgs; [
-      # sharp, dep list:
-      # http://sharp.pixelplumbing.com/en/stable/install/
-      cairo expat fontconfig freetype fribidi gettext giflib
-      glib harfbuzz lcms libcroco libexif libffi libgsf
-      libjpeg_turbo libpng librsvg libtiff vips
-      libwebp libxml2 pango pixman zlib
+      # required by sharp
+      # https://sharp.pixelplumbing.com/install
+      vips
 
       nodePackages.node-pre-gyp
     ];

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -506,7 +506,7 @@ in
         --replace "gobject-2.0" "${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}"
 
       substituteInPlace lib/vips.rb \
-        --replace "vips_libname = 'vips'" "vips_libname = '${vips}/lib/libvips${stdenv.hostPlatform.extensions.sharedLibrary}'"
+        --replace "vips_libname = 'vips'" "vips_libname = '${stdenv.lib.getLib vips}/lib/libvips${stdenv.hostPlatform.extensions.sharedLibrary}'"
     '';
   };
 

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -72,6 +72,11 @@ stdenv.mkDerivation rec {
     expat
   ] ++ stdenv.lib.optional stdenv.isDarwin ApplicationServices;
 
+  # Required by .pc file
+  propagatedBuildInputs = [
+    glib
+  ];
+
   autoreconfPhase = ''
     NOCONFIGURE=1 ./autogen.sh
   '';

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -16,6 +16,7 @@
 , python27
 , libpng ? null
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , gtk-doc
 , gobject-introspection
@@ -37,6 +38,15 @@ stdenv.mkDerivation rec {
       rm -r $out/test/test-suite/images/
     '';
   };
+
+  patches = [
+    # autogen.sh should not run configure
+    # https://github.com/libvips/libvips/pull/1566
+    (fetchpatch {
+      url = "https://github.com/libvips/libvips/commit/97a92e0e6abab652fdf99313b138bfd77d70deb4.patch";
+      sha256 = "0w1sm5wmvfp8svdpk8mz57c1n6zzy3snq0g2f8yxjamv0d2gw2dp";
+    })
+  ];
 
   nativeBuildInputs = [
     pkgconfig
@@ -63,7 +73,7 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional stdenv.isDarwin ApplicationServices;
 
   autoreconfPhase = ''
-    ./autogen.sh
+    NOCONFIGURE=1 ./autogen.sh
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -1,11 +1,25 @@
-{ stdenv, pkgconfig, glib, libxml2, expat,
-  fftw, orc, lcms, imagemagick, openexr, libtiff, libjpeg, libgsf, libexif,
-  ApplicationServices,
-  python27, libpng ? null,
-  fetchFromGitHub,
-  autoreconfHook,
-  gtk-doc,
-  gobject-introspection,
+{ stdenv
+, pkgconfig
+, glib
+, libxml2
+, expat
+, fftw
+, orc
+, lcms
+, imagemagick
+, openexr
+, libtiff
+, libjpeg
+, libgsf
+, libexif
+, ApplicationServices
+, python27
+, libpng ? null
+, fetchFromGitHub
+, autoreconfHook
+, gtk-doc
+, gobject-introspection
+,
 }:
 
 stdenv.mkDerivation rec {
@@ -24,11 +38,29 @@ stdenv.mkDerivation rec {
     '';
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook gtk-doc gobject-introspection ];
-  buildInputs = [ glib libxml2 fftw orc lcms
-    imagemagick openexr libtiff libjpeg
-    libgsf libexif python27 libpng expat ]
-    ++ stdenv.lib.optional stdenv.isDarwin ApplicationServices;
+  nativeBuildInputs = [
+    pkgconfig
+    autoreconfHook
+    gtk-doc
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+    libxml2
+    fftw
+    orc
+    lcms
+    imagemagick
+    openexr
+    libtiff
+    libjpeg
+    libgsf
+    libexif
+    python27
+    libpng
+    expat
+  ] ++ stdenv.lib.optional stdenv.isDarwin ApplicationServices;
 
   autoreconfPhase = ''
     ./autogen.sh

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
   pname = "vips";
   version = "8.9.1";
 
+  outputs = [ "bin" "out" "man" "dev" ];
+
   src = fetchFromGitHub {
     owner = "libvips";
     repo = "libvips";


### PR DESCRIPTION
###### Motivation for this change
Clean-ups for removal of libcroco. Also of `joplin`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
