### PR TITLE
glib.setupHook: run glibPreFixupPhase before gappsWrapperArgsHook

### DIFF
--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -24,4 +24,12 @@ glibPreFixupPhase() {
 
     addToSearchPath GSETTINGS_SCHEMAS_PATH "${!outputLib}/share/gsettings-schemas/$name"
 }
-preFixupPhases+=" glibPreFixupPhase"
+
+# gappsWrapperArgsHook expects GSETTINGS_SCHEMAS_PATH variable to be set by this.
+# Until we have dependency mechanism in generic builder, we need to use this ugly hack.
+if [[ " ${preFixupPhases:-} " =~ " gappsWrapperArgsHook " ]]; then
+    preFixupPhases+=" "
+    preFixupPhases="${preFixupPhases/ gappsWrapperArgsHook / glibPreFixupPhase gappsWrapperArgsHook }"
+else
+    preFixupPhases+=" glibPreFixupPhase"
+fi


### PR DESCRIPTION
###### Motivation for this change
Since we split wrapGAppsHook and move its variable initialization to preFixupPhases in #81475, it was getting run before glibPreFixupPhase which sets GSETTINGS_SCHEMAS_PATH variable gappsWrapperArgsHook depends on. Let's introduce this ugly hack to ensure glibPreFixupPhase will run before gappsWrapperArgsHook.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
