### PR TITLE
gitAndTools.git-bug: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "git-bug";
-  version = "0.6.0";
-  rev = "fc568209f073b9d775a09e0dbb8289cf9e5749bf";
+  version = "0.7.0";
+  rev = "71580c41a931a1ad2c04682e0fd701661b716c95";
   goPackagePath = "github.com/MichaelMure/git-bug";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "MichaelMure";
     repo = "git-bug";
-    sha256 = "1s18lzip52qpf52ad6m20j306mr16vnwhz9f7rirsa6b7srmcgli";
+    sha256 = "0mhqvcwa6y3hrrv88vbp22k7swzr8xw6ipm80gdpx85yp8j2wdkh";
   };
+
+  modSha256 = "1cfn49cijiarzzczrpd28x1k7ib98xyzlvn3zghwk2ngfgiah3ld";
 
   buildFlagsArray = ''
     -ldflags= 
@@ -21,10 +23,9 @@ buildGoPackage rec {
   '';
 
   postInstall = ''
-    cd go/src/${goPackagePath}
-    install -D -m 0644 misc/bash_completion/git-bug "$bin/etc/bash_completion.d/git-bug"
-    install -D -m 0644 misc/zsh_completion/git-bug "$bin/share/zsh/site-functions/git-bug"
-    install -D -m 0644 -t "$bin/share/man/man1" doc/man/*
+    install -D -m 0644 misc/bash_completion/git-bug "$out/etc/bash_completion.d/git-bug"
+    install -D -m 0644 misc/zsh_completion/git-bug "$out/share/zsh/site-functions/git-bug"
+    install -D -m 0644 -t "$out/share/man/man1" doc/man/*
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update to version 0.7.0. Includes switch to buildGoModule because Gopkg.toml
has been removed upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
