### PR TITLE
shellcheck: add manpage and docs

### DIFF
--- a/pkgs/development/tools/shellcheck/default.nix
+++ b/pkgs/development/tools/shellcheck/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, haskellPackages, haskell }:
+
+# this wraps around the haskell package
+# and puts the documentation into place
+
+let
+  # TODO: move to lib/ in separate PR
+  overrideMeta = drv: overrideFn:
+    let
+      drv' = if drv ? meta then drv else drv // { meta = {}; };
+      pos = (builtins.unsafeGetAttrPos "pname" drv');
+      meta' = drv'.meta // {
+        # copied from the mkDerivation code
+        position = pos.file + ":" + toString pos.line;
+      };
+    in drv' // { meta = meta' // overrideFn meta'; };
+
+  bin = haskell.lib.justStaticExecutables haskellPackages.ShellCheck;
+  src = haskellPackages.ShellCheck.src;
+
+  shellcheck = stdenv.mkDerivation {
+    pname = "shellcheck";
+    version = bin.version;
+
+    inherit src;
+
+    outputs = [ "bin" "man" "doc" "out" ];
+
+    phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+    installPhase = ''
+      install -Dm755 ${bin}/bin/shellcheck $bin/bin/shellcheck
+      install -Dm644 README.md $doc/share/shellcheck/README.md
+      install -Dm644 shellcheck.1 $man/share/man/man1/shellcheck.1
+      mkdir $out
+    '';
+
+    # just some file copying
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+  };
+
+in
+  overrideMeta shellcheck (old: {
+    maintainers = with lib.maintainers; [ Profpatsch ];
+    outputsToInstall = [ "bin" "man" "doc" ];
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10646,7 +10646,7 @@ in
 
   shards = callPackage ../development/tools/build-managers/shards { };
 
-  shellcheck = haskell.lib.justStaticExecutables haskellPackages.ShellCheck;
+  shellcheck = callPackage ../development/tools/shellcheck {};
 
   schemaspy = callPackage ../development/tools/database/schemaspy { };
 


### PR DESCRIPTION
The shellcheck source code contains a manpage, so let’s add that to
the output. For good measure, also copy the README to the doc output.

The overrideMeta thing is taking care of setting the right position,
so that `nix edit` points to this file instead of to the original
haskellPackages definition.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
