### PR TITLE
[20.03] dhall-nix: Fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1051,22 +1051,14 @@ self: super: {
   # `removeTrailingWhitespace` is buggy in earlier versions.
   # This will probably be able to be removed when we update to LTS-15.
   dhall_1_29_0 =
-    dontCheck (super.dhall_1_29_0.override {
+    dontCheck (super.dhall_1_29_0.overrideScope (self: super: {
       prettyprinter = self.prettyprinter_1_6_0;
-      prettyprinter-ansi-terminal =
-        self.prettyprinter-ansi-terminal.override {
-          prettyprinter = self.prettyprinter_1_6_0;
-        };
-    });
+    }));
   dhall-bash_1_0_27 = super.dhall-bash_1_0_27.override { dhall = self.dhall_1_29_0; };
-  dhall-json_1_6_1 = super.dhall-json_1_6_1.override {
+  dhall-json_1_6_1 = super.dhall-json_1_6_1.overrideScope (self: super: {
     dhall = self.dhall_1_29_0;
     prettyprinter = self.prettyprinter_1_6_0;
-    prettyprinter-ansi-terminal =
-      self.prettyprinter-ansi-terminal.override {
-        prettyprinter = self.prettyprinter_1_6_0;
-      };
-  };
+  });
 
   # Tests for dhall access the network.
   dhall_1_27_0 = dontCheck super.dhall_1_27_0;
@@ -1080,7 +1072,10 @@ self: super: {
 
   dhall-nix =
     generateOptparseApplicativeCompletion "dhall-to-nix" (
-      super.dhall-nix
+      (super.dhall-nix.overrideScope (self: super: {
+        dhall = self.dhall_1_29_0;
+        prettyprinter = self.prettyprinter_1_6_0;
+      }))
   );
 
   # https://github.com/haskell-hvr/netrc/pull/2#issuecomment-469526558

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -4225,7 +4225,6 @@ broken-packages:
   - dhall-check
   - dhall-fly
   - dhall-lsp-server
-  - dhall-nix
   - dhall-to-cabal
   - dhall-yaml
   - dhcp-lease-parser


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/81834

The fix on master is different, but I'll do that too once https://github.com/haskell-nix/hnix-store/pull/55#issuecomment-596086239 is ready

I also simplified some related overrides using `overrideScope`

I updated `haskell-packages.nix` to unmark it as broken, since it doesn't get updates anymore on this branch

###### Things done

- [x] Built `dhall-nix` and `haskellPackages.dhall-nix` successfully on NixOS