### PR TITLE
gcc: place cross-compiled target libraries in lib output

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -41,7 +41,9 @@ let
   libc_bin = if libc == null then null else getBin libc;
   libc_dev = if libc == null then null else getDev libc;
   libc_lib = if libc == null then null else getLib libc;
-  cc_solib = getLib cc;
+  cc_solib = getLib cc
+    + optionalString (targetPlatform != hostPlatform) "/${targetPlatform.config}";
+
   # The wrapper scripts use 'cat' and 'grep', so we may need coreutils.
   coreutils_bin = if nativeTools then "" else getBin coreutils;
 

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -247,13 +247,6 @@ postInstall() {
             NEW_RPATH=`echo "$PREV_RPATH" | sed 's,:[^:]*bootstrap-tools/lib,,g'`
             patchelf --set-rpath "$NEW_RPATH" "$i" && echo OK
         done
-
-        # For some reason the libs retain RPATH to $out
-        for i in "$lib"/lib/{libtsan,libasan,libubsan}.so.*.*.*; do
-            PREV_RPATH=`patchelf --print-rpath "$i"`
-            NEW_RPATH=`echo "$PREV_RPATH" | sed "s,:${out}[^:]*,,g"`
-            patchelf --set-rpath "$NEW_RPATH" "$i" && echo OK
-        done
     fi
 
     if type "install_name_tool"; then

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -133,7 +133,7 @@ if test "$noSysDirs" = "1"; then
 
     if test "$crossStageStatic" == 1; then
         # We don't want the gcc build to assume there will be a libc providing
-        # limits.h in this stagae
+        # limits.h in this stage
         makeFlagsArray+=(
             'LIMITS_H_TEST=false'
         )
@@ -203,31 +203,31 @@ postConfigure() {
 preInstall() {
     # Make ‘lib64’ symlinks to ‘lib’.
     if [ -n "$is64bit" -a -z "$enableMultilib" ]; then
-        mkdir -p "$out/lib"
-        ln -s lib "$out/lib64"
-        mkdir -p "$lib/lib"
-        ln -s lib "$lib/lib64"
+        mkdir -p "$out/${targetConfig}/lib"
+        ln -s lib "$out/${targetConfig}/lib64"
+        mkdir -p "$lib/${targetConfig}/lib"
+        ln -s lib "$lib/${targetConfig}/lib64"
     fi
 }
 
 
 postInstall() {
     # Move runtime libraries to $lib.
-    moveToOutput "lib/lib*.so*" "$lib"
-    moveToOutput "lib/lib*.la"  "$lib"
-    moveToOutput "lib/lib*.dylib" "$lib"
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.so*" "$lib"
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.la"  "$lib"
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dylib" "$lib"
     moveToOutput "share/gcc-*/python" "$lib"
 
-    for i in "$lib"/lib/*.{la,py}; do
+    for i in "$lib/${targetConfig}"/lib/*.{la,py}; do
         substituteInPlace "$i" --replace "$out" "$lib"
     done
 
     if [ -n "$enableMultilib" ]; then
-        moveToOutput "lib64/lib*.so*" "$lib"
-        moveToOutput "lib64/lib*.la"  "$lib"
-        moveToOutput "lib64/lib*.dylib" "$lib"
+        moveToOutput "${targetConfig+$targetConfig/}lib64/lib*.so*" "$lib"
+        moveToOutput "${targetConfig+$targetConfig/}lib64/lib*.la"  "$lib"
+        moveToOutput "${targetConfig+$targetConfig/}lib64/lib*.dylib" "$lib"
 
-        for i in "$lib"/lib64/*.{la,py}; do
+        for i in "$lib/${targetConfig}"/lib64/*.{la,py}; do
             substituteInPlace "$i" --replace "$out" "$lib"
         done
     fi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is my take on an alternative, subjectively cleaner implementation of #58606 and #81781. The only functional difference is that the libraries are placed in $lib/$targetConfig/lib (which is the directory convention using by the GCC build scripts) rather than $lib/lib. This requires a minor change to cc-wrapper. Subjectively, I believe it is cleaner because it unifies the handling of the cross and non-cross cases and is therefore easier to reason about.

I have tested this change by building `pkgsCross.armv7l-hf-multiplatform.hello` and `pkgsCross.aarch64-multiplatform.hello`.

While searching for potential ramifications of this change, I found a patchelf invocation that is no longer needed. I have verified that the `lib` output of the native x86_64 builds of all supported GCC versions still contain no references to their corresponding `out` output after this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @illegalprime @floki @matthewbauer @eamsden 