### PR TITLE
standardnotes: 3.0.15 -> 3.3.3

### DIFF
--- a/pkgs/applications/editors/standardnotes/default.nix
+++ b/pkgs/applications/editors/standardnotes/default.nix
@@ -1,16 +1,16 @@
 { stdenv, appimage-run, fetchurl, runtimeShell }:
 
 let
-  version = "3.0.15";
+  version = "3.3.3";
 
   plat = {
-    i386-linux = "i386";
-    x86_64-linux = "x86_64";
+    i386-linux = "-i386";
+    x86_64-linux = "";
   }.${stdenv.hostPlatform.system};
 
   sha256 = {
-    i386-linux = "0v2nsis6vb1lnhmjd28vrfxqwwpycv02j0nvjlfzcgj4b3400j7a";
-    x86_64-linux = "130n586cw0836zsbwqcz3pp3h0d4ny74ngqs4k4cvfb92556r7xh";
+    i386-linux = "2ccdf23588b09d645811e562d4fd7e02ac0e367bf2b34e373d8470d48544036d";
+    x86_64-linux = "6366d0a37cbf2cf51008a666e40bada763dd1539173de01e093bcbe4146a6bd8";
   }.${stdenv.hostPlatform.system};
 in
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "https://github.com/standardnotes/desktop/releases/download/v${version}/standard-notes-${version}-${plat}.AppImage";
+    url = "https://github.com/standardnotes/desktop/releases/download/v${version}/standard-notes-${version}${plat}.AppImage";
     inherit sha256;
   };
 

--- a/pkgs/applications/editors/standardnotes/default.nix
+++ b/pkgs/applications/editors/standardnotes/default.nix
@@ -1,7 +1,10 @@
-{ stdenv, appimage-run, fetchurl, runtimeShell }:
+{ stdenv, appimageTools, autoPatchelfHook, desktop-file-utils
+  , fetchurl, runtimeShell }:
 
 let
   version = "3.3.3";
+  pname = "standardnotes";
+  name = "${pname}-${version}";
 
   plat = {
     i386-linux = "-i386";
@@ -12,27 +15,33 @@ let
     i386-linux = "2ccdf23588b09d645811e562d4fd7e02ac0e367bf2b34e373d8470d48544036d";
     x86_64-linux = "6366d0a37cbf2cf51008a666e40bada763dd1539173de01e093bcbe4146a6bd8";
   }.${stdenv.hostPlatform.system};
-in
-
-stdenv.mkDerivation {
-  pname = "standardnotes";
-  inherit version;
 
   src = fetchurl {
     url = "https://github.com/standardnotes/desktop/releases/download/v${version}/standard-notes-${version}${plat}.AppImage";
     inherit sha256;
   };
 
-  buildInputs = [ appimage-run ];
+  appimageContents = appimageTools.extract {
+    inherit name src;
+  };
 
-  dontUnpack = true;
+  nativeBuildInputs = [ autoPatchelfHook desktop-file-utils ];
 
-  installPhase = ''
-    mkdir -p $out/{bin,share}
-    cp $src $out/share/standardNotes.AppImage
-    echo "#!${runtimeShell}" > $out/bin/standardnotes
-    echo "${appimage-run}/bin/appimage-run $out/share/standardNotes.AppImage" >> $out/bin/standardnotes
-    chmod +x $out/bin/standardnotes $out/share/standardNotes.AppImage
+in appimageTools.wrapType2 rec {
+  inherit name src;
+
+  extraInstallCommands = ''
+    # directory in /nix/store so readonly
+    cp -r  ${appimageContents}/* $out
+    cd $out
+    chmod -R +w $out
+    mv $out/bin/${name} $out/bin/${pname}
+
+    # fixup and install desktop file
+    ${desktop-file-utils}/bin/desktop-file-install --dir $out/share/applications \
+      --set-key Exec --set-value ${pname} standard-notes.desktop
+
+    rm usr/lib/* AppRun standard-notes.desktop .so*
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This package use appimage-run that i think is not intended to be used in such derivation! it lands to file in ~/.cache/appimage-run/6366d0a37cbf2cf51008a666e40bada763dd1539173de01e093bcbe4146a6bd8/squashfs-root
. Imho , we should not allow to do that.

I can't test i386 and i don't really care this package btw. but it still better than the current expression.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @tilpner @M-Gregoire 