### PR TITLE
r8125: init at 9.003.02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5881,6 +5881,12 @@
     githubId = 4579165;
     name = "Danny Bautista";
   };
+  peelz = {
+    email = "peelz.dev+nixpkgs@gmail.com";
+    github = "louistakepillz";
+    githubId = 920910;
+    name = "peelz";
+  };
   q3k = {
     email = "q3k@q3k.org";
     github = "q3k";

--- a/pkgs/os-specific/linux/r8125/default.nix
+++ b/pkgs/os-specific/linux/r8125/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "r8125";
+  # On update please verify (using `diff -r`) that the source matches the
+  # realtek version.
+  version = "9.003.02";
+
+  # This is a mirror. The original website[1] doesn't allow non-interactive
+  # downloads, instead emailing you a download link.
+  # [1] https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software
+  src = fetchFromGitHub {
+    owner = "ibmibmibm";
+    repo = "r8125";
+    rev = "${version}";
+    sha256 = "09ip17x8nhcpxkkhyyawkmd10n73j2ffh1i2nmsr7l3jfq7f9zac";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preBuild = ''
+    substituteInPlace src/Makefile --replace "BASEDIR :=" "BASEDIR ?="
+    substituteInPlace src/Makefile --replace "modules_install" "INSTALL_MOD_PATH=$out modules_install"
+  '';
+
+  makeFlags = [
+    "BASEDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}"
+  ];
+
+  buildFlags = [ "modules" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/ibmibmibm/r8125";
+    downloadPage = "https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software";
+    description = "Realtek r8125 driver";
+    longDescription = ''
+      A kernel module for Realtek 8125 2.5G network cards.
+    '';
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ peelz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16676,6 +16676,8 @@ in
 
     ply = callPackage ../os-specific/linux/ply { };
 
+    r8125 = callPackage ../os-specific/linux/r8125 { };
+
     r8168 = callPackage ../os-specific/linux/r8168 { };
 
     rtl8192eu = callPackage ../os-specific/linux/rtl8192eu { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

My motherboard has 2.5G Ethernet port that requires a [Realtek driver](https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software) to work.

Note: I had to mirror the Realtek files through a personal git repo because Realtek doesn't allow direct downloads.
<img src="https://user-images.githubusercontent.com/920910/76013469-ec1bfb80-5ee5-11ea-9288-087827673199.png" height="140">

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
