### PR TITLE
brutespray: init at 1.6.6

### DIFF
--- a/pkgs/tools/security/brutespray/default.nix
+++ b/pkgs/tools/security/brutespray/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, python3, fetchFromGitHub, makeWrapper, medusa }:
+
+stdenv.mkDerivation rec {
+  pname = "brutespray";
+  version = "1.6.6";
+
+  src = fetchFromGitHub {
+    owner = "x90skysn3k";
+    repo = pname;
+    rev = "brutespray-${version}";
+    sha256 = "1rj8fkq1xz4ph1pmldphlsa25mg6xl7i7dranb0qjx00jhfxjxjh";
+  };
+
+  postPatch = ''
+    substituteInPlace brutespray.py \
+      --replace "/usr/share/brutespray" "$out/share/brutespray"
+  '';
+
+  dontBuild = true;
+  nativeBuildInputs = [ python3.pkgs.wrapPython makeWrapper ];
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    install -Dm0755 brutespray.py $out/bin/brutespray
+    patchShebangs $out/bin
+    patchPythonScript $out/bin/brutespray
+    wrapProgram $out/bin/brutespray \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ medusa ]}
+
+    mkdir -p $out/share/brutespray
+    cp -r wordlist/ $out/share/brutespray/wordlist
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/x90skysn3k/brutespray";
+    description = "Brute-Forcing from Nmap output - Automatically attempts default creds on found services";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/tools/security/medusa/default.nix
+++ b/pkgs/tools/security/medusa/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, pkg-config, freerdp, openssl, libssh2 }:
+
+stdenv.mkDerivation rec {
+  pname = "medusa-unstable";
+  version = "2018-12-16";
+
+  src = fetchFromGitHub {
+    owner = "jmk-foofus";
+    repo = "medusa";
+    rev = "292193b3995444aede53ff873899640b08129fc7";
+    sha256 = "0njlz4fqa0165wdmd5y8lfnafayf3c4la0r8pf3hixkdwsss1509";
+  };
+
+  outputs = [ "out" "man" ];
+
+  configureFlags = [ "--enable-module-ssh=yes" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ freerdp openssl libssh2 ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/jmk-foofus/medusa";
+    description = "A speedy, parallel, and modular, login brute-forcer";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1964,6 +1964,8 @@ in
 
   massren = callPackage ../tools/misc/massren { };
 
+  medusa = callPackage ../tools/security/medusa { };
+
   megasync = libsForQt5.callPackage ../applications/misc/megasync { };
 
   megacmd = callPackage ../applications/misc/megacmd { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1284,6 +1284,8 @@ in
 
   bruteforce-luks = callPackage ../tools/security/bruteforce-luks { };
 
+  brutespray = callPackage ../tools/security/brutespray { };
+
   breakpointHook = assert stdenv.isLinux;
     makeSetupHook { } ../build-support/setup-hooks/breakpoint-hook.sh;
 


### PR DESCRIPTION
###### Motivation for this change

`brutespray` automatically attempts (default) creds on services found via `nmap` scans.

See also #81418 (cc @JoshuaFern)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
