### PR TITLE
leftwm: 0.1.10 -> 0.2.2

### DIFF
--- a/pkgs/applications/window-managers/leftwm/default.nix
+++ b/pkgs/applications/window-managers/leftwm/default.nix
@@ -1,41 +1,35 @@
 { stdenv, fetchFromGitHub, rustPlatform, libX11, libXinerama, makeWrapper }:
 
-let 
+let
     rpath = stdenv.lib.makeLibraryPath [ libXinerama libX11 ];
 in
 
 rustPlatform.buildRustPackage rec {
-    pname = "leftwm";
-    version = "0.1.10";
+  pname = "leftwm";
+  version = "0.2.2";
 
-    src = fetchFromGitHub {
-        owner = "leftwm";
-        repo = "leftwm";
-        rev = version;
-        sha256 = "190lc48clkh9vzlsfg2a70w405k7xyyw7avnxwna1glfwmbyy2ag";
-    };
+  src = fetchFromGitHub {
+    owner = "leftwm";
+    repo = "leftwm";
+    rev = version;
+    sha256 = "0x8cqc7zay19jxy7cshayjjwwjrcblqpmqrxipm2g5hhyjghk6q0";
+  };
 
-    buildInputs = [ makeWrapper libX11 libXinerama ];
+  cargoSha256 = "1kphv3vnr8ij7raf0niwz3rwly986xi5fgwqg2ya0r46ifqkgvrc";
 
-    postInstall = ''
-        wrapProgram $out/bin/leftwm --prefix LD_LIBRARY_PATH : "${rpath}"
-        wrapProgram $out/bin/leftwm-state --prefix LD_LIBRARY_PATH : "${rpath}"
-        wrapProgram $out/bin/leftwm-worker --prefix LD_LIBRARY_PATH : "${rpath}"
-    '';
+  buildInputs = [ makeWrapper libX11 libXinerama ];
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
+  postInstall = ''
+    wrapProgram $out/bin/leftwm --prefix LD_LIBRARY_PATH : "${rpath}"
+    wrapProgram $out/bin/leftwm-state --prefix LD_LIBRARY_PATH : "${rpath}"
+    wrapProgram $out/bin/leftwm-worker --prefix LD_LIBRARY_PATH : "${rpath}"
+  '';
 
-    cargoSha256 = "0mpvfix7bvc84vanha474l4gaq97ac1zy5l77z83m9jg0246yxd6";
-
-    # patch wrong version in Cargo.lock
-    cargoPatches = [ ./cargo-lock.patch ];
-
-    meta = {
-        description = "Leftwm - A tiling window manager for the adventurer";
-        homepage = https://github.com/leftwm/leftwm;
-        license = stdenv.lib.licenses.mit;
-        platforms = stdenv.lib.platforms.linux;
-        maintainers = with stdenv.lib.maintainers; [ mschneider ];
-    };
+  meta = with stdenv.lib; {
+    description = "Leftwm - A tiling window manager for the adventurer";
+    homepage = "https://github.com/leftwm/leftwm";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mschneider ];
+  };
 }


### PR DESCRIPTION
The build is currently broken on master; upgrading fixes it for
ZHF: #80379

CC @NixOS/nixos-release-managers  @mschneider

Also along for the ride:

- Upgrade cargo fetcher for https://github.com/NixOS/nixpkgs/issues/79975
- Quoted homepage for https://github.com/NixOS/rfcs/pull/45
- Switched to consistent 2-space indent
- Cleaned up the meta section


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).