### PR TITLE
quorum: init at 2.5.0

### DIFF
--- a/pkgs/applications/blockchains/quorum.nix
+++ b/pkgs/applications/blockchains/quorum.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildGoPackage, git, which }:
+{ stdenv, fetchFromGitHub, buildGoPackage, git, which }:
   
 buildGoPackage rec {
   pname = "quorum";
@@ -25,10 +25,11 @@ buildGoPackage rec {
     cp -v build/bin/geth build/bin/bootnode build/bin/swarm $bin/bin
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A permissioned implementation of Ethereum supporting data privacy";
     homepage = "https://www.goquorum.com/";
-    license = lib.licenses.lgpl3;
-    maintainers = with lib.maintainers; [ mmahut ];
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ mmahut ];
+    platforms = subtractLists ["aarch64-linux"] platforms.linux;
   };
 }

--- a/pkgs/applications/blockchains/quorum.nix
+++ b/pkgs/applications/blockchains/quorum.nix
@@ -1,0 +1,34 @@
+{ lib, fetchFromGitHub, buildGoPackage, git, which }:
+  
+buildGoPackage rec {
+  pname = "quorum";
+  version = "2.5.0";
+
+  goPackagePath = "github.com/jpmorganchase/quorum";
+
+  src = fetchFromGitHub {
+    owner = "jpmorganchase";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xfdaqp9bj5dkw12gy19lxj73zh7w80j051xclsvnd41sfah86ll";
+  };
+
+  buildInputs = [ git which ];
+
+  buildPhase = ''
+    cd "go/src/$goPackagePath"
+    make geth bootnode swarm
+  '';
+
+  installPhase = ''
+    mkdir -pv $bin/bin
+    cp -v build/bin/geth build/bin/bootnode build/bin/swarm $bin/bin
+  '';
+
+  meta = {
+    description = "A permissioned implementation of Ethereum supporting data privacy";
+    homepage = "https://www.goquorum.com/";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ mmahut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22931,6 +22931,8 @@ in
 
   particl-core = callPackage ../applications/blockchains/particl/particl-core.nix { miniupnpc = miniupnpc_2; };
 
+  quorum = callPackage ../applications/blockchains/quorum.nix { };
+
   ### GAMES
 
   _2048-in-terminal = callPackage ../games/2048-in-terminal { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
