### PR TITLE
gitlab: 12.8.1 -> 12.8.2

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,11 +1,11 @@
 {
-  "version": "12.8.1",
-  "repo_hash": "1h844a79scf3an5rv0wi332lrf7mv1zcv2mg6zllk82f7nf341gn",
+  "version": "12.8.2",
+  "repo_hash": "1d27s61kglryr5pashwfq55z7fh16fxkx1m4gc82xihwfzarf4x9",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.8.1-ee",
+  "rev": "v12.8.2-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "12.8.1",
+    "GITALY_SERVER_VERSION": "12.8.2",
     "GITLAB_PAGES_VERSION": "1.16.0",
     "GITLAB_SHELL_VERSION": "11.0.0",
     "GITLAB_WORKHORSE_VERSION": "8.21.0"

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -28,14 +28,14 @@ let
     };
   });
 in buildGoPackage rec {
-  version = "12.8.1";
+  version = "12.8.2";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "0sjkh0j36dpakqmq7l5gd1ydmx1kxgij53bjvvn37r19liqdijnx";
+    sha256 = "1zc44y5yl799vqg12w3iaivk4xwj9i4k6f198svplipa760nl9ic";
   };
 
   # Fix a check which assumes that hook files are writeable by their

--- a/pkgs/applications/version-management/gitlab/gitaly/deps.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/deps.nix
@@ -1319,8 +1319,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/ugorji/go";
-      rev = "v1.1.4";
-      sha256 = "0ma2qvn5wqvjidpdz74x832a813qnr1cxbx6n6n125ak9b3wbn5w";
+      rev = "d75b2dcb6bc8";
+      sha256 = "0di1k35gpq9bp958ywranpbskx2vdwlb38s22vl9rybm3wa5g3ps";
     };
   }
   {


### PR DESCRIPTION
**This needs to be backported to 20.03 and 19.09**

Includes multiple security fixes mentioned in
https://about.gitlab.com/releases/2020/03/04/gitlab-12-dot-8-dot-2-released/
(unfortunately, no CVE numbers as of yet)

 - Directory Traversal to Arbitrary File Read
 - Account Takeover Through Expired Link
 - Server Side Request Forgery Through Deprecated Service
 - Group Two-Factor Authentication Requirement Bypass
 - Stored XSS in Merge Request Pages
 - Stored XSS in Merge Request Submission Form
 - Stored XSS in File View
 - Stored XSS in Grafana Integration
 - Contribution Analytics Exposed to Non-members
 - Incorrect Access Control in Docker Registry via Deploy Tokens
 - Denial of Service via Permission Checks
 - Denial of Service in Design For Public Issue
 - GitHub Tokens Displayed in Plaintext on Integrations Page
 - Incorrect Access Control via LFS Import
 - Unescaped HTML in Header
 - Private Merge Request Titles Leaked via Widget
 - Project Namespace Exposed via Vulnerability Feedback Endpoint
 - Denial of Service Through Recursive Requests
 - Project Authorization Not Being Updated
 - Incorrect Permission Level For Group Invites
 - Disclosure of Private Group Epic Information
 - User IP Address Exposed via Badge images
 - Update postgresql (GitLab Omnibus)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
