### PR TITLE
new: 4 extra test/examples for the apache redwax modules

### DIFF
--- a/nixos/tests/redwax-revoke-crl.nix
+++ b/nixos/tests/redwax-revoke-crl.nix
@@ -1,0 +1,303 @@
+# RedWax test/demo of the CRL responder modules.
+#
+# This demo/test sets up:
+#
+# 1.    tiny CA hierarcye; with a CA root that then
+#       - issues a web service certificate to the webserver
+#       - issues a separate `I validate persons' sub-CA.
+#       - issues a bunch of client certs to 'people'
+#       - revoke a few of these.
+#
+# 2.    Sets up a apache httpd server without SSL to publish CRLs (plaintext, as is customary)
+#
+# 3.  	Check that this works.
+
+# RedWax   Redwax aims to decentralise trust management so that the 
+#          values security, confidentiality and privacy can be upheld 
+#          in public infrastructure and private interactions. 
+#          http://redwax.eu
+#
+# 
+# make-test-python = yourtestfunction: (import "${pkgs.path}/nixos/tests/make-test-python.nix" yourtestfunction { inherit pkgs; }):
+# import <nixos/tests/make-test-python.nix> ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
+let
+  revokeRoot = "/data/http/demo";
+in
+{
+  name = "redwax";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ dirkx ];
+  };
+
+  machine =
+    { config, ... }:
+    { networking.firewall.enable = true;
+      networking.firewall.rejectPackets = true;
+      networking.firewall.allowPing = true;
+      networking.firewall.allowedTCPPorts = [ 80 ];
+      networking.extraHosts = ''
+        ${config.networking.primaryIPAddress} site.local
+      '';
+      services.httpd = {
+        enable = true;
+        adminAddr = "admin@site.local";
+        extraModules = [
+          { name = "ca";        path = "${pkgs.apacheHttpdPackages.mod_ca}/modules/mod_ca.so"; }
+          { name = "ca_crl";    path = "${pkgs.apacheHttpdPackages.mod_ca}/modules/mod_ca_crl.so"; }
+          { name = "crl";       path = "${pkgs.apacheHttpdPackages.mod_crl}/modules/mod_crl.so"; }
+        ];
+        virtualHosts = {
+          "site.local" = {
+            documentRoot = "${revokeRoot}/docroot";
+
+            extraConfig = ''
+              CACRLCertificateRevocationList "${revokeRoot}/keys/ca-users-crl.pem"
+
+              <Location /crl>
+                  SetHandler crl
+              </Location>
+            '';
+          };
+        };
+      };
+
+      environment.systemPackages = [ pkgs.openssl ];
+
+      system.activationScripts.createDummyKey = ''
+        set -xe
+
+        dir="${revokeRoot}/keys"
+        mkdir -m 0700 -p $dir
+
+        # We use a fairly 'valid' DN; as to not having to foil the default
+        # checks for things like '2 char' country codes, etc which are in
+        # the standard openssl.conf.
+        #
+        basedn="/C=NL/ST=Zuid-Holland/L=Leiden/O=Cleansing Enterprises B.V"
+
+        # Generating CA - and use that to sign a sign two sub CAs.
+        # One that issues web server certs (that we'll use as a server)
+        # and one that issues certificates to our users.
+        #
+        ${pkgs.openssl}/bin/openssl req -new -x509 -nodes -newkey rsa:1024 \
+            -extensions v3_ca \
+            -subj "$basedn/CN=CA" \
+            -out $dir/ca.pem -keyout $dir/ca.key 
+
+        # Now create our two sub CAs. One for the services and one for the users.
+        # And sign each with the above root CA key.
+        #
+        # We specify 'nodes' to not encrypt the private keys; as to not
+        # need human interaction (typing in the password) during webserver
+        # startup.
+        #
+        cat >  $dir/extfile.cnf <<EOM
+basicConstraints=CA:TRUE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+EOM
+        ${pkgs.openssl}/bin/openssl req \
+               -new -nodes -newkey rsa:1024  \
+               -keyout $dir/ca-users.key \
+               -subj "$basedn/CN=Sub CA for users" |\
+        ${pkgs.openssl}/bin/openssl x509 -req -days 14 -set_serial $RANDOM \
+               -CA $dir/ca.pem -CAkey $dir/ca.key \
+               -extfile $dir/extfile.cnf \
+               -out $dir/ca-users.pem
+
+        rm $dir/extfile.cnf $dir/ca.key
+
+        cat $dir/ca.pem $dir/ca-users.pem > $dir/chain.pem
+
+        # Set up a minimal CA config that can create & revoke certicates. And include
+        # in the generated certs the vaiorus CRL endpoints for this demo.
+        #
+        mkdir $dir/certs $dir/crl $dir/newcerts
+        touch $dir/index.txt
+	echo 01 > $dir/serial.txt
+	echo 01 > $dir/crlnumber.txt
+        cat >  $dir/openssl.cnf <<EOM
+[ca]
+default_ca = CA_default
+
+[CA_default]
+certs=$dir/certs
+new_certs_dir= $dir/newcerts
+# crl_dir=$dir/crl
+serial=$dir/serial.txt
+certificate=$dir/ca-users.pem
+private_key=$dir/ca-users.key
+default_md        = sha256
+database=$dir/index.txt
+default_days      = 30
+crlnumber         = $dir/crlnumber.txt
+crl               = $dir/ca.crl.pem
+crl_extensions    = crl_ext
+default_crl_days  = 3
+policy            = policy
+
+[policy]
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+emailAddress            = optional
+commonName              = supplied
+
+[ req ]
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+default_md          = sha256
+x509_extensions     = v3_ca
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ req_distinguished_name ]
+
+[ usr_cert ]
+basicConstraints=CA:FALSE
+crlDistributionPoints = URI:http://site.local/crl
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+
+[ crl_ext ]
+authorityKeyIdentifier=keyid:always
+EOM
+        # Now issue certicates to our usually menagerie of users
+        #
+        for person in alice charlie malory
+        do
+           ${pkgs.openssl}/bin/openssl req \
+               -config $dir/openssl.cnf \
+               -new -nodes -newkey rsa:1024  \
+               -keyout /dev/null \
+               -subj "$basedn/CN=$person" \
+               -extensions usr_cert \
+               -out $dir/person-$person.crt
+
+           s=`cat $dir/serial.txt`
+           ${pkgs.openssl}/bin/openssl ca -config $dir/openssl.cnf \
+		-extensions usr_cert  -batch \
+		-in  $dir/person-$person.crt \
+		-out $dir/person-$person.pem  
+        done
+
+        cat $dir/index.txt
+
+        # Revoke Malory - she is up to no good. Again. 
+        # Then regenerate and resign the CRL.
+        #
+  	${pkgs.openssl}/bin/openssl ca -config $dir/openssl.cnf \
+		-batch \
+		-revoke $dir/person-malory.pem
+
+        # And charlie changed jobs
+        #
+  	${pkgs.openssl}/bin/openssl ca -config $dir/openssl.cnf \
+		-batch \
+                -crl_reason affiliationChanged \
+		-revoke $dir/person-charlie.pem
+
+  	${pkgs.openssl}/bin/openssl ca -config $dir/openssl.cnf \
+		-batch \
+		-gencrl \
+		-out $dir/ca-users-crl.pem 
+
+        # Just to quell a webserver error & warning.
+	# 
+        mkdir ${revokeRoot}/docroot
+        echo Nothing to see, now move along > ${revokeRoot}/docroot/index.html
+      '';
+    };
+
+  testScript = ''
+    # Validate alice and malory their certs against the CA; both should be ok (as this
+    # does not check the CRL).
+    #
+    machine.succeed(
+        "openssl verify -trusted ${revokeRoot}/keys/ca.pem -untrusted ${revokeRoot}/keys/ca-users.pem ${revokeRoot}/keys/person-alice.pem"
+    )
+    machine.succeed(
+        "openssl verify -CAfile ${revokeRoot}/keys/chain.pem ${revokeRoot}/keys/person-alice.pem"
+    )
+    machine.succeed(
+        "openssl verify -CAfile ${revokeRoot}/keys/chain.pem ${revokeRoot}/keys/person-charlie.pem"
+    )
+    machine.succeed(
+        "openssl verify -CAfile ${revokeRoot}/keys/chain.pem ${revokeRoot}/keys/person-malory.pem"
+    )
+
+    # Now check again - against the CRL file (which we fetch from disk - not through the CRL http
+    # endpoint. Now only Malory should fail.
+    #
+    machine.succeed(
+        "openssl verify -CRLfile ${revokeRoot}/keys/ca-users-crl.pem  -CAfile ${revokeRoot}/keys/chain.pem ${revokeRoot}/keys/person-alice.pem"
+    )
+    machine.succeed(
+        "openssl verify -CRLfile ${revokeRoot}/keys/ca-users-crl.pem  -CAfile ${revokeRoot}/keys/chain.pem ${revokeRoot}/keys/person-charlie.pem"
+    )
+    machine.succeed(
+        "openssl verify -CRLfile ${revokeRoot}/keys/ca-users-crl.pem  -CAfile ${revokeRoot}/keys/chain.pem ${revokeRoot}/keys/person-malory.pem"
+    )
+
+    # Now check again - with the CRL check - and while the CRL server is still DOWN. So both
+    # checks should fail.
+    #
+    # Commented out - as the time out on the failing network check is rather long.
+    #
+    # machine.fail(
+    #    "openssl verify -verbose -CAfile ${revokeRoot}/keys/chain.pem -crl_check -crl_download ${revokeRoot}/keys/person-alice.pem"
+    # )
+    # machine.fail(
+    #    "openssl verify -verbose -CAfile ${revokeRoot}/keys/chain.pem -crl_check -crl_download ${revokeRoot}/keys/person-malory.pem"
+    # )
+
+    # Start everything - and wait for the CRL responder to be up - and try it again. Now just Malory
+    # should fail.
+    #
+    start_all()
+ 
+    machine.wait_for_unit("httpd.service")
+
+    # First - fetch the raw thing. And display it in a human readable format.
+    # (this also valdiates the certiciates - ca-user issues).
+    #
+    machine.succeed(
+        "curl --cacert ${revokeRoot}/keys/ca.pem http://site.local/crl > crl.der"
+    )
+    machine.succeed(
+        "openssl crl -CAfile ${revokeRoot}/keys/chain.pem -in crl.der -inform DER -text -noout > /dev/stderr"
+    )
+
+    # And now interact with it using the endpoint `live' from a verify - first show the URI (there is no
+    # CRL equivalent for -ocsp_uri; hence the grep)
+    #
+    machine.succeed(
+        "openssl x509 -text -noout -in ${revokeRoot}/keys/person-alice.pem | grep URI > /dev/stderr"
+    )
+
+    # And then check the validity of Alice her certificate.
+    #
+    machine.succeed(
+        "openssl verify -verbose -CAfile ${revokeRoot}/keys/chain.pem -crl_check -show_chain -crl_download ${revokeRoot}/keys/person-alice.pem > /dev/stderr"
+    )
+
+    # Charlie and Malory are both revoked - so these two test should both fail.
+    #
+    machine.fail(
+        "openssl verify -verbose -CAfile ${revokeRoot}/keys/chain.pem -crl_check -show_chain -crl_download ${revokeRoot}/keys/person-malory.pem > /dev/stderr"
+    )
+    machine.fail(
+        "openssl verify -verbose -CAfile ${revokeRoot}/keys/chain.pem -crl_check -show_chain -crl_download ${revokeRoot}/keys/person-charlie.pem > /dev/stderr"
+    )
+  '';
+})

