### PR TITLE
cura: 4.4.0 -> 4.5.0

### DIFF
--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -2,20 +2,20 @@
 
 mkDerivation rec {
   pname = "cura";
-  version = "4.4.0";
+  version = "4.5.0";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "Cura";
-    rev = "v${version}";
-    sha256 = "131n36qhdfky584wr3zv73ckjjprwaqb5fih8yln2syf8b7ziwlz";
+    rev = version;
+    sha256 = "0fm04s912sgmr66wyb55ly4jh39ijsj6lx4fx9wn7hchlqmw5jxi";
   };
 
   materials = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "fdm_materials";
     rev = version;
-    sha256 = "141cv1f2pv2pznhgj32zg8bw3kmw9002g6rx16jq7lhclr0x3xls";
+    sha256 = "0fgkwz1anw49macq1jxjhjr79slhmx7g3zwij7g9fqyzzhrrmwqn";
   };
 
   buildInputs = [ qtbase qtquickcontrols2 qtgraphicaleffects ];

--- a/pkgs/applications/misc/curaengine/default.nix
+++ b/pkgs/applications/misc/curaengine/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "curaengine";
-  version = "4.4.0";
+  version = "4.5.0";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "CuraEngine";
     rev = version;
-    sha256 = "1m89bp4g0dldh7vv1clj110m29ajiaghdq7b49mb3y8ifgrf8rdi";
+    sha256 = "1gml8f6yqmghgncl1zggs7h2hdh05wf68jw9npg0gh7n9l7yzkk4";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A powerful, fast and robust engine for processing 3D models into 3D printing instruction";
-    homepage = https://github.com/Ultimaker/CuraEngine;
+    homepage = "https://github.com/Ultimaker/CuraEngine";
     license = licenses.agpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar gebner ];

--- a/pkgs/development/python-modules/libarcus/default.nix
+++ b/pkgs/development/python-modules/libarcus/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "libarcus";
-  version = "4.4.0";
+  version = "4.5.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "libArcus";
     rev = version;
-    sha256 = "16m7m6ak5fqw3djn4azwiamkizcc1dv7brv11kv99n3b43zzgn6d";
+    sha256 = "1sfy8skvgw6hiihs9jmfn7a13yappqwffir98pahyg7cim7p55kr";
   };
 
   disabled = pythonOlder "3.4.0";

--- a/pkgs/development/python-modules/libsavitar/default.nix
+++ b/pkgs/development/python-modules/libsavitar/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "libsavitar";
-  version = "4.4.0";
+  version = "4.5.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "libSavitar";
     rev = version;
-    sha256 = "0sm8945icbdxvyj7yiq9yhkk17ww3gjkpsbk7875qijzlgfs60j8";
+    sha256 = "1l3l8cgaxzqdk93880p2ijrabshdj5sq05cwj1i6jpmhlqc5b9rx";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/uranium/default.nix
+++ b/pkgs/development/python-modules/uranium/default.nix
@@ -2,7 +2,7 @@
 , pyqt5, numpy, scipy, shapely, libarcus, doxygen, gettext, pythonOlder }:
 
 buildPythonPackage rec {
-  version = "4.4.0";
+  version = "4.5.0";
   pname = "uranium";
   format = "other";
 
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "Ultimaker";
     repo = "Uranium";
     rev = version;
-    sha256 = "1hy7lhn48mfrmfx6mbqxzc6bfh9ndnvcwjlsb6a71mw62xg6w7c2";
+    sha256 = "1l8fwj521irla42bdbw298d3c5rjpn1nm9xhjnx7hidbqixr5d27";
   };
 
   disabled = pythonOlder "3.5.0";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New release of ultimaker cura: 4.5.0
Based on #81746 

I have created one commit which also updates the dependencies, since it looks like they have to be updated in sync. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
