### PR TITLE
[20.03] Mark git-dit as broken

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
@@ -48,6 +48,10 @@ buildRustPackage rec {
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
     description = "Decentralized Issue Tracking for git";
+    # This has not had a release in years and its cargo vendored dependencies
+    # fail to compile. It also depends on an unsupported openssl:
+    # https://github.com/NixOS/nixpkgs/issues/77503
+    broken = true;
     license = licenses.gpl2;
     maintainers = with maintainers; [ Profpatsch matthiasbeyer ];
   };


### PR DESCRIPTION
(cherry picked from commit f908cf4de86f5db899e73f0062d6351934245731)

Backport of:
https://github.com/NixOS/nixpkgs/pull/81984

ZHF: #80379