### PR TITLE
cups-pdf: init at 3.0.1

### DIFF
--- a/nixos/modules/services/printing/cups-pdf.nix
+++ b/nixos/modules/services/printing/cups-pdf.nix
@@ -1,0 +1,81 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.printing.cups-pdf;
+
+  reminder = ''
+    ### Don't edit this file. Set the NixOS option
+    ### ‘services.printing.cups-pdf.configurations’
+    ###
+    ### Read docs and find default config in
+    ### ${pkgs.cups-pdf}/share/doc
+
+
+  '';
+
+in
+
+{
+
+  options = {
+
+    services.printing.cups-pdf = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable virtual PDF printer for CUPS.
+        '';
+      };
+
+      configurations = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+        description = ''
+          Configuration names and their associated definitions.
+        '';
+        example = literalExample ''
+          { cups-pdf = '''
+              Out ''${HOME}/printed
+            ''';
+             cups-pdf-PDF-debug = '''
+              LogType 7
+            ''';
+          }
+        '';
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = with pkgs; [ cups-pdf ];
+    services.printing.drivers = with pkgs; [ cups-pdf ];
+
+    security.wrappers.cups-pdf = {
+      source = "${pkgs.cups-pdf}/lib/cups/backend.orig/cups-pdf";
+      owner = "root";
+      group = "root";
+      permissions = "u+rwx,g-rwx,o-rwx";
+    };
+
+    ###  From README file:
+    ###  ----------------
+    ###  To create multiple instances of the backend with different configurations, simply
+    ###  copy several config files in your config directory, naming them
+    ###  cups-pdf-<NAME>.conf, where <NAME> is a unique identifier for this instance.
+    ###  You can then select the new instances as URI when creating a new printer in CUPS.
+    environment.etc = mapAttrs' (name: value: {
+      name = "cups-pdf/${name}.conf";
+      value = { text = reminder + value; };
+    }) cfg.configurations;
+
+  };
+
+}

--- a/pkgs/misc/cups/drivers/cups-pdf/default.nix
+++ b/pkgs/misc/cups/drivers/cups-pdf/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchurl, cups, ghostscript }:
+
+stdenv.mkDerivation rec {
+  pname = "cups-pdf";
+  version = "3.0.1";
+
+  src = fetchurl {
+    url = "https://www.cups-pdf.de/src/${pname}_${version}.tar.gz";
+    sha256 = "0ccmm9crrm07nqzn4aikbys2bflkgzc044j1bvz6j53zzznnk1kk";
+  };
+
+  buildInputs = [ cups ghostscript ];
+
+  preBuild = ''
+    sed '/#define CP_CONFIG_PATH/s@/etc/cups@/etc/cups-pdf@' -i src/cups-pdf.h
+    substituteInPlace src/cups-pdf.h --replace "/usr/bin/gs" "${ghostscript}/bin/gs"
+    substituteInPlace extra/cups-pdf.conf --replace "/usr/bin/gs" "${ghostscript}/bin/gs"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd src >/dev/null
+    $CC -s ${pname}.c -o ${pname} -lcups
+    popd >/dev/null
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # From README: CUPS-PDF requires root privileges since it has to
+    # modify file ownerships. In order to ensure CUPS-PDF is running
+    # with the required root privileges you have to make 'root' the
+    # owner of the cups-pdf backend and set the file permissions of
+    # the backend to 0700 (root only). So we use
+    # `security.wrappers.cups-pdf' and install provided backend as
+    # source for it:
+    install -D -t $out/lib/cups/backend.orig src/cups-pdf
+
+    # Install PPDs:
+    install -D -m0644 -t $out/share/cups/model/CUPS-PDF extra/*.ppd
+
+    # Install docs:
+    install -D -m0644 -t $out/share/doc {README,ChangeLog}
+    install -D -m0644 -t $out/share/doc extra/cups-pdf.conf
+
+    # Install the real backend:
+    mkdir -p $out/lib/cups/backend
+    ln -s /run/wrappers/bin/cups-pdf $out/lib/cups/backend/cups-pdf
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A virtual PDF printer for CUPS";
+    homepage = "https://www.cups-pdf.de";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ caadar ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24886,6 +24886,8 @@ in
 
   cups-filters = callPackage ../misc/cups/filters.nix { };
 
+  cups-pdf = callPackage ../misc/cups/drivers/cups-pdf { };
+
   cups-pk-helper = callPackage ../misc/cups/cups-pk-helper.nix { };
 
   cups-kyocera = callPackage ../misc/cups/drivers/kyocera {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add ```cups-pdf```, designed to produce PDF files in a heterogeneous network by providing a PDF printer on the central fileserver.

Notes from patched [fork](https://github.com/alexivkin/CUPS-PDF-to-PDF):

> How is this better than a Save-as-PDF or Print-as-file functionality in many GTK/QT interfaces?
>
> 1. You can do post-processing, for example choose pdf filename and saving location in a standard  file save dialog, and automatically open generated PDF.
> 2. Use PDF printing from non GTK/QT apps, like Wine 
> 3. Provide consistent PDF printing experience

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
