### PR TITLE
bitwig-studio3: 3.1.2 -> 3.1.3

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -1,17 +1,16 @@
-{ fetchurl, bitwig-studio1, pulseaudio, xorg }:
+{ stdenv, fetchurl, bitwig-studio2, xorg, ... }:
 
-bitwig-studio1.overrideAttrs (oldAttrs: rec {
+bitwig-studio2.overrideAttrs (oldAttrs: rec {
   name = "bitwig-studio-${version}";
-  version = "3.1.2";
+  version = "3.1.3";
 
   src = fetchurl {
-    url = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
-    sha256 = "07djn52lz43ls6fa4k1ncz3m1nc5zv2j93hwyavnr66r0hlqy7l9";
+    url =
+      "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
+    sha256 = "11z5flmp55ywgxyccj3pzhijhaggi42i2pvacg88kcpj0cin57vl";
   };
 
-  buildInputs = oldAttrs.buildInputs ++ [ xorg.libXtst ];
-
-  runtimeDependencies = [ pulseaudio ];
+  buildInputs = bitwig-studio2.buildInputs ++ [ xorg.libXtst ];
 
   installPhase = ''
     ${oldAttrs.installPhase}
@@ -20,4 +19,5 @@ bitwig-studio1.overrideAttrs (oldAttrs: rec {
     rm -f $out/libexec/lib/jre
     cp -r opt/bitwig-studio/lib/jre $out/libexec/lib
   '';
+
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
