### PR TITLE
cached-nix-shell: init at 0.1.2

### DIFF
--- a/pkgs/tools/nix/cached-nix-shell/default.nix
+++ b/pkgs/tools/nix/cached-nix-shell/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, openssl, pkgconfig, ronn, rustPlatform }:
+
+let 
+  blake3-src = fetchFromGitHub {
+    owner = "BLAKE3-team";
+    repo = "BLAKE3";
+    rev = "0.3.1";
+    sha256 = "0wkxx2w56hsng28p8zpndsy288ix4s5qg6xqjzgjz53fbyk46hda";
+  };
+
+in rustPlatform.buildRustPackage rec {
+  pname = "cached-nix-shell";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "xzfc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0pzwknpc4qrh9pv5z0xvldql2dkj9ddksvaci86a4f8cnd86p2l6";
+  };
+
+  cargoSha256 = "1n88gcnrfdrk025hb54igc83cn5vlv8n6ndyx1ydmzhd95vhbznf";
+
+  # The BLAKE3 C library is intended to be built by the project depending on it
+  # rather than as a standalone library.
+  # https://github.com/BLAKE3-team/BLAKE3/blob/0.3.1/c/README.md#building
+  BLAKE3_CSRC = "${blake3-src}/c";
+
+  nativeBuildInputs = [ ronn ];
+
+  postBuild = ''
+    ronn -r cached-nix-shell.1.md
+  '';
+
+  postInstall = ''
+    mkdir -p $out/lib $out/share/cached-nix-shell $out/share/man/man1 $out/var/empty
+    cp target/release/build/cached-nix-shell-*/out/trace-nix.so $out/lib
+    cp rcfile.sh $out/share/cached-nix-shell/rcfile.sh
+    cp cached-nix-shell.1 $out/share/man/man1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Instant startup time for nix-shell";
+    homepage = "https://github.com/xzfc/cached-nix-shell";
+    license = with licenses; [ unlicense /* or */ mit ];
+    maintainers = with maintainers; [ xzfc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25144,6 +25144,8 @@ in
 
   brightnessctl = callPackage ../misc/brightnessctl { };
 
+  cached-nix-shell = callPackage ../tools/nix/cached-nix-shell {};
+
   calaos_installer = libsForQt5.callPackage ../misc/calaos/installer {};
 
   ccemux = callPackage ../misc/emulators/ccemux { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/xzfc/cached-nix-shell/issues/8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
