### PR TITLE
diesel-cli: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/diesel-cli/default.nix
+++ b/pkgs/development/tools/diesel-cli/default.nix
@@ -37,10 +37,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = [ "--no-default-features --features \"${features}\"" ];
   cargoPatches = [ ./cargo-lock.patch ];
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0xlcskddhy7xsiwj54gmn1xlgkfxb4dwrys7rbamfz1h8aa6ixjx";
+  cargoSha256 = "1vbb7r0dpmq8363i040bkhf279pz51c59kcq9v5qr34hs49ish8g";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ]


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.