### PR TITLE
elastix: build with python3 and enable tests

### DIFF
--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, itk, python }:
+{ stdenv, fetchFromGitHub, cmake, itk, python3 }:
 
 stdenv.mkDerivation rec {
   pname    = "elastix";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "1zrl7rz4lwsx88b2shnl985f3a97lmp4ksbd437h9y0hfjq8l0lj";
   };
-  nativeBuildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python3 ];
   buildInputs = [ itk ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -10,8 +10,15 @@ stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "1zrl7rz4lwsx88b2shnl985f3a97lmp4ksbd437h9y0hfjq8l0lj";
   };
+
   nativeBuildInputs = [ cmake python3 ];
   buildInputs = [ itk ];
+
+  doCheck = true;
+
+  preCheck = "
+    export LD_LIBRARY_PATH=$(pwd)/bin
+  ";
 
   meta = with stdenv.lib; {
     homepage = http://elastix.isi.uu.nl/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
