### PR TITLE
vaultenv: fix build

### DIFF
--- a/pkgs/development/tools/haskell/vaultenv/default.nix
+++ b/pkgs/development/tools/haskell/vaultenv/default.nix
@@ -15,6 +15,11 @@ mkDerivation rec {
 
   buildTools = [ hpack ];
 
+  prePatch = ''
+    substituteInPlace package.yaml \
+        --replace -Werror ""
+  '';
+
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [


### PR DESCRIPTION
###### Motivation for this change

Don't hard fail on warnings, having eg. some redundant imports is fine.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
