### PR TITLE
sonic-pi: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -4,7 +4,6 @@
 , fetchFromGitHub
 , fftwSinglePrec
 , ruby
-, libffi
 , aubio
 , cmake
 , pkgconfig
@@ -12,7 +11,6 @@
 , bash
 , jack2Full
 , supercollider
-, qscintilla
 , qwt
 , osmid
 }:
@@ -24,14 +22,14 @@ let
 in
 
 mkDerivation rec {
-  version = "3.1.0";
+  version = "3.2.2";
   pname = "sonic-pi";
 
   src = fetchFromGitHub {
     owner = "samaaron";
     repo = "sonic-pi";
     rev = "v${version}";
-    sha256 = "0gi4a73szaa8iz5q1gxgpsnyvhhghcfqm6bfwwxbix4m5csbfgh9";
+    sha256 = "1nlkpkpg9iz2hvf5pymvk6lqhpdpjbdrvr0hrnkc3ymj7llvf1cm";
   };
 
   buildInputs = [
@@ -39,10 +37,8 @@ mkDerivation rec {
     cmake
     pkgconfig
     qtbase
-    qscintilla
     qwt
     ruby
-    libffi
     aubio
     supercollider_single_prec
     boost
@@ -71,23 +67,34 @@ mkDerivation rec {
     popd
 
     pushd app/gui/qt
-      cp -f ruby_help.tmpl ruby_help.h
-      ../../server/ruby/bin/qt-doc.rb -o ruby_help.h
+      cp -f utils/ruby_help.tmpl utils/ruby_help.h
+      ../../server/ruby/bin/qt-doc.rb -o utils/ruby_help.h
 
-      substituteInPlace SonicPi.pro \
-        --replace "LIBS += -lrt -lqt5scintilla2" \
-                  "LIBS += -lrt -lqscintilla2 -lqwt"
+      lrelease lang/*.ts
 
-      lrelease SonicPi.pro
-      qmake SonicPi.pro
-
-      make
+      mkdir build
+      pushd build
+        cmake -G "Unix Makefiles" ..
+        make
+      popd
     popd
   '';
 
   installPhase = ''
     runHook preInstall
-    cp -r . $out
+
+    mkdir $out
+    cp -r {bin,etc} $out/
+
+    # Copy server whole.
+    mkdir -p $out/app
+    cp -r app/server $out/app/
+
+    # Copy only necessary files for the gui app.
+    mkdir -p $out/app/gui/qt/build
+    cp -r app/gui/qt/{book,fonts,help,html,images,image_source,info,lang,theme} $out/app/gui/qt/
+    cp app/gui/qt/build/sonic-pi $out/app/gui/qt/build/sonic-pi
+
     runHook postInstall
   '';
 
@@ -103,9 +110,7 @@ mkDerivation rec {
     homepage = "https://sonic-pi.net/";
     description = "Free live coding synth for everyone originally designed to support computing and music lessons within schools";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ Phlogistique kamilchm ];
+    maintainers = with lib.maintainers; [ Phlogistique kamilchm c0deaddict ];
     platforms = lib.platforms.linux;
-    # sonic-pi depends on ruby 2.4 which we don't support anymore
-    broken = true;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A new version of Sonic Pi has been released. The old version is currently broken because it depends on Ruby 2.4. This new version seems to work with Ruby 2.6.

Should this be merged in 20.03 as well so Sonic Pi can be used with that release?

I would like to become a maintainer of this package. I use it from time to time and am following the updates Sam Aaron (the creator) posts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
