### PR TITLE
python3Packages.django_compat: fix tests and re-enable

### DIFF
--- a/pkgs/development/python-modules/django-compat/default.nix
+++ b/pkgs/development/python-modules/django-compat/default.nix
@@ -5,8 +5,6 @@
 buildPythonPackage rec {
   pname = "django-compat";
   version = "1.0.15";
-  # django-compat requires django < 2.0
-  disabled = stdenv.lib.versionAtLeast django.version "2.0";
 
   # the pypi packages don't include everything required for the tests
   src = fetchFromGitHub {
@@ -15,6 +13,10 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "1pr6v38ahrsvxlgmcx69s4b5q5082f44gzi4h3c32sccdc4pwqxp";
   };
+
+  patches = [
+    ./fix-tests.diff
+  ];
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/python-modules/django-compat/fix-tests.diff
+++ b/pkgs/development/python-modules/django-compat/fix-tests.diff
@@ -1,0 +1,61 @@
+diff -Nur a/compat/tests/settings.py b/compat/tests/settings.py
+--- a/compat/tests/settings.py	2020-03-06 15:32:07.548482597 +0100
++++ b/compat/tests/settings.py	2020-03-06 15:36:45.270265678 +0100
+@@ -16,10 +16,17 @@
+     'django.contrib.admin',
+     'django.contrib.auth',
+     'django.contrib.contenttypes',
++    'django.contrib.messages',
+     'compat',
+     'compat.tests.test_app',
+ ]
+ 
++MIDDLEWARE = (
++    'django.contrib.auth.middleware.AuthenticationMiddleware',
++    'django.contrib.messages.middleware.MessageMiddleware',
++    'django.contrib.sessions.middleware.SessionMiddleware',
++)
++
+ MIDDLEWARE_CLASSES = (
+     'django.contrib.sessions.middleware.SessionMiddleware',
+     'django.middleware.common.CommonMiddleware',
+@@ -43,6 +50,7 @@
+                 'django.template.context_processors.i18n',
+                 'django.template.context_processors.tz',
+                 'django.template.context_processors.request',
++                'django.contrib.messages.context_processors.messages',
+             ],
+             'loaders': [
+                 'django.template.loaders.filesystem.Loader',
+diff -Nur a/compat/tests/test_compat.py b/compat/tests/test_compat.py
+--- a/compat/tests/test_compat.py	2020-03-06 15:32:07.548482597 +0100
++++ b/compat/tests/test_compat.py	2020-03-06 15:37:39.202835075 +0100
+@@ -9,7 +9,7 @@
+ from django.core.serializers.json import DjangoJSONEncoder
+ from django.test import TestCase, SimpleTestCase
+ from django.test.client import RequestFactory
+-from django.contrib.auth.views import logout
++from django.contrib.auth.views import auth_logout
+ try:
+     from django.urls import NoReverseMatch
+ except ImportError:
+@@ -103,7 +103,7 @@
+         Tests that passing a view name to ``resolve_url`` will result in the
+         URL path mapping to that view name.
+         """
+-        resolved_url = resolve_url(logout)
++        resolved_url = resolve_url(auth_logout)
+         self.assertEqual('/accounts/logout/', resolved_url)
+ 
+     '''
+Les fichiers binaires a/compat/tests/.test_compat.py.swp et b/compat/tests/.test_compat.py.swp sont différents
+diff -Nur a/compat/tests/urls.py b/compat/tests/urls.py
+--- a/compat/tests/urls.py	2020-03-06 15:32:07.548482597 +0100
++++ b/compat/tests/urls.py	2020-03-06 15:34:25.962377799 +0100
+@@ -2,5 +2,5 @@
+ from django.contrib.auth import views
+ 
+ urlpatterns = [
+-    url(r'^accounts/logout/$', views.logout, name='logout'),
++    url(r'^accounts/logout/$', views.auth_logout, name='logout'),
+ ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

django-compat is disable for current version of django, but is still usable. The other option is to disable tests.

All my updates are done to the tests, not the actual module code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
