### PR TITLE
collectd: 5.8.1 -> 5.10.0

### DIFF
--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -8,20 +8,13 @@ let
   plugins = callPackage ./plugins.nix args;
 in
 stdenv.mkDerivation rec {
-  version = "5.8.1";
+  version = "5.10.0";
   pname = "collectd";
 
   src = fetchurl {
     url = "https://collectd.org/files/${pname}-${version}.tar.bz2";
-    sha256 = "1njk8hh56gb755xafsh7ahmqr9k2d4lam4ddj7s7fqz0gjigv5p7";
+    sha256 = "0nrpq09q6vbbv0hjc1vfa36z8j5802500hy75m678gh2cgsmjcx0";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/rpv-tomsk/collectd/commit/d5a3c020d33cc33ee8049f54c7b4dffcd123bf83.patch";
-      sha256 = "1n65zw4d2k2bxapayaaw51ym7hy72a0cwi2abd8jgxcw3d0m5g15";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [
@@ -50,7 +43,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Daemon which collects system performance statistics periodically";
-    homepage = https://collectd.org;
+    homepage = "https://collectd.org";
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ bjornfor fpletz ];

--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -25,6 +25,7 @@
 , mongoc
 , mosquitto
 , net-snmp
+, perl
 , postgresql
 , protobufc
 , python
@@ -205,7 +206,9 @@ let
     ovs_stats = {
       buildInputs = [ yajl ];
     };
-    perl = {};
+    perl = {
+      buildInputs = [ perl ];
+    };
     pf = {};
     pinba = {
       buildInputs = [ protobufc ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Needed for libvirt 6.1.0: #81161

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - Result of `nixpkgs-review pr 82253` [1](https://github.com/Mic92/nixpkgs-review)
    <details>
      <summary>3 package built:</summary>

      - collectd
      - collectd-data
      - libcollectdclient
    </details>
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - +6MiB
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
