### PR TITLE
suitesparse: 5.4.0 → 5.7.1 + clean up

### DIFF
--- a/pkgs/development/libraries/science/math/mongoose/default.nix
+++ b/pkgs/development/libraries/science/math/mongoose/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mongoose";
+  version = "2.0.4";
+
+  outputs = [ "bin" "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "ScottKolo";
+    repo = "Mongoose";
+    rev = "v${version}";
+    sha256 = "0ymwd4n8p8s0ndh1vcbmjcsm0x2cc2b7v3baww5y6as12873bcrh";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Graph Coarsening and Partitioning Library";
+    homepage = "https://github.com/ScottKolo/Mongoose";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/development/libraries/science/math/suitesparse-graphblas/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse-graphblas/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, gnum4
+}:
+
+stdenv.mkDerivation rec {
+  pname = "suitesparse-graphblas";
+  version = "3.2.1";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "DrTimothyAldenDavis";
+    repo = "GraphBLAS";
+    rev = "v${version}";
+    sha256 = "AAwwzrpKFHy40Ldm6hTO6L0FWPYwi3kJj3zrshFwYas=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gnum4
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Graph algorithms in the language of linear algebra";
+    homepage = "http://faculty.cse.tamu.edu/davis/GraphBLAS.html";
+    license = licenses.asl20;
+    maintainers = with maintainers; [];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , gfortran
 , openblas
+, metis
 , cmake
 , fixDarwinDylibNames
 , gnum4
@@ -29,6 +30,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     openblas
+    metis
     gfortran.cc.lib
   ] ++ stdenv.lib.optional enableCuda cudatoolkit;
 
