### PR TITLE
intecture-cli: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/admin/intecture/cli.nix
+++ b/pkgs/tools/admin/intecture/cli.nix
@@ -14,10 +14,7 @@ buildRustPackage rec {
     sha256 = "16a5fkpyqkf8w20k3ircc1d0qmif7nygkzxj6mzk9609dlb0dmxq";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0dhrx6njfbd8w27ifk13g6s3ick579bhc4ijf54rfb9g6n8abafx";
+  cargoSha256 = "11r551baz3hrkyf9nv68mdf09nqyvbcfjh2rgy8babmi7jljpzav";
 
   buildInputs = [ openssl zeromq czmq zlib ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.