### PR TITLE
[19.09] gitlab 12.8.5 -> 12.8.6

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,11 +1,11 @@
 {
-  "version": "12.8.5",
-  "repo_hash": "1y5606p793w1js39420jcd2bj42cripczgrdxgg2cq0r2kq8axk8",
+  "version": "12.8.6",
+  "repo_hash": "0plcigppmg6ckmq8myj3m9adshdvqj7czx8fms71bsa9zx060wib",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.8.5-ee",
+  "rev": "v12.8.6-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "12.8.5",
+    "GITALY_SERVER_VERSION": "12.8.6",
     "GITLAB_PAGES_VERSION": "1.16.0",
     "GITLAB_SHELL_VERSION": "11.0.0",
     "GITLAB_WORKHORSE_VERSION": "8.21.0"

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -19,14 +19,14 @@ let
       };
   };
 in buildGoPackage rec {
-  version = "12.8.5";
+  version = "12.8.6";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "19pwffncihhywfac7ybry38vyj3pmdz66g5nqrvwn4xxw7ypvd24";
+    sha256 = "1rf9qmyjllkwkyi7la1dzyjh0z9sw21zdzihd7v9ngwqssfk5zfk";
   };
 
   # Fix a check which assumes that hook files are writeable by their

--- a/pkgs/applications/version-management/gitlab/update.py
+++ b/pkgs/applications/version-management/gitlab/update.py
@@ -175,6 +175,8 @@ def update_gitaly():
             f.write(repo.get_file(fn, f"v{gitaly_server_version}"))
 
     subprocess.check_output(['bundix'], cwd=gitaly_dir)
+
+    os.environ['GOROOT'] = ""
     subprocess.check_output(['vgo2nix'], cwd=gitaly_dir)
 
     for fn in ['go.mod', 'go.sum']:
@@ -197,6 +199,7 @@ def update_gitlab_shell():
         with open(gitlab_shell_dir / fn, 'w') as f:
             f.write(repo.get_file(fn, f"v{gitlab_shell_version}"))
 
+    os.environ['GOROOT'] = ""
     subprocess.check_output(['vgo2nix'], cwd=gitlab_shell_dir)
 
     for fn in ['go.mod', 'go.sum']:
@@ -217,6 +220,7 @@ def update_gitlab_workhorse():
         with open(gitlab_workhorse_dir / fn, 'w') as f:
             f.write(repo.get_file(fn, f"v{gitlab_workhorse_version}"))
 
+    os.environ['GOROOT'] = ""
     subprocess.check_output(['vgo2nix'], cwd=gitlab_workhorse_dir)
 
     for fn in ['go.mod', 'go.sum']:


### PR DESCRIPTION
###### Motivation for this change
backport of #82374

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
