### PR TITLE
stdenv/check-meta: Advertise the NIXPKGS_ALLOW_* environment variables

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -80,15 +80,15 @@ let
   pos_str = meta: meta.position or "«unknown-file»";
 
   remediation = {
-    unfree = remediate_whitelist "Unfree";
-    broken = remediate_whitelist "Broken";
-    unsupported = remediate_whitelist "UnsupportedSystem";
+    unfree = remediate_whitelist "Unfree" "UNFREE";
+    broken = remediate_whitelist "Broken" "BROKEN";
+    unsupported = remediate_whitelist "UnsupportedSystem" "UNSUPPORTED_SYSTEM";
     blacklisted = x: "";
     insecure = remediate_insecure;
     broken-outputs = remediateOutputsToInstall;
     unknown-meta = x: "";
   };
-  remediate_whitelist = allow_attr: attrs:
+  remediate_whitelist = allow_attr: allow_env_var: attrs:
     ''
       a) For `nixos-rebuild` you can set
         { nixpkgs.config.allow${allow_attr} = true; }
@@ -96,7 +96,7 @@ let
 
       b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allow${allow_attr} = true; }
-      to ~/.config/nixpkgs/config.nix.
+      to ~/.config/nixpkgs/config.nix, or you can set the NIXPKGS_ALLOW_${allow_env_var} environment variable.
     '';
 
   remediate_insecure = attrs:
@@ -127,6 +127,8 @@ let
                  "${getName attrs}"
                ];
              }
+
+           or you can set the NIXPKGS_ALLOW_INSECURE environment variable.
 
       '';
 


### PR DESCRIPTION
###### Motivation for this change
This seemed like a reasonable addition whose absence has bothered me for a while.

###### What’s new
The error raised when trying to build a package marked as broken, insecure or unfree, or that is not supported on your system, will tell you about the environment variable you can set to ignore the error. Example:

```
error: Package ‘apple-framework-Foundation’ in /home/jakob/nixpkgs/pkgs/os-specific/darwin/apple-sdk/default.nix:137 is not supported on ‘x86_64-linux’, refusing to eva
luate.

a) For `nixos-rebuild` you can set
  { nixpkgs.config.allowUnsupportedSystem = true; }
in configuration.nix to override this.

b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
  { allowUnsupportedSystem = true; }
to ~/.config/nixpkgs/config.nix, or you can set the NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM environment variable.

(use '--show-trace' to show detailed location information)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~ N/A
- [ ] ~~Determined the impact on package closure size (by running `nix path-info -S` before and after)~~ N/A
- [x] Ensured that relevant documentation is up to date (I think)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
