### PR TITLE
cloudflare-wranger: upgrade cargoSha256

### DIFF
--- a/pkgs/development/tools/cloudflare-wrangler/default.nix
+++ b/pkgs/development/tools/cloudflare-wrangler/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, pkg-config, openssl, curl, darwin
-}:
+{ stdenv, fetchFromGitHub, rustPlatform, pkg-config, openssl, curl, darwin }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cloudflare-wrangler";
@@ -8,13 +7,11 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = "wrangler";
-    rev = "v" + version;
+    rev = "v${version}";
     sha256 = "0lh06cnjddmy5h5xvbkg8f97vw2v0wr5fi7vrs3nnidiz7x4rsja";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-  cargoSha256 = "0s07143vsrb2vwj4rarx5w3wcz1zh0gi8al6cdrfqyl7nhm1mshm";
+  cargoSha256 = "1q7vilh0bynhdz5bbpig5ibaqvk2153n07gmc715qb80w92sjw7w";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -29,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    description = "A CLI tool designed for folks who are interested in using Cloudflare Workers.";
+    description = "A CLI tool designed for folks who are interested in using Cloudflare Workers";
     homepage = "https://github.com/cloudflare/wrangler";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ ];


### PR DESCRIPTION
General infrastructure improvement as part of #79975,
no functional changes expected.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).