### PR TITLE
ocamlPackages.parmap: 1.1 → 1.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/parmap/default.nix
+++ b/pkgs/development/ocaml-modules/parmap/default.nix
@@ -1,12 +1,12 @@
-{ lib, buildDunePackage, fetchzip }:
+{ lib, buildDunePackage, fetchurl }:
 
 buildDunePackage rec {
   pname = "parmap";
-  version = "1.1";
+  version = "1.1.1";
 
-  src = fetchzip {
+  src = fetchurl {
     url = "https://github.com/rdicosmo/${pname}/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "13ahqaga1palf0s0dll512cl7k43sllmwvw6r03y70kfmky1j114";
+    sha256 = "1pci7b1jqxkgmrbhr0p5j98i4van5nfmmb3sak8cyvxhwgna93j4";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Fix build with OCaml ≥ 4.09

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
