### PR TITLE
Unbreak haskell package ats-pkg

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1400,4 +1400,27 @@ self: super: {
   # https://github.com/bergmark/feed/issues/43
   feed = dontCheck super.feed;
 
+  pantry = appendPatches super.pantry [
+    # Pantry has been updated for ghc-8.8 upstream, but there hasn't been a
+    # release yet with this patch. This can probably be removed when a
+    # version of pantry is released after 0.2.0.0.
+    # https://github.com/commercialhaskell/pantry/pull/6
+    (pkgs.fetchpatch {
+      url = "https://github.com/commercialhaskell/pantry/pull/6.diff";
+      sha256 = "0aml06jshpjh3aiscs5av7y33m3d6s6x5pzdvh7pky476izfg87k";
+      excludes = [
+        ".azure/azure-linux-template.yml"
+        ".azure/azure-osx-template.yml"
+        ".azure/azure-windows-template.yml"
+        "package.yaml"
+        "pantry.cabal"
+        "stack-lts-11.yaml"
+        "stack-lts-12.yaml"
+        "stack-nightly.yaml"
+        "stack-windows.yaml"
+        "stack.yaml"
+      ];
+    })
+  ];
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1218,7 +1218,7 @@ self: super: {
   temporary-resourcet = doJailbreak super.temporary-resourcet;
 
   # Requires dhall >= 1.23.0
-  ats-pkg = super.ats-pkg.override { dhall = self.dhall_1_29_0; };
+  ats-pkg = dontCheck (super.ats-pkg.override { dhall = self.dhall_1_29_0; });
 
   # Test suite doesn't work with current QuickCheck
   # https://github.com/pruvisto/heap/issues/11

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1071,8 +1071,28 @@ self: super: {
 
   # Generate shell completion.
   cabal2nix = generateOptparseApplicativeCompletion "cabal2nix" super.cabal2nix;
-  stack = generateOptparseApplicativeCompletion "stack" (super.stack.overrideScope (self: super: {
-  }));
+
+  stack =
+    generateOptparseApplicativeCompletion
+      "stack"
+      (appendPatches super.stack [
+        # This PR fixes stack up to be able to build with Cabal-3.  This patch
+        # can probably be dropped when the next stack release is made after
+        # 2.1.3.1.
+        (pkgs.fetchpatch {
+          url = "https://github.com/commercialhaskell/stack/pull/5156.diff";
+          sha256 = "0knk6f9fh1b4fxkhvx5gfrwclal4vi2va4zy34gpmwnjr7knf42y";
+          excludes = [
+            "snapshot-lts-12.yaml"
+            "snapshot-nightly.yaml"
+            "snapshot.yaml"
+          ];
+        })
+        # This patch fixes stack up to be able to build various GHC-8.8 changes.
+        # This can hopefully be dropped when the next stack release is made
+        # after 2.1.3.1 (assuming the next stack release uses GHC-8.8).
+        ./patches/stack-ghc882-support.patch
+      ]);
 
   # musl fixes
   # dontCheck: use of non-standard strptime "%s" which musl doesn't support; only used in test

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1422,7 +1422,7 @@ self: super: {
   # https://github.com/bergmark/feed/issues/43
   feed = dontCheck super.feed;
 
-  pantry_0_2_0_0 = appendPatches super.pantry_0_2_0_0 [
+  pantry_0_2_0_0 = appendPatches (dontCheck super.pantry_0_2_0_0) [
     # pantry-0.2.0.0 doesn't build with ghc-8.8, but there is a PR adding support.
     # https://github.com/commercialhaskell/pantry/pull/6
     # Currently stack-2.1.3.1 requires pantry-0.2.0.0, but when a newer version of

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1443,4 +1443,7 @@ self: super: {
     })
   ];
 
+  # https://github.com/serokell/nixfmt/pull/62
+  nixfmt = doJailbreak super.nixfmt;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1325,11 +1325,6 @@ self: super: {
   # https://github.com/haskell-servant/servant-ekg/issues/15
   servant-ekg = doJailbreak super.servant-ekg;
 
-  # Needs ghc-lib-parser 8.8.1 (does not build with 8.8.0)
-  ormolu = doJailbreak (super.ormolu.override {
-    ghc-lib-parser = self.ghc-lib-parser_8_8_3_20200224;
-  });
-
   # krank-0.1.0 does not accept PyF-0.9.0.0.
   krank = doJailbreak super.krank;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1073,9 +1073,16 @@ self: super: {
   cabal2nix = generateOptparseApplicativeCompletion "cabal2nix" super.cabal2nix;
 
   stack =
+    let
+      stackWithOverrides =
+        super.stack.override {
+          # stack-2.1.3.1 requires pantry-0.2.0.0.
+          pantry = self.pantry_0_2_0_0;
+        };
+    in
     generateOptparseApplicativeCompletion
       "stack"
-      (appendPatches super.stack [
+      (appendPatches stackWithOverrides [
         # This PR fixes stack up to be able to build with Cabal-3.  This patch
         # can probably be dropped when the next stack release is made after
         # 2.1.3.1.
@@ -1415,11 +1422,12 @@ self: super: {
   # https://github.com/bergmark/feed/issues/43
   feed = dontCheck super.feed;
 
-  pantry = appendPatches super.pantry [
-    # Pantry has been updated for ghc-8.8 upstream, but there hasn't been a
-    # release yet with this patch. This can probably be removed when a
-    # version of pantry is released after 0.2.0.0.
+  pantry_0_2_0_0 = appendPatches super.pantry_0_2_0_0 [
+    # pantry-0.2.0.0 doesn't build with ghc-8.8, but there is a PR adding support.
     # https://github.com/commercialhaskell/pantry/pull/6
+    # Currently stack-2.1.3.1 requires pantry-0.2.0.0, but when a newer version of
+    # stack is released, it will probably use the newer pantry version, so we
+    # can completely get rid of pantry-0.2.0.0.
     (pkgs.fetchpatch {
       url = "https://github.com/commercialhaskell/pantry/pull/6.diff";
       sha256 = "0aml06jshpjh3aiscs5av7y33m3d6s6x5pzdvh7pky476izfg87k";

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -90,4 +90,8 @@ self: super: {
   # https://github.com/kowainik/relude/issues/241
   relude = dontCheck super.relude;
 
+  # The tests for semver-range need to be updated for the MonadFail change in
+  # ghc-8.8:
+  # https://github.com/adnelson/semver-range/issues/15
+  semver-range = dontCheck super.semver-range;
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5095,7 +5095,6 @@ broken-packages:
   - git-repair
   - git-sanity
   - gitdo
-  - github
   - github-backup
   - github-data
   - github-release

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9111,7 +9111,6 @@ broken-packages:
   - semigroups-actions
   - semiring
   - semiring-num
-  - semver-range
   - sendgrid-haskell
   - sendgrid-v3
   - sensei

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2397,6 +2397,7 @@ extra-packages:
   - network == 3.0.*                    # required by network-bsd, HTTP, and many others (2019-04-30)
   - parallel == 3.2.0.3                 # newer versions don't work with GHC 6.12.3
   - patience ^>= 0.1                    # required by chell-0.4.x
+  - pantry == 0.2.0.0                   # required by stack-2.1.3.1
   - persistent >=2.5 && <2.8            # pre-lts-11.x versions neeed by git-annex 6.20180227
   - persistent-sqlite < 2.7             # pre-lts-11.x versions neeed by git-annex 6.20180227
   - prettyprinter == 1.6.1              # required by ghc 8.8.x, and dhall-1.29.0

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8026,7 +8026,6 @@ broken-packages:
   - pangraph
   - panpipe
   - pansite
-  - pantry
   - pantry-tmp
   - papa
   - papa-base

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9572,7 +9572,6 @@ broken-packages:
   - stable-marriage
   - stable-memo
   - stable-tree
-  - stack
   - stack-bump
   - stack-fix
   - stack-hpc-coveralls

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5530,9 +5530,7 @@ broken-packages:
   - haskell-go-checkers
   - haskell-in-space
   - haskell-kubernetes
-  - haskell-lsp
   - haskell-lsp-client
-  - haskell-lsp-types
   - haskell-ml
   - haskell-mpfr
   - haskell-names
@@ -7192,7 +7190,6 @@ broken-packages:
   - ls-usb
   - lscabal
   - LslPlus
-  - lsp-test
   - lsystem
   - ltext
   - ltk

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3106,7 +3106,6 @@ broken-packages:
   - binary-ext
   - binary-file
   - binary-indexed-tree
-  - binary-instances
   - binary-protocol
   - binary-protocol-zmq
   - binary-search

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -76,7 +76,7 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  # LTS Haskell 15.1
+  # LTS Haskell 15.2
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -104,7 +104,7 @@ default-package-overrides:
   - aeson-schemas ==1.0.3
   - aeson-utils ==0.3.0.2
   - aeson-yak ==0.1.1.3
-  - aeson-yaml ==1.0.5.0
+  - aeson-yaml ==1.0.6.0
   - al ==0.1.4.2
   - alerts ==0.1.2.0
   - alex ==3.2.5
@@ -266,7 +266,7 @@ default-package-overrides:
   - autoexporter ==1.1.15
   - auto-update ==0.1.6
   - avers ==0.0.17.1
-  - avro ==0.4.6.0
+  - avro ==0.4.7.0
   - aws-cloudfront-signed-cookies ==0.2.0.1
   - base16-bytestring ==0.1.1.6
   - base32string ==0.9.1
@@ -354,12 +354,13 @@ default-package-overrides:
   - bv ==0.5
   - bv-little ==1.1.1
   - byteable ==0.1.1
+  - bytebuild ==0.3.4.0
   - bytedump ==1.0
   - byte-order ==0.1.2.0
   - byteorder ==1.0.4
   - bytes ==0.17
   - byteset ==0.1.1.0
-  - byteslice ==0.2.1.0
+  - byteslice ==0.2.2.0
   - bytesmith ==0.3.5.0
   - bytestring-builder ==0.10.8.2.0
   - bytestring-conversion ==0.3.1
@@ -373,7 +374,7 @@ default-package-overrides:
   - cabal-doctest ==1.0.8
   - cabal-flatpak ==0.1
   - cabal-plan ==0.6.2.0
-  - cabal-rpm ==2.0.2
+  - cabal-rpm ==2.0.4
   - cache ==0.1.3.0
   - cacophony ==0.10.1
   - calendar-recycling ==0.0.0.1
@@ -390,7 +391,7 @@ default-package-overrides:
   - cassava-megaparsec ==2.0.1
   - cast ==0.1.0.2
   - category ==0.2.5.0
-  - cayley-client ==0.4.11
+  - cayley-client ==0.4.12
   - cborg ==0.2.2.1
   - cborg-json ==0.2.2.0
   - cereal ==0.5.8.1
@@ -498,7 +499,7 @@ default-package-overrides:
   - core-text ==0.2.3.3
   - countable ==1.0
   - cpio-conduit ==0.7.0
-  - cpphs ==1.20.8
+  - cpphs ==1.20.9
   - cprng-aes ==0.6.1
   - cpu ==0.1.2
   - cpuinfo ==0.1.0.1
@@ -584,7 +585,7 @@ default-package-overrides:
   - declarative ==0.5.2
   - deepseq-generics ==0.2.0.0
   - deferred-folds ==0.9.10.1
-  - dejafu ==2.1.0.1
+  - dejafu ==2.1.0.3
   - dense-linear-algebra ==0.1.0.0
   - deque ==0.4.3
   - deriveJsonNoPrefix ==0.1.0.1
@@ -661,6 +662,7 @@ default-package-overrides:
   - elerea ==2.9.0
   - elf ==0.30
   - eliminators ==0.6
+  - elm2nix ==0.2
   - elm-bridge ==0.5.2
   - elm-core-sources ==1.0.0
   - elm-export ==0.6.0.1
@@ -724,11 +726,11 @@ default-package-overrides:
   - fft ==0.1.8.6
   - fgl ==5.7.0.2
   - filecache ==0.4.1
-  - file-embed ==0.0.11.1
+  - file-embed ==0.0.11.2
   - file-embed-lzma ==0
   - filelock ==0.1.1.4
   - filemanip ==0.3.6.3
-  - filepattern ==0.1.1
+  - filepattern ==0.1.2
   - fileplow ==0.1.0.0
   - filtrable ==0.1.3.0
   - fin ==0.1.1
@@ -836,9 +838,9 @@ default-package-overrides:
   - ghcid ==0.8.1
   - ghci-hexcalc ==0.1.1.0
   - ghcjs-codemirror ==0.0.0.2
-  - ghc-lib ==8.8.2.20200205
-  - ghc-lib-parser ==8.8.2.20200205
-  - ghc-lib-parser-ex ==8.8.5.2
+  - ghc-lib ==8.8.3.20200224
+  - ghc-lib-parser ==8.8.3.20200224
+  - ghc-lib-parser-ex ==8.8.5.3
   - ghc-paths ==0.1.0.12
   - ghc-prof ==1.4.1.6
   - ghc-source-gen ==0.3.0.0
@@ -882,7 +884,7 @@ default-package-overrides:
   - gluturtle ==0.0.58.1
   - gnuplot ==0.5.6.1
   - google-isbn ==1.0.3
-  - gothic ==0.1.3
+  - gothic ==0.1.4
   - gpolyline ==0.1.0.1
   - graph-core ==0.3.0.0
   - graphite ==0.10.0.1
@@ -903,6 +905,7 @@ default-package-overrides:
   - hamtsolo ==1.0.3
   - HandsomeSoup ==0.4.2
   - happy ==1.19.12
+  - HasBigDecimal ==0.1.1
   - hashable ==1.3.0.0
   - hashable-time ==0.2.0.2
   - hashids ==1.0.2.4
@@ -959,7 +962,7 @@ default-package-overrides:
   - hinotify ==0.4
   - hint ==0.9.0.2
   - hjsmin ==0.2.0.4
-  - hkgr ==0.2.4.1
+  - hkgr ==0.2.5.2
   - hlibcpuid ==0.2.0
   - hlibgit2 ==0.18.0.16
   - hmatrix ==0.20.0.0
@@ -1078,7 +1081,7 @@ default-package-overrides:
   - hw-mquery ==0.2.0.2
   - hw-packed-vector ==0.2.0.1
   - hw-parser ==0.1.0.2
-  - hw-prim ==0.6.2.39
+  - hw-prim ==0.6.2.40
   - hw-rankselect ==0.13.3.2
   - hw-rankselect-base ==0.3.3.0
   - hw-simd ==0.1.1.5
@@ -1121,6 +1124,7 @@ default-package-overrides:
   - ini ==0.4.1
   - inj ==1.0
   - inline-c ==0.9.0.0
+  - inline-c-cpp ==0.4.0.2
   - insert-ordered-containers ==0.2.3
   - inspection-testing ==0.4.2.2
   - instance-control ==0.1.2.0
@@ -1163,6 +1167,7 @@ default-package-overrides:
   - ix-shapable ==0.1.0
   - jack ==0.7.1.4
   - jira-wiki-markup ==1.0.0
+  - jose ==0.8.2.0
   - jose-jwt ==0.8.0
   - js-dgtable ==0.5.2
   - js-flot ==0.8.3
@@ -1172,7 +1177,7 @@ default-package-overrides:
   - jsonpath ==0.2.0.0
   - json-rpc ==1.0.1
   - json-rpc-generic ==0.2.1.5
-  - JuicyPixels ==3.3.4
+  - JuicyPixels ==3.3.5
   - JuicyPixels-extra ==0.4.1
   - JuicyPixels-scale-dct ==0.1.2
   - junit-xml ==0.1.0.0
@@ -1197,7 +1202,7 @@ default-package-overrides:
   - lackey ==1.0.11
   - LambdaHack ==0.9.5.0
   - lame ==0.2.0
-  - language-avro ==0.1.0.0
+  - language-avro ==0.1.2.0
   - language-c ==0.8.3
   - language-c-quote ==0.12.2.1
   - language-haskell-extract ==0.2.4
@@ -1333,6 +1338,7 @@ default-package-overrides:
   - miso ==1.4.0.0
   - missing-foreign ==0.1.1
   - mixed-types-num ==0.4.0.1
+  - mixpanel-client ==0.2.1
   - mltool ==0.2.0.1
   - mmap ==0.5.9
   - mmark ==0.0.7.2
@@ -1612,7 +1618,7 @@ default-package-overrides:
   - pretty-sop ==0.2.0.3
   - pretty-types ==0.3.0.1
   - primes ==0.2.1.0
-  - primitive ==0.7.0.0
+  - primitive ==0.7.0.1
   - primitive-addr ==0.1.0.2
   - primitive-extras ==0.8
   - primitive-offset ==0.2.0.0
@@ -1767,7 +1773,7 @@ default-package-overrides:
   - SafeSemaphore ==0.10.1
   - salak ==0.3.5.3
   - salak-yaml ==0.3.5.3
-  - saltine ==0.1.0.2
+  - saltine ==0.1.1.0
   - salve ==1.0.8
   - sample-frame ==0.0.3
   - sample-frame-np ==0.0.4.1
@@ -1809,6 +1815,9 @@ default-package-overrides:
   - serf ==0.1.1.0
   - serialise ==0.2.2.0
   - servant ==0.16.2
+  - servant-auth ==0.3.2.0
+  - servant-auth-server ==0.4.5.1
+  - servant-auth-swagger ==0.2.10.0
   - servant-blaze ==0.9
   - servant-cassava ==0.10
   - servant-checked-exceptions ==2.2.0.0
@@ -1836,6 +1845,7 @@ default-package-overrides:
   - servant-swagger-ui-redoc ==0.3.3.1.22.3
   - servant-websockets ==2.0.0
   - servant-yaml ==0.1.0.1
+  - serverless-haskell ==0.10.1
   - serversession ==1.0.1
   - serversession-frontend-wai ==1.0
   - ses-html ==0.4.0.0
@@ -1881,7 +1891,7 @@ default-package-overrides:
   - skylighting ==0.8.3.2
   - skylighting-core ==0.8.3.2
   - slist ==0.1.0.0
-  - small-bytearray-builder ==0.3.3.0
+  - small-bytearray-builder ==0.3.4.0
   - smallcheck ==1.1.5
   - smoothie ==0.4.2.10
   - snap-blaze ==0.2.1.5
@@ -1907,7 +1917,7 @@ default-package-overrides:
   - Spintax ==0.3.3
   - splice ==0.6.1.1
   - split ==0.2.3.4
-  - splitmix ==0.0.3
+  - splitmix ==0.0.4
   - spoon ==0.3.1
   - spreadsheet ==0.1.3.8
   - sql-words ==0.1.6.3
@@ -1970,6 +1980,7 @@ default-package-overrides:
   - symengine ==0.1.2.0
   - sysinfo ==0.1.1
   - system-argv0 ==0.1.1
+  - systemd ==2.2.0
   - system-fileio ==0.3.16.4
   - system-filepath ==0.4.14
   - system-info ==0.5.1
@@ -2039,7 +2050,7 @@ default-package-overrides:
   - text-printer ==0.5.0.1
   - text-region ==0.3.1.0
   - text-short ==0.1.3
-  - text-show ==3.8.4
+  - text-show ==3.8.5
   - text-show-instances ==3.8.3
   - text-zipper ==0.10.1
   - tfp ==1.0.1.1
@@ -2174,7 +2185,7 @@ default-package-overrides:
   - unordered-containers ==0.2.10.0
   - unordered-intmap ==0.1.1
   - unsafe ==0.0
-  - urbit-hob ==0.3.1
+  - urbit-hob ==0.3.2
   - uri-bytestring ==0.3.2.2
   - uri-bytestring-aeson ==0.1.0.7
   - uri-encode ==1.5.0.5
@@ -2333,7 +2344,7 @@ default-package-overrides:
   - zeromq4-haskell ==0.8.0
   - zeromq4-patterns ==0.3.1.0
   - zim-parser ==0.2.1.0
-  - zip ==1.3.0
+  - zip ==1.3.1
   - zip-archive ==0.4.1
   - zippers ==0.3
   - zip-stream ==0.2.0.1

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5284,7 +5284,6 @@ broken-packages:
   - gtfs-realtime
   - gtk-jsinput
   - gtk-serialized-event
-  - gtk-sni-tray
   - gtk-toy
   - gtk2hs-hello
   - gtk2hs-rpn
@@ -9622,7 +9621,6 @@ broken-packages:
   - statsd
   - statsd-client
   - statsdi
-  - status-notifier-item
   - statvfs
   - stb-image-redux
   - stc-lang
@@ -9810,7 +9808,6 @@ broken-packages:
   - Tablify
   - tabloid
   - tabs
-  - taffybar
   - tag-bits
   - tag-stream
   - tagged-exception-core
@@ -10697,7 +10694,6 @@ broken-packages:
   - xchat-plugin
   - xcp
   - xdcc
-  - xdg-desktop-entry
   - xdot
   - Xec
   - xenstore

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2922,7 +2922,6 @@ broken-packages:
   - atomo
   - atp-haskell
   - ats-format
-  - ats-pkg
   - ats-setup
   - ats-storable
   - attempt

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -7802,7 +7802,6 @@ broken-packages:
   - nix-eval
   - nix-freeze-tree
   - nix-tools
-  - nixfmt
   - nixfromnpm
   - nixpkgs-update
   - nkjp

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -635,11 +635,19 @@ self: super: builtins.intersectAttrs super {
 
   spago =
     let
+      # Spago needs a patch for MonadFail changes.
+      # https://github.com/purescript/spago/pull/584
+      # This can probably be removed when a version after spago-0.14.0 is released.
+      spagoWithPatches = appendPatch super.spago (pkgs.fetchpatch {
+        url = "https://github.com/purescript/spago/pull/584/commits/898a8e48665e5a73ea03525ce2c973455ab9ac52.patch";
+        sha256 = "05gs1hjlcf60cr6728rhgwwgxp3ildly14v4l2lrh6ma2fljhyjy";
+      });
+
       # Spago basically compiles with LTS-14, but it requires a newer version
       # of directory.  This is to work around a bug only present on windows, so
       # we can safely jailbreak spago and use the older directory package from
       # LTS-14.
-      spagoWithOverrides = doJailbreak (super.spago.override {
+      spagoWithOverrides = doJailbreak (spagoWithPatches.override {
         # spago requires dhall-1.29.0.
         dhall = self.dhall_1_29_0;
       });

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -710,4 +710,8 @@ self: super: builtins.intersectAttrs super {
   # break infinite recursion with base-orphans
   primitive = dontCheck super.primitive;
 
+  # dhall-1.29.0 tests access the network.  This override can be removed when
+  # dhall_1_29_0 is no longer used, since more recent versions of dhall don't
+  # access the network in checks.
+  dhall_1_29_0 = dontCheck super.dhall_1_29_0;
 }

--- a/pkgs/development/haskell-modules/patches/stack-ghc882-support.patch
+++ b/pkgs/development/haskell-modules/patches/stack-ghc882-support.patch
@@ -1,0 +1,104 @@
+diff --git a/src/Stack/Coverage.hs b/src/Stack/Coverage.hs
+index d95fa332..f80e121a 100644
+--- a/src/Stack/Coverage.hs
++++ b/src/Stack/Coverage.hs
+@@ -235,7 +235,7 @@ generateHpcReportForTargets opts tixFiles targetNames = do
+                              case nc of
+                                  CTest testName ->
+                                      liftM (pkgPath </>) $ parseRelFile (T.unpack testName ++ "/" ++ T.unpack testName ++ ".tix")
+-                                 _ -> fail $
++                                 _ -> liftIO $ fail $
+                                      "Can't specify anything except test-suites as hpc report targets (" ++
+                                      packageNameString name ++
+                                      " is used with a non test-suite target)"
+diff --git a/src/Stack/Package.hs b/src/Stack/Package.hs
+index b69337ce..08eb9b9f 100644
+--- a/src/Stack/Package.hs
++++ b/src/Stack/Package.hs
+@@ -463,7 +463,7 @@ makeObjectFilePathFromC
+ makeObjectFilePathFromC cabalDir namedComponent distDir cFilePath = do
+     relCFilePath <- stripProperPrefix cabalDir cFilePath
+     relOFilePath <-
+-        parseRelFile (replaceExtension (toFilePath relCFilePath) "o")
++        parseRelFile (System.FilePath.replaceExtension (toFilePath relCFilePath) "o")
+     return (componentOutputDir namedComponent distDir </> relOFilePath)
+ 
+ -- | Make the global autogen dir if Cabal version is new enough.
+diff --git a/src/Stack/Script.hs b/src/Stack/Script.hs
+index c63c9f62..70257be1 100644
+--- a/src/Stack/Script.hs
++++ b/src/Stack/Script.hs
+@@ -172,8 +172,8 @@ scriptCmd opts = do
+ 
+   toExeName fp =
+     if osIsWindows
+-      then replaceExtension fp "exe"
+-      else dropExtension fp
++      then System.FilePath.replaceExtension fp "exe"
++      else System.FilePath.dropExtension fp
+ 
+ getPackagesFromImports
+   :: FilePath -- ^ script filename
+diff --git a/src/Stack/Setup.hs b/src/Stack/Setup.hs
+index 8bbfc45c..5c5b028c 100644
+--- a/src/Stack/Setup.hs
++++ b/src/Stack/Setup.hs
+@@ -876,7 +876,7 @@ buildGhcFromSource getSetupInfo' installed (CompilerRepository url) commitId fla
+          (_,files) <- listDir (cwd </> bindistPath)
+          let
+            isBindist p = "ghc-" `isPrefixOf` (toFilePath (filename p))
+-                         && fileExtension (filename p) == ".xz"
++                         && (maybe "" id (fileExtension (filename p))) == ".xz"
+            mbindist = filter isBindist files
+          case mbindist of
+            [bindist] -> do
+diff --git a/src/Stack/Storage/Project.hs b/src/Stack/Storage/Project.hs
+index dc5318d8..984e6259 100644
+--- a/src/Stack/Storage/Project.hs
++++ b/src/Stack/Storage/Project.hs
+@@ -12,6 +12,9 @@
+ {-# LANGUAGE UndecidableInstances #-}
+ {-# OPTIONS_GHC -Wno-unused-top-binds -Wno-identities #-}
+ 
++{-# LANGUAGE DerivingStrategies #-}
++{-# LANGUAGE StandaloneDeriving #-}
++
+ -- | Work with SQLite database used for caches across a single project.
+ module Stack.Storage.Project
+     ( initProjectStorage
+diff --git a/src/Stack/Storage/User.hs b/src/Stack/Storage/User.hs
+index 3845b094..09695344 100644
+--- a/src/Stack/Storage/User.hs
++++ b/src/Stack/Storage/User.hs
+@@ -12,6 +12,9 @@
+ {-# LANGUAGE UndecidableInstances #-}
+ {-# OPTIONS_GHC -Wno-unused-top-binds -Wno-identities #-}
+ 
++{-# LANGUAGE DerivingStrategies #-}
++{-# LANGUAGE StandaloneDeriving #-}
++
+ -- | Work with SQLite database used for caches across an entire user account.
+ module Stack.Storage.User
+     ( initUserStorage
+diff --git a/src/Stack/Types/Config.hs b/src/Stack/Types/Config.hs
+index a5cc22b5..a329d353 100644
+--- a/src/Stack/Types/Config.hs
++++ b/src/Stack/Types/Config.hs
+@@ -406,7 +406,7 @@ instance FromJSON CabalConfigKey where
+ instance FromJSONKey CabalConfigKey where
+   fromJSONKey = FromJSONKeyTextParser parseCabalConfigKey
+ 
+-parseCabalConfigKey :: Monad m => Text -> m CabalConfigKey
++parseCabalConfigKey :: MonadFail m => Text -> m CabalConfigKey
+ parseCabalConfigKey "$targets" = pure CCKTargets
+ parseCabalConfigKey "$locals" = pure CCKLocals
+ parseCabalConfigKey "$everything" = pure CCKEverything
+@@ -974,7 +974,7 @@ parseConfigMonoidObject rootDir obj = do
+ 
+     return ConfigMonoid {..}
+   where
+-    handleExplicitSetupDep :: Monad m => (Text, Bool) -> m (Maybe PackageName, Bool)
++    handleExplicitSetupDep :: MonadFail m => (Text, Bool) -> m (Maybe PackageName, Bool)
+     handleExplicitSetupDep (name', b) = do
+         name <-
+             if name' == "*"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
ats-pkg is broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
