### PR TITLE
androidenv: enhance script for the generated expressions

### DIFF
--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -235,5 +235,5 @@ package manager uses. To update the expressions run the `generate.sh` script
 that is stored in the `pkgs/development/mobile/androidenv/` sub directory:
 
 ```bash
-sh ./generate.sh
+./generate.sh
 ```

--- a/pkgs/development/mobile/androidenv/convertpackages.xsl
+++ b/pkgs/development/mobile/androidenv/convertpackages.xsl
@@ -28,7 +28,7 @@
 
 {
   <!-- Convert all remote packages -->
-  <xsl:for-each select="remotePackage"><xsl:sort select="@path" />
+  <xsl:for-each select="remotePackage[not(contains(@path, ';') and substring-after(@path, ';') = 'latest')]"><xsl:sort select="@path" />
 
   <!-- Extract the package name from the path -->
   <xsl:variable name="name">

--- a/pkgs/development/mobile/androidenv/generate.sh
+++ b/pkgs/development/mobile/androidenv/generate.sh
@@ -1,16 +1,36 @@
-#!/bin/sh -e
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl libxslt
+
+set -e
+
+die() {
+    echo "$1" >&2
+    exit 1
+}
+
+fetch() {
+    local url="https://dl.google.com/android/repository/$1"
+    echo "$url -> $2"
+    curl -s "$url" -o "$2" || die "Failed to fetch $url"
+}
+
+pushd "$(dirname "$0")" &>/dev/null || exit 1
+
+mkdir -p xml
 
 # Convert base packages
-curl https://dl.google.com/android/repository/repository2-1.xml -o xml/repository2-1.xml
+fetch repository2-1.xml xml/repository2-1.xml
 xsltproc convertpackages.xsl xml/repository2-1.xml > generated/packages.nix
 
 # Convert system images
 for img in android android-tv android-wear android-wear-cn google_apis google_apis_playstore
 do
-    curl https://dl.google.com/android/repository/sys-img/$img/sys-img2-1.xml -o xml/$img-sys-img2-1.xml
+    fetch sys-img/$img/sys-img2-1.xml xml/$img-sys-img2-1.xml
     xsltproc --stringparam imageType $img convertsystemimages.xsl xml/$img-sys-img2-1.xml > generated/system-images-$img.nix
 done
 
 # Convert system addons
-curl https://dl.google.com/android/repository/addon2-1.xml -o xml/addon2-1.xml
+fetch addon2-1.xml xml/addon2-1.xml
 xsltproc convertaddons.xsl xml/addon2-1.xml > generated/addons.nix
+
+popd &>/dev/null


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Make the generation of androidenv generated expressions more reproducible.

This started by extracting the non-controversial bits from PR #58131 , that almost got approval in Apr 2019 but was not merged for [the presence of bits requiring further refinement](https://github.com/NixOS/nixpkgs/pull/58131#issuecomment-487743116).

(I was considering to propose an unrelated androidenv PR and I read in the PR template re helping reviewing PRs, so I am triaging androidenv-related PRs and trying to bring them forward.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
  - **Not applicable**.
- Built on platform(s) - **Not applicable in itself**, tested via #82118 so please refer to that.
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) - **Not applicable**
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` - **Not applicable**
- [ ] Tested execution of all binary files (usually in `./result/bin/`) - **Not applicable**
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after) - **Not applicable**
- [x] Ensured that relevant documentation is up to date
  - [x] doc/languages-frameworks/android.section.md#updating-the-generated-expressions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
