### PR TITLE
wasm-bindgen-cli: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/development/tools/wasm-bindgen-cli/default.nix
+++ b/pkgs/development/tools/wasm-bindgen-cli/default.nix
@@ -14,10 +14,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security curl ];
   nativeBuildInputs = [ pkgconfig ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1cp8ns0cywzqchdw5hkg4fhxhqb6apxwjjasf1ksf3dgjwynlhzm";
+  cargoSha256 = "1ylk9vrpajslx1zy4vqmlyqa5ygcmvir1gcn8hsr6liigf5kcz7p";
   cargoPatches = [ ./0001-Add-cargo.lock.patch ];
   cargoBuildFlags = [ "-p" pname ];
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.