### PR TITLE
python3Packages.hickle: 3.4.5 -> 3.4.6

### DIFF
--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -6,20 +6,23 @@
 , astropy
 , scipy
 , pandas
+, codecov
 , pytest
 , pytestcov
 , pytestrunner
 , coveralls
+, twine
+, check-manifest
 , lib
 }:
 
 buildPythonPackage rec {
   pname   = "hickle";
-  version = "3.4.5";
+  version = "3.4.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1d1qj3yl7635lgkqacz9r8fyhv71396l748ww4wy05ibpignjm2x";
+    sha256 = "026r6yg3amsi8k8plzsbw5rnifym6sc17y011daqyvcpb7mfs94b";
   };
 
   postPatch = ''
@@ -28,7 +31,9 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [ h5py numpy dill ];
-  checkInputs = [ pytest pytestcov pytestrunner coveralls scipy pandas astropy ];
+  checkInputs = [
+    pytest pytestcov pytestrunner coveralls scipy pandas astropy twine check-manifest codecov
+  ];
 
   meta = {
     description = "Serialize Python data to HDF5";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
