### PR TITLE
upgrade vscode extension versions for Scala

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -144,8 +144,8 @@ in
     mktplcRef = {
       name = "scala";
       publisher = "scala-lang";
-      version = "0.3.8";
-      sha256 = "17dl10m3ayf57sqgil4mr9fjdm7i8gb5clrs227b768pp2d39ll9";
+      version = "0.3.9";
+      sha256 = "0l6zrpp2klqdym977zygmbzf0478lbqmivcxa2xmqyi34c9vwli7";
     };
     meta = {
       license = stdenv.lib.licenses.mit;
@@ -156,8 +156,8 @@ in
     mktplcRef = {
       name = "metals";
       publisher = "scalameta";
-      version = "1.6.3";
-      sha256 = "1mc3awybzd2ql1b86inirhsw3j2c7cs0b0nvbjp38jjpq674bmj7";
+      version = "1.8.0";
+      sha256 = "0r1r96xclr8c3rjgs944zdim9rjq6hfajvv7yh3hn75cy684bck5";
     };
     meta = {
       license = stdenv.lib.licenses.asl20;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
to update the vscode extensions for Scala to their latest version. merging this to master is fine because vscode 1.43 is already in the master branch. The minimal vscode version to use these new versions is 1.42. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
   - [x] NixOS (commit 82b54d490663b6d87b7b34b9cfc0985df8b49c7d)

