### PR TITLE
cfdyndns: v0.0.1 -> v0.0.3

### DIFF
--- a/pkgs/applications/networking/dyndns/cfdyndns/default.nix
+++ b/pkgs/applications/networking/dyndns/cfdyndns/default.nix
@@ -1,23 +1,21 @@
-{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper, openssl }:
+{ stdenv, fetchFromGitHub, rustPlatform, pkg-config, openssl }:
 
 with rustPlatform;
 
 buildRustPackage rec {
   pname = "cfdyndns";
-  version = "0.0.1";
+  version = "0.0.3";
   src = fetchFromGitHub {
     owner = "colemickens";
     repo = "cfdyndns";
     rev = "v${version}";
-    sha256 = "1mcdjykrgh0jq6k6y664lai8sbgzk6j7k0r944f43vg63d1jql5b";
+    sha256 = "1fba0w2979dmc2wyggqx4fj52rrl1s2vpjk6mkj1811a848l1hdi";
   };
 
-  # Delete this on next update; see #79975 for details
-  legacyCargoFetcher = true;
+  cargoSha256 = "04ryin24z3pfxjxy4smngy66xs7k85g6gdzsl77cij8ifb29im99";
 
-  cargoSha256 = "1d7jpffkw2m2v37bfdqsl9sqwsl19cgglpa00lwy4ih09kzbc2n9";
-
-  buildInputs = [ makeWrapper openssl ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -30,6 +28,5 @@ buildRustPackage rec {
     license = stdenv.lib.licenses.mit;
     maintainers = with maintainers; [ colemickens ];
     platforms = with platforms; linux;
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fix `cfdyndns` by updating to `v0.0.3`.

cc: @bhipple 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
