### PR TITLE
[20.03] ion: mark as broken

### DIFF
--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -21,10 +21,12 @@ buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin;
+    # This has not had a release since 2017, and no longer compiles with the
+    # latest Rust compiler.
+    broken = false;
   };
 
   passthru = {
-	  shellPath = "/bin/ion";
+    shellPath = "/bin/ion";
   };
 }


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/82016

ZHF: #80379

(cherry picked from commit d5d648b0f6178dfe03d902bfaf94585b4f85bf7b)