### PR TITLE
FreeRADIUS improvements

### DIFF
--- a/nixos/modules/services/networking/freeradius.nix
+++ b/nixos/modules/services/networking/freeradius.nix
@@ -17,7 +17,8 @@ let
     '';
 
     serviceConfig = {
-        ExecStart = "${pkgs.freeradius}/bin/radiusd -f -d ${cfg.configDir} -l stdout -xx";
+        ExecStart = "${pkgs.freeradius}/bin/radiusd -f -d ${cfg.configDir} -l stdout" +
+                    optionalString cfg.debug " -xx";
         ExecReload = [
           "${pkgs.freeradius}/bin/radiusd -C -d ${cfg.configDir} -l stdout"
           "${pkgs.coreutils}/bin/kill -HUP $MAINPID"
@@ -38,6 +39,16 @@ let
       default = "/etc/raddb";
       description = ''
         The path of the freeradius server configuration directory.
+      '';
+    };
+
+    debug = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable debug logging for freeradius (-xx
+        option). This should not be left on, since it includes
+        sensitive data such as passwords in the logs.
       '';
     };
 
@@ -66,6 +77,7 @@ in
     };
 
     systemd.services.freeradius = freeradiusService cfg;
+    warnings = optional cfg.debug "Freeradius debug logging is enabled. This will log passwords in plaintext to the journal!";
 
   };
 

--- a/nixos/modules/services/networking/freeradius.nix
+++ b/nixos/modules/services/networking/freeradius.nix
@@ -10,8 +10,8 @@ let
   {
     description = "FreeRadius server";
     wantedBy = ["multi-user.target"];
-    after = ["network-online.target"];
-    wants = ["network-online.target"];
+    after = ["network.target"];
+    wants = ["network.target"];
     preStart = ''
       ${pkgs.freeradius}/bin/radiusd -C -d ${cfg.configDir} -l stdout
     '';

--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, talloc, finger_bsd, perl
+{ stdenv, fetchurl, fetchpatch, autoreconfHook, talloc, finger_bsd, perl
 , openssl
 , linkOpenssl? true
 , openldap
@@ -70,6 +70,12 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
   ] ++ optional (!linkOpenssl) "--with-openssl=no";
+
+  patches = stdenv.lib.optional withRest (fetchpatch {
+    # Fix HTTP/2 in rest
+    url = "https://github.com/FreeRADIUS/freeradius-server/commit/6286520698a3cc4053b4d49eb0a61d9ba77632aa.patch";
+    sha256 = "1ycvr3ql1mfkvzydnn4aiygnidicv2hgllppv37nb1p2pk02159g";
+  });
 
   postPatch = ''
     substituteInPlace src/main/checkrad.in --replace "/usr/bin/finger" "${finger_bsd}/bin/finger"

--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -81,9 +81,19 @@ stdenv.mkDerivation rec {
     substituteInPlace src/main/checkrad.in --replace "/usr/bin/finger" "${finger_bsd}/bin/finger"
   '';
 
+  # By default, freeradius will generate Diffie-Hellman parameters and
+  # self-signed TLS certificates during installation. We don't want
+  # this, for several reasons:
+  # - reproducibility (random generation)
+  # - we don't want _anybody_ to use a cert where the private key is on our public binary cache!
+  # - we don't want the certs to change each time the package is rebuilt
+  # So let's avoid anything getting into our output.
+  makeFlags = [ "LOCAL_CERT_FILES=" ];
+
   installFlags = [
     "sysconfdir=\${out}/etc"
     "localstatedir=\${TMPDIR}"
+    "INSTALL_CERT_FILES=" # see comment at makeFlags
   ];
 
   outputs = [ "out" "dev" "man" "doc" ];

--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     homepage = https://freeradius.org/;
     description = "A modular, high performance free RADIUS suite";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ sheenobu willibutz ];
+    maintainers = with maintainers; [ sheenobu willibutz fpletz lheckemann elseym ];
     platforms = with platforms; linux;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Various improvements to the freeradius package and module, for better reproducibility, not logging plaintext credentials to the journal, and maintainership.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @fpletz @WilliButz @elseym 