### PR TITLE
hydra: 2020-02-06 -> 2020-03-04

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -75,6 +75,24 @@ services.xserver.displayManager.defaultSession = "xfce+icewm";
 </programlisting>
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <package>hydra</package> has been updated to the latest <literal>master</literal>. This
+     includes a massive performance improvement thanks to several optimized queries.
+    </para>
+    <para>
+     Hydra will remain usable after the upgrade since the newly introduced <literal>ID</literal>-columns
+     are currently nullable. To use the performance gain, all empty IDs need to be filled
+     automatically by running the following command:
+<screen>
+<prompt>$ </prompt>hydra-backfill-ids
+</screen>
+    </para>
+    <para>
+     For further reference, please read the full description of the change
+     in the <link xlink:href="https://github.com/NixOS/hydra/pull/710">upstream PR</link>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/tests/hydra/default.nix
+++ b/nixos/tests/hydra/default.nix
@@ -3,6 +3,8 @@
 , pkgs ? import ../../.. { inherit system config; }
 }:
 
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+
 let
 
   trivialJob = pkgs.writeTextDir "trivial.nix" ''
@@ -27,78 +29,77 @@ let
     '';
   };
 
-  callTest = f: f { inherit system pkgs; };
+  flavours = [
+    #"stable" # XXX hydra doesn't build with stable nix atm
+    "unstable"
+    "flakes"
+  ];
 
-  hydraPkgs = {
-    inherit (pkgs) nixStable nixUnstable nixFlakes;
-  };
+  makeHydraTest = type: pkgs.lib.nameValuePair type (makeTest {
+    name = "hydra-with-${type}";
+    meta = with pkgs.stdenv.lib.maintainers; {
+      maintainers = [ pstn lewo ma27 ];
+    };
 
-  tests = pkgs.lib.flip pkgs.lib.mapAttrs hydraPkgs (name: nix:
-    callTest (import ../make-test-python.nix ({ pkgs, lib, ... }:
+    machine = { pkgs, ... }:
       {
-        name = "hydra-with-${name}";
-        meta = with pkgs.stdenv.lib.maintainers; {
-          maintainers = [ pstn lewo ma27 ];
+        virtualisation.memorySize = 1024;
+        time.timeZone = "UTC";
+
+        environment.systemPackages = [ createTrivialProject pkgs.jq ];
+        services.hydra = {
+          enable = true;
+
+          #Hydra needs those settings to start up, so we add something not harmfull.
+          hydraURL = "example.com";
+          notificationSender = "example@example.com";
+
+          package = pkgs."hydra-${type}";
+
+          extraConfig = ''
+            email_notification = 1
+          '';
         };
+        services.postfix.enable = true;
+        nix = {
+          buildMachines = [{
+            hostName = "localhost";
+            systems = [ system ];
+          }];
 
-        machine = { pkgs, ... }:
-          {
-            virtualisation.memorySize = 1024;
-            time.timeZone = "UTC";
+          binaryCaches = [];
+        };
+      };
 
-            environment.systemPackages = [ createTrivialProject pkgs.jq ];
-            services.hydra = {
-              enable = true;
+    testScript = ''
+      # let the system boot up
+      machine.wait_for_unit("multi-user.target")
+      # test whether the database is running
+      machine.wait_for_unit("postgresql.service")
+      # test whether the actual hydra daemons are running
+      machine.wait_for_unit("hydra-init.service")
+      machine.require_unit_state("hydra-queue-runner.service")
+      machine.require_unit_state("hydra-evaluator.service")
+      machine.require_unit_state("hydra-notify.service")
 
-              #Hydra needs those settings to start up, so we add something not harmfull.
-              hydraURL = "example.com";
-              notificationSender = "example@example.com";
+      machine.succeed("hydra-create-user admin --role admin --password admin")
 
-              package = pkgs.hydra.override { inherit nix; };
+      # create a project with a trivial job
+      machine.wait_for_open_port(3000)
 
-              extraConfig = ''
-                email_notification = 1
-              '';
-            };
-            services.postfix.enable = true;
-            nix = {
-              buildMachines = [{
-                hostName = "localhost";
-                systems = [ system ];
-              }];
+      # make sure the build as been successfully built
+      machine.succeed("create-trivial-project.sh")
 
-              binaryCaches = [];
-            };
-          };
+      machine.wait_until_succeeds(
+          'curl -L -s http://localhost:3000/build/1 -H "Accept: application/json" |  jq .buildstatus | xargs test 0 -eq'
+      )
 
-        testScript = ''
-          # let the system boot up
-          machine.wait_for_unit("multi-user.target")
-          # test whether the database is running
-          machine.wait_for_unit("postgresql.service")
-          # test whether the actual hydra daemons are running
-          machine.wait_for_unit("hydra-init.service")
-          machine.require_unit_state("hydra-queue-runner.service")
-          machine.require_unit_state("hydra-evaluator.service")
-          machine.require_unit_state("hydra-notify.service")
-
-          machine.succeed("hydra-create-user admin --role admin --password admin")
-
-          # create a project with a trivial job
-          machine.wait_for_open_port(3000)
-
-          # make sure the build as been successfully built
-          machine.succeed("create-trivial-project.sh")
-
-          machine.wait_until_succeeds(
-              'curl -L -s http://localhost:3000/build/1 -H "Accept: application/json" |  jq .buildstatus | xargs test 0 -eq'
-          )
-
-          machine.wait_until_succeeds(
-              'journalctl -eu hydra-notify.service -o cat | grep -q "sending mail notification to hydra@localhost"'
-          )
-        '';
-      })));
+      machine.wait_until_succeeds(
+          'journalctl -eu hydra-notify.service -o cat | grep -q "sending mail notification to hydra@localhost"'
+      )
+    '';
+  });
 
 in
