### PR TITLE
Revert "python: XStatic-Bootstrap: 3.3.7.1 -> 4.1.3.1"

### DIFF
--- a/pkgs/development/python-modules/xstatic-bootstrap/default.nix
+++ b/pkgs/development/python-modules/xstatic-bootstrap/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "XStatic-Bootstrap";
-  version = "4.1.3.1";
+  version = "3.3.7.1";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "1800e6bb5fc687604d8a893eee8c7882d800a6f3d6721799016f99a47d1dac0f";
+    sha256 = "0c949e78e8cd77983fd803a68a98df0124e0c3a872fddb9ac8e6e5b4a487f131";
   };
 
   # no tests implemented


### PR DESCRIPTION
###### Motivation for this change
xstatic-bootstrap was bumped in #71893
This broke bepasty, because bepasty currently depends on xstatic-bootstrap < 4.
bepasty is the only package in nixpkgs that depends on xstatic-bootstrap.

There is an upstream issue [here](https://github.com/bepasty/bepasty-server/issues/183), but I don't think anyone is working on this right now.

Assuming this will get merged, it will also need a backport to 20.03.

In that case, it's also relevant to ZHF aka #80379.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Lassulus (you use this, right?)
cc @FRidh (you committed this)
cc @ThomasWaldmann (upstream, will this change any time soon?)