### PR TITLE
llvmPackages_10: rc2 -> rc3

### DIFF
--- a/pkgs/development/compilers/llvm/10/clang/clang-extension-handling.patch
+++ b/pkgs/development/compilers/llvm/10/clang/clang-extension-handling.patch
@@ -1,0 +1,18 @@
+Compressed diff from
+```
+git show d21664cce1db8debe2528f36b1fbd2b8af9c9401 87dac7da68ea1e0adac78c59ef1891dcf9632b67 3a0f6e699bb6d96dc62dce6faef20ac26cf103fd
+```
+with the purpose of avoiding linker errors arising in the polly-flavoured clang.
+
+diff --git a/clang/CMakeLists.txt b/clang/CMakeLists.txt
+index 781c3eb7f2f..dc1413f4b59 100644
+--- clang/CMakeLists.txt
++++ clang/CMakeLists.txt
+@@ -864,6 +864,7 @@ add_subdirectory(utils/hmaptool)
+ 
+ if(CLANG_BUILT_STANDALONE)
+   llvm_distribution_add_targets()
++  process_llvm_pass_plugins()
+ endif()
+ 
+ configure_file(

--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python3, lld
 , fixDarwinDylibNames
 , enableManpages ? false
-, enablePolly ? false # TODO: get this info from llvm (passthru?)
 }:
 
 let
@@ -9,7 +8,7 @@ let
     pname = "clang";
     inherit version;
 
-    src = fetch "clang" "1npwv0j6812q9jar79bb5m2j4lmvp11680in45nlma8czrs52w0v";
+    src = fetch "clang" "1w7ixr16a9f0g5kv4irvhwq973wn0d418kb0p9rabyfscm05wfmq";
 
     unpackPhase = ''
       unpackFile $src
@@ -34,12 +33,12 @@ let
       "-DSPHINX_OUTPUT_MAN=ON"
       "-DSPHINX_OUTPUT_HTML=OFF"
       "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-    ] ++ stdenv.lib.optionals enablePolly [
-      "-DWITH_POLLY=ON"
-      "-DLINK_POLLY_INTO_TOOLS=ON"
     ];
 
     patches = [
+      # 10.0.0rc3-only
+      ./clang-extension-handling.patch
+
       ./purity.patch
       # https://reviews.llvm.org/D51899
       ./compiler-rt-baremetal.patch

--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation rec {
   pname = "compiler-rt";
   inherit version;
-  src = fetch pname "11qiass6gbpq3m1srqlk5gm0zcm8j4jk2cmingra237qhaxz8wv9";
+  src = fetch pname "0qv40mv91630l6f75w9g5y6v97s5shz94n82rms12gcd8mir6qp5";
 
   nativeBuildInputs = [ cmake python3 llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;

--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -6,7 +6,7 @@
 
 let
   release_version = "10.0.0";
-  candidate = "rc2";
+  candidate = "rc3";
   version = "10.0.0${candidate}"; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
@@ -14,7 +14,7 @@ let
     inherit sha256;
   };
 
-  clang-tools-extra_src = fetch "clang-tools-extra" "1yi34b6lspcpig0gnws2ba0shgmrs2jgjb3hp08mm0dg3blzk8ss";
+  clang-tools-extra_src = fetch "clang-tools-extra" "03669c93wzmbmfpv0pyzb7y4z1xc912l95iqywyx01xgdl1xws0r";
 
   tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python3 isl release_version version fetch; });
@@ -39,7 +39,6 @@ let
     clang-polly-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;
       llvm = tools.llvm-polly;
