### PR TITLE
afl: Fix afl-qemu build by applying patches for glibc-2.30

### DIFF
--- a/pkgs/tools/security/afl/qemu-patches/syscall-glibc2_30.diff
+++ b/pkgs/tools/security/afl/qemu-patches/syscall-glibc2_30.diff
@@ -1,0 +1,51 @@
+--- qemu-2.10.0-clean/linux-user/syscall.c	2020-03-12 18:47:47.898592169 +0100
++++ qemu-2.10.0/linux-user/syscall.c	2020-03-13 09:13:42.461809699 +0100
+@@ -34,6 +34,7 @@
+ #include <sys/resource.h>
+ #include <sys/swap.h>
+ #include <linux/capability.h>
++#include <linux/sockios.h> // https://lkml.org/lkml/2019/6/3/988
+ #include <sched.h>
+ #include <sys/timex.h>
+ #ifdef __ia64__
+@@ -256,7 +257,9 @@ static type name (type1 arg1,type2 arg2,
+ #endif
+ 
+ #ifdef __NR_gettid
+-_syscall0(int, gettid)
++// taken from https://patchwork.kernel.org/patch/10862231/
++#define __NR_sys_gettid __NR_gettid
++_syscall0(int, sys_gettid)
+ #else
+ /* This is a replacement for the host gettid() and must return a host
+    errno. */
+@@ -6219,7 +6222,7 @@ static void *clone_func(void *arg)
+     cpu = ENV_GET_CPU(env);
+     thread_cpu = cpu;
+     ts = (TaskState *)cpu->opaque;
+-    info->tid = gettid();
++    info->tid = sys_gettid();
+     task_settid(ts);
+     if (info->child_tidptr)
+         put_user_u32(info->tid, info->child_tidptr);
+@@ -6363,9 +6366,9 @@ static int do_fork(CPUArchState *env, un
+                mapping.  We can't repeat the spinlock hack used above because
+                the child process gets its own copy of the lock.  */
+             if (flags & CLONE_CHILD_SETTID)
+-                put_user_u32(gettid(), child_tidptr);
++                put_user_u32(sys_gettid(), child_tidptr);
+             if (flags & CLONE_PARENT_SETTID)
+-                put_user_u32(gettid(), parent_tidptr);
++                put_user_u32(sys_gettid(), parent_tidptr);
+             ts = (TaskState *)cpu->opaque;
+             if (flags & CLONE_SETTLS)
+                 cpu_set_tls (env, newtls);
+@@ -11402,7 +11405,7 @@ abi_long do_syscall(void *cpu_env, int n
+         break;
+ #endif
+     case TARGET_NR_gettid:
+-        ret = get_errno(gettid());
++        ret = get_errno(sys_gettid());
+         break;
+ #ifdef TARGET_NR_readahead
+     case TARGET_NR_readahead:

--- a/pkgs/tools/security/afl/qemu.nix
+++ b/pkgs/tools/security/afl/qemu.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation {
     "../${afl.src.name}/qemu_mode/patches/memfd.diff"
     # nix-specific patches to make installation more well-behaved
     ./qemu-patches/no-etc-install.patch
+    # patch for fixing qemu build on glibc >= 2.30
+    ./qemu-patches/syscall-glibc2_30.diff
   ];
 
   configureFlags =


### PR DESCRIPTION
Backport of #82432 (let's get that one merged first before considering this one).

I've built this with `nix build -f ~/nixpkgs afl` to ensure it builds on release-20.03 as well.

`nix-build ~/nixpkgs -A afl` also works (gives more visible output).

ZHF: #80379
