### PR TITLE
Feature/update and fix pulumi

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,50 +1,50 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "1.4.0";
+  version = "1.12.0";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-linux-x64.tar.gz";
-        sha256 = "00ywy2ba4xha6gwd42i3fdrk1myivkd1r6ijdr2vkianmg524k6f";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.12.0-linux-x64.tar.gz";
+        sha256 = "14j8f43h920k62h8bhywapphhfbj7whb9l6pjmyigld6x2jpr4mc";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v0.2.0-linux-amd64.tar.gz";
-        sha256 = "1hj4gysjipd091f106a7xz02g9cail5d11rn6j08m0xphg9cf3fn";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v1.5.0-linux-amd64.tar.gz";
+        sha256 = "1vdd5ghlsxqrfd1nrdj7hsl745k8myhxmd3gh1fq6ksa3apnh1ca";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v1.4.1-linux-amd64.tar.gz";
-        sha256 = "0r6xpsb2riqmxwxw28lbi3xd7w4ds510gw99j1rr57h5b9bq19jj";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.8.0-linux-amd64.tar.gz";
+        sha256 = "1q34kv41dbmz45s1sg0rqdxp1qlfq0ii0hy9p95lkzd7qj19qrvv";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.2.3-linux-amd64.tar.gz";
-        sha256 = "0m7fajy3cy1agsz787ak548khwj8rwahs1ibaswqfyyw092iyzb9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.5.6-linux-amd64.tar.gz";
+        sha256 = "1g5zgkqnzjqfri61p8876czn0ab2n3mjqf1acdyn8kg5q52sd8ix";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.7.0-linux-amd64.tar.gz";
-        sha256 = "1qw90l7h8yn06bz2l2995nbrc3svs223dm3ys1807amj4n2jyfwb";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.24.0-linux-amd64.tar.gz";
+        sha256 = "1fwnad5p1v4bigcr2icgzmxdn1b3x0j8c361546pqzk67vskn9fg";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-darwin-x64.tar.gz";
-        sha256 = "02vqw9gn17dy3rfh0j00k9f827l42g3nl3rhlcbc8jbgx3n9c9qy";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.12.0-darwin-x64.tar.gz";
+        sha256 = "1bg6vnxic8fzycgv8q7m1bf8pk2bxvcn0b6lwy7aa2f3kzw70q46";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v0.2.0-darwin-amd64.tar.gz";
-        sha256 = "077j9fp8ix00rcqrq8qxk3kvz6gz6sknzb2iv3qjvkh6yh292mz3";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v1.5.0-darwin-amd64.tar.gz";
+        sha256 = "1skvfg8s8f81l4yfgm49jca38cx96khk3f9rpq4ywa3r3f450kni";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v1.4.1-darwin-amd64.tar.gz";
-        sha256 = "1i2vf3bxwf8awvw183hq9bbnmznda1jpv1zqghgz2ybx4s0915nx";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.8.0-darwin-amd64.tar.gz";
+        sha256 = "0f0gnbiv2gbam5n3ng9j5rbrml0jfv9k402vd4j9ryfkly4grpa9";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.2.3-darwin-amd64.tar.gz";
-        sha256 = "123czx1c31r5r91k2jhdgmnffypnl8w1a6h9mr2rdhwgbx8hzq40";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.5.6-darwin-amd64.tar.gz";
+        sha256 = "1l610a0bvwrsbqv4s00ghbplwnk11q3c0n3py0l7w0a2mpl8izzd";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.7.0-darwin-amd64.tar.gz";
-        sha256 = "0cl0vakppxi0v8ym8b4fzhzb10nl84wd0vfik8gpfwsg7zwdzhlp";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.24.0-darwin-amd64.tar.gz";
+        sha256 = "17qq7w2wk0803y0if7dn3gnxxnfqnb4n2gcil3zgbc4yhqz4py0y";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, autoPatchelfHook }:
+{ lib, stdenv, fetchurl, autoPatchelfHook, makeWrapper }:
 
 with lib;
 
@@ -17,9 +17,10 @@ in stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     cp * $out/bin/
+    wrapProgram $out/bin/pulumi --set LD_LIBRARY_PATH "${stdenv.cc.cc.lib}/lib"
   '';
 
-  buildInputs = optionals stdenv.isLinux [ autoPatchelfHook ];
+  buildInputs = optionals stdenv.isLinux [ autoPatchelfHook makeWrapper ];
 
   meta = {
     homepage = https://pulumi.io/;

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-VERSION="1.4.0"
+VERSION="1.12.0"
 
 declare -A plugins
 plugins=(
-    ["aws"]="1.7.0"
-    ["gcp"]="1.4.1"
-    ["kubernetes"]="1.2.3"
-    ["random"]="0.2.0"
+    ["aws"]="1.24.0"
+    ["gcp"]="2.8.0"
+    ["random"]="1.5.0"
+    ["kubernetes"]="1.5.6"
 )
 
 function genMainSrc() {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Pulumi was outdated and had an issue because it requires libstdc++ at runtime. I updated pulumi and it's plugins to the latest versions and fixed the libstdc++ issue.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
