### PR TITLE
ppp: 2.4.7 -> 2.4.8 & CVE-2020-8597 fix

### DIFF
--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation rec {
         url = https://www.nikhef.nl/~janjust/ppp/ppp-2.4.7-eaptls-mppe-1.102.patch;
         sha256 = "04war8l5szql53l36043hvzgfwqp3v76kj8brbz7wlf7vs2mlkia";
       })
+      (fetchpatch {
+        name = "CVE-2020-8597.patch";
+        url = "https://github.com/paulusmack/ppp/commit/8d7970b8f3db727fe798b65f3377fe6787575426.patch";
+        sha256 = "129wnhwxmzvr3y9gzxv82jnb5y8m4yg8vkpa0xl2rwkl8anbzgkh";
+      })
       ./musl-fix-headers.patch
     ];
 

--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -1,21 +1,18 @@
-{ stdenv, fetchurl, substituteAll, libpcap, openssl }:
+{ stdenv, fetchurl, fetchpatch, fetchFromGitHub, substituteAll, libpcap, openssl }:
 
 stdenv.mkDerivation rec {
-  version = "2.4.7";
+  version = "2.4.8";
   pname = "ppp";
 
-  src = fetchurl {
-    url = "mirror://samba/ppp/${pname}-${version}.tar.gz";
-    sha256 = "0c7vrjxl52pdwi4ckrvfjr08b31lfpgwf3pp0cqy76a77vfs7q02";
+  src = fetchFromGitHub {
+    owner = "paulusmack";
+    repo = "ppp";
+    rev = "ppp-${version}";
+    sha256 = "1i88m79h6g3fzsb4yw3k8bq1grsx3hsyawm7id2vcaab0gfqzjjv";
   };
 
   patches =
     [
-      # fix for glibc>=2.28
-      (fetchurl {
-        url = "https://github.com/paulusmack/ppp/commit/3c7b86229f7bd2600d74db14b1fe5b3896be3875.patch";
-        sha256 = "0qlbi247lx3injpy8a1gcij9yilik0vfaibkpvdp88k3sa1rs69z";
-      })
       ( substituteAll {
         src = ./nix-purity.patch;
         inherit libpcap;
@@ -25,14 +22,10 @@ stdenv.mkDerivation rec {
       # Without nonpriv.patch, pppd --version doesn't work when not run as
       # root.
       ./nonpriv.patch
-      (fetchurl {
+      (fetchpatch {
         name = "CVE-2015-3310.patch";
-        url = "https://salsa.debian.org/roam/ppp/raw/ef5d585aca6b1200a52c7109caa66ef97964d76e/debian/patches/rc_mksid-no-buffer-overflow";
-        sha256 = "1dk00j7bg9nfgskw39fagnwv1xgsmyv0xnkd6n1v5gy0psw0lvqh";
-      })
-      (fetchurl {
-        url = "https://salsa.debian.org/roam/ppp/raw/ef5d585aca6b1200a52c7109caa66ef97964d76e/debian/patches/0016-pppoe-include-netinet-in.h-before-linux-in.h.patch";
-        sha256 = "1xnmqn02kc6g5y84xynjwnpv9cvrfn3nyv7h7r8j8xi7qf2aj4q8";
+        url = "https://github.com/paulusmack/ppp/commit/858976b1fc3107f1261aae337831959b511b83c2.patch";
+        sha256 = "0wirmcis67xjwllqhz9lsz1b7dcvl8shvz78lxgybc70j2sv7ih4";
       })
       (fetchurl {
         url = https://www.nikhef.nl/~janjust/ppp/ppp-2.4.7-eaptls-mppe-1.102.patch;
@@ -49,6 +42,7 @@ stdenv.mkDerivation rec {
     # everything anyway so we remove it from the Makefiles
     for file in $(find -name Makefile.linux); do
       substituteInPlace "$file" --replace '$(INSTALL) -s' '$(INSTALL)'
+      substituteInPlace "$file" --replace '-m 4550' '-m 550'
     done
   '';
 

--- a/pkgs/tools/networking/ppp/musl-fix-headers.patch
+++ b/pkgs/tools/networking/ppp/musl-fix-headers.patch
@@ -34,8 +34,8 @@ index c81213b..305aece 100644
  
 +#include <sys/cdefs.h>
 +
- void magic_init __P((void));	/* Initialize the magic number generator */
- u_int32_t magic __P((void));	/* Returns the next magic number */
+ void magic_init (void);	/* Initialize the magic number generator */
+ u_int32_t magic (void);	/* Returns the next magic number */
  
 diff --git a/pppd/plugins/rp-pppoe/if.c b/pppd/plugins/rp-pppoe/if.c
 index 91e9a57..9c0fac3 100644
@@ -119,7 +119,7 @@ index 6d71530..86d224e 100644
  #define MAX_ADDR_LEN 7
  #endif
  
--#if __GLIBC__ >= 2
+-#if !defined(__GLIBC__) || __GLIBC__ >= 2
  #include <asm/types.h>		/* glibc 2 conflicts with linux/types.h */
  #include <net/if.h>
  #include <net/if_arp.h>

--- a/pkgs/tools/networking/ppp/nix-purity.patch
+++ b/pkgs/tools/networking/ppp/nix-purity.patch
@@ -1,26 +1,26 @@
 diff --git a/pppd/Makefile.linux b/pppd/Makefile.linux
-index 1ebebec..bf90c62 100644
+index 9664f70..d07e01e 100644
 --- a/pppd/Makefile.linux
 +++ b/pppd/Makefile.linux
-@@ -120,7 +120,7 @@ CFLAGS   += -DHAS_SHADOW
+@@ -125,7 +125,7 @@ CFLAGS   += -DHAS_SHADOW
  #LIBS     += -lshadow $(LIBS)
  endif
  
--ifneq ($(wildcard /usr/include/crypt.h),)
+-ifneq ($(wildcard $(shell $(CC) --print-sysroot)/usr/include/crypt.h),)
 +ifneq ($(wildcard @glibc@/include/crypt.h),)
  CFLAGS  += -DHAVE_CRYPT_H=1
- LIBS	+= -lcrypt
+ LIBS   += -lcrypt
  endif
-@@ -132,7 +132,7 @@ endif
+@@ -137,7 +137,7 @@ endif
  
  ifdef NEEDDES
  ifndef USE_CRYPT
--CFLAGS   += -I/usr/include/openssl
+-CFLAGS   += -I$(shell $(CC) --print-sysroot)/usr/include/openssl
 +CFLAGS   += -I@openssl@/include/openssl
  LIBS     += -lcrypto
  else
  CFLAGS   += -DUSE_CRYPT=1
-@@ -178,7 +178,7 @@ LIBS	+= -ldl
+@@ -188,7 +188,7 @@ LIBS        += -ldl
  endif
  
  ifdef FILTER


### PR DESCRIPTION
###### Motivation for this change

This bumps to the latest upstream version, uses upstream versions of some patches and finally applies a new patch for CVE-2020-8597.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
