### PR TITLE
zcash: 2.1.0-1 -> 2.1.1-1; libzrustzcash: 2018-10-27 -> 0.1.0

### DIFF
--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -7,14 +7,18 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   pname = "zcash";
-  version = "2.1.0-1";
+  version = "2.1.1-1";
 
   src = fetchFromGitHub {
     owner = "zcash";
     repo  = "zcash";
     rev = "v${version}";
-    sha256 = "05bnn4lxrrcv1ha3jdfrgwg4ar576161n3j9d4gpc14ww3zgf9vz";
+    sha256 = "1g5zlfzfp31my8w8nlg5fncpr2y95iv9fm04x57sjb93rgmjdh5n";
   };
+
+  patchPhase = ''
+    sed -i"" 's,-fvisibility=hidden,,g'            src/Makefile.am
+  '';
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ gtest gmock gmp openssl wget db62 boost17x zlib
@@ -23,17 +27,15 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-boost-libdir=${boost17x.out}/lib" ];
 
-  patchPhase = ''
-    sed -i"" 's,-fvisibility=hidden,,g'            src/Makefile.am
-  '';
-
   postInstall = ''
     cp zcutil/fetch-params.sh $out/bin/zcash-fetch-params
   '';
 
+  enableParallelBuilding = true;
+
   meta = {
     description = "Peer-to-peer, anonymous electronic cash system";
-    homepage = https://z.cash/;
+    homepage = "https://z.cash/";
     maintainers = with maintainers; [ rht tkerber ];
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/applications/blockchains/zcash/librustzcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/librustzcash/default.nix
@@ -1,20 +1,17 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "librustzcash-unstable";
-  version = "2018-10-27";
+  pname = "librustzcash";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "zcash";
     repo = "librustzcash";
-    rev = "06da3b9ac8f278e5d4ae13088cf0a4c03d2c13f5";
-    sha256 = "0md0pp3k97iv7kfjpfkg14pjanhrql4vafa8ggbxpkajv1j4xldv";
+    rev = version;
+    sha256 = "0d28k29sgzrg9clynz29kpw50kbkp0a4dfdayqhmpjmsh05y6261";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "166v8cxlpfslbs5gljbh7wp0lxqakayw47ikxm9r9a39n7j36mq1";
+  cargoSha256 = "1wzyrcmcbrna6rjzw19c4lq30didzk4w6fs6wmvxp0xfg4qqdlax";
 
   installPhase = ''
     mkdir -p $out/lib
@@ -23,11 +20,12 @@ rustPlatform.buildRustPackage rec {
     cp librustzcash/include/librustzcash.h $out/include/
   '';
 
+  # The tests do pass, but they take an extremely long time to run.
   doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Rust-language assets for Zcash";
-    homepage = https://github.com/zcash/librustzcash;
+    homepage = "https://github.com/zcash/librustzcash";
     maintainers = with maintainers; [ rht tkerber ];
     license = with licenses; [ mit asl20 ];
     platforms = platforms.unix;


### PR DESCRIPTION
Upgrades `librustzcash` to its first stable release as part of
https://github.com/NixOS/nixpkgs/issues/79975 cleanups, and also updates `zcash`
itself to the latest release.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).