### PR TITLE
symmetrica: 2.0 -> 3.0.1

### DIFF
--- a/pkgs/applications/science/math/symmetrica/default.nix
+++ b/pkgs/applications/science/math/symmetrica/default.nix
@@ -1,62 +1,36 @@
 { stdenv
-, fetchurl
+, lib
+, fetchFromGitLab
 , fetchpatch
+, autoreconfHook
 }:
 stdenv.mkDerivation rec {
   pname = "symmetrica";
-  version = "2.0";
+  version = "3.0.1";
 
-  src = fetchurl {
-    url = "http://www.algorithm.uni-bayreuth.de/en/research/SYMMETRICA/SYM2_0_tar.gz";
-    sha256 = "1qhfrbd5ybb0sinl9pad64rscr08qvlfzrzmi4p4hk61xn6phlmz";
-    name = "symmetrica-2.0.tar.gz";
+  # Fork of the original symmetrica, which can be found here
+  # http://www.algorithm.uni-bayreuth.de/en/research/SYMMETRICA/index.html
+  # "This fork was created to modernize the codebase, and to resume making
+  # releases with the fixes that have accrued over the years."
+  # Also see https://trac.sagemath.org/ticket/29061#comment:3.
+  src = fetchFromGitLab {
+    owner = "sagemath";
+    repo = "symmetrica";
+    rev = version;
+    sha256 = "0wfmrzw82f5i91d7rf24mcdqcj2fmgrgy02pw4pliz7ncwaq14w3";
   };
 
-  sourceRoot = ".";
-
-  patches = [
-      # don't show banner ("SYMMETRICA VERSION X - STARTING)
-      # it doesn't contain very much helpful information and a banner is not ideal for a library
-      (fetchpatch {
-        url = "https://git.sagemath.org/sage.git/plain/build/pkgs/symmetrica/patches/de.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-        sha256 = "0df0vqixcfpzny6dkhyj87h8aznz3xn3zfwwlj8pd10bpb90k6gb";
-      })
-
-      # use int32_t and uint32_t for type INT
-      # see https://trac.sagemath.org/ticket/13413
-      (fetchpatch {
-        name = "fix_64bit_integer_overflow.patch";
-        url = "https://git.sagemath.org/sage.git/plain/build/pkgs/symmetrica/patches/int32.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-        sha256 = "0p33c85ck4kd453z687ni4bdcqr1pqx2756j7aq11bf63vjz4cyz";
-      })
-
-      (fetchpatch {
-        url = "https://git.sagemath.org/sage.git/plain/build/pkgs/symmetrica/patches/return_values.patch?id=1615f58890e8f9881c4228c78a6b39b9aab1303a";
-        sha256 = "0dmczkicwl50sivc07w3wm3jpfk78wm576dr25999jdj2ipsb7nk";
-      })
+  nativeBuildInputs = [
+    autoreconfHook
   ];
-
-  postPatch = ''
-    substituteInPlace makefile --replace gcc cc
-  '';
 
   enableParallelBuilding = true;
 
-  installPhase = ''
-    mkdir -p "$out"/{lib,share/doc/symmetrica,include/symmetrica}
-    ar crs libsymmetrica.a *.o
-    ranlib libsymmetrica.a
-    cp libsymmetrica.a "$out/lib"
-    cp *.h "$out/include/symmetrica"
-    cp README *.doc "$out/share/doc/symmetrica"
-  '';
-
-  meta = {
-    inherit version;
+  meta = with lib; {
     description = ''A collection of routines for representation theory and combinatorics'';
-    license = stdenv.lib.licenses.publicDomain;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.unix;
-    homepage = http://www.algorithm.uni-bayreuth.de/en/research/SYMMETRICA/index.html;
+    license = licenses.isc;
+    maintainers = with maintainers; [raskin];
+    platforms = platforms.unix;
+    homepage = "https://gitlab.com/sagemath/symmetrica";
   };
 }

--- a/pkgs/applications/science/math/symmetrica/default.nix
+++ b/pkgs/applications/science/math/symmetrica/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = ''A collection of routines for representation theory and combinatorics'';
     license = licenses.isc;
-    maintainers = with maintainers; [raskin];
+    maintainers = with maintainers; [raskin timokau];
     platforms = platforms.unix;
     homepage = "https://gitlab.com/sagemath/symmetrica";
   };


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This switches to the sagemath fork, since the original upstream is no
longer maintained and sagemath has effectively maintained symmetrica
through patches for a while now. The update fixes one bug in particular
that has caused failures in the sagemath test suite:

https://github.com/NixOS/nixpkgs/issues/81449
https://trac.sagemath.org/ticket/15312
https://trac.sagemath.org/ticket/29061

Regarding the licensing change:
    
https://gitlab.com/sagemath/symmetrica/-/commit/7cf91b380078a4def28dd6bab2b4607e2346c650

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
