### PR TITLE
gtklp: init at 1.3.4

### DIFF
--- a/pkgs/tools/misc/gtklp/default.nix
+++ b/pkgs/tools/misc/gtklp/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, lib, fetchurl
+, autoreconfHook, libtool, pkg-config
+, gtk2, glib, cups, gettext, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gtklp";
+  version = "1.3.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.src.tar.gz";
+    sha256 = "1arvnnvar22ipgnzqqq8xh0kkwyf71q2sfsf0crajpsr8a8601xy";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    cups
+    gettext
+    glib
+    gtk2
+    libtool
+    openssl
+  ];
+
+  patches = [
+    ./patches/mdv-fix-str-fmt.patch
+    ./patches/autoconf.patch
+  ];
+
+  preConfigure = ''
+    substituteInPlace include/defaults.h --replace "netscape" "firefox"
+    substituteInPlace include/defaults.h --replace "http://localhost:631/sum.html#STANDARD_OPTIONS" \
+                                                   "http://localhost:631/help/"
+  '';
+
+  preInstall = ''
+    install -D -m0644 -t $out/share/doc AUTHORS BUGS ChangeLog README USAGE
+  '';
+
+  meta = with lib; {
+    description = "A graphical frontend for CUPS";
+    homepage = "https://gtklp.sirtobi.com";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ caadar ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/tools/misc/gtklp/patches/autoconf.patch
+++ b/pkgs/tools/misc/gtklp/patches/autoconf.patch
@@ -1,0 +1,23 @@
+Patch origin: http://sophie.zarb.org/rpms/68e90a72e0052022f558148d97c9ea2a/files/3
+
+diff --git a/configure.ac b/configure.ac
+index b7a30e9..3768ae9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -8,6 +8,7 @@ AC_CONFIG_HEADERS([config.h])
+ 
+ AC_CONFIG_MACRO_DIR([m4])
+ AM_GNU_GETTEXT([external])
++AM_GNU_GETTEXT_REQUIRE_VERSION([0.21])
+ 
+ dnl Extra params
+ CUPSCONFIGPATH=""
+@@ -30,8 +31,6 @@ AC_SUBST(XLIBS)
+ 
+ dnl Checks for header files
+ 
+-dnl internationalization macros
+-AM_GNU_GETTEXT
+ 
+ 
+ # Forte Compiler ############################################################

--- a/pkgs/tools/misc/gtklp/patches/mdv-fix-str-fmt.patch
+++ b/pkgs/tools/misc/gtklp/patches/mdv-fix-str-fmt.patch
@@ -1,0 +1,22 @@
+Patch source: http://sophie.zarb.org/rpms/68e90a72e0052022f558148d97c9ea2a/files/1
+
+--- a/libgtklp/libgtklp.c	2020-08-25 17:31:52.427298559 +0100
++++ b/libgtklp/libgtklp.c	2020-08-25 17:36:37.728154682 +0100
+@@ -939,7 +939,7 @@
+ 		gtk_widget_show(pixmapwid);
+ 
+ 		if (strlen(gerror2) == 0)
+-			snprintf(tmplabel, (size_t) MAXLINE, gerror1);
++			snprintf(tmplabel, (size_t) MAXLINE, "%s", gerror1);
+ 		else
+ 			snprintf(tmplabel, (size_t) MAXLINE, gerror1, gerror2);
+ 		label = gtk_label_new(tmplabel);
+@@ -973,7 +973,7 @@
+ #endif
+ 	} else {
+ 		if (strlen(gerror2) == 0)
+-			g_warning(gerror1);
++			g_warning("%s", gerror1);
+ 		else
+ 			g_warning(gerror1, gerror2);
+ 	}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1104,6 +1104,8 @@ in
 
   glyr = callPackage ../tools/audio/glyr { };
 
+  gtklp = callPackage ../tools/misc/gtklp { };
+
   google-amber = callPackage ../tools/graphics/amber { };
 
   hpe-ltfs = callPackage ../tools/backup/hpe-ltfs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add GtkLP - small and easy graphical frontend to CUPS.

Especially useful when printing from Emacs (see [EmacsWiki](https://www.emacswiki.org/emacs/CupsInEmacs) page).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
