### PR TITLE
soundtracker: init at 1.0.0.1

### DIFF
--- a/pkgs/applications/audio/soundtracker/default.nix
+++ b/pkgs/applications/audio/soundtracker/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchurl
+, pkg-config
+, autoconf
+, gtk2
+, alsaLib
+, SDL
+, jack2
+, goocanvas # graphical envelope editing
+}:
+
+stdenv.mkDerivation rec {
+  pname = "soundtracker";
+  version = "1.0.0.1";
+
+  src = fetchurl {
+    # Past releases get moved to the "old releases" directory.
+    # Only the latest release (currently a prerelease) is at the top level.
+    url = "mirror://sourceforge/soundtracker/old%20releases/soundtracker-${version}.tar.bz2";
+    sha256 = "1ggliswz5ngmlnrnyhv3x1arh5w77an0ww9p53cddp9aas5q11jm";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoconf
+  ];
+  buildInputs = [
+    gtk2
+    SDL
+    jack2
+    goocanvas
+  ] ++ stdenv.lib.optional stdenv.isLinux alsaLib;
+
+  meta = with stdenv.lib; {
+    description = "A music tracking tool similar in design to the DOS program FastTracker and the Amiga legend ProTracker";
+    longDescription = ''
+      SoundTracker is a pattern-oriented music editor (similar to the DOS
+      program 'FastTracker'). Samples are lined up on tracks and patterns
+      which are then arranged to a song. Supported module formats are XM and
+      MOD; the player code is the one from OpenCP. A basic sample recorder
+      and editor is also included.
+    '';
+    homepage = "http://www.soundtracker.org/";
+    downloadPage = "https://sourceforge.net/projects/soundtracker/files/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+    # gdk/gdkx.h not found
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21508,6 +21508,8 @@ in
 
   sound-juicer = callPackage ../applications/audio/sound-juicer { };
 
+  soundtracker = callPackage ../applications/audio/soundtracker { };
+
   spice-vdagent = callPackage ../applications/virtualization/spice-vdagent { };
 
   spike = callPackage ../applications/virtualization/spike { };


### PR DESCRIPTION
###### Motivation for this change

#81815

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Could someone run a darwin build? From what I can tell it should work