### PR TITLE
nixos/release-notes: mention that dhcpcd stopped giving IPv4 addresses to bridges

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -379,6 +379,17 @@ services.xserver.displayManager.defaultSession = "xfce+icewm";
   <itemizedlist>
    <listitem>
     <para>
+     The <package>dhcpcd</package> package <link xlink:href="https://roy.marples.name/archives/dhcpcd-discuss/0002621.html">
+     does not request IPv4 addresses for tap and bridge interfaces anymore by default</link>.
+     In order to still get an address on a bridge interface, one has to disable
+     <literal>networking.useDHCP</literal> and explicitly enable
+     <literal>networking.interfaces.&lt;name&gt;.useDHCP</literal> on
+     every interface, that should get an address via DHCP. This way, dhcpcd
+     is configured in an explicit way about which interface to run on.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
       GnuPG is now built without support for a graphical passphrase entry
       by default. Please enable the <literal>gpg-agent</literal> user service
       via the NixOS option <literal>programs.gnupg.agent.enable</literal>.


### PR DESCRIPTION

###### Motivation for this change

This is about an change from [upstream dhcpcd](https://roy.marples.name/archives/dhcpcd-discuss/0002621.html). It is backwards incompatible as this locked me out of my box.

> Ignore some virtual interfaces such as Tap and Bridge by default

This was my setup, when I upgraded from `nixos-19.09` to `nixos-20.03`:

```nix
{ config, pkgs, ... }:{
  networking = {
    bridges.br0 = {
      interfaces = [ "enp2s0" "enp3s0" "enp4s0" ];
    };
    interfaces = {
      br0.useDHCP = true;
      enp2s0.useDHCP = false;
      enp3s0.useDHCP = false;
      enp4s0.useDHCP = false;
    };
  };
}
```

When I rebooted the system, I noticed that `br0` doesn't get an IPv4 address anymore. The reason was, that `dhcpcd` didn't consider a bridge as an interface, that would get an address by default.

My solution was then to change my config to this:

```nix
{ config, pkgs, ... }:{
  networking = {
    bridges.br0 = {
      interfaces = [ "enp2s0" "enp3s0" "enp4s0" ];
    };
    dhcpcd.allowInterfaces = [
      "br0"
      # and all other interfaces where I had set useDHCP = true!
    ];
  };
}
```
As I explain in the commit message, I don't see an easy way to fix this edge case. The only thing that comes to my mind right now is that we could give out an error if someone wants to set `useDHCP` on a bridge?

###### Things done

Inform users of `nixos-20.03`, that their setup might break.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Pinging @edolstra @fpletz as they are the maintainer of dhcpcd.