### PR TITLE
homeassistant: 0.106.1 -> 0.106.6

### DIFF
--- a/pkgs/development/python-modules/pyicloud/default.nix
+++ b/pkgs/development/python-modules/pyicloud/default.nix
@@ -15,11 +15,11 @@
 
 buildPythonPackage rec {
   pname = "pyicloud";
-  version = "0.9.2";
+  version = "0.9.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1jjkzf7vwms6pymnmdr893830vrymxnq455xnqp21wqhjjiy2amd";
+    sha256 = "0r171wnq2g5bw7gd59vh6flm0104ix1a6s2vhdrf8s74hipw57si";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.106.1";
+  version = "0.106.6";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];
@@ -124,6 +124,7 @@
     "configurator" = ps: with ps; [ ];
     "conversation" = ps: with ps; [ aiohttp-cors];
     "coolmaster" = ps: with ps; [ ]; # missing inputs: pycoolmasternet
+    "coronavirus" = ps: with ps; [ ]; # missing inputs: coronavirus
     "counter" = ps: with ps; [ ];
     "cover" = ps: with ps; [ ];
     "cppm_tracker" = ps: with ps; [ ]; # missing inputs: clearpasspy

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -67,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.106.1";
+  hassVersion = "0.106.6";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -84,7 +84,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "0i261hzjfhqnq7j8dwsnj2h2vmr4vnxkvk2ff910am1knzni3a2z";
+    sha256 = "11kv5lmm8nxp7yv3w43mzmgzkafddy0z6wl2878p96iyil1w7qhb";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20200220.4";
+  version = "20200220.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0cb8b6xizxz1q5r0qgwsqs53va9bxdqnp4vwf5lh8ppv9zy7hssc";
+    sha256 = "0nc44r5ybq0prsz2yid622i0xr7q0qrc4ymbk69bqg6jrmjpbdl1";
   };
 
   # no Python tests implemented

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -53,7 +53,7 @@ def get_version():
         return m.group(1)
 
 
-def parse_components(version="master"):
+def parse_components(version: str = "master"):
     components = {}
     with tempfile.TemporaryDirectory() as tmp:
         with urlopen(
@@ -61,14 +61,13 @@ def parse_components(version="master"):
         ) as response:
             tarfile.open(fileobj=BytesIO(response.read())).extractall(tmp)
         # Use part of a script from the Home Assistant codebase
-        sys.path.append(os.path.join(tmp, f"home-assistant-{version}"))
+        core_path = os.path.join(tmp, f"core-{version}")
+        sys.path.append(core_path)
         from script.hassfest.model import Integration
 
         integrations = Integration.load_dir(
             pathlib.Path(
-                os.path.join(
-                    tmp, f"home-assistant-{version}", "homeassistant/components"
-                )
+                os.path.join(core_path, "homeassistant/components")
             )
         )
         for domain in sorted(integrations):


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
