### PR TITLE
qxw: init at 20190909

### DIFF
--- a/pkgs/applications/editors/qxw/default.nix
+++ b/pkgs/applications/editors/qxw/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkg-config, gtk2, pcre }:
 
-let version = "20190909"; in stdenv.mkDerivation {
-  inherit version;
+stdenv.mkDerivation rec {
   pname = "qxw";
+  version = "20200708";
 
   src = fetchurl {
     url = "https://www.quinapalus.com/qxw-${version}.tar.gz";
-    sha256 = "1w6f2c70lbdbi2dvh3rm463ai20fhfnnxf205kyyl46gz141kz48";
+    sha256 = "1si3ila7137c7x4mp3jv1q1mh3jp0p4khir1yz1rwy0mp3znwv7d";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -23,9 +23,9 @@ let version = "20190909"; in stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "A program to help create and publish crosswords";
-    homepage    = https://www.quinapalus.com/qxw.html;
-    license     = licenses.gpl2;
+    homepage = "https://www.quinapalus.com/qxw.html";
+    license = licenses.gpl2;
     maintainers = [ maintainers.tckmn ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/editors/qxw/default.nix
+++ b/pkgs/applications/editors/qxw/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, pkg-config, gtk2, pcre }:
+
+let version = "20190909"; in stdenv.mkDerivation {
+  inherit version;
+  pname = "qxw";
+
+  src = fetchurl {
+    url = "https://www.quinapalus.com/qxw-${version}.tar.gz";
+    sha256 = "1w6f2c70lbdbi2dvh3rm463ai20fhfnnxf205kyyl46gz141kz48";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gtk2 pcre ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  patchPhase = ''
+    sed -i 's/ `dpkg-buildflags[^`]*`//g;
+            /mkdir -p/d;
+            s/cp -a/install -D/;
+            s,/usr/games,/bin,' Makefile
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A program to help create and publish crosswords";
+    homepage    = https://www.quinapalus.com/qxw.html;
+    license     = licenses.gpl2;
+    maintainers = [ maintainers.tckmn ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21324,6 +21324,8 @@ in
 
   qutebrowser = libsForQt5.callPackage ../applications/networking/browsers/qutebrowser { };
 
+  qxw = callPackage ../applications/editors/qxw {};
+
   rabbitvcs = callPackage ../applications/version-management/rabbitvcs {};
 
   rakarrack = callPackage ../applications/audio/rakarrack {


### PR DESCRIPTION
###### Motivation for this change

Adds a derivation for [the `qxw` program](https://www.quinapalus.com/qxw.html).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
