### PR TITLE
nixos/iio: explain why you might want IIO sensor support.

### DIFF
--- a/nixos/modules/hardware/sensor/iio.nix
+++ b/nixos/modules/hardware/sensor/iio.nix
@@ -12,7 +12,8 @@ with lib;
           Enable this option to support IIO sensors.
 
           IIO sensors are used for orientation and ambient light
-          sensors on some mobile devices.'';
+          sensors on some mobile devices.
+        '';
         type = types.bool;
         default = false;
       };

--- a/nixos/modules/hardware/sensor/iio.nix
+++ b/nixos/modules/hardware/sensor/iio.nix
@@ -8,7 +8,11 @@ with lib;
   options = {
     hardware.sensor.iio = {
       enable = mkOption {
-        description = "Enable this option to support IIO sensors.";
+        description = ''
+          Enable this option to support IIO sensors.
+
+          IIO sensors are used for orientation and ambient light
+          sensors on some mobile devices.'';
         type = types.bool;
         default = false;
       };


### PR DESCRIPTION
###### Motivation for this change

The option doesn't explain what IIO sensors are, or why you might want them. Googling mostly shows results about the "Linux Industrial I/O subsystem", and it takes a bit of digging to discover that some mobile devices use IIO sensors for orientation and illumination, and that the iio proxy that this option enables is meant to relay such events to the rest of userspace for things like automatic screen rotation.

###### Things done

Documentation-only change.