### PR TITLE
varnishPackages.*: restore after accidental removal

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -2,7 +2,7 @@
 , python3, makeWrapper }:
 
 let
-  common = { version, sha256, extraNativeBuildInputs ? [] }:
+  common = { version, sha256 }:
     stdenv.mkDerivation rec {
       pname = "varnish";
       inherit version;
@@ -30,12 +30,15 @@ let
 
       outputs = [ "out" "dev" "man" ];
 
+      doCheck = true;
+
       meta = with stdenv.lib; {
         description = "Web application accelerator also known as a caching HTTP reverse proxy";
         homepage = https://www.varnish-cache.org;
         license = licenses.bsd2;
         maintainers = with maintainers; [ fpletz ];
         platforms = platforms.unix;
+        broken = versionAtLeast version "6.2"; # tests crash with core dump
       };
     };
 in

--- a/pkgs/servers/varnish/digest.nix
+++ b/pkgs/servers/varnish/digest.nix
@@ -1,15 +1,29 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, libmhash, docutils }:
 
-stdenv.mkDerivation rec {
-  version = "1.0.2";
-  name = "${varnish.name}-digest-${version}";
+stdenv.mkDerivation {
+  pname = "${varnish.name}-digest";
+  version = "2019-09-27";
 
-  src = fetchFromGitHub {
-    owner = "varnish";
-    repo = "libvmod-digest";
-    rev = "libvmod-digest-${version}";
-    sha256 = "0jwkqqalydn0pwfdhirl5zjhbc3hldvhh09hxrahibr72fgmgpbx";
-  };
+  src = {
+    "6.0.5" = fetchFromGitHub {
+      owner = "varnish";
+      repo = "libvmod-digest";
+      rev = "2b7f74b8897765372f2c7d7c760229bd8740fea2";  # https://github.com/varnish/libvmod-digest/commits/6.0
+      sha256 = "1zpnj7wrhn3qia2jfzawb0kz0ryk2hxmky44dd12pz0yww04ig96";
+    };
+    "6.2.2" = fetchFromGitHub {
+      owner = "varnish";
+      repo = "libvmod-digest";
+      rev = "2b7f74b8897765372f2c7d7c760229bd8740fea2";  # https://github.com/varnish/libvmod-digest/commits/6.2
+      sha256 = "1zpnj7wrhn3qia2jfzawb0kz0ryk2hxmky44dd12pz0yww04ig96";
+    };
+    "6.3.1" = fetchFromGitHub {
+      owner = "varnish";
+      repo = "libvmod-digest";
+      rev = "1793bea9e9b7c7dce4d8df82397d22ab9fa296f0";  # https://github.com/varnish/libvmod-digest/commits/6.3
+      sha256 = "0n33g8ml4bsyvcvl5lk7yng1ikvmcv8dd6bc1mv2lj4729pp97nn";
+    };
+  }.${varnish.version};
 
   nativeBuildInputs = [ autoreconfHook pkgconfig docutils ];
   buildInputs = [ varnish libmhash ];
@@ -21,7 +35,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "VMOD_DIR=$(out)/lib/varnish/vmods" ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ];
+  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
   doCheck = true;
 
@@ -29,5 +43,6 @@ stdenv.mkDerivation rec {
     description = "Digest and HMAC vmod";
     homepage = https://github.com/varnish/libvmod-digest;
     inherit (varnish.meta) license platforms maintainers;
+    broken = versionAtLeast varnish.version "6.2"; # tests crash with core dump
   };
 }

--- a/pkgs/servers/varnish/digest.nix
+++ b/pkgs/servers/varnish/digest.nix
@@ -43,6 +43,5 @@ stdenv.mkDerivation {
     description = "Digest and HMAC vmod";
     homepage = https://github.com/varnish/libvmod-digest;
     inherit (varnish.meta) license platforms maintainers;
-    broken = versionAtLeast varnish.version "6.2"; # tests crash with core dump
   };
 }

--- a/pkgs/servers/varnish/dynamic.nix
+++ b/pkgs/servers/varnish/dynamic.nix
@@ -38,6 +38,5 @@ stdenv.mkDerivation {
     description = "Dynamic director similar to the DNS director from Varnish 3";
     homepage = https://github.com/nigoroll/libvmod-dynamic;
     inherit (varnish.meta) license platforms maintainers;
-    broken = versionAtLeast varnish.version "6.2"; # tests crash with core dump
   };
 }

--- a/pkgs/servers/varnish/dynamic.nix
+++ b/pkgs/servers/varnish/dynamic.nix
@@ -1,15 +1,29 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, docutils }:
 
