### PR TITLE
libva: 2.5.0 -> 2.6.1

### DIFF
--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -6,14 +6,14 @@
 
 stdenv.mkDerivation rec {
   name = "libva-${lib.optionalString minimal "minimal-"}${version}";
-  version = "2.5.0";
+  version = "2.6.1";
 
   # update libva-utils and vaapiIntel as well
   src = fetchFromGitHub {
     owner  = "01org";
     repo   = "libva";
     rev    = version;
-    sha256 = "0pys6blkh8ayxmxgfh7qrjzzcrzzn14z5d8q4a34ffqk90b6r93z";
+    sha256 = "1x34kf38p5rf52bf54ljr9f7knnbilm7kbszqnfk3lzsqrfc7r2g";
   };
 
   outputs = [ "dev" "out" ];


### PR DESCRIPTION
This updates `libva` to latest stable release (2.6.1).