### PR TITLE
chromium: Update the VA-API patch (fix #81909)

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/patches/vaapi-fix.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/vaapi-fix.patch
@@ -1,6 +1,6 @@
 --- a/media/gpu/vaapi/vaapi_video_decode_accelerator.cc
 +++ b/media/gpu/vaapi/vaapi_video_decode_accelerator.cc
-@@ -635,6 +635,7 @@
+@@ -641,6 +641,7 @@ void VaapiVideoDecodeAccelerator::AssignPictureBuffers(
    // |vpp_vaapi_wrapper_| for VaapiPicture to DownloadFromSurface() the VA's
    // internal decoded frame.
    if (buffer_allocation_mode_ != BufferAllocationMode::kNone &&
@@ -8,24 +8,22 @@
        !vpp_vaapi_wrapper_) {
      vpp_vaapi_wrapper_ = VaapiWrapper::Create(
          VaapiWrapper::kVideoProcess, VAProfileNone,
-@@ -650,7 +651,8 @@
-     // only used as a copy destination. Therefore, the VaapiWrapper used and
-     // owned by |picture| is |vpp_vaapi_wrapper_|.
+@@ -665,7 +666,8 @@ void VaapiVideoDecodeAccelerator::AssignPictureBuffers(
+     PictureBuffer buffer = buffers[i];
+     buffer.set_size(requested_pic_size_);
      std::unique_ptr<VaapiPicture> picture = vaapi_picture_factory_->Create(
 -        (buffer_allocation_mode_ == BufferAllocationMode::kNone)
 +        ((buffer_allocation_mode_ == BufferAllocationMode::kNone) ||
 +         (buffer_allocation_mode_ == BufferAllocationMode::kWrapVdpau))
              ? vaapi_wrapper_
              : vpp_vaapi_wrapper_,
-         make_context_current_cb_, bind_image_cb_, buffers[i]);
-@@ -1077,6 +1079,14 @@
+         make_context_current_cb_, bind_image_cb_, buffer);
+@@ -1093,6 +1095,12 @@ VaapiVideoDecodeAccelerator::GetSupportedProfiles() {
 
  VaapiVideoDecodeAccelerator::BufferAllocationMode
  VaapiVideoDecodeAccelerator::DecideBufferAllocationMode() {
 +  // NVIDIA blobs use VDPAU
-+  if (base::StartsWith(VaapiWrapper::GetVendorStringForTesting(),
-+              "Splitted-Desktop Systems VDPAU",
-+              base::CompareCase::SENSITIVE)) {
++  if (VaapiWrapper::GetImplementationType() == VAImplementation::kNVIDIAVDPAU) {
 +    LOG(INFO) << "VA-API driver on VDPAU backend";
 +    return BufferAllocationMode::kWrapVdpau;
 +  }
@@ -33,7 +31,7 @@
    // TODO(crbug.com/912295): Enable a better BufferAllocationMode for IMPORT
    // |output_mode_| as well.
    if (output_mode_ == VideoDecodeAccelerator::Config::OutputMode::IMPORT)
-@@ -1089,7 +1099,7 @@
+@@ -1105,7 +1113,7 @@ VaapiVideoDecodeAccelerator::DecideBufferAllocationMode() {
    // depends on the bitstream and sometimes it's not enough to cover the amount
    // of frames needed by the client pipeline (see b/133733739).
    // TODO(crbug.com/911754): Enable for VP9 Profile 2.
@@ -44,7 +42,7 @@
      // an extra allocation for both |client_| and |decoder_|, see
 --- a/media/gpu/vaapi/vaapi_video_decode_accelerator.h
 +++ b/media/gpu/vaapi/vaapi_video_decode_accelerator.h
-@@ -204,6 +204,7 @@
+@@ -204,6 +204,7 @@ class MEDIA_GPU_EXPORT VaapiVideoDecodeAccelerator
      // Using |client_|s provided PictureBuffers and as many internally
      // allocated.
      kNormal,
@@ -52,3 +50,25 @@
    };
 
    // Decides the concrete buffer allocation mode, depending on the hardware
+--- a/media/gpu/vaapi/vaapi_wrapper.cc
++++ b/media/gpu/vaapi/vaapi_wrapper.cc
+@@ -131,6 +131,9 @@ media::VAImplementation VendorStringToImplementationType(
+   } else if (base::StartsWith(va_vendor_string, "Intel iHD driver",
+                               base::CompareCase::SENSITIVE)) {
+     return media::VAImplementation::kIntelIHD;
++  } else if (base::StartsWith(va_vendor_string, "Splitted-Desktop Systems VDPAU",
++                              base::CompareCase::SENSITIVE)) {
++    return media::VAImplementation::kNVIDIAVDPAU;
+   }
+   return media::VAImplementation::kOther;
+ }
+--- a/media/gpu/vaapi/vaapi_wrapper.h
++++ b/media/gpu/vaapi/vaapi_wrapper.h
+@@ -79,6 +79,7 @@ enum class VAImplementation {
+   kIntelIHD,
+   kOther,
+   kInvalid,
++  kNVIDIAVDPAU,
+ };
+
+ // This class handles VA-API calls and ensures proper locking of VA-API calls


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Simply updating the patch should be enough to fix the VA-API build again (~~my build progress is currently at `28717/37651`~~). It does successfully build now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
