### PR TITLE
libkml: init at 1.3.0

### DIFF
--- a/pkgs/development/libraries/libkml/default.nix
+++ b/pkgs/development/libraries/libkml/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, boost
+, expat
+, zlib
+, uriparser
+, minizip
+, gtest
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libkml";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "libkml";
+    repo = pname;
+    rev = version;
+    sha256 = "0gl4cqfps9mzx6hzf3dc10hy5y8smpyf1s31sqm7w343hgsllv0z";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_TESTING=ON"
+  ];
+
+  buildInputs = [
+    gtest
+    boost
+    expat
+    zlib
+    uriparser
+    minizip
+  ];
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$PWD/lib
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Reference implementation of OGC KML 2.2";
+    homepage = https://github.com/libkml/libkml;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ costrouc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4062,7 +4062,7 @@ in
   pixd = callPackage ../tools/misc/pixd { };
 
   hey = callPackage ../tools/networking/hey { };
-  
+
   hhpc = callPackage ../tools/misc/hhpc { };
 
   hiera-eyaml = callPackage ../tools/system/hiera-eyaml { };
@@ -12842,6 +12842,8 @@ in
   libjson-rpc-cpp = callPackage ../development/libraries/libjson-rpc-cpp { };
 
   libkate = callPackage ../development/libraries/libkate { };
+
+  libkml = callPackage ../development/libraries/libkml { };
 
   libksba = callPackage ../development/libraries/libksba { };
 


### PR DESCRIPTION
Adding libkml with all tests enabled

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
