### PR TITLE
openorienteering-mapper: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "OpenOrienteering-Mapper";
-  version = "0.9.1";
+  version = "0.9.2";
 
   buildInputs = [ gdal qtbase qttools qtlocation qtimageformats
                   qtsensors clipper zlib proj doxygen cups];
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "OpenOrienteering";
     repo = "mapper";
     rev = "v${version}";
-    sha256 = "1fyhvf2y89hj7wj89kxccx3dqcja6ndy3w4rx1vmzrp246jpz7wb";
+    sha256 = "1787f2agjzcyizk2m60icb44yv9dlwv6irw3k53fqfmwkhkd2h5p";
   };
 
   cmakeFlags =
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
       OpenOrienteering Mapper is an orienteering mapmaking program
       and provides a free alternative to the existing proprietary solution.
     '';
-    homepage = https://www.openorienteering.org/apps/mapper/;
+    homepage = "https://www.openorienteering.org/apps/mapper/";
     license = licenses.gpl3;
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ mpickering sikmir ];


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/OpenOrienteering/mapper/releases/tag/v0.9.2)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/kg90wyw7nb7f58i95028g1fmnbyz515g-OpenOrienteering-Mapper-0.9.1
/nix/store/kg90wyw7nb7f58i95028g1fmnbyz515g-OpenOrienteering-Mapper-0.9.1	708.4M
$ nix path-info -Sh /nix/store/ddvzib8s7sgi0cmpmid01vpfpaxb9dwq-OpenOrienteering-Mapper-0.9.2
/nix/store/ddvzib8s7sgi0cmpmid01vpfpaxb9dwq-OpenOrienteering-Mapper-0.9.2	709.3M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
