### PR TITLE
httplz: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/networking/httplz/default.nix
+++ b/pkgs/tools/networking/httplz/default.nix
@@ -21,10 +21,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = [ "--bin httplz" ];
   cargoPatches = [ ./cargo-lock.patch ];
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1ajxfvj1pv6yq84zgrh7vjzghpb2y8qd5r09gzwdvww5rbj920fq";
+  cargoSha256 = "13hk9m09jff3bxbixsjvksiir4j4mak4ckvlq45bx5d5lh8sapxl";
 
   postInstall = ''
     wrapProgram $out/bin/httplz \


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.