### PR TITLE
python3Packages.batchgenerators: init at 0.19.7

### DIFF
--- a/pkgs/development/python-modules/batchgenerators/default.nix
+++ b/pkgs/development/python-modules/batchgenerators/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchPypi
+, pytest
+, unittest2
+, future
+, numpy
+, scipy
+, scikitlearn
+, scikitimage
+, threadpoolctl
+}:
+
+
+buildPythonPackage rec {
+  pname = "batchgenerators";
+  version = "0.19.7";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qqzwqf5r0q6jh8avz4f9kf8x96crvdnkznhf24pbm0faf8yk67q";
+  };
+
+  propagatedBuildInputs = [ future numpy scipy scikitlearn scikitimage threadpoolctl ];
+  checkInputs = [ pytest unittest2 ];
+
+  checkPhase = "pytest tests";
+
+  meta = {
+    description = "2D and 3D image data augmentation for deep learning";
+    homepage = "https://github.com/MIC-DKFZ/batchgenerators";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/threadpoolctl/default.nix
+++ b/pkgs/development/python-modules/threadpoolctl/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, flit
+, pytest
+, pytestcov
+, numpy
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "threadpoolctl";
+  version = "2.0.0";
+
+  disabled = isPy27;
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "joblib";
+    repo = pname;
+    rev = version;
+    sha256 = "16z4n82f004i4l1jw6qrzazda1m6v2yjnpqlp71ipa8mzy9kw7dw";
+  };
+
+  checkInputs = [ pytest pytestcov numpy scipy ];
+
+  checkPhase = "pytest tests -k 'not test_nested_prange_blas'";
+  # cython doesn't get run on the tests when added to nativeBuildInputs, breaking this test
+
+  meta = with lib; {
+    homepage = "https://github.com/joblib/threadpoolctl";
+    description = "Helpers to limit number of threads used in native libraries";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1782,6 +1782,8 @@ in {
 
   base58 = callPackage ../development/python-modules/base58 {};
 
+  batchgenerators = callPackage ../development/python-modules/batchgenerators { };
+
   batinfo = callPackage ../development/python-modules/batinfo {};
 
   bcdoc = callPackage ../development/python-modules/bcdoc {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6708,6 +6708,8 @@ in {
 
   threadpool = callPackage ../development/python-modules/threadpool { };
 
+  threadpoolctl = callPackage ../development/python-modules/threadpoolctl { };
+
   rocket-errbot = callPackage ../development/python-modules/rocket-errbot {  };
 
   Yapsy = callPackage ../development/python-modules/yapsy { };


### PR DESCRIPTION
python3Packages.threadpoolctl: init at 2.0.0

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
