### PR TITLE
rtl-sdr: fix cross compilation

### DIFF
--- a/pkgs/applications/radio/rtl-sdr/default.nix
+++ b/pkgs/applications/radio/rtl-sdr/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0lmvsnb4xw4hmz6zs0z5ilsah5hjz29g1s0050n59fllskqr3b8k";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake libusb1 ];
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ libusb1 ];
 
   # TODO: get these fixes upstream:
   # * Building with -DINSTALL_UDEV_RULES=ON tries to install udev rules to


### PR DESCRIPTION
This patch partially fixes #81985.
Cross-compiling rtl-sdr is possible using this patch.
Use nix build -f <nixpkgs-path> -A pkgsCross.raspberryPi.rtl-sdr to build rtl-sdr.

The error that occured when trying to do this before was as follows:

`/nix/store/ldb2v2z0198abkp2minr9a9vz5np4mn4-cmake-3.16.4-armv6l-unknown-linux-gnueabihf/nix-support/setup-hook: line 107: cmake: command not found`

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

I want to be able to cross-compile rtl_433 using NixOS. This is a first step towards that goal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] **Is on by default?** Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] **Seems N/A** Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] **Not sure how this works** Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - note: this fails because it's cross-compiled, but the cross-compiled binary is of the correct type (`ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /nix/store/b996ssrajnrjkni0fz3k7ihrp0m77ahr-glibc-2.30-armv6l-unknown-linux-gnueabihf/lib/ld-linux-armhf.so.3, for GNU/Linux 2.6.32, not stripped
`)
- [ ] **Expect low impact** Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] **N/A** Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Should this be merged to master or to another branch? I can't tell what's expected here.