### PR TITLE
openrgb: init at unstable-2020-03-03

### DIFF
--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, qmake
+, fetchFromGitHub
+, fetchFromGitLab
+, libusb1 
+, hidapi
+, qt5
+, wrapQtAppsHook
+, makeWrapper
+, hicolor-icon-theme
+, openrazer-daemon
+}:
+stdenv.mkDerivation rec {
+  pname = "openrgb";
+  version = "unstable-${date}";
+
+  date = "2020-03-03";
+
+  src = fetchFromGitHub {
+    owner = "CalcProgrammer1";
+    repo = "OpenRGB";
+    rev = "d7298cafd02232a4da3843a5e6c810cb2ccd99f4";
+    sha256 = "0gjj8z3574dxx41d38khhq91c6g2z5jiws5k9hg0lryks97341ak";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ libusb1 hidapi wrapQtAppsHook ];
+
+  propagatedBuildInputs = [ hicolor-icon-theme openrazer-daemon ];
+
+  nativeBuildInputs = [ qmake makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace OpenRGB.pro \
+      --replace '$$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$_PRO_FILE_PWD_ rev-parse HEAD)' "${src.rev}" \
+      --replace '$$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$_PRO_FILE_PWD_ show -s --format=%ci HEAD)' "${date}" \
+      --replace '$$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$_PRO_FILE_PWD_ rev-parse --abbrev-ref HEAD)' "master"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 OpenRGB $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open source RGB lighting control that doesn't depend on manufacturer software.";
+    maintainers = with maintainers; [ evanjs ];
+    longDescription = ''
+      The goal of this project is to create an easy-to-use open source
+      software program and library for accessing and controlling
+      RGB lights on various PC hardware including motherboards,
+      RAM modules, graphics cards, cooling devices, and peripherals.
+    '';
+  };
+}

--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -12,15 +12,15 @@
 }:
 stdenv.mkDerivation rec {
   pname = "openrgb";
-  version = "unstable-${date}";
+  version = "0.1";
 
-  date = "2020-03-03";
+  date = "2020-03-28";
 
   src = fetchFromGitHub {
     owner = "CalcProgrammer1";
     repo = "OpenRGB";
-    rev = "d7298cafd02232a4da3843a5e6c810cb2ccd99f4";
-    sha256 = "0gjj8z3574dxx41d38khhq91c6g2z5jiws5k9hg0lryks97341ak";
+    rev = "release_${version}";
+    sha256 = "1jxyvf9ihb7kfvl1yp5d6w32hcbcxrjk11b1msyclkqwkd3r4b9m";
     fetchSubmodules = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5673,6 +5673,10 @@ in
 
   openobex = callPackage ../tools/bluetooth/openobex { };
 
+  openrgb = callPackage ../applications/misc/openrgb {
+    inherit (qt5) qmake wrapQtAppsHook;
+  };
+
   openresolv = callPackage ../tools/networking/openresolv { };
 
   opensc = callPackage ../tools/security/opensc {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://gitlab.com/CalcProgrammer1/OpenRGB/-/wikis/home

Currently, there are no GUI-based tools to manage e.g. Razer devices on NixOS.
This utility provides a way to manage RGB functionality for many different types of devices.

###### Notes
This application will currently segfault if you try to detect or dump devices without access to `i2c` devices (or rather, it won't perform any length checks, and will try to get the current index of an empty list of `SMBus` devices)
Alternatively, you can just run the application as root.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @adisbladis 