### PR TITLE
pythonPackages.ffmpeg-normalize: init at 1.15.7

### DIFF
--- a/pkgs/applications/video/ffmpeg-normalize/default.nix
+++ b/pkgs/applications/video/ffmpeg-normalize/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, ffmpeg
+, tqdm
+}:
+
+buildPythonApplication rec {
+  pname = "ffmpeg-normalize";
+  version = "1.15.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0161939f864e973b11d50170c657baf3e1433147f46c74a74ed5025a822e9a2d";
+  };
+
+  propagatedBuildInputs = [ ffmpeg tqdm ];
+
+  checkPhase = ''
+    $out/bin/ffmpeg-normalize --help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "Normalize audio via ffmpeg";
+    homepage = "https://github.com/slhck/ffmpeg-normalize";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11449,6 +11449,8 @@ in
 
   ffmpeg-sixel = callPackage ../development/libraries/ffmpeg-sixel { };
 
+  ffmpeg-normalize = python3Packages.callPackage ../applications/video/ffmpeg-normalize { };
+
   ffms = callPackage ../development/libraries/ffms { };
 
   fftw = callPackage ../development/libraries/fftw { };


### PR DESCRIPTION
###### Motivation for this change

New Python module for normalizing audio via ffmpeg

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
