### PR TITLE
phpPackages.exts.pdo_odbc: init for all versions of php

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -2,7 +2,7 @@
 , bzip2, curl, libxml2, openssl, gmp5, icu, oniguruma, libsodium, html-tidy
 , libzip, zlib, pcre, pcre2, libxslt, aspell, openldap, cyrus_sasl, uwimap
 , pam, libiconv, enchant1, libXpm, gd, libwebp, libjpeg, libpng, freetype
-, libffi, freetds, postgresql, sqlite, recode, net-snmp }:
+, libffi, freetds, postgresql, sqlite, recode, net-snmp, unixODBC }:
 
 let
   self = with self; {
@@ -821,7 +821,7 @@ let
       # pdo_firebird (7.4, 7.3, 7.2)
       { name = "pdo_mysql"; configureFlags = [ "--with-pdo-mysql=mysqlnd" ]; }
       # pdo_oci (7.4, 7.3, 7.2)
-      # pdo_odbc (7.4, 7.3, 7.2)
+      { name = "pdo_odbc"; configureFlags = [ "--with-pdo-odbc=unixODBC,${unixODBC}" ]; }
       { name = "pdo_pgsql"; configureFlags = [ "--with-pdo-pgsql=${postgresql}" ]; }
       { name = "pdo_sqlite"; buildInputs = [ sqlite ]; configureFlags = [ "--with-pdo-sqlite=${sqlite.dev}" ]; }
       { name = "pgsql"; buildInputs = [ pcre' ]; configureFlags = [ "--with-pgsql=${postgresql}" ]; }

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -704,11 +704,13 @@ let
     # Name passed is the name of the extension and is automatically used
     # to add the configureFlag "--enable-${name}", which can be overriden.
     #
-    # Build inputs is used for extra deps that may be needed.
+    # Build inputs is used for extra deps that may be needed. And zendExtension
+    # will mark the extension as a zend extension or not.
     mkExtension = {
       name
       , configureFlags ? [ "--enable-${name}" ]
       , buildInputs ? []
+      , zendExtension ? false
       , ...
     }: stdenv.mkDerivation {
       pname = "php-ext-${name}";
@@ -718,7 +720,7 @@ let
 
       enableParallelBuilding = true;
       nativeBuildInputs = [ php autoconf pkgconfig re2c ];
-      inherit configureFlags buildInputs;
+      inherit configureFlags buildInputs zendExtension;
 
       preConfigure = "phpize";
 
@@ -811,7 +813,7 @@ let
       { name = "mysqli"; configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ]; }
       # oci8 (7.4, 7.3, 7.2)
       # odbc (7.4, 7.3, 7.2)
-      { name = "opcache"; buildInputs = [ pcre' ]; }
+      { name = "opcache"; buildInputs = [ pcre' ]; zendExtension = true; }
       { name = "pcntl"; }
       { name = "pdo"; }
       { name = "pdo_dblib";


### PR DESCRIPTION
###### Motivation for this change
You mentioned that this module was missing, so here it comes :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
