### PR TITLE
Python: patch interpreter to handle NIX_PYTHONHOME

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.7/0001-Process-NIX_PYTHONHOME-before-venv-is-processed.patch
+++ b/pkgs/development/interpreters/python/cpython/3.7/0001-Process-NIX_PYTHONHOME-before-venv-is-processed.patch
@@ -1,0 +1,42 @@
+From b56a60dd058f86d765259bfb6cb52b4bcab3ca4f Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Sat, 14 Mar 2020 13:42:47 +0100
+Subject: [PATCH] Process NIX_PYTHONHOME before venv is processed
+
+---
+ Lib/site.py | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/Lib/site.py b/Lib/site.py
+index e981a14208..adc02bd023 100644
+--- a/Lib/site.py
++++ b/Lib/site.py
+@@ -462,6 +462,17 @@ def enablerlcompleter():
+ 
+     sys.__interactivehook__ = register_readline
+ 
++
++def nixenv(known_paths):
++    global PREFIXES
++    prefix = os.environ.pop("NIX_PYTHONHOME", None)
++    if prefix and not os.environ.get("PYTHONHOME", None):
++        sys.prefix = sys.exec_prefix = prefix
++        addsitepackages(known_paths, [sys.prefix])
++        PREFIXES = [sys.prefix]
++    return known_paths
++
++
+ def venv(known_paths):
+     global PREFIXES, ENABLE_USER_SITE
+ 
+@@ -569,6 +580,7 @@ def main():
+         # fix __file__ and __cached__ of already imported modules too.
+         abs_paths()
+ 
++    known_paths = nixenv(known_paths)
+     known_paths = venv(known_paths)
+     if ENABLE_USER_SITE is None:
+         ENABLE_USER_SITE = check_enableusersite()
+-- 
+2.25.1
+

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -29,6 +29,7 @@
 , rebuildBytecode ? true
 , stripBytecode ? false
 , includeSiteCustomize ? true
+, includeNixEnvPatch ? true
 }:
 
 assert x11Support -> tcl != null
@@ -121,7 +122,11 @@ in with passthru; stdenv.mkDerivation {
           sha256 = "1h18lnpx539h5lfxyk379dxwr8m2raigcjixkf133l4xy3f4bzi2";
         }
     )
-  ];
+  ] ++ optionals includeNixEnvPatch [
+    (./. + "/${sourceVersion.major}.${sourceVersion.minor}/0001-Process-NIX_PYTHONHOME-before-venv-is-processed.patch")
+  ]
+  
+  ;
 
   postPatch = ''
   '' + optionalString (x11Support && (tix != null)) ''

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -148,6 +148,7 @@ in {
     rebuildBytecode = false;
     stripBytecode = true;
     includeSiteCustomize = false;
+    includeNixEnvPatch = false;
   }).overrideAttrs(old: {
     pname = "python3-minimal";
     meta = old.meta // {

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -30,7 +30,7 @@ let
     # Python 2 does not support venv
     # TODO: PyPy executable name is incorrect, it should be pypy-c or pypy-3c instead of pypy and pypy3.
     plain-venv = rec {
-      env = runCommand "${python.name}-venv" {} ''
+      env = runCommand "${python.name}-plain-venv" {} ''
         ${python.interpreter} -m venv $out
       '';
       interpreter = "${env}/bin/${python.executable}";
@@ -41,14 +41,14 @@ let
     # Venv built using Python Nix environment (python.buildEnv)
     # TODO: Cannot create venv from a  nix env
     # Error: Command '['/nix/store/ddc8nqx73pda86ibvhzdmvdsqmwnbjf7-python3-3.7.6-venv/bin/python3.7', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1.
-    # nixenv-venv = rec {
-    #   env = runCommand "${python.name}-venv" {} ''
-    #     ${pythonEnv.interpreter} -m venv $out
-    #   '';
-    #   interpreter = "${env}/bin/${pythonEnv.executable}";
-    #   is_venv = "True";
-    #   is_nixenv = "True";
-    # };
+    nixenv-venv = rec {
+      env = runCommand "${python.name}-nixenv-venv" {} ''
+        ${pythonEnv.interpreter} -m venv $out
+      '';
+      interpreter = "${env}/bin/${pythonEnv.executable}";
+      is_venv = "True";
+      is_nixenv = "True";
+    };
   };
 
   # All PyPy package builds are broken at the moment

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -37,7 +37,7 @@ let
             if [ -f "$prg" ]; then
               rm -f "$out/bin/$prg"
               if [ -x "$prg" ]; then
-                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set NIX_PYTHONPREFIX "$out" --set NIX_PYTHONEXECUTABLE ${pythonExecutable} --set NIX_PYTHONPATH ${pythonPath} ${if permitUserSite then "" else ''--set PYTHONNOUSERSITE "true"''} ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
+                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set NIX_PYTHONHOME "$out" ${if permitUserSite then "" else ''--set PYTHONNOUSERSITE "true"''} ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
               fi
             fi
           done


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Still need to test...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
