### PR TITLE
coqPackages.hierarchy-builder: init at 0.9.0

### DIFF
--- a/pkgs/development/coq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/coq-modules/hierarchy-builder/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, which, coq, coq-elpi }:
+
+let
+  versions = {
+      "0.9.0" =  {
+        rev = "v0.9.0";
+        sha256 = "1yss9f732r7bjaswgn46vd1rr3688ir0vz37wxkmy598xhrnd2ak";
+      };
+  };
+  version = x: versions.${x} // {version = x;};
+  params = {
+   "8.10" = version "0.9.0";
+   "8.11" = version "0.9.0";
+  };
+  param = params.${coq.coq-version};
+in
+
+stdenv.mkDerivation rec {
+  name = "coq${coq.coq-version}-hierarchy-builder-${param.version}";
+
+  src = fetchFromGitHub {
+    owner = "math-comp";
+    repo = "hierarchy-builder";
+    inherit (param) rev sha256;
+  };
+
+  propagatedBuildInputs = [ coq-elpi ];
+  buildInputs = [ coq coq.ocaml coq.ocamlPackages.elpi ];
+
+  installPhase = ''make -f Makefile.coq VFILES=structures.v COQLIB=$out/lib/coq/${coq.coq-version}/ install'';
+
+  meta = {
+    description = "Coq plugin embedding ELPI.";
+    maintainers = [ stdenv.lib.maintainers.cohencyril ];
+    license = stdenv.lib.licenses.lgpl21;
+    inherit (coq.meta) platforms;
+    inherit (src.meta) homepage;
+  };
+
+  passthru = {
+    compatibleCoqVersions = stdenv.lib.flip builtins.hasAttr params;
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -31,13 +31,14 @@ let
       flocq = callPackage ../development/coq-modules/flocq {};
       gappalib = callPackage ../development/coq-modules/gappalib {};
       heq = callPackage ../development/coq-modules/heq {};
+      hierarchy-builder = callPackage ../development/coq-modules/hierarchy-builder {};
       HoTT = callPackage ../development/coq-modules/HoTT {};
       interval = callPackage ../development/coq-modules/interval {};
       InfSeqExt = callPackage ../development/coq-modules/InfSeqExt {};
       iris = callPackage ../development/coq-modules/iris {};
       ltac2 = callPackage ../development/coq-modules/ltac2 {};
       math-classes = callPackage ../development/coq-modules/math-classes { };
-      inherit (callPackage ../development/coq-modules/mathcomp { })
+      inherit (callPackage ../development/coq-modules/mathcomp {})
         mathcompGen mathcompGenSingle ssreflect
 
         mathcompCorePkgs mathcomp


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding the first release of a new coq package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
