### PR TITLE
miniserve: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/tools/misc/miniserve/default.nix
+++ b/pkgs/tools/misc/miniserve/default.nix
@@ -1,26 +1,26 @@
-{ stdenv, rustPlatform, fetchFromGitHub, cmake, pkgconfig, zlib, openssl }:
+{ stdenv, rustPlatform, fetchFromGitHub, cmake, pkg-config, zlib, openssl }:
 
 rustPlatform.buildRustPackage rec {
   pname = "miniserve";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner  = "svenstaro";
     repo   = "miniserve";
     rev    = "v${version}";
-    sha256 = "06cxkkf3sf84prba65dymr1hg7mwizmsax0dlljh0lcmvlcpzi08";
+    sha256 = "0ybxnxjg0vqm4q60z4zjl3hfls0s2rvy44m6jgyhlj1p6cr3dbyw";
   };
 
-  cargoSha256 = "1v4rvk6h78797wshw3m0qabb7g4i4mbj1vs5d41izgb0swnzk4vy";
+  cargoSha256 = "0ypxv9wqcnjxjdrvdparddpssrarnifr43dq7kcr4l3fd1anl40a";
 
   RUSTC_BOOTSTRAP = 1;
 
-  nativeBuildInputs = [ cmake pkgconfig zlib ];
+  nativeBuildInputs = [ cmake pkg-config zlib ];
   buildInputs = [ openssl ];
 
   meta = with stdenv.lib; {
     description = "For when you really just want to serve some files over HTTP right now!";
-    homepage    = https://github.com/svenstaro/miniserve;
+    homepage    = "https://github.com/svenstaro/miniserve";
     license     = with licenses; [ mit ];
     maintainers = with maintainers; [ nequissimus ];
     platforms   = platforms.linux;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[CHANGELOG](https://github.com/svenstaro/miniserve/blob/master/CHANGELOG.md#060---2020-03-14)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
