### PR TITLE
Fix zxcvbn-hs & zxcvbn-dvorak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -10962,4 +10962,3 @@ broken-packages:
   - ztar
   - zuramaru
   - Zwaluw
-  - zxcvbn-dvorak

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -10963,4 +10963,3 @@ broken-packages:
   - zuramaru
   - Zwaluw
   - zxcvbn-dvorak
-  - zxcvbn-hs


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The zxcvbn-hs and zxcvbn-dvorak packages work fine, so I unmarked them as broken.

```
> nix-build --no-out-link -A haskellPackages.zxcvbn-dvorak --arg config '{ allowBroken = true; }'
/nix/store/nfkq4fdszd7xd060rkiwvkajbgdj36d9-zxcvbn-dvorak-0.1.0.0

> nix-build --no-out-link -A haskellPackages.zxcvbn-hs --arg config '{ allowBroken = true; }'
/nix/store/cwxs6z1kj48jrkn7nf4rik59vxb6wfvz-zxcvbn-hs-0.2.1.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
