### PR TITLE
stdenv: update ARM bootstrap tarballs

### DIFF
--- a/pkgs/stdenv/linux/bootstrap-files/armv5tel.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/armv5tel.nix
@@ -1,12 +1,18 @@
 {
+  # Note: do not use Hydra as a source URL. Ask a member of the
+  # infrastructure team to mirror the job.
   busybox = import <nix/fetchurl.nix> {
-    url = https://hydra.nixos.org/build/112609163/download/2/busybox;
-    sha256 = "0dc5471dc6a5f69ad98eb7445f51a61e88aa5792d7a677025bf012bdb513b763";
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv5tel.dist/latest
+    # from build: https://hydra.nixos.org/build/114203025
+    url = http://tarballs.nixos.org/stdenv-linux/armv5tel/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox;
+    # note: the following hash is different than the above hash, due to executable = true
+    sha256 = "0qxp2fsvs4phbc17g9npj9bsm20ylr8myi5pivcrmxm5qqflgi8d";
     executable = true;
   };
-
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = https://hydra.nixos.org/build/112609163/download/1/bootstrap-tools.tar.xz;
-    sha256 = "ca0564eca4eb944649ce10ec70859640427bf2241243af62812b163176487e02";
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv5tel.dist/latest
+    # from build: https://hydra.nixos.org/build/114203025
+    url = http://tarballs.nixos.org/stdenv-linux/armv5tel/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz;
+    sha256 = "28327343db5ecc7f7811449ec69280d5867fa5d1d377cab0426beb9d4e059ed6";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-files/armv5tel.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/armv5tel.nix
@@ -4,7 +4,7 @@
   busybox = import <nix/fetchurl.nix> {
     # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv5tel.dist/latest
     # from build: https://hydra.nixos.org/build/114203025
-    url = http://tarballs.nixos.org/stdenv-linux/armv5tel/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox;
+    url = "http://tarballs.nixos.org/stdenv-linux/armv5tel/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox";
     # note: the following hash is different than the above hash, due to executable = true
     sha256 = "0qxp2fsvs4phbc17g9npj9bsm20ylr8myi5pivcrmxm5qqflgi8d";
     executable = true;
@@ -12,7 +12,7 @@
   bootstrapTools = import <nix/fetchurl.nix> {
     # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv5tel.dist/latest
     # from build: https://hydra.nixos.org/build/114203025
-    url = http://tarballs.nixos.org/stdenv-linux/armv5tel/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz;
+    url = "http://tarballs.nixos.org/stdenv-linux/armv5tel/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz";
     sha256 = "28327343db5ecc7f7811449ec69280d5867fa5d1d377cab0426beb9d4e059ed6";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-files/armv6l.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/armv6l.nix
@@ -4,7 +4,7 @@
   busybox = import <nix/fetchurl.nix> {
     # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv6l.dist/latest
     # from build: https://hydra.nixos.org/build/114202834
-    url = http://tarballs.nixos.org/stdenv-linux/armv6l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox;
+    url = "http://tarballs.nixos.org/stdenv-linux/armv6l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox";
     # note: the following hash is different than the above hash, due to executable = true
     sha256 = "1q02537cq56wlaxbz3s3kj5vmh6jbm27jhvga6b4m4jycz5sxxp6";
     executable = true;
@@ -12,7 +12,7 @@
   bootstrapTools = import <nix/fetchurl.nix> {
     # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv6l.dist/latest
     # from build: https://hydra.nixos.org/build/114202834
-    url = http://tarballs.nixos.org/stdenv-linux/armv6l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz;
+    url = "http://tarballs.nixos.org/stdenv-linux/armv6l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz";
     sha256 = "0810fe74f8cd09831f177d075bd451a66b71278d3cc8db55b07c5e38ef3fbf3f";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-files/armv6l.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/armv6l.nix
@@ -1,12 +1,18 @@
 {
+  # Note: do not use Hydra as a source URL. Ask a member of the
+  # infrastructure team to mirror the job.
   busybox = import <nix/fetchurl.nix> {
-    url = https://hydra.nixos.org/build/112609441/download/2/busybox;
-    sha256 = "e6f6aecb675e924a96516f4379445dd2c0ba8b9c438fbfbaa2dc14ccce2802e0";
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv6l.dist/latest
+    # from build: https://hydra.nixos.org/build/114202834
+    url = http://tarballs.nixos.org/stdenv-linux/armv6l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox;
+    # note: the following hash is different than the above hash, due to executable = true
+    sha256 = "1q02537cq56wlaxbz3s3kj5vmh6jbm27jhvga6b4m4jycz5sxxp6";
     executable = true;
   };
-
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = https://hydra.nixos.org/build/112609441/download/1/bootstrap-tools.tar.xz;
-    sha256 = "7a3f20def1a17ebf0edb5a92c403558429bcc2ac3d931b5e1bd88606cb217778";
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv6l.dist/latest
+    # from build: https://hydra.nixos.org/build/114202834
+    url = http://tarballs.nixos.org/stdenv-linux/armv6l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz;
+    sha256 = "0810fe74f8cd09831f177d075bd451a66b71278d3cc8db55b07c5e38ef3fbf3f";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-files/armv7l.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/armv7l.nix
@@ -4,7 +4,7 @@
   busybox = import <nix/fetchurl.nix> {
     # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv7l.dist/latest
     # from build: https://hydra.nixos.org/build/114203060
-    url = http://tarballs.nixos.org/stdenv-linux/armv7l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox;
+    url = "http://tarballs.nixos.org/stdenv-linux/armv7l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox";
     # note: the following hash is different than the above hash, due to executable = true
     sha256 = "18qc6w2yykh7nvhjklsqb2zb3fjh4p9r22nvmgj32jr1mjflcsjn";
     executable = true;
@@ -12,7 +12,7 @@
   bootstrapTools = import <nix/fetchurl.nix> {
     # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv7l.dist/latest
     # from build: https://hydra.nixos.org/build/114203060
-    url = http://tarballs.nixos.org/stdenv-linux/armv7l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz;
+    url = "http://tarballs.nixos.org/stdenv-linux/armv7l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz";
     sha256 = "cf2968e8085cd3e6b3e9359624060ad24d253800ede48c5338179f6e0082c443";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap-files/armv7l.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/armv7l.nix
@@ -1,12 +1,18 @@
 {
+  # Note: do not use Hydra as a source URL. Ask a member of the
+  # infrastructure team to mirror the job.
   busybox = import <nix/fetchurl.nix> {
-    url = https://hydra.nixos.org/build/112609103/download/2/busybox;
-    sha256 = "566a469dac214b31e4abdb0a91d32550bab1be5858d329e1b6074eef05370ca3";
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv7l.dist/latest
+    # from build: https://hydra.nixos.org/build/114203060
+    url = http://tarballs.nixos.org/stdenv-linux/armv7l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox;
+    # note: the following hash is different than the above hash, due to executable = true
+    sha256 = "18qc6w2yykh7nvhjklsqb2zb3fjh4p9r22nvmgj32jr1mjflcsjn";
     executable = true;
   };
-
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = https://hydra.nixos.org/build/112609103/download/1/bootstrap-tools.tar.xz;
-    sha256 = "79fa2d7722aeb856c7c9b62a3fd64b6d261fd6f6bcbac486f0a2a7d823210550";
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv7l.dist/latest
+    # from build: https://hydra.nixos.org/build/114203060
+    url = http://tarballs.nixos.org/stdenv-linux/armv7l/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz;
+    sha256 = "cf2968e8085cd3e6b3e9359624060ad24d253800ede48c5338179f6e0082c443";
   };
 }


### PR DESCRIPTION

###### Motivation for this change

follow-up to https://github.com/NixOS/nixpkgs/pull/79793

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
