### PR TITLE
mesos: Remove kevincox as maintainer.

### DIFF
--- a/pkgs/applications/networking/cluster/marathon/default.nix
+++ b/pkgs/applications/networking/cluster/marathon/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = https://mesosphere.github.io/marathon;
     description = "Cluster-wide init and control system for services in cgroups or Docker containers";
     license = licenses.asl20;
-    maintainers = with maintainers; [ kamilchm kevincox pradeepchhetri ];
+    maintainers = with maintainers; [ kamilchm pradeepchhetri ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -256,7 +256,7 @@ in stdenv.mkDerivation rec {
     homepage    = "http://mesos.apache.org";
     license     = licenses.asl20;
     description = "A cluster manager that provides efficient resource isolation and sharing across distributed applications, or frameworks";
-    maintainers = with maintainers; [ cstrahan kevincox offline ];
+    maintainers = with maintainers; [ cstrahan offline ];
     platforms   = platforms.unix;
   };
 }


### PR DESCRIPTION
kevincox no longer uses mesos so is not a suitable maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
