### PR TITLE
navi: init 2.1.1

### DIFF
--- a/pkgs/applications/misc/navi/default.nix
+++ b/pkgs/applications/misc/navi/default.nix
@@ -1,0 +1,33 @@
+{ rustPlatform, fetchFromGitHub, stdenv, fzf, makeWrapper, openssl, pkgconfig }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "navi";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "denisidoro";
+    repo = "navi";
+    rev = "v${version}";
+    sha256 = "1195f7c3ij2mkv0k1h9fwn6jkyjb01w0p6mj2xc39w5f6i0c0hwp";
+  };
+
+  cargoSha256 = "0ks25w0dncaiw3ma05r8jrng3cczancrynnpgdksbvgz49lg3wjw";
+
+  postInstall = ''
+    mkdir -p $out/share/navi/
+    mv shell $out/share/navi/
+
+    wrapProgram "$out/bin/navi" \
+      --suffix "PATH" : "${fzf}/bin"
+  '';
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "An interactive cheatsheet tool for the command-line";
+    homepage = "https://github.com/denisidoro/navi";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ mrVanDalo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5240,6 +5240,8 @@ in
 
   nat-traverse = callPackage ../tools/networking/nat-traverse { };
 
+  navi = callPackage ../applications/misc/navi { };
+
   navilu-font = callPackage ../data/fonts/navilu { stdenv = stdenvNoCC; };
 
   nawk = callPackage ../tools/text/nawk { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A nice cheat sheet tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
