### PR TITLE
nixos/opendkim: Deprecate configFile in favor of settings option

### DIFF
--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -8,18 +8,15 @@ let
 
   defaultSock = "local:/run/opendkim/opendkim.sock";
 
-  keyFile = "${cfg.keyPath}/${cfg.selector}.private";
-
-  args = [ "-f" "-l"
-           "-p" cfg.socket
-           "-d" cfg.domains
-           "-k" keyFile
-           "-s" cfg.selector
-         ] ++ optionals (cfg.configFile != null) [ "-x" cfg.configFile ];
+  configFile = pkgs.writeText "opendkim.conf" (with generators;
+    # TODO: Define a format as in https://github.com/NixOS/nixpkgs/pull/75584
+    toKeyValue { mkKeyValue = mkKeyValueDefault {} " "; } (filterAttrs (name: value: value != null) cfg.settings)
+  );
 
 in {
   imports = [
     (mkRenamedOptionModule [ "services" "opendkim" "keyFile" ] [ "services" "opendkim" "keyPath" ])
+    (mkRemovedOptionModule [ "services" "opendkim" "configFile" ] "Replaced with services.opendkim.settings")
   ];
 
   ###### interface
@@ -57,8 +54,9 @@ in {
         default = "csl:${config.networking.hostName}";
         example = "csl:example.com,mydomain.net";
         description = ''
-          Local domains set (see <literal>opendkim(8)</literal> for more information on datasets).
-          Messages from them are signed, not verified.
+          Local domains set (see <citerefentry><refentrytitle>opendkim
+          </refentrytitle><manvolnum>8</manvolnum></citerefentry> for more
+          information on datasets). Messages from them are signed, not verified.
         '';
       };
 
@@ -76,10 +74,25 @@ in {
         description = "Selector to use when signing.";
       };
 
-      configFile = mkOption {
-        type = types.nullOr types.path;
-        default = null;
-        description = "Additional opendkim configuration.";
+      settings = mkOption {
+        type = with types; lazyAttrsOf (nullOr (oneOf [ bool str int ]));
+        example = literalExample ''
+          {
+            Canonicalization = "relaxed/simple";
+            LogWhy = true;
+            MilterDebug = 6;
+            UMask = "0002";
+          }
+        '';
+        description = ''
+          Configuration for opendkim, see <citerefentry><refentrytitle>
+          opendkim.conf </refentrytitle><manvolnum>5</manvolnum></citerefentry>
+          or <link xlink:href="http://www.opendkim.org/opendkim.conf.5.html"/>
+          for supported values. A value of <literal>null</literal> represents an
+          unset value. Note that only if <literal>settings.KeyTable</literal> is
+          unset, <option>domains</option> and <option>selector</option> are
+          applied.
+        '';
       };
 
     };
@@ -90,6 +103,22 @@ in {
   ###### implementation
 
   config = mkIf cfg.enable {
+
+    services.opendkim.settings = {
+      Background = false;
+      Syslog = true;
+
+      # Set this to null so we don't have to check for this key existing below
+      KeyTable = mkOptionDefault null;
+
+      # TODO: Use https://github.com/NixOS/nixpkgs/pull/82743 in the future
+      Socket = mkDefault cfg.socket;
+      # These settings wouldn't have any effect when KeyTable is set
+      Domain = mkIf (cfg.settings.KeyTable == null) (mkDefault cfg.domains);
+      Selector = mkIf (cfg.settings.KeyTable == null) (mkDefault cfg.selector);
+      KeyFile = mkIf (cfg.settings.KeyTable == null && cfg.settings.Selector != null)
+        (mkDefault "${cfg.keyPath}/${cfg.settings.Selector}.private");
+    };
 
     users.users = optionalAttrs (cfg.user == "opendkim") {
       opendkim = {
@@ -113,22 +142,22 @@ in {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
+      preStart = mkIf (cfg.settings.Selector != null) ''
         cd "${cfg.keyPath}"
-        if ! test -f ${cfg.selector}.private; then
-          ${pkgs.opendkim}/bin/opendkim-genkey -s ${cfg.selector} -d all-domains-generic-key
+        if ! test -f ${cfg.settings.Selector}.private; then
+          ${pkgs.opendkim}/bin/opendkim-genkey -s ${cfg.settings.Selector} -d all-domains-generic-key
           echo "Generated OpenDKIM key! Please update your DNS settings:\n"
           echo "-------------------------------------------------------------"
-          cat ${cfg.selector}.txt
+          cat ${cfg.settings.Selector}.txt
           echo "-------------------------------------------------------------"
         fi
       '';
 
       serviceConfig = {
-        ExecStart = "${pkgs.opendkim}/bin/opendkim ${escapeShellArgs args}";
+        ExecStart = "${pkgs.opendkim}/bin/opendkim -x ${configFile}";
         User = cfg.user;
         Group = cfg.group;
-        RuntimeDirectory = optional (cfg.socket == defaultSock) "opendkim";
+        RuntimeDirectory = optional (cfg.settings.Socket == defaultSock) "opendkim";
       };
     };
 

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -108,6 +108,8 @@ in {
       Background = false;
       Syslog = true;
 
+      UMask = mkDefault "0002";
+
       # Set this to null so we don't have to check for this key existing below
       KeyTable = mkOptionDefault null;
 


### PR DESCRIPTION
###### Motivation for this change
Because https://github.com/NixOS/nixpkgs/pull/75584 still takes some work and I saw https://github.com/NixOS/nixpkgs/pull/78126, I decided to implement the `settings` concept from NixOS/rfcs#42 for opendkim. This makes everything much nicer, especially for third-party code like [nixos-mailserver](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver) (for which I will submit a PR to make it compatible with the changes here).

Unfortunately I found no backwards compatible way to keep `configFile` working, so I just removed it, which also simplifies the module a lot, and in addition allows other modules to read values from `settings` (which wouldn't always be possible with a `configFile` option).

I have yet to test this properly.

Removes the need for https://github.com/NixOS/nixpkgs/pull/78126 and closes https://github.com/NixOS/nixpkgs/issues/27260

Ping @aanderse @qknight @abbradar @brprice @Valodim

###### Things done

- [ ] Tested it