### PR TITLE
buildRustCrate: only link build deps into build script

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -102,19 +102,16 @@ in ''
 
   # Remove duplicate linker flags from the build dependencies.
   if [[ -e target/link.build ]]; then
-    sort -u target/link.build > target/link.build.sorted
-    mv target/link.build.sorted target/link.build
+    sort -uo target/link.build target/link.build
   fi
 
   # Remove duplicate linker flags from the dependencies.
-  sort -u target/link > target/link.sorted
-  mv target/link.sorted target/link
+  sort -uo target/link target/link
   tr '\n' ' ' < target/link > target/link_
 
   # Remove duplicate linker flags from the that are written
   # to the derivation's output.
-  sort -u target/link.final > target/link.final.sorted
-  mv target/link.final.sorted target/link.final
+  sort -uo target/link.final target/link.final
 
   EXTRA_BUILD=""
   BUILD_OUT_DIR=""

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -56,32 +56,66 @@ in ''
     i=$1
     ln -s -f $i/lib/*.rlib $2 #*/
     ln -s -f $i/lib/*.so $i/lib/*.dylib $2 #*/
-    if [ -e "$i/lib/link" ]; then
-        cat $i/lib/link >> target/link
-        cat $i/lib/link >> target/link.final
-    fi
     if [ -e $i/env ]; then
         source $i/env
     fi
   }
 
+  # The following steps set up the dependencies of the crate. Two
+  # kinds of dependencies are distinguished: build dependencies
+  # (used by the build script) and crate dependencies. For each
+  # dependency we have to:
+  #
+  # - Make its Rust library available to rustc. This is done by
+  #   symlinking all library dependencies into a directory that
+  #   can be provided to rustc.
+  # - Accumulate linking flags. These flags are largely used for
+  #   linking native libraries.
+  #
+  # The crate link flags are added to the `link` and `link.final`
+  # files. The `link` file is used for linkage in the current
+  # crate. The `link.final` file will be copied to the output and can
+  # be used by downstream crates to get the linker flags of this
+  # crate.
+
   mkdir -p target/{deps,lib,build,buildDeps}
   chmod uga+w target -R
   echo ${extraLinkFlags} > target/link
   echo ${extraLinkFlags} > target/link.final
+
+  # Prepare crate dependencies
   for i in ${completeDepsDir}; do
     symlink_dependency $i target/deps
+    if [ -e "$i/lib/link" ]; then
+      cat $i/lib/link >> target/link
+      cat $i/lib/link >> target/link.final
+    fi
   done
+
+  # Prepare crate build dependencies that are used for the build script.
   for i in ${completeBuildDepsDir}; do
-     symlink_dependency $i target/buildDeps
+    symlink_dependency $i target/buildDeps
+    if [ -e "$i/lib/link" ]; then
+      cat $i/lib/link >> target/link.build
+    fi
   done
-  if [[ -e target/link ]]; then
-    sort -u target/link > target/link.sorted
-    mv target/link.sorted target/link
-    sort -u target/link.final > target/link.final.sorted
-    mv target/link.final.sorted target/link.final
-    tr '\n' ' ' < target/link > target/link_
+
+  # Remove duplicate linker flags from the build dependencies.
+  if [[ -e target/link.build ]]; then
+    sort -u target/link.build > target/link.build.sorted
+    mv target/link.build.sorted target/link.build
   fi
+
+  # Remove duplicate linker flags from the dependencies.
+  sort -u target/link > target/link.sorted
+  mv target/link.sorted target/link
+  tr '\n' ' ' < target/link > target/link_
+
+  # Remove duplicate linker flags from the that are written
+  # to the derivation's output.
+  sort -u target/link.final > target/link.final.sorted
+  mv target/link.final.sorted target/link.final
+
   EXTRA_BUILD=""
   BUILD_OUT_DIR=""
   export CARGO_PKG_NAME=${crateName}
@@ -120,15 +154,14 @@ in ''
   elif [[ -e "build.rs" ]]; then
      BUILD="build.rs"
   fi
+
+  # Compile and run the build script, when available.
   if [[ ! -z "$BUILD" ]] ; then
      echo_build_heading "$BUILD" ${libName}
      mkdir -p target/build/${crateName}
      EXTRA_BUILD_FLAGS=""
-     if [ -e target/link_ ]; then
-       EXTRA_BUILD_FLAGS=$(cat target/link_)
-     fi
      if [ -e target/link.build ]; then
-       EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS $(cat target/link.build)"
+       EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS $(tr '\n' ' ' < target/link.build)"
      fi
      noisily rustc --crate-name build_script_build $BUILD --crate-type bin ${rustcOpts} \
        ${crateFeatures} --out-dir target/build/${crateName} --emit=dep-info,link \

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -79,6 +79,7 @@ build_bin_test_file() {
     build_bin_test "$derived_crate_name" "$file"
 }
 
+# Add additional link options that were provided by the build script.
 setup_link_paths() {
   EXTRA_LIB=""
   if [[ -e target/link_ ]]; then


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

According to the Cargo documentation:

> The build script does not have access to the dependencies listed in
> the dependencies or dev-dependencies section (they’re not built
> yet!). Also, build dependencies are not available to the package
> itself unless also explicitly added in the [dependencies] table.

https://doc.rust-lang.org/cargo/reference/build-scripts.html

This change separates linkage of regular dependencies and build
dependencies.

Tested with `buildRustCrateTests` and some personal crates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
