### PR TITLE
[20.03][Security] bluez: 5.52 -> 5.53 for CVE-2020-0556

### DIFF
--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bluez";
-  version = "5.52";
+  version = "5.53";
 
   src = fetchurl {
     url = "mirror://kernel/linux/bluetooth/${pname}-${version}.tar.xz";
-    sha256 = "02jng21lp6fb3c2bh6vf9y7cj4gaxwk29dfc32ncy0lj0gi4q57p";
+    sha256 = "1g1qg6dz6hl3csrmz75ixr12lwv836hq3ckb259svvrg62l2vaiq";
   };
 
   pythonPath = with python3.pkgs; [
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Bluetooth support for Linux";
-    homepage = http://www.bluez.org/;
+    homepage = "http://www.bluez.org/";
     license = with licenses; [ gpl2 lgpl21 ];
     platforms = platforms.linux;
     repositories.git = https://git.kernel.org/pub/scm/bluetooth/bluez.git;


### PR DESCRIPTION
See here for details:
https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00352.html

(cherry picked from commit 8f8b6459e9f38bc21df4976265f96b4541b917ec)