### PR TITLE
jquery-ui: patch CVE-2016-7103.

### DIFF
--- a/nixos/lib/testing/jquery-ui.nix
+++ b/nixos/lib/testing/jquery-ui.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, fetchurl, fetchpatch, unzip }:
 
 stdenv.mkDerivation rec {
   name = "jquery-ui-1.11.4";
@@ -7,6 +7,14 @@ stdenv.mkDerivation rec {
     url = "https://jqueryui.com/resources/download/${name}.zip";
     sha256 = "0ciyaj1acg08g8hpzqx6whayq206fvf4whksz2pjgxlv207lqgjh";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/jquery/jquery-ui/pull/1622.patch";
+      sha256 = "0ip563kz6lhwiims5djrxq3mvb7jx9yzkpsqxxhbi9n6qzz7y2az";
+      name = "CVE-2016-7103";
+    })
+  ];
 
   buildInputs = [ unzip ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #57149

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