@@ -71,6 +73,7 @@ stdenv.mkDerivation rec {
     make library        \
         JOBS=$NIX_BUILD_CORES \
         BLAS=-lopenblas \
+        MY_METIS_LIB=-lmetis \
         LAPACK=""       \
         ${stdenv.lib.optionalString openblas.blas64 "CFLAGS=-DBLAS64"}
 
@@ -78,7 +81,9 @@ stdenv.mkDerivation rec {
     # Bundling is done by building the static libraries, extracting objects from
     # them and combining the objects into one shared library.
     mkdir -p static
-    make static JOBS=$NIX_BUILD_CORES AR_TARGET=$(pwd)/static/'$(LIBRARY).a'
+    make static JOBS=$NIX_BUILD_CORES \
+        MY_METIS_LIB=-lmetis \
+        AR_TARGET=$(pwd)/static/'$(LIBRARY).a'
     (
         cd static
         for i in lib*.a; do

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -3,7 +3,6 @@
 , gfortran
 , openblas
 , metis
-, cmake
 , fixDarwinDylibNames
 , gnum4
 , enableCuda ? false
@@ -24,7 +23,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    cmake
     gnum4
   ] ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
@@ -34,12 +32,13 @@ stdenv.mkDerivation rec {
     gfortran.cc.lib
   ] ++ stdenv.lib.optional enableCuda cudatoolkit;
 
-  dontUseCmakeConfigure = true;
-
   preConfigure = ''
     mkdir -p $out/lib
     mkdir -p $dev/include
     mkdir -p $doc/share/doc/${pname}-${version}
+
+    # Mongoose and GraphBLAS are packaged separately
+    sed -i "Makefile" -e '/GraphBLAS\|Mongoose/d'
 
     sed -i "SuiteSparse_config/SuiteSparse_config.mk" \
         -e '/CHOLMOD_CONFIG ?=/ s/$/ -DNPARTITION/'

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -33,80 +33,33 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional enableCuda cudatoolkit;
 
   preConfigure = ''
-    mkdir -p $out/lib
-    mkdir -p $dev/include
-    mkdir -p $doc/share/doc/${pname}-${version}
-
     # Mongoose and GraphBLAS are packaged separately
     sed -i "Makefile" -e '/GraphBLAS\|Mongoose/d'
-
-    sed -i "SuiteSparse_config/SuiteSparse_config.mk" \
-        -e '/CHOLMOD_CONFIG ?=/ s/$/ -DNPARTITION/'
-  ''
-  + stdenv.lib.optionalString stdenv.isDarwin ''
-    sed -i "SuiteSparse_config/SuiteSparse_config.mk" \
-        -e 's/^[[:space:]]*\(LIB = -lm\) -lrt/\1/'
-  ''
-  + stdenv.lib.optionalString enableCuda ''
-    sed -i "SuiteSparse_config/SuiteSparse_config.mk" \
-        -e 's|^[[:space:]]*\(CUDA_ROOT     =\)|CUDA_ROOT = ${cudatoolkit}|' \
-        -e 's|^[[:space:]]*\(GPU_BLAS_PATH =\)|GPU_BLAS_PATH = $(CUDA_ROOT)|' \
-        -e 's|^[[:space:]]*\(GPU_CONFIG    =\)|GPU_CONFIG = -I$(CUDA_ROOT)/include -DGPU_BLAS -DCHOLMOD_OMP_NUM_THREADS=$(NIX_BUILD_CORES) |' \
-        -e 's|^[[:space:]]*\(CUDA_PATH     =\)|CUDA_PATH = $(CUDA_ROOT)|' \
-        -e 's|^[[:space:]]*\(CUDART_LIB    =\)|CUDART_LIB = $(CUDA_ROOT)/lib64/libcudart.so|' \
-        -e 's|^[[:space:]]*\(CUBLAS_LIB    =\)|CUBLAS_LIB = $(CUDA_ROOT)/lib64/libcublas.so|' \
-        -e 's|^[[:space:]]*\(CUDA_INC_PATH =\)|CUDA_INC_PATH = $(CUDA_ROOT)/include/|' \
-        -e 's|^[[:space:]]*\(NV20          =\)|NV20 = -arch=sm_20 -Xcompiler -fPIC|' \
-        -e 's|^[[:space:]]*\(NV30          =\)|NV30 = -arch=sm_30 -Xcompiler -fPIC|' \
-        -e 's|^[[:space:]]*\(NV35          =\)|NV35 = -arch=sm_35 -Xcompiler -fPIC|' \
-        -e 's|^[[:space:]]*\(NVCC          =\) echo|NVCC = $(CUDA_ROOT)/bin/nvcc|' \
-        -e 's|^[[:space:]]*\(NVCCFLAGS     =\)|NVCCFLAGS = $(NV20) -O3 -gencode=arch=compute_20,code=sm_20 -gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_60,code=sm_60|'
   '';
 
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-DNTIMER";
+  makeFlags = [
+    "INSTALL=${placeholder "out"}"
+    "INSTALL_INCLUDE=${placeholder "dev"}/include"
+    "JOBS=$(NIX_BUILD_CORES)"
+    "BLAS=-lopenblas"
+    "MY_METIS_LIB=-lmetis"
+    "LAPACK="
+  ] ++ stdenv.lib.optionals openblas.blas64 [
+    "CFLAGS=-DBLAS64"
+  ] ++ stdenv.lib.optionals enableCuda [
+    "CUDA_PATH=${cudatoolkit}"
+    "CUDART_LIB=${cudatoolkit.lib}/lib/libcudart.so"
+    "CUBLAS_LIB=${cudatoolkit}/lib/libcublas.so"
+  ];
 
-  buildPhase = ''
-    runHook preBuild
+  buildFlags = [
+    # Build individual shared libraries, not demos
+    "library"
+  ];
 
-    # Build individual shared libraries
-    make library        \
-        JOBS=$NIX_BUILD_CORES \
-        BLAS=-lopenblas \
-        MY_METIS_LIB=-lmetis \
-        LAPACK=""       \
-        ${stdenv.lib.optionalString openblas.blas64 "CFLAGS=-DBLAS64"}
-
-    # Build libsuitesparse.so which bundles all the individual libraries.
-    # Bundling is done by building the static libraries, extracting objects from
-    # them and combining the objects into one shared library.
-    mkdir -p static
-    make static JOBS=$NIX_BUILD_CORES \
-        MY_METIS_LIB=-lmetis \
-        AR_TARGET=$(pwd)/static/'$(LIBRARY).a'
-    (
-        cd static
-        for i in lib*.a; do
-          ar -x $i
-        done
-    )
-    ${if enableCuda then "${cudatoolkit}/bin/nvcc" else "${stdenv.cc.outPath}/bin/cc"} \
-        static/*.o                                                                     \
-        ${if stdenv.isDarwin then "-dynamiclib" else "--shared"}                       \
-        -o "lib/libsuitesparse${stdenv.hostPlatform.extensions.sharedLibrary}"         \
-        -lopenblas                                                                     \
-        ${stdenv.lib.optionalString enableCuda "-lcublas"}
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    cp -r lib $out/
-    cp -r include $dev/
-    cp -r share $doc/
-  ''
-  + stdenv.lib.optionalString stdenv.isDarwin ''
+  # Likely fixed after 5.7.1
+  # https://github.com/DrTimothyAldenDavis/SuiteSparse/commit/f6daae26ee391e475e2295e77c839aa7c1a8b784
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     # The fixDarwinDylibNames in nixpkgs can't seem to fix all the libraries.
     # We manually fix them up here.
     fixDarwinDylibNames() {
@@ -125,15 +78,6 @@ stdenv.mkDerivation rec {
     }
 
     fixDarwinDylibNames $(find "$out" -name "*.dylib")
-  ''
-  + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-    # Fix rpaths
-    cd $out
-    find -name \*.so\* -type f -exec \
-      patchelf --set-rpath "$out/lib:${stdenv.lib.makeLibraryPath buildInputs}" {} \;
-  ''
-  + ''
-    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   pname = "suitesparse";
-  version = "5.4.0";
+  version = "5.7.1";
 
   outputs = [ "out" "dev" "doc" ];
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "DrTimothyAldenDavis";
     repo = "SuiteSparse";
     rev = "v${version}";
-    sha256 = "sha256:1jwqn86z9xxcj6gsiymmws40zfvdcclprffsmdasdjnjax00z9sk";
+    sha256 = "SA9SQKRDKUI1GilNMuCXljcvovLUwRKBUi/tiQ4dl5w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -31,8 +31,8 @@ buildPythonPackage rec {
     export CVXOPT_BLAS_LIB_DIR=${openblasCompat}/lib
     export CVXOPT_BLAS_LIB=openblas
     export CVXOPT_LAPACK_LIB=openblas
-    export CVXOPT_SUITESPARSE_LIB_DIR=${suitesparse}/lib
-    export CVXOPT_SUITESPARSE_INC_DIR=${suitesparse}/include
+    export CVXOPT_SUITESPARSE_LIB_DIR=${lib.getLib suitesparse}/lib
+    export CVXOPT_SUITESPARSE_INC_DIR=${lib.getDev suitesparse}/include
   '' + lib.optionalString withGsl ''
     export CVXOPT_BUILD_GSL=1
     export CVXOPT_GSL_LIB_DIR=${gsl}/lib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24308,6 +24308,8 @@ in
   suitesparse_5_3 = callPackage ../development/libraries/science/math/suitesparse {};
   suitesparse = suitesparse_5_3;
 
+  suitesparse-graphblas = callPackage ../development/libraries/science/math/suitesparse-graphblas {};
+
   superlu = callPackage ../development/libraries/science/math/superlu {};
 
   symmetrica = callPackage ../applications/science/math/symmetrica {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25152,6 +25152,8 @@ in
 
   mongoc = callPackage ../development/libraries/mongoc { };
 
+  mongoose = callPackage ../development/libraries/science/math/mongoose {};
+
   morph = callPackage ../tools/package-management/morph { };
 
   mupen64plus = callPackage ../misc/emulators/mupen64plus { };


### PR DESCRIPTION
###### Motivation for this change
Also had split (e.g. GEGL depends only on umfpack) in the works but it does not make sense to delay it.

cc @knedlsepp @ttuegel @jluttine 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