-  tests
+
+pkgs.lib.listToAttrs (map makeHydraTest flavours)

--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -1,0 +1,137 @@
+{ stdenv, perlPackages, buildEnv, fetchFromGitHub
+, makeWrapper, autoconf, automake, libtool, unzip, pkgconfig, sqlite, libpqxx
+, gitAndTools, mercurial, darcs, subversion, bazaar, openssl, bzip2, libxslt
+, guile, perl, postgresql, nukeReferences, git, boehmgc, nlohmann_json
+, docbook_xsl, openssh, gnused, coreutils, findutils, gzip, lzma, gnutar
+, rpm, dpkg, cdrkit, pixz, lib, boost, autoreconfHook
+}:
+
+{ nix, src, version, flavour, broken ? false }:
+
+with stdenv;
+
+if lib.versions.major nix.version == "1"
+  then throw "This Hydra version doesn't support Nix 1.x"
+else
+
+let
+  perlDeps = buildEnv {
+    name = "hydra-perl-deps";
+    paths = with perlPackages; lib.closePropagation
+      [ ModulePluggable
+        CatalystActionREST
+        CatalystAuthenticationStoreDBIxClass
+        CatalystDevel
+        CatalystDispatchTypeRegex
+        CatalystPluginAccessLog
+        CatalystPluginAuthorizationRoles
+        CatalystPluginCaptcha
+        CatalystPluginSessionStateCookie
+        CatalystPluginSessionStoreFastMmap
+        CatalystPluginStackTrace
+        CatalystPluginUnicodeEncoding
+        CatalystTraitForRequestProxyBase
+        CatalystViewDownload
+        CatalystViewJSON
+        CatalystViewTT
+        CatalystXScriptServerStarman
+        CatalystXRoleApplicator
+        CryptRandPasswd
+        DBDPg
+        DBDSQLite
+        DataDump
+        DateTime
+        DigestSHA1
+        EmailMIME
+        EmailSender
+        FileSlurp
+        IOCompress
+        IPCRun
+        JSON
+        JSONAny
+        JSONXS
+        LWP
+        LWPProtocolHttps
+        NetAmazonS3
+        NetPrometheus
+        NetStatsd
+        PadWalker
+        Readonly
+        SQLSplitStatement
+        SetScalar
+        Starman
+        SysHostnameLong
+        TermSizeAny
+        TestMore
+        TextDiff
+        TextTable
+        XMLSimple
+        nix
+        nix.perl-bindings
+        git
+        boehmgc
+      ];
+  };
+in stdenv.mkDerivation rec {
+  pname = "hydra-with-${flavour}";
+
+  inherit stdenv src version;
+
+  buildInputs =
+    [ makeWrapper autoconf automake libtool unzip nukeReferences sqlite libpqxx
+      gitAndTools.top-git mercurial /*darcs*/ subversion bazaar openssl bzip2 libxslt
+      perlDeps perl nix
+      postgresql # for running the tests
+      nlohmann_json
+      boost
+    ];
+
+  hydraPath = lib.makeBinPath (
+    [ sqlite subversion openssh nix coreutils findutils pixz
+      gzip bzip2 lzma gnutar unzip git gitAndTools.top-git mercurial /*darcs*/ gnused bazaar
+    ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
+
+  NIX_CFLAGS_COMPILE = "-pthread";
+
+  shellHook = ''
+    PATH=$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$(pwd)/src/hydra-evaluator:$PATH
+    PERL5LIB=$(pwd)/src/lib:$PERL5LIB;
+  '';
+
+  enableParallelBuilding = true;
+
+  preCheck = ''
+    patchShebangs .
+    export LOGNAME=''${LOGNAME:-foo}
+  '';
+
+  postInstall = ''
+    mkdir -p $out/nix-support
+    for i in $out/bin/*; do
+        read -n 4 chars < $i
+        if [[ $chars =~ ELF ]]; then continue; fi
+        wrapProgram $i \
+            --prefix PERL5LIB ':' $out/libexec/hydra/lib:$PERL5LIB \
+            --prefix PATH ':' $out/bin:$hydraPath \
+            --set HYDRA_RELEASE ${version} \
+            --set HYDRA_HOME $out/libexec/hydra \
+            --set NIX_RELEASE ${nix.name or "unknown"}
+    done
+  ''; # */
+
+  dontStrip = true;
+
+  passthru = { inherit perlDeps flavour; };
+
+  meta = with stdenv.lib; {
+    description = "Nix-based continuous build system";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ma27 ];
+    inherit broken;
+  };
+}

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -1,143 +1,40 @@
-{ stdenv, nix, perlPackages, buildEnv, fetchFromGitHub
-, makeWrapper, autoconf, automake, libtool, unzip, pkgconfig, sqlite, libpqxx
-, gitAndTools, mercurial, darcs, subversion, bazaar, openssl, bzip2, libxslt
-, guile, perl, postgresql, nukeReferences, git, boehmgc, nlohmann_json
-, docbook_xsl, openssh, gnused, coreutils, findutils, gzip, lzma, gnutar
-, rpm, dpkg, cdrkit, pixz, lib, boost, autoreconfHook
-}:
+{ hydra-unwrapped, fetchFromGitHub, nix, nixFlakes, nixUnstable }:
 
-with stdenv;
-
-if lib.versions.major nix.version == "1"
-  then throw "This Hydra version doesn't support Nix 1.x"
-else
-
-let
-  perlDeps = buildEnv {
-    name = "hydra-perl-deps";
-    paths = with perlPackages; lib.closePropagation
-      [ ModulePluggable
-        CatalystActionREST
-        CatalystAuthenticationStoreDBIxClass
-        CatalystDevel
-        CatalystDispatchTypeRegex
-        CatalystPluginAccessLog
-        CatalystPluginAuthorizationRoles
-        CatalystPluginCaptcha
-        CatalystPluginSessionStateCookie
-        CatalystPluginSessionStoreFastMmap
-        CatalystPluginStackTrace
-        CatalystPluginUnicodeEncoding
-        CatalystTraitForRequestProxyBase
-        CatalystViewDownload
-        CatalystViewJSON
-        CatalystViewTT
-        CatalystXScriptServerStarman
-        CatalystXRoleApplicator
-        CryptRandPasswd
-        DBDPg
-        DBDSQLite
-        DataDump
-        DateTime
-        DigestSHA1
-        EmailMIME
-        EmailSender
-        FileSlurp
-        IOCompress
-        IPCRun
-        JSON
-        JSONAny
-        JSONXS
-        LWP
-        LWPProtocolHttps
-        NetAmazonS3
-        NetPrometheus
-        NetStatsd
-        PadWalker
-        Readonly
-        SQLSplitStatement
-        SetScalar
-        Starman
-        SysHostnameLong
-        TermSizeAny
-        TestMore
-        TextDiff
-        TextTable
-        XMLSimple
-        nix
-        nix.perl-bindings
-        git
-        boehmgc
-      ];
-  };
-in stdenv.mkDerivation rec {
-  pname = "hydra";
-  version = "2020-02-06";
-
-  inherit stdenv;
-
-  src = fetchFromGitHub {
-    owner = "NixOS";
-    repo = pname;
-    rev = "2b4f14963b16b21ebfcd6b6bfa7832842e9b2afc";
-    sha256 = "16q0cffcsfx5pqd91n9k19850c1nbh4vvbd9h8yi64ihn7v8bick";
+{
+  hydra-stable = hydra-unwrapped {
+    broken = true;
+    flavour = "nix-stable";
+    inherit nix;
+    version = "2020-03-04";
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "hydra";
+      rev = "123bee1db599818f34f880a756a44339c57c7ade";
+      sha256 = "0psjhpyfa39zh4ymva27xri7xpz69cp4miafx7729jibgi28dynv";
+    };
   };
 
-  buildInputs =
-    [ makeWrapper autoconf automake libtool unzip nukeReferences sqlite libpqxx
-      gitAndTools.top-git mercurial darcs subversion bazaar openssl bzip2 libxslt
-      guile # optional, for Guile + Guix support
-      perlDeps perl nix
-      postgresql # for running the tests
-      nlohmann_json
-      boost
-    ];
+  hydra-unstable = hydra-unwrapped {
+    version = "2020-03-04";
+    flavour = "nix-unstable";
+    nix = nixUnstable;
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "hydra";
+      rev = "123bee1db599818f34f880a756a44339c57c7ade";
+      sha256 = "0psjhpyfa39zh4ymva27xri7xpz69cp4miafx7729jibgi28dynv";
+    };
+  };
 
-  hydraPath = lib.makeBinPath (
-    [ sqlite subversion openssh nix coreutils findutils pixz
-      gzip bzip2 lzma gnutar unzip git gitAndTools.top-git mercurial darcs gnused bazaar
-    ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
-
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-
-  configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
-
-  NIX_CFLAGS_COMPILE = "-pthread";
-
-  shellHook = ''
-    PATH=$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$(pwd)/src/hydra-evaluator:$PATH
-    PERL5LIB=$(pwd)/src/lib:$PERL5LIB;
-  '';
-
-  enableParallelBuilding = true;
-
-  preCheck = ''
-    patchShebangs .
-    export LOGNAME=''${LOGNAME:-foo}
-  '';
-
-  postInstall = ''
-    mkdir -p $out/nix-support
-    for i in $out/bin/*; do
-        read -n 4 chars < $i
-        if [[ $chars =~ ELF ]]; then continue; fi
-        wrapProgram $i \
-            --prefix PERL5LIB ':' $out/libexec/hydra/lib:$PERL5LIB \
-            --prefix PATH ':' $out/bin:$hydraPath \
-            --set HYDRA_RELEASE ${version} \
-            --set HYDRA_HOME $out/libexec/hydra \
-            --set NIX_RELEASE ${nix.name or "unknown"}
-    done
-  ''; # */
-
-  dontStrip = true;
-
-  passthru.perlDeps = perlDeps;
-
-  meta = with stdenv.lib; {
-    description = "Nix-based continuous build system";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ ma27 ];
+  hydra-flakes = hydra-unwrapped {
+    version = "2020-03-04";
+    flavour = "nix-flakes";
+    nix = nixFlakes;
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "hydra";
+      rev = "101a9b3797cb94d8177c997b3db5af97b0f48e6b";
+      sha256 = "04p6lvd7g5k99pyrx4ya9vlrp3296mrp82rf69yfh4v62k9brck3";
+    };
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12029,7 +12029,12 @@ in
 
   hwloc = callPackage ../development/libraries/hwloc {};
 
-  hydra = callPackage ../development/tools/misc/hydra { };
+  hydra-unwrapped = callPackage ../development/tools/misc/hydra/common.nix { };
+
+  inherit (callPackage ../development/tools/misc/hydra { })
+    hydra-stable hydra-unstable hydra-flakes;
+
+  hydra = hydra-unstable;
 
   hydra-cli = callPackage ../development/tools/misc/hydra-cli { };
 


### PR DESCRIPTION
###### Motivation for this change

:warning: I only tested the migration in a local setup and not yet on my Hydra instance.

Updates Hydra to the latest `master` (and `flake`) revision to incorporate the massive performance improvements.

Before this is mergable, the following things should be discussed:

* I had to split the sources for several hydra variants (a.k.a. flake-support, unstable and stable), however `hydra-stable` is currently broken since Hydra doesn't compile with nix 2.3. For now, I marked it as broken (since upstream uses `pkgs.nixFlakes` on Hydra), however we could fix it:
   * Pin Hydra with `nix-stable` to an older revision (and risking that it lacks appropriate maintenance).
   * Patch Hydra to support Nix 2.3 again (I actually attempted to do this today but this requires a bit more effort).
* A few weeks ago I was asked if this should be backported to 20.03. I think that it should since Graham provided pretty useful migration instructions and I played around with it locally and the migration feels pretty smooth. However that's up to our release managers.
* (out of scope) We should consider marking this package as deprecated for 20.09 or 21.03 (depending on when flakes will be stabilized) as there's no point in maintaining this package (in addition to the Nix expressions in `nixos/hydra`) as soon as flakes are out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
