### PR TITLE
linuxPackages.rtl88x2bu: init at 2020-03-05

### DIFF
--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, kernel, bc }:
+
+stdenv.mkDerivation rec {
+  name = "rtl88x2bu-${kernel.version}-${version}";
+  version = "unstable-2020-05-19";
+
+  src = fetchFromGitHub {
+    owner = "cilynx";
+    repo = "rtl88x2BU";
+    rev = "0f159d7cd937a12b818121cb1f1c4910bd1adc72";
+    sha256 = "0flqnvzfdb4wsiiqv9vf5gfwd5fgpjvhs9zhqknnv1cmp8msgw6y";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = [ bc ];
+  buildInputs = kernel.moduleBuildDependencies;
+
+  prePatch = ''
+    substituteInPlace ./Makefile \
+      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
+      --replace /sbin/depmod \# \
+      --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Realtek rtl88x2bu driver";
+    homepage = "https://github.com/cilynx/rtl88x2bu";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.ralith ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16704,6 +16704,8 @@ in
 
     rtl8821ce = callPackage ../os-specific/linux/rtl8821ce { };
 
+    rtl88x2bu = callPackage ../os-specific/linux/rtl88x2bu { };
+
     rtlwifi_new = callPackage ../os-specific/linux/rtlwifi_new { };
 
     openafs = callPackage ../servers/openafs/1.6/module.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This got my TP-Link Archer T3U working on 19.09. Also seems to build fine with newer kernels. Not sure how we'll know if/when upstream gets support, or whether that's even a possibility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
