### PR TITLE
svgbob: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/tools/graphics/svgbob/default.nix
+++ b/pkgs/tools/graphics/svgbob/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   sourceRoot = "source/svgbob_cli";
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "0mnq1s809f394x83gjv9zljr07c94k48zkrwxs6ibi19shgmrnnd";
+  cargoSha256 = "1y9jsnxmz51zychmmzp6mi29pb5ks2qww7lk5bshkhp56v51sm8d";
 
   # Test tries to build outdated examples
   doCheck = false;


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.