### PR TITLE
FreeBSD packages: Init at 13.1

### DIFF
--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -44,8 +44,8 @@ $ nix-env -qa hello --json
                 "mips32-linux",
                 "x86_64-darwin",
                 "i686-cygwin",
-                "i686-freebsd",
-                "x86_64-freebsd",
+                "i686-freebsd13",
+                "x86_64-freebsd13",
                 "i686-openbsd",
                 "x86_64-openbsd"
             ],

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -47,9 +47,10 @@ rec {
         else if final.isUClibc              then "uclibc"
         else if final.isAndroid             then "bionic"
         else if final.isLinux /* default */ then "glibc"
+        else if final.isFreeBSD             then "fblibc"
+        else if final.isNetBSD              then "nblibc"
         else if final.isAvr                 then "avrlibc"
         else if final.isNone                then "newlib"
-        else if final.isNetBSD              then "nblibc"
         # TODO(@Ericson2314) think more about other operating systems
         else                                     "native/impure";
       # Choose what linker we wish to use by default. Someday we might also

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -13,7 +13,7 @@ let
     "x86_64-darwin" "i686-darwin" "aarch64-darwin" "armv7a-darwin"
 
     # FreeBSD
-    "i686-freebsd" "x86_64-freebsd"
+    "i686-freebsd13" "x86_64-freebsd13"
 
     # Genode
     "aarch64-genode" "i686-genode" "x86_64-genode"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -305,13 +305,11 @@ rec {
 
   x86_64-netbsd = {
     config = "x86_64-unknown-netbsd";
-    libc = "nblibc";
   };
 
   # this is broken and never worked fully
   x86_64-netbsd-llvm = {
     config = "x86_64-unknown-netbsd";
-    libc = "nblibc";
     useLLVM = true;
   };
 

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -303,6 +303,11 @@ rec {
 
   # BSDs
 
+  x86_64-freebsd = {
+    config = "x86_64-unknown-freebsd13";
+    useLLVM = true;
+  };
+
   x86_64-netbsd = {
     config = "x86_64-unknown-netbsd";
   };

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -59,7 +59,7 @@ rec {
     isiOS          = { kernel = kernels.ios; };
     isLinux        = { kernel = kernels.linux; };
     isSunOS        = { kernel = kernels.solaris; };
-    isFreeBSD      = { kernel = kernels.freebsd; };
+    isFreeBSD      = { kernel = { name = "freebsd"; }; };
     isNetBSD       = { kernel = kernels.netbsd; };
     isOpenBSD      = { kernel = kernels.openbsd; };
     isWindows      = { kernel = kernels.windows; };

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -16,17 +16,17 @@ with lib.systems.doubles; lib.runTests {
   testall = mseteq all (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ wasi ++ windows ++ embedded ++ mmix ++ js ++ genode ++ redox);
 
   testarm = mseteq arm [ "armv5tel-linux" "armv6l-linux" "armv6l-netbsd" "armv6l-none" "armv7a-linux" "armv7a-netbsd" "armv7l-linux" "armv7l-netbsd" "arm-none" "armv7a-darwin" ];
-  testi686 = mseteq i686 [ "i686-linux" "i686-freebsd" "i686-genode" "i686-netbsd" "i686-openbsd" "i686-cygwin" "i686-windows" "i686-none" "i686-darwin" ];
+  testi686 = mseteq i686 [ "i686-linux" "i686-freebsd13" "i686-genode" "i686-netbsd" "i686-openbsd" "i686-cygwin" "i686-windows" "i686-none" "i686-darwin" ];
   testmips = mseteq mips [ "mips64el-linux" "mipsel-linux" "mipsel-netbsd" ];
   testmmix = mseteq mmix [ "mmix-mmixware" ];
   testriscv = mseteq riscv [ "riscv32-linux" "riscv64-linux" "riscv32-netbsd" "riscv64-netbsd" "riscv32-none" "riscv64-none" ];
   testriscv32 = mseteq riscv32 [ "riscv32-linux" "riscv32-netbsd" "riscv32-none" ];
   testriscv64 = mseteq riscv64 [ "riscv64-linux" "riscv64-netbsd" "riscv64-none" ];
-  testx86_64 = mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-genode" "x86_64-redox" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" "x86_64-windows" "x86_64-none" ];
+  testx86_64 = mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd13" "x86_64-genode" "x86_64-redox" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" "x86_64-windows" "x86_64-none" ];
 
   testcygwin = mseteq cygwin [ "i686-cygwin" "x86_64-cygwin" ];
   testdarwin = mseteq darwin [ "x86_64-darwin" "i686-darwin" "aarch64-darwin" "armv7a-darwin" ];
-  testfreebsd = mseteq freebsd [ "i686-freebsd" "x86_64-freebsd" ];
+  testfreebsd = mseteq freebsd [ "i686-freebsd13" "x86_64-freebsd13" ];
   testgenode = mseteq genode [ "aarch64-genode" "i686-genode" "x86_64-genode" ];
   testredox = mseteq redox [ "x86_64-redox" ];
   testgnu = mseteq gnu (linux /* ++ kfreebsd ++ ... */);

--- a/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi, libxcrypt }:
+{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi, libxcrypt
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
+}:
 
 let
 
@@ -99,6 +101,8 @@ stdenv.mkDerivation {
     for f in $out/lib/*/*builtins-i?86*; do
       ln -s "$f" $(echo "$f" | sed -e 's/builtins-i.86/builtins-i386/')
     done
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -156,7 +156,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
         echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
-      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
+      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && stdenv.targetPlatform.useLLVM or false) ''
         echo "-lunwind" >> $out/nix-support/cc-ldflags
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags

--- a/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;
+  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isWasm) libunwind;
 
   cmakeFlags = lib.optionals (stdenv.hostPlatform.useLLVM or false) [
     "-DLLVM_ENABLE_LIBCXX=ON"

--- a/pkgs/development/compilers/llvm/11/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/11/compiler-rt/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, xcbuild, libllvm, libcxxabi, libxcrypt }:
+{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, xcbuild, libllvm, libcxxabi, libxcrypt
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
+}:
 
 let
 
@@ -108,6 +110,8 @@ stdenv.mkDerivation {
     for f in $out/lib/*/*builtins-i?86*; do
       ln -s "$f" $(echo "$f" | sed -e 's/builtins-i.86/builtins-i386/')
     done
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/11/default.nix
+++ b/pkgs/development/compilers/llvm/11/default.nix
@@ -172,7 +172,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
         echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
-      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
+      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && stdenv.targetPlatform.useLLVM or false) ''
         echo "-lunwind" >> $out/nix-support/cc-ldflags
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags

--- a/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, llvm_meta, cmake, fetch, libcxx, libunwind, llvm, version
 , enableShared ? !stdenv.hostPlatform.isStatic
 , standalone ? stdenv.hostPlatform.useLLVM or false
-, withLibunwind ? !stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm
+, withLibunwind ? !stdenv.isDarwin && !stdenv.hostPlatform.isWasm
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/12/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/12/compiler-rt/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, xcbuild, libllvm, libcxxabi, libxcrypt }:
+{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, xcbuild, libllvm, libcxxabi, libxcrypt
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
+}:
 
 let
 
@@ -94,6 +96,8 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -163,7 +163,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
         echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
-      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
+      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && stdenv.targetPlatform.useLLVM or false) ''
         echo "-lunwind" >> $out/nix-support/cc-ldflags
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags

