### PR TITLE
zz: init at 2020-03-02

### DIFF
--- a/pkgs/development/compilers/zz/default.nix
+++ b/pkgs/development/compilers/zz/default.nix
@@ -1,0 +1,28 @@
+{ lib, rustPlatform, fetchFromGitHub, makeWrapper, z3 }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "zz-unstable";
+  version = "2020-03-02";
+
+  src = fetchFromGitHub {
+    owner = "aep";
+    repo = "zz";
+    rev = "2dd92b959f7c34bf99af84b263e3864a5c41a0fe";
+    sha256 = "14ch5qgga2vpxvb53v4v4y6cwy3kkm10x1vbfpyfa7im57syib85";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  cargoSha256 = "1m9az3adbkx2ab6fkg64cr7f9d73jbx8kx2pmgpw29csmh9hzqjy";
+
+  postInstall = ''
+    wrapProgram $out/bin/zz --prefix PATH ":" "${lib.getBin z3}/bin"
+  '';
+
+  meta = with lib; {
+    description = "🍺🐙 ZetZ a zymbolic verifier and tranzpiler to bare metal C";
+    homepage = "https://github.com/aep/zz";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14938,6 +14938,8 @@ in
 
   zita-resampler = callPackage ../development/libraries/audio/zita-resampler { };
 
+  zz = callPackage ../development/compilers/zz { };
+
   zziplib = callPackage ../development/libraries/zziplib { };
 
   gsignond = callPackage ../development/libraries/gsignond {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/aep/zz

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
