### PR TITLE
prusa-slicer: 2.1.1 -> 2.2.0

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -1,32 +1,34 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, cmake, pkgconfig
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig
 , boost, cereal, curl, eigen, expat, glew, libpng, tbb, wxGTK31
 , gtest, nlopt, xorg, makeDesktopItem
+, cgal_5, gmp, ilmbase, mpfr, qhull, openvdb, systemd
 }:
-let
-  nloptVersion = if lib.hasAttr "version" nlopt
-                 then lib.getAttr "version" nlopt
-                 else "2.4";
-in
 stdenv.mkDerivation rec {
   pname = "prusa-slicer";
-  version = "2.1.1";
+  version = "2.2.0";
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
     cmake
-    makeWrapper
     pkgconfig
   ];
 
   buildInputs = [
     boost
     cereal
+    cgal_5
     curl
     eigen
     expat
     glew
+    gmp
+    ilmbase
     libpng
+    mpfr
+    nlopt
+    openvdb
+    systemd
     tbb
     wxGTK31
     xorg.libX11
@@ -35,31 +37,34 @@ stdenv.mkDerivation rec {
   checkInputs = [ gtest ];
 
   # The build system uses custom logic - defined in
-  # xs/src/libnest2d/cmake_modules/FindNLopt.cmake in the package source -
-  # for finding the nlopt library, which doesn't pick up the package in the nix store.
-  # We need to set the path via the NLOPT environment variable instead.
+  # cmake/modules/FindNLopt.cmake in the package source - for finding the nlopt
+  # library, which doesn't pick up the package in the nix store.  We
+  # additionally need to set the path via the NLOPT environment variable.
   NLOPT = nlopt;
 
-  # Disable compiler warnings that clutter the build log
+  # Disable compiler warnings that clutter the build log.
   # It seems to be a known issue for Eigen:
   # http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
   NIX_CFLAGS_COMPILE = "-Wno-ignored-attributes";
+
+  # prusa-slicer uses dlopen on `libudev.so` at runtime
+  NIX_LDFLAGS = "-ludev";
 
   prePatch = ''
     # In nix ioctls.h isn't available from the standard kernel-headers package
     # like in other distributions. The copy in glibc seems to be identical to the
     # one in the kernel though, so we use that one instead.
     sed -i 's|"/usr/include/asm-generic/ioctls.h"|<asm-generic/ioctls.h>|g' src/libslic3r/GCodeSender.cpp
-  '' + lib.optionalString (lib.versionOlder "2.5" nloptVersion) ''
+
     # Since version 2.5.0 of nlopt we need to link to libnlopt, as libnlopt_cxx
     # now seems to be integrated into the main lib.
-    sed -i 's|nlopt_cxx|nlopt|g' src/libnest2d/cmake_modules/FindNLopt.cmake
+    sed -i 's|nlopt_cxx|nlopt|g' cmake/modules/FindNLopt.cmake
   '';
 
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "PrusaSlicer";
-    sha256 = "0i393nbc2salb4j5l2hvy03ng7hmf90d2xj653pw9bsikhj0r3jd";
+    sha256 = "0954k9sm09y8qnz1jyswyysg10k54ywz8mswnwa4n2hnpq9qx73m";
     rev = "version_${version}";
   };
 
@@ -88,6 +93,6 @@ stdenv.mkDerivation rec {
     description = "G-code generator for 3D printer";
     homepage = https://github.com/prusa3d/PrusaSlicer;
     license = licenses.agpl3;
-    maintainers = with maintainers; [ tweber ];
+    maintainers = with maintainers; [ moredread tweber ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to latest version, `2.2.0`. Several new dependencies and a bit of cleanup.

cc @mweinelt @ArdaXi @baracoder @thorstenweber83 as you were interested in the previous PRs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
