### PR TITLE
nixos/systemd: apply .link even when networkd is disabled

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -712,6 +712,14 @@ auth required pam_succeed_if.so uid >= 1000 quiet
      For further reference, please read <link xlink:href="https://github.com/NixOS/nixpkgs/pull/68953">#68953</link> or the corresponding <link xlink:href="https://discourse.nixos.org/t/predictable-network-interface-names-in-initrd/4055">discourse thread</link>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <link linkend="opt-systemd.network.links">systemd.network.links</link> option is now respected
+     even when <link linkend="opt-systemd.network.enable">systemd-networkd</command> is disabled.
+     This mirrors the behaviour of systemd - It's udev that parses <literal>.link</literal> files,
+     not <command>systemd-networkd</command>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/services/networking/zerotierone.nix
+++ b/nixos/modules/services/networking/zerotierone.nix
@@ -69,13 +69,14 @@ in
     environment.systemPackages = [ cfg.package ];
 
     # Prevent systemd from potentially changing the MAC address
-    environment.etc."systemd/network/50-zerotier.link".text = ''
-      [Match]
-      OriginalName=zt*
-
-      [Link]
-      AutoNegotiation=false
-      MACAddressPolicy=none
-    '';
+    systemd.network.links."50-zerotier" = {
+      matchConfig = {
+        OriginalName = "zt*";
+      };
+      linkConfig = {
+        AutoNegotiation = false;
+        MACAddressPolicy = "none";
+      };
+    };
   };
 }

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -5,11 +5,10 @@
 , networkd }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };
-with pkgs.lib;
 
 let
