### PR TITLE
nixos/dysnomia: explain what dysnomia is.

### DIFF
--- a/nixos/modules/services/misc/dysnomia.nix
+++ b/nixos/modules/services/misc/dysnomia.nix
@@ -74,7 +74,7 @@ in
       enable = mkOption {
         type = types.bool;
         default = false;
-        description = "Whether to enable Dysnomia";
+        description = "Whether to enable Dysnomia, a tool for managing mutable components, primarily in combination with Disnix";
       };
 
       enableAuthentication = mkOption {


### PR DESCRIPTION
Currently this module appears in the NixOS options list
with no explanation of what it is. Multiple programs called
dysnomia exist, so this is an attempt to clarify which one
this is meant to be.

Signed-off-by: David Anderson <dave@natulte.net>