--- a/nixos/tests/redwax-revoke-ocsp.nix
+++ b/nixos/tests/redwax-revoke-ocsp.nix
@@ -1,0 +1,389 @@
+# RedWax test/demo of the OCSP and CRL responder modules.
+#
+# This demo/test sets up:
+#
+# 1.    tiny CA hierarcye; with a CA root that then
+#       - issues a web service certificate to the webserver
+#       - issues a separate `I validate persons' sub-CA.
+#       - issues a bunch of client certs to 'people'
+#       - revoke a few of these.
+#
+# 2.    Sets up a apache httpd server with SSL to host an OCSP endpoint
+#
+# 3.    Check that this works.
+#
+# Note that we'll use a OCSP specific certificate to sign the OCSP
+#      response. As opposed to signing it with the CA that issued
+#      the certificates that are revoked. This way we can limit
+#      the damage in case that OCSP private key leaks out (as all
+#      it can done due to its critical extension/CA:FALSE is
+#      sign OCSP responses.
+#
+# RedWax   Redwax aims to decentralise trust management so that the
+#          values security, confidentiality and privacy can be upheld
+#          in public infrastructure and private interactions.
+#          http://redwax.eu
+#
+#
+# make-test-python = yourtestfunction: (import "${pkgs.path}/nixos/tests/make-test-python.nix" yourtestfunction { inherit pkgs; }):
+# import <nixos/tests/make-test-python.nix> ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
+let
+  revokeRoot = "/data/http/demo";
+in
+{
+  name = "redwax";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ dirkx ];
+  };
+
+  machine =
+    { config, ... }:
+    { networking.firewall.enable = true;
+      networking.firewall.rejectPackets = true;
+      networking.firewall.allowPing = true;
+      networking.firewall.allowedTCPPorts = [ 443 ];
+      networking.extraHosts = ''
+        ${config.networking.primaryIPAddress} site.local
+      '';
+      services.httpd = {
+        enable = true;
+        adminAddr = "admin@site.local";
+        extraModules = [
+          { name = "ca";        path = "${pkgs.apacheHttpdPackages.mod_ca}/modules/mod_ca.so"; }
+          { name = "ca_simple";    path = "${pkgs.apacheHttpdPackages.mod_ca}/modules/mod_ca_simple.so"; }
+          { name = "ca_crl";    path = "${pkgs.apacheHttpdPackages.mod_ca}/modules/mod_ca_crl.so"; }
+          { name = "ocsp";      path = "${pkgs.apacheHttpdPackages.mod_ocsp}/modules/mod_ocsp.so"; }
+        ];
+        virtualHosts = {
+          "site.local" = {
+            documentRoot = "${revokeRoot}/docroot";
+            # We need port 80; as openssl does not know how to
+            # fetch CRLs over https.
+            #
+            forceSSL = true;
+            sslServerCert = "${revokeRoot}/keys/server.pem";
+            sslServerKey =  "${revokeRoot}/keys/server.key";
+
+            # Obsolete from apache-httpd-2.4.8; the chain should now be
+            # in the server.pem file and ordered; as per below commented
+            # out example.
+            #
+            # sslServerChain = "${revokeRoot}/keys/chain-web.pem";
+            # sslServerCert = "${revokeRoot}/keys/server-and-chain.pem";
+
+            extraConfig = ''
+
+              # Source of our revoked certs list:
+              CACRLCertificateRevocationList "${revokeRoot}/keys/ca-users-crl.pem"
+
+              # The CA this OCSP endpoint is for:
+              CASimpleCertificate "${revokeRoot}/keys/ca-users.pem"
+
+              <Location /ocsp>
+                  SetHandler ocsp
+
+                  OcspSigningCertificate "${revokeRoot}/keys/ocsp.pem"
+                  OcspSigningKey "${revokeRoot}/keys/ocsp.key"
+              </Location>
+            '';
+          };
+        };
+      };
+
+      environment.systemPackages = [ pkgs.openssl ];
+
+      system.activationScripts.createDummyKey = ''
+        set -xe
+
+        dir="${revokeRoot}/keys"
+        mkdir -m 0700 -p $dir
+
+        # We use a fairly 'valid' DN; as to not having to foil the default
+        # checks for things like '2 char' country codes, etc which are in
+        # the standard openssl.conf.
+        #
+        basedn="/C=NL/ST=Zuid-Holland/L=Leiden/O=Cleansing Enterprises B.V"
+
+        # Generating CA - and use that to sign a sign two sub CAs.
+        # One that issues web server certs (that we'll use as a server)
+        # and one that issues certificates to our users.
+        #
+        ${pkgs.openssl}/bin/openssl req -new -x509 -nodes -newkey rsa:1024 \
+            -extensions v3_ca \
+            -subj "$basedn/CN=CA" \
+            -out $dir/ca.pem -keyout $dir/ca.key
+
+        # Now create our two sub CAs. One for the services and one for the users.
+        # And sign each with the above root CA key.
+        #
+        # We specify 'nodes' to not encrypt the private keys; as to not
+        # need human interaction (typing in the password) during webserver
+        # startup.
+        #
+        cat >  $dir/extfile.cnf <<EOM
+basicConstraints = CA:TRUE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+EOM
+        for subca in web users
+        do
+           ${pkgs.openssl}/bin/openssl req \
+               -new -nodes -newkey rsa:1024  \
+               -keyout $dir/ca-$subca.key \
+               -subj "$basedn/CN=Sub CA for $subca" |\
+           ${pkgs.openssl}/bin/openssl x509 -req -days 14 -set_serial $RANDOM \
+               -CA $dir/ca.pem -CAkey $dir/ca.key \
+               -extfile $dir/extfile.cnf \
+               -out $dir/ca-$subca.pem
+        done
+
+        # Create an OCSP signer; as we want to avoid having to have
+        # the key of the ca-users near the web-server; we create a
+        # more neutered one (CA:False, critical on just OCSP signing).
+        #
+  	# Standards (and openssl) expect this ocsp signing cert to be
+        # under the same CA as the one that it signs OCSP related
+        # requests of.
+        #
+        cat >  $dir/extfile.cnf <<EOM
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, OCSPSigning
+EOM
+        ${pkgs.openssl}/bin/openssl req \
+               -new -nodes -newkey rsa:1024  \
+               -keyout $dir/ocsp.key \
+               -subj "$basedn/CN=OCSP Department" |\
+        ${pkgs.openssl}/bin/openssl x509 -req -days 14 -set_serial $RANDOM \
+               -CA $dir/ca-users.pem -CAkey $dir/ca-users.key \
+               -extfile $dir/extfile.cnf \
+               -out $dir/ocsp.pem
+
+        # We no longer need the root CA key - as we've
+        # signed our two worker sub CA's. And they'll
+        # do the rest.
+        #
+        rm $dir/extfile.cnf $dir/ca.key
+
+        # Make a full chain - somewhat superfluous, but polite nevertheless. See the comment
+        # above near sslServerChain.
+        #
+        cat $dir/ca-web.pem $dir/ca.pem > $dir/chain-web.pem
+        cat $dir/ca-users.pem $dir/ca.pem > $dir/chain-user.pem
+        cat $dir/ocsp.pem $dir/ca.pem > $dir/chain-ocsp.pem
+        cat $dir/ca.pem $dir/ca-*.pem $dir/ocsp.pem  > $dir/chain.pem
+
+        # Use the CA Web sub ca to sign a localhost cert. We keep this very simple; a
+        # more realistic example would set all sort of x509v3 extensions; such as an
+        # key IDs and SubjectAltNames.
+        #
+        ${pkgs.openssl}/bin/openssl req -new -nodes -newkey rsa:1024  -keyout $dir/server.key \
+            -subj "$basedn/CN=site.local" \
+            -out $dir/server.csr
+
+        ${pkgs.openssl}/bin/openssl x509 -req -days 14 -set_serial $RANDOM \
+              -CA $dir/ca-web.pem -CAkey $dir/ca-web.key \
+              -in $dir/server.csr \
+              -out $dir/server.pem
+        rm $dir/server.csr
+
+        # SSLCertificateChainFile was obsoleted in apache 2.4.8 - its role taken over by
+        # having them concatenated into SSLCertificateFile. So we create that here; sorted
+        # from leaf to root.
+        cat $dir/server.pem $dir/ca-users.pem $dir/ca.pem > $dir/server-and-chain.pem
+
+        # We know longer need the Web CA key; but we do keep the ca-users key; as that
+        # is what the service needs to sign certificate requests.
+        #
+        rm $dir/ca-web.key
+
+        # Set up a minimal CA config that can create & revoke certicates. And include
+        # in the generated certs the vaiorus OCSP and CRL endpoints for this demo.
+        #
+        # Note: This is a bit more complex than it should be; but we need to do this because
+        # mod_ca_simple/ca_crl is too simple; it only takes normal CRL files at this time.
+        # And the other option (LDAP) is even more complex to set up.
+        #
+        mkdir $dir/certs $dir/crl $dir/newcerts
+        touch $dir/index.txt
+        echo 01 > $dir/serial.txt
+        echo 01 > $dir/crlnumber.txt
+        cat >  $dir/openssl.cnf <<EOM
+[ca]
+default_ca = CA_default
+
+[CA_default]
+certs=$dir/certs
+new_certs_dir= $dir/newcerts
+# crl_dir=$dir/crl
+serial=$dir/serial.txt
+certificate=$dir/ca-users.pem
+private_key=$dir/ca-users.key
+default_md        = sha256
+database=$dir/index.txt
+default_days      = 30
+crlnumber         = $dir/crlnumber.txt
+crl               = $dir/ca.crl.pem
+crl_extensions    = crl_ext
+default_crl_days  = 3
+policy            = policy
+
+[policy]
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+emailAddress            = optional
+commonName              = supplied
+
+[ req ]
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+default_md          = sha256
+x509_extensions     = v3_ca
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ req_distinguished_name ]
+
+[ usr_cert ]
+basicConstraints=CA:FALSE
+# authorityInfoAccess = OCSP;URI:https://site.local/ocsp, caIssuers; URI:https://site.local/web-users.crt
+authorityInfoAccess = OCSP;URI:https://site.local/ocsp
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+
+[ crl_ext ]
+authorityKeyIdentifier=keyid:always
+
+[ ocsp ]
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, OCSPSigning
+EOM
+        # Now issue certicates to our usually menagerie of users
+        #
+        for person in alice charlie malory
+        do
+           ${pkgs.openssl}/bin/openssl req \
+               -config $dir/openssl.cnf \
+               -new -nodes -newkey rsa:1024  \
+               -keyout /dev/null \
+               -subj "$basedn/CN=$person" \
+               -extensions usr_cert \
+               -out $dir/person-$person.crt
+
+           s=`cat $dir/serial.txt`
+           ${pkgs.openssl}/bin/openssl ca -config $dir/openssl.cnf \
+                -extensions usr_cert  -batch \
+                -in  $dir/person-$person.crt \
+                -out $dir/person-$person.pem
+
+           rm $dir/person-$person.crt
+           # cp $dir/newcerts/$s.pem $dir/person-$person.pem
+        done
+
+        cat $dir/index.txt
+
+        # Revoke Malory - she is up to no good. Again.
+        #
+        ${pkgs.openssl}/bin/openssl ca -config $dir/openssl.cnf \
+                -batch \
+                -revoke $dir/person-malory.pem
+
+        # Revoke Charlie - he is now working somewhere else.
+        #
+        ${pkgs.openssl}/bin/openssl ca -config $dir/openssl.cnf \
+                -batch \
+                -crl_reason affiliationChanged \
+                -revoke $dir/person-charlie.pem
+
+        # Then regenerate and resign the CRL.
+        #
+        ${pkgs.openssl}/bin/openssl ca -config $dir/openssl.cnf \
+                -batch \
+                -gencrl \
+                -out $dir/ca-users-crl.pem
+
+        # Just to quell a webserver error & warning.
+        #
+        mkdir ${revokeRoot}/docroot
+        echo Nothing to see, now move along > ${revokeRoot}/docroot/index.html
+
+      '';
+    };
+
+  testScript = ''
+    # First we validate that w've set up the certs/revocs correctly.
+
+    # Validate alice and malory their certs against the CA; both should be ok (as this
+    # does not check the OCSP responder / crl file.
+    #
+    machine.succeed(
+        "openssl verify -trusted ${revokeRoot}/keys/ca.pem -untrusted ${revokeRoot}/keys/ca-users.pem ${revokeRoot}/keys/person-alice.pem"
+    )
+    machine.succeed(
+        "openssl verify -CAfile ${revokeRoot}/keys/chain-user.pem ${revokeRoot}/keys/person-alice.pem"
+    )
+    machine.succeed(
+        "openssl verify -CAfile ${revokeRoot}/keys/chain.pem ${revokeRoot}/keys/person-malory.pem"
+    )
+
+    # Now check again - against the CRL file (which we fetch from disk). Now only Malory should fail.
+    #
+    machine.succeed(
+        "openssl verify -CRLfile ${revokeRoot}/keys/ca-users-crl.pem  -CAfile ${revokeRoot}/keys/chain-user.pem ${revokeRoot}/keys/person-alice.pem"
+    )
+    machine.succeed(
+        "openssl verify -CRLfile ${revokeRoot}/keys/ca-users-crl.pem  -CAfile ${revokeRoot}/keys/chain.pem ${revokeRoot}/keys/person-malory.pem"
+    )
+    # Check that we have the right URI
+    #
+    machine.succeed(
+        "openssl x509 -noout -ocsp_uri -in ${revokeRoot}/keys/person-alice.pem | grep 'https://site.local/ocsp' > /dev/stderr"
+    )
+    # And this completes the setup test. next up is the actual
+    # OCSP endpoint test.
+
+    start_all()
+    machine.wait_for_unit("httpd.service")
+
+    machine.succeed(
+        "openssl ocsp -issuer ${revokeRoot}/keys/ca-users.pem -CAfile ${revokeRoot}/keys/ca.pem -cert ${revokeRoot}/keys/person-alice.pem -cert ${revokeRoot}/keys/person-charlie.pem -cert ${revokeRoot}/keys/person-malory.pem -resp_text -url https://site.local/ocsp > /dev/stderr"
+    )
+
+    # This should show something such as:
+    #
+    #   OCSP Response Data:
+    #   ....
+    #         detailed information & signature certificate
+    #   ....
+    #   Response verify OK
+    #   /data/http/demo/keys/person-alice.pem: good
+    #         This Update: Feb 15 22:10:32 2020 GMT
+    #         Next Update: Feb 18 22:10:32 2020 GMT
+    #   /data/http/demo/keys/person-charlie.pem: revoked
+    #         This Update: Feb 15 22:10:32 2020 GMT
+    #         Next Update: Feb 18 22:10:32 2020 GMT
+    #         Reason: affiliationChanged
+    #         Revocation Time: Feb 15 22:10:32 2020 GMT
+    #   /data/http/demo/keys/person-malory.pem: revoked
+    #         This Update: Feb 15 22:10:32 2020 GMT
+    #         Next Update: Feb 18 22:10:32 2020 GMT
+    #         Reason: unspecified
+    #         Revocation Time: Feb 15 22:10:31 2020 GMT
+  '';
+})

