### PR TITLE
opentx: 2.2.1 -> 2.3.5, fix build

### DIFF
--- a/pkgs/applications/misc/opentx/default.nix
+++ b/pkgs/applications/misc/opentx/default.nix
@@ -1,50 +1,38 @@
-{ stdenv, fetchFromGitHub
-, cmake, gcc-arm-embedded, binutils-arm-embedded, python
-, qt5, SDL, gtest
+{ stdenv, mkDerivation, fetchFromGitHub
+, cmake, gcc-arm-embedded, python3Packages
+, qtbase, qtmultimedia, qttranslations, SDL, gtest
 , dfu-util, avrdude
 }:
 
-let
-
-  version = "2.2.1";
-
-in stdenv.mkDerivation {
-
+mkDerivation rec {
   pname = "opentx";
-  inherit version;
+  version = "2.3.5";
 
   src = fetchFromGitHub {
     owner = "opentx";
     repo = "opentx";
     rev = version;
-    sha256 = "01lnnkrxach21aivnx1k1iqhih02nixh8c4nk6rpw408p13him9g";
+    sha256 = "18iv3c74y9fpp1045s2l7l2dqfn9riyagrwmfwp2mmf2ccsrwz2g";
   };
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [
-    cmake
-    gcc-arm-embedded binutils-arm-embedded
-  ];
+  nativeBuildInputs = [ cmake gcc-arm-embedded python3Packages.pillow ];
 
-  buildInputs = with qt5; [
-    python python.pkgs.pyqt4
-    qtbase qtmultimedia qttranslations
-    SDL
-  ];
+  buildInputs = [ qtbase qtmultimedia qttranslations SDL ];
 
   postPatch = ''
-    sed -i companion/src/burnconfigdialog.cpp -e 's|/usr/.*bin/dfu-util|${dfu-util}/bin/dfu-util|'
-    sed -i companion/src/burnconfigdialog.cpp -e 's|/usr/.*bin/avrdude|${avrdude}/bin/avrdude|'
+    sed -i companion/src/burnconfigdialog.cpp \
+      -e 's|/usr/.*bin/dfu-util|${dfu-util}/bin/dfu-util|' \
+      -e 's|/usr/.*bin/avrdude|${avrdude}/bin/avrdude|'
   '';
 
   cmakeFlags = [
     "-DGTEST_ROOT=${gtest.src}/googletest"
-    "-DQT_TRANSLATIONS_DIR=${qt5.qttranslations}/translations"
+    "-DQT_TRANSLATIONS_DIR=${qttranslations}/translations"
     # XXX I would prefer to include these here, though we will need to file a bug upstream to get that changed.
     #"-DDFU_UTIL_PATH=${dfu-util}/bin/dfu-util"
     #"-DAVRDUDE_PATH=${avrdude}/bin/avrdude"
-    "-DNANO=NO"
   ];
 
   meta = with stdenv.lib; {
@@ -54,11 +42,10 @@ in stdenv.mkDerivation {
       firmware to the radio, backing up model settings, editing settings and
       running radio simulators.
     '';
-    homepage = https://open-tx.org/;
-    license = stdenv.lib.licenses.gpl2;
-    platforms = [ "i686-linux" "x86_64-linux" ];
-    maintainers = with maintainers; [ elitak ];
-    broken = true;
+    homepage = "https://www.open-tx.org/";
+    license = licenses.gpl2;
+    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ elitak lopsided98 ];
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20930,10 +20930,7 @@ in
 
   opentimestamps-client = python3Packages.callPackage ../tools/misc/opentimestamps-client {};
 
-  opentx = callPackage ../applications/misc/opentx {
-    gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
-    binutils-arm-embedded = pkgsCross.arm-embedded.buildPackages.binutils;
-  };
+  opentx = libsForQt5.callPackage ../applications/misc/opentx { };
 
   opera = callPackage ../applications/networking/browsers/opera {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates opentx to the latest version. I switched to using `gcc-arm-embedded` instead of the Nix built cross-compiler because another part of the code wanted to use `newlib_nano`, and it could not be easily disabled. In general, I have found that Nix's `arm-embedded` platform is usually unusable because of issues like this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @elitak 