### PR TITLE
junicode: update to 1.002 and correct license

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3169,6 +3169,12 @@
     githubId = 4458;
     name = "Ivan Kozik";
   };
+  ivan-timokhin = {
+    email = "nixpkgs@ivan.timokhin.name";
+    name = "Ivan Timokhin";
+    github = "ivan-timokhin";
+    githubId = 9802104;
+  };
   ivan-tkatchev = {
     email = "tkatchev@gmail.com";
     name = "Ivan Tkatchev";

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -1,9 +1,12 @@
 { lib, fetchzip }:
 
-fetchzip {
-  name = "junicode-1.002";
+let
+  pname = "junicode";
+  version = "1.002";
+in fetchzip {
+  name = "${pname}-${version}";
 
-  url = mirror://sourceforge/junicode/junicode/junicode-1.002/junicode-1.002.zip;
+  url = "mirror://sourceforge/junicode/junicode/junicode-${version}/junicode-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -15,6 +15,7 @@ fetchzip {
   meta = {
     homepage = http://junicode.sourceforge.net/;
     description = "A Unicode font for medievalists";
+    maintainers = with lib.maintainers; [ ivan-timokhin ];
     license = lib.licenses.ofl;
   };
 }

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -1,16 +1,16 @@
 { lib, fetchzip }:
 
 fetchzip {
-  name = "junicode-0.7.8";
+  name = "junicode-1.002";
 
-  url = mirror://sourceforge/junicode/junicode/junicode-0-7-8/junicode-0-7-8.zip;
+  url = mirror://sourceforge/junicode/junicode/junicode-1.002/junicode-1.002.zip;
 
   postFetch = ''
     mkdir -p $out/share/fonts
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/junicode-ttf
   '';
 
-  sha256 = "0q4si9pnbif36154sv49kzc7ygivgflv81nzmblpz3b2p77g9956";
+  sha256 = "1n170gw41lr0zr5958z5cgpg6i1aa7kj7iq9s6gdh1cqq7hhgd08";
 
   meta = {
     homepage = http://junicode.sourceforge.net/;

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -15,6 +15,6 @@ fetchzip {
   meta = {
     homepage = http://junicode.sourceforge.net/;
     description = "A Unicode font for medievalists";
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.ofl;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update Junicode to the latest available version. Among other changes, Greek alphabet has been moved into a separate font, Foulis Greek, included alongside Junicode variants.

While at it, I have noticed that the license in the metadata doesn't match the one on the [project site](http://junicode.sourceforge.net/), and changed that as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  The fonts at least look correct in fontforge.
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  Decreased from 3.0M to 2.2M
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  `meta.maintainers` is not set; other than that, I think everything fits.
