### PR TITLE
katago: init at 1.3.5

### DIFF
--- a/pkgs/games/katago/default.nix
+++ b/pkgs/games/katago/default.nix
@@ -1,0 +1,97 @@
+{ stdenv
+, gcc8Stdenv
+, lib
+, libzip
+, boost
+, cmake
+, makeWrapper
+, fetchFromGitHub
+, cudnn ? null
+, cudatoolkit ? null
+, libGL_driver ? null
+, opencl-headers ? null
+, ocl-icd ? null
+, gperftools ? null
+, cudaSupport ? false
+, useTcmalloc ? true}:
+
+assert cudaSupport -> (
+  libGL_driver != null && 
+  cudatoolkit != null &&
+  cudnn != null);
+
+assert !cudaSupport -> (
+  opencl-headers != null &&
+  ocl-icd != null);
+
+assert useTcmalloc -> (
+  gperftools != null);
+
+let
+  env = if cudaSupport 
+    then gcc8Stdenv
+    else stdenv;
+
+in env.mkDerivation rec {
+  pname = "katago";
+  version = "1.3.5";
+
+  src = fetchFromGitHub {
+    owner = "lightvector";
+    repo = "katago";
+    rev = "v${version}";
+    sha256 = "1625s3fh0xc2ldgyl6sjdjmpliyys7rzzkcys6h9x6k828g8n0lq";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libzip
+    boost
+  ] ++ lib.optionals cudaSupport [
+    cudnn
+    libGL_driver
+  ] ++ lib.optionals (!cudaSupport) [
+    opencl-headers
+    ocl-icd
+  ] ++ lib.optionals useTcmalloc [
+    gperftools
+  ];
+
+  cmakeFlags = [
+    "-DNO_GIT_REVISION=ON"
+  ] ++ lib.optionals cudaSupport [
+    "-DUSE_BACKEND=CUDA"
+  ] ++ lib.optionals (!cudaSupport) [
+    "-DUSE_BACKEND=OPENCL"
+  ] ++ lib.optionals useTcmalloc [
+    "-DUSE_TCMALLOC=ON"
+  ];
+
+  preConfigure = ''
+    cd cpp/
+  '' + lib.optionalString cudaSupport ''
+    export CUDA_PATH="${cudatoolkit}"
+    export EXTRA_LDFLAGS="-L/run/opengl-driver/lib"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin; cp katago $out/bin;
+  '' + lib.optionalString cudaSupport ''
+    wrapProgram $out/bin/katago \
+      --prefix LD_LIBRARY_PATH : "/run/opengl-driver/lib"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Go engine modeled after AlphaGo Zero";
+    homepage    = "https://github.com/lightvector/katago";
+    license     = licenses.mit;
+    maintainers = [ maintainers.omnipotententity ];
+    platforms   = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23299,6 +23299,14 @@ in
 
   ja2-stracciatella = callPackage ../games/ja2-stracciatella { };
 
+  katago = callPackage ../games/katago { };
+
+  katagoWithCuda = katago.override {
+    cudaSupport = true;
+    cudnn = cudnn_cudatoolkit_10_1;
+    cudatoolkit = cudatoolkit_10_1;
+  };
+
   klavaro = callPackage ../games/klavaro {};
 
   kobodeluxe = callPackage ../games/kobodeluxe { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Katago is the current strongest open source go AI engine.  This derivation provides both the OpenCL (default) and CUDA versions of the engine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
