### PR TITLE
simple-viewer-gl: init at 3.1.7

### DIFF
--- a/pkgs/applications/graphics/simple-viewer-gl/default.nix
+++ b/pkgs/applications/graphics/simple-viewer-gl/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, fetchFromBitbucket
+, pkg-config
+, cmake
+, glfw3
+, libjpeg
+, libpng
+, lcms2
+, zlib
+, libexif
+, libXrandr
+, libXcursor
+, giflib
+, libtiff
+, libwebp
+, ilmbase
+, openexr
+, openjpeg
+, imlib2
+, curl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "simple-viewer-gl";
+  version = "3.1.7";
+
+  src = fetchFromBitbucket {
+    owner = "andreyu";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0kqv1lcv32r7y9507gdb4frnm9l24qchpxygccdgahsd5lgri1ab";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    giflib
+    glfw3
+    ilmbase
+    imlib2
+    lcms2
+    libXcursor
+    libXrandr
+    libexif
+    libjpeg
+    libpng
+    libtiff
+    libwebp
+    openexr
+    openjpeg
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m0755 -t $out/bin sviewgl
+    pushd .. >/dev/null
+    install -D -m0644 -t $out/share/doc/ config.example README.md Copying.txt
+    install -D -m0644 -t $out/share/applications/ sviewgl.desktop
+    install -D -m0644 -t $out/share/icons/ res/Icon-1024.png
+    popd >/dev/null
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tiny image viewer based on OpenGL";
+    homepage = "https://www.ugolnik.info/simple-viewer-gl";
+    license = licenses.gpl2;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ caadar ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22082,6 +22082,8 @@ in
 
   simple-scan = gnome3.simple-scan;
 
+  simple-viewer-gl = callPackage ../applications/graphics/simple-viewer-gl { };
+
   siproxd = callPackage ../applications/networking/siproxd { };
 
   skypeforlinux = callPackage ../applications/networking/instant-messengers/skypeforlinux { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add ```simple-viewer-gl``` - tiny image viewer for Linux and macOS, based on OpenGL. Supported formats: PNG, JPEG, PSD, XCF, SVG, GIF, TIFF, TARGA, ICO, BMP, PNM, DDS, BMP, XWD, SCR (ZX-Spectrum screen), XPM, WebP.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
