### PR TITLE
[wip] appimageTools: add a new buildAppImage wrapper

### DIFF
--- a/pkgs/applications/networking/browsers/beakerbrowser/default.nix
+++ b/pkgs/applications/networking/browsers/beakerbrowser/default.nix
@@ -1,0 +1,15 @@
+{ buildAppImage, fetchurl, stdenv }:
+
+buildAppImage rec {
+  pname = "beakerbrowser";
+  version = "0.8.8";
+  src = fetchurl {
+    url = "https://github.com/beakerbrowser/beaker/releases/download/${version}/Beaker.Browser.${version}.AppImage";
+    sha256 = "a190f1ca3266b2cb62a76b5a957a3e42b14726ca2732a2797c6fce40aaead695";
+  };
+  meta = {
+    description = "Experimental peer-to-peer Web browser";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ genesis ];
+  };
+}

--- a/pkgs/build-support/appimage/build-appimage.nix
+++ b/pkgs/build-support/appimage/build-appimage.nix
@@ -1,0 +1,49 @@
+{ appimageTools, autoPatchelfHook, stdenv, desktop-file-utils
+  , hicolor-icon-theme,gtk3, gsettings-desktop-schemas }:
+
+# fetchzip is for compatibility, bother AppImage builder about that :
+# https://docs.appimage.org/packaging-guide/distribution.html#do-not-put-appimages-into-other-archives
+
+# some src.url can be hard to follow, you can download them with firefox
+# "simple mass downloader" addon then use the "export selected item to file"
+# available in the right menu.
+
+{
+  pname,
+  version,
+  src,
+  meta,
+  ...
+} @attrs:
+  let
+    name = "${attrs.pname}-${attrs.version}.AppImage";
+    attrs' = builtins.removeAttrs attrs ["version" "pname"];
+    #nativeBuildInputs = [  ];
+
+    #appimageTools
+  in appimageTools.wrapType2 (attrs' //  {
+    inherit name src;
+    /* extraPkgs = ps:
+      appimageTools.defaultFhsEnvArgs.multiPkgs ps
+      ++ (with ps; [ desktop-file-utils autoPatchelfHook ]); */
+
+    /* buildInputs = [ desktop-file-utils autoPatchelfHook ]; */
+    /* extraBuildCommands = */
+    /* extraInstallCommands = attrs.extraInstallCommands or ''
+      # fixup and install desktop file
+      desktopitem="$(ls $out/*.desktop)"
+      desktop-file-install "$desktopitem" --dir $out/share/applications \
+        --set-key Exec --set-value $out/bin/${name}
+      mv $out/share/applications/"$desktopitem" $out/share/applications/$name.desktop
+
+      #PLANNED: write a more generic code to read icon path from $desktopitem
+      #install -m 444 -D $icon $out/share/icons/hicolor/512x512/apps/$icon
+    ''; */
+
+    meta = {
+      license = stdenv.lib.licenses.unfree;
+      platforms = [ "x86_64-linux" ];
+      description = throw "please write meta.description";
+      maintainers = throw "please write meta.maintainers";
+    } // attrs'.meta;
+} // attrs')

--- a/pkgs/games/colobot/default.nix
+++ b/pkgs/games/colobot/default.nix
@@ -1,0 +1,15 @@
+{ buildAppImage, fetchurl, stdenv }:
+
+buildAppImage rec {
+  pname = "colobot";
+  version = "0.1.12-alpha";
+  src = fetchurl {
+    url = "https://colobot.info/files/releases/0.1.12-alpha/Colobot-${version}-x86_64.AppImage";
+    sha256 = "da1b5b3ac8a072d1999c2ac8c65a6c1e0aad3c1a97e5dfd72c9a8c7f30c60fa5";
+  };
+  meta = {
+    description = "RTS game, where you can program your units (bots) in a language called CBOT";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ genesis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -115,6 +115,8 @@ in
 
   appimageTools = callPackage ../build-support/appimage { };
 
+  appimagePackages = recurseIntoAttrs (callPackage ./appimage-packages.nix { });
+
   ensureNewerSourcesHook = { year }: makeSetupHook {}
     (writeScript "ensure-newer-sources-hook.sh" ''
       postUnpackHooks+=(_ensureNewerSources)
@@ -140,6 +142,8 @@ in
     name = "gog-unpack-hook";
     deps = [ innoextract file-rename ]; }
     ../build-support/setup-hooks/gog-unpack.sh;
+
+  buildAppImage = callPackage ../build-support/appimage/build-appimage.nix { };
 
   buildEnv = callPackage ../build-support/buildenv { }; # not actually a package
 
@@ -2465,6 +2469,8 @@ in
     nodejs = nodejs-10_x;
   };
 
+  colobot = callPackage ../games/colobot {};
+
   colord = callPackage ../tools/misc/colord { };
 
   colord-gtk = callPackage ../tools/misc/colord-gtk { };
@@ -3492,7 +3498,7 @@ in
   fuse-7z-ng = callPackage ../tools/filesystems/fuse-7z-ng { };
 
   fuse-overlayfs = callPackage ../tools/filesystems/fuse-overlayfs {};
-  
+
   fusee-interfacee-tk = callPackage ../applications/misc/fusee-interfacee-tk { };
 
   fusee-launcher = callPackage ../development/tools/fusee-launcher { };
@@ -9819,6 +9825,8 @@ in
   bazelisk = callPackage ../development/tools/bazelisk { };
 
   buildBazelPackage = callPackage ../build-support/build-bazel-package { };
+
+  beakerbrowser = callPackage ../applications/networking/browsers/beakerbrowser { };
 
   bear = callPackage ../development/tools/build-managers/bear { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Provide a new bundle of appimage without pollute the nixpkgs with  small appimageTools.wrapType derivation. 
in a first time, discussion was about adding a recurseIntoAttrs method and a ./pkgs/top-level/appimage-packages.nix on the example of haxe-packages.nix . Now we add a new method on appimageTools.

will close #38037 , #76849 ...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @worldofpeace 
cc @jtojnar 
cc @tilpner 
cc @Mic92 
cc @dtzWill 