### PR TITLE
python37Packages.vtk: Fix build

### DIFF
--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, cmake, libGLU, libGL, libX11, xorgproto, libXt, libtiff
+, fetchpatch
 , qtLib ? null
 , enablePython ? false, python ? null
 # Darwin support
@@ -20,6 +21,13 @@ stdenv.mkDerivation rec {
     url = "${meta.homepage}files/release/${majorVersion}/VTK-${version}.tar.gz";
     sha256 = "0nm7xwwj7rnsxjdv2ssviys8nhci4n9iiiqm2y14s520hl2dsp1d";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.kitware.com/vtk/vtk/-/commit/706f1b397df09a27ab8981ab9464547028d0c322.diff";
+      sha256 = "1q3pi5h40g05pzpbqp75xlgzvbfvyw8raza51svmi7d8dlslqybx";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -60,7 +68,7 @@ stdenv.mkDerivation rec {
     description = "Open source libraries for 3D computer graphics, image processing and visualization";
     homepage = http://www.vtk.org/;
     license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = with stdenv.lib.maintainers; [ knedlsepp ];
     platforms = with stdenv.lib.platforms; unix;
   };
 }


### PR DESCRIPTION
#### Motivation for this change
This should fix the build of vtk.
#80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
