### PR TITLE
tests: Fix signal-desktop

### DIFF
--- a/nixos/tests/signal-desktop.nix
+++ b/nixos/tests/signal-desktop.nix
@@ -17,6 +17,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
     services.xserver.enable = true;
     test-support.displayManager.auto.user = "alice";
     environment.systemPackages = [ pkgs.signal-desktop ];
+    virtualisation.memorySize = 1024;
   };
 
   enableOCR = true;


### PR DESCRIPTION
This test fails due to OOM on the VM. Setting the memory of the VM to
1024 lets the test succeed.

Cc: @flokli

###### Motivation for this change

The test failed repeatedly on a private Hydra instance and when tested on a local machine.

###### Things done

Set `virtualisation.memorySize = 1024;`

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
