### PR TITLE
rmount: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/tools/filesystems/rmount/default.nix
+++ b/pkgs/tools/filesystems/rmount/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
 
   pname   = "rmount";
-  version = "1.0.1";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "Luis-Hebendanz";
     repo = "rmount";
-    sha256 = "1wjmfvbsq3126z51f2ivj85cjmkrzdm2acqsiyqs57qga2g6w5p9";
+    sha256 = "0j1ayncw1nnmgna7vyx44vwinh4ah1b0l5y8agc7i4s8clbvy3h0";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
#### Motivation for this change
Updating rmount to its newest version 1.1.0

###### Things done
Updated rmount to its newest version 1.1.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
