### PR TITLE
faustPhysicalModeling: init at 2.20.2

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -703,6 +703,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     free = false;
   };
 
+  stk = {
+    shortName = "stk";
+    fullName = "Synthesis Tool Kit 4.3";
+    url = https://github.com/thestk/stk/blob/master/LICENSE;
+  };
+
   tcltk = spdx {
     spdxId = "TCL";
     fullName = "TCL/TK License";

--- a/pkgs/applications/audio/faustPhysicalModeling/default.nix
+++ b/pkgs/applications/audio/faustPhysicalModeling/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+stdenv.mkDerivation rec {
+  pname = "faustPhysicalModeling";
+  version = "2.20.2";
+
+  src = fetchFromGitHub {
+    owner = "grame-cncm";
+    repo = "faust";
+    rev = version;
+    sha256 = "1mm93ba26b7q69hvabzalg30dh8pl858nj4m2bb57pznnp09lq9a";
+  };
+
+  buildInputs = [ faust2jaqt faust2lv2 ];
+
+  buildPhase = ''
+    cd examples/physicalModeling
+
+    for f in *MIDI.dsp; do
+      faust2jaqt -time -vec -double -midi -nvoices 16 -t 99999 $f
+      faust2lv2  -time -vec -double -gui -nvoices 16 -t 99999 $f
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2 $out/bin
+    mv *.lv2/ $out/lib/lv2
+    for f in $(find . -executable -type f); do
+      cp $f $out/bin/
+    done
+  '';
+
+  meta = with lib; {
+    description = "The physical models included with faust compiled as jack standalone and lv2 instruments";
+    homepage = "https://github.com/grame-cncm/faust/tree/master-dev/examples/physicalModeling";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ magnetophon ];
+  };
+}

--- a/pkgs/applications/audio/faustStk/default.nix
+++ b/pkgs/applications/audio/faustStk/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+
+stdenv.mkDerivation rec {
+  pname = "faustPhhysicalModeling";
+  version = "2.20.2";
+
+  src = fetchFromGitHub {
+    owner = "grame-cncm";
+    repo = "faust";
+    rev = version;
+    sha256 = "1mm93ba26b7q69hvabzalg30dh8pl858nj4m2bb57pznnp09lq9a";
+  };
+
+  buildInputs = [ faust2jaqt faust2lv2 ];
+
+  buildPhase = ''
+    cd examples/physicalModeling/faust-stk
+
+    for f in *.dsp; do
+      faust2jaqt -time -vec  -midi -nvoices 8 -t 99999 $f
+      faust2lv2  -time -vec -double -gui -nvoices 32 -t 99999 $f
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2 $out/bin
+    mv *.lv2/ $out/lib/lv2
+    for f in $(find . -executable -type f); do
+      cp $f $out/bin/
+    done
+  '';
+  meta = with lib; {
+    description = "The physical modeling instruments included with faust, compiled as jack standalone and lv2 instruments";
+    homepage = "https://ccrma.stanford.edu/~rmichon/faustSTK/";
+    license = licenses.stk;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27449,6 +27449,8 @@ in
 
   faustlive = callPackage ../applications/audio/faust/faustlive.nix { };
 
+  faustPhysicalModeling = callPackage ../applications/audio/faustPhysicalModeling  { };
+
   faustStk = callPackage ../applications/audio/faustStk  { };
 
   fceux = callPackage ../misc/emulators/fceux { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27449,6 +27449,8 @@ in
 
   faustlive = callPackage ../applications/audio/faust/faustlive.nix { };
 
+  faustStk = callPackage ../applications/audio/faustStk  { };
+
   fceux = callPackage ../misc/emulators/fceux { };
 
   flockit = callPackage ../tools/backup/flockit { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This would have been one package if it wasn't for the different licences.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
