### PR TITLE
rust_1_38, rust_1_42: drop patch version from attr

### DIFF
--- a/pkgs/development/compilers/rust/1_38.nix
+++ b/pkgs/development/compilers/rust/1_38.nix
@@ -18,5 +18,5 @@ import ./default.nix {
     x86_64-apple-darwin = "b2310c97ffb964f253c4088c8d29865f876a49da2a45305493af5b5c7a3ca73d";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_38_0;
+  selectRustPackage = pkgs: pkgs.rust_1_38;
 }

--- a/pkgs/development/compilers/rust/1_42.nix
+++ b/pkgs/development/compilers/rust/1_42.nix
@@ -34,7 +34,7 @@ import ./default.nix {
     x86_64-apple-darwin = "b6504003ab70b11f278e0243a43ba9d6bf75e8ad6819b4058a2b6e3991cc8d7a";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_42_0;
+  selectRustPackage = pkgs: pkgs.rust_1_42;
 
   rustcPatches = [
     ./0001-Allow-getting-no_std-from-the-config-file.patch

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -385,6 +385,8 @@ mapAliases ({
   ruby_2_5_0 = throw "deprecated 2018-0213: use a newer version of ruby";
   rubyPackages_2_4 = throw "deprecated 2019-12: use a newer version of rubyPackages instead";
   rubygems = throw "deprecated 2016-03-02: rubygems is now bundled with ruby";
+  rust_1_38_0 = rust_1_38; # added 2020-03-13
+  rust_1_42_0 = rust_1_42; # added 2020-03-13
   rxvt_unicode-with-plugins = rxvt-unicode; # added 2020-02-02
   rxvt_unicode = rxvt-unicode-unwrapped; # added 2020-02-02
   urxvt_autocomplete_all_the_things = rxvt-unicode-plugins.autocomplete-all-the-things; # added 2020-02-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8825,17 +8825,17 @@ in
     inherit (darwin) apple_sdk;
   };
 
-  rust_1_42_0 = callPackage ../development/compilers/rust/1_42_0.nix {
+  rust_1_42 = callPackage ../development/compilers/rust/1_42.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
-  rust_1_38_0 = callPackage ../development/compilers/rust/1_38_0.nix {
+  rust_1_38 = callPackage ../development/compilers/rust/1_38.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
-  rust = rust_1_42_0;
+  rust = rust_1_42;
 
-  rustPackages_1_42_0 = rust_1_42_0.packages.stable;
-  rustPackages_1_38_0 = rust_1_38_0.packages.stable;
-  rustPackages = rustPackages_1_42_0;
+  rustPackages_1_42 = rust_1_42.packages.stable;
+  rustPackages_1_38 = rust_1_38.packages.stable;
+  rustPackages = rustPackages_1_42;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;
   inherit (rust) makeRustPlatform;
@@ -8918,7 +8918,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
   rustracerd = callPackage ../development/tools/rust/racerd {
-    inherit (rustPackages_1_38_0) rustPlatform;
+    inherit (rustPackages_1_38) rustPlatform;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
   rust-bindgen = callPackage ../development/tools/rust/bindgen { };
@@ -21905,7 +21905,7 @@ in
 
   thunderbird = callPackage ../applications/networking/mailreaders/thunderbird {
     inherit (gnome2) libIDL;
-    inherit (rustPackages_1_38_0) cargo rustc;
+    inherit (rustPackages_1_38) cargo rustc;
     libpng = libpng_apng;
     gtk3Support = true;
   };


### PR DESCRIPTION
(targeting staging to avoid conflicts with the rust upgrade)

I find it extremely unlikely we'll ever package two different patch
versions of the same minor Rust version.  New patch versions should
generally be compatible, so we shouldn't give people the expectation
they'll be able to pin to one.  And by including the patch version in
the attribute name, we'd have to change the attribute every time a
patch version was released, which would unnecessarily create diff
noise and maintenance headaches for what should be a seamless upgrade.