### PR TITLE
ssh-askpass-fullscreen: init at 1.2

### DIFF
--- a/pkgs/tools/networking/ssh-askpass-fullscreen/default.nix
+++ b/pkgs/tools/networking/ssh-askpass-fullscreen/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkg-config, gtk2, openssh }:
+
+stdenv.mkDerivation rec {
+  pname = "ssh-askpass-fullscreen";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "atj";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zldhylln412974cnxyqcrrc6b4ry3m9s5ijq3dnwz2g7nz1bx9d";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk2
+    openssh
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A small SSH askpass GUI using GTK+2";
+    homepage = "https://github.com/atj/ssh-askpass-fullscreen";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ caadar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6552,6 +6552,8 @@ in
 
   soapui = callPackage ../applications/networking/soapui { };
 
+  ssh-askpass-fullscreen = callPackage ../tools/networking/ssh-askpass-fullscreen { };
+
   sshguard = callPackage ../tools/security/sshguard {};
 
   sshping = callPackage ../tools/networking/sshping {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add ssh-askpass-fullscreen: a small SSH askpass GUI using GTK+2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
