### PR TITLE
bulk_extractor: init at 1.6.0

### DIFF
--- a/pkgs/tools/misc/bulk-extractor/default.nix
+++ b/pkgs/tools/misc/bulk-extractor/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, flex, openssl, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "bulk_extractor";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "simsong";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0z4zb508gdsblv5jxcnpkwnhll3m6850rdy5v829c0marf9wyc5c";
+    fetchSubmodules = true;
+  };
+
+  configureFlags = ["--disable-BEViewer"];
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [autoreconfHook];
+  buildInputs = [flex openssl zlib];
+
+  meta = with stdenv.lib; {
+    description = "A program for scanning and extracting useful information";
+    longDescription = ''
+      bulk_extractor is a C++ program that scans a disk image, a file, or a directory of files and extracts useful information without
+      parsing the file system or file system structures. The results are stored in feature files that can be easily inspected, parsed,
+      or processed with automated tools.
+    '';
+    homepage = "https://github.com/simsong/bulk_extractor";
+    downloadPage = "http://downloads.digitalcorpora.org/downloads/bulk_extractor/";
+    changelog = "https://github.com/simsong/bulk_extractor/blob/v${version}/ChangeLog";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lightdiscord ];
+    platforms = ["x86_64-linux"];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26507,6 +26507,8 @@ in
 
   coz = callPackage ../development/tools/analysis/coz {};
 
+  bulk_extractor = callPackage ../tools/misc/bulk-extractor {};
+
   keycard-cli = callPackage ../tools/security/keycard-cli {};
 
   sieveshell = with python3.pkgs; toPythonApplication managesieve;


### PR DESCRIPTION
###### Motivation for this change

Add missing package for #81418 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
