### PR TITLE
home-manager: 2020-01-04 -> 2020-03-07

### DIFF
--- a/pkgs/tools/package-management/home-manager/default.nix
+++ b/pkgs/tools/package-management/home-manager/default.nix
@@ -6,13 +6,13 @@
 stdenv.mkDerivation rec {
 
   pname = "home-manager";
-  version = "2020-01-04";
+  version = "2020-03-07";
 
   src = fetchFromGitHub {
     owner = "rycee";
     repo = "home-manager";
-    rev = "1b7b1bc294e99ab1795fe7dad183c1d2ae58a099";
-    sha256 = "02kwym8n41d5ba9lccnl5q3y10sw35p1da5b66mxldfr6d930pbj";
+    rev = "5c1e7349bbd9b51fe41ea96b67c380feef996b90";
+    sha256 = "03lw5pq878zbkkwm5abr01p77radn2zgfyvwlra7fhywbl76l83x";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

It has been a couple of months since the last bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
