### PR TITLE
build-support/rust: specify proper path to Cargo.lock

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation (filteredArgs // {
 
     export RUST_LOG=${logLevel}
   '' + stdenv.lib.optionalString validateCargoDeps ''
-    if ! diff source/Cargo.lock $cargoDepsCopy/Cargo.lock ; then
+    if ! diff ''${sourceRoot:-source}/Cargo.lock $cargoDepsCopy/Cargo.lock ; then
       echo
       echo "ERROR: cargoSha256 is out of date"
       echo

--- a/pkgs/development/tools/rust/cargo-raze/default.nix
+++ b/pkgs/development/tools/rust/cargo-raze/default.nix
@@ -3,20 +3,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-raze";
-  version = "0.2.10";
+  version = "0.2.15";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1fznh8jygzyzphw7762qc2jv0370z7qjqk1vkql0g246iqby8pq9";
+    sha256 = "0cbbf0r753h4m42h0z44yn99cbwkchacf703j2i9gdi7d60ns92p";
   };
+
   sourceRoot = "source/impl";
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "06rl7v0f1lgj9ii07fcnaxmhn28ckr03cpf5b93q8ripm5qh7my9";
+  cargoSha256 = "1d9ra80bilgmn44a4dzjvc4cyl9wv6bzkp8mavr6qjpjq57x4sin";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ curl libgit2 openssl ]
@@ -26,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with stdenv.lib; {
     description = "Generate Bazel BUILD files from Cargo dependencies";
-    homepage = https://github.com/google/cargo-raze;
+    homepage = "https://github.com/google/cargo-raze";
     license = licenses.asl20;
     maintainers = with maintainers; [ elasticdog ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change

When building a crate from a subdir (specified by `sourceRoot`), the
diffing fails as the builder tries to compare `source/Cargo.lock` to the
one in `$cargoDepsCopy`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
