### PR TITLE
jelly: init at 0.1.31

### DIFF
--- a/pkgs/development/interpreters/jelly/default.nix
+++ b/pkgs/development/interpreters/jelly/default.nix
@@ -13,6 +13,9 @@ python3Packages.buildPythonApplication {
 
   propagatedBuildInputs = [ python3Packages.sympy ];
 
+  # checks are disabled because jelly has no tests, and the default is to run
+  # the output binary with no arguments, which exits with status 1 and causes
+  # the build to fail
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/development/interpreters/jelly/default.nix
+++ b/pkgs/development/interpreters/jelly/default.nix
@@ -1,0 +1,25 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication {
+  pname = "jelly";
+  version = "0.1.31";
+
+  src = fetchFromGitHub {
+    owner = "DennisMitchell";
+    repo = "jellylanguage";
+    rev = "70c9fd93ab009c05dc396f8cc091f72b212fb188";
+    sha256 = "1rpclqagvigp5qhvgnjavvy463f1drshnc1mfxm6z7ygzs0l0yz6";
+  };
+
+  propagatedBuildInputs = [ python3Packages.sympy ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A recreational programming language inspired by J";
+    homepage    = https://github.com/DennisMitchell/jellylanguage;
+    license     = licenses.mit;
+    maintainers = [ maintainers.tckmn ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9166,6 +9166,8 @@ in
 
   janet = callPackage ../development/interpreters/janet {};
 
+  jelly = callPackage ../development/interpreters/jelly {};
+
   jimtcl = callPackage ../development/interpreters/jimtcl {};
 
   jmeter = callPackage ../applications/networking/jmeter {};


### PR DESCRIPTION
##### Motivation for this change

Add a derivation for [the Jelly programming language](https://github.com/DennisMitchell/jellylanguage).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
