### PR TITLE
wmfocus: 1.1.2 -> 1.1.3

### DIFF
--- a/pkgs/applications/window-managers/i3/wmfocus.nix
+++ b/pkgs/applications/window-managers/i3/wmfocus.nix
@@ -1,21 +1,18 @@
-{ stdenv, fetchFromGitHub, rustPlatform,
-  xorg, python3, pkgconfig, cairo, libxkbcommon }:
+{ stdenv, fetchFromGitHub, rustPlatform
+, xorg, python3, pkgconfig, cairo, libxkbcommon }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wmfocus";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "svenstaro";
     repo = pname;
     rev = version;
-    sha256 = "0jx0h2zyghs3bp4sg8f3vk5rkyprz2dqfqs0v72vmkp3cvgzxbvs";
+    sha256 = "17qdsqp9072yr7rcm6g1h620rff95ldawr8ldpkbjmkh0rc86skn";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1xmc28ns59jcmnv17102s2084baxqdvi0ibbyqwb108385qnixzf";
+  cargoSha256 = "1nsdvzrsgprwq7lsvfpymqslhggdzfk3840y8x92qjb0l2g4jhw1";
 
   nativeBuildInputs = [ python3 pkgconfig ];
   buildInputs = [ cairo libxkbcommon xorg.xcbutilkeysyms ];
@@ -27,9 +24,9 @@ rustPlatform.buildRustPackage rec {
 
   meta = with stdenv.lib; {
     description = "Visually focus windows by label";
+    homepage = "https://github.com/svenstaro/wmfocus";
+    license = licenses.mit;
     maintainers = with maintainers; [ synthetica ];
     platforms = platforms.linux;
-    license = licenses.mit;
-    homepage = https://github.com/svenstaro/wmfocus;
   };
 }


### PR DESCRIPTION
Also includes updates for:

- https://github.com/NixOS/nixpkgs/issues/79975
- https://github.com/NixOS/rfcs/pull/45

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).