### PR TITLE
Update elmPackages

### DIFF
--- a/pkgs/development/compilers/elm/packages/node-packages.nix
+++ b/pkgs/development/compilers/elm/packages/node-packages.nix
@@ -103,13 +103,13 @@ let
         sha512 = "MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==";
       };
     };
-    "@types/node-13.9.1" = {
+    "@types/node-13.9.2" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "13.9.1";
+      version = "13.9.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz";
-        sha512 = "E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==";
+        url = "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz";
+        sha512 = "bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg==";
       };
     };
     "@types/responselike-1.0.0" = {
@@ -6573,7 +6573,7 @@ in
       sources."@types/cacheable-request-6.0.1"
       sources."@types/http-cache-semantics-4.0.0"
       sources."@types/keyv-3.1.1"
-      sources."@types/node-13.9.1"
+      sources."@types/node-13.9.2"
       sources."@types/responselike-1.0.0"
       sources."cacheable-lookup-2.0.0"
       sources."cacheable-request-7.0.1"


### PR DESCRIPTION
###### Motivation for this change

Upgrade `elm-language-server` to 1.6.3.

Other elm packages updated:

- elm-hot 1.1.4
- elm-upgrade 0.19.8
- elm-live 4.0.2

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @turboMaCk @Razzeee @BrianHicks 
