### PR TITLE
[backport-19.09] yubioath-desktop: 4.3.6 -> 5.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5393,6 +5393,20 @@
     githubId = 807447;
     name = "Robert Scott";
   };
+  risson = {
+    name = "Marc Schmitt";
+    email = "marc.schmitt@risson.space";
+    github = "rissson";
+    githubId = 18313093;
+    keys = [
+      { longkeyid = "rsa4096/0xF6FD87B15C263EC9";
+        fingerprint = "8A0E 6A7C 08AB B9DE 67DE  2A13 F6FD 87B1 5C26 3EC9";
+      }
+      { longkeyid = "ed25519/0xBBB7A6801DF1E03F";
+        fingerprint = "C0A7 A9BB 115B C857 4D75  EA99 BBB7 A680 1DF1 E03F";
+      }
+    ];
+  };
   rittelle = {
     email = "rittelle@posteo.de";
     github = "rittelle";

--- a/pkgs/applications/misc/yubioath-desktop/default.nix
+++ b/pkgs/applications/misc/yubioath-desktop/default.nix
@@ -1,21 +1,21 @@
 { stdenv, fetchurl, mkDerivation
-, qmake, qtbase, qtquickcontrols
+, qmake, qtbase, qtquickcontrols2, qtgraphicaleffects
 , python3, pyotherside
 , pcsclite, yubikey-personalization
 , yubikey-manager, makeWrapper }:
 
 mkDerivation rec {
   pname = "yubioath-desktop";
-  version = "4.3.6";
+  version = "5.0.2";
 
   src = fetchurl {
     url = "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-${version}.tar.gz";
-    sha256 = "0s04anjbb5zm98kfdpp9hr68k3mx3gqlp8fa1miy7nq87pr4f7a5";
+    sha256 = "19ingk0ab88a22s04apcw8kx9xygxlbk8kp4xnb8pmf8z3k6l2gf";
   };
 
   doCheck = false;
 
-  buildInputs = [ stdenv qtbase qtquickcontrols python3 ];
+  buildInputs = [ stdenv qtbase qtquickcontrols2 qtgraphicaleffects python3 ];
 
   nativeBuildInputs = [ qmake makeWrapper python3.pkgs.wrapPython ];
 
@@ -48,11 +48,18 @@ mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Yubikey Desktop Authenticator";
+    description = "Yubico Authenticator";
+    longDescription = ''
+      Application for generating Open Authentication (OATH) time-based TOTP and
+      event-based HOTP one-time password codes, with the help of a YubiKey that
+      protects the shared secrets.
+    '';
 
-    homepage = https://www.yubico.com/support/knowledge-base/categories/articles/yubico-authenticator-download/;
+    homepage = "https://developers.yubico.com/yubioath-desktop";
+    downloadPage = "https://developers.yubico.com/yubioath-desktop/Releases/";
+    changelog = "https://developers.yubico.com/yubioath-desktop/Release_Notes.html";
 
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = with maintainers; [ mic92 ];
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = with maintainers; [ mic92 risson ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Backporting #81162

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Mic92 