### PR TITLE
xmage: init at 1.4.42V6

### DIFF
--- a/pkgs/games/xmage/default.nix
+++ b/pkgs/games/xmage/default.nix
@@ -32,6 +32,7 @@ EOS
     description = "Magic Another Game Engine";
     license = licenses.mit;
     maintainers = with maintainers; [ matthiasbeyer ];
+    homepage = "http://xmage.de/";
   };
 
 }

--- a/pkgs/games/xmage/default.nix
+++ b/pkgs/games/xmage/default.nix
@@ -28,5 +28,11 @@ EOS
     chmod +x $out/bin/xmage
   '';
 
+  meta = with stdenv.lib; {
+    description = "Magic Another Game Engine";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+
 }
 

--- a/pkgs/games/xmage/default.nix
+++ b/pkgs/games/xmage/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "14s4885ldi0rplqmab5m775plsqmmm0m89j402caiqm2q9mzvkhd";
   };
 
+  preferLocalBuild = true;
+
   unpackPhase = ''
     ${unzip}/bin/unzip $src
   '';

--- a/pkgs/games/xmage/default.nix
+++ b/pkgs/games/xmage/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchurl
+, jdk8
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  name    = "xmage";
+  version = "1.4.42V6";
+
+  src = fetchurl {
+    url    = "https://github.com/magefree/mage/releases/download/xmage_1.4.42V6/xmage_${version}.zip";
+    sha256 = "14s4885ldi0rplqmab5m775plsqmmm0m89j402caiqm2q9mzvkhd";
+  };
+
+  unpackPhase = ''
+    ${unzip}/bin/unzip $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -rv ./* $out
+
+    cat << EOS > $out/bin/xmage
+exec ${jdk8}/bin/java -Xms256m -Xmx512m -XX:MaxPermSize=384m -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -jar $out/mage-client/lib/mage-client-1.4.42.jar
+EOS
+
+    chmod +x $out/bin/xmage
+  '';
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7565,6 +7565,8 @@ in
   xfsprogs = callPackage ../tools/filesystems/xfsprogs { };
   libxfs = xfsprogs.dev;
 
+  xmage = callPackage ../games/xmage { };
+
   xml2 = callPackage ../tools/text/xml/xml2 { };
 
   xmlformat = callPackage ../tools/text/xml/xmlformat { };


### PR DESCRIPTION
###### Motivation for this change

Corona

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
