### PR TITLE
wire-desktop (linux): 3.12.2916 -> 3.14.2921

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -21,12 +21,12 @@ let
 
   version = {
     x86_64-darwin = "3.12.3490";
-    x86_64-linux = "3.12.2916";
+    x86_64-linux = "3.14.2921";
   }.${system} or throwSystem;
 
   sha256 = {
     x86_64-darwin = "0xvhx3r99fl1v1cdqj6sk46kzxv9qi7j754amkhv7knrpmgyp55z";
-    x86_64-linux = "0xx03cpy6kapbjpygwranxjg1a0p8s1xq3cpapvi55rnkbk0qvjw";
+    x86_64-linux = "1dygf8lhwp40rhhd94gaky2vl0b96yz18hv2b7krkz2l3qf7w3cl";
   }.${system} or throwSystem;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Linux client asks for update. [CHANGELOG](https://medium.com/wire-news/linux-3-14-2921-f8e5d013dc7d). It seems there is no Darwin version yet - updating only linux.

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