--- a/nixos/tests/redwax-sign.nix
+++ b/nixos/tests/redwax-sign.nix
@@ -1,0 +1,380 @@
+# Test case 1
+#    - Sign an CSR uploaded through a web interface.
+#
+#      Use that, and the locally kept private key, to access
+#      a secure area on the webserver.
+#
+# Test case 2
+#    - Produce a PKCS#12 signed private/public keypair and
+#      cert on the webserver (so we get no repudiation) and 
+#      give it to us.
+#
+#      Use that cert to a secure area on the webserver.
+#
+# This demo/test sets up:
+#
+# 1.    tiny CA hierarcye; with a CA root that then
+#       - issues a web service certificate to the webserver
+#       - issues a separate `I validate persons' sub-CA.
+#
+# 2.    Sets up a apache httpd server with SSL. 
+#
+# 3.    Usecase 1: Hooks into that a red wax CSR signing module
+#       on an area for which you need no authentication
+# 
+#       Usecase 2: Same - but now for issuing pkcs#12 key/cert
+#       packages.
+#
+# 4.    Sets up an apache location that needs x509 client
+#       authentication.
+#
+# 5.    Show that you cannot get a file from that location.
+#
+# 6.    Usecase 1: Then generate a CSR; gets it signed by above server
+#       and then shows you can get the above file if you
+#       use the issued client cert.
+#
+#       Usecase 2: Then ask for a certicate & private key from the server
+#       and shows you can get the above file if you use the issued 
+#  	client cer and private key given to you.
+#
+# 7.    And show that Malory; who somehow got her hands on the
+#       servers private key -- cannot use that to get her hands
+#       on the file.
+#
+# RedWax   Redwax aims to decentralise trust management so that the 
+#          values security, confidentiality and privacy can be upheld 
+#          in public infrastructure and private interactions. 
+#          http://redwax.eu
+#
+# 
+# make-test-python = yourtestfunction: (import "${pkgs.path}/nixos/tests/make-test-python.nix" yourtestfunction { inherit pkgs; }):
+# import <nixos/tests/make-test-python.nix> ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
+let
+  signWebRoot = "/data/http/demo";
+in
+{
+  name = "redwax";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ dirkx ];
+  };
+
+  machine =
+    { config, ... }:
+    { networking.firewall.enable = true;
+      networking.firewall.rejectPackets = true;
+      networking.firewall.allowPing = true;
+      networking.firewall.allowedTCPPorts = [ 443 ];
+      networking.extraHosts = ''
+        ${config.networking.primaryIPAddress} site.local
+      '';
+      services.httpd = {
+        enable = true;
+        adminAddr = "admin@site.local";
+        extraModules = [
+          { name = "ca";        path = "${pkgs.apacheHttpdPackages.mod_ca}/modules/mod_ca.so"; }
+          { name = "ca_simple"; path = "${pkgs.apacheHttpdPackages.mod_ca}/modules/mod_ca_simple.so"; }
+          { name = "csr";       path = "${pkgs.apacheHttpdPackages.mod_csr}/modules/mod_csr.so"; }
+          { name = "pkcs12";    path = "${pkgs.apacheHttpdPackages.mod_pkcs12}/modules/mod_pkcs12.so"; }
+        ];
+        virtualHosts = {
+          "site.local" = {
+            documentRoot = "${signWebRoot}/docroot";
+            forceSSL = true;
+            sslServerCert = "${signWebRoot}/keys/server.pem";
+            sslServerKey =  "${signWebRoot}/keys/server.key";
+
+            # We could just have ca-web.pem here; as curl already has
+            # the ca. We do not do that - as having the full chain
+            # advertised makes it easier for people to understand
+            # what is happening if they have no notion of this 
+            # particular ca (and they then also conveniently have the 
+            # root to add to their local ca trust store).
+            
+            # Obsolete from apache-httpd-2.4.8; the chain should now be
+            # in the server.pem file and ordered; as per below commented
+            # out example.
+            #
+            sslServerChain = "${signWebRoot}/keys/chain-web.pem";
+            # sslServerCert = "${signWebRoot}/keys/server-and-chain.pem";
+
+            extraConfig = ''
+              Header always set Strict-Transport-Security "max-age=15552000"
+
+              # backend configuration:
+              #
+              # use system clock as the time source
+              CASimpleTime on
+              # assign a random serial number
+              CASimpleSerialRandom on
+
+              # Algorithm to use for signing certs; and the keys to use
+              # for signing.
+              #
+              CASimpleAlgorithm   RSA
+              CASimpleCertificate "${signWebRoot}/keys/ca-users.pem"
+              CASimpleKey         "${signWebRoot}/keys/ca-users.key"
+
+              # Not strictly needed - but a lot of desktop tools behave
+              # more sensible when these v3 extensions are present; and
+              # auto-prompt the user from the keystore.
+              #
+              CASimpleExtension basicConstraints CA:FALSE
+              CASimpleExtension keyUsage critical,nonRepudiation,digitalSignature,keyEncipherment
+              # See rfc5280 -- id-kp-clientAuth
+              CASimpleExtension extendedKeyUsage OID:1.3.6.1.5.5.7.3.2 
+              CASimpleExtension subjectKeyIdentifier hash
+              CASimpleExtension authorityKeyIdentifier keyid,issuer
+
+              # Number of days the issued certificate is valid for.
+              #
+              CASimpleDays 5
+
+              # Front end Area were we can get a cert signed for use case 1.
+              #
+              <Location /issue>
+                  SetHandler csr
+
+                  # Fields that the user can supply (and how many)
+                  #
+                  CsrSubjectRequest CN 1
+                  CsrSubjectRequest OU 1
+
+                  # Fields that are under control of the webmaster, with
+                  # fixed values.
+                  #
+                  CsrSubjectSet O "Cleansing Enterpises Ltd"
+                  CsrSubjectSet L "Bittezauberhalte"
+                  CsrSubjectSet C "DE"
+              </Location>
+
+              # Front end Area were we can get a signed cert and
+              # a private key - test case 2.
+              #
+              <Location /issue12>
+                  SetHandler pkcs12
+
+                  # Fields that the user can supply (and how many)
+                  #
+                  Pkcs12SubjectRequest CN 1
+                  Pkcs12SubjectRequest OU 1
+
+                  # Fields that are under control of the webmaster, with
+                  # fixed values.
+                  #
+                  Pkcs12SubjectSet O "Cleansing Enterpises Ltd"
+                  Pkcs12SubjectSet L "Trusty Town"
+                  Pkcs12SubjectSet C "DE"
+              </Location>
+
+              # Area requiring a x509 cert signed by 'us'. To show
+              # that we need a signed cert as per above process. In
+              # a more federated setting; where you'd accept people
+              # vetted by your peers - you'd proably use a directory
+              # with these (and SSLCACertificatePath). But if you just
+              # trust a few - you can simply concatenate them.
+              #
+              SSLCACertificateFile "${signWebRoot}/keys/chain-user.pem"
+              <Location /secrets>
+                  SSLVerifyClient require
+                  SSLVerifyDepth 2
+              </Location>
+            '';
+          };
+        };
+      };
+
+      environment.systemPackages = [ pkgs.openssl ];
+
+      system.activationScripts.createDummyKey = ''
+        set -xe
+
+        dir="${signWebRoot}/keys"
+        mkdir -m 0700 -p $dir
+
+        # We use a fairly 'valid' DN; as to not having to foil the default
+        # checks for things like '2 char' country codes, etc which are in
+        # the standard openssl.conf.
+        #
+        basedn="/C=NL/ST=Zuid-Holland/L=Leiden/O=Cleansing Enterprises B.V"
+
+        # Generating CA - and use that to sign a sign two sub CAs.
+        # One that issues web server certs (that we'll use as a server)
+        # and one that issues certificates to our users.
+        #
+        # We need this `split in two' to make it easier to stop Malory
+        # from pretending to be a user if she has stolen a web server 
+        # private key.
+        #
+        ${pkgs.openssl}/bin/openssl req -new -x509 -nodes -newkey rsa:1024 \
+            -extensions v3_ca \
+            -subj "$basedn/CN=CA" \
+            -out $dir/ca.pem -keyout $dir/ca.key 
+
+        # Now create our two sub CAs. One for the services and one for the users.
+        # And sign each with the above root CA key.
+        #
+        cat >  $dir/extfile.cnf <<EOM
+basicConstraints=CA:TRUE
+EOM
+        # We specify 'nodes' to not encrypt the private keys; as to not
+        # need human interaction (typing in the password) during webserver
+        # startup.
+        #
+        for subca in web users
+        do
+           ${pkgs.openssl}/bin/openssl req \
+               -new -nodes -newkey rsa:1024  \
+               -keyout $dir/ca-$subca.key \
+               -subj "$basedn/CN=Sub CA for $subca" \
+               -out $dir/ca-$subca.csr
+
+           ${pkgs.openssl}/bin/openssl x509 -req -days 14 -set_serial $RANDOM \
+               -CA $dir/ca.pem -CAkey $dir/ca.key \
+               -extfile $dir/extfile.cnf \
+               -in $dir/ca-$subca.csr \
+               -out $dir/ca-$subca.pem
+
+           rm $dir/ca-$subca.csr
+        done
+
+        # We know longer need the root CA key - as we've
+        # signed our two worker sub CA's. And they'll
+        # do the rest.
+        #
+        rm $dir/extfile.cnf $dir/ca.key
+
+        # Make a full chain - somewhat superfluous, but polite nevertheless. See the comment
+        # above near sslServerChain.
+        #
+        cat $dir/ca-web.pem $dir/ca.pem > $dir/chain-web.pem
+        cat $dir/ca-users.pem $dir/ca.pem > $dir/chain-user.pem
+        cat $dir/ca-*.pem $dir/ca.pem > $dir/chain.pem
+
+        # Use the CA Web sub ca to sign a localhost cert. We keep this very simple; a
+        # more realistic example would set all sort of x509v3 extensions; such as an 
+        # key IDs and SubjectAltNames.
+        #
+        ${pkgs.openssl}/bin/openssl req -new -nodes -newkey rsa:1024  -keyout $dir/server.key \
+            -subj "$basedn/CN=site.local" \
+            -out $dir/server.csr
+
+        ${pkgs.openssl}/bin/openssl x509 -req -days 14 -set_serial $RANDOM \
+              -CA $dir/ca-web.pem -CAkey $dir/ca-web.key \
+              -in $dir/server.csr \
+              -out $dir/server.pem 
+        rm $dir/server.csr 
+
+        # SSLCertificateChainFile was obsoleted in apache 2.4.8 - its role taken over by
+        # having them concatenated into SSLCertificateFile. So we create that here; sorted
+        # from leaf to root.
+        cat $dir/server.pem $dir/ca-users.pem $dir/ca.pem > $dir/server-and-chain.pem
+
+        # We know longer need the Web CA key; but we do keep the ca-users key; as that
+        # is what the service needs to sign certificate requests.
+        #
+        rm $dir/ca-web.key
+
+        # Put a text file in the secet directory to test against.
+        #
+        mkdir -p "${signWebRoot}/docroot/secrets"
+
+        echo A solid plan for world domination. > "${signWebRoot}/docroot/secrets/bizplan.txt"
+        echo Nothing to see, now move along.> "${signWebRoot}/docroot/public.txt"
+
+        find "${signWebRoot}" -type f -print
+      '';
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("httpd.service")
+
+    machine.succeed("journalctl  -u apache.service > /dev/stderr")
+
+    # machine.succeed("find / -type f -name *error_log | xargs cat > /dev/stderr")
+    # machine.succeed("find / -type f -name *error-log | xargs cat > /dev/stderr")
+
+    # Show that we cannot access the secret directory without properly identifying; but
+    # that we can see the public part just fine.
+    #
+    machine.succeed(
+        "curl --cacert ${signWebRoot}/keys/ca.pem https://site.local/public.txt || journalctl  -u apache.service > /dev/stderr"
+    )
+    machine.fail(
+        "curl --cacert ${signWebRoot}/keys/ca.pem https://site.local/secrets/bizplan.txt"
+    )
+
+    # Use case 1 -- Get a CSR signed; generate/keep the private key locally.
+   
+    # Next up - get ourselves a client certificate so we can see the secert bizplan.
+
+    # create a signing request for Alice (in pkcs#10 format, the default)
+    #
+    machine.succeed(
+        "openssl req -new -subj /CN=Ignored -nodes -out alice.csr -keyout alice.key"
+    )
+
+    # Offer it to the webserver for signing. Use the CA to check that we're talkinging
+    # to a server we trust. And then sent it the CSR we generated along with the
+    # values we want for the CN and the OU.
+    #
+    # Obviously - this is a bit fake - as this server signs anything. You'd normally
+    # have some type of auth, temporary token or admin approval in here.
+    #
+    machine.succeed(
+        "curl --cacert ${signWebRoot}/keys/ca.pem --data-urlencode subject-CN=Alice --data-urlencode subject-OU=PestControlDepartment --data-urlencode pkcs10@alice.csr https://site.local/issue > alice.p7"
+    )
+
+    # extract the signed public segment
+    machine.succeed("openssl pkcs7 -in alice.p7 -inform DER -print_certs -out alice.crt")
+
+    # Show the signature.
+    #
+    machine.succeed("openssl x509 -in alice.crt -noout -text > /dev/stderr")
+
+    # And (just) the subject that actually got signed.
+    machine.succeed("openssl x509 -in alice.crt -noout -subject > /dev/stderr")
+
+    # Confirm that we can access the secret directory when we properly identify.
+    #
+    machine.succeed(
+        "curl --cacert ${signWebRoot}/keys/ca.pem --cert alice.crt --key alice.key https://site.local/secrets/bizplan.txt > /dev/stderr"
+    )
+
+    # Use case 2 -- Have the whole generation happen on the sever side (so no repudation, Bob
+    # has always trusted the system more than Alice).
+    #
+    # The challenge is a temporary password that will encrypt the returned p12 package.
+    #
+    machine.succeed(
+        "curl --cacert ${signWebRoot}/keys/ca.pem --data-urlencode subject-CN=Bob --data-urlencode subject-OU=VerminControlDepartment  --data-urlencode challenge=foo https://site.local/issue12 > bob.p12"
+    )
+
+    # extract the signed public segment from the encrypted p12 package.
+    #
+    machine.succeed(
+        "openssl pkcs12 -in bob.p12 -password pass:foo -nokeys         -out bob.crt"
+    )
+    machine.succeed(
+        "openssl pkcs12 -in bob.p12 -password pass:foo -nocerts -nodes -out bob.key"
+    )
+
+    machine.succeed("openssl x509 -in bob.crt -noout -subject > /dev/stderr")
+
+    # And show that Bob has access too.
+    #
+    machine.succeed(
+        "curl --cacert ${signWebRoot}/keys/ca.pem --cert bob.crt --key bob.key https://site.local/secrets/bizplan.txt > /dev/stderr"
+    )
+
+    # And finally show that evil Malory - who managed to exfiltrate the private key of the
+    # webserver by some hook or crook - can -not- abuse this to get access; despite the
+    # keys rolling up to the same root.
+    #
+    machine.fail(
+        "curl --cacert ${signWebRoot}/keys/ca.pem --cert ${signWebRoot}/keys/server.pem --key  ${signWebRoot}/keys/server.key https://site.local/secrets/bizplan.txt > /dev/stderr"
+    )
+  '';
+})

