### PR TITLE
gitAndTools.git-trim: init at 0.2.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -140,6 +140,10 @@ let
 
   git-test = callPackage ./git-test { };
 
+  git-trim = callPackage ./git-trim {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   git-workspace = callPackage ./git-workspace {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/applications/version-management/git-and-tools/git-trim/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-trim/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, rustPlatform, fetchFromGitHub, pkg-config, openssl, libiconv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-trim";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "foriequal0";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0gfmv9bwhh6bv0s9kfbxq9wsvrk3zz3ibavbpp9l8cpqc3145pqy";
+  };
+
+  cargoSha256 = "0xklczk4vbh2mqf76r3rsfyclyza9imf6yss7vbkm9w4ir3ar9f3";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ] ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  postInstall = ''
+    install -Dm644 docs/git-trim.md.1 $out/share/man/man1/git-trim.1
+  '';
+
+  # fails with sandbox
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Automatically trims your branches whose tracking remote refs are merged or gone";
+    homepage = "https://github.com/foriequal0/git-trim";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/foriequal0/git-trim

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
