### PR TITLE
surge: init at 1.7.1

### DIFF
--- a/pkgs/applications/audio/surge/default.nix
+++ b/pkgs/applications/audio/surge/default.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitHub, premake5, pkgconfig, cmake
 ,cairo, libxkbcommon, libxcb, xcb-util-cursor, xcbutilkeysyms, ncurses, which, getopt
-,python, gnome3, lato }:
+,python, gnome3, lato, pcre, libpthreadstubs, libXdmcp, xcbutilrenderutil, xcbutilimage, libsndfile }:
 
 stdenv.mkDerivation rec {
   pname = "surge";
-  version = "1.6.6";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "surge-synthesizer";
     repo = pname;
     rev = "release_${version}";
-    sha256 = "0al021f516ybhnp3lhqx8i6c6hpfaw3gqfwwxx3lx3hh4b8kjfjw";
+    sha256 = "1jhk8iaqh89dnci4446b47315v2lc8gclraygk8m9jl20zpjxl0l";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ premake5 pkgconfig cmake ncurses which getopt python ];
 
-  buildInputs = [  cairo libxkbcommon libxcb xcb-util-cursor xcbutilkeysyms gnome3.zenity lato ];
+  buildInputs = [  cairo libxkbcommon libxcb xcb-util-cursor xcbutilkeysyms gnome3.zenity lato pcre libpthreadstubs libXdmcp xcbutilrenderutil xcbutilimage libsndfile ];
 
   buildFlags = [ "config=release_x64" ];
 
