### PR TITLE
feed2mail: init at 2020-03-10

### DIFF
--- a/pkgs/tools/misc/feed2mail/default.nix
+++ b/pkgs/tools/misc/feed2mail/default.nix
@@ -1,0 +1,40 @@
+{ lib, python2Packages, fetchFromGitHub
+, configurationString ? null
+}:
+
+
+assert lib.asserts.assertMsg ( configurationString != null )
+  "You need to pass a configuration string to the feed2mail  package";
+
+let
+  configFile = builtins.toFile "feed2mail-config" configurationString;
+in
+python2Packages.buildPythonApplication rec {
+  pname = "feed2mail";
+  version = "2020-03-10";
+
+  src = fetchFromGitHub {
+    owner = "jonashaag";
+    repo = pname;
+    rev = "facd4d207bd7332f06b46b59a190710affa6c493";
+    sha256 = "0md75l93s03zxza8gmlqa9a9z88474wkk33h84wd7p9f91gvi0k3";
+  };
+
+  propagatedBuildInputs = with python2Packages; [ html2text feedparser ];
+  installPhase = ''
+    mkdir -p $out/bin/
+
+    # hackedy hack
+    echo "#!/usr/bin/env python" | cat - feed2mail.py > $out/bin/feed2mail.py
+    ln -s ${configFile} $out/bin/config.py
+
+    chmod +x $out/bin/feed2mail.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/jonashaag/feed2mail";
+    description = "not-that-messy rss2email clone";
+    license = licenses.isc;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -327,6 +327,8 @@ in
 
   fet-sh = callPackage ../tools/misc/fet-sh { };
 
+  feed2mail = callPackage ../tools/misc/feed2mail { };
+
   fetchbower = callPackage ../build-support/fetchbower {
     inherit (nodePackages) bower2nix;
   };


### PR DESCRIPTION
###### Motivation for this change

I want to use this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Maybe the hack with the configuration module is not as we do it,... please guide me if another option is preffered.

@jonashaag look what I've done :joy:  (author of the package).