### PR TITLE
bisonpp: init at 1.21-45

### DIFF
--- a/pkgs/development/tools/parsing/bisonpp/default.nix
+++ b/pkgs/development/tools/parsing/bisonpp/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bisonpp";
+  version = "1.21-45";
+
+  src = fetchFromGitHub {
+    owner = "jarro2783";
+    repo = "bisonpp";
+    rev = version;
+    sha256 = "0mp6cvbm2rfjwff3n9xz0gfxmdamad55nlr9f5q5dy0h6c43mh8x";
+  };
+
+  meta = with stdenv.lib; {
+    description = "The original bison++ project, brought up to date with modern compilers";
+    homepage = https://github.com/jarro2783/bisonpp;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ costrouc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4062,7 +4062,7 @@ in
   pixd = callPackage ../tools/misc/pixd { };
 
   hey = callPackage ../tools/networking/hey { };
-  
+
   hhpc = callPackage ../tools/misc/hhpc { };
 
   hiera-eyaml = callPackage ../tools/system/hiera-eyaml { };
@@ -9804,6 +9804,8 @@ in
 
   bison = callPackage ../development/tools/parsing/bison { };
   yacc = bison; # TODO: move to aliases.nix
+
+  bisonpp = callPackage ../development/tools/parsing/bisonpp { };
 
   blackmagic = callPackage ../development/tools/misc/blackmagic { };
 


### PR DESCRIPTION
Adding bisonpp library (no tests included)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Needed for building https://github.com/omnisci/omniscidb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
