### PR TITLE
gcc: fix building cross-compiler on 32-bit host platforms

### DIFF
--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -245,12 +245,6 @@ stdenv.mkDerivation ({
 
   inherit (stdenv) is64bit;
 
-  # In this particular combination it stopped creating lib output at all.
-  # TODO: perhaps find a better fix?  (ideally understand what's going on)
-  postFixup = if crossStageStatic && targetPlatform.isMusl && targetPlatform.is32bit
-    then ''mkdir "$lib"''
-    else null;
-
   meta = {
     homepage = https://gcc.gnu.org/;
     license = stdenv.lib.licenses.gpl3Plus;  # runtime support libraries are typically LGPLv3+

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -201,11 +201,11 @@ postConfigure() {
 
 
 preInstall() {
+    mkdir -p "$out/${targetConfig}/lib"
+    mkdir -p "$lib/${targetConfig}/lib"
     # Make ‘lib64’ symlinks to ‘lib’.
     if [ -n "$is64bit" -a -z "$enableMultilib" ]; then
-        mkdir -p "$out/${targetConfig}/lib"
         ln -s lib "$out/${targetConfig}/lib64"
-        mkdir -p "$lib/${targetConfig}/lib"
         ln -s lib "$lib/${targetConfig}/lib64"
     fi
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes building cross-compiler on 32-bit host platforms, which was broken by #81844.

Some quirk/bug of `moveToOutput` seems to sometimes prevent it from creating the output if it does not already exist. Therefore we need to manually create the output. On 64-bit host platforms, the output gets created here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/gcc/builder.sh#L208. Note that the `is64bit` variable refers to the host platform, although it would probably make more sense for it to refer to the target platform. This is why this bug does not occur for 32-bit ARM cross-compilers.

I'm not sure why #81844 triggered the problem with `moveToOutput`, as that function's code is hard for me to understand: https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/multiple-outputs.sh#L93

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @matthewbauer @misuzu 