### PR TITLE
howard-hinnant-date: allow access to zoneinfo

### DIFF
--- a/pkgs/development/libraries/howard-hinnant-date/default.nix
+++ b/pkgs/development/libraries/howard-hinnant-date/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, curl, fetchpatch }:
+{ stdenv, fetchFromGitHub, cmake, curl, tzdata, fetchpatch, substituteAll }:
 
 stdenv.mkDerivation rec {
   pname = "howard-hinnant-date-unstable";
@@ -16,6 +16,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/HowardHinnant/date/commit/e56b2dce7e89a92e1b9b35caa13b3e938c4cedea.patch";
       sha256 = "0m3qbhq7kmm9qa3jm6d2px7c1dxdj5k9lffgdvqnrwmhxwj1p9n2";
     })
+    # Without this patch, this library will drop a `tzdata` directory into
+    # `~/Downloads` if it cannot find `/usr/share/zoneinfo`. Make the path it
+    # searches for `zoneinfo` be the one from the `tzdata` package.
+    (substituteAll {
+      src = ./make-zoneinfo-available.diff;
+      inherit tzdata;
+    })
   ];
 
   nativeBuildInputs = [ cmake ];
@@ -24,6 +31,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_TZ_LIB=true"
     "-DBUILD_SHARED_LIBS=true"
+    "-DUSE_SYSTEM_TZ_DB=true"
   ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/howard-hinnant-date/make-zoneinfo-available.diff
+++ b/pkgs/development/libraries/howard-hinnant-date/make-zoneinfo-available.diff
@@ -1,0 +1,13 @@
+diff --git a/src/tz.cpp b/src/tz.cpp
+index 68436c3..2bfe19e 100644
+--- a/src/tz.cpp
++++ b/src/tz.cpp
+@@ -349,7 +349,7 @@ discover_tz_dir()
+     struct stat sb;
+     using namespace std;
+ #  ifndef __APPLE__
+-    CONSTDATA auto tz_dir_default = "/usr/share/zoneinfo";
++    CONSTDATA auto tz_dir_default = "@tzdata@/share/zoneinfo";
+     CONSTDATA auto tz_dir_buildroot = "/usr/share/zoneinfo/uclibc";
+ 
+     // Check special path which is valid for buildroot with uclibc builds


### PR DESCRIPTION
This fixes the situtation where, if `/usr/share/zoneinfo` was
inaccessible/didn't otherwise exist, `howard-hinnant-date` would
download and drop a `~/Downloads/tzdata` directory containing some
timezone information from IANA [1]. To avoid this, we make use of the
`tzdata`'s `zoneinfo`, preventing the dropping of random directories and
files.

[1] https://data.iana.org/time-zones/releases/tzdata2019c.tar.gz

(cherry picked from commit 25057960cec97234e3a6cabbc96c9fcb0f18b933)

This fixes a bug which breaks the clock module. See
<https://github.com/Alexays/Waybar/issues/566>.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