-stdenv.mkDerivation rec {
-  version = "0.4";
-  name = "${varnish.name}-dynamic-${version}";
+stdenv.mkDerivation {
+  pname = "${varnish.name}-dynamic";
+  version = "2019-10-10";
 
-  src = fetchFromGitHub {
-    owner = "nigoroll";
-    repo = "libvmod-dynamic";
-    rev = "v${version}";
-    sha256 = "1n94slrm6vn3hpymfkla03gw9603jajclg84bjhwb8kxsk3rxpmk";
-  };
+  src = {
+    "6.0.5" = fetchFromGitHub {
+      owner = "nigoroll";
+      repo = "libvmod-dynamic";
+      rev = "b72c723acff5b2ef46c9de8cef036cee3a380a64"; # https://github.com/nigoroll/libvmod-dynamic/commits/6.0
+      sha256 = "0gknnyfv0srf1gagl887mk0ibmj1aj96d6yyq27p2wylwckzqymi";
+    };
+    "6.2.2" = fetchFromGitHub {
+      owner = "nigoroll";
+      repo = "libvmod-dynamic";
+      rev = "4070f9f3f114630630e1a99c2bb9007856a31f39"; # https://github.com/nigoroll/libvmod-dynamic/commits/6.2
+      sha256 = "0m01hyjy80n4xzpjlzvmk8nw8bzj3cdraiirkz7klanpjgj7i74f";
+    };
+    "6.3.1" = fetchFromGitHub {
+      owner = "nigoroll";
+      repo = "libvmod-dynamic";
+      rev = "71820eb7f91ad7e87755d02e522893a9e12dd55b"; # https://github.com/nigoroll/libvmod-dynamic/commits/master
+      sha256 = "1i2d77qzrfcax9l39b1cmk809ksly22p43x51ij8pgl55674lffy";
+    };
+  }.${varnish.version};
 
   nativeBuildInputs = [ pkgconfig docutils autoreconfHook varnish.python ];
   buildInputs = [ varnish ];
@@ -18,9 +32,12 @@ stdenv.mkDerivation rec {
   '';
   configureFlags = [ "VMOD_DIR=$(out)/lib/varnish/vmods" ];
 
+  doCheck = true;
+
   meta = with stdenv.lib; {
     description = "Dynamic director similar to the DNS director from Varnish 3";
     homepage = https://github.com/nigoroll/libvmod-dynamic;
     inherit (varnish.meta) license platforms maintainers;
+    broken = versionAtLeast varnish.version "6.2"; # tests crash with core dump
   };
 }

--- a/pkgs/servers/varnish/geoip2.nix
+++ b/pkgs/servers/varnish/geoip2.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, libmaxminddb, docutils }:
+
+stdenv.mkDerivation {
+  pname = "${varnish.name}-geoip2";
+  version = "2020-03-11";
+
+  src = fetchFromGitHub {
+    owner = "fgsch";
+    repo = "libvmod-geoip2";
+    rev = "c96a72bb1d403b361610befa015b29c6eeadce10";
+    sha256 = "0727n5h6prngigpiykrrzpw94j64dh45b9vydnb9wvafm1g13ds4";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace autogen.sh  --replace "''${dataroot}/aclocal"         "${varnish.dev}/share/aclocal"
+    substituteInPlace Makefile.am --replace "''${VARNISH_DATAROOT}/aclocal" "${varnish.dev}/share/aclocal"
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig docutils ];
+  buildInputs = [ varnish libmaxminddb ];
+  configureFlags = [ "VMOD_DIR=$(out)/lib/varnish/vmods" ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "A Varnish master VMOD to query MaxMind GeoIP2 DB files";
+    homepage = https://github.com/fgsch/libvmod-geoip2;
+    inherit (varnish.meta) license platforms maintainers;
+    broken = versionAtLeast varnish.version "6.2"; # tests crash with core dump
+  };
+}

--- a/pkgs/servers/varnish/geoip2.nix
+++ b/pkgs/servers/varnish/geoip2.nix
@@ -27,6 +27,5 @@ stdenv.mkDerivation {
     description = "A Varnish master VMOD to query MaxMind GeoIP2 DB files";
     homepage = https://github.com/fgsch/libvmod-geoip2;
     inherit (varnish.meta) license platforms maintainers;
-    broken = versionAtLeast varnish.version "6.2"; # tests crash with core dump
   };
 }

--- a/pkgs/servers/varnish/modules.nix
+++ b/pkgs/servers/varnish/modules.nix
@@ -1,15 +1,29 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, docutils, removeReferencesTo }:
 
