### PR TITLE
Revert "pari: 2.11.2 -> 2.11.3"

### DIFF
--- a/pkgs/applications/science/math/pari/default.nix
+++ b/pkgs/applications/science/math/pari/default.nix
@@ -12,11 +12,11 @@ assert withThread -> libpthreadstubs != null;
 
 stdenv.mkDerivation rec {
   pname = "pari";
-  version = "2.11.3";
+  version = "2.11.2";
 
   src = fetchurl {
     url = "https://pari.math.u-bordeaux.fr/pub/pari/unix/${pname}-${version}.tar.gz";
-    sha256 = "1jd65h2psrmba2dx7rkf5qidf9ka0cwbsg20pd18k45ggr30l467";
+    sha256 = "0fck8ssmirl8fy7s4mspgrxjs5sag76xbshqlqzkcl3kqyrk4raa";
   };
 
   buildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#81950

Breaks sage, its main consumer: https://trac.sagemath.org/ticket/29313