### PR TITLE
alsaequal: init at 0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8173,6 +8173,12 @@
     githubId = 474343;
     name = "Xavier Zwirtz";
   };
+  ymeister = {
+    name = "Yuri Meister";
+    email = "47071325+ymeister@users.noreply.github.com";
+    github = "ymeister";
+    githubId = 47071325;
+  };
 }
 
   

--- a/pkgs/tools/audio/alsaequal/caps_9.x.patch
+++ b/pkgs/tools/audio/alsaequal/caps_9.x.patch
@@ -1,0 +1,21 @@
+--- ./ctl_equal.c
++++ ./ctl_equal.c
+@@ -167,7 +167,7 @@
+ 	snd_ctl_equal_t *equal;
+ 	const char *controls = ".alsaequal.bin";
+ 	const char *library = "/usr/lib/ladspa/caps.so";
+-	const char *module = "Eq";
++	const char *module = "Eq10";
+ 	long channels = 2;
+ 	const char *sufix = " Playback Volume";
+ 	int err, i, index;
+--- ./pcm_equal.c
++++ ./pcm_equal.c
+@@ -151,7 +151,7 @@
+ 	snd_config_t *sconf = NULL;
+ 	const char *controls = ".alsaequal.bin";
+ 	const char *library = "/usr/lib/ladspa/caps.so";
+-	const char *module = "Eq";
++	const char *module = "Eq10";
+ 	long channels = 2;
+ 	int err;

--- a/pkgs/tools/audio/alsaequal/default.nix
+++ b/pkgs/tools/audio/alsaequal/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl
+, alsaLib, caps
+}:
+
+stdenv.mkDerivation rec {
+  name = "alsaequal";
+  version = "0.6";
+
+  src = fetchurl {
+    url = "https://thedigitalmachine.net/tools/alsaequal-${version}.tar.bz2";
+    sha256 = "1w3g9q5z3nrn3mwdhaq6zsg0jila8d102dgwgrhj9vfx58apsvli";
+  };
+
+  buildInputs = [ alsaLib ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  # Borrowed from Arch Linux's AUR
+  patches = [
+    # Adds executable permissions to resulting libraries
+    # and changes their destination directory from "usr/lib/alsa-lib" to "lib/alsa-lib" to better align with nixpkgs filesystem hierarchy.
+    ./makefile.patch
+    # Fixes control port check, which resulted in false error.
+    ./false_error.patch
+    # Fixes name change of an "Eq" to "Eq10" method in version 9 of caps library.
+    ./caps_9.x.patch
+  ];
+
+  postPatch = ''
+    sed -i 's#/usr/lib/ladspa/caps\.so#${caps}/lib/ladspa/caps\.so#g' ctl_equal.c pcm_equal.c
+  '';
+
+  preInstall = ''
+    mkdir -p "$out/lib/alsa-lib"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Real-time adjustable equalizer plugin for ALSA";
+    homepage = "https://thedigitalmachine.net/alsaequal.html";
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/tools/audio/alsaequal/default.nix
+++ b/pkgs/tools/audio/alsaequal/default.nix
@@ -38,5 +38,6 @@ stdenv.mkDerivation rec {
     description = "Real-time adjustable equalizer plugin for ALSA";
     homepage = "https://thedigitalmachine.net/alsaequal.html";
     license = licenses.gpl2;
+    maintainers = with maintainers; [ ymeister ];
   };
 }

--- a/pkgs/tools/audio/alsaequal/false_error.patch
+++ b/pkgs/tools/audio/alsaequal/false_error.patch
@@ -1,0 +1,13 @@
+--- ./ctl_equal.c
++++ ./ctl_equal.c
+@@ -263,8 +263,8 @@
+ 	for(i = 0; i < equal->num_input_controls; i++) {
+ 		if(equal->control_data->control[i].type == LADSPA_CNTRL_INPUT) {
+ 			index = equal->control_data->control[i].index;
+-			if(equal->klass->PortDescriptors[index] !=
+-					(LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL)) {
++			if(equal->klass->PortDescriptors[index] &
++					(LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL) == 0) {
+ 				SNDERR("Problem with control file %s, %d.", controls, index);
+ 				return -1;
+ 			}

--- a/pkgs/tools/audio/alsaequal/makefile.patch
+++ b/pkgs/tools/audio/alsaequal/makefile.patch
@@ -1,0 +1,13 @@
+--- ./Makefile
++++ ./Makefile
+@@ -45,8 +45,8 @@
+
+ install: all
+ 	@echo Installing...
+-	$(Q)install -m 644 $(SND_PCM_BIN) ${DESTDIR}/usr/lib/alsa-lib/
+-	$(Q)install -m 644 $(SND_CTL_BIN) ${DESTDIR}/usr/lib/alsa-lib/
++	$(Q)install -m 755 $(SND_PCM_BIN) ${DESTDIR}/lib/alsa-lib/
++	$(Q)install -m 755 $(SND_CTL_BIN) ${DESTDIR}/lib/alsa-lib/
+
+ uninstall:
+ 	@echo Un-installing...

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -521,6 +521,8 @@ in
   acoustidFingerprinter = callPackage ../tools/audio/acoustid-fingerprinter {
     ffmpeg = ffmpeg_2;
   };
+  
+  alsaequal = callPackage ../tools/audio/alsaequal { };
 
   acpica-tools = callPackage ../tools/system/acpica-tools { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
**Project description**
Alsaequal is a real-time adjustable equalizer plugin for ALSA. It can be adjusted using an ALSA compatible mixer, like alsamixergui or alsamixer.

Alsaequal uses the Eq CAPS LADSPA Plugin as it's default equalizer but you can change it to use almost any LADSPA plugin, like mbeq from the swh-plugin package. Though alsaequal is primarily intended to be used as an equalizer you should be able to use it to control any LADSPA plugin. It's similar in functionality to the LADSPA plugin provided with ALSA but allows for real-time controls as opposed to static controls defined in the asoundrc file.

**Metadata**

* homepage URL: https://thedigitalmachine.net/alsaequal.html
* source URL: https://thedigitalmachine.net/alsaequal.html
* license: gpl2
* platforms: linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
