### PR TITLE
Revert "defaultGemConfig: remove asciidoctor-diagram JARs"

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -39,15 +39,6 @@ let
 in
 
 {
-  asciidoctor-diagram = { version, ruby, ... }: {
-    postInstall = ''
-      # Delete vendored JAR files unless using JRuby.
-      if ruby -e 'exit(RUBY_PLATFORM != "java")'; then
-          rm -v $out/${ruby.gemPath}/gems/$gemName-${version}/lib/*.jar
-      fi
-    '';
-  };
-
   atk = attrs: {
     dependencies = attrs.dependencies ++ [ "gobject-introspection" ];
     nativeBuildInputs = [ rake bundler pkgconfig ];


### PR DESCRIPTION
This reverts commit 1ac11cc1c1858af1cef725d68cacf7102366e588.

asciidoctor-diagram starts Java processes, so the JARs are necessary
on all platforms.

See https://github.com/NixOS/nixpkgs/pull/77149#issuecomment-594576339.

@nomeata please test