### PR TITLE
[20.03] ocamlPackages_latest.phylogenetics: dune2/fix meta

### DIFF
--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, buildDunePackage, fetchFromGitHub, ppx_deriving
+{ stdenv, buildDune2Package, fetchFromGitHub, ppx_deriving
 , alcotest, biocaml, gnuplot, lacaml, menhir, owl }:
 
-buildDunePackage rec {
+buildDune2Package rec {
   pname = "phylogenetics";
   version = "unstable-2019-11-15";
 
@@ -20,7 +20,7 @@ buildDunePackage rec {
   doCheck = false;  # many tests require bppsuite
 
   meta = with stdenv.lib; {
-    inherit (std.meta) homepage;
+    inherit (src.meta) homepage;
     description = "Bioinformatics library for Ocaml";
     maintainers = [ maintainers.bcdarwin ];
     license = licenses.cecill-b;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix eval for 20.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/nixos-release-managers @vbgl @bcdarwin 