### PR TITLE
coqPackages.dpdgraph: enable for Coq ≥ 8.9

### DIFF
--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -1,6 +1,18 @@
 { stdenv, fetchFromGitHub, autoreconfHook, coq }:
 
 let params = {
+  "8.11" = {
+    version = "0.6.7";
+    sha256 = "01vpi7scvkl4ls1z2k2x9zd65wflzb667idj759859hlz3ps9z09";
+  };
+  "8.10" = {
+    version = "0.6.6";
+    sha256 = "1gjrm5zjzw4cisiwdr5b3iqa7s4cssa220xr0k96rwgk61rcjd8w";
+  };
+  "8.9" = {
+    version = "0.6.5";
+    sha256 = "1f34z24yg05b1096gqv36jr3vffkcjkf9qncii3pzhhvagxd0w2f";
+  };
   "8.8" = {
     version = "0.6.3";
     rev = "0acbd0a594c7e927574d5f212cc73a486b5305d2";
@@ -18,7 +30,6 @@ let params = {
   };
   "8.5" = {
     version = "0.6";
-    rev = "v0.6";
     sha256 = "0qvar8gfbrcs9fmvkph5asqz4l5fi63caykx3bsn8zf0xllkwv0n";
   };
 };
@@ -30,7 +41,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Karmaki";
     repo = "coq-dpdgraph";
-    inherit (param) rev sha256;
+    rev = param.rev or "v${param.version}";
+    inherit (param) sha256;
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

Make `dpdgraph` available for recent versions of Coq.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
