### PR TITLE
caprice32: 4.5.0 -> 4.6.0

### DIFF
--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpng SDL freetype zlib ];
 
   makeFlags = [
-    "APP_PATH=${placeholder ''out''}/share/caprice32/"
+    "APP_PATH=${placeholder "out"}/share/caprice32"
     "RELEASE=1"
-    "DESTDIR=${placeholder ''out''}"
+    "DESTDIR=${placeholder "out"}"
     "prefix=/"
   ];
 

--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -3,27 +3,31 @@
 stdenv.mkDerivation rec {
 
   pname = "caprice32";
-  version = "4.5.0";
+  version = "4.6.0";
 
   src = fetchFromGitHub {
     repo = "caprice32";
     rev = "v${version}";
     owner = "ColinPitrat";
-    sha256 = "056vrf5yq1574g93ix8hnjqqbdqza3qcjv0f8rvpsslqcbizma9y";
+    sha256 = "0hng5krwgc1h9bz1xlkp2hwnvas965nd7sb3z9mb2m6x9ghxlacz";
   };
 
-  postPatch = "substituteInPlace cap32.cfg --replace /usr/local $out";
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libpng SDL freetype zlib ];
 
-  #fix GIT_HASH avoid depend on git 
-  makeFlags = [ "GIT_HASH=${src.rev}" "DESTDIR=$(out)" "prefix=/"];
+  makeFlags = [
+    "APP_PATH=${placeholder ''out''}/share/caprice32/"
+    "RELEASE=1"
+    #"WITH_IPF=0"
+    "DESTDIR=${placeholder ''out''}"
+    "prefix=/"
+  ];
 
   meta = with stdenv.lib; {
     description = "A complete emulation of CPC464, CPC664 and CPC6128";
-    homepage = https://github.com/ColinPitrat/caprice32 ;
+    homepage = "https://github.com/ColinPitrat/caprice32";
     license = licenses.gpl2;
     maintainers = [ maintainers.genesis ];
     platforms = platforms.linux;
-  };  
+  };
 }

--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, libpng, pkgconfig, SDL, freetype, zlib }:
+{ stdenv, fetchFromGitHub, desktop-file-utils, libpng
+, pkgconfig, SDL, freetype, zlib }:
 
 stdenv.mkDerivation rec {
 
@@ -12,16 +13,29 @@ stdenv.mkDerivation rec {
     sha256 = "0hng5krwgc1h9bz1xlkp2hwnvas965nd7sb3z9mb2m6x9ghxlacz";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ desktop-file-utils pkgconfig ];
   buildInputs = [ libpng SDL freetype zlib ];
 
   makeFlags = [
     "APP_PATH=${placeholder ''out''}/share/caprice32/"
     "RELEASE=1"
-    #"WITH_IPF=0"
     "DESTDIR=${placeholder ''out''}"
     "prefix=/"
   ];
+
+  postInstall = ''
+    mkdir -p $out/share/icons/
+    mv $out/share/caprice32/resources/freedesktop/caprice32.png $out/share/icons/
+    mv $out/share/caprice32/resources/freedesktop/emulators.png $out/share/icons/
+
+    desktop-file-install --dir $out/share/applications \
+      $out/share/caprice32/resources/freedesktop/caprice32.desktop
+
+    desktop-file-install --dir $out/share/desktop-directories \
+      $out/share/caprice32/resources/freedesktop/Emulators.directory
+
+    install -Dm644 $out/share/caprice32/resources/freedesktop/caprice32.menu -t $out/etc/xdg/menus/applications-merged/
+  '';
 
   meta = with stdenv.lib; {
     description = "A complete emulation of CPC464, CPC664 and CPC6128";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
