### PR TITLE
git-codereview: init at 2020-01-15

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -70,6 +70,8 @@ let
 
   git-codeowners = callPackage ./git-codeowners { };
 
+  git-codereview = callPackage ./git-codereview { };
+
   git-cola = callPackage ./git-cola { };
 
   git-crypt = callPackage ./git-crypt { };

--- a/pkgs/applications/version-management/git-and-tools/git-codereview/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-codereview/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage {
+  pname = "git-codereview";
+  version = "2020-01-15";
+  goPackagePath = "golang.org/x/review";
+
+  src = fetchFromGitHub {
+    owner = "golang";
+    repo = "review";
+    rev = "f51a73253c4da005cfdf18a036e11185c04c8ce3";
+    sha256 = "0c4vsyy5zp7pngqn4q87xipndghxyw2x57dkv1kxnrffckx1s3pc";
+  };
+
+  meta = with lib; {
+    description = "Manage the code review process for Git changes using a Gerrit server";
+    homepage = "https://golang.org/x/review/git-codereview";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.edef ];
+  };
+}


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).