### PR TITLE
gitstatus: Fix build of the internally used libgit2 fork

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
@@ -2,13 +2,15 @@
 
 libgit2.overrideAttrs (oldAttrs: {
   cmakeFlags = oldAttrs.cmakeFlags ++ [
-    "-DUSE_BUNDLED_ZLIB=ON"
-    "-DUSE_ICONV=OFF"
     "-DBUILD_CLAR=OFF"
-    "-DUSE_SSH=OFF"
-    "-DUSE_HTTPS=OFF"
     "-DBUILD_SHARED_LIBS=OFF"
-    "-DUSE_EXT_HTTP_PARSER=OFF"
+    "-DREGEX_BACKEND=builtin"
+    "-DUSE_BUNDLED_ZLIB=ON"
+    "-DUSE_HTTPS=OFF"
+    "-DUSE_HTTP_PARSER=builtin"  # overwritten from libgit2
+    "-DUSE_ICONV=OFF"
+    "-DUSE_SSH=OFF"
+    "-DZERO_NSEC=ON"
   ];
   src = fetchFromGitHub {
     owner = "romkatv";


### PR DESCRIPTION
###### Motivation for this change

In 6733ece `-DUSE_HTTP_PARSER=system` was introduced, which does not seem
to work with this fork. So instead fallback to the `builtin`.

Also sync with upstream cmake flags.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@mmlb @flokli 
