### PR TITLE
wireshark: use relative cmake LIBDIR

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -26,6 +26,8 @@ in stdenv.mkDerivation {
   cmakeFlags = [
     "-DBUILD_wireshark=${if withQt then "ON" else "OFF"}"
     "-DENABLE_APPLICATION_BUNDLE=${if withQt && stdenv.isDarwin then "ON" else "OFF"}"
+    # Fix `extcap` and `plugins` paths. See https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16444
+    "-DCMAKE_INSTALL_LIBDIR=lib"
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

`wireshark` expects `CMAKE_INSTALL_LIBDIR` to be relative and prefixes
it with `CMAKE_INSTALL_PREFIX` in some places to make it absolute.
This results in duplicate absolute paths being accessed, which don't exist like:
```
/nix/store/d1lshac7vwnmhl09fwc04pzmcgn1y219-wireshark-qt-3.2.2//nix/store/d1lshac7vwnmhl09fwc04pzmcgn1y219-wireshark-qt-3.2.2/lib/wireshark/extcap
```

Therefore `extcap` binaries like `sshdump` can't be used.

Making `CMAKE_INSTALL_LIBDIR` relative fixes this issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
