### PR TITLE
aucatctl: init at 0.1

### DIFF
--- a/pkgs/applications/audio/aucatctl/default.nix
+++ b/pkgs/applications/audio/aucatctl/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, sndio, libbsd }:
+
+stdenv.mkDerivation rec {
+  pname = "aucatctl";
+  version = "0.1";
+  src = fetchurl {
+    url = "http://www.sndio.org/${pname}-${version}.tar.gz";
+    sha256 = "524f2fae47db785234f166551520d9605b9a27551ca438bd807e3509ce246cf0";
+  };
+
+  buildInputs = [ sndio ] ++ stdenv.lib.optionals stdenv.isLinux [ libbsd ];
+
+  outputs = [ "out" "man" ];
+
+  prePatch = stdenv.lib.optionalString stdenv.isLinux ''
+    # Required patching to build on Linux.
+    substituteInPlace Makefile \
+      --replace '-lsndio' '-lsndio -lbsd' \
+      --replace '/usr/local' '${placeholder "out"}'
+
+    # Fix warning about implicit declaration of function 'strlcpy'
+    substituteInPlace aucatctl.c \
+      --replace '#include <string.h>' '#include <bsd/string.h>'
+  '';
+
+  postInstall = ''
+    moveToOutput share/man $man
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The aucatctl utility sends MIDI messages to control sndiod and/or aucat volumes";
+    homepage = http://www.sndio.org;
+    license = licenses.isc;
+    maintainers = with maintainers; [ sna ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/audio/aucatctl/default.nix
+++ b/pkgs/applications/audio/aucatctl/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ sndio ]
-    ++ stdenv.lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isBSD)
+    ++ stdenv.lib.optional (!stdenv.isDarwin && !stdenv.targetPlatform.isBSD)
     libbsd;
 
   outputs = [ "out" "man" ];
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   preBuild = ''
     makeFlagsArray+=("PREFIX=$out")
   '' + stdenv.lib.optionalString
-    (!stdenv.isDarwin && !stdenv.hostPlatform.isBSD) ''
+    (!stdenv.isDarwin && !stdenv.targetPlatform.isBSD) ''
       makeFlagsArray+=(LDADD="-lsndio -lbsd")
 
       # Fix warning about implicit declaration of function 'strlcpy'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18343,6 +18343,8 @@ in
 
   astroid = callPackage ../applications/networking/mailreaders/astroid { };
 
+  aucatctl = callPackage ../applications/audio/aucatctl { };
+
   audacious = callPackage ../applications/audio/audacious { };
   audaciousQt5 = libsForQt5.callPackage ../applications/audio/audacious/qt-5.nix { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Allows those who use sndiod to adjust the volume of audio programs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
