### PR TITLE
ocsigen-i18n: 3.4.0 → 3.5.0

### DIFF
--- a/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
+++ b/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
@@ -1,12 +1,11 @@
-{ stdenv, fetchurl, ocamlPackages }:
+{ stdenv, fetchzip, ocamlPackages }:
 
 stdenv.mkDerivation rec
 {
   pname = "ocsigen-i18n";
-  version = "3.4.0";
+  version = "3.5.0";
 
-  buildInputs = with ocamlPackages; [ ocaml findlib ];
-
+  buildInputs = with ocamlPackages; [ ocaml findlib ppx_tools ];
 
   dontStrip = true;
 
@@ -15,9 +14,9 @@ stdenv.mkDerivation rec
     make bindir=$out/bin install
   '';
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/besport/${pname}/archive/${version}.tar.gz";
-    sha256 = "0i7cck6zlgwjpksb4s1jpy193h85jixf4d0nmqj09y3zcpn2i8gb";
+    sha256 = "1qsgwfl64b53w235wm7nnchqinzgsvd2gb52xm0kra2wlwp69rfq";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
