### PR TITLE
pytorch-bin: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/pytorch/bin.nix
+++ b/pkgs/development/python-modules/pytorch/bin.nix
@@ -1,0 +1,120 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi, pythonOlder, python
+, cffi, click, numpy, pyyaml, pillow, six, future, tensorflow-tensorboard
+, protobuf, openmpi, typing, requests
+, cudatoolkit, cudnn, addOpenGLRunpath }:
+
+let
+  cpython = "cp${python.sourceVersion.major}${python.sourceVersion.minor}";
+  sha256 = {
+    cp27 = "1hc2yvkmdalvvm08g3lvl6w64z2452q4k20gadydavnz8hg4s797";
+    cp35 = "0a8qbzsmcxqp9s8vbzr39hlikj4n86gszx14gi1mlpp8iq76ml2l";
+    cp36 = "1g3xcrzkbyjal1r8v70ljzmxrf7zs1ijbg842ln79jwym8sg6ml8";
+    cp37 = "0a4xkg3fiiwxgwqb5fb77dan9k008ahmx9hdnpj1ck27gfzh7zwg";
+    cp38 = "0y0p8fpbxphkzqk1wbrm3r0h9zrx8r3c8hra9imbllb0pk31ajah";
+  }."${cpython}";
+in buildPythonPackage rec {
+  pname = "pytorch";
+  version = "1.4.0";
+
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit format version sha256;
+    pname = "torch";
+
+    python = cpython;
+    abi = if cpython == "cp38"
+      then cpython
+      else "${cpython}m";
+    platform = "manylinux1_x86_64";
+  };
+
+  nativeBuildInputs = [ addOpenGLRunpath ];
+
+  propagatedBuildInputs = [
+    cffi click numpy pyyaml
+    # openmpi support
+    openmpi
+    # the following are required for tensorboard support
+    pillow six future tensorflow-tensorboard protobuf
+    # other?
+    requests
+  ] ++ lib.optional (pythonOlder "3.5") typing;
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  postFixup = let
+    cuda_paths = [
+      cudatoolkit.out
+      cudatoolkit.lib
+      cudnn
+      # nvidia_x11
+    ];
+
+    base_lib_paths = [
+      stdenv.cc.cc.lib
+    ];
+
+    rpath = lib.makeLibraryPath (base_lib_paths ++ cuda_paths);
+  in ''
+    rrPathArr=(
+      "$out/${python.sitePackages}/torch/lib"
+      "$out/${python.sitePackages}/torch"
+      "$out/${python.sitePackages}/caffe2/python"
+      "${rpath}"
+    )
+
+    # The the bash array into a colon-separated list of RPATHs.
+    rrPath=$(IFS=$':'; echo "''${rrPathArr[*]}")
+    echo "patching with the following rpath: $rrPath"
+
+    find $out/${python.sitePackages} -type f -executable | while read lib; do
+      echo "patching $lib..."
+      chmod a+rx "$lib"
+      patchelf --set-rpath "$rrPath" "$lib"
+      addOpenGLRunpath "$lib"
+    done
+  '';
+
+  pythonImportsCheck = [
+    "torch"
+    "torch.nn"
+    "torch.nn.functional"
+    # "torch.Tensor"
+    # Tensor Attributes
+    "torch.autograd"
+    "torch.cuda"
+    "torch.distributed"
+    "torch.distributions"
+    "torch.hub"
+    "torch.jit"
+    "torch.nn.init"
+    "torch.onnx"
+    "torch.optim"
+    # Quantization
+    # Distributed RPC Framework
+    "torch.random"
+    "torch.sparse"
+    # "torch.Storage"
+    "torch.utils.bottleneck"
+    "torch.utils.checkpoint"
+    "torch.utils.cpp_extension"
+    "torch.utils.data"
+    "torch.utils.dlpack"
+    "torch.utils.model_zoo"
+    "torch.utils.tensorboard"
+    # Type Info
+    # Named Tensors
+    # Named Tensors operator coverage
+    # torch.__config__
+  ];
+
+  meta = with lib; {
+    description = "Open source, prototype-to-production deep learning platform";
+    homepage    = https://pytorch.org/;
+    license     = licenses.bsd3;
+    platforms   = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ eadwu ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3635,12 +3635,10 @@ in {
     cudaSupport = pkgs.config.cudaSupport or false;
   };
 
-  pyro-ppl = callPackage ../development/python-modules/pyro-ppl {};
-
-  opt-einsum = if isPy27 then
-      callPackage ../development/python-modules/opt-einsum/2.nix {}
-    else
-      callPackage ../development/python-modules/opt-einsum {};
+  pytorch-bin = callPackage ../development/python-modules/pytorch/bin.nix {
+    cudnn = pkgs.cudnn_cudatoolkit_10_1;
+    cudatoolkit = pkgs.cudatoolkit_10_1;
+  };
 
   pytorchWithCuda = self.pytorch.override {
     cudaSupport = true;
@@ -3649,6 +3647,13 @@ in {
   pytorchWithoutCuda = self.pytorch.override {
     cudaSupport = false;
   };
+
+  pyro-ppl = callPackage ../development/python-modules/pyro-ppl {};
+
+  opt-einsum = if isPy27 then
+      callPackage ../development/python-modules/opt-einsum/2.nix {}
+    else
+      callPackage ../development/python-modules/opt-einsum {};
 
   pythondialog = callPackage ../development/python-modules/pythondialog { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
Not perfect, literally clumped together by copying bits from `tensorflow-bin`.
###### Motivation for this change
But in case anyone comes by and wants a CUDA-enabled pytorch without compiling from source for Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
