### PR TITLE
http2tcp: init at 0.5

### DIFF
--- a/pkgs/development/python-modules/wsgitools/default.nix
+++ b/pkgs/development/python-modules/wsgitools/default.nix
@@ -1,0 +1,28 @@
+{lib
+,buildPythonPackage
+,fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "wsgitools";
+  version = "0.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0q6kmrkqf02fgww7z1g9cw8f70fimdzs1bvv9inb7fsk0c3pcf1i";
+  };
+
+  meta = with lib; {
+    maintainers = with maintainers; [ clkamp ];
+    description = "A set of tools working with WSGI";
+    longDescription = ''
+      wsgitools is a set of tools working with WSGI (see PEP 333). It
+      includes classes for filtering content, middlewares for caching,
+      logging and tracebacks as well as two backends for SCGI. Goals
+      in writing it were portability and simplicity.
+    '';
+    homepage = "https://subdivi.de/~helmut/wsgitools/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/networking/http2tcp/default.nix
+++ b/pkgs/tools/networking/http2tcp/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, python3
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "http2tcp";
+  version = "0.5";
+
+  src = fetchurl {
+    url = "https://www.linta.de/~aehlig/http2tcp/${pname}-${version}.tar.gz";
+    sha256 = "34fb83c091689dee398ca80db76487e0c39abb17cef390d845ffd888009a5caa";
+  };
+
+  buildInputs = [
+    (python3.withPackages (ps: [
+      ps.wsgitools
+    ]))
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/${pname}}
+    cp http2tcp* $out/bin
+    cp Protocol $out/share/${pname}/
+  '';
+
+  meta = with lib; {
+    maintainers = with maintainers; [ clkamp ];
+    description = "A tool for tunneling TCP connections via HTTP GET requests";
+    longDescription = ''
+      The http2tcp tools allow to tunnel tcp connections (presumably
+      ssh) via syntactically correct http requests. It is designed to
+      work in the presence of so-called "transparent"
+      store-and-forward proxies disallowing POST requests.
+
+      It also turned out to be useful to stabilise connections where
+      the client's internet connection is unreliable (frequent long
+      network outages, rapidly changing IP address, etc).
+    '';
+    homepage = "https://www.linta.de/~aehlig/http2tcp/";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -947,6 +947,8 @@ in
 
   hpe-ltfs = callPackage ../tools/backup/hpe-ltfs { };
 
+  http2tcp = callPackage ../tools/networking/http2tcp { };
+
   httperf = callPackage ../tools/networking/httperf { };
 
   ili2c = callPackage ../tools/misc/ili2c { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6218,6 +6218,8 @@ in {
 
   wsgiproxy2 = callPackage ../development/python-modules/wsgiproxy2 { };
 
+  wsgitools = callPackage ../development/python-modules/wsgitools { };
+
   wurlitzer = callPackage ../development/python-modules/wurlitzer { };
 
   xcaplib = callPackage ../development/python-modules/xcaplib { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
