### PR TITLE
rPackages.rhdf5: fix installation for v1.4.3

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -312,7 +312,7 @@ let
     Rglpk = [ pkgs.glpk ];
     RGtk2 = [ pkgs.gtk2.dev ];
     rhdf5 = [ pkgs.zlib ];
-    Rhdf5lib = [ pkgs.zlib ];
+    Rhdf5lib = [ pkgs.zlib.dev ];
     Rhpc = [ pkgs.zlib pkgs.bzip2.dev pkgs.icu pkgs.lzma.dev pkgs.openmpi pkgs.pcre.dev ];
     Rhtslib = [ pkgs.zlib.dev pkgs.automake pkgs.autoconf ];
     rjags = [ pkgs.jags ];

--- a/pkgs/development/r-modules/patches/Rhdf5lib.patch
+++ b/pkgs/development/r-modules/patches/Rhdf5lib.patch
@@ -1,12 +1,13 @@
 diff --git a/configure b/configure
-index e2d292e..b13c0db 100755
+index 8eed99e..e4d0f02 100755
 --- a/configure
 +++ b/configure
-@@ -2880,6 +2880,7 @@ $MAKE
+@@ -3964,6 +3964,8 @@ echo ${ZLIB_HOME}
+ 
  echo "building the hdf5 library...";
  cd ../;
- ## we add the '-w' flag to suppress all the warnings hdf5 prints
 +sed -i 's#/bin/mv#mv#' configure
++ 
  ./configure --with-pic --enable-shared=no --enable-cxx \
-     --with-szlib \
-     CXX="${CXX}" CXFLAGS="${CXXFLAGS} -w" \
+     --with-szlib=${SZIP_DIR}/szip --with-zlib=${ZLIB_HOME} \
+     CXX="${CXX}" CXXFLAGS="${CXXFLAGS} ${CXXPICFLAGS}" \


### PR DESCRIPTION
#81975 #### Motivation for this change
Rhdf5lib doesn't install. Fails due to configuration failure

###### Things done
switch zlib to zlib.dev
updated patch which broke when the underlying configure file changed upstream
tested installation using nix-env
tested in rstudio. library rhd5 now loads

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
