### PR TITLE
kodi 18.5 -> 18.6

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -43,15 +43,15 @@ assert vdpauSupport -> libvdpau != null;
 assert useWayland -> wayland != null && wayland-protocols != null && waylandpp != null && libxkbcommon != null;
 
 let
-  kodiReleaseDate = "20191116";
-  kodiVersion = "18.5";
+  kodiReleaseDate = "20200301";
+  kodiVersion = "18.6";
   rel = "Leia";
 
   kodi_src = fetchFromGitHub {
     owner  = "xbmc";
     repo   = "xbmc";
     rev    = "${kodiVersion}-${rel}";
-    sha256 = "0pcrraj1ddzrd296br10yjnaxgb3iym74xzixcakaqhhp00f5hf6";
+    sha256 = "0rwymipn5hljy5xrslzmrljmj6f9wb191wi7gjw20wl6sv44d0bk";
   };
 
   cmakeProto = fetchurl {
@@ -193,15 +193,6 @@ in stdenv.mkDerivation {
       pkgconfig gnumake
       autoconf automake libtool # still needed for some components. Check if that is the case with 19.0
     ] ++ lib.optionals useWayland [ wayland-protocols ];
-
-    patches = [
-      # Adds missing cassert includes, fixing builds. This will be unnecessary
-      # after 18.6 is released (which will contain this patch)
-      (fetchpatch {
-        url = "https://github.com/xbmc/xbmc/commit/d5947e6733fd564edb68df91fd6d389d9fb82319.patch";
-        sha256 = "1shlbsbfba3074wdyhl42vgin6jfzl7sy3zsvxaxkpx8g7my9jn2";
-      })
-    ];
 
     cmakeFlags = [
       "-Dlibdvdcss_URL=${libdvdcss.src}"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrade of the kodi release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
