### PR TITLE
[20.03] sit: mark as broken

### DIFF
--- a/pkgs/applications/version-management/sit/default.nix
+++ b/pkgs/applications/version-management/sit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, cmake, libzip, gnupg, 
+{ stdenv, fetchFromGitHub, rustPlatform, cmake, libzip, gnupg,
   # Darwin
   libiconv, CoreFoundation, Security }:
 
@@ -28,5 +28,8 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ dywedir yrashk ];
     platforms = platforms.all;
+    # Upstream has not had a release in several years, and dependencies no
+    # longer compile with the latest Rust compiler.
+    broken = true;
   };
 }


### PR DESCRIPTION
Dependencies in the Cargo.lock fail to build due to mutable self borrows.

Backport of https://github.com/NixOS/nixpkgs/pull/82018

ZHF: https://github.com/NixOS/nixpkgs/issues/80379

(cherry picked from commit a2514c22a8054b85b5123bf5a35891e7c2177ca4)