### PR TITLE
pytest-html: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/pytest-html/default.nix
+++ b/pkgs/development/python-modules/pytest-html/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
+, pytest, pytest-metadata, setuptools_scm }:
+
+buildPythonPackage rec {
+  pname = "pytest-html";
+  version = "2.1.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14cy5iixi6i8i5r5xvvkhwk48zgxnb1ypbp0g1343mwfdihshic6";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ pytest pytest-metadata ];
+
+  meta = with stdenv.lib; {
+    description = "Plugin for generating HTML reports";
+    homepage = "https://github.com/pytest-dev/pytest-html";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ mpoquet ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-metadata/default.nix
+++ b/pkgs/development/python-modules/pytest-metadata/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, setuptools_scm }:
+
+buildPythonPackage rec {
+  pname = "pytest-metadata";
+  version = "1.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1fk6icip2x1nh4kzhbc8cnqrs77avpqvj7ny3xadfh6yhn9aaw90";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ pytest ];
+
+  meta = with stdenv.lib; {
+    description = "Plugin for accessing test session metadata";
+    homepage = "https://github.com/pytest-dev/pytest-metadata";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ mpoquet ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2389,6 +2389,8 @@ in {
 
   pytest-forked = callPackage ../development/python-modules/pytest-forked { };
 
+  pytest-html = callPackage ../development/python-modules/pytest-html { };
+
   pytest-metadata = callPackage ../development/python-modules/pytest-metadata { };
 
   pytest-rerunfailures = callPackage ../development/python-modules/pytest-rerunfailures { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2389,6 +2389,8 @@ in {
 
   pytest-forked = callPackage ../development/python-modules/pytest-forked { };
 
+  pytest-metadata = callPackage ../development/python-modules/pytest-metadata { };
+
   pytest-rerunfailures = callPackage ../development/python-modules/pytest-rerunfailures { };
 
   pytest-relaxed = callPackage ../development/python-modules/pytest-relaxed { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Abstract
- Adds [pytest-html](https://github.com/pytest-dev/pytest-html), a pytest plugin that enables the generation of test reports in html.
- Adds [pytest-metadata](https://github.com/pytest-dev/pytest-metadata) as it is required by pytest-html.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Tested the generation of html test reports with the packages added in this PR on [my project that uses them](https://framagit.org/batsim/batsim/-/blob/master/release.nix#L81), everything seems fins. 
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
