### PR TITLE
dav1d: 0.5.2 -> 0.6.0

### DIFF
--- a/pkgs/development/libraries/dav1d/default.nix
+++ b/pkgs/development/libraries/dav1d/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab
+{ stdenv, fetchFromGitLab, fetchpatch
 , meson, ninja, nasm, pkgconfig
 , withTools ? false # "dav1d" binary
 , withExamples ? false, SDL2 # "dav1dplay" binary
@@ -9,15 +9,22 @@ assert useVulkan -> withExamples;
 
 stdenv.mkDerivation rec {
   pname = "dav1d";
-  version = "0.5.2";
+  version = "0.6.0";
 
   src = fetchFromGitLab {
     domain = "code.videolan.org";
     owner = "videolan";
     repo = pname;
     rev = version;
-    sha256 = "0acxlgyz6c8ckw8vfgn60y2zg2n00l5xsq5jlxvwbh5w5pkc3ahf";
+    sha256 = "1gr859xzbqrsp892v9zzzgrg8smnnzgc1jmb68qzl54a4g6jrxm0";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://code.videolan.org/videolan/dav1d/-/commit/e04227c5f6729b460e0b8e5fb52eae2d5acd15ef.patch";
+      sha256 = "18mpvwviqx0x9k6av98vgpjqlzcjd89g8496zsbf57bw5dadij3l";
+    })
+  ];
 
   nativeBuildInputs = [ meson ninja nasm pkgconfig ];
   # TODO: doxygen (currently only HTML and not build by default).
@@ -38,6 +45,8 @@ stdenv.mkDerivation rec {
       subsampling and bit-depth parameters.
     '';
     inherit (src.meta) homepage;
+    changelog = "https://code.videolan.org/videolan/dav1d/-/tags/${version}";
+    # More technical: https://code.videolan.org/videolan/dav1d/blob/${version}/NEWS
     license = licenses.bsd2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ primeos ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

**Update:** ~~The build with `dav1dplay` fails, we should probably wait until this MR is merged: https://code.videolan.org/videolan/dav1d/-/merge_requests/934/diffs~~ `dav1dplay` works now.
Tested via `mpv` and `dav1dplay`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
