### PR TITLE
adminer: init at 4.7.6

### DIFF
--- a/pkgs/servers/adminer/default.nix
+++ b/pkgs/servers/adminer/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, libbsd, fetchurl, phpPackages, php }:
+
+stdenv.mkDerivation rec {
+  version = "4.7.6";
+  pname = "adminer";
+
+  # not using fetchFromGitHub as the git repo relies on submodules that are included in the tar file
+  src = fetchurl {
+    url = "https://github.com/vrana/adminer/releases/download/v${version}/adminer-${version}.tar.gz";
+    sha256 = "1zgvscz7jk32qga8hp2dg89h7y72v05vz4yh4lq2ahhwwkbnsxpi";
+  };
+
+  nativeBuildInputs = with phpPackages; [ php composer ];
+
+  buildPhase = ''
+    composer --no-cache run compile
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp adminer-${version}.php $out/adminer.php
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Database management in a single PHP file";
+    homepage = "https://www.adminer.org";
+    license = with licenses; [ asl20 gpl2 ];
+    maintainers = with maintainers; [ sstef ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -541,6 +541,8 @@ in
     pname = "OPNplug";
   };
 
+  adminer = callPackage ../servers/adminer { };
+
   advancecomp = callPackage ../tools/compression/advancecomp {};
 
   aefs = callPackage ../tools/filesystems/aefs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Creation of the Adminer package that can then be used in an nginx with php (or other web server) instance to publish the service. This is a web-based database admin tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
