### PR TITLE
bambootracker: init at 0.4.3

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -1,0 +1,72 @@
+{ mkDerivation
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, installShellFiles
+, qmake
+, qtbase
+, qtmultimedia
+, qttools
+, alsaSupport ? stdenv.hostPlatform.isLinux
+, alsaLib
+, pulseSupport ? stdenv.hostPlatform.isLinux
+, libpulseaudio
+, jackSupport ? stdenv.hostPlatform.isUnix
+, libjack2
+}:
+let
+
+  inherit (stdenv.lib) optional optionals;
+
+in
+mkDerivation rec {
+  pname = "bambootracker";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "rerrahkr";
+    repo = "BambooTracker";
+    rev = "v${version}";
+    sha256 = "0gq40qmsdavsyl2d6a71rwp4mjlwvp1c8bry32srn4hliwfnvqa6";
+  };
+
+  # Fix macOS build until new release
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/rerrahkr/BambooTracker/commit/45346ed99559d44c2e32a5c6138a0835b212e875.patch";
+      sha256 = "1xkiqira1kpcqkacycy0y7qm1brhf89amliv42byijl4palmykh2";
+    })
+  ];
+
+  preConfigure = "cd BambooTracker";
+
+  nativeBuildInputs = [ qmake qttools installShellFiles ];
+
+  buildInputs = [ qtbase qtmultimedia ]
+    ++ optional alsaSupport alsaLib
+    ++ optional pulseSupport libpulseaudio
+    ++ optional jackSupport libjack2;
+
+  qmakeFlags = [ "CONFIG+=release" "CONFIG-=debug" ]
+    ++ optional pulseSupport "CONFIG+=use_pulse"
+    ++ optionals jackSupport [ "CONFIG+=use_jack" "CONFIG+=jack_has_rename" ];
+
+  postInstall = ''
+    install -Dm644 ../BambooTracker.desktop $out/share/applications/BambooTracker.desktop
+    installManPage ../BambooTracker*.1
+
+    cp -r ../{demos,licenses,skins,LICENSE} $out/share/BambooTracker/
+
+    for size in 16x16 256x256; do
+      install -Dm644 res/icon/icon_$size.png $out/share/icons/hicolor/$size/apps/BambooTracker.png
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tracker for YM2608 (OPNA) which was used in NEC PC-8801/9801 series computers";
+    homepage = "https://github.com/rerrahkr/BambooTracker";
+    license = licenses.gpl2Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ OPNA2608 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19099,6 +19099,8 @@ in
 
   azpainter = callPackage ../applications/graphics/azpainter { };
 
+  bambootracker = libsForQt5.callPackage ../applications/audio/bambootracker { };
+
   cadence =  qt5.callPackage ../applications/audio/cadence { };
 
   cheesecutter = callPackage ../applications/audio/cheesecutter { };


### PR DESCRIPTION
###### Motivation for this change
Been in my local checkout for awhile, decided to push since it was mentioned in https://github.com/NixOS/nixpkgs/issues/81815.

Ping @fgaz because you were interested in packaging it. Give it a look, let me know how it looks to you.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) (new package -> 326780408)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