-stdenv.mkDerivation rec {
-  version = "0.15.0";
-  name = "${varnish.name}-modules-${version}";
+stdenv.mkDerivation {
+  pname = "${varnish.name}-modules";
+  version = "2020-03-03";
 
-  src = fetchFromGitHub {
-    owner = "varnish";
-    repo = "varnish-modules";
-    rev = version;
-    sha256 = "00p9syl765lfg1d2ka7da6h46dfl388f8h36x9cmrjix95rg0yr8";
-  };
+  src = {
+    "6.0.5" = fetchFromGitHub {
+      owner = "varnish";
+      repo = "varnish-modules";
+      rev = "0d555b627333cd9190a40870f380ace5664f6d0d"; # https://github.com/varnish/varnish-modules/commits/6.0
+      sha256 = "1lwgjhgr5yw0d17kbqwlaj5pkn70wvaqqjpa1i0n459nx5cf5pqj";
+    };
+    "6.2.2" = fetchFromGitHub {
+      owner = "varnish";
+      repo = "varnish-modules";
+      rev = "3608d1ec11793de1bc94492b4a2d1b8d48a6ca98"; # https://github.com/varnish/varnish-modules/commits/6.2
+      sha256 = "0b6vvx3sfm5rd38dn32pxbzdvx2nvjsr61fywz1qbx25y3q5mczh";
+    };
+    "6.3.1" = fetchFromGitHub {
+      owner = "varnish";
+      repo = "varnish-modules";
+      rev = "0f695f4c485029c77cb4d22b97d2bde32f5c8d3d"; # https://github.com/varnish/varnish-modules/commits/6.3
+      sha256 = "0s6ylfsifvk6dq6vvnbfy14jvz8lnfynlsxi8lgixls3j2h7rnmw";
+    };
+  }.${varnish.version};
 
   nativeBuildInputs = [
     autoreconfHook
@@ -28,9 +42,12 @@ stdenv.mkDerivation rec {
 
   postInstall = "find $out -type f -exec remove-references-to -t ${varnish.dev} '{}' +"; # varnish.dev captured only as __FILE__ in assert messages
 
+  doCheck = true;
+
   meta = with stdenv.lib; {
     description = "Collection of Varnish Cache modules (vmods) by Varnish Software";
     homepage = https://github.com/varnish/varnish-modules;
     inherit (varnish.meta) license platforms maintainers;
+    broken = versionAtLeast varnish.version "6.2"; # tests crash with core dump
   };
 }

--- a/pkgs/servers/varnish/modules.nix
+++ b/pkgs/servers/varnish/modules.nix
@@ -48,6 +48,5 @@ stdenv.mkDerivation {
     description = "Collection of Varnish Cache modules (vmods) by Varnish Software";
     homepage = https://github.com/varnish/varnish-modules;
     inherit (varnish.meta) license platforms maintainers;
-    broken = versionAtLeast varnish.version "6.2"; # tests crash with core dump
   };
 }

--- a/pkgs/servers/varnish/packages.nix
+++ b/pkgs/servers/varnish/packages.nix
@@ -5,11 +5,21 @@
     varnish = varnish60;
     digest  = callPackage ./digest.nix   { varnish = varnish60; };
     dynamic = callPackage ./dynamic.nix  { varnish = varnish60; };
+    modules = callPackage ./modules.nix  { varnish = varnish60; };
+    geoip2  = callPackage ./geoip2.nix   { varnish = varnish60; };
   };
   varnish62Packages = {
     varnish = varnish62;
+    digest  = callPackage ./digest.nix   { varnish = varnish62; };
+    dynamic = callPackage ./dynamic.nix  { varnish = varnish62; };
+    modules = callPackage ./modules.nix  { varnish = varnish62; };
+    geoip2  = callPackage ./geoip2.nix   { varnish = varnish62; };
   };
   varnish63Packages = {
     varnish = varnish63;
+    digest  = callPackage ./digest.nix   { varnish = varnish63; };
+    dynamic = callPackage ./dynamic.nix  { varnish = varnish63; };
+    modules = callPackage ./modules.nix  { varnish = varnish63; };
+    geoip2  = callPackage ./geoip2.nix   { varnish = varnish63; };
   };
 }


### PR DESCRIPTION
Restore `varnishPackages.modules` and `varnishPackages.geoip` which have been accidentally removed together with old versions of Varnish (https://github.com/NixOS/nixpkgs/commit/fbb11656255aaf4d7e34d0bcaff56dec276709b8)

Fixes: https://github.com/NixOS/nixpkgs/issues/81524