### PR TITLE
eva: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/misc/eva/default.nix
+++ b/pkgs/tools/misc/eva/default.nix
@@ -4,10 +4,7 @@ rustPlatform.buildRustPackage rec {
   pname = "eva";
   version = "0.2.7";
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0n3xvlmp4l925nbz8lx6dr9yrrfh6z7b9z8wd6sli3a1dq26d6bg";
+  cargoSha256 = "1lycjw5i169xx73qw8gknbakrxikdbr65fmqx7xq2mafc0hb1zyn";
 
   src = fetchFromGitHub {
     owner = "NerdyPepper";


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.