### PR TITLE
sia-ui: init at 1.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -880,6 +880,12 @@
     githubId = 14111;
     name = "Brandon Dimcheff";
   };
+  be7a = {
+    email = "github@be7a.de";
+    github = "0xbe7a";
+    gitHubId = 6232980;
+    name = "Bela Stoyan";
+  };
   bendlas = {
     email = "herwig@bendlas.net";
     github = "bendlas";

--- a/pkgs/applications/blockchains/sia-ui/default.nix
+++ b/pkgs/applications/blockchains/sia-ui/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, makeDesktopItem, appimageTools }:
+
+let
+  pname = "sia-ui";
+  version = "1.4.3";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://sia.tech/releases/Sia-UI-v${version}.AppImage";
+    sha256 = "3ab7905f9075dd6a80953d1427bbc99ce1fc48f60d135bcfb136dcd267b11671";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in appimageTools.wrapType2 rec {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/sia-ui.desktop $out/share/applications/sia-ui.desktop
+    install -m 444 -D ${appimageContents}/sia-ui.png $out/share/icons/hicolor/512x512/apps/sia-ui.png
+    substituteInPlace $out/share/applications/sia-ui.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A electron webapp to manage and interface with the Sia daemon";
+    homepage = "https://sia.tech/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ be7a ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/blockchains/sia-ui/default.nix
+++ b/pkgs/applications/blockchains/sia-ui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeDesktopItem, appimageTools }:
+{ stdenv, fetchurl, makeDesktopItem, appimageTools, gtk3 }:
 
 let
   pname = "sia-ui";
@@ -10,9 +10,14 @@ let
     sha256 = "3ab7905f9075dd6a80953d1427bbc99ce1fc48f60d135bcfb136dcd267b11671";
   };
 
+  xdg_dirs = builtins.concatStringsSep ":" [
+    "${gtk3}/share/gsettings-schemas/${gtk3.name}"
+  ];
+
   appimageContents = appimageTools.extractType2 {
     inherit name src;
   };
+
 in appimageTools.wrapType2 rec {
   inherit name src;
 
@@ -22,6 +27,10 @@ in appimageTools.wrapType2 rec {
     install -m 444 -D ${appimageContents}/sia-ui.png $out/share/icons/hicolor/512x512/apps/sia-ui.png
     substituteInPlace $out/share/applications/sia-ui.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+   profile = ''
+    export XDG_DATA_DIRS="${xdg_dirs}''${XDG_DATA_DIRS:+:"''$XDG_DATA_DIRS"}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6448,6 +6448,8 @@ in
 
   shunit2 = callPackage ../tools/misc/shunit2 { };
 
+  sia-ui = callPackage ../applications/blockchains/sia-ui { };
+
   sic = callPackage ../applications/networking/irc/sic { };
 
   siege = callPackage ../tools/networking/siege {};


### PR DESCRIPTION
###### Motivation for this change
Sia is the "leading decentralized cloud storage platform" and the wallet was missing from nixpkgs
###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
