### PR TITLE
pdf-parser: init at 0.7.4

### DIFF
--- a/pkgs/tools/misc/pdf-parser/default.nix
+++ b/pkgs/tools/misc/pdf-parser/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, python3Packages, fetchzip }:
+
+python3Packages.buildPythonApplication {
+  pname = "pdf-parser";
+  version = "0.7.4";
+
+  src = fetchzip {
+    url = "https://didierstevens.com/files/software/pdf-parser_V0_7_4.zip";
+    sha256 = "1j39yww2yl4cav8xgd4zfl5jchbbkvffnrynkamkzvz9dd5np2mh";
+  };
+
+  format = "other";
+
+  installPhase = ''
+    install -Dm555 pdf-parser.py $out/bin/pdf-parser.py
+  '';
+
+  preFixup = ''
+    substituteInPlace $out/bin/pdf-parser.py \
+      --replace '/usr/bin/python' '${python3Packages.python}/bin/python'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Parse a PDF document";
+    longDescription = ''
+      This tool will parse a PDF document to identify the fundamental elements used in the analyzed file.
+      It will not render a PDF document.
+    '';
+    homepage = "https://blog.didierstevens.com/programs/pdf-tools/";
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.lightdiscord ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26531,6 +26531,8 @@ in
 
   hashdeep = callPackage ../tools/security/hashdeep { };
 
+  pdf-parser = callPackage ../tools/misc/pdf-parser {};
+
   fluxboxlauncher = callPackage ../applications/misc/fluxboxlauncher {};
 
   btcdeb = callPackage ../applications/blockchains/btcdeb {};


### PR DESCRIPTION
###### Motivation for this change

Add missing package for #81418 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
