### PR TITLE
androidenv: use runtimeShell instead of stdenv.shell

### DIFF
--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -15,7 +15,7 @@ rec {
   };
 
   emulateApp = import ./emulate-app.nix {
-    inherit (pkgs) stdenv lib;
+    inherit (pkgs) stdenv lib runtimeShell;
     inherit composeAndroidPackages;
   };
 

--- a/pkgs/development/mobile/androidenv/emulate-app.nix
+++ b/pkgs/development/mobile/androidenv/emulate-app.nix
@@ -1,4 +1,4 @@
-{ composeAndroidPackages, stdenv, lib }:
+{ composeAndroidPackages, stdenv, lib, runtimeShell }:
 { name, app ? null
 , platformVersion ? "16", abiVersion ? "armeabi-v7a", systemImageType ? "default"
 , enableGPU ? false, extraAVDFiles ? []
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
 
     cat > $out/bin/run-test-emulator << "EOF"
-    #! ${stdenv.shell} -e
+    #!${runtimeShell} -e
 
     # We need a TMPDIR
     if [ "$TMPDIR" = "" ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

From #56408 :
> Whenever we create scripts that are installed to $out, we must use runtimeShell
> in order to get the shell that can be executed on the machine we create the
> package for. This is relevant for cross-compiling. The only use case for
> stdenv.shell are scripts that are executed as part of the build system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I smoke tested this alongside [another change I made](https://github.com/NixOS/nixpkgs/pull/82118#issuecomment-596728121). I hope this is sufficient, please advise me otherwise.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
     - Ubuntu Bionic on Travis CI.  
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date - **Not applicable**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
