### PR TITLE
nixos/orangefs: fix module and build

### DIFF
--- a/nixos/modules/services/network-filesystems/orangefs/server.nix
+++ b/nixos/modules/services/network-filesystems/orangefs/server.nix
@@ -10,8 +10,11 @@ let
   # Maximum handle number is 2^63
   maxHandle = 9223372036854775806;
 
+  # handles start at 3
+  offset = 3;
+
   # One range of handles for each meta/data instance
-  handleStep = maxHandle / (length aliases) / 2;
+  handleStep = (maxHandle - offset) / (length aliases) / 2;
 
   fileSystems = mapAttrsToList (name: fs: ''
     <FileSystem>
@@ -25,7 +28,7 @@ let
       ${concatStringsSep "\n" (
           imap0 (i: alias:
             let
-              begin = i * handleStep + 3;
+              begin = i * handleStep + offset;
               end = begin + handleStep - 1;
             in "Range ${alias} ${toString begin}-${toString end}") aliases
        )}
@@ -35,7 +38,7 @@ let
       ${concatStringsSep "\n" (
           imap0 (i: alias:
             let
-              begin = i * handleStep + 3 + (length aliases) * handleStep;
+              begin = i * handleStep + (length aliases) * handleStep + offset;
               end = begin + handleStep - 1;
             in "Range ${alias} ${toString begin}-${toString end}") aliases
        )}

--- a/pkgs/tools/filesystems/orangefs/default.nix
+++ b/pkgs/tools/filesystems/orangefs/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, bison, flex, autoreconfHook
-, openssl, db, attr, perl, tcsh
+, openssl, db, attr, perl, tcsh, fetchpatch
 , enableLmdb ? false
 } :
 
@@ -11,6 +11,26 @@ stdenv.mkDerivation rec {
     url = "http://download.orangefs.org/current/source/orangefs-${version}.tar.gz";
     sha256 = "15669f5rcvn44wkas0mld0qmyclrmhbrw4bbbp66sw3a12vgn4sm";
   };
+
+  patches = let
+    urlBase = "https://github.com/waltligon/orangefs/commit/";
+  in [
+    (fetchpatch {
+      name = "glib-2.28-1";
+      url = "${urlBase}560f1e624687781d92561507295d1e7833187fc4.patch";
+      sha256 = "0bp4znzrzhfwfwpkpffacxdg0511wxv5zff7754k94r467rq9nx5";
+    })
+    (fetchpatch {
+      name = "glib-2.28-2";
+      url = "${urlBase}63ba2f50483339c195d1def845befe6adab16f35.patch";
+      sha256 = "0239blp0yzsc02cjrnsyllz48wkqcc22g4h48rff08wadi56cfnc";
+    })
+    (fetchpatch {
+      name = "glib-2.30";
+      url = "${urlBase}ce93eeeeb26ba555f1cc6f8d48f7dd4ccecc5851.patch";
+      sha256 = "15hff3nb9sp85k243k4ij5jhk6hpb63nq8ipil6fn76k41hv4ciz";
+    })
+  ];
 
   nativeBuildInputs = [ bison flex perl autoreconfHook ];
   buildInputs = [ openssl db attr tcsh ];

--- a/pkgs/tools/filesystems/orangefs/default.nix
+++ b/pkgs/tools/filesystems/orangefs/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, bison, flex, autoreconfHook
 , openssl, db, attr, perl, tcsh
+, enableLmdb ? false
 } :
 
 stdenv.mkDerivation rec {
@@ -32,8 +33,9 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc/orangefs"
     "--enable-shared"
     "--enable-fast"
+    "--enable-racache"
     "--with-ssl=${stdenv.lib.getDev openssl}"
-  ];
+  ] ++ stdenv.lib.optional enableLmdb "--with-db-backend=lmdb";
 
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Fixes a bug in the module that generates a wrong list of handles with a just a single server.
The latest glibc update (>2.28) broke the build. 

Needs backport to 20.03 (https://github.com/NixOS/nixpkgs/issues/80379)

###### Things done
* Fix handle calculation in module
* Add option to build with lmdb (faster meta data)
* Enable read ahead cache
* Add patches for glibc > 2.28

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
