### PR TITLE
pythonPackages.pvlib: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/development/python-modules/pvlib/default.nix
+++ b/pkgs/development/python-modules/pvlib/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "pvlib";
-  version = "0.7.0";
+  version = "0.7.1";
 
   # Support for Python <3.5 dropped in 0.6.3 on June 1, 2019.
   disabled = pythonOlder "3.5";
 
   src = fetchPypi{
     inherit pname version;
-    sha256 = "ee935ba52f1d4a514cc3baa743db0377af732952faf800f20ffd8071fa2107c2";
+    sha256 = "1kqwnkbkdv4m3r68pd39va6wqvhr34a6hx4d6q5lfkibclg35c3d";
   };
 
   checkInputs = [ pytest mock pytest-mock ];
@@ -19,8 +19,8 @@ buildPythonPackage rec {
   # Skip a few tests that try to access some URLs
   checkPhase = ''
     runHook preCheck
-    pushd pvlib/test
-    pytest . -k "not test_read_srml_dt_index and not test_read_srml_month_from_solardata and not test_get_psm3"
+    pushd pvlib/tests
+    pytest . -k "not test_read_srml_dt_index and not test_read_srml_month_from_solardata and not test_get_psm3 and not test_pvgis"
     popd
     runHook postCheck
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Upgrade Python package pvlib.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
