### PR TITLE
jellyfin-mpv-shim: init at 1.4.1

### DIFF
--- a/pkgs/applications/video/jellyfin-mpv-shim/default.nix
+++ b/pkgs/applications/video/jellyfin-mpv-shim/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, fetchurl
+, mpv, python-mpv-jsonipc, jellyfin-apiclient-python
+, pillow, tkinter, pystray, jinja2, pywebview }:
+
+buildPythonApplication rec {
+  pname = "jellyfin-mpv-shim";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "iwalton3";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "195vplq4182pq62sn6ci0a8p57k6zv8pk1gmifmwdv69wzaph043";
+    fetchSubmodules = true; # needed for display_mirror css file
+  };
+
+  # override $HOME directory:
+  #   error: [Errno 13] Permission denied: '/homeless-shelter'
+  #
+  # remove jellyfin_mpv_shim/win_utils.py:
+  #   ModuleNotFoundError: No module named 'win32gui'
+  preCheck = ''
+    export HOME=$TMPDIR
+
+    rm jellyfin_mpv_shim/win_utils.py
+  '';
+
+  propagatedBuildInputs = [
+    jellyfin-apiclient-python
+    mpv
+    pillow
+    python-mpv-jsonipc
+
+    # gui dependencies
+    pystray
+    tkinter
+
+    # display_mirror dependencies
+    jinja2
+    pywebview
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/iwalton3/jellyfin-mpv-shim";
+    description = "Allows casting of videos to MPV via the jellyfin mobile and web app.";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/development/python-modules/jellyfin-apiclient-python/default.nix
+++ b/pkgs/development/python-modules/jellyfin-apiclient-python/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub, requests
+, websocket_client, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "jellyfin-apiclient-python";
+  version = "1.4.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "iwalton3";
+    repo = "jellyfin-apiclient-python";
+    rev = "v${version}";
+    sha256 = "0b4ij19xjwn0wm5076fx8n4phjbsfx84x9qdrwm8c2r3ld8w7hk4";
+  };
+
+  propagatedBuildInputs = [ requests websocket_client ];
+
+  pythonImportsCheck = [ "jellyfin_apiclient_python" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/iwalton3/jellyfin-apiclient-python";
+    description = "Python API client for Jellyfin";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/development/python-modules/pystray/default.nix
+++ b/pkgs/development/python-modules/pystray/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, pillow, xlib, six, xvfb_run, sphinx }:
+
+buildPythonPackage rec {
+  pname = "pystray";
+  version = "0.15.0";
+
+  src = fetchFromGitHub {
+    owner = "moses-palmer";
+    repo = "pystray";
+    rev = "v${version}";
+    sha256 = "0m5raxahyix3lmmbjbrsfd9yhr4vdil8gcy155hh6lqm2b1fmmss";
+  };
+
+  propagatedBuildInputs = [ pillow xlib six ];
+  nativeBuildInputs = [ sphinx ];
+  checkInputs = [ xvfb_run ];
+
+  checkPhase = ''
+    rm tests/icon_tests.py # test needs user input
+
+    xvfb-run -s '-screen 0 800x600x24' python setup.py test
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/moses-palmer/pystray";
+    description = "This library allows you to create a system tray icon";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/development/python-modules/python-mpv-jsonipc/default.nix
+++ b/pkgs/development/python-modules/python-mpv-jsonipc/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "python-mpv-jsonipc";
-  version = "1.1.6";
+  version = "1.1.7";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "iwalton3";
     repo = "python-mpv-jsonipc";
     rev = "v${version}";
-    sha256 = "08bs6qrcf5fi72jijmr2w7zs6aa5976dwv04f11ajwhj6i8kfq35";
+    sha256 = "1a8lcvgwf7a19d4dj1wkkpxk44c2z9gsyz1xv4wpxi3gxlplcmcz";
   };
 
   # 'mpv-jsonipc' does not have any tests

--- a/pkgs/development/python-modules/pywebview/default.nix
+++ b/pkgs/development/python-modules/pywebview/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "pywebview";
+  version = "3.2";
+
+  src = fetchFromGitHub {
+    owner = "r0x0r";
+    repo = "pywebview";
+    rev = version;
+    sha256 = "0anwm6s0pp7xmgylr4m52v7lw825sdby7fajcl929l099n757gq7";
+  };
+
+  # disabled due to error in loading unittest
+  # don't know how to make test from: None
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/r0x0r/pywebview";
+    description = "Lightweight cross-platform wrapper around a webview.";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1904,6 +1904,8 @@ in
 
   jellyfin = callPackage ../servers/jellyfin { ffmpeg = ffmpeg_4; };
 
+  jellyfin-mpv-shim = python3Packages.callPackage ../applications/video/jellyfin-mpv-shim { };
+
   jotta-cli = callPackage ../applications/misc/jotta-cli { };
 
   jwt-cli = callPackage ../tools/security/jwt-cli {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -805,6 +805,8 @@ in {
 
   jc = callPackage ../development/python-modules/jc { };
 
+  jellyfin-apiclient-python = callPackage ../development/python-modules/jellyfin-apiclient-python { };
+
   jira = callPackage ../development/python-modules/jira { };
 
   jsonpath = callPackage ../development/python-modules/jsonpath { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1347,6 +1347,8 @@ in {
 
   pywebpush = callPackage ../development/python-modules/pywebpush { };
 
+  pywebview = callPackage ../development/python-modules/pywebview { };
+
   pywick = callPackage ../development/python-modules/pywick { };
 
   pyxml = disabledIf isPy3k (callPackage ../development/python-modules/pyxml{ });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1245,6 +1245,8 @@ in {
 
   pystache = callPackage ../development/python-modules/pystache { };
 
+  pystray = callPackage ../development/python-modules/pystray { };
+
   pytelegrambotapi = callPackage ../development/python-modules/pyTelegramBotAPI { };
 
   pytesseract = callPackage ../development/python-modules/pytesseract { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Tested using Jellyfin 10.4.3 and mpv 0.32.0 under sway 1.4.

Needed to update python-mpv-jsonipc to 1.1.7 and added jellyfin-apiclient-python at 1.4.0.

When running the checks a `[Errno 13] Permission denied: '/homeless-shelter'` error occurs. I grepped in nixpkgs where other packages just set  `HOME=$TMPDIR` - is this acceptable?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/x4vkx44zvd2q3g9vlmmb8qrz831fifbd-jellyfin-mpv-shim-1.4.1	 443.1M
/nix/store/rxh4y34gh2gfc3rlb5wrirxzzkx7aa5k-python3.7-jellyfin-apiclient-python-1.4.0	  109.7M
/nix/store/5iv2ldpp410l80spdkl8zkgmbinzdkm9-python3.7-python-mpv-jsonipc-1.1.6	  109.9M
/nix/store/7g0z4prrd163p1ajmw97s2vhs34qnizd-python3.7-python-mpv-jsonipc-1.1.7	  109.9M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
