### PR TITLE
pythonPackages.slither-analyzer: fixed dependencies (+1 package)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3349,6 +3349,12 @@
     githubId = 1608697;
     name = "Jens Binkert";
   };
+  jerengie = {
+    email = "me@jerengie.de";
+    github = "jerengie";
+    githubID = 1221065;
+    name = "Jens-Rene Giesen";
+  };
   jerith666 = {
     email = "github@matt.mchenryfamily.org";
     github = "jerith666";

--- a/pkgs/development/python-modules/crytic-compile/default.nix
+++ b/pkgs/development/python-modules/crytic-compile/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildPythonPackage, fetchPypi, makeWrapper, pythonOlder
+, setuptools
+, pysha3
+, solc
+}:
+
+buildPythonPackage rec {
+  pname = "crytic-compile";
+  version = "0.1.6";
+
+  disabled = pythonOlder "3.6";
+
+  # No Python tests
+  doCheck = false;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "32c30a9c4e6d2122fe01b21648127bca949c43402ed5a91c10bf3aa34a53731a";
+  };
+  
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ pysha3 setuptools ];
+
+  postFixup = ''
+    wrapProgram $out/bin/crytic-compile \
+      --prefix PATH : "${lib.makeBinPath [ solc ]}"
+  '';
+
+  meta = with lib; {
+    description = "Abstraction layer for smart contract build systems";
+    longDescription = ''
+      Crytic-compile is a library to help smart contract compilation.
+      It is used in many Crytic tools, e.g. Slither.
+    '';
+    homepage = "https://github.com/crytic/crytic-compile";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ jerengie ];
+  };
+}

--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -2,6 +2,8 @@
 , prettytable
 , setuptools
 , solc
+, pysha3
+, crytic-compile
 }:
 
 buildPythonPackage rec {
@@ -19,7 +21,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  propagatedBuildInputs = [ prettytable setuptools ];
+  propagatedBuildInputs = [ pysha3 crytic-compile prettytable setuptools ];
 
   postFixup = ''
     wrapProgram $out/bin/slither \
@@ -33,8 +35,8 @@ buildPythonPackage rec {
       runs a suite of vulnerability detectors, prints visual information about
       contract details, and provides an API to easily write custom analyses.
     '';
-    homepage = https://github.com/trailofbits/slither;
+    homepage = "https://github.com/trailofbits/slither";
     license = licenses.agpl3;
-    maintainers = [ maintainers.asymmetric ];
+    maintainers = [ maintainers.asymmetric maintainers.jerengie ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1552,6 +1552,8 @@ in
 
   crudini = callPackage ../tools/misc/crudini { };
 
+  crytic-compile = with python3Packages; toPythonApplication crytic-compile;
+
   csv2odf = callPackage ../applications/office/csv2odf { };
 
   csvkit = callPackage ../tools/text/csvkit { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -573,6 +573,8 @@ in {
 
   crc32c = callPackage ../development/python-modules/crc32c { };
 
+  crytic-compile = callPackage ../development/python-modules/crytic-compile { };
+
   curio = callPackage ../development/python-modules/curio { };
 
   dendropy = callPackage ../development/python-modules/dendropy { };


### PR DESCRIPTION
###### Motivation for this change
`pythonPackage.slither-analyzer` can not be built at this moment.
This is due to missing / unlisted dependencies in the package formula.
This PR provides a fix for this and updates the formula to include the existing `pythonPackage.pysha3` package.
Additionally, another dependency, `crytic-compile`, is packaged as `pythonPackage.crytic-compile` in this PR.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
