### PR TITLE
seabreeze: udev rules not installed

### DIFF
--- a/pkgs/development/python-modules/seabreeze/default.nix
+++ b/pkgs/development/python-modules/seabreeze/default.nix
@@ -6,8 +6,9 @@
 }:
 
 ## Usage
-# In NixOS, simply add the `udev` multiple output to services.udev.packages:
-#   services.udev.packages = [ pkgs.python3Packages.seabreeze.udev ];
+# In NixOS, add the package to services.udev.packages for non-root plugdev
+# users to get device access permission:
+#    services.udev.packages = [ pkgs.python3Packages.seabreeze ];
 
 buildPythonPackage rec {
   pname = "seabreeze";
@@ -20,11 +21,9 @@ buildPythonPackage rec {
     sha256 = "0bc2s9ic77gz9m40w89snixphxlzib60xa4f49n4zasjrddfz1l8";
   };
 
-  outputs = [ "out" "udev" ];
-
   postInstall = ''
-    mkdir -p $udev/lib/udev/rules.d
-    cp misc/10-oceanoptics.rules $udev/lib/udev/rules.d/10-oceanoptics.rules
+    mkdir -p $out/etc/udev/rules.d
+    cp misc/10-oceanoptics.rules $out/etc/udev/rules.d/10-oceanoptics.rules
   '';
 
   # underlying c libraries are tested and fail


### PR DESCRIPTION
fixes #82229

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
