### PR TITLE
torchvision: 0.2.1 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/torchvision/default.nix
+++ b/pkgs/development/python-modules/torchvision/default.nix
@@ -1,40 +1,32 @@
 { buildPythonPackage
-, fetchPypi
+, isPy3k
+, fetchFromGitHub
 , python
+, which
 , six
 , numpy
 , pillow
 , pytorch
 , lib
+, enableCUDA ? false
+, cudatoolkit ? null
 }:
 
-let
-  cpython = "cp${python.sourceVersion.major}${python.sourceVersion.minor}";
-
-  sha256 = {
-    cp27 = "0fvj41zlrsd1bhhlypdzip34a67bx0915r1dcvi1rnfq979h0d9j";
-    cp35 = "0yz4kgbyrc6k6hh0vf8y9zdj2wyaasns1f9rzmmcz84kzwbvm1cy";
-    cp36 = "1mjy0aqdziwinj5iqz24p8z19glfavmp4ngzmwchg733pwqx98zy";
-    cp37 = "1zmgwnhsr0ackr2h9cpp5yw3y13pp7fj76zb11jkalpb158fr5m6";
-    cp38 = "11bsx74m0aly54j9c2ab5bjf7fk89hlr8v1scfi5wb6y779m8hxa";
-  }."${cpython}";
-in buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "torchvision";
   version = "0.5.0";
 
-  format = "wheel";
-
-  src = fetchPypi {
-    inherit pname version sha256;
-    format = "wheel";
-
-    python = cpython;
-    abi = if cpython == "cp38"
-      then cpython
-      else "${cpython}m";
-    platform = "manylinux1_x86_64";
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "vision";
+    rev = "v${version}";
+    sha256 = "1q4mik66scnqfdvyi46h5py27jk6dx5vkb3g6kz7d0xbcjv9866m";
   };
 
+  # manually check compatibility
+  PYTORCH_VERSION = pytorch.version;
+  nativeBuildInputs = [ which ]
+    ++ lib.optionals enableCUDA [ cudatoolkit ];
   propagatedBuildInputs = [ six numpy pillow pytorch ];
 
   meta = {

--- a/pkgs/development/python-modules/torchvision/default.nix
+++ b/pkgs/development/python-modules/torchvision/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , fetchPypi
+, python
 , six
 , numpy
 , pillow
@@ -7,16 +8,31 @@
 , lib
 }:
 
-buildPythonPackage rec {
-  version = "0.2.1";
-  pname   = "torchvision";
+let
+  cpython = "cp${python.sourceVersion.major}${python.sourceVersion.minor}";
+
+  sha256 = {
+    cp27 = "0fvj41zlrsd1bhhlypdzip34a67bx0915r1dcvi1rnfq979h0d9j";
+    cp35 = "0yz4kgbyrc6k6hh0vf8y9zdj2wyaasns1f9rzmmcz84kzwbvm1cy";
+    cp36 = "1mjy0aqdziwinj5iqz24p8z19glfavmp4ngzmwchg733pwqx98zy";
+    cp37 = "1zmgwnhsr0ackr2h9cpp5yw3y13pp7fj76zb11jkalpb158fr5m6";
+    cp38 = "11bsx74m0aly54j9c2ab5bjf7fk89hlr8v1scfi5wb6y779m8hxa";
+  }."${cpython}";
+in buildPythonPackage rec {
+  pname = "torchvision";
+  version = "0.5.0";
 
   format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit pname version sha256;
     format = "wheel";
-    sha256 = "18gvdabkmzfjg47ns0lw38mf85ry28nq1mas5rzlwvb4l5zmw2ms";
+
+    python = cpython;
+    abi = if cpython == "cp38"
+      then cpython
+      else "${cpython}m";
+    platform = "manylinux1_x86_64";
   };
 
   propagatedBuildInputs = [ six numpy pillow pytorch ];
@@ -25,6 +41,7 @@ buildPythonPackage rec {
     description = "PyTorch vision library";
     homepage    = "https://pytorch.org/";
     license     = lib.licenses.bsd3;
+    platforms   = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [ ericsagnes ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
Darwin filenames are kinda not following a pattern.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
