### PR TITLE
unison: fix build with ocamlPackages_4_09

### DIFF
--- a/pkgs/applications/networking/sync/unison/4.08-compatibility.patch
+++ b/pkgs/applications/networking/sync/unison/4.08-compatibility.patch
@@ -1,0 +1,52 @@
+From 29fa058c3127f3b47c347dcaa4a94f4c0e888308 Mon Sep 17 00:00:00 2001
+From: Jaap Boender <jaapb@kerguelen.org>
+Date: Thu, 21 Mar 2019 12:26:51 +0000
+Subject: [PATCH] Compatibility with OCaml 4.08
+
+---
+ src/files.ml                 | 2 +-
+ src/recon.ml                 | 4 ++--
+ src/system/system_generic.ml | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/files.ml b/src/files.ml
+index ba42ad57..5babf21e 100644
+--- a/src/files.ml
++++ b/src/files.ml
+@@ -722,7 +722,7 @@ let get_files_in_directory dir =
+   with End_of_file ->
+     dirh.System.closedir ()
+   end;
+-  Sort.list (<) !files
++  List.sort String.compare !files
+ 
+ let ls dir pattern =
+   Util.convertUnixErrorsToTransient
+diff --git a/src/recon.ml b/src/recon.ml
+index 5ed358d7..0df2cfe4 100644
+--- a/src/recon.ml
++++ b/src/recon.ml
+@@ -651,8 +651,8 @@ let rec reconcile
+ 
+ (* Sorts the paths so that they will be displayed in order                   *)
+ let sortPaths pathUpdatesList =
+-  Sort.list
+-    (fun (p1, _) (p2, _) -> Path.compare p1 p2 <= 0)
++  List.sort
++    Path.compare
+     pathUpdatesList
+ 
+ let rec enterPath p1 p2 t =
+diff --git a/src/system/system_generic.ml b/src/system/system_generic.ml
+index ed8e18f3..0e28a781 100755
+--- a/src/system/system_generic.ml
++++ b/src/system/system_generic.ml
+@@ -47,7 +47,7 @@ let open_out_gen = open_out_gen
+ let chmod = Unix.chmod
+ let chown = Unix.chown
+ let utimes = Unix.utimes
+-let link = Unix.link
++let link s d = Unix.link s d
+ let openfile = Unix.openfile
+ let opendir f =
+   let h = Unix.opendir f in

--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -27,6 +27,12 @@ stdenv.mkDerivation (rec {
     "UISTYLE=${if enableX11 then "gtk2" else "text"}"
   ] ++ stdenv.lib.optional (!ocaml.nativeCompilers) "NATIVE=false";
 
+  patches = [
+    # NOTE: Only needed until Unison 2.51.3 is released!
+    ./4.08-compatibility.patch
+    ./lablgtk.patch
+  ];
+
   preInstall = "mkdir -p $out/bin";
 
   postInstall = if enableX11 then ''

--- a/pkgs/applications/networking/sync/unison/lablgtk.patch
+++ b/pkgs/applications/networking/sync/unison/lablgtk.patch
@@ -1,0 +1,31 @@
+From 2e7ea9481c6c3ff2ec513c39f73cfe15c0763c06 Mon Sep 17 00:00:00 2001
+From: daviddavid <geiger.david68210@gmail.com>
+Date: Mon, 26 Feb 2018 13:36:36 +0100
+Subject: [PATCH] Fix for lablgtk >= 2.18.6
+
+---
+ src/uigtk2.ml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/uigtk2.ml b/src/uigtk2.ml
+index 2ba6d79..04c4da4 100644
+--- a/src/uigtk2.ml
++++ b/src/uigtk2.ml
+@@ -89,12 +89,12 @@ let fontItalic = lazy (Pango.Font.from_string "italic")
+ (* This does not work with the current version of Lablgtk, due to a bug
+ let icon =
+   GdkPixbuf.from_data ~width:48 ~height:48 ~has_alpha:true
+-    (Gpointer.region_of_string Pixmaps.icon_data)
++    (Gpointer.region_of_bytes Pixmaps.icon_data)
+ *)
+ let icon =
+   let p = GdkPixbuf.create ~width:48 ~height:48 ~has_alpha:true () in
+   Gpointer.blit
+-    (Gpointer.region_of_string Pixmaps.icon_data) (GdkPixbuf.get_pixels p);
++    (Gpointer.region_of_bytes Pixmaps.icon_data) (GdkPixbuf.get_pixels p);
+   p
+ 
+ let leftPtrWatch =
+-- 
+2.25.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22044,7 +22044,6 @@ in
 
   unison = callPackage ../applications/networking/sync/unison {
     enableX11 = config.unison.enableX11 or true;
-    ocamlPackages = ocaml-ng.ocamlPackages_4_09;
   };
 
   unpaper = callPackage ../tools/graphics/unpaper { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22044,7 +22044,7 @@ in
 
   unison = callPackage ../applications/networking/sync/unison {
     enableX11 = config.unison.enableX11 or true;
-    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+    ocamlPackages = ocaml-ng.ocamlPackages_4_09;
   };
 
   unpaper = callPackage ../tools/graphics/unpaper { };


### PR DESCRIPTION
###### Motivation for this change
Fixes #61867 and #61505, bumps the ocaml version unison is built
against to 4.09. The patches included here appear in the trunk version
of unison, but were not backported to 2.51.2.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
