### PR TITLE
fetchsvn: Fix for cross

### DIFF
--- a/pkgs/build-support/fetchsvn/builder.sh
+++ b/pkgs/build-support/fetchsvn/builder.sh
@@ -2,10 +2,6 @@ source $stdenv/setup
 
 header "exporting $url (r$rev) into $out"
 
-if test "$sshSupport"; then
-    export SVN_SSH="$openssh/bin/ssh"
-fi
-
 if test -n "$http_proxy"; then
     # Configure proxy
     mkdir .subversion

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -1,7 +1,13 @@
-{stdenvNoCC, subversion, glibcLocales, sshSupport ? true, openssh ? null}:
-{url, rev ? "HEAD", md5 ? "", sha256 ? ""
+{ stdenvNoCC, buildPackages
+, subversion, glibcLocales, sshSupport ? true, openssh ? null
+}:
+
+{ url, rev ? "HEAD", md5 ? "", sha256 ? ""
 , ignoreExternals ? false, ignoreKeywords ? false, name ? null
-, preferLocalBuild ? true }:
+, preferLocalBuild ? true
+}:
+
+assert sshSupport -> openssh != null;
 
 let
   repoName = with stdenvNoCC.lib;
@@ -32,13 +38,16 @@ else
 stdenvNoCC.mkDerivation {
   name = name_;
   builder = ./builder.sh;
-  nativeBuildInputs = [ subversion glibcLocales ];
+  nativeBuildInputs = [ subversion glibcLocales ]
+    ++ stdenvNoCC.lib.optional sshSupport openssh;
+
+  SVN_SSH = if sshSupport then "${buildPackages.openssh}/bin/ssh" else null;
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
   outputHash = sha256;
 
-  inherit url rev sshSupport openssh ignoreExternals ignoreKeywords;
+  inherit url rev ignoreExternals ignoreKeywords;
 
   impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
   inherit preferLocalBuild;


### PR DESCRIPTION
###### Motivation for this change

Just use `nativeBuildInputs` at build time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
