### PR TITLE
eigen: fetch source from gitlab

### DIFF
--- a/pkgs/development/libraries/eigen/2.0.nix
+++ b/pkgs/development/libraries/eigen/2.0.nix
@@ -1,15 +1,14 @@
-{stdenv, fetchurl, cmake}:
+{ stdenv, fetchFromGitLab, cmake }:
 
-let
-  v = "2.0.17";
-in
-stdenv.mkDerivation {
-  name = "eigen-${v}";
+stdenv.mkDerivation rec {
+  pname = "eigen";
+  version = "2.0.17";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/eigen/eigen/get/${v}.tar.bz2";
-    name = "eigen-${v}.tar.bz2";
-    sha256 = "0q4ry2pmdb9lvm0g92wi6s6qng3m9q73n5flwbkfcz1nxmbfhmbj";
+  src = fetchFromGitLab {
+    owner = "libeigen";
+    repo = "eigen";
+    rev = version;
+    sha256 = "0d4knrcz04pxmxaqs5r3wv092950kl1z9wsw87vdzi9kgvc6wl0b";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -17,7 +16,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
     license = licenses.lgpl3Plus;
-    homepage = http://eigen.tuxfamily.org ;
+    homepage = "https://eigen.tuxfamily.org";
     maintainers = with stdenv.lib.maintainers; [ sander raskin ];
     branch = "2";
     platforms = with stdenv.lib.platforms; unix;

--- a/pkgs/development/libraries/eigen/default.nix
+++ b/pkgs/development/libraries/eigen/default.nix
@@ -1,16 +1,14 @@
-{stdenv, fetchurl, cmake}:
+{ stdenv, fetchFromGitLab, cmake }:
 
-let
-  version = "3.3.7";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "eigen";
-  inherit version;
+  version = "3.3.7";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/eigen/eigen/get/${version}.tar.gz";
-    name = "eigen-${version}.tar.gz";
-    sha256 = "1nnh0v82a5xibcjaph51mx06mxbllk77fvihnd5ba0kpl23yz13y";
+  src = fetchFromGitLab {
+    owner = "libeigen";
+    repo = "eigen";
+    rev = version;
+    sha256 = "1i3cvg8d70dk99fl3lrv3wqhfpdnm5kx01fl7r2bz46sk9bphwm1";
   };
 
   patches = [
@@ -22,7 +20,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
     license = licenses.lgpl3Plus;
-    homepage = http://eigen.tuxfamily.org ;
+    homepage = "https://eigen.tuxfamily.org";
     platforms = platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ sander raskin ];
     inherit version;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
@svanderburg @7c6f434c
###### Motivation for this change
Migrated over to Gitlab.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
