### PR TITLE
zsh-powerlevel10k: v1.2.0 → v1.3.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "gitstatus";
-  version = "unstable-2020-02-26";
+  version = "unstable-2020-03-06";
 
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "gitstatus";
-    rev = "c0e5a24299c1a1a71434dac1de6ea650e80fbe49";
-    sha256 = "0fj84cvr5a895jqgg86raakx6lqyyhahf1dgzgx05y2gfvnxxh8m";
+    rev = "c07996bc3ea1912652f52a816b830a5a3ee9b49c";
+    sha256 = "07s8hwx3i5mnafi2xfim44z3q2nsvlcibfdxj17w8mkjhfpywi00";
   };
 
   buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     sed -i "1i GITSTATUS_DAEMON=$out/bin/gitstatusd" gitstatus.plugin.zsh
   '';
   installPhase = ''
-    install -Dm755 gitstatusd $out/bin/gitstatusd
+    install -Dm755 usrbin/gitstatusd $out/bin/gitstatusd
     install -Dm444 gitstatus.plugin.zsh $out
   '';
 

--- a/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "powerlevel10k";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "powerlevel10k";
     rev = "v${version}";
-    sha256 = "1hvhql7564j6n6xwg4wckzvzs4fk5zlrdxkx5nd9i3g2d477nbac";
+    sha256 = "1w2iy9anc3cxb5kffrdz8knml8nsl6v3lcrdsigfzfp0zignb4cw";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

New upstream release.

https://github.com/romkatv/powerlevel10k/releases/tag/v1.3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@flokli @maralorn @andir 