### PR TITLE
sfxr-qt: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/applications/audio/sfxr-qt/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/default.nix
@@ -10,12 +10,12 @@
 
 mkDerivation rec {
   pname = "sfxr-qt";
-  version = "1.2.0";
+  version = "1.3.0";
   src = fetchFromGitHub {
     owner = "agateau";
     repo = "sfxr-qt";
     rev = version;
-    sha256 = "1ndw1dcmzvkrc6gnb0y057zb4lqlhwrv18jlbx26w3s4xrbxqr41";
+    sha256 = "15yjgjl1c5k816mnpc09104zq0ack2a3mjsxmhcik7cmjkfiipr5";
     fetchSubmodules = true;
   };
   nativeBuildInputs = [
@@ -27,10 +27,9 @@ mkDerivation rec {
     qtquickcontrols2
     SDL
   ];
-  configurePhase = "cmake . -DCMAKE_INSTALL_PREFIX=$out";
 
   meta = with lib; {
-    homepage = https://github.com/agateau/sfxr-qt;
+    homepage = "https://github.com/agateau/sfxr-qt";
     description = "A sound effect generator, QtQuick port of sfxr";
     license = licenses.gpl2;
     maintainers = with maintainers; [ fgaz ];


### PR DESCRIPTION
###### Motivation for this change

New release. I also cleaned up some stuff.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
