### PR TITLE
suitesparse: Enable parallel building

### DIFF
--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation rec {
 
     # Build individual shared libraries
     make library        \
+        JOBS=$NIX_BUILD_CORES \
         BLAS=-lopenblas \
         LAPACK=""       \
         ${stdenv.lib.optionalString openblas.blas64 "CFLAGS=-DBLAS64"}
@@ -64,7 +65,7 @@ stdenv.mkDerivation rec {
     # Bundling is done by building the static libraries, extracting objects from
     # them and combining the objects into one shared library.
     mkdir -p static
-    make static AR_TARGET=$(pwd)/static/'$(LIBRARY).a'
+    make static JOBS=$NIX_BUILD_CORES AR_TARGET=$(pwd)/static/'$(LIBRARY).a'
     (
         cd static
         for i in lib*.a; do


### PR DESCRIPTION
##### Motivation for this change
Building suitesparse currently takes around 45 minutes on hydra. This should considerably speed things up.
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.suitesparse.x86_64-linux#tabs-charts

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
