### PR TITLE
afew: 2.0.0 -> 3.0.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/afew/default.nix
+++ b/pkgs/applications/networking/mailreaders/afew/default.nix
@@ -2,18 +2,22 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "afew";
-  version = "2.0.0";
+  version = "3.0.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0j60501nm242idf2ig0h7p6wrg58n5v2p6zfym56v9pbvnbmns0s";
+    sha256 = "18j3xyzchlslcrkycr2i59jg73cb6yh5s7l3qnl6sa7vgxcbhq7c";
   };
 
   nativeBuildInputs = with python3Packages; [ sphinx setuptools_scm ];
 
   propagatedBuildInputs = with python3Packages; [
     python3Packages.setuptools python3Packages.notmuch chardet dkimpy
-  ] ++ stdenv.lib.optional (!python3Packages.isPy3k) subprocess32;
+  ];
+
+  checkInputs = with python3Packages; [
+    freezegun notmuch
+  ];
 
   makeWrapperArgs = [
     ''--prefix PATH ':' "${notmuch}/bin"''


### PR DESCRIPTION
MailMover: many fixes

  Previously, MailMover didn't properly preserve flags when renaming files, and
  moved all mail to `cur`. This was fixed. Also, MailMover gained a test suite.

New filters: PropagateTags[ByRegex]InThreadFilter

  These filters allow propagating tags set to a message to the whole thread.

New command line argument: --notmuch-args= in move mode

  In move mode, afew calls `notmuch new` after moving mails around. This
  prevents `afew -m` from being used in a pre-new hook in `notmuch`.

  Now it's possible to specify notmuch args, so something like `afew -m
  --notmuch-args=--no-hooks` can live happily in a pre-new hook.

Python 3.4 and 3.5 support dropped

  afew stopped supporting the older python versions 3.4 and 3.5, and removed
  some more Python 2 compatibility code. (`from __future__ import …`, utf-8
  headers, relative imports, …)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
