### PR TITLE
Octoprint 1.4.0 with Python 3 (WIP; help needed)

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, python2 }:
-
+{ stdenv, lib, fetchFromGitHub, python3 }:
 let
   mkOverride = attrname: version: sha256:
     self: super: {
@@ -17,6 +16,9 @@ let
       (mkOverride "tornado"     "4.5.3"  "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d")
       (mkOverride "psutil"      "5.6.7"  "ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa")
 
+      # Octoprint holds back jinja2 to 2.8.1 due to breaking changes.
+      # This old version does not have updated test config for pytest 4,
+      # and pypi tarball doesn't contain tests dir anyways.
       (pself: psuper: {
         sentry-sdk = psuper.sentry-sdk.overridePythonAttrs (oldAttrs: rec {
           version = "0.13.2";
@@ -26,12 +28,7 @@ let
           };
           checkInputs = with pself; [flask bottle falcon];
         });
-      })
 
-      # Octoprint holds back jinja2 to 2.8.1 due to breaking changes.
-      # This old version does not have updated test config for pytest 4,
-      # and pypi tarball doesn't contain tests dir anyways.
-      (pself: psuper: {
         jinja2 = psuper.jinja2.overridePythonAttrs (oldAttrs: rec {
           version = "2.8.1";
           src = oldAttrs.src.override {
@@ -44,70 +41,37 @@ let
     ]);
   };
 
-  ignoreVersionConstraints = [
-    "Click"
-    "Flask-Assets"
-    "Flask-Babel"
-    "Flask-Principal"
-    "emoji"
-    "flask"
-    "future"
-    "futures"
-    "monotonic"
-    "markdown"
-    "pkginfo"
-    "psutil"
-    "pyserial"
-    "requests"
-    "rsa"
-    "sarge"
-    "scandir"
-    "semantic_version"
-    "watchdog"
-    "websocket-client"
-    "wrapt"
-    "sentry-sdk"
-    "werkzeug" # 0.16 just deprecates some stuff
-  ];
-
-in py.pkgs.buildPythonApplication rec {
+in
+py.pkgs.buildPythonApplication rec {
   pname = "OctoPrint";
-  version = "1.3.12";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner  = "foosel";
     repo   = "OctoPrint";
     rev    = version;
-    sha256 = "1lmqssgwjyhknjf3x58g7cr0fqz7fs5a3rl07r69wfpch63ranyd";
+    sha256 = "1zla1ayr62lkvkr828dh3y287rzj3rv1hpij9kws44ynn4i582ga";
   };
 
   propagatedBuildInputs = with py.pkgs; [
-    awesome-slugify flask_assets rsa requests pkginfo watchdog
-    semantic-version flask_principal werkzeug flaskbabel tornado
-    psutil pyserial flask_login netaddr markdown sockjs-tornado
+    awesome-slugify flask flask_assets rsa requests pkginfo watchdog
+    semantic-version werkzeug flaskbabel tornado
+    psutil pyserial flask_login netaddr markdown
     pylru pyyaml sarge feedparser netifaces click websocket_client
-    scandir chainmap future futures wrapt monotonic emoji
-    frozendict cachelib sentry-sdk typing filetype
+    scandir chainmap future wrapt monotonic emoji jinja2
+    frozendict cachelib sentry-sdk filetype markupsafe
   ] ++ lib.optionals stdenv.isDarwin [ py.pkgs.appdirs ];
 
   checkInputs = with py.pkgs; [ nose mock ddt ];
 
-  postPatch = ''
-    sed -r -i \
-      ${lib.concatStringsSep "\n" (map (e:
-        ''-e 's@${e}[<>=]+.*@${e}",@g' \''
-      ) ignoreVersionConstraints)}
-      setup.py
-  '';
-
   checkPhase = ''
-    HOME=$(mktemp -d) nosetests ${lib.optionalString stdenv.isDarwin "--exclude=test_set_external_modification"}
+    HOME=$(mktemp -d) nosetests --exclude-test=util.test_pip.test_check_setup ${lib.optionalString stdenv.isDarwin "--exclude=test_set_external_modification"}
   '';
 
   meta = with stdenv.lib; {
     homepage = https://octoprint.org/;
     description = "The snappy web interface for your 3D printer";
     license = licenses.agpl3;
-    maintainers = with maintainers; [ abbradar gebner ];
+    maintainers = with maintainers; [ abbradar gebner WhittlesJr ];
   };
 }

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -11,11 +11,22 @@ let
       });
     };
 
-  py = python2.override {
+  py = python3.override {
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
-      (mkOverride "flask"       "0.10.1" "0wrkavjdjndknhp8ya8j850jq7a1cli4g5a93mg8nh1xz2gq50sc")
-      (mkOverride "flask_login" "0.2.11" "1rg3rsjs1gwi2pw6vr9jmhaqm9b3vc9c4hfcsvp4y8agbh7g3mc3")
+      (mkOverride "flask"       "0.12.5" "fac2b9d443e49f7e7358a444a3db5950bdd0324674d92ba67f8f1f15f876b14f")
       (mkOverride "tornado"     "4.5.3"  "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d")
+      (mkOverride "psutil"      "5.6.7"  "ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa")
+
+      (pself: psuper: {
+        sentry-sdk = psuper.sentry-sdk.overridePythonAttrs (oldAttrs: rec {
+          version = "0.13.2";
+          src = oldAttrs.src.override {
+            inherit version;
+            sha256 = "ff1fa7fb85703ae9414c8b427ee73f8363232767c9cd19158f08f6e4f0b58fc7";
+          };
+          checkInputs = with pself; [flask bottle falcon];
+        });
+      })
 
       # Octoprint holds back jinja2 to 2.8.1 due to breaking changes.
       # This old version does not have updated test config for pytest 4,


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
See #82292

This is a stab at updating to Octoprint 1.4.0 with Python 3. It's not currently working, because of a mysterious duplicated package that I can't seem to figure out. Jinja2 is not building because it sees a duplicated dependency (MarkupSafe). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@abbradar @gebner @peterhoeg 