-      enablePolly = true;
     };
 
     llvm-manpages = lowPrio (tools.llvm.override {

--- a/pkgs/development/compilers/llvm/10/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/10/libc++/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "libc++";
   inherit version;
 
-  src = fetch "libcxx" "0d83z1dbr6kkwcq72kqpdkvnndjvcjx7w80qlkvqlv7r2zai5kjg";
+  src = fetch "libcxx" "1cjxiby8nq95g02rgx08iy86pswpi66b9wmxqjiyga1s92nb19j0";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/10/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/10/libc++abi.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "libc++abi";
   inherit version;
 
-  src = fetch "libcxxabi" "001rnpgya6y0vcsy5jqcc7ria666mswbzw4avdps6dgs6caqrfpd";
+  src = fetch "libcxxabi" "1xs7dr91qzz7lq9am4q3vcj2jf1gx23ar1jbnhn763011hl94vs0";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;

--- a/pkgs/development/compilers/llvm/10/libunwind.nix
+++ b/pkgs/development/compilers/llvm/10/libunwind.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "libunwind";
   inherit version;
 
-  src = fetch pname "0194s3qqqz4qcrzdfy7c931sm3d9hnjk624gldja85mwz1v1x9a8";
+  src = fetch pname "1dm7l75ajnjy6kbg2157v2g5gfia3n47fc56ayryyp2jdvbgprwl";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/compilers/llvm/10/lld.nix
+++ b/pkgs/development/compilers/llvm/10/lld.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   pname = "lld";
   inherit version;
 
-  src = fetch pname "0z0a1h94hx0wj5289gvp99bvvj2ghid94xj2c5acmh1df8cx1vna";
+  src = fetch pname "1w9c9xmzbdnkwgal612hqz2lxj9jgqpfzxr2rllcspmf6v7arvf4";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/10/lldb.nix
+++ b/pkgs/development/compilers/llvm/10/lldb.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (rec {
   pname = "lldb";
   inherit version;
 
-  src = fetch pname "0nh26a4mxd54k5f9gpizr55vdalkzym2l82kvfh3lm8lvimypga1";
+  src = fetch pname "06qzh13cr20wrd5925698yq696bhl68zbvm7kjxp7c2rx5swxmg8";
 
   patches = [ ./lldb-procfs.patch ];
 

--- a/pkgs/development/compilers/llvm/10/llvm-extension-handling.patch
+++ b/pkgs/development/compilers/llvm/10/llvm-extension-handling.patch
@@ -1,0 +1,146 @@
+Compressed diff from
+```
+git show d21664cce1db8debe2528f36b1fbd2b8af9c9401 87dac7da68ea1e0adac78c59ef1891dcf9632b67 3a0f6e699bb6d96dc62dce6faef20ac26cf103fd
+```
+with the purpose of avoiding linker errors arising in the polly-flavoured clang.
+
+diff --git a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+index a02c2a5a23f..faf8f561faa 100644
+--- llvm/CMakeLists.txt
++++ llvm/CMakeLists.txt
+@@ -1069,6 +1069,7 @@ endif()
+ # after all targets are created.
+ include(LLVMDistributionSupport)
+ llvm_distribution_add_targets()
++process_llvm_pass_plugins(GEN_CONFIG)
+ 
+ # This allows us to deploy the Universal CRT DLLs by passing -DCMAKE_INSTALL_UCRT_LIBRARIES=ON to CMake
+ if (MSVC AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_INSTALL_UCRT_LIBRARIES)
+@@ -1093,5 +1094,3 @@ endif()
+ if (LLVM_INCLUDE_UTILS AND LLVM_INCLUDE_TOOLS)
+   add_subdirectory(utils/llvm-locstats)
+ endif()
+-
+-process_llvm_pass_plugins()
+diff --git a/llvm/cmake/modules/AddLLVM.cmake b/llvm/cmake/modules/AddLLVM.cmake
+index fd69786544a..8fbb33a22fd 100644
+--- llvm/cmake/modules/AddLLVM.cmake
++++ llvm/cmake/modules/AddLLVM.cmake
+@@ -884,53 +884,71 @@ function(add_llvm_pass_plugin name)
+     if (TARGET intrinsics_gen)
+       add_dependencies(obj.${name} intrinsics_gen)
+     endif()
+-    message(STATUS "Registering ${name} as a pass plugin (static build: ${LLVM_${name_upper}_LINK_INTO_TOOLS})")
+-    set_property(GLOBAL APPEND PROPERTY LLVM_COMPILE_EXTENSIONS ${name})
++    set_property(GLOBAL APPEND PROPERTY LLVM_STATIC_EXTENSIONS ${name})
+   elseif(NOT ARG_NO_MODULE)
+     add_llvm_library(${name} MODULE ${ARG_UNPARSED_ARGUMENTS})
+   else()
+     add_llvm_library(${name} OBJECT ${ARG_UNPARSED_ARGUMENTS})
+   endif()
++  message(STATUS "Registering ${name} as a pass plugin (static build: ${LLVM_${name_upper}_LINK_INTO_TOOLS})")
+ 
+ endfunction(add_llvm_pass_plugin)
+ 
+-# Generate X Macro file for extension handling. It provides a
+-# HANDLE_EXTENSION(extension_namespace, ExtensionProject) call for each extension
+-# allowing client code to define HANDLE_EXTENSION to have a specific code be run for
+-# each extension.
++# process_llvm_pass_plugins([GEN_CONFIG])
++#
++# Correctly set lib dependencies between plugins and tools, based on tools
++# registered with the ENABLE_PLUGINS option.
++#
++# if GEN_CONFIG option is set, also generate X Macro file for extension
++# handling. It provides a HANDLE_EXTENSION(extension_namespace, ExtensionProject)
++# call for each extension allowing client code to define
++# HANDLE_EXTENSION to have a specific code be run for each extension.
+ #
+-# Also correctly set lib dependencies between plugins and tools.
+ function(process_llvm_pass_plugins)
+-  get_property(LLVM_EXTENSIONS GLOBAL PROPERTY LLVM_COMPILE_EXTENSIONS)
+-  file(WRITE "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp" "//extension handlers\n")
+-  foreach(llvm_extension ${LLVM_EXTENSIONS})
+-    string(TOLOWER ${llvm_extension} llvm_extension_lower)
+-
+-    string(TOUPPER ${llvm_extension} llvm_extension_upper)
+-    string(SUBSTRING ${llvm_extension_upper} 0 1 llvm_extension_upper_first)
+-    string(SUBSTRING ${llvm_extension_lower} 1 -1 llvm_extension_lower_tail)
+-    string(CONCAT llvm_extension_project ${llvm_extension_upper_first} ${llvm_extension_lower_tail})
+-
+-    if(LLVM_${llvm_extension_upper}_LINK_INTO_TOOLS)
+-      file(APPEND "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp" "HANDLE_EXTENSION(${llvm_extension_project})\n")
+-
+-      get_property(llvm_plugin_targets GLOBAL PROPERTY LLVM_PLUGIN_TARGETS)
+-      foreach(llvm_plugin_target ${llvm_plugin_targets})
+-        set_property(TARGET ${llvm_plugin_target} APPEND PROPERTY LINK_LIBRARIES ${llvm_extension})
+-        set_property(TARGET ${llvm_plugin_target} APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${llvm_extension})
+-      endforeach()
+-    else()
+-      add_llvm_library(${llvm_extension_lower} MODULE obj.${llvm_extension_lower})
+-    endif()
++  cmake_parse_arguments(ARG
++      "GEN_CONFIG" "" ""
++    ${ARGN})
+ 
++  if(ARG_GEN_CONFIG)
++      get_property(LLVM_STATIC_EXTENSIONS GLOBAL PROPERTY LLVM_STATIC_EXTENSIONS)
++  else()
++      include(LLVMConfigExtensions)
++  endif()
++
++  # Add static plugins to each plugin target.
++  foreach(llvm_extension ${LLVM_STATIC_EXTENSIONS})
++    get_property(llvm_plugin_targets GLOBAL PROPERTY LLVM_PLUGIN_TARGETS)
++    foreach(llvm_plugin_target ${llvm_plugin_targets})
++      set_property(TARGET ${llvm_plugin_target} APPEND PROPERTY LINK_LIBRARIES ${llvm_extension})
++      set_property(TARGET ${llvm_plugin_target} APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${llvm_extension})
++    endforeach()
+   endforeach()
+-  file(APPEND "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp" "#undef HANDLE_EXTENSION\n")
+ 
+-  # only replace if there's an actual change
+-  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+-    "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp"
+-    "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def")
+-  file(REMOVE "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp")
++  # Eventually generate the extension header, and store config to a cmake file
++  # for usage in third-party configuration.
++  if(ARG_GEN_CONFIG)
++      set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
++      set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
++      file(WRITE
++          "${llvm_cmake_builddir}/LLVMConfigExtensions.cmake"
++          "set(LLVM_STATIC_EXTENSIONS ${LLVM_STATIC_EXTENSIONS})")
++      install(FILES
++          ${llvm_cmake_builddir}/LLVMConfigExtensions.cmake
++          DESTINATION ${LLVM_INSTALL_PACKAGE_DIR}
++          COMPONENT cmake-exports)
++
++      file(WRITE "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp" "//extension handlers\n")
++      foreach(llvm_extension ${LLVM_STATIC_EXTENSIONS})
++        file(APPEND "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp" "HANDLE_EXTENSION(${llvm_extension})\n")
++      endforeach()
++      file(APPEND "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp" "#undef HANDLE_EXTENSION\n")
++
++      # only replace if there's an actual change
++      execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
++        "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp"
++        "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def")
++      file(REMOVE "${LLVM_BINARY_DIR}/include/llvm/Support/Extension.def.tmp")
++  endif()
+ endfunction()
+ 
+ function(export_executable_symbols target)
+diff --git a/llvm/cmake/modules/CMakeLists.txt b/llvm/cmake/modules/CMakeLists.txt
+index 9cf22b436fa..af757d6199a 100644
+--- llvm/cmake/modules/CMakeLists.txt
++++ llvm/cmake/modules/CMakeLists.txt
+@@ -136,6 +136,7 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+     FILES_MATCHING PATTERN *.cmake
+     PATTERN .svn EXCLUDE
+     PATTERN LLVMConfig.cmake EXCLUDE
++    PATTERN LLVMConfigExtensions.cmake EXCLUDE
+     PATTERN LLVMConfigVersion.cmake EXCLUDE
+     PATTERN LLVM-Config.cmake EXCLUDE
+     PATTERN GetHostTriple.cmake EXCLUDE)

--- a/pkgs/development/compilers/llvm/10/llvm.nix
+++ b/pkgs/development/compilers/llvm/10/llvm.nix
@@ -31,8 +31,8 @@ in stdenv.mkDerivation (rec {
   pname = "llvm";
   inherit version;
 
-  src = fetch pname "01azqqygm83s6l1g35kqkc7da06dkc8jxpb4zsd420lmhfhw4gws";
-  polly_src = fetch "polly" "00nvnh0jhi1s5gcyfnb30h9g2j18z79kipiy878bkawg53f4z2xf";
+  src = fetch pname "1pa322iwqg071gxdn5wxri263j6aki6ag36xbdzbyi3g8m8v8jci";
+  polly_src = fetch "polly" "0p9dmv4hxwx4f5k1v4r9b5jp7fbi71ajpmrv3xf3vmp6m4i3r0pc";
 
   unpackPhase = ''
     unpackFile $src
@@ -53,6 +53,11 @@ in stdenv.mkDerivation (rec {
     ++ optional enablePFM libpfm; # exegesis
 
   propagatedBuildInputs = [ ncurses zlib ];
+
+  patches = [
+    # 10.0.0rc3-only
+    ./llvm-extension-handling.patch
+  ];
 
   postPatch = optionalString stdenv.isDarwin ''
     substituteInPlace cmake/modules/AddLLVM.cmake \

--- a/pkgs/development/compilers/llvm/10/openmp.nix
+++ b/pkgs/development/compilers/llvm/10/openmp.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   pname = "openmp";
   inherit version;
 
-  src = fetch pname "1fpvpsbrrpngm8zplhdbkhnk79mhfdf3xsw1rwcfcv564gilla3w";
+  src = fetch pname "0axdxar18rvk9r4yx7y55ywqr3070mixag9sg2fcck1jzwfgymjb";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

http://lists.llvm.org/pipermail/llvm-dev/2020-March/139729.html

###### Things done

- `s/rc2/rc3/g`
- updated hashes
- additionally cherry-picked 3 commits from `llvm-project/master`:
  - llvm/llvm-project@d21664c
  - llvm/llvm-project@3a0f6e6
  - llvm/llvm-project@87dac7d

such that clang can automatically pick up the polly plugin from the
`llvm-polly` build.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
