### PR TITLE
libssh: 0.8.7 -> 0.8.8

### DIFF
--- a/pkgs/development/libraries/libssh/default.nix
+++ b/pkgs/development/libraries/libssh/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, pkgconfig, cmake, zlib, openssl, libsodium }:
 
 stdenv.mkDerivation rec {
-  name = "libssh-0.8.7";
+  pname = "libssh";
+  version = "0.8.8";
 
   src = fetchurl {
-    url = "https://www.libssh.org/files/0.8/${name}.tar.xz";
-    sha256 = "14nmwfnnrhkwcfk5hn7azl905ivbh4wllmsbw5abd80b5yi4qc23";
+    url = "https://www.libssh.org/files/0.8/${pname}-${version}.tar.xz";
+    sha256 = "1qk5bm9r6199jbfk54f8w24vkl52051g8s3kmq4z2kdc6vbpy4jb";
   };
 
   postPatch = ''
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "SSH client library";
+    homepage = "https://libssh.org";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ sander ];
     platforms = platforms.all;


### PR DESCRIPTION
Fixes [CVE-2019-14889](https://nvd.nist.gov/vuln/detail/CVE-2019-14889).
Release notes: https://www.libssh.org/2019/12/10/libssh-0-9-3-and-libssh-0-8-8-security-release/

###### Motivation for this change

#77264

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
