### PR TITLE
emacs: improve setup hook

### DIFF
--- a/pkgs/build-support/emacs/setup-hook.sh
+++ b/pkgs/build-support/emacs/setup-hook.sh
@@ -1,13 +1,25 @@
 addEmacsVars () {
-  if test -d $1/share/emacs/site-lisp; then
-      # it turns out, that the trailing : is actually required
+  for lispDir in \
+      "$1/share/emacs/site-lisp" \
+      "$1/share/emacs/site-lisp/"* \
+      "$1/share/emacs/site-lisp/elpa/"*; do
+    # Add the path to the Emacs load path if it is a directory
+    # containing .el files and it has not already been added to the
+    # load path.
+    if [[ -d $lispDir && "$(echo "$lispDir"/*.el)" && ${EMACSLOADPATH-} != *"$lispDir":* ]] ; then
+      # It turns out, that the trailing : is actually required
       # see https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Search.html
-      export EMACSLOADPATH="$1/share/emacs/site-lisp:${EMACSLOADPATH-}"
-  fi
+      export EMACSLOADPATH="$lispDir:${EMACSLOADPATH-}"
+    fi
+  done
 }
 
-# If this is for a wrapper derivation, emacs and the dependencies are all
-# run-time dependencies. If this is for precompiling packages into bytecode,
-# emacs is a compile-time dependency of the package.
-addEnvHooks "$hostOffset" addEmacsVars
-addEnvHooks "$targetOffset" addEmacsVars
+if [[ ! -v emacsHookDone ]]; then
+  emacsHookDone=1
+
+  # If this is for a wrapper derivation, emacs and the dependencies are all
+  # run-time dependencies. If this is for precompiling packages into bytecode,
+  # emacs is a compile-time dependency of the package.
+  addEnvHooks "$hostOffset" addEmacsVars
+  addEnvHooks "$targetOffset" addEmacsVars
+fi


### PR DESCRIPTION
- Add packages installed in a sub-directory of site-lisp, such as mu4e, to EMACSLOADPATH.

- Add ELPA packages to EMACSLOADPATH.

- Add each package only once to EMACSLOADPATH. Before, each package would typically be added twice for each transitive dependency leading to a huge variable for a package having many dependencies.

The load path problem with can be observed by running, e.g.,

```shell
nix-build --pure -E 'with import ./. {}; emacsWithPackages (epkgs: [(epkgs.trivialBuild {pname="foo";version="0";src=writeText "foo.el" "(require '"'"'ivy)";packageRequires=[epkgs.ivy];})])'
```

in a Nixpkgs clone with and without this patch applied.

Fixed #78680