### PR TITLE
borgbackup: 1.1.10 → 1.1.11

### DIFF
--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -2,11 +2,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "borgbackup";
-  version = "1.1.10";
+  version = "1.1.11";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "1pp70p4n5kamvcbl4d8021ggrxhyykmg9isjg4yd3wags8b19d7g";
+    sha256 = "190gjzx83b6p64nqj840x382dgz9gfv0gm7wj585lnkrpa90j29n";
   };
 
   nativeBuildInputs = with python3.pkgs; [
@@ -58,7 +58,7 @@ python3.pkgs.buildPythonApplication rec {
     HOME=$(mktemp -d) py.test --pyargs borg.testsuite
   '';
 
-  # 63 failures, needs pytest-benchmark
+  # 64 failures, needs pytest-benchmark
   doCheck = false;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
#### Motivation for this change

New upstream release. https://github.com/borgbackup/borg/blob/1.1.11/docs/changes.rst#version-1111-2020-03-08

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
