### PR TITLE
onionbalance: init at 0.2.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -801,6 +801,7 @@
   ./services/security/nginx-sso.nix
   ./services/security/oauth2_proxy.nix
   ./services/security/oauth2_proxy_nginx.nix
+  ./services/security/onionbalance.nix
   ./services/security/privacyidea.nix
   ./services/security/physlock.nix
   ./services/security/shibboleth-sp.nix

--- a/nixos/modules/services/security/onionbalance.nix
+++ b/nixos/modules/services/security/onionbalance.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkEnableOption mkIf mkOption types;
+
+  cfg = config.services.onionbalance;
+in {
+  options = {
+    services.onionbalance = {
+      enable = mkEnableOption "Onionbalance load balancer";
+
+      settings = mkOption {
+        type = types.attrs;
+        default = { };
+        example = {
+          services = [{
+            instances = [{
+              address =
+                "wmilwokvqistssclrjdi5arzrctn6bznkwmosvfyobmyv2fc3idbpwyd.onion";
+              name = "node1";
+            }];
+            key =
+              "/run/secrets/mvfqbrdcl2ldfkcr5q4577z6c6crujtj2bwfcvbfwlxvz3e53gg46sid.key";
+          }];
+        };
+        description = ''
+          Config file for onionbalance https://onionbalance.readthedocs.io/en/latest.'';
+      };
+
+      verbosity = mkOption {
+        type = types.enum [ "debug" "info" "warning" "error" "critical" ];
+        default = "info";
+        description = "Minimum verbosity level for logging.";
+      };
+
+      tor.controlPort = mkOption {
+        type = types.nullOr (types.either types.int types.str);
+        default = config.services.tor.controlPort;
+        description = "Tor controller port";
+      };
+    };
+  };
+
+  # implementation
+  config = mkIf cfg.enable {
+
+    services.tor.enable = true;
+
+    systemd.services.onionbalance = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "networking.target" "tor.service" ];
+
+      serviceConfig = {
+        User = "onionbalance";
+        Group = "tor";
+      };
+
+      script = let
+        configFile =
+          pkgs.writeText "config.json" (builtins.toJSON cfg.settings);
+      in ''
+        ${pkgs.onionbalance}/bin/onionbalance -v ${cfg.verbosity} -c ${configFile} -p ${
+          toString cfg.tor.controlPort
+        }
+      '';
+    };
+
+    users.users.onionbalance = {
+      description = "onionbalance Daemon User";
+      createHome = false;
+      extraGroups = [ "tor" ];
+    };
+  };
+}

--- a/pkgs/tools/security/onionbalance/default.nix
+++ b/pkgs/tools/security/onionbalance/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, fetchFromGitHub, buildPythonApplication
+, setuptools, setproctitle, stem, future, pyyaml, cryptography, pycrypto
+, pexpect, mock, pytest, pytest-mock, tox
+}:
+
+buildPythonApplication rec {
+  pname = "onionbalance";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "asn-d6";
+    repo = "onionbalance";
+    rev =  version;
+    sha256 = "0v2rrc7y6blxvsxg04yqn81sjwymi09wwm7mdgmh53zc0ryh9zv6";
+  };
+
+  propagatedBuildInputs = [ setuptools setproctitle stem pyyaml cryptography pycrypto future ];
+
+  checkInputs = [ pexpect mock pytest pytest-mock tox ];
+
+  meta = with lib; {
+    description = "OnionBalance provides load-balancing and redundancy for Tor hidden services";
+    homepage = "https://onionbalance.readthedocs.org/";
+    maintainers = with maintainers; [ colemickens ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libevent, openssl, zlib, torsocks
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libevent, openssl, zlib, torsocks
 , libseccomp, systemd, libcap, lzma, zstd, scrypt
 
 # for update.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "geoip" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ libevent openssl zlib lzma zstd scrypt ] ++
     stdenv.lib.optionals stdenv.isLinux [ libseccomp systemd libcap ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7177,6 +7177,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
 
+  onionbalance = python3Packages.callPackage ../tools/security/onionbalance {};
+
   tor = callPackage ../tools/security/tor {
     # remove this, when libevent's openssl is upgraded to 1_1_0 or newer.
     libevent = libevent.override {


### PR DESCRIPTION
###### Motivation for this change

Add `onionbalance` to nixpkgs.

Requires a newer version of Tor that hasn't released as stable yet. See #86267.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
