### PR TITLE
lz4: 1.9.1 -> 1.9.2

### DIFF
--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -4,22 +4,14 @@
 
 stdenv.mkDerivation rec {
   pname = "lz4";
-  version = "1.9.1";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
-    sha256 = "1l1caxrik1hqs40vj3bpv1pikw6b74cfazv5c0v6g48zpcbmshl0";
+    sha256 = "0lpaypmk70ag2ks3kf2dl4ac3ba40n5kc1ainkp9wfjawz76mh61";
     rev = "v${version}";
     repo = pname;
     owner = pname;
   };
-
-  patches = [
-    # Fix detection of Darwin
-    (fetchpatch {
-      url = "https://github.com/lz4/lz4/commit/024216ef7394b6411eeaa5b52d0cec9953a44249.patch";
-      sha256 = "0j0j2pr6pkplxf083hlwl5q4cfp86q3wd8mc64bcfcr7ysc5pzl3";
-    })
-  ];
 
   # TODO(@Ericson2314): Separate binaries and libraries
   outputs = [ "bin" "out" "dev" ];
@@ -61,7 +53,7 @@ stdenv.mkDerivation rec {
       multiple GB/s per core, typically reaching RAM speed limits on
       multi-core systems.
     '';
-    homepage = https://lz4.github.io/lz4/;
+    homepage = "https://lz4.github.io/lz4/";
     license = with licenses; [ bsd2 gpl2Plus ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change

Fixes: https://nvd.nist.gov/vuln/detail/CVE-2019-17543 (see also #73666)
Release notes: https://github.com/lz4/lz4/releases/tag/v1.9.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
