### PR TITLE
bppsuite: init at 2.4.1

### DIFF
--- a/pkgs/applications/science/biology/bppsuite/default.nix
+++ b/pkgs/applications/science/biology/bppsuite/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, cmake, bpp-core, bpp-seq, bpp-phyl, bpp-popgen }:
+
+stdenv.mkDerivation rec {
+  pname = "bppsuite";
+
+  inherit (bpp-core) version;
+
+  src = fetchFromGitHub {
+    owner = "BioPP";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wdwcgczqbc3m116vakvi0129wm3acln3cfc7ivqnalwvi6lrpds";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ bpp-core bpp-seq bpp-phyl bpp-popgen ];
+
+  meta = bpp-core.meta // {
+    changelog = "https://github.com/BioPP/bppsuite/blob/master/ChangeLog";
+  };
+}

--- a/pkgs/development/libraries/science/biology/bpp-core/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-core/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "bpp-core";
+  version = "2.4.1";
+
+  src = fetchFromGitHub { owner = "BioPP";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ma2cl677l7s0n5sffh66cy9lxp5wycm50f121g8rx85p95vkgwv";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$(pwd)/src
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/lib/cmake/bpp-core/bpp-core-targets.cmake  \
+      --replace 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'
+  '';
+  # prevents cmake from exporting incorrect INTERFACE_INCLUDE_DIRECTORIES
+  # of form /nix/store/.../nix/store/.../include,
+  # probably due to relative vs absolute path issue
+
+  doCheck = !stdenv.isDarwin;
+
+  meta = with stdenv.lib; {
+    homepage = "http://biopp.univ-montp2.fr/wiki/index.php/Main_Page";
+    changelog = "https://github.com/BioPP/bpp-core/blob/master/ChangeLog";
+    description = "C++ bioinformatics libraries and tools";
+    maintainers = with maintainers; [ bcdarwin ];
+    license = licenses.cecill20;
+  };
+}

--- a/pkgs/development/libraries/science/biology/bpp-phyl/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-phyl/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cmake, bpp-core, bpp-seq }:
+
+stdenv.mkDerivation rec {
+  pname = "bpp-phyl";
+
+  inherit (bpp-core) version;
+
+  src = fetchFromGitHub {
+    owner = "BioPP";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "192zks6wyk903n06c2lbsscdhkjnfwms8p7jblsmk3lvjhdipb20";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ bpp-core bpp-seq ];
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$(pwd)/src
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/lib/cmake/${pname}/${pname}-targets.cmake  \
+      --replace 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'
+  '';
+
+  doCheck = !stdenv.isDarwin;
+
+  meta = bpp-core.meta // {
+    changelog = "https://github.com/BioPP/bpp-phyl/blob/master/ChangeLog";
+  };
+}

--- a/pkgs/development/libraries/science/biology/bpp-popgen/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-popgen/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, cmake, bpp-core, bpp-seq }:
+
+stdenv.mkDerivation rec {
+  pname = "bpp-popgen";
+
+  inherit (bpp-core) version;
+
+  src = fetchFromGitHub {
+    owner = "BioPP";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0bz0fhrq3dri6a0hvfc3zlvrns8mrzzlnicw5pyfa812gc1qwfvh";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ bpp-core bpp-seq ];
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$(pwd)/src
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/lib/cmake/${pname}/${pname}-targets.cmake  \
+      --replace 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'
+  '';
+  # prevents cmake from exporting incorrect INTERFACE_INCLUDE_DIRECTORIES
+  # of form /nix/store/.../nix/store/.../include,
+  # probably due to relative vs absolute path issue
+
+  doCheck = !stdenv.isDarwin;
+
+  meta = bpp-core.meta // {
+    changelog = "https://github.com/BioPP/bpp-popgen/blob/master/ChangeLog";
+  };
+}

--- a/pkgs/development/libraries/science/biology/bpp-seq/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-seq/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, cmake, bpp-core }:
+
+stdenv.mkDerivation rec {
+  pname = "bpp-seq";
+
+  inherit (bpp-core) version;
+
+  src = fetchFromGitHub {
+    owner = "BioPP";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1mc09g8jswzsa4wgrfv59jxn15ys3q8s0227p1j838wkphlwn2qk";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ bpp-core ];
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$(pwd)/src
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/lib/cmake/${pname}/${pname}-targets.cmake  \
+      --replace 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'
+  '';
+  # prevents cmake from exporting incorrect INTERFACE_INCLUDE_DIRECTORIES
+  # of form /nix/store/.../nix/store/.../include,
+  # probably due to relative vs absolute path issue
+
+  doCheck = !stdenv.isDarwin;
+
+  meta = bpp-core.meta // { 
+    changelog = "https://github.com/BioPP/bpp-seq/blob/master/ChangeLog";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24394,6 +24394,8 @@ in
 
   bpp-phyl = callPackage ../development/libraries/science/biology/bpp-phyl { };
 
+  bpp-popgen = callPackage ../development/libraries/science/biology/bpp-popgen { };
+
   bpp-seq = callPackage ../development/libraries/science/biology/bpp-seq { };
 
   cd-hit = callPackage ../applications/science/biology/cd-hit { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24390,6 +24390,8 @@ in
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
+  bpp-core = callPackage ../development/libraries/science/biology/bpp-core { };
+
   cd-hit = callPackage ../applications/science/biology/cd-hit { };
 
   cmtk = callPackage ../applications/science/biology/cmtk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24398,6 +24398,8 @@ in
 
   bpp-seq = callPackage ../development/libraries/science/biology/bpp-seq { };
 
+  bppsuite = callPackage ../applications/science/biology/bppsuite { };
+
   cd-hit = callPackage ../applications/science/biology/cd-hit { };
 
   cmtk = callPackage ../applications/science/biology/cmtk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24392,6 +24392,8 @@ in
 
   bpp-core = callPackage ../development/libraries/science/biology/bpp-core { };
 
+  bpp-seq = callPackage ../development/libraries/science/biology/bpp-seq { };
+
   cd-hit = callPackage ../applications/science/biology/cd-hit { };
 
   cmtk = callPackage ../applications/science/biology/cmtk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24392,6 +24392,8 @@ in
 
   bpp-core = callPackage ../development/libraries/science/biology/bpp-core { };
 
+  bpp-phyl = callPackage ../development/libraries/science/biology/bpp-phyl { };
+
   bpp-seq = callPackage ../development/libraries/science/biology/bpp-seq { };
 
   cd-hit = callPackage ../applications/science/biology/cd-hit { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [NA] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
