### PR TITLE
wpsoffice: 11.1.0.9080 -> 11.1.0.9126

### DIFF
--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -1,22 +1,44 @@
-{ stdenv, fetchurl
-, libX11, glib, xorg, fontconfig, freetype
-, zlib, libpng12, libICE, libXrender, cups
-, alsaLib, atk, cairo, dbus, expat
-, gdk-pixbuf, gtk2-x11, lzma, pango, zotero
-, sqlite, libuuid, qt5, dpkg }:
-
-stdenv.mkDerivation rec{
+# Build tools
+{ stdenv, fetchurl, dpkg,
+# Dependencies
+  alsaLib, atk, cairo, dbus,
+  expat, fontconfig, freetype, gdk-pixbuf,
+  gtk2-x11, glib, primusLib, xorg,
+  libtool, lzma, pango, nspr, qt5, qt4,
+  nss, sqlite, libuuid, zlib, cups, file,
+  wrapGAppsHook
+}:
+let
+  deps = [
+    alsaLib atk cairo dbus.lib
+    expat fontconfig.lib
+    freetype gdk-pixbuf gtk2-x11 glib
+    primusLib xorg.libICE libtool.lib
+    lzma pango nspr qt5.qtbase qt4
+    nss xorg.libSM sqlite libuuid
+    xorg.libX11 xorg.libxcb
+    xorg.libXcomposite xorg.libXcursor
+    xorg.libXdamage xorg.libXfixes
+    xorg.libXi xorg.libXrandr
+    xorg.libXrender xorg.libXScrnSaver
+    xorg.libXtst xorg.libXext zlib cups
+  ];
+  libPath = stdenv.lib.makeLibraryPath deps;
+in
+stdenv.mkDerivation rec {
   pname = "wpsoffice";
-  version = "11.1.0.9080";
+  version = "11.1.0.9126";
 
   src = fetchurl {
-    url = "http://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/9080/wps-office_11.1.0.9080.XA_amd64.deb";
-    sha256 = "1731e9aea22ef4e558ad66b1373d863452b4f570aecf09d448ae28a821333454";
+    url = "http://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/9126/wps-office_11.1.0.9126.XA_amd64.deb";
+    sha256 = "10d5sgpl1i70rj2596i6865hj0xdlzwdrwiplz41zys6l4zbmfp7";
   };
   unpackCmd = "dpkg -x $src .";
   sourceRoot = ".";
 
-  nativeBuildInputs = [ qt5.wrapQtAppsHook dpkg ];
+  nativeBuildInputs = [ wrapGAppsHook qt5.wrapQtAppsHook dpkg ];
+  dontWrapQtApps = true;
+  dontWrapGApps = true;
 
   meta = {
     description = "Office program originally named Kingsoft Office";
@@ -26,43 +48,6 @@ stdenv.mkDerivation rec{
     license = stdenv.lib.licenses.unfreeRedistributable;
     maintainers = [ stdenv.lib.maintainers.mlatus ];
   };
-
-  libPath = with xorg; stdenv.lib.makeLibraryPath [
-    libX11
-    libpng12
-    glib
-    libSM
-    libXext
-    fontconfig
-    zlib
-    freetype
-    libICE
-    cups
-    libXrender
-    libxcb
-
-    alsaLib
-    atk
-    cairo
-    dbus.daemon.lib
-    expat
-    fontconfig.lib
-    gdk-pixbuf
-    gtk2-x11
-    lzma
-    pango
-    zotero
-    sqlite
-    libuuid
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXfixes
-    libXi
-    libXrandr
-    libXScrnSaver
-    libXtst
-  ];
 
   dontPatchELF = true;
 
@@ -77,18 +62,31 @@ stdenv.mkDerivation rec{
     cp -r usr/* $out
     # Avoid forbidden reference error due use of patchelf
     rm -r *
-    for i in wps wpp et wpspdf; do
-      patchelf \
-        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --force-rpath --set-rpath "$(patchelf --print-rpath $prefix/office6/$i):${stdenv.cc.cc.lib}/lib64:${libPath}" \
-        $prefix/office6/$i
+    bins=$(find $prefix/office6 -maxdepth 1 -executable ! -type d|grep -v '.*\.so\.*')
+    for i in $bins; do
+      origin_rpath=$(patchelf --print-rpath $i)
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $i || true
+      patchelf --force-rpath --set-rpath "$origin_rpath''${origin_rpath:+:}${stdenv.cc.cc.lib}/lib64:${libPath}" $i || true
+    done
+
+    for i in et wpp wps wpspdf;do
       substituteInPlace $out/bin/$i \
         --replace /opt/kingsoft/wps-office $prefix
     done
+
     for i in $out/share/applications/*;do
       substituteInPlace $i \
         --replace /usr/bin $out/bin \
         --replace /opt/kingsoft/wps-office $prefix
+    done
+  '';
+
+  postFixup = ''
+    bins=$(find $prefix/office6 -maxdepth 1 -executable ! -type d|grep -v '.*\.so\.*')
+    for i in $bins;do
+      echo Wrapping $i
+      wrapQtApp $i
+      wrapGApp $i
     done
   '';
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update wpsoffice

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


# Help wanted

The application generally works, but with following problems:
1. Open `Settings` and `Skin Center`, which will execvp `./result/opt/kingsoft/wps-office/office6/promecefpluginhost`, silently fails and exit.
2. Using `wpp` to open some `.ppt` files crashes without error messages;
3. `et` does not display CJK words correctly.