### PR TITLE
chirp: 20200213 -> 20200227

### DIFF
--- a/pkgs/applications/radio/chirp/default.nix
+++ b/pkgs/applications/radio/chirp/default.nix
@@ -4,11 +4,11 @@
 }:
 python2.pkgs.buildPythonApplication rec {
   pname = "chirp-daily";
-  version = "20200213";
+  version = "20200227";
 
   src = fetchurl {
     url = "https://trac.chirp.danplanet.com/chirp_daily/daily-${version}/${pname}-${version}.tar.gz";
-    sha256 = "189kg3425wggib1cggcj49bk01pq3j4b8mks7najpp1rjsl5f2i1";
+    sha256 = "1my9q0xdw2nq68lh2gsd8qkjbcq60ryxd08py04nkdfs1wy6hpdp";
   };
 
   propagatedBuildInputs = with python2.pkgs; [


### PR DESCRIPTION
###### Motivation for this change
Fix for [this Yaesu bug](https://chirp.danplanet.com/projects/chirp/repository/revisions/8a707d754ab0).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

r? @the-kenny 