### PR TITLE
nixos/home-assistant: fix bug causing config file not to be written (including `http.server_port`) 

### DIFF
--- a/nixos/tests/home-assistant-config.nix
+++ b/nixos/tests/home-assistant-config.nix
@@ -1,0 +1,65 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+let
+  configDir = "/var/lib/hass";
+  configFile = "${configDir}/configuration.yaml";
+  port = 4000;
+
+  mkHass = { machineAttrs ? {}, hassAttrs ? {} }:
+      { pkgs, ... }:
+      {
+        services.home-assistant = {
+          inherit configDir port;
+          enable = true;
+        } // hassAttrs;
+      } // machineAttrs;
+in {
+  name = "home-assistant-config";
+
+  nodes = {
+    hassMinimal = mkHass {};
+
+    hassTimeZone = mkHass {
+      machineAttrs = { time.timeZone = "UTC"; };
+    };
+
+    hassNoDefault = mkHass {
+      hassAttrs = { applyDefaultConfig = false; };
+    };
+  };
+
+  testScript = let
+    portStr = toString port;
+  in ''
+    start_all()
+
+
+    def check_availability(hass):
+        hass.wait_for_unit("home-assistant.service")
+        with subtest("Check that Home Assistant can be reached via port ${portStr}"):
+            hass.wait_for_open_port(${portStr})
+            hass.succeed("curl --fail http://localhost:${portStr}")
+
+
+    check_availability(hassMinimal)
+    with subtest("Check that port is set"):
+        config = hassMinimal.succeed("cat ${configFile}")
+        assert "server_port: ${portStr}" in config
+
+    check_availability(hassTimeZone)
+    with subtest("Check that default_config, port and time_zone are set"):
+        config = hassTimeZone.succeed("cat ${configFile}")
+        assert "server_port: ${portStr}" in config
+        assert "time_zone: UTC" in config
+
+    hassNoDefault.wait_for_unit("home-assistant.service")
+
+    with subtest("Check that server port is not set"):
+        config = hassNoDefault.succeed("cat ${configFile}")
+        assert "server_port: ${portStr}" not in config
+
+    # It cannot be reached because defaults (i.e. http.server_port, frontend) are not set
+    with subtest("Check that Home Assistant cannot be reached via port ${portStr}"):
+        hassNoDefault.wait_for_closed_port(${portStr})
+  '';
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This fixes  #82076 by ensuring that the configuration.yaml file is always (over)written. I think this approach simplifies things a bit, and to me aligns more with what I would assume "default config" means. I'm not sure it's the right way though, since it changes the behaviour of  `applyDefaultConfig`.

It would be great to get some feedback on a few points in particular:

* Would is be better to set `defaultConfig` to a subset of the contents of the default configuration.yaml file plus the port and timezone? For now I just have frontend in there. This might be less of a breaking change but it would mean keeping up to date when home-assistant changes that file. For reference, this is what that file looks like:
    ```
    # Configure a default setup of Home Assistant (frontend, api, etc)
    default_config:

    # Uncomment this if you are using SSL/TLS, running in Docker container, etc.
    # http:
    #   base_url: example.duckdns.org:8123

    # Text to speech
    tts:
      - platform: google_translate

    # These files all start off empty
    group: !include groups.yaml
    automation: !include automations.yaml
    script: !include scripts.yaml
    scene: !include scenes.yaml
    ```
* Tests: I've never written nixos tests before, so I don't know if this is the right approach, or whether this kind of test is necessary. Either way, it was useful to debug the problem.

NOTE: some of the home-assistant tests seem to be failing currently, but this appears to be caused by #82441

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
