### PR TITLE
toggldesktop: take mkDerivation as input

### DIFF
--- a/pkgs/applications/misc/toggldesktop/default.nix
+++ b/pkgs/applications/misc/toggldesktop/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchzip, buildEnv, makeDesktopItem, runCommand, writeText, pkgconfig
+{ mkDerivation, lib, fetchzip, buildEnv, makeDesktopItem, runCommand, writeText, pkgconfig
 , cmake, qmake, cacert, jsoncpp, libX11, libXScrnSaver, lua, openssl, poco
 , qtbase, qtwebengine, qtx11extras, sqlite }:
 
 let
   name = "toggldesktop-${version}";
-  version = "7.4.231";
+  version = "7.5.42";
 
   src = fetchzip {
     url = "https://github.com/toggl/toggldesktop/archive/v${version}.tar.gz";
     sha256 = "01hqkx9dljnhwnyqi6mmzfp02hnbi2j50rsfiasniqrkbi99x9v1";
   };
 
-  bugsnag-qt = stdenv.mkDerivation rec {
+  bugsnag-qt = mkDerivation rec {
     pname = "bugsnag-qt";
     version = "20180522.005732";
 
@@ -24,7 +24,7 @@ let
     buildInputs = [ qtbase ];
   };
 
-  qxtglobalshortcut = stdenv.mkDerivation rec {
+  qxtglobalshortcut = mkDerivation rec {
     pname = "qxtglobalshortcut";
     version = "f584471dada2099ba06c574bdfdd8b078c2e3550";
 
@@ -37,7 +37,7 @@ let
     buildInputs = [ qtbase qtx11extras ];
   };
 
-  qt-oauth-lib = stdenv.mkDerivation rec {
+  qt-oauth-lib = mkDerivation rec {
     pname = "qt-oauth-lib";
     version = "20190125.190943";
 
@@ -62,7 +62,7 @@ let
     mkdir -p $out/lib/pkgconfig && ln -s ${poco-pc} $_/poco.pc
   '';
 
-  libtoggl = stdenv.mkDerivation {
+  libtoggl = mkDerivation {
     name = "libtoggl-${version}";
     inherit src version;
 
@@ -77,7 +77,7 @@ let
     '';
   };
 
-  toggldesktop = stdenv.mkDerivation {
+  toggldesktop = mkDerivation {
     name = "${name}-unwrapped";
     inherit src version;
 
@@ -108,7 +108,7 @@ let
     ];
   };
 
-  toggldesktop-icons = stdenv.mkDerivation {
+  toggldesktop-icons = mkDerivation {
     name = "${name}-icons";
     inherit (toggldesktop) src sourceRoot;
 
@@ -138,7 +138,7 @@ buildEnv {
   inherit name;
   paths = [ desktopItem toggldesktop-icons toggldesktop-wrapped ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Client for Toggl time tracking service";
     homepage = https://github.com/toggl/toggldesktop;
     license = licenses.bsd3;

--- a/pkgs/applications/misc/toggldesktop/default.nix
+++ b/pkgs/applications/misc/toggldesktop/default.nix
@@ -4,7 +4,7 @@
 
 let
   name = "toggldesktop-${version}";
-  version = "7.5.42";
+  version = "7.4.231";
 
   src = fetchzip {
     url = "https://github.com/toggl/toggldesktop/archive/v${version}.tar.gz";


### PR DESCRIPTION
###### Motivation for this change

I was investigating why `toggldesktop` wasn't working for me. Running it results in the following error:

```
$ QT_DEBUG_PLUGINS=1 toggldesktop
QFactoryLoader::QFactoryLoader() checking directory path "/run/wrappers/lib/qt-5.12.7/plugins/platforms" ...
QFactoryLoader::QFactoryLoader() checking directory path "/home/int-index/.nix-profile/lib/qt-5.12.7/plugins/platforms" ...
QFactoryLoader::QFactoryLoader() checking directory path "/etc/profiles/per-user/int-index/lib/qt-5.12.7/plugins/platforms" ...
QFactoryLoader::QFactoryLoader() checking directory path "/nix/var/nix/profiles/default/lib/qt-5.12.7/plugins/platforms" ...
QFactoryLoader::QFactoryLoader() checking directory path "/run/current-system/sw/lib/qt-5.12.7/plugins/platforms" ...
QFactoryLoader::QFactoryLoader() checking directory path "/nix/store/9527zk7zkwjxhpabkgd7b3q2anm8p6zd-toggldesktop-7.5.42-unwrapped/platforms" ...
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

[1]    29789 abort (core dumped)  QT_DEBUG_PLUGINS=1 toggldesktop
```

According to https://nixos.wiki/wiki/Qt the fix is to use `wrapQtAppsHook`, which is added by Qt5's `mkDerivation`. That's also what https://github.com/NixOS/nixpkgs/issues/65399#issuecomment-515464616 says.

Unfortunately, this change *does not fix* `toggldesktop`. I'm submitting because it seems like the right thing to do anyway, and to ask if there are other things I could try. cc @yegortimoshenko @ttuegel 


###### Things done

* Use latest version
* Use Qt5 `mkDerivation`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
