### PR TITLE
pythonPackages.salmon-mail: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/salmon-mail/default.nix
+++ b/pkgs/development/python-modules/salmon-mail/default.nix
@@ -1,22 +1,26 @@
-{ stdenv, buildPythonPackage, fetchPypi, nose, dnspython
-,  chardet, lmtpd, python-daemon, six, jinja2, mock }:
+{ stdenv, buildPythonPackage, fetchPypi, dnspython, chardet, lmtpd
+, python-daemon, six, jinja2, mock, click }:
 
 buildPythonPackage rec {
   pname = "salmon-mail";
-  version = "3.1.1";
+  version = "3.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ddd9nwdmiibk3jaampznm8nai5b7zalp0f8c65l71674300bqnw";
+    sha256 = "0q2m6xri1b7qv46rqpv2qfdgk2jvswj8lpaacnxwjna3m685fhfx";
   };
 
-  checkInputs = [ nose jinja2 mock ];
-  propagatedBuildInputs = [ chardet dnspython lmtpd python-daemon six ];
+  checkInputs = [ jinja2 mock ];
+  propagatedBuildInputs = [ chardet dnspython lmtpd python-daemon six click ];
+
+  # Darwin tests fail without this. See:
+  # https://github.com/NixOS/nixpkgs/pull/82166#discussion_r399909846
+  __darwinAllowLocalNetworking = true;
 
   # The tests use salmon executable installed by salmon itself so we need to add
   # that to PATH
   checkPhase = ''
-    PATH=$out/bin:$PATH nosetests .
+    PATH=$out/bin:$PATH python setup.py test
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Upgrade Python package salmon-mail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
