### PR TITLE
habitat: 0.30.2 -> 0.90.6

### DIFF
--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -1,27 +1,23 @@
-{ lib, fetchFromGitHub, rustPlatform, pkgconfig
-, libsodium, libarchive, openssl }:
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig
+, libsodium, libarchive, openssl, zeromq }:
 
-with rustPlatform;
-
-buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "habitat";
-  version = "0.30.2";
+  # Newer versions required protobuf, which requires some finesse to get to
+  # compile with the vendored protobuf crate.
+  version = "0.90.6";
 
   src = fetchFromGitHub {
     owner = "habitat-sh";
     repo = "habitat";
     rev = version;
-    sha256 = "0pqrm85pd9hqn5fwqjbyyrrfh4k7q9mi9qy9hm8yigk5l8mw44y1";
+    sha256 = "0rwi0lkmhlq4i8fba3s9nd9ajhz2dqxzkgfp5i8y0rvbfmhmfd6b";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
-
-  cargoSha256 = "1ahfm5agvabqqqgjsyjb95xxbc7mng1mdyclcakwp1m1qdkxx9p0";
-
-  buildInputs = [ libsodium libarchive openssl ];
+  cargoSha256 = "08sncz0jgsr2s821j3s4bk7d54xqwmnld7m57avavym1xqvsnbmy";
 
   nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libsodium libarchive openssl zeromq ];
 
   cargoBuildFlags = ["--package hab"];
 
@@ -32,12 +28,11 @@ buildRustPackage rec {
     runHook postCheck
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "An application automation framework";
-    homepage = https://www.habitat.sh;
+    homepage = "https://www.habitat.sh";
     license = licenses.asl20;
-    maintainers = [ maintainers.rushmorem ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
-    broken = true; # mark temporary as broken due git dependencies
+    maintainers = with maintainers; [ rushmorem ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
The build has been broken on master for a very long time, for want of an
upgrade. This continues the effort put forth here:
https://github.com/NixOS/nixpkgs/pull/63105

Note that while there are newer versions than this, upgrading to those requires
getting some Cargo protobuf dependencies to compile. Since this fixes the
failing build, it seems like a good start.

Also includes Rust upgrade for https://github.com/NixOS/nixpkgs/issues/79975

Changelog:
https://github.com/habitat-sh/habitat/blob/master/CHANGELOG.md#0906-2019-11-13

CC @rushmorem @boj


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).