### PR TITLE
[19.09] backport protonvpn cli ng

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3184,6 +3184,16 @@
     githubId = 4611077;
     name = "Raymond Gauthier";
   };
+  jtcoolen = {
+    email = "jtcoolen@pm.me";
+    name = "Julien Coolen";
+    github = "jtcoolen";
+    githubId = 54635632;
+    keys = [{
+      longkeyid = "rsa4096/0x19642151C218F6F5";
+      fingerprint = "4C68 56EE DFDA 20FB 77E8  9169 1964 2151 C218 F6F5";
+    }];
+  };
   jtobin = {
     email = "jared@jtobin.io";
     github = "jtobin";

--- a/pkgs/applications/networking/protonvpn-cli-ng/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli-ng/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchFromGitHub, python3Packages, openvpn, dialog }:
+
+python3Packages.buildPythonApplication rec {
+  name = "protonvpn-cli-ng";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "protonvpn";
+    repo = "protonvpn-cli-ng";
+    rev = "v${version}";
+    sha256 = "11fvnnr5p3qdc4y10815jnydcjvxlxwkkq9kvaajg0yszq84rwkz";
+  };
+
+  propagatedBuildInputs = (with python3Packages; [
+      requests
+      docopt
+      setuptools
+      pythondialog
+    ]) ++ [
+      dialog
+      openvpn
+    ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Linux command-line client for ProtonVPN";
+    homepage = "https://github.com/protonvpn/protonvpn-cli-ng";
+    maintainers = [ maintainers.jtcoolen ];
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/protonvpn-cli-ng/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli-ng/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "protonvpn-cli-ng";
-  version = "2.2.0";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "protonvpn";
     repo = "protonvpn-cli-ng";
     rev = "v${version}";
-    sha256 = "11fvnnr5p3qdc4y10815jnydcjvxlxwkkq9kvaajg0yszq84rwkz";
+    sha256 = "0ixjb02kj4z79whm1izd8mrn2h0rp9cmw4im1qvp93rahqxdd4n8";
   };
 
   propagatedBuildInputs = (with python3Packages; [
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "Linux command-line client for ProtonVPN";
     homepage = "https://github.com/protonvpn/protonvpn-cli-ng";
-    maintainers = [ maintainers.jtcoolen ];
+    maintainers = [ maintainers.jtcoolen maintainers.jefflabonte ];
     license = licenses.gpl3;
     platforms = platforms.unix;
   };

--- a/pkgs/development/python-modules/pythondialog/default.nix
+++ b/pkgs/development/python-modules/pythondialog/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pythondialog";
-  version = "3.5.0";
+  version = "3.5.1";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "11ydvllwll23qmcd3saachcxzn1dj5if3kc36p37ncf06xc5c0m4";
+    sha256 = "34a0687290571f37d7d297514cc36bd4cd044a3a4355271549f91490d3e7ece8";
   };
 
   patchPhase = ''

--- a/pkgs/development/python-modules/pythondialog/default.nix
+++ b/pkgs/development/python-modules/pythondialog/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pythondialog";
-  version = "3.4.0";
+  version = "3.5.0";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1728ghsran47jczn9bhlnkvk5bvqmmbihabgif5h705b84r1272c";
+    sha256 = "11ydvllwll23qmcd3saachcxzn1dj5if3kc36p37ncf06xc5c0m4";
   };
 
   patchPhase = ''

--- a/pkgs/development/python-modules/pythondialog/default.nix
+++ b/pkgs/development/python-modules/pythondialog/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "pythondialog";
+  version = "3.4.0";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1728ghsran47jczn9bhlnkvk5bvqmmbihabgif5h705b84r1272c";
+  };
+
+  patchPhase = ''
+    substituteInPlace dialog.py --replace ":/bin:/usr/bin" ":$out/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Python interface to the UNIX dialog utility and mostly-compatible programs";
+    homepage = "http://pythondialog.sourceforge.net/";
+    license = licenses.lgpl3;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20074,6 +20074,8 @@ in
 
   protonvpn-cli = callPackage ../applications/networking/protonvpn-cli { };
 
+  protonvpn-cli-ng = callPackage ../applications/networking/protonvpn-cli-ng { };
+
   ps2client = callPackage ../applications/networking/ps2client { };
 
   psi = callPackage ../applications/networking/instant-messengers/psi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3194,6 +3194,8 @@ in {
     cudaSupport = false;
   };
 
+  pythondialog = callPackage ../development/python-modules/pythondialog { };
+
   python2-pythondialog = callPackage ../development/python-modules/python2-pythondialog { };
 
   pyRFC3339 = callPackage ../development/python-modules/pyrfc3339 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

protonvpn-cli is not supported anymore by protonvpn. protonvpn-cli-ng is the cli recommanded by ProtonVPN

(see https://github.com/ProtonVPN/protonvpn-cli-ng).

###### Things done

For pythondialog, it brings init from PR #68636 and update from #75361 and #76059 .
For protonvpn-cli-ngL it brings init from PR #77407 and update to 2.2.2 from PR #81735 .

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
