### PR TITLE
vorbis-tools: bump debian patchseries from -6 to -11.

### DIFF
--- a/pkgs/applications/audio/vorbis-tools/default.nix
+++ b/pkgs/applications/audio/vorbis-tools/default.nix
@@ -3,8 +3,8 @@
 
 let
   debPatch = fetchzip {
-    url = "mirror://debian/pool/main/v/vorbis-tools/vorbis-tools_1.4.0-6.debian.tar.xz";
-    sha256 = "1xmmpdvxyr84lazlg23c6ck5ic97ga2rkiqabb1d98ix2zdzyqz5";
+    url = "mirror://debian/pool/main/v/vorbis-tools/vorbis-tools_1.4.0-11.debian.tar.xz";
+    sha256 = "0kvmd5nslyqplkdb7pnmqj47ir3y5lmaxd12wmrnqh679a8jhcyi";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
###### Motivation for this change

Fixes #57191, CVE-2014-9638, CVE-2014-9639, CVE-2015-6749,
CVE-2017-11331.

Signed-off-by: David Anderson <dave@natulte.net>

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
