### PR TITLE
ion: mark as broken

### DIFF
--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -13,10 +13,7 @@ buildRustPackage rec {
     sha256 = "0i0acl5nw254mw8dbfmb4792rr71is98a5wg32yylfnlrk7zlf8z";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1hs01b1rhbpafxlhw661k907rznqhcgyng85njkb99bg4lxwxaap";
+  cargoSha256 = "0f266kygvw2id771g49s25qsbqb6a0gr1r0czkcj96n5r0wg8wrn";
 
   meta = with stdenv.lib; {
     description = "Modern system shell with simple (and powerful) syntax";
@@ -24,10 +21,12 @@ buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin;
+    # This has not had a release since 2017, and no longer compiles with the
+    # latest Rust compiler.
+    broken = false;
   };
 
   passthru = {
-	  shellPath = "/bin/ion";
+    shellPath = "/bin/ion";
   };
 }


### PR DESCRIPTION
As noted in the comment, its Rust vendor directory no longer compiles. That
said, we can still compute the new `cargoSha256` for https://github.com/NixOS/nixpkgs/issues/79975, and the package fails in
precisely the same way.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).