### PR TITLE
corerad: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -2,16 +2,22 @@
 
 buildGoModule rec {
   pname = "corerad";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "mdlayher";
     repo = "corerad";
     rev = "v${version}";
-    sha256 = "04w77cahnphgd8b09a67dkrgx9jh8mvgjfjydj6drcw67v0d18c0";
+    sha256 = "0nxrksv98mxs5spykhzpydwjzii5cc6gk8az7irs3fdi4jx6pq1w";
   };
 
   modSha256 = "0vbbpndqwwz1mc59j7liaayxaj53cs8s3javgj3pvhkn4vp65p7c";
+
+  buildFlagsArray = ''
+    -ldflags=
+    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1583280117
+    -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mdlayher/corerad";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New beta release of CoreRAD, which also supports linking in the current version and tag timestamp.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Built and tested on NixOS:

```
[matt@routnerr-2:~/src/nixpkgs]$ nix-build -A corerad
these derivations will be built:
  /nix/store/71axxsdxc3jqiz9bh87pa3i5p9c12qhd-corerad-0.2.2.drv
building '/nix/store/71axxsdxc3jqiz9bh87pa3i5p9c12qhd-corerad-0.2.2.drv'...
[...]

[matt@routnerr-2:~/src/nixpkgs]$ ./result/bin/corerad -h
CoreRAD v0.2.2 BETA (2020-03-03)
flags:
  -c string
        path to configuration file (default "corerad.toml")
  -init
        write out a default configuration file to "corerad.toml" and exit

[matt@routnerr-2:~/src/nixpkgs]$ ./result/bin/corerad -init

[matt@routnerr-2:~/src/nixpkgs]$ ./result/bin/corerad
2020/03/03 19:22:16 CoreRAD v0.2.2 BETA (2020-03-03) starting with configuration file "corerad.toml"
2020/03/03 19:22:16 eth0: advertise is false, skipping initialization
2020/03/03 19:22:16 starting HTTP debug listener on "localhost:9430": prometheus: false, pprof: false
^C2020/03/03 19:22:18 received interrupt, shutting down
```

The latest git tag's timestamp is hardcoded at the moment, but it uses the git tag's timestamp:

```
$ git log -1 --format=%ct v0.2.2
1583280117
```

I haven't found an easy way to incorporate the above shell command into the package build, but would appreciate suggestions!

/cc @jonringer @kalbasit @danderson 