### PR TITLE
mesa: 19.3.3 -> 20.0.1

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -27,7 +27,7 @@
 with stdenv.lib;
 
 let
-  version = "19.3.3";
+  version = "20.0.1";
   branch  = versions.major version;
 in
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
     ];
-    sha256 = "02czqdqf64i3az5p1allnxycyjad3x35cj0hz0017mi5pc84ikl1";
+    sha256 = "1r6xxrhh86ldwbzrsy4gpv8v49l181mvfkcfq2zlnlmhihzvllv1";
   };
 
   prePatch = "patchShebangs .";
@@ -191,8 +191,18 @@ stdenv.mkDerivation {
   };
 
   meta = with stdenv.lib; {
-    description = "An open source implementation of OpenGL";
-    homepage = https://www.mesa3d.org/;
+    description = "An open source 3D graphics library";
+    longDescription = ''
+      The Mesa project began as an open-source implementation of the OpenGL
+      specification - a system for rendering interactive 3D graphics. Over the
+      years the project has grown to implement more graphics APIs, including
+      OpenGL ES (versions 1, 2, 3), OpenCL, OpenMAX, VDPAU, VA API, XvMC, and
+      Vulkan.  A variety of device drivers allows the Mesa libraries to be used
+      in many different environments ranging from software emulation to
+      complete hardware acceleration for modern GPUs.
+    '';
+    homepage = "https://www.mesa3d.org/";
+    changelog = "https://www.mesa3d.org/relnotes/${version}.html";
     license = licenses.mit; # X11 variant, in most files
     platforms = platforms.mesaPlatforms;
     maintainers = with maintainers; [ vcunat ];

--- a/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
+++ b/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
@@ -1,4 +1,4 @@
-From 6d22383149e4cdc646c68e29238f41d895a4705b Mon Sep 17 00:00:00 2001
+From 46b10f2bc28fd79d561c8c49bbae3aee6a4cf0e6 Mon Sep 17 00:00:00 2001
 From: David McFarland <corngood@gmail.com>
 Date: Mon, 6 Aug 2018 15:52:11 -0300
 Subject: [PATCH] disk_cache: include dri driver path in cache key
@@ -12,10 +12,10 @@ timestamps in /nix/store are zero.
  3 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/meson_options.txt b/meson_options.txt
-index 626baf3..579c15b 100644
+index 1a2dd8ebd12..2ac741af5a6 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -341,6 +341,12 @@ option(
+@@ -348,6 +348,12 @@ option(
    value : true,
    description : 'Enable direct rendering in GLX and EGL for DRI',
  )
@@ -29,10 +29,10 @@ index 626baf3..579c15b 100644
    'I-love-half-baked-turnips',
    type : 'boolean',
 diff --git a/src/util/disk_cache.c b/src/util/disk_cache.c
-index 0cd92ca..fc1c173 100644
+index d1f14736725..2ed328f292e 100644
 --- a/src/util/disk_cache.c
 +++ b/src/util/disk_cache.c
-@@ -395,8 +395,10 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
+@@ -402,8 +402,10 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
  
     /* Create driver id keys */
     size_t id_size = strlen(driver_id) + 1;
@@ -43,7 +43,7 @@ index 0cd92ca..fc1c173 100644
     cache->driver_keys_blob_size += gpu_name_size;
  
     /* We sometimes store entire structs that contains a pointers in the cache,
-@@ -417,6 +419,7 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
+@@ -424,6 +426,7 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
     uint8_t *drv_key_blob = cache->driver_keys_blob;
     DRV_KEY_CPY(drv_key_blob, &cache_version, cv_size)
     DRV_KEY_CPY(drv_key_blob, driver_id, id_size)
@@ -52,13 +52,13 @@ index 0cd92ca..fc1c173 100644
     DRV_KEY_CPY(drv_key_blob, &ptr_size, ptr_size_size)
     DRV_KEY_CPY(drv_key_blob, &driver_flags, driver_flags_size)
 diff --git a/src/util/meson.build b/src/util/meson.build
-index f69ebe9..e2bd8e2 100644
+index 9da29cc7390..5f549bb1d99 100644
 --- a/src/util/meson.build
 +++ b/src/util/meson.build
-@@ -158,7 +158,12 @@ _libmesa_util = static_library(
-   [files_mesa_util, format_srgb],
+@@ -170,7 +170,12 @@ _libmesa_util = static_library(
    include_directories : inc_common,
    dependencies : deps_for_libmesa_util,
+   link_with: libmesa_format,
 -  c_args : [c_msvc_compat_args, c_vis_args],
 +  c_args : [
 +    c_msvc_compat_args, c_vis_args,
@@ -70,5 +70,4 @@ index f69ebe9..e2bd8e2 100644
  )
  
 -- 
-2.24.1
-
+2.25.1

--- a/pkgs/development/libraries/mesa/missing-includes.patch
+++ b/pkgs/development/libraries/mesa/missing-includes.patch
@@ -9,17 +9,6 @@
  #include "pipe/p_compiler.h"
  #include "pipe/p_state.h"
  
---- ./src/gallium/state_trackers/nine/threadpool.h.orig	2015-05-07 14:10:53.443337212 +0200
-+++ ./src/gallium/state_trackers/nine/threadpool.h	2015-05-07 14:11:04.210307653 +0200
-@@ -24,6 +24,8 @@
- #ifndef _THREADPOOL_H_
- #define _THREADPOOL_H_
- 
-+#include <pthread.h>
-+
- #define MAXTHREADS 1
- 
- struct threadpool {
 --- ./src/util/rand_xor.c.orig	2017-06-20 00:38:57.199474067 +0200
 +++ ./src/util/rand_xor.c	2017-06-20 00:40:31.351279557 +0200
 @@ -23,7 +23,9 @@


### PR DESCRIPTION
New APIs implemented: Vulkan 1.2
Mesa 20 also prefers `iris` (new driver) over `i965` by default on newer Intel iGPUs (Gen8+).
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I noticed that the package is a bit outdated.

**Note:** Alternatively we could switch to `19.3.5` ("This is a bug fix release, and the final 19.3.x release. Users are encouraged to migrate to 20.0.x in order to obtain future fixes.") and e.g. wait for `20.0.2` (but `20.0.1` should be stable).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
