### PR TITLE
openblas: disable optimisation pending fix

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/0001-Disable-optimised-aarch64-dgemm_beta-pending-fix.patch
+++ b/pkgs/development/libraries/science/math/openblas/0001-Disable-optimised-aarch64-dgemm_beta-pending-fix.patch
@@ -1,0 +1,26 @@
+From 6cb9aa7c69c20a677ca9fb1bc5fa1580e3236fbd Mon Sep 17 00:00:00 2001
+From: Tom Hall <tahall256@protonmail.ch>
+Date: Sat, 14 Mar 2020 11:55:45 +0000
+Subject: [PATCH] Disable optimised aarch64 dgemm_beta pending fix
+
+Identified as source of https://github.com/xianyi/OpenBLAS/issues/2496,
+but not yet fixed.
+---
+ kernel/arm64/KERNEL.ARMV8 | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/kernel/arm64/KERNEL.ARMV8 b/kernel/arm64/KERNEL.ARMV8
+index fe32d313..33d12f94 100644
+--- a/kernel/arm64/KERNEL.ARMV8
++++ b/kernel/arm64/KERNEL.ARMV8
+@@ -102,7 +102,6 @@ CDOTKERNEL     = zdot.S
+ ZDOTKERNEL     = zdot.S
+ DSDOTKERNEL    = dot.S
+ 
+-DGEMM_BETA     = dgemm_beta.S
+ SGEMM_BETA     = sgemm_beta.S
+ 
+ SGEMMKERNEL    =  sgemm_kernel_$(SGEMM_UNROLL_M)x$(SGEMM_UNROLL_N).S
+-- 
+2.24.1
+

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -123,6 +123,12 @@ stdenv.mkDerivation rec {
     buildPackages.stdenv.cc
   ];
 
+  # Disable an optimisation which seems to cause issues, pending an
+  # upstream fix: https://github.com/xianyi/OpenBLAS/issues/2496
+  patches = stdenv.lib.optionals stdenv.hostPlatform.isAarch64 [
+    ./0001-Disable-optimised-aarch64-dgemm_beta-pending-fix.patch
+  ];
+
   makeFlags = mkMakeFlagsFromConfig (config // {
     FC = "${stdenv.cc.targetPrefix}gfortran";
     CC = "${stdenv.cc.targetPrefix}${if stdenv.cc.isClang then "clang" else "cc"}";


### PR DESCRIPTION
See https://github.com/xianyi/OpenBLAS/issues/2496

###### Motivation for this change
R is broken (test failure) on aarch64, due to a bug in OpenBLAS (Other packages may also be broken, they just don't have tests that show the breakage). The bug seems to be in code optimised for a specific platform, so reverting to the generic C implementation seems sensible until an upstream fix is available.

ZHF #80379 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
