### PR TITLE
arangodb_3_*: version bump

### DIFF
--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchFromGitHub, openssl, zlib, cmake, python2, perl, snappy, lzo, which }:
+{ stdenv, gcc8Stdenv, lib, fetchFromGitHub, openssl_1_1, zlib, cmake, python2, python3, perl, snappy, lzo, which }:
 
 let
-  common = { version, sha256 }: stdenv.mkDerivation {
+  common = { version, sha256, stdenv, python }: stdenv.mkDerivation {
     pname = "arangodb";
     inherit version;
 
@@ -12,16 +12,16 @@ let
       inherit sha256;
     };
 
-    nativeBuildInputs = [ cmake python2 perl which ];
-    buildInputs = [ openssl zlib snappy lzo ];
+    nativeBuildInputs = [ cmake python perl which ];
+    buildInputs = [ openssl_1_1 zlib snappy lzo ];
 
     # prevent failing with "cmake-3.13.4/nix-support/setup-hook: line 10: ./3rdParty/rocksdb/RocksDBConfig.cmake.in: No such file or directory"
-    dontFixCmake       =                     lib.versionAtLeast version "3.5";
-    NIX_CFLAGS_COMPILE = lib.optionalString (lib.versionAtLeast version "3.5") "-Wno-error";
-    preConfigure       = lib.optionalString (lib.versionAtLeast version "3.5") "patchShebangs utils";
+    dontFixCmake       = true;
+    NIX_CFLAGS_COMPILE = "-Wno-error";
+    preConfigure       = "patchShebangs utils";
 
     postPatch = ''
-      sed -ie 's!/bin/echo!echo!' 3rdParty/V8/v*/gypfiles/*.gypi
+      find 3rdParty/V8  -type f  -name '*.gypi'  -exec sed -ie 's!/bin/echo!echo!' {} \;
 
       # with nixpkgs, it has no sense to check for a version update
       substituteInPlace js/client/client.js --replace "require('@arangodb').checkAvailableVersions();" ""
@@ -54,15 +54,33 @@ let
   };
 in {
   arangodb_3_3 = common {
-    version = "3.3.24";
-    sha256 = "18175789j4y586qvpcsaqxmw7d6vc3s29qm1fja5c7wzimx6ilyp";
+    version = "3.3.25";
+    sha256 = "0xpmksnvcwmv6dd9yig3ywbx12d1lxyp2wg68cg3rjlvsycrvm9n";
+    stdenv = gcc8Stdenv;
+    python = python2;
   };
   arangodb_3_4 = common {
     version = "3.4.8";
     sha256 = "0vm94lf1i1vvs04vy68bkkv9q43rsaf1y3kfs6s3jcrs3ay0h0jn";
+    stdenv = gcc8Stdenv;
+    python = python2;
   };
   arangodb_3_5 = common {
-    version = "3.5.1";
-    sha256 = "1jw3j7vaq3xgkxiqg0bafn4b2169jq7f3y0l7mrpnrpijn77rkrv";
+    version = "3.5.4";
+    sha256 = "1dcc4s415rararw5lw829p9c6qkj2nj5q0sb72rdyjm61l2q1zlj";
+    stdenv = stdenv;
+    python = python2;
+  };
+  arangodb_3_6 = common {
+    version = "3.6.2";
+    sha256 = "1wvx498jp3gi9r2zn6g8b4sc7i3arr125y0nw25w8gks8i8n4j48";
+    stdenv = stdenv;
+    python = python2;
+  };
+  arangodb_3_7 = common {
+    version = "3.7.0-alpha.1";
+    sha256 = "0a7vk8ffw6scz8014lz6v777fzyi4m0ghfqzbicfdy6acmpf9sql";
+    stdenv = stdenv;
+    python = python3;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -647,10 +647,9 @@ in
 
   arandr = callPackage ../tools/X11/arandr { };
 
-  inherit (callPackages ../servers/nosql/arangodb {
-    stdenv = gcc8Stdenv;
-  }) arangodb_3_3 arangodb_3_4 arangodb_3_5;
-  arangodb = arangodb_3_4;
+  inherit (callPackages ../servers/nosql/arangodb {})
+    arangodb_3_3 arangodb_3_4 arangodb_3_5 arangodb_3_6 arangodb_3_7;
+  arangodb = arangodb_3_6;
 
   arcanist = callPackage ../development/tools/misc/arcanist {};
 


### PR DESCRIPTION
###### Motivation for this change

update ArangoDB minor versions, set `pkgs.arangodb` to `3.6.x`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
