### PR TITLE
[20.03] heatseeker: 1.5.1 -> 1.7.1

### DIFF
--- a/pkgs/tools/misc/heatseeker/default.nix
+++ b/pkgs/tools/misc/heatseeker/default.nix
@@ -1,19 +1,17 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
-with rustPlatform;
-
-buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "heatseeker";
-  version = "1.5.1";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "rschmitt";
     repo = "heatseeker";
     rev = "v${version}";
-    sha256 = "1fcrbjwnhcz71i70ppy0rcgk5crwwmbkm9nrk1kapvks33pv0az7";
+    sha256 = "1x7mdyf1m17s55f6yjdr1j510kb7a8f3zkd7lb2kzdc7nd3vgaxg";
   };
 
-  cargoSha256 = "0m3sxbz1iii31s30cnv1970i1mwfhl6gm19k8wv0n7zji30ayx07";
+  cargoSha256 = "0qfjsgfywp3brmmkp6nmwnwp0gwljyi3ddfa35kzfqylsdn1x91b";
 
   # some tests require a tty, this variable turns them off for Travis CI,
   # which we can also make use of
@@ -21,7 +19,7 @@ buildRustPackage rec {
 
   meta = with stdenv.lib; {
     description = "A general-purpose fuzzy selector";
-    homepage = https://github.com/rschmitt/heatseeker;
+    homepage = "https://github.com/rschmitt/heatseeker";
     license = licenses.mit;
     maintainers = [ maintainers.michaelpj ];
     platforms = platforms.unix;


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/82017

ZHF: #80379

(cherry picked from commit 9044bdef6a6aa1e216518020b47516990a00d304)