-  router = { config, pkgs, ... }:
-    with pkgs.lib;
+  router = { config, pkgs, lib, ... }:
+    with lib;
     let
       vlanIfs = range 1 (length config.virtualisation.vlans);
     in {
@@ -85,7 +84,7 @@ let
     static = {
       name = "Static";
       nodes.router = router;
-      nodes.client = { pkgs, ... }: with pkgs.lib; {
+      nodes.client = { pkgs, lib, ... }: with lib; {
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
@@ -137,7 +136,7 @@ let
     dhcpSimple = {
       name = "SimpleDHCP";
       nodes.router = router;
-      nodes.client = { pkgs, ... }: with pkgs.lib; {
+      nodes.client = { pkgs, lib, ... }: with lib; {
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
@@ -193,7 +192,7 @@ let
     dhcpOneIf = {
       name = "OneInterfaceDHCP";
       nodes.router = router;
-      nodes.client = { pkgs, ... }: with pkgs.lib; {
+      nodes.client = { pkgs, lib, ... }: with lib; {
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
@@ -232,7 +231,7 @@ let
         '';
     };
     bond = let
-      node = address: { pkgs, ... }: with pkgs.lib; {
+      node = address: { pkgs, lib, ... }: with lib; {
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
@@ -268,7 +267,7 @@ let
         '';
     };
     bridge = let
-      node = { address, vlan }: { pkgs, ... }: with pkgs.lib; {
+      node = { address, vlan }: { pkgs, lib, ... }: with lib; {
         virtualisation.vlans = [ vlan ];
         networking = {
           useNetworkd = networkd;
@@ -281,7 +280,7 @@ let
       name = "Bridge";
       nodes.client1 = node { address = "192.168.1.2"; vlan = 1; };
       nodes.client2 = node { address = "192.168.1.3"; vlan = 2; };
-      nodes.router = { pkgs, ... }: with pkgs.lib; {
+      nodes.router = { pkgs, lib, ... }: with lib; {
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
@@ -318,7 +317,7 @@ let
     macvlan = {
       name = "MACVLAN";
       nodes.router = router;
-      nodes.client = { pkgs, ... }: with pkgs.lib; {
+      nodes.client = { pkgs, lib, ... }: with lib; {
         environment.systemPackages = [ pkgs.iptables ]; # to debug firewall rules
         virtualisation.vlans = [ 1 ];
         networking = {
@@ -372,7 +371,7 @@ let
         '';
     };
     sit = let
-      node = { address4, remote, address6 }: { pkgs, ... }: with pkgs.lib; {
+      node = { address4, remote, address6 }: { pkgs, lib, ... }: with lib; {
         virtualisation.vlans = [ 1 ];
         networking = {
           useNetworkd = networkd;
@@ -414,7 +413,7 @@ let
         '';
     };
     vlan = let
-      node = address: { pkgs, ... }: with pkgs.lib; {
+      node = address: { pkgs, lib, ... }: with lib; {
         #virtualisation.vlans = [ 1 ];
         networking = {
           useNetworkd = networkd;
@@ -527,7 +526,7 @@ let
           '';
         };
       };
-      nodes.client_with_privacy = { pkgs, ... }: with pkgs.lib; {
+      nodes.client_with_privacy = { pkgs, lib, ... }: with lib; {
         virtualisation.vlans = [ 1 ];
         networking = {
           useNetworkd = networkd;
@@ -540,7 +539,7 @@ let
           };
         };
       };
-      nodes.client = { pkgs, ... }: with pkgs.lib; {
+      nodes.client = { pkgs, lib, ... }: with lib; {
         virtualisation.vlans = [ 1 ];
         networking = {
           useNetworkd = networkd;
@@ -603,9 +602,9 @@ let
 
       testScript = ''
         targetIPv4Table = """
-        10.0.0.0/16 proto static scope link mtu 1500 
-        192.168.1.0/24 proto kernel scope link src 192.168.1.2 
-        192.168.2.0/24 via 192.168.1.1 proto static 
+        10.0.0.0/16 proto static scope link mtu 1500
+        192.168.1.0/24 proto kernel scope link src 192.168.1.2
+        192.168.2.0/24 via 192.168.1.1 proto static
         """.strip()
 
         targetIPv6Table = """
@@ -657,6 +656,6 @@ let
     };
   };
 
-in mapAttrs (const (attrs: makeTest (attrs // {
+in pkgs.lib.mapAttrs (pkgs.lib.const (attrs: makeTest (attrs // {
   name = "${attrs.name}-Networking-${if networkd then "Networkd" else "Scripted"}";
 }))) testCases

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -654,6 +654,31 @@ let
             ), "The IPv6 routing table has not been properly cleaned:\n{}".format(ipv6Residue)
       '';
     };
+    # even with disabled networkd, systemd.network.links should work
+    # (as it's handled by udev, not networkd)
+    link = {
+      name = "Link";
+      nodes.client = { pkgs, ... }: {
+        virtualisation.vlans = [ 1 ];
+        networking = {
+          useNetworkd = networkd;
+          useDHCP = false;
+        };
+        systemd.network.links."50-foo" = {
+          matchConfig = {
+            Name = "foo";
+            Driver = "dummy";
+          };
+          linkConfig.MTUBytes = "1442";
+        };
+      };
+      testScript = ''
+        print(client.succeed("ip l add name foo type dummy"))
+        print(client.succeed("stat /etc/systemd/network/50-foo.link"))
+        client.succeed("udevadm settle")
+        assert "mtu 1442" in client.succeed("ip l show dummy0")
+      '';
+    };
   };
 
 in pkgs.lib.mapAttrs (pkgs.lib.const (attrs: makeTest (attrs // {


### PR DESCRIPTION
###### Motivation for this change
The `systemd.network.links` option is now respected even when systemd-networkd is disabled.
This mirrors the behaviour of systemd - It's udev that parses `.link` files,
not systemd-networkd.

I added a test that creates a dummy interface and checks for the MTU to be set according to the `.link` file.

Follow-up of https://github.com/NixOS/nixpkgs/pull/77405#issuecomment-597357774

Thanks to @NinjaTrappeur for helping me unclutter some of the module code and being ~~a rubberduck~~ infinite recursion slayer / father of the dragon and liberator of slaves.

cc @obadz @danielfullmer 

Should probably be backported to 20.03, given we don't default to networkd, meaning `.link` file handling is broken there.

@GrahamcOfBorg build nixosTests.networking.networkd.link nixosTests.networking.scripted.link

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
