### PR TITLE
WIP hyperopt: init at 0.2.3

### DIFF
--- a/pkgs/development/python-modules/bson/default.nix
+++ b/pkgs/development/python-modules/bson/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, python-dateutil
+}:
+
+buildPythonPackage rec {
+  pname = "bson";
+  version = "0.5.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n01axc6vnszmbz1mx64d2blrb78hbcvlnl4v4a5h39mzb8nv844";
+  };
+
+  propagatedBuildInputs = [
+    python-dateutil
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/py-bson/bson";
+    description = "Independent BSON codec for Python that doesn’t depend on MongoDB.";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.GuillaumeDesforges ];
+  };
+}

--- a/pkgs/development/python-modules/hyperopt/default.nix
+++ b/pkgs/development/python-modules/hyperopt/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, pandas
+, networkx
+, scikitlearn
+, future
+, tqdm
+, cloudpickle
+, decorator
+, nose
+, pytest
+, ipython
+, ipyparallel
+, matplotlib
+, lightgbm
+, bson
+, pyspark
+}:
+
+let
+  # this package needs networkx 2.2 specifically
+  networkx-2_2 = buildPythonPackage rec {
+    pname = "networkx";
+    version = "2.2";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "45e56f7ab6fe81652fb4bc9f44faddb0e9025f469f602df14e3b2551c2ea5c8b";
+      extension = "zip";
+    };
+    
+    propagatedBuildInputs = [
+      decorator
+    ];
+
+    checkInputs = [
+        nose
+    ];
+  };
+in
+  buildPythonPackage rec {
+    pname = "hyperopt";
+    version = "0.2.3";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1rp0rz6i7arczlq8dc3jyjp9y07789c3m1mz45lhhhcmzjnhwifz";
+    };
+
+    propagatedBuildInputs = [
+      numpy
+      scipy
+      pandas
+      scikitlearn
+      networkx-2_2
+      future
+      tqdm
+      cloudpickle
+    ];
+
+    # checks not working at the moment
+    # see https://github.com/hyperopt/hyperopt/issues/580
+    # doCheck = false;
+    checkPhase = ''
+        nosetests
+    '';
+
+    checkInputs = [
+        nose
+        pytest
+        ipython
+        ipyparallel
+        matplotlib
+        scikitlearn
+        bson
+        pyspark
+    ];
+
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/hyperopt/hyperopt";
+      description = "Hyperopt is a Python library for serial and parallel optimization over awkward search spaces";
+      license = licenses.bsd3;
+      maintainers = [ maintainers.GuillaumeDesforges ];
+    };
+  }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -521,6 +521,8 @@ in {
 
   browsermob-proxy = disabledIf isPy3k (callPackage ../development/python-modules/browsermob-proxy {});
 
+  bson = callPackage ../development/python-modules/bson { };
+
   bt_proximity = callPackage ../development/python-modules/bt-proximity { };
 
   bugseverywhere = throw "bugseverywhere has been removed: Abandoned by upstream."; # Added 2019-11-27
@@ -3632,6 +3634,8 @@ in {
 
   greatfet = callPackage ../development/python-modules/greatfet { };
 
+  hyperopt = callPackage ../development/python-modules/hyperopt { };
+  
   pygreat = callPackage ../development/python-modules/pygreat { };
 
   pytorch = callPackage ../development/python-modules/pytorch {


### PR DESCRIPTION
###### Motivation for this change
`hyperopt` was not part of nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Additional information
Following https://github.com/NixOS/nixpkgs/pull/74783 because I deleted my forked repo.

Todos from previous PR:
- [ ] make tests work
    - [ ] make it work without a pinned networkx (hyperopt specifies 2.2, current nixpkgs networkx is 2.4)
    - [x] some issues about missing files in tests