### PR TITLE
lilypond: fix broken meta.homepage

### DIFF
--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Music typesetting system";
-    homepage = http://lilypond.org/;
+    homepage = "http://lilypond.org/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ marcweber yurrriq ];
     platforms = platforms.all;

--- a/pkgs/misc/lilypond/fonts.nix
+++ b/pkgs/misc/lilypond/fonts.nix
@@ -7,7 +7,6 @@ let
       inherit version;
       pname = "openlilypond-font-${fontName}";
 
-
       src = fetchFromGitHub {
         inherit rev sha256;
         owner = "OpenLilyPondFonts";
@@ -31,8 +30,7 @@ let
       '';
 
       meta = with stdenv.lib; {
-        inherit (src.meta) homepage;
-        inherit (lilypond.meta) platforms;
+        inherit (lilypond.meta) homepage platforms;
         description = "${fontName} font for LilyPond";
         license = licenses.ofl;
         maintainers = with maintainers; [ yurrriq ];


### PR DESCRIPTION
The `src.meta` attribute does not exist, and even if it did the derivation does
not have a `rec` to reference it. This appears to be breaking all ofBorg meta
evaluation checks:

```
while evaluating the attribute 'homepage' at /var/lib/ofborg/checkout/repo/38dca4e3aa6bca43ea96d2fcc04e8229/mr-est/eval-0-gleber.ewr1.nix.ci/pkgs/misc/lilypond/fonts.nix:34:27:
undefined variable 'src' at /var/lib/ofborg/checkout/repo/38dca4e3aa6bca43ea96d2fcc04e8229/mr-est/eval-0-gleber.ewr1.nix.ci/pkgs/misc/lilypond/fonts.nix:34:18
```
https://gist.github.com/GrahamcOfBorg/cd87009bfee1a9c0d4f0d828b82ee09a


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).