### PR TITLE
capitaine-cursors: 3 -> 4

### DIFF
--- a/pkgs/data/icons/capitaine-cursors/default.nix
+++ b/pkgs/data/icons/capitaine-cursors/default.nix
@@ -1,35 +1,38 @@
 { stdenv, fetchFromGitHub
-, inkscape, xcursorgen }:
+, bc, inkscape, xcursorgen }:
 
 stdenv.mkDerivation rec {
   pname = "capitaine-cursors";
-  version = "3";
+  version = "4";
 
   src = fetchFromGitHub {
     owner = "keeferrourke";
     repo = pname;
     rev = "r${version}";
-    sha256 = "0pnfbmrn9nv8pryv6cbjcq5hl9366hzvz1kd8vsdkgb2nlfv5gdv";
+    sha256 = "0652ydy73x29z7wc6ccyqihmfg4bk0ksl7yryycln6c7i0iqfmc9";
   };
 
   postPatch = ''
     patchShebangs .
   '';
 
-  buildInputs  =[
+  buildInputs = [
+    bc
     inkscape
     xcursorgen
   ];
 
   buildPhase = ''
-    # https://github.com/NixOS/nixpkgs/blob/master/pkgs/data/fonts/emojione/default.nix#L16
-    HOME="$NIX_BUILD_ROOT" ./build.sh
+    # Shut up inkscape's warnings
+    export HOME="$NIX_BUILD_ROOT"
+
+    ./build.sh --max-dpi xxxhd --type dark --platform unix
+    ./build.sh --max-dpi xxxhd --type light --platform unix
   '';
 
   installPhase = ''
     install -dm 0755 $out/share/icons
     cp -pr dist $out/share/icons/capitaine-cursors
-    cp -pr dist-white $out/share/icons/capitaine-cursors-white
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
