### PR TITLE
nettools: 1.60_p20170221182432 -> 1.60_p20180626073013

### DIFF
--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "net-tools";
-  version = "1.60_p20170221182432";
+  version = "1.60_p20180626073013";
 
   src = fetchurl {
     url = "mirror://gentoo/distfiles/${pname}-${version}.tar.xz";
-    sha256 = "08r4r2a24g5bm8jwgfa998gs1fld7fgbdf7pilrpsw1m974xn04a";
+    sha256 = "0mzsjjmz5kn676w2glmxwwd8bj0xy9dhhn21aplb435b767045q4";
   };
 
   preBuild =


### PR DESCRIPTION
###### Motivation for this change

Because _p2017... cannot be fetched: 404.

The change is minimal: Adjusting whether usage messages are printed to
stdout or stderr.

It's hard to find stable source links for nettools and we resort to
fetching patched sources out of other distros' tarball caches because
this package is deprecated:
  https://lwn.net/Articles/710533/
  https://lwn.net/Articles/710535/
  https://wiki.linuxfoundation.org/networking/iproute2

The advice is to switch to iproute2, but NixOS activation scripts use
`domainname` from nettools, for which neither iproute2 nor systemd
offers a replacement.  I inquired about this on iproute2's mailing list:
  https://lore.kernel.org/netdev/CAPwpnyTDpkX2hxiqYLxTuMM38cq+whPSC0yoee-YPLEAwfvqpQ@mail.gmail.com/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
    - [x] Tested execution of some binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
