### PR TITLE
Checked maintainers

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -193,14 +193,7 @@ rec {
        (showOption ["foo" "bar" "baz"]) == "foo.bar.baz"
        (showOption ["foo" "bar.baz" "tux"]) == "foo.\"bar.baz\".tux"
   */
-  showOption = parts: let
-    escapeOptionPart = part:
-      let
-        escaped = lib.strings.escapeNixString part;
-      in if escaped == "\"${part}\""
-         then part
-         else escaped;
-    in (concatStringsSep ".") (map escapeOptionPart parts);
+  showOption = parts: concatMapStringsSep "." escapeNixIdentifier parts;
   showFiles = files: concatStringsSep " and " (map (f: "`${f}'") files);
   unknownModule = "<unknown-file>";
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -315,6 +315,21 @@ rec {
   */
   escapeNixString = s: escape ["$"] (builtins.toJSON s);
 
+  /* Quotes a string if it can't be used as an identifier directly.
+
+     Type: string -> string
+
+     Example:
+       escapeNixIdentifier "hello"
+       => "hello"
+       escapeNixIdentifier "0abc"
+       => "\"0abc\""
+  */
+  escapeNixIdentifier = s:
+    # Regex from https://github.com/NixOS/nix/blob/d048577909e383439c2549e849c5c2f2016c997e/src/libexpr/lexer.l#L91
+    if builtins.match "[a-zA-Z_][a-zA-Z0-9_'-]*" s != null
+    then s else escapeNixString s;
+
   # Obsolete - use replaceStrings instead.
   replaceChars = builtins.replaceStrings or (
     del: new: s:

--- a/lib/tests/maintainers.nix
+++ b/lib/tests/maintainers.nix
@@ -1,0 +1,75 @@
+# to run these tests:
+# nix-build nixpkgs/lib/tests/maintainers.nix
+# If nothing is output, all tests passed
+{ pkgs ? import ../.. {} }:
+
+let
+  inherit (pkgs) lib;
+  inherit (lib) types;
+
+  maintainerModule = { config, ... }: {
+    options = {
+      name = lib.mkOption {
+        type = types.str;
+      };
+      email = lib.mkOption {
+        type = types.str;
+      };
+      github = lib.mkOption {
+        type = types.nullOr types.str;
+        default = null;
+      };
+      githubId = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+      };
+      keys = lib.mkOption {
+        type = types.listOf (types.submodule {
+          options.longkeyid = lib.mkOption { type = types.str; };
+          options.fingerprint = lib.mkOption { type = types.str; };
+        });
+        default = [];
+      };
+    };
+  };
+
+  checkMaintainer = handle: uncheckedAttrs:
+  let
+      prefix = [ "lib" "maintainers" handle ];
+      checkedAttrs = (lib.modules.evalModules {
+        inherit prefix;
+        modules = [
+          maintainerModule
+          {
+            _file = toString ../../maintainers/maintainer-list.nix;
+            config = uncheckedAttrs;
+          }
+        ];
+      }).config;
+
+      checkGithubId = lib.optional (checkedAttrs.github != null && checkedAttrs.githubId == null) ''
+        echo ${lib.escapeShellArg (lib.showOption prefix)}': If `github` is specified, `githubId` must be too.'
+        # Calling this too often would hit non-authenticated API limits, but this
+        # shouldn't happen since such errors will get fixed rather quickly
+        info=$(curl -sS https://api.github.com/users/${checkedAttrs.github})
+        id=$(jq -r '.id' <<< "$info")
+        echo "The GitHub ID for GitHub user ${checkedAttrs.github} is $id:"
+        echo -e "    githubId = $id;\n"
+      '';
+    in lib.deepSeq checkedAttrs checkGithubId;
+
+  missingGithubIds = lib.concatLists (lib.mapAttrsToList checkMaintainer lib.maintainers);
+
+  success = pkgs.runCommandNoCC "checked-maintainers-success" {} ">$out";
+
+  failure = pkgs.runCommandNoCC "checked-maintainers-failure" {
+    nativeBuildInputs = [ pkgs.curl pkgs.jq ];
+    outputHash = "sha256:${lib.fakeSha256}";
+    outputHAlgo = "sha256";
+    outputHashMode = "flat";
+    SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+  } ''
+    ${lib.concatStringsSep "\n" missingGithubIds}
+    exit 1
+  '';
+in if missingGithubIds == [] then success else failure

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -3,7 +3,10 @@
 # This script is used to test that the module system is working as expected.
 # By default it test the version of nixpkgs which is defined in the NIX_PATH.
 
-cd ./modules
+# https://stackoverflow.com/a/246128/6605742
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd "$DIR"/modules
 
 pass=0
 fail=0

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ((import ../.).cleanSource ../..) {} }:
+{ pkgs ? import ../.. {} }:
 
 pkgs.runCommandNoCC "nixpkgs-lib-tests" {
   buildInputs = [ pkgs.nix (import ./check-eval.nix) ];
@@ -17,8 +17,8 @@ pkgs.runCommandNoCC "nixpkgs-lib-tests" {
     cacheDir=$TEST_ROOT/binary-cache
     nix-store --init
 
-    cd ${pkgs.path}/lib/tests
-    bash ./modules.sh
+    cp -r ${../.} lib
+    bash lib/tests/modules.sh
 
     touch $out
 ''

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -1,7 +1,7 @@
 { pkgs ? import ../.. {} }:
 
 pkgs.runCommandNoCC "nixpkgs-lib-tests" {
-  buildInputs = [ pkgs.nix (import ./check-eval.nix) ];
+  buildInputs = [ pkgs.nix (import ./check-eval.nix) (import ./maintainers.nix { inherit pkgs; }) ];
   NIX_PATH = "nixpkgs=${toString pkgs.path}";
 } ''
     datadir="${pkgs.nix}/share"

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2279,7 +2279,7 @@
   Enteee = {
     email = "nix@duckpond.ch";
     github = "Enteee";
-    githubid = 5493775;
+    githubId = 5493775;
     name = "Ente";
   };
   enzime = {
@@ -3035,6 +3035,7 @@
     name = "Guanpeng Xu";
   };
   hexa = {
+    email = "hexa@darmstadt.ccc.de";
     github = "mweinelt";
     githubId = 131599;
     name = "Martin Weinelt";
@@ -3225,6 +3226,7 @@
     name = "Michele Catalano";
   };
   isgy = {
+    name = "isgy";
     email = "isgy@teiyg.com";
     github = "isgy";
     githubId = 13622947;
@@ -3263,7 +3265,7 @@
     email = "ivar.scholten@protonmail.com";
     github = "IvarWithoutBones";
     githubId = 41924494;
-    Name = "Ivar";
+    name = "Ivar";
   };
   ivegotasthma = {
     email = "ivegotasthma@protonmail.com";
@@ -3797,7 +3799,7 @@
     email = "KAction@disroot.org";
     github = "kaction";
     githubId = 44864956;
-    key = [{
+    keys = [{
       longkeyid = "ed25519/0x749FD4DFA2E94236";
       fingerprint = "3F87 0A7C A7B4 3731 2F13  6083 749F D4DF A2E9 4236";
     }];
@@ -4064,7 +4066,7 @@
   kristian-brucaj = {
     email = "kbrucaj@gmail.com";
     github = "kristian-brucaj";
-    githubID = "8893110";
+    githubId = 8893110;
     name = "Kristian Brucaj";
   };
   kristoff3r = {
@@ -6644,6 +6646,7 @@
     name = "Fabian Schmitthenner";
   };
   schmittlauch = {
+    name = "Trolli Schmittlauch";
     email = "t.schmittlauch+nixos@orlives.de";
     github = "schmittlauch";
   };
@@ -6743,7 +6746,7 @@
   servalcatty = {
     email = "servalcat@pm.me";
     github = "servalcatty";
-    githubid = 51969817;
+    githubId = 51969817;
     name = "Serval";
     keys = [{
       longkeyid = "rsa4096/0x4A2AAAA382F8294C";
@@ -7783,7 +7786,7 @@
   valebes = {
     email = "valebes@gmail.com";
     github = "valebes";
-    githubid = 10956211;
+    githubId = 10956211;
     name = "Valerio Besozzi";
   };
   valeriangalliat = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -100,6 +100,7 @@
   abbradar = {
     email = "ab@fmap.me";
     github = "abbradar";
+    githubId = 1174810;
     name = "Nikolay Amiantov";
   };
   abhi18av = {
@@ -135,6 +136,7 @@
   acairncross = {
     email = "acairncross@gmail.com";
     github = "acairncross";
+    githubId = 1517066;
     name = "Aiken Cairncross";
   };
   acowley = {
@@ -146,6 +148,7 @@
   adamt = {
     email = "mail@adamtulinius.dk";
     github = "adamtulinius";
+    githubId = 749381;
     name = "Adam Tulinius";
   };
   adelbertc = {
@@ -229,6 +232,7 @@
   aforemny = {
     email = "alexanderforemny@googlemail.com";
     github = "aforemny";
+    githubId = 610962;
     name = "Alexander Foremny";
   };
   afranchuk = {
@@ -276,6 +280,7 @@
   ak = {
     email = "ak@formalprivacy.com";
     github = "alexanderkjeldaas";
+    githubId = 339369;
     name = "Alexander Kjeldaas";
   };
   akavel = {
@@ -383,6 +388,7 @@
   alunduil = {
     email = "alunduil@gmail.com";
     github = "alunduil";
+    githubId = 169249;
     name = "Alex Brandt";
   };
   alva = {
@@ -404,6 +410,7 @@
   ambrop72 = {
     email = "ambrop7@gmail.com";
     github = "ambrop72";
+    githubId = 2626481;
     name = "Ambroz Bizjak";
   };
   amiddelk = {
@@ -473,11 +480,13 @@
   andreabedini = {
     email = "andrea@kzn.io";
     github = "andreabedini";
+    githubId = 69135;
     name = "Andrea Bedini";
   };
   andres = {
     email = "ksnixos@andres-loeh.de";
     github = "kosmikus";
+    githubId = 293191;
     name = "Andres Loeh";
   };
   andrestylianos = {
@@ -507,6 +516,7 @@
   andsild = {
     email = "andsild@gmail.com";
     github = "andsild";
+    githubId = 3808928;
     name = "Anders Sildnes";
   };
   aneeshusa = {
@@ -560,6 +570,7 @@
   antono = {
     email = "self@antono.info";
     github = "antono";
+    githubId = 7622;
     name = "Antono Vasiljev";
   };
   antonxy = {
@@ -742,7 +753,8 @@
   };
   auntie = {
     email = "auntieNeo@gmail.com";
-    github = "auntie";
+    github = "auntieNeo";
+    githubId = 574938;
     name = "Jonathan Glines";
   };
   avaq = {
@@ -760,6 +772,7 @@
   averelld = {
     email = "averell+nixos@rxd4.com";
     github = "averelld";
+    githubId = 687218;
     name = "averelld";
   };
   avitex = {
@@ -815,11 +828,13 @@
   backuitist = {
     email = "biethb@gmail.com";
     github = "backuitist";
+    githubId = 1017537;
     name = "Bruno Bieth";
   };
   badi = {
     email = "abdulwahidc@gmail.com";
     github = "badi";
+    githubId = 35324;
     name = "Badi' Abdul-Wahid";
   };
   balajisivaraman = {
@@ -943,6 +958,7 @@
   berdario = {
     email = "berdario@gmail.com";
     github = "berdario";
+    githubId = 752835;
     name = "Dario Bertini";
   };
   bergey = {
@@ -1024,6 +1040,7 @@
   bluescreen303 = {
     email = "mathijs@bluescreen303.nl";
     github = "bluescreen303";
+    githubId = 16330;
     name = "Mathijs Kwik";
   };
   bobakker = {
@@ -1053,6 +1070,7 @@
   boothead = {
     email = "ben@perurbis.com";
     github = "boothead";
+    githubId = 87764;
     name = "Ben Ford";
   };
   borisbabic = {
@@ -1473,6 +1491,7 @@
   coconnor = {
     email = "coreyoconnor@gmail.com";
     github = "coreyoconnor";
+    githubId = 34317;
     name = "Corey O'Connor";
   };
   codsl = {
@@ -1566,6 +1585,7 @@
   cransom = {
     email = "cransom@hubns.net";
     github = "cransom";
+    githubId = 1957293;
     name = "Casey Ransom";
   };
   CrazedProgrammer = {
@@ -1725,6 +1745,7 @@
   davidrusu = {
     email = "davidrusu.me@gmail.com";
     github = "davidrusu";
+    githubId = 1832378;
     name = "David Rusu";
   };
   davidtwco = {
@@ -1818,6 +1839,7 @@
   DerGuteMoritz = {
     email = "moritz@twoticketsplease.de";
     github = "DerGuteMoritz";
+    githubId = 19733;
     name = "Moritz Heidkamp";
   };
   dermetfan = {
@@ -1835,6 +1857,7 @@
   desiderius = {
     email = "didier@devroye.name";
     github = "desiderius";
+    githubId = 1311761;
     name = "Didier J. Devroye";
   };
   devhell = {
@@ -1864,6 +1887,7 @@
   dgonyeo = {
     email = "derek@gonyeo.com";
     github = "dgonyeo";
+    githubId = 2439413;
     name = "Derek Gonyeo";
   };
   dhkl = {
@@ -1983,6 +2007,7 @@
   doublec = {
     email = "chris.double@double.co.nz";
     github = "doublec";
+    githubId = 16599;
     name = "Chris Double";
   };
   dpaetzel = {
@@ -2048,6 +2073,7 @@
   dxf = {
     email = "dingxiangfei2009@gmail.com";
     github = "dingxiangfei2009";
+    githubId = 6884440;
     name = "Ding Xiang Fei";
   };
   dysinger = {
@@ -2113,6 +2139,7 @@
   edanaher = {
     email = "nixos@edanaher.net";
     github = "edanaher";
+    githubId = 984691;
     name = "Evan Danaher";
   };
   edef = {
@@ -2262,6 +2289,7 @@
   emmanuelrosa = {
     email = "emmanuel_rosa@aol.com";
     github = "emmanuelrosa";
+    githubId = 13485450;
     name = "Emmanuel Rosa";
   };
   endgame = {
@@ -2337,6 +2365,7 @@
   ericsagnes = {
     email = "eric.sagnes@gmail.com";
     github = "ericsagnes";
+    githubId = 367880;
     name = "Eric Sagnes";
   };
   ericson2314 = {
@@ -2376,6 +2405,7 @@
   ertes = {
     email = "esz@posteo.de";
     github = "ertes";
+    githubId = 1855930;
     name = "Ertugrul Söylemez";
   };
   esclear = {
@@ -2485,6 +2515,7 @@
   fare = {
     email = "fahree@gmail.com";
     github = "fare";
+    githubId = 8073;
     name = "Francois-Rene Rideau";
   };
   farlion = {
@@ -2496,6 +2527,7 @@
   fdns = {
     email = "fdns02@gmail.com";
     github = "fdns";
+    githubId = 541748;
     name = "Felipe Espinoza";
   };
   ffinkdevs = {
@@ -2622,6 +2654,7 @@
   fragamus = {
     email = "innovative.engineer@gmail.com";
     github = "fragamus";
+    githubId = 119691;
     name = "Michael Gough";
   };
 
@@ -2640,11 +2673,13 @@
   freezeboy = {
     email = "freezeboy@users.noreply.github.com";
     github = "freezeboy";
+    githubId = 13279982;
     name = "freezeboy";
   };
   Fresheyeball = {
     email = "fresheyeball@gmail.com";
-    github = "fresheyeball";
+    github = "Fresheyeball";
+    githubId = 609279;
     name = "Isaac Shapira";
   };
   fridh = {
@@ -2748,6 +2783,7 @@
   garbas = {
     email = "rok@garbas.si";
     github = "garbas";
+    githubId = 20208;
     name = "Rok Garbas";
   };
   garrison = {
@@ -2759,6 +2795,7 @@
   gavin = {
     email = "gavin.rogers@holo.host";
     github = "gavinrogers";
+    githubId = 2430469;
     name = "Gavin Rogers";
   };
   gazally = {
@@ -2906,6 +2943,7 @@
   gridaphobe = {
     email = "eric@seidel.io";
     github = "gridaphobe";
+    githubId = 201997;
     name = "Eric Seidel";
   };
   guibert = {
@@ -3054,6 +3092,7 @@
     email = "me@hkjn.me";
     name = "Henrik Jonsson";
     github = "hkjn";
+    githubId = 287215;
     keys = [{
       longkeyid = "rsa4096/0x03EFBF839A5FDC15";
       fingerprint = "D618 7A03 A40A 3D56 62F5  4B46 03EF BF83 9A5F DC15";
@@ -3304,6 +3343,7 @@
   jasoncarr = {
     email = "jcarr250@gmail.com";
     github = "jasoncarr0";
+    githubId = 6874204;
     name = "Jason Carr";
   };
   j-keck = {
@@ -3315,6 +3355,7 @@
   j03 = {
     email = "github@johannesloetzsch.de";
     github = "johannesloetzsch";
+    githubId = 175537;
     name = "Johannes Lötzsch";
   };
   jagajaga = {
@@ -3441,7 +3482,8 @@
   };
   jeschli = {
     email = "jeschli@gmail.com";
-    github = "jeschli";
+    github = "Jeschli";
+    githubId = 10786794;
     name = "Markus Hihn";
   };
   jethro = {
@@ -3453,6 +3495,7 @@
   jfb = {
     email = "james@yamtime.com";
     github = "tftio";
+    githubId = 143075;
     name = "James Felix Black";
   };
   jflanglois = {
@@ -3512,6 +3555,7 @@
   jitwit = {
     email = "jrn@bluefarm.ca";
     github = "jitwit";
+    githubId = 51518420;
     name = "jitwit";
   };
   jlesquembre = {
@@ -3553,6 +3597,7 @@
   joamaki = {
     email = "joamaki@gmail.com";
     github = "joamaki";
+    githubId = 1102396;
     name = "Jussi Maki";
   };
   joelburget = {
@@ -3575,6 +3620,7 @@
     email = "admin@cryto.net";
     name = "Sven Slootweg";
     github = "joepie91";
+    githubId = 1663259;
   };
   joesalisbury = {
     email = "salisbury.joseph@gmail.com";
@@ -3648,6 +3694,7 @@
   jonathanmarler = {
     email = "johnnymarler@gmail.com";
     github = "marler8997";
+    githubId = 304904;
     name = "Jonathan Marler";
   };
   jonathanreeve = {
@@ -3753,6 +3800,7 @@
   juliendehos = {
     email = "dehos@lisic.univ-littoral.fr";
     github = "juliendehos";
+    githubId = 11947756;
     name = "Julien Dehos";
   };
   jumper149 = {
@@ -3786,6 +3834,7 @@
   jyp = {
     email = "jeanphilippe.bernardy@gmail.com";
     github = "jyp";
+    githubId = 27747;
     name = "Jean-Philippe Bernardy";
   };
   jzellner = {
@@ -3835,6 +3884,7 @@
   kampfschlaefer = {
     email = "arnold@arnoldarts.de";
     github = "kampfschlaefer";
+    githubId = 3831860;
     name = "Arnold Krille";
   };
   karantan = {
@@ -3992,6 +4042,7 @@
     email = "adrian@kummerlaender.eu";
     name = "Adrian Kummerlaender";
     github = "KnairdA";
+    githubId = 498373;
   };
   knedlsepp = {
     email = "josef.kemetmueller@gmail.com";
@@ -4014,6 +4065,7 @@
   kolbycrouch = {
     email = "kjc.devel@gmail.com";
     github = "kolbycrouch";
+    githubId = 6346418;
     name = "Kolby Crouch";
   };
   konimex = {
@@ -4025,6 +4077,7 @@
   koral = {
     email = "koral@mailoo.org";
     github = "k0ral";
+    githubId = 524268;
     name = "Koral";
   };
   kovirobi = {
@@ -4126,6 +4179,7 @@
   laikq = {
     email = "gwen@quasebarth.de";
     github = "laikq";
+    githubId = 55911173;
     name = "Gwendolyn Quasebarth";
   };
   lasandell = {
@@ -4143,6 +4197,7 @@
   lassulus = {
     email = "lassulus@gmail.com";
     github = "Lassulus";
+    githubId = 621759;
     name = "Lassulus";
   };
   lattfein = {
@@ -4197,6 +4252,7 @@
   lebastr = {
     email = "lebastr@gmail.com";
     github = "lebastr";
+    githubId = 887072;
     name = "Alexander Lebedev";
   };
   ledif = {
@@ -4232,6 +4288,7 @@
   leonardoce = {
     email = "leonardo.cecchi@gmail.com";
     github = "leonardoce";
+    githubId = 1572058;
     name = "Leonardo Cecchi";
   };
   leshainc = {
@@ -4395,6 +4452,7 @@
   lovek323 = {
     email = "jason@oconal.id.au";
     github = "lovek323";
+    githubId = 265084;
     name = "Jason O'Conal";
   };
   lovesegfault = {
@@ -4434,6 +4492,7 @@
   ltavard = {
     email = "laure.tavard@univ-grenoble-alpes.fr";
     github = "ltavard";
+    githubId = 8555953;
     name = "Laure Tavard";
   };
   luc65r = {
@@ -4497,6 +4556,7 @@
   lumi = {
     email = "lumi@pew.im";
     github = "lumi-me-not";
+    githubId = 26020062;
     name = "lumi";
   };
   luz = {
@@ -4680,6 +4740,7 @@
   matthewbauer = {
     email = "mjbauer95@gmail.com";
     github = "matthewbauer";
+    githubId = 19036;
     name = "Matthew Bauer";
   };
   matthiasbeyer = {
@@ -4697,6 +4758,7 @@
   matti-kariluoma = {
     email = "matti@kariluo.ma";
     github = "matti-kariluoma";
+    githubId = 279868;
     name = "Matti Kariluoma";
   };
   maurer = {
@@ -4822,6 +4884,7 @@
   melsigl = {
     email = "melanie.bianca.sigl@gmail.com";
     github = "melsigl";
+    githubId = 15093162;
     name = "Melanie B. Sigl";
   };
   melkor333 = {
@@ -4890,6 +4953,7 @@
   michaelpj = {
     email = "michaelpj@gmail.com";
     github = "michaelpj";
+    githubId = 1699466;
     name = "Michael Peyton Jones";
   };
   michalrus = {
@@ -4901,6 +4965,7 @@
   michelk = {
     email = "michel@kuhlmanns.info";
     github = "michelk";
+    githubId = 1404919;
     name = "Michel Kuhlmann";
   };
   michojel = {
@@ -4974,6 +5039,7 @@
   mirdhyn = {
     email = "mirdhyn@gmail.com";
     github = "mirdhyn";
+    githubId = 149558;
     name = "Merlin Gaillard";
   };
   mirrexagon = {
@@ -5009,6 +5075,7 @@
   mkf = {
     email = "m@mikf.pl";
     github = "mkf";
+    githubId = 7753506;
     name = "Michał Krzysztof Feiler";
     keys = [{
       longkeyid = "rsa4096/0xE35C2D7C2C6AC724";
@@ -5058,6 +5125,7 @@
   mmlb = {
     email = "manny@peekaboo.mmlb.icu";
     github = "mmlb";
+    githubId = 708570;
     name = "Manuel Mendez";
   };
   mnacamura = {
@@ -5087,6 +5155,7 @@
   Mogria = {
     email = "m0gr14@gmail.com";
     github = "mogria";
+    githubId = 754512;
     name = "Mogria";
   };
   monsieurp = {
@@ -5144,6 +5213,7 @@
   MP2E = {
     email = "MP2E@archlinux.us";
     github = "MP2E";
+    githubId = 167708;
     name = "Cray Elliott";
   };
   mpcsh = {
@@ -5167,6 +5237,7 @@
   mpscholten = {
     email = "marc@mpscholten.de";
     github = "mpscholten";
+    githubId = 2072185;
     name = "Marc Scholten";
   };
   mpsyco = {
@@ -5184,6 +5255,7 @@
   mredaelli = {
     email = "massimo@typish.io";
     github = "mredaelli";
+    githubId = 3073833;
     name = "Massimo Redaelli";
   };
   mrkkrp = {
@@ -5251,6 +5323,7 @@
   MtP = {
     email = "marko.nixos@poikonen.de";
     github = "MtP76";
+    githubId = 2176611;
     name = "Marko Poikonen";
   };
   mtreskin = {
@@ -5316,6 +5389,7 @@
   nand0p = {
     email = "nando@hex7.com";
     github = "nand0p";
+    githubId = 1916245;
     name = "Fernando Jose Pando";
   };
   Nate-Devv = {
@@ -5589,6 +5663,7 @@
   olynch = {
     email = "owen@olynch.me";
     github = "olynch";
+    githubId = 4728903;
     name = "Owen Lynch";
   };
   omnipotententity = {
@@ -5612,6 +5687,7 @@
   orbitz = {
     email = "mmatalka@gmail.com";
     github = "orbitz";
+    githubId = 75299;
     name = "Malcolm Matalka";
   };
   orivej = {
@@ -5747,6 +5823,7 @@
   pcarrier = {
     email = "pc@rrier.ca";
     github = "pcarrier";
+    githubId = 8641;
     name = "Pierre Carrier";
   };
   periklis = {
@@ -5892,6 +5969,7 @@
   plchldr = {
     email = "mail@oddco.de";
     github = "plchldr";
+    githubId = 11639001;
     name = "Jonas Beyer";
   };
   plcplc = {
@@ -5915,6 +5993,7 @@
   pmeunier = {
     email = "pierre-etienne.meunier@inria.fr";
     github = "P-E-Meunier";
+    githubId = 17021304;
     name = "Pierre-Étienne Meunier";
   };
   pmiddend = {
@@ -5944,6 +6023,7 @@
   polyrod = {
     email = "dc1mdp@gmail.com";
     github = "polyrod";
+    githubId = 24878306;
     name = "Maurizio Di Pietro";
   };
   pombeirp = {
@@ -6123,11 +6203,13 @@
   raboof = {
     email = "arnout@bzzt.net";
     github = "raboof";
+    githubId = 131856;
     name = "Arnout Engelen";
   };
   rafaelgg = {
     email = "rafael.garcia.gallego@gmail.com";
     github = "rafaelgg";
+    githubId = 1016742;
     name = "Rafael García";
   };
   raquelgb = {
@@ -6299,6 +6381,7 @@
   rickynils = {
     email = "rickynils@gmail.com";
     github = "rickynils";
+    githubId = 16779;
     name = "Rickard Nilsson";
   };
   rika = {
@@ -6376,11 +6459,13 @@
   rob = {
     email = "rob.vermaas@gmail.com";
     github = "rbvermaa";
+    githubId = 353885;
     name = "Rob Vermaas";
   };
   robberer = {
     email = "robberer@freakmail.de";
     github = "robberer";
+    githubId = 6204883;
     name = "Longrin Wischnewski";
   };
   robbinch = {
@@ -6500,6 +6585,7 @@
   rvolosatovs = {
     email = "rvolosatovs@riseup.net";
     github = "rvolosatovs";
+    githubId = 12877905;
     name = "Roman Volosatovs";
   };
   ryanartecona = {
@@ -6511,6 +6597,7 @@
   ryansydnor = {
     email = "ryan.t.sydnor@gmail.com";
     github = "ryansydnor";
+    githubId = 1832096;
     name = "Ryan Sydnor";
   };
   ryantm = {
@@ -6602,6 +6689,7 @@
   sander = {
     email = "s.vanderburg@tudelft.nl";
     github = "svanderburg";
+    githubId = 1153271;
     name = "Sander van der Burg";
   };
   sargon = {
@@ -6637,6 +6725,7 @@
   scalavision = {
     email = "scalavision@gmail.com";
     github = "scalavision";
+    githubId = 3958212;
     name = "Tom Sorlie";
   };
   schmitthenner = {
@@ -6649,6 +6738,7 @@
     name = "Trolli Schmittlauch";
     email = "t.schmittlauch+nixos@orlives.de";
     github = "schmittlauch";
+    githubId = 1479555;
   };
   schneefux = {
     email = "schneefux+nixos_pkg@schneefux.xyz";
@@ -6687,6 +6777,7 @@
   scubed2 = {
     email = "scubed2@gmail.com";
     github = "scubed2";
+    githubId = 7401858;
     name = "Sterling Stein";
   };
   sdier = {
@@ -6792,6 +6883,7 @@
   shazow = {
     email = "andrey.petrov@shazow.net";
     github = "shazow";
+    githubId = 6292;
     name = "Andrey Petrov";
   };
   sheenobu = {
@@ -6815,16 +6907,19 @@
   shlevy = {
     email = "shea@shealevy.com";
     github = "shlevy";
+    githubId = 487050;
     name = "Shea Levy";
   };
   shmish111 = {
     email = "shmish111@gmail.com";
     github = "shmish111";
+    githubId = 934267;
     name = "David Smith";
   };
   shnarazk = {
     email = "shujinarazaki@protonmail.com";
     github = "shnarazk";
+    githubId = 997855;
     name = "Narazaki Shuji";
   };
   shou = {
@@ -6912,6 +7007,7 @@
   sjmackenzie = {
     email = "setori88@gmail.com";
     github = "sjmackenzie";
+    githubId = 158321;
     name = "Stewart Mackenzie";
   };
   sjourdois = {
@@ -7045,6 +7141,7 @@
   sprock = {
     email = "rmason@mun.ca";
     github = "sprock";
+    githubId = 6391601;
     name = "Roger Mason";
   };
   spwhitt = {
@@ -7056,6 +7153,7 @@
   srghma = {
     email = "srghma@gmail.com";
     github = "srghma";
+    githubId = 7573215;
     name = "Sergei Khoma";
   };
   srgom = {
@@ -7273,6 +7371,7 @@
   taha = {
     email = "xrcrod@gmail.com";
     github = "tgharib";
+    githubId = 6457015;
     name = "Taha Gharib";
   };
   tailhook = {
@@ -7356,6 +7455,7 @@
   tckmn = {
     email = "andy@tck.mn";
     github = "tckmn";
+    githubId = 2389333;
     name = "Andy Tockman";
   };
   teh = {
@@ -7385,11 +7485,13 @@
   tesq0 = {
     email = "mikolaj.galkowski@gmail.com";
     github = "tesq0";
+    githubId = 26417242;
     name = "Mikolaj Galkowski";
   };
   teto = {
     email = "mcoudron@hotmail.com";
     github = "teto";
+    githubId = 886074;
     name = "Matthieu Coudron";
   };
   tex = {
@@ -7431,6 +7533,7 @@
   the-kenny = {
     email = "moritz@tarn-vedra.de";
     github = "the-kenny";
+    githubId = 31167;
     name = "Moritz Ulrich";
   };
   thedavidmeister = {
@@ -7518,11 +7621,13 @@
   timbertson = {
     email = "tim@gfxmonk.net";
     github = "timbertson";
+    githubId = 14172;
     name = "Tim Cuthbertson";
   };
   timma = {
     email = "kunduru.it.iitb@gmail.com";
     github = "ktrsoft";
+    githubId = 12712927;
     name = "Timma";
   };
   timokau = {
@@ -7574,6 +7679,7 @@
   tnias = {
     email = "phil@grmr.de";
     github = "tnias";
+    githubId = 9853194;
     name = "Philipp Bartsch";
   };
   tobim = {
@@ -7669,6 +7775,7 @@
   tscholak = {
     email = "torsten.scholak@googlemail.com";
     github = "tscholak";
+    githubId = 1568873;
     name = "Torsten Scholak";
   };
   tstrobel = {
@@ -7690,6 +7797,7 @@
   tvestelind = {
     email = "tomas.vestelind@fripost.org";
     github = "tvestelind";
+    githubId = 699403;
     name = "Tomas Vestelind";
   };
   tvorog = {
@@ -7701,11 +7809,13 @@
   tweber = {
     email = "tw+nixpkgs@360vier.de";
     github = "thorstenweber83";
+    githubId = 9413924;
     name = "Thorsten Weber";
   };
   twey = {
     email = "twey@twey.co.uk";
-    github = "twey";
+    github = "Twey";
+    githubId = 101639;
     name = "James ‘Twey’ Kay";
   };
   twhitehead = {
@@ -7769,6 +7879,7 @@
   uwap = {
     email = "me@uwap.name";
     github = "uwap";
+    githubId = 2212422;
     name = "uwap";
   };
   va1entin = {
@@ -7792,6 +7903,7 @@
   valeriangalliat = {
     email = "val@codejam.info";
     github = "valeriangalliat";
+    githubId = 3929133;
     name = "Valérian Galliat";
   };
   valodim = {
@@ -7839,6 +7951,7 @@
   vcanadi = {
     email = "vito.canadi@gmail.com";
     github = "vcanadi";
+    githubId = 8889722;
     name = "Vitomir Čanadi";
   };
   vcunat = {
@@ -7901,6 +8014,7 @@
   viric = {
     email = "viric@viric.name";
     github = "viric";
+    githubId = 66664;
     name = "Lluís Batlle i Rossell";
   };
   virusdave = {
@@ -7912,6 +8026,7 @@
   vizanto = {
     email = "danny@prime.vc";
     github = "vizanto";
+    githubId = 326263;
     name = "Danny Wilson";
   };
   vklquevs = {
@@ -7941,6 +8056,7 @@
   vmchale = {
     email = "tmchale@wisc.edu";
     github = "vmchale";
+    githubId = 13259982;
     name = "Vanessa McHale";
   };
   volhovm = {
@@ -8064,6 +8180,7 @@
   wscott = {
     email = "wsc9tt@gmail.com";
     github = "wscott";
+    githubId = 31487;
     name = "Wayne Scott";
   };
   wucke13 = {
@@ -8117,6 +8234,7 @@
   xnaveira = {
     email = "xnaveira@gmail.com";
     github = "xnaveira";
+    githubId = 2534411;
     name = "Xavier Naveira";
   };
   xnwdd = {
@@ -8158,6 +8276,7 @@
   y0no = {
     email = "y0no@y0no.fr";
     github = "y0no";
+    githubId = 2242427;
     name = "Yoann Ono";
   };
   yarny = {
@@ -8239,6 +8358,7 @@
   yvesf = {
     email = "yvesf+nix@xapek.org";
     github = "yvesf";
+    githubId = 179548;
     name = "Yves Fischer";
   };
   yvt = {
@@ -8268,6 +8388,7 @@
   zalakain = {
     email = "ping@umazalakain.info";
     github = "umazalakain";
+    githubId = 1319905;
     name = "Uma Zalakain";
   };
   zaninime = {
@@ -8428,6 +8549,7 @@
     name  = "Nicholas Gerstle";
     email = "ngerstle@gmail.com";
     github = "ngerstle";
+    githubId = 1023752;
   };
   xavierzwirtz = {
     email = "me@xavierzwirtz.com";


### PR DESCRIPTION
###### Motivation for this change
Since https://github.com/NixOS/nixpkgs/pull/66361 was merged, the maintainers list is accumulating a lot of handles without `githubId`s, or other problems such as misspelled `githubId` (partial fix in #82446) or missing name or email.

(Updated) This PR implements maintainer checks, evaluated by @GrahamcOfBorg once NixOS/ofborg#438 is merged. This guards against all of above problems. For additional convenience (and because it's possible), the error shows the correct `githubId` if it's missing:
```
lib.maintainers.infinisil: If `github` is specified, `githubId` must be too.
The GitHub ID for GitHub user infinisil is 20525370:
    githubId = 20525370;
```

All of the problems were also fixed in an initial commit, which was done by copy pasting directly from the error.

Ping @grahamc, ping @roberth for the module stuff

###### Things done

- [ ] <s>Confirmed that ofborg can catch maintainer list errors</s>