### PR TITLE
nix-generate-from-cpan: remove "unkown" license and improve core module detection

### DIFF
--- a/maintainers/scripts/nix-generate-from-cpan.pl
+++ b/maintainers/scripts/nix-generate-from-cpan.pl
@@ -6,6 +6,7 @@ use warnings;
 
 use CPAN::Meta();
 use CPANPLUS::Backend();
+use Module::CoreList;
 use Getopt::Long::Descriptive qw( describe_options );
 use JSON::PP qw( encode_json );
 use Log::Log4perl qw(:easy);
@@ -278,14 +279,8 @@ sub get_deps {
     foreach my $n ( $deps->required_modules ) {
         next if $n eq "perl";
 
-        # Figure out whether the module is a core module by attempting
-        # to `use` the module in a pure Perl interpreter and checking
-        # whether it succeeded. Note, $^X is a magic variable holding
-        # the path to the running Perl interpreter.
-        if ( system("env -i $^X -M$n -e1 >/dev/null 2>&1") == 0 ) {
-            DEBUG("skipping Perl-builtin module $n");
-            next;
-        }
+        my @core = Module::CoreList->find_modules(qr/^$n$/);
+        next if (@core);
 
         my $pkg = module_to_pkg( $cb, $n );
 

--- a/maintainers/scripts/nix-generate-from-cpan.pl
+++ b/maintainers/scripts/nix-generate-from-cpan.pl
@@ -164,7 +164,7 @@ Readonly::Hash my %LICENSE_MAP => (
 
     # License not provided in metadata.
     unknown => {
-        licenses => [qw( unknown )],
+        licenses => [],
         amb      => 1
     }
 );


### PR DESCRIPTION
###### Motivation for this change
Fixed a couple small annoyances with nix-generate-from-cpan script. Removed the "unknown" license from package meta and improved core module detection.

###### Things done
* Remove license meta if license is not provided. Leave the warning in place. This is consistent with cpan2nix (https://github.com/volth/cpan2nix) used for generating top-level Perl packages.
* Use Module::CoreList to detect and filter core modules. Prevents false negatives that were happening with previous method.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
