### PR TITLE
unpfs: upgrade cargo fetcher and cargoSha256

### DIFF
--- a/pkgs/servers/unpfs/default.nix
+++ b/pkgs/servers/unpfs/default.nix
@@ -13,10 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   sourceRoot = "source/example/unpfs";
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1d33nwj3i333a6ji3r3037mgg553lc3wsawm0pz13kbvhjf336i8";
+  cargoSha256 = "13mk86d8ql2196039qb7z0rx4svwffw1mzpiyxp35gg5fhcphriq";
 
   RUSTC_BOOTSTRAP = 1;
 


### PR DESCRIPTION
Infra upgrade as part of #79975; no functional change expected.