### PR TITLE
vscode-extensions.WakaTime.vscode-wakatime: prefer local wakatime

### DIFF
--- a/pkgs/misc/vscode-extensions/wakatime/default.nix
+++ b/pkgs/misc/vscode-extensions/wakatime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib
 , wakatime, vscode-utils }:
 
 let
@@ -12,12 +12,18 @@ in
       sha256 = "0bwxz8dg00k8frnvkvcngll5yaf9k7z13dg309vmw8xbdgkiyid4";
     };
 
-    postPatch = ''
-      mkdir -p wakatime-master
-      cp -rt wakatime-master --no-preserve=all ${wakatime}/lib/python*/site-packages/wakatime
+    postUnpack = ''
+      mkdir -p $sourceRoot/wakatime-master
+      cp -rt $sourceRoot/wakatime-master --no-preserve=all ${wakatime}/lib/python*/site-packages/wakatime
     '';
 
-    meta = with stdenv.lib; {
+    # Should check on every version bump
+    # https://github.com/wakatime/vscode-wakatime/blob/8c5065e6c6309fb0dc0dc94d4829d738058002ea/src/dependencies.ts#L30
+    postPatch = ''
+      sed -i "s@\(this.standalone\)\(?this.checkAndInstallStandaloneCli(e)\)@(!this.isCliInstalled()\&\&\1)\2@" dist/extension.js
+    '';
+
+    meta = with lib; {
       description = ''
         Visual Studio Code plugin for automatic time tracking and metrics generated
         from your programming activity


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Use the wakatime in the extension directory. Or if you put `standalone = false` in the wakatime config but that's unnecessary work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
