### PR TITLE
PHP extensions as packages

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -1,4 +1,8 @@
-{ stdenv, lib, pkgs, fetchgit, php, autoconf, pkgconfig, re2c }:
+{ stdenv, lib, pkgs, fetchgit, php, autoconf, pkgconfig, re2c
+, bzip2, curl, libxml2, openssl, gmp5, icu, oniguruma, libsodium, html-tidy
+, libzip, zlib, pcre, pcre2, libxslt, aspell, openldap, cyrus_sasl, uwimap
+, pam, libiconv, enchant1, libXpm, gd, libwebp, libjpeg, libpng, freetype
+, libffi, freetds, postgresql, sqlite, recode, net-snmp }:
 
 let
   self = with self; {
@@ -731,6 +735,162 @@ let
     extensionData = let
       pcre' = if (lib.versionAtLeast php.version "7.3") then pcre2 else pcre;
     in [
+      { name = "bcmath"; }
+      { name = "bz2"; buildInputs = [ bzip2 ]; configureFlags = [ "--with-bz2=${bzip2.dev}" ]; }
+      { name = "calendar"; }
+      { name = "ctype"; }
+      { name = "curl"; buildInputs = [ curl ]; configureFlags = [ "--with-curl=${curl.dev}" ]; }
+      { name = "dba"; }
+      { name = "dom";
+        buildInputs = [ libxml2 ];
+        configureFlags = [ "--enable-dom" ]
+          # Required to build on darwin.
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+      { name = "enchant";
+        buildInputs = [ enchant1 ];
+        configureFlags = [ "--with-enchant=${enchant1}" ];
+        # enchant1 doesn't build on darwin.
+        enable = (!stdenv.isDarwin); }
+      { name = "exif"; }
+      { name = "ffi"; buildInputs = [ libffi ]; enable = lib.versionAtLeast php.version "7.4"; }
+      { name = "fileinfo"; buildInputs = [ pcre' ]; }
+      { name = "filter"; buildInputs = [ pcre' ]; }
+      { name = "ftp"; buildInputs = [ openssl ]; }
+      { name = "gd";
+        buildInputs = [ zlib gd ];
+        configureFlags = [
+          "--enable-gd"
+          "--with-external-gd=${gd.dev}"
+          "--enable-gd-jis-conv"
+        ];
+        enable = lib.versionAtLeast php.version "7.4"; }
+      { name = "gd";
+        buildInputs = [ zlib gd libXpm ];
+        configureFlags = [
+          "--with-gd=${gd.dev}"
+          "--with-freetype-dir=${freetype.dev}"
+          "--with-jpeg-dir=${libjpeg.dev}"
+          "--with-png-dir=${libpng.dev}"
+          "--with-webp-dir=${libwebp}"
+          "--with-xpm-dir=${libXpm.dev}"
+          "--with-zlib-dir=${zlib.dev}"
+          "--enable-gd-jis-conv"
+        ];
+        enable = lib.versionOlder php.version "7.4"; }
+      ## gettext (7.2, 7.3, 7.4) -- configure: error: Cannot locate header file libintl.h
+      #{ name = "gettext";
+      #  buildInputs = [ gettext ];
+      #  configureFlags = "--with-gettext=${gettext}"; }
+      { name = "gmp";
+        buildInputs = [ gmp5 ];
+        configureFlags = [ "--with-gmp=${gmp5.dev}" ];
+        # gmp5 doesn't build on darwin.
+        enable = (!stdenv.isDarwin); }
+      { name = "hash"; enable = lib.versionOlder php.version "7.4"; }
+      { name = "iconv"; configureFlags = if stdenv.isDarwin then
+                           [ "--with-iconv=${libiconv}" ]
+                         else
+                           [ "--with-iconv" ]; }
+      { name = "imap";
+        buildInputs = [ uwimap openssl pam pcre' ];
+        configureFlags = [ "--with-imap=${uwimap}" "--with-imap-ssl" ];
+        # uwimap doesn't build on darwin.
+        enable = (!stdenv.isDarwin); }
+      # interbase (7.3, 7.2)
+      { name = "intl"; buildInputs = [ icu ]; }
+      { name = "json"; }
+      { name = "ldap";
+        buildInputs = [ openldap cyrus_sasl ];
+        configureFlags = [
+          "--with-ldap"
+          "LDAP_DIR=${openldap.dev}"
+          "LDAP_INCDIR=${openldap.dev}/include"
+          "LDAP_LIBDIR=${openldap.out}/lib"
+        ] ++ lib.optional stdenv.isLinux "--with-ldap-sasl=${cyrus_sasl.dev}"; }
+      { name = "mbstring"; buildInputs = [ oniguruma ]; }
+      { name = "mysqli"; configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ]; }
+      # oci8 (7.4, 7.3, 7.2)
+      # odbc (7.4, 7.3, 7.2)
+      { name = "opcache"; buildInputs = [ pcre' ]; }
+      { name = "pcntl"; }
+      { name = "pdo"; }
+      { name = "pdo_dblib";
+        configureFlags = [ "--with-pdo-dblib=${freetds}" ];
+        # Doesn't seem to work on darwin.
+        enable = (!stdenv.isDarwin); }
+      # pdo_firebird (7.4, 7.3, 7.2)
+      { name = "pdo_mysql"; configureFlags = [ "--with-pdo-mysql=mysqlnd" ]; }
+      # pdo_oci (7.4, 7.3, 7.2)
+      # pdo_odbc (7.4, 7.3, 7.2)
+      { name = "pdo_pgsql"; configureFlags = [ "--with-pdo-pgsql=${postgresql}" ]; }
+      { name = "pdo_sqlite"; buildInputs = [ sqlite ]; configureFlags = [ "--with-pdo-sqlite=${sqlite.dev}" ]; }
+      { name = "pgsql"; buildInputs = [ pcre' ]; configureFlags = [ "--with-pgsql=${postgresql}" ]; }
+      { name = "phar"; buildInputs = [ pcre' openssl ]; }
+      { name = "posix"; }
+      { name = "pspell"; configureFlags = [ "--with-pspell=${aspell}" ]; }
+      ## readline (7.4, 7.3, 7.2) -- configure: error: Please reinstall libedit - I cannot find readline.h
+      #{ name = "readline";
+      #  buildInputs = [ libedit readline ];
+      #  configureFlags = [ "--with-readline=${readline.dev}" ]; }
+      { name = "recode";
+        configureFlags = [ "--with-recode=${recode}" ];
+        # Removed in php 7.4.
+        enable = lib.versionOlder php.version "7.4"; }
+      { name = "session"; }
+      { name = "shmop"; }
+      { name = "simplexml";
+        buildInputs = [ libxml2 pcre' ];
+        configureFlags = [ "--enable-simplexml" ]
+          # Required to build on darwin.
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+      { name = "snmp";
+        buildInputs = [ net-snmp openssl ];
+        configureFlags = [ "--with-snmp" ];
+        # net-snmp doesn't build on darwin.
+        enable = (!stdenv.isDarwin); }
+      { name = "soap";
+        buildInputs = [ libxml2 ];
+        configureFlags = [ "--enable-soap" ]
+          # Required to build on darwin.
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+      { name = "sockets"; }
+      { name = "sodium"; buildInputs = [ libsodium ]; }
+      { name = "sysvmsg"; }
+      { name = "sysvsem"; }
+      { name = "sysvshm"; }
+      { name = "tidy"; configureFlags = [ "--with-tidy=${html-tidy}" ]; }
+      { name = "tokenizer"; }
+      { name = "wddx";
+        buildInputs = [ libxml2 ];
+        configureFlags = [ "--enable-wddx" "--with-libxml-dir=${libxml2.dev}" ];
+        # Removed in php 7.4.
+        enable = lib.versionOlder php.version "7.4"; }
+      { name = "xml";
+        buildInputs = [ libxml2 ];
+        configureFlags = [ "--enable-xml" ]
+          # Required to build on darwin.
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+      { name = "xmlreader";
+        buildInputs = [ libxml2 ];
+        configureFlags = [ "--enable-xmlreader CFLAGS=-I../.." ]
+          # Required to build on darwin.
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+      { name = "xmlrpc";
+        buildInputs = [ libxml2 libiconv ];
+        configureFlags = [ "--with-xmlrpc" ]
+          # Required to build on darwin.
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+      { name = "xmlwriter";
+        buildInputs = [ libxml2 ];
+        configureFlags = [ "--enable-xmlwriter" ]
+          # Required to build on darwin.
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+      { name = "xsl"; buildInputs = [ libxslt libxml2 ]; configureFlags = [ "--with-xsl=${libxslt.dev}" ]; }
+      { name = "zend_test"; }
+      { name = "zip"; buildInputs = [ libzip pcre' ];
+        configureFlags = [ "--with-zip" ]
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]
+          ++ lib.optional (lib.versionOlder php.version "7.3") [ "--with-libzip" ]; }
     ];
 
     # Convert the list of attrs:

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -728,7 +728,9 @@ let
     # want to build.
     #
     # These will be passed as arguments to mkExtension above.
-    extensionData = [
+    extensionData = let
+      pcre' = if (lib.versionAtLeast php.version "7.3") then pcre2 else pcre;
+    in [
     ];
 
     # Convert the list of attrs:


### PR DESCRIPTION
##### Motivation for this change

So this is based on some work I've done a long time ago and based on things that @gustavderdrache use to customize PHP in Nix.

It seems to work quite well on top of #79377 by @Ma27 :)

So the goal here is to build the different native extensions as separate derivations and then use them to compose a PHP package.

##### Example: Our default install of php doesn't have bz2 support.

Then I build a PHP using the following command:
```bash
nix-build --expr 'with import ./. {}; php74.buildEnv { exts = pp: with pp.exts; [ bz2 ]; }'
```

It builds a bit and I get a result symlink back, then when I run `./result/bin/php -m` I can see `bz2` in the list of modules.

I've got most extensions to work with two notable exceptions:
 - readline
 - gettext

But I don't think that's a blocker for merging this. This still would provide new extensions for people needing some of the "native" extensions that we don't have enabled or even flags for without the need of compiling them themselves.

The next step would be to provide a minimal PHP to compose on top of and to use this minimal one to build our default php setup.

I've gone through *all* extensions for php 7.2, 7.3 and 7.4 and made sure that I have either made a comment or a build for each and everyone of the extensions in these three minor versions of php.

Some of the ones are oracle and other weird databases that we may have pecl's for anyways, so those I've left as comments for now. But they should be easy to move if needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