--- a/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, llvm_meta, cmake, python3, fetch, libcxx, libunwind, llvm, version
 , enableShared ? !stdenv.hostPlatform.isStatic
 , standalone ? stdenv.hostPlatform.useLLVM or false
-, withLibunwind ? !stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm
+, withLibunwind ? !stdenv.isDarwin && !stdenv.hostPlatform.isWasm
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvm_meta, version, src, cmake, python3, xcbuild, libllvm, libcxxabi, libxcrypt }:
+{ lib, stdenv, llvm_meta, version, src, cmake, python3, xcbuild, libllvm, libcxxabi, libxcrypt
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
+}:
 
 let
 
@@ -99,6 +101,8 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/13/default.nix
+++ b/pkgs/development/compilers/llvm/13/default.nix
@@ -163,7 +163,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
         echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
-      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
+      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && stdenv.targetPlatform.useLLVM or false) ''
         echo "-lunwind" >> $out/nix-support/cc-ldflags
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags

--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, llvm_meta, cmake, python3, src, cxx-headers, libunwind, version
 , enableShared ? !stdenv.hostPlatform.isStatic
 , standalone ? stdenv.hostPlatform.useLLVM or false
-, withLibunwind ? !stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm
+, withLibunwind ? !stdenv.isDarwin && !stdenv.hostPlatform.isWasm
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/llvm/14/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/14/compiler-rt/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, llvm_meta, version
 , monorepoSrc, runCommand
 , cmake, python3, xcbuild, libllvm, libcxxabi, libxcrypt
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
 }:
 
 let
@@ -110,6 +111,8 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -166,7 +166,7 @@ let
         ]
         ++ lib.optional (!stdenv.targetPlatform.isWasm) "--unwindlib=libunwind"
         ++ lib.optional
-          (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false)
+          (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && stdenv.targetPlatform.useLLVM or false)
           "-lunwind"
         ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
     };

--- a/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake python3 ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;
+  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isWasm) libunwind;
 
   cmakeFlags = [
     "-DLIBCXXABI_LIBCXX_INCLUDES=${cxx-headers}/include/c++/v1"

--- a/pkgs/development/compilers/llvm/5/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi }:
+{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
+}:
 
 let
 
@@ -86,6 +88,8 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/linux/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/linux/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/linux/crtendS.o
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/freebsd/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
+  buildInputs = lib.optional (!stdenv.isDarwin) libunwind;
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do

--- a/pkgs/development/compilers/llvm/6/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/6/compiler-rt/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi }:
+{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
+}:
 
 let
 
@@ -86,6 +88,8 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/linux/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/linux/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/linux/crtendS.o
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/freebsd/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
+  buildInputs = lib.optional (!stdenv.isDarwin) libunwind;
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do

--- a/pkgs/development/compilers/llvm/7/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi }:
+{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
+}:
 
 let
 
@@ -89,6 +91,8 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -163,7 +163,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
         echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
-      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
+      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && stdenv.targetPlatform.useLLVM or false) ''
         echo "-lunwind" >> $out/nix-support/cc-ldflags
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags

--- a/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, llvm_meta, cmake, fetch, libcxx, libunwind, llvm, version
 , fetchpatch
 , standalone ? stdenv.hostPlatform.useLLVM or false
-, withLibunwind ? !stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm
+, withLibunwind ? !stdenv.isDarwin && !stdenv.hostPlatform.isWasm
   # on musl the shared objects don't build
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:

--- a/pkgs/development/compilers/llvm/8/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi }:
+{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
+}:
 
 let
 
@@ -89,6 +91,8 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -164,7 +164,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
         echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
-      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
+      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && stdenv.targetPlatform.useLLVM or false) ''
         echo "-lunwind" >> $out/nix-support/cc-ldflags
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags

--- a/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;
+  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isWasm) libunwind;
 
   cmakeFlags = lib.optionals (stdenv.hostPlatform.useLLVM or false) [
     "-DLLVM_ENABLE_LIBCXX=ON"

--- a/pkgs/development/compilers/llvm/9/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/9/compiler-rt/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi }:
+{ lib, stdenv, llvm_meta, version, fetch, cmake, python3, libllvm, libcxxabi
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
+}:
 
 let
 
@@ -88,6 +90,8 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/9/default.nix
+++ b/pkgs/development/compilers/llvm/9/default.nix
@@ -164,7 +164,7 @@ let
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
       '' + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
         echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
-      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
+      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && stdenv.targetPlatform.useLLVM or false) ''
         echo "-lunwind" >> $out/nix-support/cc-ldflags
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags

--- a/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;
+  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isWasm) libunwind;
 
   cmakeFlags = lib.optionals (stdenv.hostPlatform.useLLVM or false) [
     "-DLLVM_ENABLE_LIBCXX=ON"

--- a/pkgs/development/compilers/llvm/git/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/git/compiler-rt/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, llvm_meta, version
 , monorepoSrc, runCommand
 , cmake, python3, xcbuild, libllvm, libcxxabi
+, doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD
 }:
 
 let
@@ -106,6 +107,8 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
+  '' + lib.optionalString doFakeLibgcc ''
+    ln -s $out/lib/freebsd/libclang_rt.builtins-*.a $out/lib/libgcc.a
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/git/default.nix
+++ b/pkgs/development/compilers/llvm/git/default.nix
@@ -166,7 +166,7 @@ let
         ]
         ++ lib.optional (!stdenv.targetPlatform.isWasm) "--unwindlib=libunwind"
         ++ lib.optional
