### PR TITLE
afl: Fix afl-qemu build by applying new patches

### DIFF
--- a/pkgs/tools/security/afl/qemu-patches/syscall-glibc2_30.diff
+++ b/pkgs/tools/security/afl/qemu-patches/syscall-glibc2_30.diff
@@ -1,0 +1,51 @@
+--- qemu-2.10.0-clean/linux-user/syscall.c	2020-03-12 18:47:47.898592169 +0100
++++ qemu-2.10.0/linux-user/syscall.c	2020-03-13 09:13:42.461809699 +0100
+@@ -34,6 +34,7 @@
+ #include <sys/resource.h>
+ #include <sys/swap.h>
+ #include <linux/capability.h>
++#include <linux/sockios.h> // https://lkml.org/lkml/2019/6/3/988
+ #include <sched.h>
+ #include <sys/timex.h>
+ #ifdef __ia64__
+@@ -256,7 +257,9 @@ static type name (type1 arg1,type2 arg2,
+ #endif
+ 
+ #ifdef __NR_gettid
+-_syscall0(int, gettid)
++// taken from https://patchwork.kernel.org/patch/10862231/
++#define __NR_sys_gettid __NR_gettid
++_syscall0(int, sys_gettid)
+ #else
+ /* This is a replacement for the host gettid() and must return a host
+    errno. */
+@@ -6219,7 +6222,7 @@ static void *clone_func(void *arg)
+     cpu = ENV_GET_CPU(env);
+     thread_cpu = cpu;
+     ts = (TaskState *)cpu->opaque;
+-    info->tid = gettid();
++    info->tid = sys_gettid();
+     task_settid(ts);
+     if (info->child_tidptr)
+         put_user_u32(info->tid, info->child_tidptr);
+@@ -6363,9 +6366,9 @@ static int do_fork(CPUArchState *env, un
+                mapping.  We can't repeat the spinlock hack used above because
+                the child process gets its own copy of the lock.  */
+             if (flags & CLONE_CHILD_SETTID)
+-                put_user_u32(gettid(), child_tidptr);
++                put_user_u32(sys_gettid(), child_tidptr);
+             if (flags & CLONE_PARENT_SETTID)
+-                put_user_u32(gettid(), parent_tidptr);
++                put_user_u32(sys_gettid(), parent_tidptr);
+             ts = (TaskState *)cpu->opaque;
+             if (flags & CLONE_SETTLS)
+                 cpu_set_tls (env, newtls);
+@@ -11402,7 +11405,7 @@ abi_long do_syscall(void *cpu_env, int n
+         break;
+ #endif
+     case TARGET_NR_gettid:
+-        ret = get_errno(gettid());
++        ret = get_errno(sys_gettid());
+         break;
+ #ifdef TARGET_NR_readahead
+     case TARGET_NR_readahead:

--- a/pkgs/tools/security/afl/qemu.nix
+++ b/pkgs/tools/security/afl/qemu.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation {
     "../${afl.src.name}/qemu_mode/patches/memfd.diff"
     # nix-specific patches to make installation more well-behaved
     ./qemu-patches/no-etc-install.patch
+    # patch for fixing qemu build on glibc >= 2.30
+    ./qemu-patches/syscall-glibc2_30.diff
   ];
 
   configureFlags =


### PR DESCRIPTION
These patches are gathered from different sources,
such as https://patchwork.kernel.org/patch/10862231/ for the
`gettid` patch.
Another patch comes from the issue in the AFL repository.
The ultimate goal is to get these patches upstream as well,
so we don't keep these general patches only within nixos.

A PR is created against Google/AFL
https://github.com/google/AFL/pull/79,
but it might take a while before it's landed, considering the history
of the project (there are more PRs open).

ZHF: #80379

Fixes issue #82232

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

Zero hydra failures, and I want to be able to use AFL without manually patching out the QEMU support from my local nixpkgs repository. I'm not using QEMU, but could imagine others wanting to use it.

Another solution might be dropping support for the qemu-mode, but I think keeping it is preferable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] **Default on NixOS?** Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] **Not sure how to do** Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] **N/A** Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).