### PR TITLE
firefox: mark as broken on 32-bit buildPlatform

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -1,4 +1,4 @@
-{ config, lib, callPackage, fetchurl }:
+{ config, stdenv, lib, callPackage, fetchurl }:
 
 let
   common = opts: callPackage (import ./common.nix opts) {};
@@ -23,6 +23,8 @@ rec {
       maintainers = with lib.maintainers; [ eelco andir ];
       platforms = lib.platforms.unix;
       badPlatforms = lib.platforms.darwin;
+      broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".
+                                             # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
       license = lib.licenses.mpl20;
     };
     updateScript = callPackage ./update.nix {


### PR DESCRIPTION
Since Firefox 60, build on 32-bit platforms fails with "out of memory".

32-bit platforms are not excluded from `meta.platforms` nor added to `meta.badPlatforms` because this is not limitation of host platform.

Cross-compilation of 32-bit `firefox` on 64-bit machine might work.