### PR TITLE
wxmaxima: 18.02.0 -> 20.02.4

### DIFF
--- a/pkgs/applications/science/math/wxmaxima/default.nix
+++ b/pkgs/applications/science/math/wxmaxima/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wxmaxima";
-  version = "19.03.0";
+  version = "20.02.4";
 
   src = fetchFromGitHub {
-    owner = "andrejv";
+    owner = "wxMaxima-developers";
     repo = "wxmaxima";
     rev = "Version-${version}";
-    sha256 = "0s7bdykc77slqix28cyaa6x8wvxrn8461mkdgxflvi2apwsl56aa";
+    sha256 = "106a7jrjwfmymzj70nsv44fm3jbxngr8pmkaghhpwy0ln38lhf54";
   };
 
   buildInputs = [ wxGTK maxima gnome3.adwaita-icon-theme ];

--- a/pkgs/applications/science/math/wxmaxima/default.nix
+++ b/pkgs/applications/science/math/wxmaxima/default.nix
@@ -21,12 +21,10 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(--prefix PATH ":" ${maxima}/bin)
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Cross platform GUI for the computer algebra system Maxima";
     license = licenses.gpl2;
-    homepage = https://wxmaxima-developers.github.io/wxmaxima/;
+    homepage = "https://wxmaxima-developers.github.io/wxmaxima/";
     platforms = platforms.linux;
     maintainers = [ maintainers.peti ];
   };


### PR DESCRIPTION
###### Motivation for this change
This updates `wxmaxima` to a recent release. The commit description is 18.02.0 -> 20.02.4, because in the last version bump (1c6a193b3ed36dd08e35a7b0ea1d28b72133d6c6), the version string was changed, but the hash was not. So the version currently in `nixpkgs` really is `18.02.0` (can also be seen from running `wxmaxima --version`).

Whats the policy for such changes? Should it be mentioned in the commit message?

Also the upstream source repository changed. The original repository at https://github.com/andrejv/wxmaxima redirects to https://github.com/wxMaxima-developers/wxmaxima.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
