### PR TITLE
nixos/release-combined: disable i686 iso_minimal

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -48,7 +48,8 @@ in rec {
       "nixos.channel"
       "nixos.dummy.x86_64-linux"
       "nixos.iso_minimal.aarch64-linux"
-      "nixos.iso_minimal.i686-linux"
+      # https://github.com/NixOS/nixpkgs/issues/82435
+      # "nixos.iso_minimal.i686-linux"
       "nixos.iso_minimal.x86_64-linux"
       "nixos.iso_plasma5.x86_64-linux"
       "nixos.manual.x86_64-linux"


### PR DESCRIPTION
###### Motivation for this change
It is blocking the channel.

https://github.com/NixOS/nixpkgs/issues/82435
