### PR TITLE
libnotify: 0.7.8 → 0.7.9

### DIFF
--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -3,7 +3,8 @@
 , meson
 , ninja
 , pkgconfig
-, fetchpatch
+, libxslt
+, docbook-xsl-ns
 , glib
 , gdk-pixbuf
 , gobject-introspection
@@ -12,23 +13,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libnotify";
-  version = "0.7.8";
+  version = "0.7.9";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "man" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1371csx0n92g60b5dmai4mmzdnx8081mc3kcgc6a0xipcq5rw839";
+    sha256 = "ZsBRftFt968ljoMgj6r1Bpcn39ZplcS7xRwWlU1nR2E=";
   };
-
-  patches = [
-    # Fix darwin build
-    # https://gitlab.gnome.org/GNOME/libnotify/merge_requests/9
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/libnotify/commit/55eb69247fe2b479ea43311503042fc03bf4e67d.patch";
-      sha256 = "1hlb5b7c5axiyir1i5j2pi94bm2gyr1ybkp6yaqy7yk6iiqlvv50";
-    })
-  ];
 
   mesonFlags = [
     # disable tests as we don't need to depend on GTK (2/3)
@@ -42,6 +34,8 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkgconfig
+    libxslt
+    docbook-xsl-ns
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
We added manpage upstream 🎉 (https://gitlab.gnome.org/GNOME/libnotify/issues/4)

https://ftp.gnome.org/pub/GNOME/sources/libnotify/0.7/libnotify-0.7.9.news

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
