### PR TITLE
liberio: init at unstable-2019-12-11

### DIFF
--- a/pkgs/development/libraries/liberio/default.nix
+++ b/pkgs/development/libraries/liberio/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, systemd
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "liberio";
+  version = "unstable-2019-12-11";
+
+  src = fetchFromGitHub {
+    owner = "EttusResearch";
+    repo = "liberio";
+    rev = "81777e500d1c3b88d5048d46643fb5553eb5f786";
+    sha256 = "1n40lj5g497mmqh14vahdhy3jwvcry2pkc670p4c9f1pggp6ysgk";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    systemd
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Ettus Research DMA I/O Library";
+    homepage = "https://github.com/EttusResearch/liberio";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.doronbehar ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4902,6 +4902,8 @@ in
 
   libevdev = callPackage ../development/libraries/libevdev { };
 
+  liberio = callPackage ../development/libraries/liberio { };
+
   libevdevplus = callPackage ../development/libraries/libevdevplus { };
 
   libfann = callPackage ../development/libraries/libfann { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

An optional dependency for [uhd](https://github.com/EttusResearch/uhd).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).