### PR TITLE
amdvlk: init at 2020.Q2.5

### DIFF
--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -1,0 +1,85 @@
+{ stdenv
+, lib
+, fetchpatch
+, fetchRepoProject
+, cmake
+, ninja
+, patchelf
+, perl
+, pkgconfig
+, python3
+, expat
+, libdrm
+, ncurses
+, openssl
+, wayland
+, xorg
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "amdvlk";
+  version = "2020.Q2.5";
+
+  src = fetchRepoProject {
+    name = "${pname}-src";
+    manifest = "https://github.com/GPUOpen-Drivers/AMDVLK.git";
+    rev = "refs/tags/v-${version}";
+    sha256 = "008adby8vx12ma155x64n7aj9vp9ygqgij3mm3q20i187db7d1ab";
+  };
+
+  buildInputs = [
+    expat
+    ncurses
+    openssl
+    wayland
+    xorg.libX11
+    xorg.libxcb
+    xorg.xcbproto
+    xorg.libXext
+    xorg.libXrandr
+    xorg.libXft
+    xorg.libxshmfence
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    patchelf
+    perl
+    pkgconfig
+    python3
+  ];
+
+  rpath = lib.makeLibraryPath [
+    libdrm
+    stdenv.cc.cc.lib
+    xorg.libX11
+    xorg.libxcb
+    xorg.libxshmfence
+  ];
+
+  cmakeDir = "../drivers/xgl";
+
+  installPhase = ''
+    install -Dm755 -t $out/lib icd/amdvlk64.so
+    install -Dm644 -t $out/share/vulkan/icd.d ../drivers/AMDVLK/json/Redhat/amd_icd64.json
+
+    substituteInPlace $out/share/vulkan/icd.d/amd_icd64.json --replace \
+      "/usr/lib64" "$out/lib"
+
+    patchelf --set-rpath "$rpath" $out/lib/amdvlk64.so
+  '';
+
+  # Keep the rpath, otherwise vulkaninfo and vkcube segfault
+  dontPatchELF = true;
+
+  meta = with stdenv.lib; {
+    description = "AMD Open Source Driver For Vulkan";
+    homepage = "https://github.com/GPUOpen-Drivers/AMDVLK";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ Flakebi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11261,6 +11261,8 @@ in
   allegro4 = callPackage ../development/libraries/allegro {};
   allegro5 = callPackage ../development/libraries/allegro/5.nix {};
 
+  amdvlk = callPackage ../development/libraries/amdvlk {};
+
   amrnb = callPackage ../development/libraries/amrnb { };
 
   amrwb = callPackage ../development/libraries/amrwb { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[AMDVLK](https://github.com/GPUOpen-Drivers/AMDVLK) is the official open source Vulkan driver from AMD.
The `share/vulkan/icd.d/amd_icd64.json` file makes this the default driver if amdvlk is added to `environment.systemPackages`.
(To switch between multiple drivers setting `export VK_ICD_FILENAMES=/nix/store/<hash>-amdvlk-2020.Q1.2/share/vulkan/icd.d/amd_icd64.json` can be used.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
