### PR TITLE
kicad-unstable-small: init to build kicad-unstable's base on hydra

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -2,7 +2,6 @@
 , libX11, gettext, glew, glm, cairo, curl, openssl, boost, pkgconfig
 , doxygen, pcre, libpthreadstubs, libXdmcp, fetchpatch, lndir, callPackages
 
-, pname ? "kicad"
 , stable ? true
 , baseName ? "kicad"
 , versions ? { }
@@ -20,26 +19,26 @@ with lib;
 let
 
   versionConfig = versions.${baseName};
-  baseVersion = "${versions.${baseName}.kicadVersion.version}";
 
   # oce on aarch64 fails a test
   withOCE = oceSupport && !stdenv.isAarch64;
   withOCC = (withOCCT && !withOCE) || (oceSupport && stdenv.isAarch64);
 
-  kicad-libraries = callPackages ./libraries.nix versionConfig.libVersion;
+  libraries = callPackages ./libraries.nix versionConfig.libVersion;
 
 in
 stdenv.mkDerivation rec {
 
-  inherit pname;
-  version = "base-${baseVersion}";
+  i18n = libraries.i18n;
+
+  pname = "kicad-base";
+  version = "${versions.${baseName}.kicadVersion.version}";
 
   src = fetchFromGitLab (
     {
       group = "kicad";
       owner = "code";
       repo = "kicad";
-      rev = baseVersion;
     } // versionConfig.kicadVersion.src
   );
 
@@ -113,7 +112,7 @@ stdenv.mkDerivation rec {
 
   postInstall = optional (withI18n) ''
     mkdir -p $out/share
-    lndir ${kicad-libraries.i18n}/share $out/share
+    lndir ${i18n}/share $out/share
   '';
 
   meta = {

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -56,9 +56,11 @@ stdenv.mkDerivation rec {
   # tagged releases don't have "unknown"
   # kicad nightlies use git describe --dirty
   # nix removes .git, so its approximated here
+  # "-1" appended to indicate we're adding a patch
   postPatch = ''
     substituteInPlace CMakeModules/KiCadVersion.cmake \
-      --replace "unknown" ${builtins.substring 0 10 src.rev}
+      --replace "unknown" "${builtins.substring 0 10 src.rev}-1" \
+      --replace "${version}" "${version}-1"
   '';
 
   makeFlags = optional (debug) [ "CFLAGS+=-Og" "CFLAGS+=-ggdb" ];
@@ -123,7 +125,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.kicad-pcb.org/";
     license = licenses.agpl3;
-    maintainers = with maintainers; [ evils kiwi berce ];
-    platforms = with platforms; linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -35,16 +35,15 @@ let
   python = python3;
   wxPython = python3Packages.wxPython_4_0;
 
-  libraries = callPackages ./libraries.nix versionConfig.libVersion;
+in
+stdenv.mkDerivation rec {
+
+  passthru.libraries = callPackages ./libraries.nix versionConfig.libVersion;
   base = callPackage ./base.nix {
-    pname = baseName;
     inherit versions stable baseName;
     inherit wxGTK python wxPython;
     inherit debug withI18n withOCCT oceSupport ngspiceSupport scriptingSupport;
   };
-
-in
-stdenv.mkDerivation rec {
 
   inherit pname;
   version = versions.${baseName}.kicadVersion.version;
@@ -63,7 +62,7 @@ stdenv.mkDerivation rec {
 
   # wrapGAppsHook added the equivalent to ${base}/share
   # though i noticed no difference without it
-  makeWrapperArgs = [
+  makeWrapperArgs = with passthru.libraries; [
     "--prefix XDG_DATA_DIRS : ${base}/share"
     "--prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share"
     "--prefix XDG_DATA_DIRS : ${gnome3.defaultIconTheme}/share"
@@ -73,13 +72,13 @@ stdenv.mkDerivation rec {
     "--prefix XDG_DATA_DIRS : ${cups}/share"
     "--prefix GIO_EXTRA_MODULES : ${gnome3.dconf}/lib/gio/modules"
 
-    "--set KISYSMOD ${libraries.footprints}/share/kicad/modules"
-    "--set KICAD_SYMBOL_DIR ${libraries.symbols}/share/kicad/library"
-    "--set KICAD_TEMPLATE_DIR ${libraries.templates}/share/kicad/template"
-    "--prefix KICAD_TEMPLATE_DIR : ${libraries.symbols}/share/kicad/template"
-    "--prefix KICAD_TEMPLATE_DIR : ${libraries.footprints}/share/kicad/template"
+    "--set KISYSMOD ${footprints}/share/kicad/modules"
+    "--set KICAD_SYMBOL_DIR ${symbols}/share/kicad/library"
+    "--set KICAD_TEMPLATE_DIR ${templates}/share/kicad/template"
+    "--prefix KICAD_TEMPLATE_DIR : ${symbols}/share/kicad/template"
+    "--prefix KICAD_TEMPLATE_DIR : ${footprints}/share/kicad/template"
   ]
-  ++ optionals (with3d) [ "--set KISYS3DMOD ${libraries.packages3d}/share/kicad/modules/packages3d" ]
+  ++ optionals (with3d) [ "--set KISYS3DMOD ${packages3d}/share/kicad/modules/packages3d" ]
   ++ optionals (ngspiceSupport) [ "--prefix LD_LIBRARY_PATH : ${libngspice}/lib" ]
 
   # infinisil's workaround for #39493

--- a/pkgs/applications/science/electronics/kicad/libraries.nix
+++ b/pkgs/applications/science/electronics/kicad/libraries.nix
@@ -13,21 +13,27 @@
 with lib;
 let
   mkLib = name:
-    stdenv.mkDerivation
-      {
-        pname = "kicad-${name}";
-        version = "${version}";
-        src = fetchFromGitHub (
-          {
-            owner = "KiCad";
-            repo = "kicad-${name}";
-            rev = version;
-            inherit name;
-          } // (libSources.${name} or { })
-        );
-        nativeBuildInputs = [ cmake ];
-        meta.license = licenses.cc-by-sa-40;
+    stdenv.mkDerivation {
+      pname = "kicad-${name}";
+      version = "${version}";
+      src = fetchFromGitHub (
+        {
+          owner = "KiCad";
+          repo = "kicad-${name}";
+          rev = version;
+          inherit name;
+        } // (libSources.${name} or { })
+      );
+      nativeBuildInputs = [ cmake ];
+
+      meta = rec {
+        license = licenses.cc-by-sa-40;
+        platforms = stdenv.lib.platforms.all;
+        # the 3d models are a ~1 GiB download and occupy ~5 GiB in store.
+        # this would exceed the hydra output limit
+        hydraPlatforms = if (name == "packages3d" ) then [ ] else platforms;
       };
+    };
 in
 {
   symbols = mkLib "symbols";
@@ -56,6 +62,9 @@ in
       );
       buildInputs = [ gettext ];
       nativeBuildInputs = [ cmake ];
-      meta.license = licenses.gpl2; # https://github.com/KiCad/kicad-i18n/issues/3
+      meta = {
+        license = licenses.gpl2; # https://github.com/KiCad/kicad-i18n/issues/3
+        platforms = stdenv.lib.platforms.all;
+      };
     };
 }

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,25 +27,25 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2020-04-25";
+      version =			"2020-05-06";
       src = {
-        rev =			"3759799d1e03b2da6a0dcd72273e4978880fc8f1";
-        sha256 =		"0ba14fla8m5zli68wfjkfc4ymvj4j8z92y3jigxs8hys0450bybi";
+        rev =			"c92181621e2e51dc8aae1bd9f4483bb3301ffaa5";
+        sha256 =		"0s50xn5gbjy7yxnp9yiynxvxi2mkcrp6yghgdzclpm40rnfyi0v5";
       };
     };
     libVersion = {
-      version =			"2020-04-25";
+      version =			"2020-05-06";
       libSources = {
-        i18n.rev =		"fc14baa52ca56a58b0048ab860bf31887d3cf8eb";
-        i18n.sha256 =		"05nayab7dkjyq7g3i9q7k55hcckpc0cmq4bbklmxx16rx4rbhzc6";
-        symbols.rev =		"0f9ff2d17237f90bb649bf0a52b6d454f68197e8";
-        symbols.sha256 =	"1a54428syn2xksc00n2bvh1alrx2vrqmp7cg7d2rn8nlq8yk4qd5";
+        i18n.rev =		"f29cab831eb823165fa2c5efab5d9c9b443e62e2";
+        i18n.sha256 =		"0cc0zvpml75yxphay3281f762ls08fzvv538cd5hmkr8xqlj3vbi";
+        symbols.rev =		"d4245ae8cf633095a0994ab01492bd56cd124112";
+        symbols.sha256 =	"11pynjgji3skw42q5mryz98f8z418k43jy6s2k90w6jv638z3cb0";
         templates.rev =		"7db8d4d0ea0711f1961d117853547fb3edbc3857";
         templates.sha256 =	"1hppcsrkn4dk6ggby6ckh0q65qxkywrbyxa4lwpaf7pxjyv498xg";
-        footprints.rev =	"61df6d8853b4c68cca0ac87784c0a33cff9394d3";
-        footprints.sha256 =	"0blmhk8pwd4mi6rlsr4lf4lq7j01h6xbpbvr3pm8pmw8zylhi54v";
-        packages3d.rev =	"88bcf2e817fe000bb2c05e14489afc3b1a4e10ed";
-        packages3d.sha256 =	"0z9p1fn5xbz940kr5jz2ibzf09hpdi1c9izmabkffvrnfy6408x6";
+        footprints.rev =	"3bff23ee339bc48490bb39deba5d8b2f1f42733e";
+        footprints.sha256 =	"0430r8k49ib6w1sjr8fx42szbz960yhlzg4w80jl5bwasq67nqwd";
+        packages3d.rev =	"889a3dd550233ec51baed4a04a01d4cc64a8d747";
+        packages3d.sha256 =	"152zv4j51v8skqlvrabblpcqpbn5yf3grisjj8vnwf7kdd41chb2";
       };
     };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24894,9 +24894,16 @@ in
 
   fped = callPackage ../applications/science/electronics/fped { };
 
+  # this is a wrapper for kicad.base and kicad.libraries
   kicad = callPackage ../applications/science/electronics/kicad { };
   kicad-small = kicad.override { pname = "kicad-small"; with3d = false; };
-  kicad-unstable = kicad.override { pname = "kicad-unstable"; debug = true; };
+  kicad-unstable = kicad.override { pname = "kicad-unstable"; stable = false; };
+  # mostly here so the kicad-unstable components (except packages3d) get built
+  kicad-unstable-small = kicad.override {
+    pname = "kicad-unstable-small";
+    stable = false;
+    with3d = false;
+  };
 
   librepcb = libsForQt5.callPackage ../applications/science/electronics/librepcb { };
 


### PR DESCRIPTION
###### Motivation for this change
`kicad-unstable` does not get built by hydra

###### Things done

* add `kicad-unstable-small` so the components of `kicad-unstable` that hydra can build, get build
* make the CLI utilities available by linking to them them in the wrapper
* move `libraries` and `base` out of the `let` block so they can be addressed directly
* bump kicad-unstable to latest versions

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).