-          (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false)
+          (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && stdenv.targetPlatform.useLLVM or false)
           "-lunwind"
         ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
     };

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake python3 ];
-  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;
+  buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isWasm) libunwind;
 
   cmakeFlags = [
     "-DLLVM_ENABLE_RUNTIMES=libcxxabi"

--- a/pkgs/os-specific/bsd/freebsd/compat-fix-typedefs-locations.patch
+++ b/pkgs/os-specific/bsd/freebsd/compat-fix-typedefs-locations.patch
@@ -1,0 +1,32 @@
+--- a/tools/build/cross-build/include/common/sys/_types.h
++++ b/tools/build/cross-build/include/common/sys/_types.h
+@@ -47,3 +47,6 @@
+  * Neither GLibc nor macOS define __va_list but many FreeBSD headers require it.
+  */
+ typedef __builtin_va_list __va_list;
++
++typedef __UINTPTR_TYPE__ __uintptr_t;
++typedef __INTPTR_TYPE__ __intptr_t;
+--- a/tools/build/cross-build/include/common/sys/types.h
++++ b/tools/build/cross-build/include/common/sys/types.h
+@@ -49,9 +49,6 @@
+ #include <sys/sysmacros.h>
+ #endif
+ 
+-typedef __UINTPTR_TYPE__ __uintptr_t;
+-typedef __INTPTR_TYPE__ __intptr_t;
+-
+ /* needed for gencat */
+ typedef int __nl_item;
+ 
+--- a/tools/build/cross-build/include/linux/sys/types.h
++++ b/tools/build/cross-build/include/linux/sys/types.h
+@@ -39,6 +39,8 @@
+ 
+ #include_next <sys/types.h>
+ 
++#include <sys/_types.h>
++
+ #ifndef __size_t
+ typedef __SIZE_TYPE__ __size_t;
+ #endif

--- a/pkgs/os-specific/bsd/freebsd/compat-install-dirs.patch
+++ b/pkgs/os-specific/bsd/freebsd/compat-install-dirs.patch
@@ -1,0 +1,42 @@
+diff --git a/tools/build/Makefile b/tools/build/Makefile
+index 948a5f9dfdb..592af84eeae 100644
+--- a/tools/build/Makefile
++++ b/tools/build/Makefile
+@@ -327,15 +327,15 @@ host-symlinks:
+ # and cross-tools stages. We do this here using mkdir since mtree may not exist
+ # yet (this happens if we are crossbuilding from Linux/Mac).
+ INSTALLDIR_LIST= \
+-	bin \
+-	lib/casper \
+-	lib/geom \
+-	usr/include/casper \
+-	usr/include/private/ucl \
+-	usr/include/private/zstd \
+-	usr/lib \
+-	usr/libdata/pkgconfig \
+-	usr/libexec
++	${BINDIR} \
++	${LIBDIR}/casper \
++	${LIBDIR}/geom \
++	${INCLUDEDIR}/casper \
++	${INCLUDEDIR}/private/ucl \
++	${INCLUDEDIR}/private/zstd \
++	${LIBDIR} \
++	${LIBDIR}/libdata/pkgconfig \
++	${LIBEXECDIR}
+ 
+ installdirs:
+ 	mkdir -p ${INSTALLDIR_LIST:S,^,${DESTDIR}/,}
+@@ -352,9 +352,9 @@ installdirs:
+ 	    rm -rf "${DESTDIR}/${_dir}"; \
+ 	fi
+ .endfor
+-	ln -sfn bin ${DESTDIR}/sbin
+-	ln -sfn ../bin ${DESTDIR}/usr/bin
+-	ln -sfn ../bin ${DESTDIR}/usr/sbin
++	ln -sfn bin ${DESTDIR}/${SBINDIR}
++	ln -sfn ../bin ${DESTDIR}/${BINDIR}
++	ln -sfn ../bin ${DESTDIR}/${SBINDIR}
+ .for _group in ${INCSGROUPS:NINCS}
+ 	mkdir -p "${DESTDIR}/${${_group}DIR}"
+ .endfor

--- a/pkgs/os-specific/bsd/freebsd/compat-setup-hook.sh
+++ b/pkgs/os-specific/bsd/freebsd/compat-setup-hook.sh
@@ -1,0 +1,6 @@
+# See pkgs/build-support/setup-hooks/role.bash
+getHostRole
+
+export NIX_LDFLAGS${role_post}+=" -legacy"
+export NIX_CFLAGS_COMPILE${role_post}+=" -isystem @out@/0-include"
+export NIX_CFLAGS_COMPILE${role_post}+=" -isystem @out@/1-include"

--- a/pkgs/os-specific/bsd/freebsd/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/default.nix
@@ -1,0 +1,900 @@
+{ stdenv, lib, stdenvNoCC
+, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget, pkgsHostHost, pkgsTargetTarget
+, buildPackages, splicePackages, newScope
+, bsdSetupHook, makeSetupHook
+, fetchgit, fetchurl, coreutils, groff, mandoc, byacc, flex, which, m4, gawk, substituteAll, runtimeShell
+, zlib, expat, libmd
+, runCommand, writeShellScript, writeText, symlinkJoin
+}:
+
+let
+  inherit (buildPackages.buildPackages) rsync;
+
+  version = "13.1.0";
+
+  # `BuildPackages.fetchgit` avoids some probably splicing-caused infinite
+  # recursion.
+  freebsdSrc = buildPackages.fetchgit {
+    url = "https://git.FreeBSD.org/src.git";
+    rev = "release/${version}";
+    sha256 = "14nhk0kls83xfb64d5xy14vpi6k8laswjycjg80indq9pkcr2rlv";
+  };
+
+  freebsdSetupHook = makeSetupHook {
+    name = "freebsd-setup-hook";
+  } ./setup-hook.sh;
+
+  otherSplices = {
+    selfBuildBuild = pkgsBuildBuild.freebsd;
+    selfBuildHost = pkgsBuildHost.freebsd;
+    selfBuildTarget = pkgsBuildTarget.freebsd;
+    selfHostHost = pkgsHostHost.freebsd;
+    selfTargetTarget = pkgsTargetTarget.freebsd or {}; # might be missing
+  };
+
+  mkBsdArch = stdenv':  {
+    x86_64 = "amd64";
+    aarch64 = "arm64";
+    i486 = "i386";
+    i586 = "i386";
+    i686 = "i386";
+  }.${stdenv'.hostPlatform.parsed.cpu.name}
+    or stdenv'.hostPlatform.parsed.cpu.name;
+
+  install-wrapper = ''
+    set -eu
+
+    args=()
+    declare -i path_args=0
+
+    while (( $# )); do
+      if (( $# == 1 )); then
+        if (( path_args > 1)) || [[ "$1" = */ ]]; then
+          mkdir -p "$1"
+        else
+          mkdir -p "$(dirname "$1")"
+        fi
+      fi
+      case $1 in
+        -C) ;;
+        -o | -g) shift ;;
+        -s) ;;
+        -m | -l)
+          # handle next arg so not counted as path arg
+          args+=("$1" "$2")
+          shift
+          ;;
+        -*) args+=("$1") ;;
+        *)
+          path_args+=1
+          args+=("$1")
+          ;;
+      esac
+      shift
+    done
+  '';
+
+in lib.makeScopeWithSplicing
+  splicePackages
+  newScope
+  otherSplices
+  (_: {})
+  (_: {})
+  (self: let
+    inherit (self) mkDerivation;
+  in {
+  inherit freebsdSrc;
+
+  # Why do we have splicing and yet do `nativeBuildInputs = with self; ...`?
+  # See note in ../netbsd/default.nix.
+
+  compatIfNeeded = lib.optional (!stdenvNoCC.hostPlatform.isFreeBSD) self.compat;
+
+  mkDerivation = lib.makeOverridable (attrs: let
+    stdenv' = if attrs.noCC or false then stdenvNoCC else stdenv;
+  in stdenv'.mkDerivation (rec {
+    pname = "${attrs.pname or (baseNameOf attrs.path)}-freebsd";
+    inherit version;
+    src = runCommand "${pname}-filtered-src" {
+      nativeBuildInputs = [ rsync ];
+    } ''
+      for p in ${lib.concatStringsSep " " ([ attrs.path ] ++ attrs.extraPaths or [])}; do
+        set -x
+        path="$out/$p"
+        mkdir -p "$(dirname "$path")"
+        src_path="${freebsdSrc}/$p"
+        if [[ -d "$src_path" ]]; then src_path+=/; fi
+        rsync --chmod="+w" -r "$src_path" "$path"
+        set +x
+      done
+    '';
+
+    extraPaths = [ ];
+
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal
+      install tsort lorder mandoc groff #statHook
+    ];
+    buildInputs = with self; compatIfNeeded;
+
+    HOST_SH = stdenv'.shell;
+
+    # Since STRIP below is the flag
+    STRIPBIN = "${stdenv.cc.bintools.targetPrefix}strip";
+
+    makeFlags = [
+      "STRIP=-s" # flag to install, not command
+    ] ++ lib.optional (!stdenv.hostPlatform.isFreeBSD) "MK_WERROR=no";
+
+    # amd64 not x86_64 for this on unlike NetBSD
+    MACHINE_ARCH = mkBsdArch stdenv';
+
+    MACHINE = mkBsdArch stdenv';
+
+    MACHINE_CPUARCH = MACHINE_ARCH;
+
+    COMPONENT_PATH = attrs.path or null;
+
+    strictDeps = true;
+
+    meta = with lib; {
+      maintainers = with maintainers; [ ericson2314 ];
+      platforms = platforms.unix;
+      license = licenses.bsd2;
+    };
+  } // lib.optionalAttrs stdenv'.hasCC {
+    # TODO should CC wrapper set this?
+    CPP = "${stdenv'.cc.targetPrefix}cpp";
+  } // lib.optionalAttrs stdenv'.isDarwin {
+    MKRELRO = "no";
+  } // lib.optionalAttrs (stdenv'.cc.isClang or false) {
+    HAVE_LLVM = lib.versions.major (lib.getVersion stdenv'.cc.cc);
+  } // lib.optionalAttrs (stdenv'.cc.isGNU or false) {
+    HAVE_GCC = lib.versions.major (lib.getVersion stdenv'.cc.cc);
+  } // lib.optionalAttrs (stdenv'.isx86_32) {
+    USE_SSP = "no";
+  } // lib.optionalAttrs (attrs.headersOnly or false) {
+    installPhase = "includesPhase";
+    dontBuild = true;
+  } // attrs));
+
+  ##
+  ## START BOOTSTRAPPING
+  ##
+  makeMinimal = mkDerivation rec {
+    inherit (self.make) path;
+
+    buildInputs = with self; [];
+    nativeBuildInputs = with buildPackages.netbsd; [ bsdSetupHook freebsdSetupHook ];
+
+    skipIncludesPhase = true;
+
+    makeFlags = [];
+
+    postPatch = ''
+      patchShebangs configure
+      ${self.make.postPatch}
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+
+      sh ./make-bootstrap.sh
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      install -D bmake "$out/bin/bmake"
+      ln -s "$out/bin/bmake" "$out/bin/make"
+      mkdir -p "$out/share"
+      cp -r "$BSDSRCDIR/share/mk" "$out/share/mk"
+      find "$out/share/mk" -type f -print0 |
+        while IFS= read -r -d "" f; do
+          substituteInPlace "$f" --replace 'usr/' ""
+        done
+      substituteInPlace "$out/share/mk/bsd.symver.mk" \
+        --replace '/share/mk' "$out/share/mk"
+
+      runHook postInstall
+    '';
+
+    postInstall = lib.optionalString (!stdenv.targetPlatform.isFreeBSD) ''
+      boot_mk="$BSDSRCDIR/tools/build/mk"
+      cp "$boot_mk"/Makefile.boot* "$out/share/mk"
+      replaced_mk="$out/share/mk.orig"
+      mkdir "$replaced_mk"
+      mv "$out"/share/mk/bsd.{lib,prog}.mk "$replaced_mk"
+      for m in bsd.{lib,prog}.mk; do
+        cp "$boot_mk/$m" "$out/share/mk"
+        substituteInPlace "$out/share/mk/$m" --replace '../../../share/mk' '../mk.orig'
+      done
+    '';
+
+    extraPaths = with self; make.extraPaths;
+  };
+
+  # Wrap NetBSD's install
+  boot-install = buildPackages.writeShellScriptBin "boot-install" (install-wrapper + ''
+
+    ${buildPackages.netbsd.install}/bin/xinstall "''${args[@]}"
+  '');
+
+  compat = mkDerivation rec {
+    pname = "compat";
+    path = "tools/build";
+    extraPaths = [
+      "lib/libc/db"
+      "lib/libc/stdlib" # getopt
+      "lib/libc/gen" # getcap
+      "lib/libc/locale" # rpmatch
+    ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "lib/libc/string" # strlcpy
+      "lib/libutil"
+    ] ++ [
+      "contrib/libc-pwcache"
+      "contrib/libc-vis"
+      "sys/libkern"
+      "sys/kern/subr_capability.c"
+
+      # Take only individual headers, or else we will clobber native libc, etc.
+
+      "sys/rpc/types.h"
+
+      # Listed in Makekfile as INC
+      "include/mpool.h"
+      "include/ndbm.h"
+      "include/err.h"
+      "include/stringlist.h"
+      "include/a.out.h"
+      "include/nlist.h"
+      "include/db.h"
+      "include/getopt.h"
+      "include/nl_types.h"
+      "include/elf.h"
+      "sys/sys/ctf.h"
+
+      # Listed in Makekfile as SYSINC
+
+      "sys/sys/capsicum.h"
+      "sys/sys/caprights.h"
+      "sys/sys/imgact_aout.h"
+      "sys/sys/nlist_aout.h"
+      "sys/sys/nv.h"
+      "sys/sys/dnv.h"
+      "sys/sys/cnv.h"
+
+      "sys/sys/elf32.h"
+      "sys/sys/elf64.h"
+      "sys/sys/elf_common.h"
+      "sys/sys/elf_generic.h"
+      "sys/${mkBsdArch stdenv}/include"
+    ] ++ lib.optionals stdenv.hostPlatform.isx86 [
+      "sys/x86/include"
+    ] ++ [
+
+      "sys/sys/queue.h"
+      "sys/sys/md5.h"
+      "sys/sys/sbuf.h"
+      "sys/sys/tree.h"
+      "sys/sys/font.h"
+      "sys/sys/consio.h"
+      "sys/sys/fnv_hash.h"
+
+      "sys/crypto/chacha20/_chacha.h"
+      "sys/crypto/chacha20/chacha.h"
+      # included too, despite ".c"
+      "sys/crypto/chacha20/chacha.c"
+
+      "sys/fs"
+      "sys/ufs"
+      "sys/sys/disk"
+
+      "lib/libcapsicum"
+      "lib/libcasper"
+    ];
+
+    patches = [
+      ./compat-install-dirs.patch
+      ./compat-fix-typedefs-locations.patch
+    ];
+
+    preBuild = ''
+      NIX_CFLAGS_COMPILE+=' -I../../include -I../../sys'
+
+      cp ../../sys/${mkBsdArch stdenv}/include/elf.h ../../sys/sys
+      cp ../../sys/${mkBsdArch stdenv}/include/elf.h ../../sys/sys/${mkBsdArch stdenv}
+    '' + lib.optionalString stdenv.hostPlatform.isx86 ''
+      cp ../../sys/x86/include/elf.h ../../sys/x86
+    '';
+
+    setupHooks = [
+      ../../../build-support/setup-hooks/role.bash
+      ./compat-setup-hook.sh
+    ];
+
+    # This one has an ifdefed `#include_next` that makes it annoying.
+    postInstall = ''
+      rm ''${!outputDev}/0-include/libelf.h
+    '';
+
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal
+      boot-install
+
+      which
+    ];
+    buildInputs = [ expat zlib ];
+
+    makeFlags = [
+      "STRIP=-s" # flag to install, not command
+      "MK_WERROR=no"
+      "HOST_INCLUDE_ROOT=${lib.getDev stdenv.cc.libc}/include"
+      "INSTALL=boot-install"
+    ];
+
+    preIncludes = ''
+      mkdir -p $out/{0,1}-include
+      cp --no-preserve=mode -r cross-build/include/common/* $out/0-include
+    '' + lib.optionalString stdenv.hostPlatform.isLinux ''
+      cp --no-preserve=mode -r cross-build/include/linux/* $out/1-include
+    '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      cp --no-preserve=mode -r cross-build/include/darwin/* $out/1-include
+    '';
+  };
+
+  libnetbsd = mkDerivation {
+    path = "lib/libnetbsd";
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal mandoc groff
+      (if stdenv.hostPlatform == stdenv.buildPlatform
+       then boot-install
+       else install)
+    ];
+    patches = lib.optionals (!stdenv.hostPlatform.isFreeBSD) [
+      ./libnetbsd-do-install.patch
+      #./libnetbsd-define-__va_list.patch
+    ];
+    makeFlags = [
+      "STRIP=-s" # flag to install, not command
+      "MK_WERROR=no"
+    ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "INSTALL=boot-install";
+    buildInputs = with self; compatIfNeeded;
+  };
+
+  # HACK: to ensure parent directories exist. This emulates GNU
+  # install’s -D option. No alternative seems to exist in BSD install.
+  install = let binstall = writeShellScript "binstall" (install-wrapper + ''
+
+    @out@/bin/xinstall "''${args[@]}"
+  ''); in mkDerivation {
+    path = "usr.bin/xinstall";
+    extraPaths = with self; [ mtree.path ];
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal mandoc groff
+      (if stdenv.hostPlatform == stdenv.buildPlatform
+       then boot-install
+       else install)
+    ];
+    skipIncludesPhase = true;
+    buildInputs = with self; compatIfNeeded ++ [ libmd libnetbsd ];
+    makeFlags = [
+      "STRIP=-s" # flag to install, not command
+      "MK_WERROR=no"
+      "TESTSDIR=${builtins.placeholder "test"}"
+    ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "INSTALL=boot-install";
+    postInstall = ''
+      install -D -m 0550 ${binstall} $out/bin/binstall
+      substituteInPlace $out/bin/binstall --subst-var out
+      mv $out/bin/install $out/bin/xinstall
+      ln -s ./binstall $out/bin/install
+    '';
+    outputs = [ "out" "man" "test" ];
+  };
+
+  # Don't add this to nativeBuildInputs directly.  Use statHook instead.
+  stat = mkDerivation {
+    path = "usr.bin/stat";
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal install mandoc groff
+    ];
+  };
+
+  # stat isn't in POSIX, and NetBSD stat supports a completely
+  # different range of flags than GNU stat, so including it in PATH
+  # breaks stdenv.  Work around that with a hook that will point
+  # NetBSD's build system and NetBSD stat without including it in
+  # PATH.
+  statHook = makeSetupHook {
+    name = "netbsd-stat-hook";
+  } (writeText "netbsd-stat-hook-impl" ''
+    makeFlagsArray+=(TOOL_STAT=${self.stat}/bin/stat)
+  '');
+
+  tsort = mkDerivation {
+    path = "usr.bin/tsort";
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal install mandoc groff
+    ];
+  };
+
+  lorder = mkDerivation rec {
+    path = "usr.bin/lorder";
+    noCC = true;
+    dontBuild = true;
+    installPhase = ''
+      mkdir -p "$out/bin" "$man/share/man"
+      mv "lorder.sh" "$out/bin/lorder"
+      chmod +x "$out/bin/lorder"
+      mv "lorder.1" "$man/share/man"
+    '';
+    nativeBuildInputs = [ bsdSetupHook freebsdSetupHook ];
+    buildInputs = [];
+    outputs = [ "out" "man" ];
+  };
+
+  ##
+  ## END BOOTSTRAPPING
+  ##
+
+  ##
+  ## START COMMAND LINE TOOLS
+  ##
+  make = mkDerivation {
+    path = "contrib/bmake";
+    version = "9.2";
+    postPatch = ''
+      # make needs this to pick up our sys make files
+      export NIX_CFLAGS_COMPILE+=" -D_PATH_DEFSYSPATH=\"$out/share/mk\""
+
+    '' + lib.optionalString stdenv.isDarwin ''
+      substituteInPlace $BSDSRCDIR/share/mk/bsd.sys.mk \
+        --replace '-Wl,--fatal-warnings' "" \
+        --replace '-Wl,--warn-shared-textrel' ""
+    '';
+    postInstall = ''
+      make -C $BSDSRCDIR/share/mk FILESDIR=$out/share/mk install
+    '';
+    extraPaths = [ "share/mk" ]
+      ++ lib.optional (!stdenv.hostPlatform.isFreeBSD) "tools/build/mk";
+  };
+  mtree = mkDerivation {
+    path = "contrib/mtree";
+    extraPaths = with self; [ mknod.path ];
+  };
+
+  mknod = mkDerivation {
+    path = "sbin/mknod";
+  };
+
+  rpcgen = mkDerivation rec {
+    path = "usr.bin/rpcgen";
+    patches = lib.optionals (stdenv.hostPlatform.libc == "glibc") [
+      # `WUNTRACED` is defined privately `bits/waitflags.h` in glibc.
+      # But instead of having a regular header guard, it has some silly
+      # non-modular logic. `stdlib.h` will include it if `sys/wait.h`
+      # hasn't yet been included (for it would first), and vice versa.
+      #
+      # The problem is that with the FreeBSD compat headers, one of
+      # those headers ends up included other headers...which ends up
+      # including the other one, this means by the first time we reach
+      # `#include `<bits/waitflags.h>`, both `_SYS_WAIT_H` and
+      # `_STDLIB_H` are already defined! Thus, we never ned up including
+      # `<bits/waitflags.h>` and defining `WUNTRACED`.
+      #
+      # This hacks around this by manually including `WUNTRACED` until
+      # the problem is fixed properly in glibc.
+      ./rpcgen-glibc-hack.patch
+    ];
+  };
+
+  gencat = mkDerivation {
+    path = "usr.bin/gencat";
+  };
+
+  file2c = mkDerivation {
+    path = "usr.bin/file2c";
+    MK_TESTS = "no";
+  };
+
+  libnv = mkDerivation {
+    path = "lib/libnv";
+    extraPaths = [
+      "sys/contrib/libnv"
+      "sys/sys"
+    ];
+    MK_TESTS = "no";
+  };
+
+  libsbuf = mkDerivation {
+    path = "lib/libsbuf";
+    extraPaths = [
+      "sys/kern"
+    ];
+    MK_TESTS = "no";
+  };
+
+  libelf = mkDerivation {
+    path = "lib/libelf";
+    extraPaths = [
+      "contrib/elftoolchain/libelf"
+      "contrib/elftoolchain/common"
+      "sys/sys/elf32.h"
+      "sys/sys/elf64.h"
+      "sys/sys/elf_common.h"
+    ];
+    BOOTSTRAPPING = !stdenv.isFreeBSD;
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal install mandoc groff
+
+      m4
+    ];
+    MK_TESTS = "no";
+  };
+
+  libdwarf = mkDerivation {
+    path = "lib/libdwarf";
+    extraPaths = [
+      "contrib/elftoolchain/libdwarf"
+      "contrib/elftoolchain/common"
+      "sys/sys/elf32.h"
+      "sys/sys/elf64.h"
+      "sys/sys/elf_common.h"
+    ];
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal install mandoc groff
+
+      m4
+    ];
+    buildInputs = with self; compatIfNeeded ++ [
+      libelf
+    ];
+    MK_TESTS = "no";
+  };
+
+  uudecode = mkDerivation {
+    path = "usr.bin/uudecode";
+    MK_TESTS = "no";
+  };
+
+  config = mkDerivation {
+    path = "usr.sbin/config";
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal install mandoc groff
+
+      flex byacc file2c
+    ];
+    buildInputs = with self; compatIfNeeded ++ [ libnv libsbuf ];
+  };
+  ##
+  ## END COMMAND LINE TOOLS
+  ##
+
+  ##
+  ## START HEADERS
+  ##
+  include = mkDerivation {
+    path = "include";
+
+    extraPaths = [
+      "contrib/libc-vis"
+      "etc/mtree/BSD.include.dist"
+      "sys"
+    ];
+
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal
+      install
+      mandoc groff rsync /*nbperf*/ rpcgen
+
+      # HACK use NetBSD's for now
+      buildPackages.netbsd.mtree
+    ];
+
+    patches = [
+      ./no-perms-BSD.include.dist.patch
+    ];
+
+    # The makefiles define INCSDIR per subdirectory, so we have to set
+    # something else on the command line so those definitions aren't
+    # overridden.
+    postPatch = ''
+      find "$BSDSRCDIR" -name Makefile -exec \
+        sed -i -E \
+          -e 's_/usr/include_''${INCSDIR0}_' \
+          {} \;
+    '';
+
+    makeFlags = [
+      "RPCGEN_CPP=${buildPackages.stdenv.cc.cc}/bin/cpp"
+    ];
+
+    # multiple header dirs, see above
+    postConfigure = ''
+      makeFlags=''${makeFlags/INCSDIR/INCSDIR0}
+    '';
+
+    headersOnly = true;
+
+    MK_HESIOD = "yes";
+
+    meta.platforms = lib.platforms.freebsd;
+  };
+
+  ##
+  ## END HEADERS
+  ##
+
+  csu = mkDerivation {
+    path = "lib/csu";
+    extraPaths = with self; [
+      "lib/Makefile.inc"
+      "lib/libc/include/libc_private.h"
+    ];
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal
+      install
+
+      flex byacc gencat
+    ];
+    buildInputs = with self; [ include ];
+    MK_TESTS = "no";
+    meta.platforms = lib.platforms.freebsd;
+  };
+
+  libc = mkDerivation rec {
+    pname = "libc";
+    path = "lib/libc";
+    extraPaths = [
+      "etc/group"
+      "etc/master.passwd"
+      "etc/shells"
+      "lib/libmd"
+      "lib/libutil"
+      "lib/msun"
+      "sys/kern"
+      "sys/libkern"
+      "sys/sys"
+      "sys/crypto/chacha20"
+      "include/rpcsvc"
+      "contrib/jemalloc"
+      "contrib/gdtoa"
+      "contrib/libc-pwcache"
+      "contrib/libc-vis"
+      "contrib/tzcode/stdtime"
+
+      # libthr
+      "lib/libthr"
+      "lib/libthread_db"
+      "libexec/rtld-elf"
+
+      # librpcsvc
+      "lib/librpcsvc"
+
+      # librt
+      "lib/librt"
+
+      # libcrypt
+      "lib/libcrypt"
+      "lib/libmd"
+      "sys/crypto/sha2"
+    ];
+
+    patches = [
+      # Hack around broken propogating MAKEFLAGS to submake, just inline logic
+      ./libc-msun-arch-subdir.patch
+
+      # Don't force -lcompiler-rt, we don't actually call it that
+      ./libc-no-force--lcompiler-rt.patch
+
+      # Fix extra include dir to get rpcsvc headers.
+      ./librpcsvc-include-subdir.patch
+    ];
+
+    postPatch = ''
+      substituteInPlace $COMPONENT_PATH/Makefile --replace '.include <src.opts.mk>' ""
+    '';
+
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal
+      install
+
+      flex byacc gencat rpcgen
+    ];
+    buildInputs = with self; [ include csu ];
+    NIX_CFLAGS_COMPILE = "-B${self.csu}/lib";
+
+    makeFlags = [
+      "STRIP=-s" # flag to install, not command
+      # lib/libc/gen/getgrent.c has sketchy cast from `void *` to enum
+      "MK_WERROR=no"
+    ];
+
+    MK_SYMVER = "yes";
+    MK_SSP = "yes";
+    MK_NLS = "yes";
+    MK_ICONV = "no"; # TODO make srctop
+    MK_NS_CACHING = "yes";
+    MK_INET6_SUPPORT = "yes";
+    MK_HESIOD = "yes";
+    MK_NIS = "yes";
+    MK_HYPERV = "yes";
+    MK_FP_LIBC = "yes";
+
+    MK_TCSH = "no";
+    MK_MALLOC_PRODUCTION = "yes";
+
+    MK_TESTS = "no";
+
+    postInstall = ''
+      pushd ${self.include}
+      find . -type d -exec mkdir -p $out/\{} \;
+      find . \( -type f -o -type l \) -exec cp -pr \{} $out/\{} \;
+      popd
+
+      pushd ${self.csu}
+      find . -type d -exec mkdir -p $out/\{} \;
+      find . \( -type f -o -type l \) -exec cp -pr \{} $out/\{} \;
+      popd
+
+      sed -i -e 's| [^ ]*/libc_nonshared.a||' $out/lib/libc.so
+
+      $CC -nodefaultlibs -lgcc -shared -o $out/lib/libgcc_s.so
+
+      NIX_CFLAGS_COMPILE+=" -B$out/lib"
+      NIX_CFLAGS_COMPILE+=" -I$out/include"
+      NIX_LDFLAGS+=" -L$out/lib"
+
+      make -C $BSDSRCDIR/lib/libthr $makeFlags
+      make -C $BSDSRCDIR/lib/libthr $makeFlags install
+
+      make -C $BSDSRCDIR/lib/msun $makeFlags
+      make -C $BSDSRCDIR/lib/msun $makeFlags install
+
+      make -C $BSDSRCDIR/lib/librpcsvc $makeFlags
+      make -C $BSDSRCDIR/lib/librpcsvc $makeFlags install
+
+      make -C $BSDSRCDIR/lib/libutil $makeFlags
+      make -C $BSDSRCDIR/lib/libutil $makeFlags install
+
+      make -C $BSDSRCDIR/lib/librt $makeFlags
+      make -C $BSDSRCDIR/lib/librt $makeFlags install
+
+      make -C $BSDSRCDIR/lib/libcrypt $makeFlags
+      make -C $BSDSRCDIR/lib/libcrypt $makeFlags install
+    '';
+
+    meta.platforms = lib.platforms.freebsd;
+  };
+
+  ##
+  ## Kernel
+  ##
+
+  libspl = mkDerivation {
+    path = "cddl/lib/libspl";
+    extraPaths = [
+      "sys/contrib/openzfs/lib/libspl"
+      "sys/contrib/openzfs/include"
+
+      "cddl/compat/opensolaris/include"
+      "sys/contrib/openzfs/module/icp/include"
+      "sys/modules/zfs"
+    ];
+    # nativeBuildInputs = with buildPackages.freebsd; [
+    #   bsdSetupHook freebsdSetupHook
+    #   makeMinimal install mandoc groff
+
+    #   flex byacc file2c
+    # ];
+    # buildInputs = with self; compatIfNeeded ++ [ libnv libsbuf ];
+    meta.license = lib.licenses.cddl;
+  };
+
+  ctfconvert = mkDerivation {
+    path = "cddl/usr.bin/ctfconvert";
+    extraPaths = [
+      "cddl/compat/opensolaris"
+      "cddl/contrib/opensolaris"
+      "sys/cddl/compat/opensolaris"
+      "sys/cddl/contrib/opensolaris"
+      "sys/contrib/openzfs"
+    ];
+    OPENSOLARIS_USR_DISTDIR = "$(SRCTOP)/cddl/contrib/opensolaris";
+    OPENSOLARIS_SYS_DISTDIR = "$(SRCTOP)/sys/cddl/contrib/opensolaris";
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal install mandoc groff
+
+      # flex byacc file2c
+    ];
+    buildInputs = with self; compatIfNeeded ++ [
+      libelf libdwarf zlib libspl
+    ];
+    meta.license = lib.licenses.cddl;
+  };
+
+  xargs-j = substituteAll {
+    name = "xargs-j";
+    shell = runtimeShell;
+    src = ../xargs-j.sh;
+    dir = "bin";
+    isExecutable = true;
+  };
+
+  sys = mkDerivation (let
+    cfg = "MINIMAL";
+  in rec {
+    path = "sys";
+
+    nativeBuildInputs = with buildPackages.freebsd; [
+      bsdSetupHook freebsdSetupHook
+      makeMinimal install mandoc groff
+
+      config rpcgen file2c gawk uudecode xargs-j
+      #ctfconvert
+    ];
+
+    patches = [
+      ./sys-gnu-date.patch
+      ./sys-no-explicit-intrinsics-dep.patch
+    ];
+
+    # --dynamic-linker /red/herring is used when building the kernel.
+    NIX_ENFORCE_PURITY = 0;
+
+    AWK = "${buildPackages.gawk}/bin/awk";
+
+    CWARNEXTRA = "-Wno-error=shift-negative-value -Wno-address-of-packed-member";
+
+    MK_CTF = "no";
+
+    KODIR = "${builtins.placeholder "out"}/kernel";
+    KMODDIR = "${builtins.placeholder "out"}/kernel";
+    DTBDIR = "${builtins.placeholder"out"}/dbt";
+
+    KERN_DEBUGDIR = "${builtins.placeholder "out"}/debug";
+    KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
+    KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
+
+    skipIncludesPhase = true;
+
+    configurePhase = ''
+      runHook preConfigure
+
+      for f in conf/kmod.mk contrib/dev/acpica/acpica_prep.sh; do
+        substituteInPlace "$f" --replace 'xargs -J' 'xargs-j '
+      done
+
+      for f in conf/*.mk; do
+        substituteInPlace "$f" --replace 'KERN_DEBUGDIR}''${' 'KERN_DEBUGDIR_'
+      done
+
+      cd ${mkBsdArch stdenv}/conf
+      sed -i ${cfg} \
+        -e 's/WITH_CTF=1/WITH_CTF=0/' \
+        -e '/KDTRACE/d'
+      config ${cfg}
+
+      runHook postConfigure
+    '';
+    preBuild = ''
+      cd ../compile/${cfg}
+    '';
+  });
+
+})

--- a/pkgs/os-specific/bsd/freebsd/libc-msun-arch-subdir.patch
+++ b/pkgs/os-specific/bsd/freebsd/libc-msun-arch-subdir.patch
@@ -1,0 +1,11 @@
+--- a/lib/libc/Makefile
++++ b/lib/libc/Makefile
+@@ -194,7 +194,7 @@ SUBDIR.${MK_TESTS}+= tests
+ # recording a build dependency
+ CFLAGS+= -I${SRCTOP}/lib/libutil
+ # Same issue with libm
+-MSUN_ARCH_SUBDIR != ${MAKE} -B -C ${SRCTOP}/lib/msun -V ARCH_SUBDIR
++MSUN_ARCH_SUBDIR = ${MACHINE_CPUARCH:S/i386/i387/}
+ # unfortunately msun/src contains both private and public headers
+ CFLAGS+= -I${SRCTOP}/lib/msun/${MSUN_ARCH_SUBDIR}
+ .if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"

--- a/pkgs/os-specific/bsd/freebsd/libc-no-force--lcompiler-rt.patch
+++ b/pkgs/os-specific/bsd/freebsd/libc-no-force--lcompiler-rt.patch
@@ -1,0 +1,10 @@
+--- a/lib/libc/Makefile
++++ b/lib/libc/Makefile
+@@ -58,7 +58,6 @@ CFLAGS+=${CANCELPOINTS_CFLAGS}
+ # Link with static libcompiler_rt.a.
+ #
+ LDFLAGS+= -nodefaultlibs
+-LIBADD+=	compiler_rt
+ 
+ .if ${MK_SSP} != "no" && \
+     (${LIBC_ARCH} == "i386" || ${MACHINE_ARCH:Mpower*} != "")

--- a/pkgs/os-specific/bsd/freebsd/libnetbsd-do-install.patch
+++ b/pkgs/os-specific/bsd/freebsd/libnetbsd-do-install.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index 22710f3d933..22effc848cf 100644
+--- a/lib/libnetbsd/Makefile
++++ b/lib/libnetbsd/Makefile
+@@ -9,6 +9,26 @@ CFLAGS+=	-I${.CURDIR}
+ 
+ SRCS+=	efun.c sockaddr_snprintf.c strsuftoll.c util.c util.h
+ 
+-INTERNALLIB=
++INCSGROUPS= INCS SYSINCS NETINETINCS
++
++INCS+= \
++	glob.h \
++	pthread.h \
++	rmd160.h \
++	sha1.h \
++	sha2.h \
++	stdlib.h \
++	util.h
++
++SYSINCSDIR= ${INCLUDEDIR}/sys
++SYSINCS+= \
++	sys/cdefs.h \
++	sys/event.h \
++	sys/types.h \
++	sys/wait.h
++
++NETINETINCSDIR= ${INCLUDEDIR}/netinet
++NETINETINCS+= \
++	netinet/in.h
+ 
+ .include <bsd.lib.mk>

--- a/pkgs/os-specific/bsd/freebsd/librpcsvc-include-subdir.patch
+++ b/pkgs/os-specific/bsd/freebsd/librpcsvc-include-subdir.patch
@@ -1,0 +1,11 @@
+--- a/lib/librpcsvc/Makefile
++++ b/lib/librpcsvc/Makefile
+@@ -20,7 +20,7 @@ OTHERSRCS+= yp_passwd.c yp_update.c
+ 
+ RPCCOM=	RPCGEN_CPP=${CPP:Q} rpcgen -C
+ 
+-INCDIRS= -I${SYSROOT:U${DESTDIR}}/usr/include/rpcsvc
++INCDIRS= -I${INCLUDEDIR}/rpcsvc
+ 
+ CFLAGS+= -DYP ${INCDIRS}
+ 

--- a/pkgs/os-specific/bsd/freebsd/no-perms-BSD.include.dist.patch
+++ b/pkgs/os-specific/bsd/freebsd/no-perms-BSD.include.dist.patch
@@ -1,0 +1,11 @@
+--- a/etc/mtree/BSD.include.dist
++++ b/etc/mtree/BSD.include.dist
+@@ -3,7 +3,7 @@
+ # Please see the file src/etc/mtree/README before making changes to this file.
+ #
+ 
+-/set type=dir uname=root gname=wheel mode=0755
++/set type=dir
+ .
+     arpa
+     ..

--- a/pkgs/os-specific/bsd/freebsd/rpcgen-glibc-hack.patch
+++ b/pkgs/os-specific/bsd/freebsd/rpcgen-glibc-hack.patch
@@ -1,0 +1,15 @@
+--- a/usr.bin/rpcgen/rpc_scan.c
++++ b/usr.bin/rpcgen/rpc_scan.c
+@@ -43,8 +43,12 @@ __FBSDID("$FreeBSD$");
+  */
+ 
+ #include <sys/types.h>
+ 
++// glibc + compat is broken from silly indirect header guard
++#define _SYS_WAIT_H
++# include <bits/waitflags.h>
++#undef _SYS_WAIT_H
+ #include <sys/wait.h>
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <string.h>

--- a/pkgs/os-specific/bsd/freebsd/setup-hook.sh
+++ b/pkgs/os-specific/bsd/freebsd/setup-hook.sh
@@ -1,0 +1,12 @@
+setFreeBSDSrcTop() {
+  makeFlags="SRCTOP=$BSDSRCDIR $makeFlags"
+}
+
+addFreeBSDMakeFlags() {
+  makeFlags="SBINDIR=${!outputBin}/bin $makeFlags"
+  makeFlags="LIBEXECDIR=${!outputLib}/libexec $makeFlags"
+  makeFlags="INCLUDEDIR=${!outputDev}/include $makeFlags"
+}
+
+postUnpackHooks+=(setFreeBSDSrcTop)
+preConfigureHooks+=(addFreeBSDMakeFlags)

--- a/pkgs/os-specific/bsd/freebsd/sys-gnu-date.patch
+++ b/pkgs/os-specific/bsd/freebsd/sys-gnu-date.patch
@@ -1,0 +1,13 @@
+diff --git a/sys/conf/newvers.sh b/sys/conf/newvers.sh
+index c594724d814..d5287c7b992 100644
+--- a/sys/conf/newvers.sh
++++ b/sys/conf/newvers.sh
+@@ -177,7 +177,7 @@ u=${USER:-root}
+ d=$(pwd)
+ h=${HOSTNAME:-$(hostname)}
+ if [ -n "$SOURCE_DATE_EPOCH" ]; then
+-	if ! t=$(date -r $SOURCE_DATE_EPOCH 2>/dev/null); then
++	if ! t=$(date -d @$SOURCE_DATE_EPOCH 2>/dev/null); then
+ 		echo "Invalid SOURCE_DATE_EPOCH" >&2
+ 		exit 1
+ 	fi

--- a/pkgs/os-specific/bsd/freebsd/sys-no-explicit-intrinsics-dep.patch
+++ b/pkgs/os-specific/bsd/freebsd/sys-no-explicit-intrinsics-dep.patch
@@ -1,0 +1,45 @@
+diff --git a/sys/modules/aesni/Makefile b/sys/modules/aesni/Makefile
+index cb8c744adde..1c327331890 100644
+--- a/sys/modules/aesni/Makefile
++++ b/sys/modules/aesni/Makefile
+@@ -1,7 +1,6 @@
+ # $FreeBSD$
+ 
+ .PATH: ${SRCTOP}/sys/crypto/aesni
+-.PATH: ${SRCTOP}/contrib/llvm-project/clang/lib/Headers
+ 
+ KMOD=	aesni
+ SRCS=	aesni.c
+@@ -40,8 +39,8 @@ intel_sha256.o: intel_sha256.c
+ aesni_ghash.o: aesni.h
+ aesni_wrap.o: aesni.h
+ aesni_ccm.o: aesni.h
+-intel_sha1.o: sha_sse.h immintrin.h shaintrin.h tmmintrin.h xmmintrin.h
+-intel_sha256.o: sha_sse.h immintrin.h shaintrin.h tmmintrin.h xmmintrin.h
++intel_sha1.o: sha_sse.h
++intel_sha256.o: sha_sse.h
+ 
+ .include <bsd.kmod.mk>
+ 
+diff --git a/sys/modules/blake2/Makefile b/sys/modules/blake2/Makefile
+index e4b3fb9f126..5bfd9c2ae02 100644
+--- a/sys/modules/blake2/Makefile
++++ b/sys/modules/blake2/Makefile
+@@ -3,7 +3,6 @@
+ .PATH:	${SRCTOP}/sys/contrib/libb2
+ .PATH:	${SRCTOP}/sys/crypto/blake2
+ .PATH:	${SRCTOP}/sys/opencrypto
+-.PATH:	${SRCTOP}/contrib/llvm-project/clang/lib/Headers
+ 
+ KMOD	= blake2
+ 
+@@ -64,8 +63,7 @@ ${src:S/.c/.o/}: ${src}
+ 	    -D_MM_MALLOC_H_INCLUDED -Wno-unused-function ${.IMPSRC}
+ 	${CTFCONVERT_CMD}
+ 
+-${src:S/.c/.o/}: intrin.h emmintrin.h tmmintrin.h smmintrin.h immintrin.h \
+-    x86intrin.h ${SRCS:M*.h}
++${src:S/.c/.o/}: ${SRCS:M*.h}
+ .endfor
+ 
+ # FreeBSD-specific sources:

--- a/pkgs/os-specific/bsd/xargs-j.sh
+++ b/pkgs/os-specific/bsd/xargs-j.sh
@@ -1,0 +1,17 @@
+#! @shell@
+
+declare -a args=()
+
+token=$1
+shift
+
+while (( $# )); do
+    if [[ "$1" = "$token" ]]; then
+        mapfile -t -O $(("${#args[@]}" + 1)) args
+    else
+        args+=("$1")
+    fi
+    shift
+done
+
+exec "${args[@]}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14586,7 +14586,7 @@ with pkgs;
     # assumption is that or any later version is good.
     choose = platform:
       /**/ if platform.isDarwin then 11
-      else if platform.isFreeBSD then 7
+      else if platform.isFreeBSD then 12
       else if platform.isAndroid then 12
       else if platform.system == "armv6l-linux" then 7  # This fixes armv6 cross-compilation
       else if platform.isLinux then 11
@@ -19024,6 +19024,7 @@ with pkgs;
       if stdenv.targetPlatform.useiOSPrebuilt
       then targetPackages.darwin.iosSdkPkgs.libraries or darwin.iosSdkPkgs.libraries
       else targetPackages.darwin.LibsystemCross or (throw "don't yet have a `targetPackages.darwin.LibsystemCross for ${stdenv.targetPlatform.config}`")
+    else if name == "fblibc" then targetPackages.freebsdCross.libc or freebsdCross.libc
     else if name == "nblibc" then targetPackages.netbsdCross.libc or netbsdCross.libc
     else if name == "wasilibc" then targetPackages.wasilibc or wasilibc
     else if name == "relibc" then targetPackages.relibc or relibc
@@ -37727,6 +37728,11 @@ with pkgs;
   bsdSetupHook = makeSetupHook {
     name = "bsd-setup-hook";
   } ../os-specific/bsd/setup-hook.sh;
+
+  freebsd = callPackage ../os-specific/bsd/freebsd {};
+  freebsdCross = callPackage ../os-specific/bsd/freebsd {
+    stdenv = crossLibcStdenv;
+  };
 
   netbsd = callPackage ../os-specific/bsd/netbsd {};
   netbsdCross = callPackage ../os-specific/bsd/netbsd {


### PR DESCRIPTION
###### Motivation for this change

Have working
```sh
nix-build -A pkgsCross.x86_64-freebsd.hello
nix-build -A pkgsCross.x86_64-freebsd.zlib
nix-build -A pkgsCross.x86_64-freebsd.zstd
nix-build -A pkgsCross.x86_64-freebsd.freebsd.sys
```

~~Running out of memory as NetBSD `makeMinimal` fails to build. Weird, know what's up @matthewbauer?~~

Oh netbsd make is cached, duh, this is freebsd libc itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @wahjava