### PR TITLE
glances: 3.1.3 -> 3.1.4

### DIFF
--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -8,31 +8,18 @@
 
 buildPythonApplication rec {
   pname = "glances";
-  version = "3.1.3";
+  version = "3.1.4";
   disabled = isPyPy;
 
   src = fetchFromGitHub {
     owner = "nicolargo";
     repo = "glances";
     rev = "v${version}";
-    sha256 = "15yz8sbw3k3n0729g2zcwsxc5iyhkyrhqza6fnipxxpsskwgqbwp";
+    sha256 = "1lr186rc3fvldy2m2yx1hxzdlxll93pjabs01sxz48kkpsvbiydi";
   };
 
   # Some tests fail in the sandbox (they e.g. require access to /sys/class/power_supply):
-  patches = lib.optional (doCheck && stdenv.isLinux) ./skip-failing-tests.patch
-    ++ [
-      (fetchpatch {
-        # Correct unitest
-        url = "https://github.com/nicolargo/glances/commit/abf64ffde31113f5f46ef286703ff061fc57395f.patch";
-        sha256 = "00krahqq89jvbgrqx2359cndmvq5maffhpj163z10s1n7q80kxp1";
-      })
-
-      (fetchpatch {
-        # Fix IP plugin initialization issue
-        url = "https://github.com/nicolargo/glances/commit/48cb5ef8053d823302e7e53490fb22cec2fabb0f.patch";
-        sha256 = "1590qgcr8w3d9ddpgd9mk5j6q6aq29341vr8bi202yjwwiv2bia9";
-      })
-    ];
+  patches = lib.optional (doCheck && stdenv.isLinux) ./skip-failing-tests.patch;
 
   # On Darwin this package segfaults due to mismatch of pure and impure
   # CoreFoundation. This issues was solved for binaries but for interpreted
@@ -64,6 +51,7 @@ buildPythonApplication rec {
   meta = with lib; {
     homepage = "https://nicolargo.github.io/glances/";
     description = "Cross-platform curses-based monitoring tool";
+    changelog = "https://github.com/nicolargo/glances/releases/tag/v${version}";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ jonringer primeos koral ];
   };

--- a/pkgs/applications/system/glances/skip-failing-tests.patch
+++ b/pkgs/applications/system/glances/skip-failing-tests.patch
@@ -50,11 +50,3 @@ diff --git a/unitest.py b/unitest.py
      def test_006_swap(self):
          """Check MEMSWAP plugin."""
          stats_to_check = ['used', 'free', 'total']
-@@ -191,6 +196,7 @@ class TestGlances(unittest.TestCase):
-         self.assertTrue(type(stats_grab) is list, msg='Folders stats is not a list')
-         print('INFO: Folders stats: %s' % stats_grab)
- 
-+    @unittest.skip("Fails on NixOS (TODO)")
-     def test_012_ip(self):
-         """Check IP plugin."""
-         print('INFO: [TEST_012] Check IP stats')


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
