### PR TITLE
bgpq3: init at 0.1.35

### DIFF
--- a/pkgs/tools/networking/bgpq3/default.nix
+++ b/pkgs/tools/networking/bgpq3/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "bgpq3";
+  version = "0.1.35";
+
+  src = fetchFromGitHub {
+    owner = "snar";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0fd5a3krq0i906m0iivgphiqq88cw6c0w1q4n7lmzyq9201mb8wj";
+  };
+
+  # Fix binary install location. Remove with next upstream release.
+  preInstall = "mkdir -p $out/bin";
+
+  meta = with stdenv.lib; {
+    description = "bgp filtering automation tool";
+    homepage = "https://github.com/snar/bgpq3";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ b4dm4n ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18436,6 +18436,8 @@ in
 
   bgpdump = callPackage ../tools/networking/bgpdump { };
 
+  bgpq3 = callPackage ../tools/networking/bgpq3 { };
+
   blackbox = callPackage ../applications/version-management/blackbox { };
 
   bleachbit = callPackage ../applications/misc/bleachbit { };


### PR DESCRIPTION
###### Motivation for this change

Add `bgpq3` package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