--- a/nixos/tests/redwax-timeserver.nix
+++ b/nixos/tests/redwax-timeserver.nix
@@ -1,0 +1,234 @@
+# Test case for an RFC 3161 (RFC 5816) compliant timeserver (over HTTP).
+#
+# Here we timestamp (i.e. add a time & sign) a document. Using the timestamping
+# protocol defined in RFC 3161 (and commonly supported in office tools - e.g. see
+# 'TimeStamping Service' in Open Office / Libre Office).
+# 
+# This demo/test sets up:
+#
+# 1.	tiny CA hierarcye; with a CA root that then
+#	- issues a web service certificate to the webserver
+#	- issues a separate time stamping certificate.
+#       The setup is slightly more complex as usual because
+#       we need true x509v3 certificates; with the timeStamping
+#   	marked as `critical' to please enterprise tools such
+#	as those from Adobe and Microsoft.
+#
+# 2.	Sets up a apache httpd server with SSL.
+#
+# 3.	Hooks into that a red wax timesever module that
+#	relies on the time of the operating system.
+#
+# 4.	Then generates a small 1kByte file to sign/timestamp.
+#
+# 5.	Uses curl to get this signed; checking that the
+#	web server certificate is trusted (not that key - 
+#	we'd just leak the SHA256 checksum of the document
+#	that we wanted to sign (and the metadata that we'd
+#	want to sign).
+#
+# 6.	The uses the 'CA' certificate and the path through
+#  	the time server to check the signature on the
+#	document its timestamp.
+#
+# Note that it is fairly common to have time servers running
+# on port 80 / without encryption. Running the timeserver on
+# https is mostly as it is good practice -and- to illustrate
+# the point made in 2.1/#11 of RFC 3161 about using *different*
+# keys for the transport security and for the time signature.
+#
+# The policy (TimestampDefaultPolicy) is set to a demo value; a
+# real server would use one within their enterprise OID range.
+#
+# The requirements for this OID are laid down in RFC3628; an
+# enterprise prefix can be requested through pen @ IANA.
+#
+# RedWax   Redwax aims to decentralise trust management so that the 
+#	   values security, confidentiality and privacy can be upheld 
+#          in public infrastructure and private interactions. 
+#          http://redwax.eu
+# 
+# RFC3161: Internet X.509 Public Key Infrastructure Time-Stamp Protocol (TSP)
+#          https://tools.ietf.org/html/rfc3161
+#
+# RFC5816  Update to specify the hash of the signer certificate when
+# 	   a non SHA1 hash is used (SHA256 in this demo).
+#          https://tools.ietf.org/html/rfc5816
+# 
+# RFC3628  Policy Requirements for Time-Stamping Authorities (TSAs)
+#          https://www.ietf.org/rfc/rfc3628.txt
+# make-test-python = yourtestfunction: (import "${pkgs.path}/nixos/tests/make-test-python.nix" yourtestfunction { inherit pkgs; }):
+# import <nixos/tests/make-test-python.nix> ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
+let
+  tsWebRoot = "/data/http/ts";
+in
+{
+  name = "redwax";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ dirkx ];
+  };
+
+  machine =
+    { config, ... }:
+    { networking.firewall.enable = true;
+      networking.firewall.rejectPackets = true;
+      networking.firewall.allowPing = true;
+      networking.firewall.allowedTCPPorts = [ 443 ];
+      networking.extraHosts = ''
+        ${config.networking.primaryIPAddress} tts.local
+      '';
+      services.httpd = {
+        enable = true;
+        adminAddr = "admin@tts.local";
+        extraModules = [
+          { name = "ca";        path = "${pkgs.apacheHttpdPackages.mod_ca}/modules/mod_ca.so"; }
+          { name = "ca_simple"; path = "${pkgs.apacheHttpdPackages.mod_ca}/modules/mod_ca_simple.so"; }
+          { name = "timestamp"; path = "${pkgs.apacheHttpdPackages.mod_timestamp}/modules/mod_timestamp.so"; }
+        ];
+        virtualHosts = {
+          "tts.local" = {
+            documentRoot = tsWebRoot;
+            forceSSL = true;
+            sslServerKey =  "${tsWebRoot}/keys/server.key";
+            sslServerCert = "${tsWebRoot}/keys/server.pem";
+            extraConfig = ''
+              Header always set Strict-Transport-Security "max-age=15552000"
+
+              # backend configuration:
+              #
+              # use system clock as the time source
+              CASimpleTime on
+              # assign a random serial number
+              CASimpleSerialRandom on
+
+              <Location /timestamp>
+                  SetHandler timestamp
+                  TimestampSigningCertificate "${tsWebRoot}/keys/ts-service.pem"
+                  TimestampSigningKey         "${tsWebRoot}/keys/ts-service.key"
+                  TimestampDigest 		SHA256
+                  TimestampDefaultPolicy 	1.2.3.4.5
+                  Require all granted
+              </Location>
+            '';
+          };
+        };
+      };
+
+      environment.systemPackages = [ pkgs.openssl ];
+
+      system.activationScripts.createDummyKey = ''
+        set -xe
+
+        dir="${tsWebRoot}/keys"
+        mkdir -m 0700 -p $dir
+
+	# We use a fairly 'valid' DN; as to not having to foil the default
+	# checks for things like '2 char' country codes, etc.
+	#
+        basedn="/C=NL/ST=Zuid-Holland/L=Leiden/O=Koelie-kerk"
+
+        # We need to construct two certificates; one for the web server (optional; http fine too)
+        # and one for the time stamping sevice. See section 2.1/#11 of RFC 3161 for the rationale
+        # behind separate keys/certs ((https://tools.ietf.org/html/rfc3161).
+        
+        # Generating CA - and use that to sign a server and service cert.
+        #
+        ${pkgs.openssl}/bin/openssl req -new -x509 -nodes -newkey rsa:1024 \
+            -extensions v3_ca \
+            -subj "$basedn/CN=CA" \
+            -out $dir/ca.pem -keyout $dir/ca.key 
+
+        # Generating key for server. We are a bit pedantic about subjectAltNames as
+        # some enterprise tools that use time-stamping severs seem to be strict on this.
+        #
+        ${pkgs.openssl}/bin/openssl req -new -nodes -newkey rsa:1024  -keyout $dir/server.key \
+            -subj "$basedn/CN=tts.local" \
+            -extensions v3_req \
+            -addext subjectAltName=DNS:tts.local \
+            -out $dir/temp.csr
+
+        # We're generating a v3 cert (as we need subjectAltName); which does
+        # not have the requered extension block in the default openssl.cnf. So
+        # we generate one.
+	#
+	# Note - we're avoiding reliance on true bash (bourne is enough) by
+	# explictly creating the ext. files.
+        #
+        cat >  $dir/extfile.cnf <<EOM
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyEncipherment 
+EOM
+
+        ${pkgs.openssl}/bin/openssl x509 -req -days 14 -set_serial 2 \
+              -CA $dir/ca.pem -CAkey $dir/ca.key \
+              -extfile $dir/extfile.cnf \
+              -in $dir/temp.csr \
+              -out $dir/server.pem
+        rm $dir/temp.csr $dir/extfile.cnf
+
+        # Generating key for service
+        #
+        ${pkgs.openssl}/bin/openssl req -new -nodes -newkey rsa:1024 -keyout $dir/ts-service.key \
+            -subj "$basedn/CN=Grote klokken doen bim-bam - timestamps service" \
+            -out $dir/temp.csr
+
+        # The signed cert needs timestamping as a critical usage extension.
+        #
+        echo extendedKeyUsage=critical,timeStamping > $dir/extfile.cnf
+
+        ${pkgs.openssl}/bin/openssl x509 -req -days 14 -set_serial 3 \
+              -CA $dir/ca.pem -CAkey $dir/ca.key \
+              -extfile $dir/extfile.cnf \
+              -in $dir/temp.csr \
+              -in $dir/temp.csr \
+              -out $dir/ts-service.pem 
+        rm $dir/temp.csr $dir/extfile.cnf
+
+        # CA key not needed from this point onwards; as we've
+        # signed verything we wanted to sign.
+        rm $dir/ca.key 
+
+        # We need a chain to verify the signature on the timestamp.
+        #
+        cat $dir/ts-service.pem $dir/ca.pem > $dir/fullchain-ts-service.pem
+      '';
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("httpd.service")
+
+    # generate a file to sign
+    machine.succeed("dd if=/dev/urandom of=data.raw count=1 bs=1024")
+
+    # create a signing request for this file
+    machine.succeed(
+        "openssl ts -query -data data.raw -cert -sha256 -no_nonce -out request.tsq"
+    )
+
+    # offer it to the signing server
+    machine.succeed(
+        "curl --cacert ${tsWebRoot}/keys/ca.pem -H Content-type:application/timestamp-query --data-binary @request.tsq https://tts.local/timestamp > reply.tsq"
+    )
+
+    # dump the content of the reply.
+    #
+    machine.succeed("openssl ts -reply -text -in reply.tsq")
+
+    # verify that it is actually signed & valid - and matches the hash of our file
+    #
+    machine.succeed(
+        "openssl ts -verify -in reply.tsq -data data.raw -CAfile ${tsWebRoot}/keys/fullchain-ts-service.pem"
+    )
+
+    # In this simple, cannonical case - we can also check straight against the CA - as there
+    # is nothing in between.
+    #
+    machine.succeed(
+        "openssl ts -verify -in reply.tsq -data data.raw -CAfile ${tsWebRoot}/keys/ca.pem"
+    )
+  '';
+})


### PR DESCRIPTION
4 extra test/examples for the apache redwax modules (ocsp, crl, document/timestamp signing and certificate assigning/signing) for 0.2.3.

Replaces #80187 that (against 0.2.1)

- [X ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X ] NixOS
   - [X ] macOS
   - [ ] other Linux distributions
- [X ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
