### PR TITLE
gerbil: add wrapper to set GERBIL_HOME

### DIFF
--- a/pkgs/development/compilers/gerbil/build.nix
+++ b/pkgs/development/compilers/gerbil/build.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeStaticLibraries,
+{ stdenv, makeStaticLibraries, makeWrapper,
   coreutils, rsync, bash,
   openssl, zlib, sqlite, libxml2, libyaml, libmysqlclient, lmdb, leveldb, postgresql,
   version, git-version, gambit, src }:
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs_libraries = [ openssl zlib sqlite libxml2 libyaml libmysqlclient lmdb leveldb postgresql ];
   buildInputs_staticLibraries = map makeStaticLibraries buildInputs_libraries;
 
-  buildInputs = [ gambit rsync bash ]
+  buildInputs = [ gambit rsync bash makeWrapper ]
     ++ buildInputs_libraries ++ buildInputs_staticLibraries;
 
   NIX_CFLAGS_COMPILE = "-I${libmysqlclient}/include/mysql -L${libmysqlclient}/lib/mysql";
@@ -85,6 +85,11 @@ else
   exec ${gambit}/bin/gsi \$GSIOPTIONS \$GERBIL_HOME/lib/gxi-init "\$@"
 fi
 EOF
+
+    for exe in gxpkg gxprof gxtags; do
+      wrapProgram "$out/bin/$exe" --set-default GERBIL_HOME "$out"
+    done
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Motivation for this change

gxpkg, gxtags, and gxprof all need GERBIL_HOME set in order to function.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @fare