### PR TITLE
ankisyncd, nixos/ankisyncd: init at 2.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4544,6 +4544,12 @@
     githubId = 1711539;
     name = "matklad";
   };
+  matt-snider = {
+    email = "matt.snider@protonmail.com";
+    github = "matt-snider";
+    githubId = 11810057;
+    name = "Matt Snider";
+  };
   matthewbauer = {
     email = "mjbauer95@gmail.com";
     github = "matthewbauer";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -405,6 +405,7 @@
   ./services/mail/sympa.nix
   ./services/mail/nullmailer.nix
   ./services/misc/airsonic.nix
+  ./services/misc/ankisyncd.nix
   ./services/misc/apache-kafka.nix
   ./services/misc/autofs.nix
   ./services/misc/autorandr.nix

--- a/nixos/modules/services/misc/ankisyncd.nix
+++ b/nixos/modules/services/misc/ankisyncd.nix
@@ -1,0 +1,79 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.ankisyncd;
+
+  name = "ankisyncd";
+
+  stateDir = "/var/lib/${name}";
+
+  authDbPath = "${stateDir}/auth.db";
+
+  sessionDbPath = "${stateDir}/session.db";
+
+  configFile = pkgs.writeText "ankisyncd.conf" (lib.generators.toINI {} {
+    sync_app = {
+      host = cfg.host;
+      port = cfg.port;
+      data_root = stateDir;
+      auth_db_path = authDbPath;
+      session_db_path = sessionDbPath;
+
+      base_url = "/sync/";
+      base_media_url = "/msync/";
+    };
+  });
+in
+  {
+    options.services.ankisyncd = {
+      enable = mkEnableOption "ankisyncd";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.ankisyncd;
+        defaultText = literalExample "pkgs.ankisyncd";
+        description = "The package to use for the ankisyncd command.";
+      };
+
+      host = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "ankisyncd host";
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 27701;
+        description = "ankisyncd port";
+      };
+
+      openFirewall = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Whether to open the firewall for the specified port.";
+      };
+    };
+
+    config = mkIf cfg.enable {
+      networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+
+      environment.etc."ankisyncd/ankisyncd.conf".source = configFile;
+
+      systemd.services.ankisyncd = {
+        description = "ankisyncd - Anki sync server";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        path = [ cfg.package ];
+
+        serviceConfig = {
+          Type = "simple";
+          DynamicUser = true;
+          StateDirectory = name;
+          ExecStart = "${cfg.package}/bin/ankisyncd";
+          Restart = "always";
+        };
+      };
+    };
+  }

--- a/pkgs/servers/ankisyncd/default.nix
+++ b/pkgs/servers/ankisyncd/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, fetchFromGitHub
+, python3
+, anki
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "ankisyncd";
+  version = "2.1.0";
+  src = fetchFromGitHub {
+    owner = "tsudoko";
+    repo = "anki-sync-server";
+    rev = version;
+    sha256 = "6a140afa94fdb1725fed716918875e3d2ad0092cb955136e381c9d826cc4927c";
+  };
+  format = "other";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/${python3.sitePackages}
+
+    cp -r ankisyncd utils ankisyncd.conf $out/${python3.sitePackages}
+    mkdir $out/share
+    cp ankisyncctl.py $out/share/
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    PYTHONPATH="$PYTHONPATH:$out/${python3.sitePackages}:${anki}"
+
+    makeWrapper "${python3.interpreter}" "$out/bin/ankisyncd" \
+          --set PYTHONPATH $PYTHONPATH \
+          --add-flags "-m ankisyncd"
+
+    makeWrapper "${python3.interpreter}" "$out/bin/ankisyncctl" \
+          --set PYTHONPATH $PYTHONPATH \
+          --add-flags "$out/share/ankisyncctl.py"
+  '';
+
+  checkInputs = with python3.pkgs; [
+    pytest
+    webtest
+  ];
+
+  buildInputs = [ ];
+
+  propagatedBuildInputs = [ anki ];
+
+  checkPhase = ''
+    # Exclude tests that require sqlite's sqldiff command, since
+    # it isn't yet packaged for NixOS, although 2 PRs exist:
+    # - https://github.com/NixOS/nixpkgs/pull/69112
+    # - https://github.com/NixOS/nixpkgs/pull/75784
+    # Once this is merged, these tests can be run as well.
+    pytest --ignore tests/test_web_media.py tests/
+  '';
+
+  meta = with lib; {
+    description = "Self-hosted Anki sync server";
+    maintainers = with maintainers; [ matt-snider ];
+    homepage = "https://github.com/tsudoko/anki-sync-server";
+    license = licenses.agpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -126,6 +126,8 @@ in
 
   addOpenGLRunpath = callPackage ../build-support/add-opengl-runpath { };
 
+  ankisyncd = callPackage ../servers/ankisyncd { };
+
   avro-tools = callPackage ../development/tools/avro-tools { };
 
   # Zip file format only allows times after year 1980, which makes e.g. Python wheel building fail with:


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

[ankisyncd](https://github.com/tsudoko/anki-sync-server/) is a python application for synchronizing [Anki](https://apps.ankiweb.net/) data. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
