### PR TITLE
linuxPackages{,_latest,_next}_hardened_ia32Emulation: init

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -8,7 +8,7 @@
 #
 # See also <nixos/modules/profiles/hardened.nix>
 
-{ stdenv, version }:
+{ stdenv, version, ia32Emulation ? false }:
 
 with stdenv.lib;
 with import ../../../../lib/kernel.nix { inherit (stdenv) lib; inherit version; };
@@ -19,7 +19,7 @@ optionalAttrs (stdenv.hostPlatform.platform.kernelArch == "x86_64") {
   DEFAULT_MMAP_MIN_ADDR = freeform "65536";  # Prevent allocation of first 64K of memory
 
   # Reduce attack surface by disabling various emulations
-  IA32_EMULATION     = no;
+  IA32_EMULATION     = if ia32Emulation then yes else no;
   X86_X32            = no;
   # Note: this config depends on EXPERT y and so will not take effect, hence
   # it is left "optional" for now.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16827,28 +16827,37 @@ in
   linuxPackages_latest_xen_dom0 = recurseIntoAttrs (linuxPackagesFor (pkgs.linux_latest.override { features.xen_dom0=true; }));
 
   # Hardened linux
-  hardenedLinuxPackagesFor = kernel: linuxPackagesFor (kernel.override {
-    features.ia32Emulation = false;
+  hardenedLinuxPackagesFor = kernel: { ia32Emulation ? false }: linuxPackagesFor (kernel.override {
+    features = { inherit ia32Emulation; };
     structuredExtraConfig = import ../os-specific/linux/kernel/hardened-config.nix {
-      inherit stdenv;
+      inherit stdenv ia32Emulation;
       inherit (kernel) version;
     };
     kernelPatches = kernel.kernelPatches ++ [ kernelPatches.tag_hardened ];
     modDirVersionArg = kernel.modDirVersion + "-hardened";
   });
 
-  linuxPackages_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux);
+  linuxPackages_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux {});
   linux_hardened = linuxPackages_hardened.kernel;
 
-  linuxPackages_latest_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux_latest);
+  linuxPackages_hardened_ia32Emulation = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux { ia32Emulation = true; });
+  linux_hardened_ia32Emulation = linuxPackages_hardened_ia32Emulation.kernel;
+
+  linuxPackages_latest_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux_latest {});
   linux_latest_hardened = linuxPackages_latest_hardened.kernel;
 
-  linuxPackages_testing_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux_testing);
+  linuxPackages_latest_hardened_ia32Emulation = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux_latest { ia32Emulation = true; });
+  linux_latest_hardened_ia32Emulation = linuxPackages_latest_hardened_ia32Emulation.kernel;
+
+  linuxPackages_testing_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux_testing {});
   linux_testing_hardened = linuxPackages_testing_hardened.kernel;
 
-  linuxPackages_xen_dom0_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor (pkgs.linux.override { features.xen_dom0=true; }));
+  linuxPackages_testing_hardened_ia32Emulation = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux_testing { ia32Emulation = true; });
+  linux_testing_hardened_ia32Emulation = linuxPackages_testing_hardened_ia32Emulation.kernel;
 
-  linuxPackages_latest_xen_dom0_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor (pkgs.linux_latest.override { features.xen_dom0=true; }));
+  linuxPackages_xen_dom0_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor (pkgs.linux.override { features.xen_dom0=true; }) {});
+
+  linuxPackages_latest_xen_dom0_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor (pkgs.linux_latest.override { features.xen_dom0=true; }) {});
 
   # Hardkernel (Odroid) kernels.
   linuxPackages_hardkernel_4_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_hardkernel_4_14);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

These are variants of the hardened kernels that leave 32-bit x86
emulation enabled. Though it increases the attack surface, they're
relatively well-trodden code paths, and since I know people currently
sometimes opt for the vanilla kernel in lieu of a hardened one that lets
them continue using Wine, Steam, etc., in practice it'll offer people a
net benefit to security.

Resolves #79798.

@GrahamcOfBorg build linuxPackages_latest_hardened_ia32Emulation

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).