### PR TITLE
sage: fix test suite with docutils 0.15

### DIFF
--- a/pkgs/applications/science/math/sage/patches/docutils-0.15.patch
+++ b/pkgs/applications/science/math/sage/patches/docutils-0.15.patch
@@ -1,0 +1,24 @@
+diff --git a/src/sage/misc/sphinxify.py b/src/sage/misc/sphinxify.py
+index 4849c2bffa..76b7bc8602 100644
+--- a/src/sage/misc/sphinxify.py
++++ b/src/sage/misc/sphinxify.py
+@@ -25,6 +25,7 @@ from __future__ import absolute_import, print_function
+ import os
+ import re
+ import shutil
++import warnings
+ from tempfile import mkdtemp
+ from sphinx.application import Sphinx
+ 
+@@ -120,7 +121,10 @@ smart_quotes = no""")
+     # buildername, confoverrides, status, warning, freshenv).
+     sphinx_app = Sphinx(srcdir, confdir, outdir, doctreedir, format,
+                         confoverrides, None, None, True)
+-    sphinx_app.build(None, [rst_name])
++    with warnings.catch_warnings():
++        # Quick and dirty workaround for https://trac.sagemath.org/ticket/28856#comment:19
++        warnings.simplefilter("ignore")
++        sphinx_app.build(None, [rst_name])
+     sys.path = old_sys_path
+ 
+     # We need to remove "_" from __builtin__ that the gettext module installs

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -52,6 +52,11 @@ stdenv.mkDerivation rec {
     # Parallelize docubuild using subprocesses, fixing an isolation issue. See
     # https://groups.google.com/forum/#!topic/sage-packaging/YGOm8tkADrE
     ./patches/sphinx-docbuild-subprocesses.patch
+
+    # Fix doctest failures with docutils 0.15:
+    # https://nix-cache.s3.amazonaws.com/log/dzmzrb2zvardsmpy7idg7djkizmkzdhs-sage-tests-8.9.drv
+    # https://trac.sagemath.org/ticket/28856#comment:19
+    ./patches/docutils-0.15.patch
   ];
 
   # Since sage unfortunately does not release bugfix releases, packagers must


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The better way to fix this would be to backport the upstream sphinx
patch:

https://github.com/sphinx-doc/sphinx/commit/faedcc48ccb942b9a7b758b699b30f0d026c0771

Unfortunately it doesn't apply cleanly and isn't worth the effort
of backporting. Let's hope we can switch to python3 sage and the recent
sphinx version that comes with it before this becomes a problem.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