@@ -29,16 +29,15 @@ stdenv.mkDerivation rec {
     substituteInPlace src/common/gui/PopupEditorDialog.cpp --replace zenity ${gnome3.zenity}/bin/zenity
   '';
 
-  configurePhase = ''
-      ./build-linux.sh premake
-      python scripts/linux/emit-vector-piggy.py .
-    '';
+  buildPhase = ''
+    ./build-linux.sh build;
+  '';
 
   installPhase = ''
     mkdir -p $out/lib/lv2
-    cp -r target/lv2/Release/Surge.lv2/ $out/lib/lv2
-    mkdir -p $out/lib/vst
-    cp target/vst3/Release/Surge.so $out/lib/vst
+    cp -r buildlin/surge_products/Surge.lv2/ $out/lib/lv2
+    mkdir -p $out/lib/vst3
+    cp -r buildlin/surge_products/Surge.vst3/ $out/lib/vst3
     mkdir -p $out/share/surge
     cp -r resources/data/* $out/share/surge/
   '';
@@ -46,7 +45,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
   installCheckPhase = ''
     ./build-linux.sh build -p headless
-    ./target/headless/Release/Surge/Surge-Headless
+    ./buildlin/surge-headless
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/surge/default.nix
+++ b/pkgs/applications/audio/surge/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, premake5, pkgconfig, cmake
-,cairo, libxkbcommon, libxcb, xcb-util-cursor, xcbutilkeysyms, ncurses, which, getopt
-,python, gnome3, lato, pcre, libpthreadstubs, libXdmcp, xcbutilrenderutil, xcbutilimage, libsndfile }:
+{ stdenv, fetchFromGitHub, cmake, git, pkg-config, python3
+, cairo, libsndfile, libxcb, libxkbcommon, xcbutil, xcbutilcursor, xcbutilkeysyms, zenity
+}:
 
 stdenv.mkDerivation rec {
   pname = "surge";
@@ -10,49 +10,39 @@ stdenv.mkDerivation rec {
     owner = "surge-synthesizer";
     repo = pname;
     rev = "release_${version}";
-    sha256 = "1jhk8iaqh89dnci4446b47315v2lc8gclraygk8m9jl20zpjxl0l";
+    sha256 = "1b3ccc78vrpzy18w7070zfa250dnd1bww147xxcnj457vd6n065s";
+    leaveDotGit = true; # for SURGE_VERSION
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ premake5 pkgconfig cmake ncurses which getopt python ];
+  nativeBuildInputs = [ cmake git pkg-config python3 ];
+  buildInputs = [ cairo libsndfile libxcb libxkbcommon xcbutil xcbutilcursor xcbutilkeysyms zenity ];
 
-  buildInputs = [  cairo libxkbcommon libxcb xcb-util-cursor xcbutilkeysyms gnome3.zenity lato pcre libpthreadstubs libXdmcp xcbutilrenderutil xcbutilimage libsndfile ];
-
-  buildFlags = [ "config=release_x64" ];
-
-  enableParallelBuilding = true;
-
-  patchPhase = ''
-    patchShebangs build-linux.sh
+  postPatch = ''
     substituteInPlace src/common/SurgeStorage.cpp --replace "/usr/share/Surge" "$out/share/surge"
-    substituteInPlace src/linux/UserInteractionsLinux.cpp --replace 'execlp("zenity"' 'execlp("${gnome3.zenity}/bin/zenity"'
-    substituteInPlace src/common/gui/PopupEditorDialog.cpp --replace zenity ${gnome3.zenity}/bin/zenity
-  '';
-
-  buildPhase = ''
-    ./build-linux.sh build;
+    substituteInPlace src/common/gui/PopupEditorDialog.cpp --replace '"zenity' '"${zenity}/bin/zenity'
+    substituteInPlace src/linux/UserInteractionsLinux.cpp --replace '"zenity' '"${zenity}/bin/zenity'
+    substituteInPlace vstgui.surge/vstgui/lib/platform/linux/x11fileselector.cpp --replace /usr/bin/zenity ${zenity}/bin/zenity
   '';
 
   installPhase = ''
-    mkdir -p $out/lib/lv2
-    cp -r buildlin/surge_products/Surge.lv2/ $out/lib/lv2
-    mkdir -p $out/lib/vst3
-    cp -r buildlin/surge_products/Surge.vst3/ $out/lib/vst3
-    mkdir -p $out/share/surge
-    cp -r resources/data/* $out/share/surge/
+    mkdir -p $out/lib/lv2 $out/lib/vst3 $out/share/surge
+    cp -r surge_products/Surge.lv2 $out/lib/lv2/
+    cp -r surge_products/Surge.vst3 $out/lib/vst3/
+    cp -r ../resources/data/* $out/share/surge/
   '';
 
   doInstallCheck = true;
   installCheckPhase = ''
-    ./build-linux.sh build -p headless
-    ./buildlin/surge-headless
+    cd ..
+    build/surge-headless
   '';
 
   meta = with stdenv.lib; {
-    description = "LV2 & VST Synthesizer plug-in (previously released as Vember Audio Surge)";
+    description = "LV2 & VST3 synthesizer plug-in (previously released as Vember Audio Surge)";
     homepage = "https://surge-synthesizer.github.io";
     license = licenses.gpl3;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ magnetophon ];
+    maintainers = with maintainers; [ magnetophon orivej ];
   };
 }

--- a/pkgs/applications/audio/surge/default.nix
+++ b/pkgs/applications/audio/surge/default.nix
@@ -1,0 +1,59 @@
+{ stdenv, fetchFromGitHub, premake5, pkgconfig, cmake
+,cairo, libxkbcommon, libxcb, xcb-util-cursor, xcbutilkeysyms, ncurses, which, getopt
+,python, gnome3, lato }:
+
+stdenv.mkDerivation rec {
+  pname = "surge";
+  version = "1.6.6";
+
+  src = fetchFromGitHub {
+    owner = "surge-synthesizer";
+    repo = pname;
+    rev = "release_${version}";
+    sha256 = "0al021f516ybhnp3lhqx8i6c6hpfaw3gqfwwxx3lx3hh4b8kjfjw";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ premake5 pkgconfig cmake ncurses which getopt python ];
+
+  buildInputs = [  cairo libxkbcommon libxcb xcb-util-cursor xcbutilkeysyms gnome3.zenity lato ];
+
+  buildFlags = [ "config=release_x64" ];
+
+  enableParallelBuilding = true;
+
+  patchPhase = ''
+    patchShebangs build-linux.sh
+    substituteInPlace src/common/SurgeStorage.cpp --replace "/usr/share/Surge" "$out/share/surge"
+    substituteInPlace src/linux/UserInteractionsLinux.cpp --replace 'execlp("zenity"' 'execlp("${gnome3.zenity}/bin/zenity"'
+    substituteInPlace src/common/gui/PopupEditorDialog.cpp --replace zenity ${gnome3.zenity}/bin/zenity
+  '';
+
+  configurePhase = ''
+      ./build-linux.sh premake
+      python scripts/linux/emit-vector-piggy.py .
+    '';
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2
+    cp -r target/lv2/Release/Surge.lv2/ $out/lib/lv2
+    mkdir -p $out/lib/vst
+    cp target/vst3/Release/Surge.so $out/lib/vst
+    mkdir -p $out/share/surge
+    cp -r resources/data/* $out/share/surge/
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    ./build-linux.sh build -p headless
+    ./target/headless/Release/Surge/Surge-Headless
+  '';
+
+  meta = with stdenv.lib; {
+    description = "LV2 & VST Synthesizer plug-in (previously released as Vember Audio Surge)";
+    homepage = "https://surge-synthesizer.github.io";
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23135,7 +23135,10 @@ in
 
   surf-display = callPackage ../desktops/surf-display { };
 
-  surge = callPackage ../applications/audio/surge { };
+  surge = callPackage ../applications/audio/surge {
+    inherit (gnome3) zenity;
+    git = gitMinimal;
+  };
 
   sunvox = callPackage ../applications/audio/sunvox { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23135,6 +23135,8 @@ in
 
   surf-display = callPackage ../desktops/surf-display { };
 
+  surge = callPackage ../applications/audio/surge { };
+
   sunvox = callPackage ../applications/audio/sunvox { };
 
   swh_lv2 = callPackage ../applications/audio/swh-lv2 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
