### PR TITLE
Introduce `networking.hostFiles` option

### DIFF
--- a/nixos/modules/services/networking/cjdns.nix
+++ b/nixos/modules/services/networking/cjdns.nix
@@ -140,13 +140,15 @@ in
         connectTo = mkOption {
           type = types.attrsOf ( types.submodule ( connectToSubmodule ) );
           default = { };
-          example = {
-            "192.168.1.1:27313" = {
-              hostname = "homer.hype";
-              password = "5kG15EfpdcKNX3f2GSQ0H1HC7yIfxoCoImnO5FHM";
-              publicKey = "371zpkgs8ss387tmr81q04mp0hg1skb51hw34vk1cq644mjqhup0.k";
-            };
-          };
+          example = literalExample ''
+            {
+              "192.168.1.1:27313" = {
+                hostname = "homer.hype";
+                password = "5kG15EfpdcKNX3f2GSQ0H1HC7yIfxoCoImnO5FHM";
+                publicKey = "371zpkgs8ss387tmr81q04mp0hg1skb51hw34vk1cq644mjqhup0.k";
+              };
+            }
+          '';
           description = ''
             Credentials for making UDP tunnels.
           '';
@@ -185,13 +187,15 @@ in
         connectTo = mkOption {
           type = types.attrsOf ( types.submodule ( connectToSubmodule ) );
           default = { };
-          example = {
-            "01:02:03:04:05:06" = {
-              hostname = "homer.hype";
-              password = "5kG15EfpdcKNX3f2GSQ0H1HC7yIfxoCoImnO5FHM";
-              publicKey = "371zpkgs8ss387tmr81q04mp0hg1skb51hw34vk1cq644mjqhup0.k";
-            };
-          };
+          example = literalExample ''
+            {
+              "01:02:03:04:05:06" = {
+                hostname = "homer.hype";
+                password = "5kG15EfpdcKNX3f2GSQ0H1HC7yIfxoCoImnO5FHM";
+                publicKey = "371zpkgs8ss387tmr81q04mp0hg1skb51hw34vk1cq644mjqhup0.k";
+              };
+            }
+          '';
           description = ''
             Credentials for connecting look similar to UDP credientials
             except they begin with the mac address.


### PR DESCRIPTION
###### Motivation for this change
When blocklists are built with a derivation, using `extraHosts` would
require IFD (import-from-derivation), since the result of the derivation needs to be converted to
a string again.

By introducing this option no IFD is needed for such use-cases, since
the fetched files can be assigned directly.

A second commit changes the cjdns module to use this new option so no IFD is needed. A third commit just fixes a doc rendering issue in the cjdns module.

This change will be useful for https://github.com/NixOS/nixpkgs/pull/80113 as well, so ping @pasqui23 

Ping @oxij @regellosigkeitsaxiom for the networking module

Ping @ehmry @joachifm for related issues https://github.com/NixOS/nixpkgs/issues/20422 and https://github.com/NixOS/nixpkgs/pull/21592

###### Things done

- [x] Built `nix-build nixos --arg configuration ./config.nix -A config.environment.etc.hosts.source` before and after this change, making sure nothing changes, even with `extraHosts` and `services.cjdns` enabled (and configured).
- [x] Built the docs with `nix-build nixos/release.nix -A manualHTML.x86_64-linux` successfully