### PR TITLE
ocamlPackages.ppx_import: 1.5-3 → 1.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml
+{ lib, fetchurl, buildDunePackage, ocaml
 , ounit, ppx_deriving, ppx_tools_versioned
 }:
 
@@ -8,24 +8,21 @@ else
 
 buildDunePackage rec {
   pname = "ppx_import";
-  version = "1.5-3";
+  version = "1.7.1";
 
-  src = fetchFromGitHub {
-    owner = "ocaml-ppx";
-    repo = "ppx_import";
-    rev = "bd627d5afee597589761d6fee30359300b5e1d80";
-    sha256 = "1f9bphif1izhyx72hvwpkd9kxi9lfvygaicy6nbxyp6qgc87z4nm";
+  src = fetchurl {
+    url = "https://github.com/ocaml-ppx/ppx_import/releases/download/v${version}/ppx_import-v${version}.tbz";
+    sha256 = "16dyxfb7syz659rqa7yq36ny5vzl7gkqd7f4m6qm2zkjc1gc8j4v";
   };
 
   buildInputs = [ ounit ppx_deriving ];
   propagatedBuildInputs = [ ppx_tools_versioned ];
 
   doCheck = true;
-  checkTarget = "test";
 
   meta = {
     description = "A syntax extension that allows to pull in types or signatures from other compiled interface files";
     license = lib.licenses.mit;
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/ocaml-ppx/ppx_import";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml ≥ 4.08

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
