### PR TITLE
rx: 0.3.2 -> 0.4.0

### DIFF
--- a/pkgs/applications/graphics/rx/default.nix
+++ b/pkgs/applications/graphics/rx/default.nix
@@ -1,5 +1,5 @@
 { stdenv, rustPlatform, fetchFromGitHub, makeWrapper
-, cmake, pkgconfig
+, cmake, pkg-config
 , xorg ? null
 , libGL ? null }:
 
@@ -7,18 +7,18 @@ with stdenv.lib;
 
 rustPlatform.buildRustPackage rec {
   pname = "rx";
-  version = "0.3.2";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "cloudhead";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1n5s7v2z13550gkqz7w6dw62jdy60wdi8w1lfa23609b4yhg4w94";
+    sha256 = "1pln65pqy39ijrld11d06klwzfhhzmrgdaxijpx9q7w9z66zmqb8";
   };
 
-  cargoSha256 = "077cs9bf7f3h5aschcv7pbbnpaq1rg79j7f6pnyrzkmn7gxzicg3";
+  cargoSha256 = "143a5x61s7ywk0ljqd10jkfvs6lrhlibkm2a9lw41wq13mgzb78j";
 
-  nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
+  nativeBuildInputs = [ cmake pkg-config makeWrapper ];
 
   buildInputs = optionals stdenv.isLinux
   (with xorg; [
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     description = "Modern and extensible pixel editor implemented in Rust";
-    homepage = "https://cloudhead.io/rx/";
+    homepage = "https://rx.cloudhead.io/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ minijackson filalex77 ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
```
0.4.0

  New features

    * Command history with <up>/<down> arrows
    * Command-line <tab> completion on files and directories
    * New command `:wq` to write and quit

  Changes

    * Much lower CPU usage when no user input
    * `input/delay` setting removed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
