### PR TITLE
Remove snap from broken packages list

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9377,7 +9377,6 @@ broken-packages:
   - smuggler
   - snake
   - snake-game
-  - snap
   - snap-accept
   - snap-auth-cli
   - snap-blaze-clay


### PR DESCRIPTION
###### Motivation for this change

The latest `snap` on hackage is buildable from `nixpkgs`, since it bumped dependencies for ghc-8.8.2.

Apologies for not being familiar with the nixpkgs haskell process (e.g. - I'm not sure if inclusion on the `broken` list is automated, making this PR unnecessary).

cc @cdepillabout (Thanks for your haskell-updates call-to-action!)

If this goes through, I can test the many `snap-*` dependencies which were probably only marked broken because `snap` itself was marked broken, and unbreak those.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
