### PR TITLE
nixos/nextcloud: fix upgrade path from 19.09 to 20.03

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -648,6 +648,55 @@ auth required pam_succeed_if.so uid >= 1000 quiet
        <xref linkend="opt-environment.systemPackages"/>.
      </para>
    </listitem>
+   <listitem>
+    <para>
+     <package>nextcloud</package> has been updated to <literal>v18.0.2</literal>. This means
+     that users from NixOS 19.09 can't upgrade directly since you can only move one version
+      forward and 19.09 uses <literal>v16.0.8</literal>.
+    </para>
+    <para>
+     To provide a safe upgrade-path and to circumvent similar issues in the future, the following
+     measures were taken:
+     <itemizedlist>
+      <listitem>
+       <para>
+        The <package>pkgs.nextcloud</package>-attribute has been removed and replaced with
+        versioned attributes (currently <package>pkgs.nextcloud17</package> and
+        <package>pkgs.nextcloud18</package>). With this change major-releases can be backported
+        without breaking stuff and to make upgrade-paths easier.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Existing setups will be detected using
+        <link linkend="opt-system.stateVersion">system.stateVersion</link>: by default,
+        <package>nextcloud17</package> will be used, but will raise a warning which notes
+        that after that deploy it's recommended to update to the latest stable version
+        (<package>nextcloud18</package>) by declaring the newly introduced setting
+        <link linkend="opt-services.nextcloud.package">services.nextcloud.package</link>.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Users with an overlay (e.g. to use <package>nextcloud</package> at version
+        <literal>v18</literal> on <literal>19.09</literal>) will get an evaluation error
+        by default. This is done to ensure that our
+        <link linkend="opt-services.nextcloud.package">package</link>-option doesn't select an
+        older version by accident. It's recommended to use <package>pkgs.nextcloud18</package>
+        or to set <link linkend="opt-services.nextcloud.package">package</link> to
+        <package>pkgs.nextcloud</package> explicitly.
+       </para>
+      </listitem>
+     </itemizedlist>
+    </para>
+    <warning>
+     <para>
+      Please note that if you're comming from <literal>19.03</literal> or older, you have
+      to manually upgrade to <literal>19.09</literal> first to upgrade your server
+      to Nextcloud v16.
+     </para>
+    </warning>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/web-apps/nextcloud.xml
+++ b/nixos/modules/services/web-apps/nextcloud.xml
@@ -113,5 +113,53 @@
    maintenance:install</literal>! This command tries to install the application
    and can cause unwanted side-effects!</para>
   </warning>
+
+  <para>
+   Nextcloud doesn't allow to move more than one major-version forward. If you're e.g. on
+   <literal>v16</literal>, you cannot upgrade to <literal>v18</literal>, you need to upgrade to
+   <literal>v17</literal> first. This is ensured automatically as long as the
+   <link linkend="opt-system.stateVersion">stateVersion</link> is declared properly. In that case
+   the oldest version available (one major behind the one from the previous NixOS
+   release) will be selected by default and the module will generate a warning that reminds
+   the user to upgrade to latest Nextcloud <emphasis>after</emphasis> that deploy.
+  </para>
+ </section>
+
+ <section xml:id="module-services-nextcloud-maintainer-info">
+  <title>Maintainer information</title>
+
+  <para>
+   As stated in the previous paragraph, we must provide a clean upgrade-path for Nextcloud
+   since it cannot move more than one major version forward on a single upgrade. This chapter
+   adds some notes how Nextcloud updates should be rolled out in the future.
+  </para>
+
+  <para>
+   While minor and patch-level updates are no problem and can be done directly in the
+   package-expression (and should be backported to supported stable branches after that),
+   major-releases should be added in a new attribute (e.g. Nextcloud <literal>v19.0.0</literal>
+   should be available in <literal>nixpkgs</literal> as <literal>pkgs.nextcloud19</literal>).
+   To provide simple upgrade paths it's generally useful to backport those as well to stable
+   branches. As long as the package-default isn't altered, this won't break existing setups.
+   After that, the versioning-warning in the <literal>nextcloud</literal>-module should be
+   updated to make sure that the
+   <link linkend="opt-services.nextcloud.package">package</link>-option selects the latest version
+   on fresh setups.
+  </para>
+
+  <para>
+   If major-releases will be abandoned by upstream, we should check first if those are needed
+   in NixOS for a safe upgrade-path before removing those. In that case we shold keep those
+   packages, but mark them as insecure in an expression like this (in
+   <literal>&lt;nixpkgs/pkgs/servers/nextcloud/default.nix&gt;</literal>):
+<programlisting>/* ... */
+{
+  nextcloud17 = generic {
+    version = "17.0.x";
+    sha256 = "0000000000000000000000000000000000000000000000000000";
+    insecure = true;
+  };
+}</programlisting>
+  </para>
  </section>
 </chapter>

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -1,24 +1,37 @@
 { stdenv, fetchurl }:
 
-stdenv.mkDerivation rec {
-  pname = "nextcloud";
-  version = "18.0.2";
+let
+  generic = { version, sha256, insecure ? false }: stdenv.mkDerivation rec {
+    pname = "nextcloud";
+    inherit version;
 
-  src = fetchurl {
-    url = "https://download.nextcloud.com/server/releases/${pname}-${version}.tar.bz2";
-    sha256 = "10fbdq0366iai2kpw6v6p78mnn9gz8x0xzsbqrp109yx4c4nccyh";
+    src = fetchurl {
+      url = "https://download.nextcloud.com/server/releases/${pname}-${version}.tar.bz2";
+      inherit sha256;
+    };
+
+    installPhase = ''
+      mkdir -p $out/
+      cp -R . $out/
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Sharing solution for files, calendars, contacts and more";
+      homepage = https://nextcloud.com;
+      maintainers = with maintainers; [ schneefux bachp globin fpletz ma27 ];
+      license = licenses.agpl3Plus;
+      platforms = with platforms; unix;
+      knownVulnerabilities = optional insecure "Nextcloud version ${version} is EOL";
+    };
+  };
+in {
+  nextcloud17 = generic {
+    version = "17.0.4";
+    sha256 = "0cj5mng0nmj3hz30pyz3g19kj3mkm5ca8si3sw3arv61dmw6c5g6";
   };
 
-  installPhase = ''
-    mkdir -p $out/
-    cp -R . $out/
-  '';
-
-  meta = {
-    description = "Sharing solution for files, calendars, contacts and more";
-    homepage = https://nextcloud.com;
-    maintainers = with stdenv.lib.maintainers; [ schneefux bachp globin fpletz ];
-    license = stdenv.lib.licenses.agpl3Plus;
-    platforms = with stdenv.lib.platforms; unix;
+  nextcloud18 = generic {
+    version = "18.0.2";
+    sha256 = "10fbdq0366iai2kpw6v6p78mnn9gz8x0xzsbqrp109yx4c4nccyh";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5356,7 +5356,8 @@ in
 
   grocy = callPackage ../servers/grocy { };
 
-  nextcloud = callPackage ../servers/nextcloud { };
+  inherit (callPackage ../servers/nextcloud {})
+    nextcloud17 nextcloud18;
 
   nextcloud-client = libsForQt5.callPackage ../applications/networking/nextcloud-client { };
 


### PR DESCRIPTION
###### Motivation for this change

As described in #82056, the upgrade path of `nextcloud` from 19.09 to 20.03 is broken as we'd have to move two major versions forward which isn't supported by Nextcloud.

This PR introduces versioned attributes for Nextcloud and a few assertions (relying on the `stateVersion`) to help users with upgrading.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
