### PR TITLE
Backport lcov fixes to 20.03

### DIFF
--- a/pkgs/development/tools/analysis/lcov/default.nix
+++ b/pkgs/development/tools/analysis/lcov/default.nix
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
   patches =
     [ (fetchpatch {
         url = https://github.com/linux-test-project/lcov/commit/ebfeb3e179e450c69c3532f98cd5ea1fbf6ccba7.patch;
-        sha256 = "1z9jfqpj34jnzdvmqr5fs8hl56bvbwd8xhlbg3chcswbjj97vk7l";
+        sha256 = "0dalkqbjb6a4vp1lcsxd39dpn5fzdf7ihsjbiviq285s15nxdj1j";
       })
       (fetchpatch {
         url = https://github.com/linux-test-project/lcov/commit/75fbae1cfc5027f818a0bb865bf6f96fab3202da.patch;
-        sha256 = "1wgd4y7vhvfnxyhdd0z2pi9ys6l0z88f14i69a7prb296m1zwg5j";
+        sha256 = "0v1hn0511dxqbf50ppwasc6vmg0m6rns7ydbdy2rdbn0j7gxw30x";
       })
     ];
 

--- a/pkgs/development/tools/analysis/lcov/default.nix
+++ b/pkgs/development/tools/analysis/lcov/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, perl}:
+ {stdenv, fetchurl, fetchpatch, perl, perlPackages, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "lcov-1.14";
@@ -8,11 +8,26 @@ stdenv.mkDerivation rec {
     sha256 = "06h7ixyznf6vz1qvksjgy5f3q2nw9akf6zx59npf0h3l32cmd68l";
   };
 
-  buildInputs = [ perl ];
+  patches =
+    [ (fetchpatch {
+        url = https://github.com/linux-test-project/lcov/commit/ebfeb3e179e450c69c3532f98cd5ea1fbf6ccba7.patch;
+        sha256 = "1z9jfqpj34jnzdvmqr5fs8hl56bvbwd8xhlbg3chcswbjj97vk7l";
+      })
+      (fetchpatch {
+        url = https://github.com/linux-test-project/lcov/commit/75fbae1cfc5027f818a0bb865bf6f96fab3202da.patch;
+        sha256 = "1wgd4y7vhvfnxyhdd0z2pi9ys6l0z88f14i69a7prb296m1zwg5j";
+      })
+    ];
+
+  buildInputs = [ perl makeWrapper ];
 
   preBuild = ''
     patchShebangs bin/
     makeFlagsArray=(PREFIX=$out LCOV_PERL_PATH=$(command -v perl))
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/lcov --set PERL5LIB ${perlPackages.makeFullPerlPath [ perlPackages.PerlIOgzip perlPackages.JSON ]}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14608,6 +14608,21 @@ let
     };
   };
 
+  PerlIOgzip = buildPerlPackage {
+    pname = "PerlIO-gzip";
+    version = "0.20";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/N/NW/NWCLARK/PerlIO-gzip-0.20.tar.gz";
+      sha256 = "4848679a3f201e3f3b0c5f6f9526e602af52923ffa471a2a3657db786bd3bdc5";
+    };
+    buildInputs = [ pkgs.zlib ];
+    NIX_CFLAGS_LINK = "-L${pkgs.zlib.out}/lib -lz";
+    meta = {
+      description = "Perl extension to provide a PerlIO layer to gzip/gunzip";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   PerlIOutf8_strict = buildPerlPackage {
     pname = "PerlIO-utf8_strict";
     version = "0.007";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

lcov is currently broken on gcc 9.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
