### PR TITLE
tensorflow: 1.15.1 -> 1.15.2

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -69,7 +69,7 @@ let
 
   tfFeature = x: if x then "1" else "0";
 
-  version = "1.15.1";
+  version = "1.15.2";
   variant = if cudaSupport then "-gpu" else "";
   pname = "tensorflow${variant}";
 
@@ -100,7 +100,7 @@ let
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      sha256 = "1j8vysfblkyydrr67qr3i7kvaq5ygnjlx8hw9a9pc95ac462jq7i";
+      sha256 = "1q0848drjvnaaa38dgns8knmpmkj5plzsc98j20m5ybv68s55w78";
     };
 
     patches = [
@@ -297,9 +297,9 @@ let
 
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
       sha256 = if cudaSupport then
-        "1p544yk7jcspgc4qr4amw11ds16c2an5yxvagx5pmwawz0s083pf"
+        "05fx3jwgdh1nlr1kfy6w3mlbl5m8165lggcqgk5mpxx4kzicvr1y"
       else
-        "1dqbw3k3avqiy9xpgs44l6z65ab5rjjlxwig8z7gcl7fw9h6sbq9";
+        "0q0rwsb2yginqm6vv11zmbs7z2rdk7blyg5fk2jjkmkjrwzpazzg";
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow/lift-gast-restriction.patch
+++ b/pkgs/development/python-modules/tensorflow/lift-gast-restriction.patch
@@ -3,9 +3,9 @@ index 992f2eae22..d9386f9b13 100644
 --- a/tensorflow/tools/pip_package/setup.py
 +++ b/tensorflow/tools/pip_package/setup.py
 @@ -54,7 +54,7 @@ REQUIRED_PACKAGES = [
-     'astor >= 0.6.0',
-     'backports.weakref >= 1.0rc1;python_version<"3.4"',
      'enum34 >= 1.1.6;python_version<"3.4"',
+     # functools comes with python3, need to install the backport for python2
+     'functools32 >= 3.2.3;python_version<"3"',
 -    'gast == 0.2.2',
 +    'gast >= 0.2.2',
      'google_pasta >= 0.1.6',


### PR DESCRIPTION
###### Motivation for this change

The 1.15.1 release of tensorflow was apparently revoked (I'm guessing due to the security issues therein) and there's only 1.15.2 now in this series.  I've just made the obvious changes and verified it builds (both cpu and gpu) but haven't done any other extensive testing.

Happy to retarget this to another branch or withdraw in favor of a more complete update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
