### PR TITLE
airwave: fix VST SDK and Qt plugins

### DIFF
--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -1,5 +1,5 @@
 { stdenv, multiStdenv, cmake, fetchFromGitHub, file, libX11, makeWrapper
-, qt5, requireFile, unzip, wine
+, qt5, fetchurl, unzip, wine
 }:
 
 let
@@ -14,13 +14,12 @@ let
   };
 
   vst-sdk = stdenv.mkDerivation rec {
-    name = "vstsdk368_08_11_2017_build_121";
-    src = requireFile {
-      name = "${name}.zip";
-      url = "http://www.steinberg.net/en/company/developers.html";
-      sha256 = "e0f235d8826d70f1ae0ae5929cd198acae1ecff74612fde5c60cbfb45c2f4a70";
-    };
+    name = "vstsdk366_27_06_2016_build_61";
     nativeBuildInputs = [ unzip ];
+    src = fetchurl {
+      url = "https://www.steinberg.net/sdk_downloads/${name}.zip";
+      sha256 = "05gsr13bpi2hhp34rvhllsvmn44rqvmjdpg9fsgfzgylfkz0kiki";
+    };
     installPhase = "cp -r . $out";
     meta.license = stdenv.lib.licenses.unfree;
   };
@@ -63,7 +62,7 @@ multiStdenv.mkDerivation {
   # Cf. https://github.com/phantom-code/airwave/issues/57
   hardeningDisable = [ "format" ];
 
-  cmakeFlags = [ "-DVSTSDK_PATH=${vst-sdk}/VST2_SDK" ];
+  cmakeFlags = [ "-DVSTSDK_PATH=${vst-sdk}" ];
 
   postInstall = ''
     mv $out/bin $out/libexec

--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -41,7 +41,7 @@ multiStdenv.mkDerivation {
 
   src = airwave-src;
 
-  nativeBuildInputs = [ cmake makeWrapper ];
+  nativeBuildInputs = [ cmake makeWrapper qt5.wrapQtAppsHook ];
 
   buildInputs = [ file libX11 qt5.qtbase wine-xembed ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
* VST SDK 3.6.8 (`vstsdk368_08_11_2017_build_121.zip`) has fallen off the Internet.
* VST SDK 3.6.14 (`vst-sdk_3.6.14_build-24_2019-11-29.zip`) can be automatically downloaded from Steinberg's servers or from GitHub but does not contain the required VST2 SDK headers.

###### Things done

* Made the package use VST SDK 3.6.6 (`vstsdk366_27_06_2016_build_61`).
* Raised an [issue on the Steinberg VST SDK GitHub](https://github.com/steinbergmedia/vst3sdk/issues/51).
* Also added `qt5.wrapQtAppsHook` into nativeBuildInputs as per #65399 (`qt5.mkDerivation` is not an option because of `multiStdenv.mkDerivation` - but hey, now it builds and runs!)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
