### PR TITLE
zoxide: init at 0.2.0

### DIFF
--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, rustPlatform, fzf }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "zoxide";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ajeetdsouza";
+    repo = "zoxide";
+    rev = "v${version}";
+    sha256 = "0s0zrkn48rgsf2fqpgsl0kix4l6w7k7pwssvdja6y3a4c097qmnm";
+  };
+
+  buildInputs = [
+    # Example Run-time Additional Dependencies
+    fzf
+  ];
+
+  cargoSha256 = "1p65ml2qj5dpc6nczfvf341fk7y4yi5ma1x6kfr3d32wnv6m4hgh";
+
+  meta = with stdenv.lib; {
+    description = "A fast cd command that learns your habits";
+    homepage = "https://github.com/ajeetdsouza/zoxide";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ysndr ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -12,7 +12,6 @@ rustPlatform.buildRustPackage rec {
   };
 
   buildInputs = [
-    # Example Run-time Additional Dependencies
     fzf
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3078,6 +3078,8 @@ in
 
   zeek = callPackage ../applications/networking/ids/zeek { };
 
+  zoxide = callPackage ../tools/misc/zoxide { };
+
   zzuf = callPackage ../tools/security/zzuf { };
 
   ### DEVELOPMENT / EMSCRIPTEN
@@ -3498,7 +3500,7 @@ in
   fuse-7z-ng = callPackage ../tools/filesystems/fuse-7z-ng { };
 
   fuse-overlayfs = callPackage ../tools/filesystems/fuse-overlayfs {};
-  
+
   fusee-interfacee-tk = callPackage ../applications/misc/fusee-interfacee-tk { };
 
   fusee-launcher = callPackage ../development/tools/fusee-launcher { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I started using zoxide as an alternative to `z` and thought it would be nice to have it included in nixpkgs as well.
zoxide seems to be in a very early state though so I'd be fine to include it in my personal nur repo for some time until it proves stable enough to be added here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
