### PR TITLE
ipbt: init at 20190601.d1519e0

### DIFF
--- a/pkgs/tools/misc/ipbt/default.nix
+++ b/pkgs/tools/misc/ipbt/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, perl, ncurses }:
+
+stdenv.mkDerivation rec {
+  version = "20190601.d1519e0";
+  pname = "ipbt";
+
+  src = fetchurl {
+    url = "https://www.chiark.greenend.org.uk/~sgtatham/ipbt/ipbt-${version}.tar.gz";
+    sha256 = "1aj8pajdd81vq2qw6vzfm27i0aj8vfz9m7k3sda30pnsrizm06d5";
+  };
+
+  nativeBuildInputs = [ perl ];
+  buildInputs = [ ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "A high-tech ttyrec player for Unix";
+    homepage = "https://www.chiark.greenend.org.uk/~sgtatham/ipbt/";
+    license = licenses.mit;
+    maintainers = [ maintainers.tckmn ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7012,6 +7012,8 @@ in
 
   ttylog = callPackage ../tools/misc/ttylog { };
 
+  ipbt = callPackage ../tools/misc/ipbt { };
+
   tuir = callPackage ../applications/misc/tuir { };
 
   turses = callPackage ../applications/networking/instant-messengers/turses { };


### PR DESCRIPTION
##### Motivation for this change

Adds a derivation for [the `ipbt` program](https://www.chiark.greenend.org.uk/~sgtatham/ipbt/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
