### PR TITLE
mixx: Build with libshout 2.4.1

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitHub, chromaprint
+{ stdenv, mkDerivation, fetchurl, fetchFromGitHub, chromaprint
 , fftw, flac, faad2, glibcLocales, mp4v2
 , libid3tag, libmad, libopus, libshout, libsndfile, libusb1, libvorbis
 , libGLU, libxcb, lilv, lv2, opusfile
@@ -6,6 +6,17 @@
 , qtx11extras, rubberband, scons, sqlite, taglib, upower, vamp-plugin-sdk
 }:
 
+let
+  # Because libshout 2.4.2 and newer seem to break streaming in mixxx, build it
+  # with 2.4.1 instead.
+  libshout241 = libshout.overrideAttrs (o: rec {
+    name = "libshout-2.4.1";
+    src = fetchurl {
+      url = "http://downloads.xiph.org/releases/libshout/${name}.tar.gz";
+      sha256 = "0kgjpf8jkgyclw11nilxi8vyjk4s8878x23qyxnvybbgqbgbib7k";
+    };
+  });
+in
 mkDerivation rec {
   pname = "mixxx";
   version = "2.2.3";
@@ -18,7 +29,7 @@ mkDerivation rec {
   };
 
   buildInputs = [
-    chromaprint fftw flac faad2 glibcLocales mp4v2 libid3tag libmad libopus libshout libsndfile
+    chromaprint fftw flac faad2 glibcLocales mp4v2 libid3tag libmad libopus libshout241 libsndfile
     libusb1 libvorbis libxcb libGLU lilv lv2 opusfile pkgconfig portaudio portmidi protobuf qtbase qtscript qtsvg
     qtx11extras rubberband scons sqlite taglib upower vamp-plugin-sdk
   ];


### PR DESCRIPTION
Because libshout 2.4.2 and newer seem to break streaming in mixxx, build
it with 2.4.1 instead.

This actually fixes the problem.

###### Motivation for this change

DJing without streaming is just half the fun, especially in times of Corona.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Should probably be backported to the stable channel 19.09