### PR TITLE
client-ip-echo: 0.1.0.4 -> 0.1.0.5

### DIFF
--- a/pkgs/servers/misc/client-ip-echo/client-ip-echo.nix
+++ b/pkgs/servers/misc/client-ip-echo/client-ip-echo.nix
@@ -1,12 +1,12 @@
 { mkDerivation, fetchFromGitHub, base, bytestring, network, stdenv }:
 mkDerivation {
   pname = "client-ip-echo";
-  version = "0.1.0.4";
+  version = "0.1.0.5";
   src = fetchFromGitHub {
     owner = "jerith666";
     repo = "client-ip-echo";
-    rev = "58d1bc627c21008236afb1af4c09ba8153c95dad";
-    sha256 = "153fab87qq080a819bqbdan925045icqwxldwj3ps40w2ssn7a53";
+    rev = "e81db98d04c13966b2ec114e01f82487962055a7";
+    sha256 = "02rzzbm1mdqh5zx5igd0s7pwkcsk64lx40rclxw3485348brc6ya";
   };
   isLibrary = false;
   isExecutable = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
