### PR TITLE
scikit-survival: init at 0.11

### DIFF
--- a/pkgs/development/python-modules/scikit-survival/default.nix
+++ b/pkgs/development/python-modules/scikit-survival/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cython
+, ecos
+, joblib
+, numexpr
+, numpy
+, osqp
+, pandas
+, scikitlearn
+, scipy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "scikit-survival";
+  version = "0.15.0.post0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "572c3ac6818a9d0944fc4b8176eb948051654de857e28419ecc5060bcc6fbf37";
+  };
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    ecos
+    joblib
+    numexpr
+    numpy
+    osqp
+    pandas
+    scikitlearn
+    scipy
+  ];
+
+  pythonImportsCheck = [ "sksurv" ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  # Hack needed to make pytest + cython work
+  # https://github.com/NixOS/nixpkgs/pull/82410#issuecomment-827186298
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    cp -r $TMP/$sourceRoot/tests $HOME
+    pushd $HOME
+  '';
+  postCheck = "popd";
+
+  # very long tests, unnecessary for a leaf package
+  disabledTests = [
+    "test_coxph"
+    "test_datasets"
+    "test_ensemble_selection"
+    "test_minlip"
+    "test_pandas_inputs"
+    "test_survival_svm"
+    "test_tree"
+  ];
+
+  meta = with lib; {
+    description = "Survival analysis built on top of scikit-learn";
+    homepage = "https://github.com/sebp/scikit-survival";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ GuillaumeDesforges ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7265,6 +7265,8 @@ in {
 
   scripttest = callPackage ../development/python-modules/scripttest { };
 
+  scikit-survival = callPackage ../development/python-modules/scikit-survival { };
+
   scs = callPackage ../development/python-modules/scs { scs = pkgs.scs; };
 
   sdnotify = callPackage ../development/python-modules/sdnotify { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add scikit-survival to nixpkgs

https://github.com/sebp/scikit-survival

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


## Motivation

scikit-survival was missing from nixpkgs

## Notes

Had to PR the package because of requirements issues.
Will put back src on actual source when PR is merged.
See https://github.com/sebp/scikit-survival/pull/98