### PR TITLE
gummi: 0.6.6 -> 0.8.1

### DIFF
--- a/pkgs/applications/misc/gummi/default.nix
+++ b/pkgs/applications/misc/gummi/default.nix
@@ -1,37 +1,33 @@
-{ stdenv, pkgs, makeWrapper, pango
-, glib, gnome2, gnome3, gtk2-x11, gtkspell2, poppler
+{ stdenv, pkgs
+, glib, gnome3, gtk3, gtksourceview3, gtkspell3, poppler, texlive
 , pkgconfig, intltool, autoreconfHook, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.6.6";
+  version = "0.8.1";
   pname = "gummi";
 
   src = pkgs.fetchFromGitHub {
     owner = "alexandervdm";
     repo = "gummi";
     rev = version;
-    sha256 = "1vw8rhv8qj82l6l22kpysgm9mxilnki2kjmvxsnajbqcagr6s7cn";
+    sha256 = "0wxgmzazqiq77cw42i5fn2hc22hhxf5gbpl9g8y3zlnp21lw9y16";
   };
 
   nativeBuildInputs = [
-    pkgconfig intltool autoreconfHook makeWrapper wrapGAppsHook
+    pkgconfig intltool autoreconfHook wrapGAppsHook
   ];
   buildInputs = [
-    glib gnome2.gtksourceview pango gtk2-x11 gtkspell2 poppler
-    gnome3.adwaita-icon-theme
+    glib gtksourceview3 gtk3 gtkspell3 poppler
+    texlive.bin.core # needed for synctex
   ];
-
-  preConfigure = ''
-    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${pkgs.gnome2.gtksourceview}/share")
-  '';
 
   postInstall = ''
     install -Dpm644 COPYING $out/share/licenses/$name/COPYING
   '';
 
   meta = {
-    homepage = http://gummi.midnightcoding.org/;
+    homepage = "https://gummi.app";
     description = "Simple LaTex editor for GTK users";
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ flokli ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
New upstream release. Ported from gtk2 to gtk3!

Spellchecking is still broken, though. That is not a problem specific to gummi, but gtkspell/enchant, as far as I can tell.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @flokli 