### PR TITLE
mstflint: 4.4 -> 4.14

### DIFF
--- a/pkgs/tools/misc/mstflint/default.nix
+++ b/pkgs/tools/misc/mstflint/default.nix
@@ -1,19 +1,26 @@
-{ stdenv, fetchurl, zlib, libibmad }:
+{ stdenv, autoreconfHook, fetchFromGitHub, zlib, libibmad, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "mstflint-4.4.0-1.12.gd1edd58";
+  pname = "mstflint";
+  version = "4.14.0-1";
 
-  src = fetchurl {
-    url = "https://www.openfabrics.org/downloads/mstflint/${name}.tar.gz";
-    sha256 = "0kg33i5s5zdc7kigww62r0b824zfw06r757fl6jwrq7lj91j0380";
+  src = fetchFromGitHub {
+    owner = "Mellanox";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xrwx623vl17cqzpacil74m2fi4xrshgvvzxiplz1wq47gq7wp1i";
   };
 
-  buildInputs = [ zlib libibmad ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ zlib libibmad openssl ];
+
+  hardeningDisable = [ "format" ];
+
+  dontDisableStatic = true;  # the build fails without this. should probably be reported upstream
 
   meta = with stdenv.lib; {
-    homepage = "https://www.openfabrics.org/";
-    license = licenses.gpl2;
+    homepage = "https://github.com/Mellanox/mstflint";
+    license = with licenses; [ gpl2 bsd2 ];
     platforms = platforms.linux;
-    broken = true; # 2018-04-11
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
fix build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
