### PR TITLE
zoxide: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1560,6 +1560,16 @@
     githubId = 490965;
     name = "Craig Swank";
   };
+  cust0dian = {
+    name = "Serg Nesterov";
+    email = "i.am.cust0dian@gmail.com";
+    github = "cust0dian";
+    githubId = 389387;
+    keys = [{
+      longkeyid = "rsa4096/0x1512F6EB84AECC8C";
+      fingerprint = "6E7D BA30 DB5D BA60 693C  3BE3 1512 F6EB 84AE CC8C";
+    }];
+  };
   cwoac = {
     email = "oliver@codersoffortune.net";
     github = "cwoac";

--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "zoxide";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ajeetdsouza";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0s0zrkn48rgsf2fqpgsl0kix4l6w7k7pwssvdja6y3a4c097qmnm";
+  };
+
+  cargoSha256 = "1p65ml2qj5dpc6nczfvf341fk7y4yi5ma1x6kfr3d32wnv6m4hgh";
+
+  meta = with stdenv.lib; {
+    description = "A fast cd command that learns your habits";
+    homepage = "https://github.com/ajeetdsouza/zoxide";
+    license = licenses.mit;
+    maintainers = [ maintainers.cust0dian ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2188,6 +2188,8 @@ in
 
   xmousepasteblock = callPackage ../tools/X11/xmousepasteblock { };
 
+  zoxide = callPackage ../tools/misc/zoxide { };
+
   mar1d = callPackage ../games/mar1d { } ;
 
   mcrypt = callPackage ../tools/misc/mcrypt { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/ajeetdsouza/zoxide — A fast cd command that learns your habits


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
