### PR TITLE
Enable nvidia-optical-flow-sdk when building opencv4 with cuda

### DIFF
--- a/pkgs/development/libraries/nvidia-optical-flow-sdk/default.nix
+++ b/pkgs/development/libraries/nvidia-optical-flow-sdk/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "nvidia-optical-flow-sdk";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "NVIDIAOpticalFlowSDK";
+    rev = "79c6cee80a2df9a196f20afd6b598a9810964c32";
+    sha256 = "1y6igwv75v1ynqm7j6la3ky0f15mgnj1jyyak82yvhcsx1aax0a1";
+  };
+
+  # # We only need the header files. The library files are
+  # # in the nvidia_x11 driver.
+  installPhase = ''
+    mkdir -p $out/include
+    cp -R * $out/include
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Nvidia optical flow headers for computing the relative motion of pixels between images";
+    homepage = "https://developer.nvidia.com/opticalflow-sdk";
+    license = licenses.bsd3; # applies to the header files only
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/libraries/opencv/cuda_opt_flow.patch
+++ b/pkgs/development/libraries/opencv/cuda_opt_flow.patch
@@ -1,0 +1,26 @@
+diff --git a/opencv_contrib/cudaoptflow/CMakeLists.txt b/opencv_contrib/cudaoptflow/CMakeLists.txt
+index e5b823ab4a..a728060d0b 100644
+--- a/opencv_contrib/cudaoptflow/CMakeLists.txt
++++ b/opencv_contrib/cudaoptflow/CMakeLists.txt
+@@ -11,18 +11,6 @@ ocv_define_module(cudaoptflow opencv_video opencv_optflow opencv_cudaarithm open
+ set(NVIDIA_OPTICAL_FLOW_1_0_HEADERS_COMMIT "79c6cee80a2df9a196f20afd6b598a9810964c32")
+ set(NVIDIA_OPTICAL_FLOW_1_0_HEADERS_MD5 "ca5acedee6cb45d0ec610a6732de5c15")
+ set(NVIDIA_OPTICAL_FLOW_1_0_HEADERS_PATH "${OpenCV_BINARY_DIR}/3rdparty/NVIDIAOpticalFlowSDK_1_0_Headers")
+-ocv_download(FILENAME "${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_COMMIT}.zip"
+-               HASH ${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_MD5}
+-               URL
+-                 "https://github.com/NVIDIA/NVIDIAOpticalFlowSDK/archive/"
+-               DESTINATION_DIR "${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_PATH}"
+-               STATUS NVIDIA_OPTICAL_FLOW_1_0_HEADERS_DOWNLOAD_SUCCESS
+-               ID "NVIDIA_OPTICAL_FLOW"
+-               UNPACK RELATIVE_URL)
+ 
+-if(NOT NVIDIA_OPTICAL_FLOW_1_0_HEADERS_DOWNLOAD_SUCCESS)
+-  message(STATUS "Failed to download NVIDIA_Optical_Flow_1_0 Headers")
+-else()
+-  add_definitions(-DHAVE_NVIDIA_OPTFLOW=1)
+-  ocv_include_directories(SYSTEM "${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_PATH}/NVIDIAOpticalFlowSDK-${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_COMMIT}")
+-endif()
+\ No newline at end of file
++add_definitions(-DHAVE_NVIDIA_OPTFLOW=1)
++ocv_include_directories(SYSTEM "${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_PATH}")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13585,6 +13585,8 @@ in
 
   nvidia-video-sdk = callPackage ../development/libraries/nvidia-video-sdk { };
 
+  nvidia-optical-flow-sdk = callPackage ../development/libraries/nvidia-optical-flow-sdk { };
+
   nvtop = callPackage ../tools/system/nvtop {
     nvidia_x11 = linuxPackages.nvidia_x11.override { libsOnly = true; };
   };


### PR DESCRIPTION
###### Motivation for this change

fixes #81103

This adds and enables nvidia's optical flow sdk which causes cuda 4 to fail to build when cuda is enabled.

###### Things done
Patched CMakeLists.txt in opencv contrib to avoid trying to download opencv headers.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
