### PR TITLE
util-linux: 2.33.2 -> 2.35.1

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "util-linux";
-  version = "2.33.2";
+  version = "2.35.1";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/util-linux/v${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "15yf2dh4jd1kg6066hydlgdhhs2j3na13qld8yx30qngqvmfh6v3";
+    sha256 = "1yfpy6bkab4jw61mpx48gfy24yrqp4a7arvpis8csrkk53fkxpnr";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/util-linux/rtcwake-search-PATH-for-shutdown.patch
+++ b/pkgs/os-specific/linux/util-linux/rtcwake-search-PATH-for-shutdown.patch
@@ -2,26 +2,68 @@ Search $PATH for the shutdown binary instead of hard-coding /sbin/shutdown,
 which isn't valid on NixOS (and a compatibility link on most other modern
 distros anyway).
 
-  -- nckx <github@tobias.gr>
 --- a/include/pathnames.h
 +++ b/include/pathnames.h
-@@ -53,7 +53,7 @@
+@@ -50,8 +50,8 @@
  #ifndef _PATH_LOGIN
- #define _PATH_LOGIN		"/bin/login"
+ # define _PATH_LOGIN		"/bin/login"
  #endif
 -#define _PATH_SHUTDOWN		"/sbin/shutdown"
-+#define _PATH_SHUTDOWN   "shutdown"
-
+-#define _PATH_POWEROFF		"/sbin/poweroff"
++#define _PATH_SHUTDOWN		"shutdown"
++#define _PATH_POWEROFF		"poweroff"
+ 
  #define _PATH_TERMCOLORS_DIRNAME "terminal-colors.d"
  #define _PATH_TERMCOLORS_DIR	"/etc/" _PATH_TERMCOLORS_DIRNAME
 --- a/sys-utils/rtcwake.c
 +++ b/sys-utils/rtcwake.c
-@@ -575,7 +575,7 @@ int main(int argc, char **argv)
- 		arg[i++] = "now";
- 		arg[i]   = NULL;
- 		if (!ctl.dryrun) {
--			execv(arg[0], arg);
+@@ -587,29 +587,29 @@ int main(int argc, char **argv)
+ 		char *arg[5];
+ 		int i = 0;
+ 
+-		if (!access(_PATH_SHUTDOWN, X_OK)) {
+-			arg[i++] = _PATH_SHUTDOWN;
+-			arg[i++] = "-h";
+-			arg[i++] = "-P";
+-			arg[i++] = "now";
+-			arg[i]   = NULL;
+-		} else if (!access(_PATH_POWEROFF, X_OK)) {
+-			arg[i++] = _PATH_POWEROFF;
+-			arg[i]   = NULL;
+-		} else {
+-			arg[i] 	 = NULL;
+-		}
++		arg[i++] = _PATH_SHUTDOWN;
++		arg[i++] = "-h";
++		arg[i++] = "-P";
++		arg[i++] = "now";
++		arg[i]   = NULL;
+ 
+-		if (arg[0]) {
+-			if (ctl.verbose)
+-				printf(_("suspend mode: off; executing %s\n"),
+-						arg[0]);
+-			if (!ctl.dryrun) {
+-				execv(arg[0], arg);
++		if (ctl.verbose)
++			printf(_("suspend mode: off; executing %s\n"),
++					arg[0]);
++
++		if (!ctl.dryrun) {
 +			execvp(arg[0], arg);
- 			warn(_("failed to execute %s"), _PATH_SHUTDOWN);
- 			rc = EXIT_FAILURE;
- 		}
++			if (ctl.verbose) {
+ 				warn(_("failed to execute %s"), arg[0]);
+-				rc = EX_EXEC_ENOENT;
++				// Reuse translations.
++				printf(_("suspend mode: off; executing %s\n"),
++						_PATH_POWEROFF);
+ 			}
+-		} else {
++
++			i = 0;
++			arg[i++] = _PATH_POWEROFF;
++			arg[i]   = NULL;
++			execvp(arg[0], arg);
+ 			/* Failed to find shutdown command */
+ 			warn(_("failed to find shutdown command"));
+ 			rc = EX_EXEC_ENOENT;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrade util-linux to 2.35.1, which brings many new features and some bug fixes.
For example, `lscpu` now reports CPU vulnerabilities.

Release notes of minor update can be found in:
- https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.34/v2.34-ReleaseNotes
- https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.35/v2.35-ReleaseNotes

`rtcwake` now tries both `shutdown` and `poweroff` when provided `-m off`, so the patch related is updated. cc @nckx 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - 81.4M -> 82.5M
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
