### PR TITLE
nixos/oci-containers can depend on arbitrary systemd services

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -188,6 +188,36 @@ let
           '';
         };
 
+        requiresServices = mkOption {
+          type = with types; listOf str;
+          default = [];
+          description = ''
+            Define which other services this one depends on. They will be added to only Requires for the unit.
+          '';
+          example = literalExample ''
+            services.oci-containers = {
+              node1 = {
+                requiresServices = [ "ncsd.service" ];
+              }
+            }
+          '';
+        };
+
+        afterServices = mkOption {
+          type = with types; listOf str;
+          default = [];
+          description = ''
+            Define which other services this one will delay until they have started. They will be added to only the After for the unit.
+          '';
+          example = literalExample ''
+            services.oci-containers = {
+              node1 = {
+                afterServices = [ "ncsd.service" ];
+              }
+            }
+          '';
+        };
+
         extraOptions = mkOption {
           type = with types; listOf str;
           default = [];
@@ -212,8 +242,8 @@ let
     dependsOn = map (x: "${cfg.backend}-${x}.service") container.dependsOn;
   in {
     wantedBy = [] ++ optional (container.autoStart) "multi-user.target";
-    after = lib.optionals (cfg.backend == "docker") [ "docker.service" "docker.socket" ] ++ dependsOn;
-    requires = dependsOn;
+    after = lib.optionals (cfg.backend == "docker") [ "docker.service" "docker.socket" ] ++ dependsOn ++ container.afterServices;
+    requires = dependsOn ++ container.requiresServices;
     environment = proxy_env;
 
     path =


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/81814


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
