### PR TITLE
tensorflow: 1.15.1 -> 1.15.2

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -69,7 +69,7 @@ let
 
   tfFeature = x: if x then "1" else "0";
 
-  version = "1.15.1";
+  version = "1.15.2";
   variant = if cudaSupport then "-gpu" else "";
   pname = "tensorflow${variant}";
 
@@ -100,7 +100,7 @@ let
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      sha256 = "1j8vysfblkyydrr67qr3i7kvaq5ygnjlx8hw9a9pc95ac462jq7i";
+      sha256 = "1q0848drjvnaaa38dgns8knmpmkj5plzsc98j20m5ybv68s55w78";
     };
 
     patches = [
@@ -294,12 +294,10 @@ let
       TF_SYSTEM_LIBS = null;
 
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
-      # FIXME: can't (re)produce this output with current bazel.
-      # FIXME: build log: https://gist.github.com/andir/eff3e9c8eda5b56c8ea84903aed9cc35
       sha256 = if cudaSupport then
-        "0bzkqjnw1crf0v91yb1frvy0l7kmjawbfwdhm89h73i8fqjab8jw"
+        "1qygfcvvn9vysap9nk6xccxi9mgmzyxiywz6k456f811l1v70p2c"
       else
-        "1d7czp43a3a4aksvdcskbdy7dgifily1amqbz9fa6d8mkhdj5if5";
+        "0kfjanw0mfbh30vi1ms2xlg8yp429cbyfriik6yxd5cla2pncg2j";
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow/lift-gast-restriction.patch
+++ b/pkgs/development/python-modules/tensorflow/lift-gast-restriction.patch
@@ -3,9 +3,9 @@ index 992f2eae22..d9386f9b13 100644
 --- a/tensorflow/tools/pip_package/setup.py
 +++ b/tensorflow/tools/pip_package/setup.py
 @@ -54,7 +54,7 @@ REQUIRED_PACKAGES = [
-     'astor >= 0.6.0',
-     'backports.weakref >= 1.0rc1;python_version<"3.4"',
      'enum34 >= 1.1.6;python_version<"3.4"',
+     # functools comes with python3, need to install the backport for python2
+     'functools32 >= 3.2.3;python_version<"3"',
 -    'gast == 0.2.2',
 +    'gast >= 0.2.2',
      'google_pasta >= 0.1.6',


### PR DESCRIPTION
###### Motivation for this change
#81772 for master. It should have gone to master first. I didn't realize the PR was against 20.03 and had no counterpart for master.

cc @dylex

(cherry picked from commit 0a5ec494b574ccd3db3b234c7d6637d127bd16da)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
