### PR TITLE
next: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/applications/networking/browsers/next/default.nix
+++ b/pkgs/applications/networking/browsers/next/default.nix
@@ -15,13 +15,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "next";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "atlas-engineer";
     repo = "next";
     rev = version;
-    sha256 = "1gkmr746rqqg94698a051gv79fblc8n9dq0zg04llba44adhpmjl";
+    sha256 = "1gqkp185wcwaxr8py90hqk44nqjblrrdwvig19gizrbzr2gx2zhy";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
New upstream version [1.5.0](https://github.com/atlas-engineer/next/releases/tag/1.5.0).  
For some reason it's not tagged as "release" on GitHub, but it is listed in the [CHANGELOG.md](https://github.com/atlas-engineer/next/blob/master/documents/CHANGELOG.org#150).

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @nlewo