### PR TITLE
openjpeg: patch CVE-2020-6851 and CVE-2020-8112

### DIFF
--- a/pkgs/development/libraries/openjpeg/2.x.nix
+++ b/pkgs/development/libraries/openjpeg/2.x.nix
@@ -28,5 +28,10 @@ callPackage ./generic.nix (args // rec {
       name = "CVE-2020-6851.patch";
       sha256 = "1lfwlzqxb69cwzjp8v9lijz4c2qhf3b8m6sq1khipqlgrb3l58xw";
     })
+    (fetchpatch {
+      url = "https://github.com/uclouvain/openjpeg/commit/05f9b91e60debda0e83977e5e63b2e66486f7074.patch";
+      name = "CVE-2020-8112.patch";
+      sha256 = "16kykc8wbq9kx9w9kkf3i7snak82m184qrl9bpxvkjl7h0n9aw49";
+    })
   ];
 })

--- a/pkgs/development/libraries/openjpeg/2.x.nix
+++ b/pkgs/development/libraries/openjpeg/2.x.nix
@@ -23,5 +23,10 @@ callPackage ./generic.nix (args // rec {
       name = "CVE-2019-12973-2.patch";
       sha256 = "1jkkfw13l7nx4hxdhc7z17f4vfgqcaf09zpl235kypbxx1ygc7vq";
     })
+    (fetchpatch {
+      url = "https://github.com/uclouvain/openjpeg/commit/024b8407392cb0b82b04b58ed256094ed5799e04.patch";
+      name = "CVE-2020-6851.patch";
+      sha256 = "1lfwlzqxb69cwzjp8v9lijz4c2qhf3b8m6sq1khipqlgrb3l58xw";
+    })
   ];
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

* #77939, https://nvd.nist.gov/vuln/detail/CVE-2020-6851, https://github.com/uclouvain/openjpeg/issues/1228
* #79726, https://nvd.nist.gov/vuln/detail/CVE-2020-8112, https://github.com/uclouvain/openjpeg/issues/1231

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
