### PR TITLE
crystal: 0.32.1 -> 0.33.0

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -214,6 +214,15 @@ in rec {
     };
   };
 
+  binaryCrystal_0_32 = genericBinary {
+    version = "0.32.1";
+    sha256s = {
+      x86_64-linux  = "1mwpr87ix14vsdlswy3qjgc4pn9k5585wp3wyypbclz42f4gsc8c";
+      i686-linux    = "17zfvvrzcd0hrxj3pcir3gwl95gazg7a49hk1kf88dhk0cj0hmis";
+      x86_64-darwin = "155wf1rnc5kh3y6gn5pjh185p3nvq50lfill1b714sm3kmqfh099";
+    };
+  };
+
   crystal_0_27 = generic {
     version = "0.27.2";
     sha256  = "0vxqnpqi85yh0167nrkbksxsni476iwbh6y3znbvbjbbfhsi3nsj";
@@ -248,7 +257,13 @@ in rec {
     binary = binaryCrystal_0_31;
   };
 
-  crystal = crystal_0_32;
+  crystal_0_33 = generic {
+    version = "0.33.0";
+    sha256  = "1zg0qixcws81s083wrh54hp83ng2pa8iyyafaha55mzrh8293jbi";
+    binary = binaryCrystal_0_32;
+  };
+
+  crystal = crystal_0_33;
 
   crystal2nix = callPackage ./crystal2nix.nix {};
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update crystal to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
