### PR TITLE
meson: allow unsetting the --buildtype flag

### DIFF
--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -21,9 +21,11 @@ mesonConfigurePhase() {
         -Dwrap_mode=${mesonWrapMode:-nodownload} \
         $mesonFlags"
 
-    mesonBuildType="${mesonBuildType-plain}"
-    mesonBuildTypeFlag="${mesonBuildType:+--buildtype=${mesonBuildType@Q} }"
-    mesonFlags="${crossMesonFlags+$crossMesonFlags }$mesonBuildTypeFlag$mesonFlags"
+    if [[ -z "${dontAddMesonBuildType-}" ]]; then
+        mesonFlags="--buildtype=${mesonBuildType:-plain} $mesonFlags"
+    fi
+
+    mesonFlags="${crossMesonFlags+$crossMesonFlags }$mesonFlags"
 
     echo "meson flags: $mesonFlags ${mesonFlagsArray[@]}"
 

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -21,7 +21,9 @@ mesonConfigurePhase() {
         -Dwrap_mode=${mesonWrapMode:-nodownload} \
         $mesonFlags"
 
-    mesonFlags="${crossMesonFlags+$crossMesonFlags }--buildtype=${mesonBuildType:-plain} $mesonFlags"
+    mesonBuildType="${mesonBuildType-plain}"
+    mesonBuildTypeFlag="${mesonBuildType:+--buildtype=${mesonBuildType@Q} }"
+    mesonFlags="${crossMesonFlags+$crossMesonFlags }$mesonBuildTypeFlag$mesonFlags"
 
     echo "meson flags: $mesonFlags ${mesonFlagsArray[@]}"
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Meson allows setting properties in many ways.  In our case we have the buildtype set in the Meson project options file, and we would like to be able to ask the nixpkgs setup hook not to override it. 

This PR does not change the default behaviour (which is to specify `--buildtype=plain`), but allows the user to not pass the `--buildtype` flag at all by explicitly setting `mesonBuildType = ""`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
