### PR TITLE
satallax: Fix build with GCC9

### DIFF
--- a/pkgs/applications/science/logic/satallax/default.nix
+++ b/pkgs/applications/science/logic/satallax/default.nix
@@ -9,6 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "1kvxn8mc35igk4vigi5cp7w3wpxk2z3bgwllfm4n3h2jfs0vkpib";
   };
 
+  patches = [
+    # GCC9 doesn't allow default value in friend declaration.
+    ./fix-declaration-gcc9.patch
+  ];
+
   preConfigure = ''
     mkdir fake-tools
     echo "echo 'Nix-build-host.localdomain'" > fake-tools/hostname

--- a/pkgs/applications/science/logic/satallax/fix-declaration-gcc9.patch
+++ b/pkgs/applications/science/logic/satallax/fix-declaration-gcc9.patch
@@ -1,0 +1,21 @@
+diff --git i/minisat/core/SolverTypes.h w/minisat/core/SolverTypes.h
+--- i/minisat/core/SolverTypes.h
++++ w/minisat/core/SolverTypes.h
+@@ -47,7 +47,7 @@ struct Lit {
+     int     x;
+ 
+     // Use this as a constructor:
+-    friend Lit mkLit(Var var, bool sign = false);
++    friend Lit mkLit(Var var, bool sign);
+ 
+     bool operator == (Lit p) const { return x == p.x; }
+     bool operator != (Lit p) const { return x != p.x; }
+@@ -55,7 +55,7 @@ struct Lit {
+ };
+ 
+ 
+-inline  Lit  mkLit     (Var var, bool sign) { Lit p; p.x = var + var + (int)sign; return p; }
++inline  Lit  mkLit     (Var var, bool sign = false) { Lit p; p.x = var + var + (int)sign; return p; }
+ inline  Lit  operator ~(Lit p)              { Lit q; q.x = p.x ^ 1; return q; }
+ inline  Lit  operator ^(Lit p, bool b)      { Lit q; q.x = p.x ^ (unsigned int)b; return q; }
+ inline  bool sign      (Lit p)              { return p.x & 1; }


### PR DESCRIPTION
###### Motivation for this change
Build was broken because GCC9 doesn't accept this declaration anymore.

Unfortunately upstream doesn't seem to continue developmente anymore :/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
