### PR TITLE
cheesecutter: init at unstable-2019-12-06

### DIFF
--- a/pkgs/applications/audio/cheesecutter/0001-fix-impure-build-date-display.patch
+++ b/pkgs/applications/audio/cheesecutter/0001-fix-impure-build-date-display.patch
@@ -1,0 +1,26 @@
+diff --git a/src/ct2util.d b/src/ct2util.d
+index 523cadc..e462b09 100644
+--- a/src/ct2util.d
++++ b/src/ct2util.d
+@@ -105,7 +105,7 @@ int main(string[] args) {
+ 	speeds.length = 32;
+ 	masks.length = 32;
+ 	void printheader() {
+-		enum hdr = "CheeseCutter 2 utilities" ~ com.util.versionInfo;
++		enum hdr = "CheeseCutter 2 utilities";
+ 		writefln(hdr);
+ 		writefln("\nUsage: \t%s <command> <options> <infile> <-o outfile>",args[0]);
+ 		writefln("\t%s import <infile> <infile2> <-o outfile>",args[0]);
+diff --git a/src/ui/ui.d b/src/ui/ui.d
+index e418dda..21af408 100644
+--- a/src/ui/ui.d
++++ b/src/ui/ui.d
+@@ -231,7 +231,7 @@ class Infobar : Window {
+ 	  
+ 		screen.clrtoeol(0, headerColor);
+ 
+-		enum hdr = "CheeseCutter 2.9" ~ com.util.versionInfo;
++		enum hdr = "CheeseCutter 2.9";
+ 		screen.cprint(4, 0, 1, headerColor, hdr);
+ 		screen.cprint(screen.width - 14, 0, 1, headerColor, "F12 = Help");
+ 		int c1 = audio.player.isPlaying ? 13 : 12;

--- a/pkgs/applications/audio/cheesecutter/default.nix
+++ b/pkgs/applications/audio/cheesecutter/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch
+, acme, ldc, patchelf
+, SDL
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cheesecutter";
+  version = "unstable-2019-12-06";
+
+  src = fetchFromGitHub {
+    owner = "theyamo";
+    repo = "CheeseCutter";
+    rev = "6b433c5512d693262742a93c8bfdfb353d4be853";
+    sha256 = "1szlcg456b208w1237581sg21x69mqlh8cr6v8yvbhxdz9swxnwy";
+  };
+
+  nativeBuildInputs = [ acme ldc patchelf ];
+
+  buildInputs = [ SDL ];
+
+  patches = [
+    ./0001-fix-impure-build-date-display.patch
+  ];
+
+  makefile = "Makefile.ldc";
+
+  installPhase = ''
+    for exe in {ccutter,ct2util}; do
+      install -D $exe $out/bin/$exe
+    done
+
+    mkdir -p $out/share/cheesecutter/example_tunes
+    cp -r tunes/* $out/share/cheesecutter/example_tunes
+  '';
+
+  postFixup = ''
+    rpath=$(patchelf --print-rpath $out/bin/ccutter)
+    patchelf --set-rpath "$rpath:${lib.makeLibraryPath buildInputs}" $out/bin/ccutter
+  '';
+
+  meta = with lib; {
+    description = "A tracker program for composing music for the SID chip.";
+    homepage = "https://github.com/theyamo/CheeseCutter/";
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ OPNA2608 ];
+  };
+}

--- a/pkgs/development/compilers/acme/default.nix
+++ b/pkgs/development/compilers/acme/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchsvn }:
+
+stdenv.mkDerivation rec {
+  pname = "acme";
+  version = "120";
+
+  src = fetchsvn {
+    url = "svn://svn.code.sf.net/p/acme-crossass/code-0/trunk";
+    rev = version;
+    sha256 = "0w17b8f8bis22m6l5bg8qg8nniy20f8yg2xmzjipblmc39vpv6s2";
+  };
+
+  sourceRoot = "code-0-r${src.rev}/src";
+
+  makeFlags = [ "BINDIR=$(out)/bin" ];
+
+  meta = with stdenv.lib; {
+    description = "A multi-platform cross assembler for 6502/6510/65816 CPUs.";
+    homepage = "https://sourceforge.net/projects/acme-crossass/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ OPNA2608 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8774,6 +8774,8 @@ in
     inherit (darwin.apple_sdk.frameworks) OpenGL;
   };
 
+  acme = callPackage ../development/compilers/acme { };
+
   nasm = callPackage ../development/compilers/nasm { };
 
   nvidia_cg_toolkit = callPackage ../development/compilers/nvidia-cg-toolkit { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18362,6 +18362,8 @@ in
 
   cadence =  qt5.callPackage ../applications/audio/cadence { };
 
+  cheesecutter = callPackage ../applications/audio/cheesecutter { };
+
   milkytracker = callPackage ../applications/audio/milkytracker { };
 
   schismtracker = callPackage ../applications/audio/schismtracker { };


### PR DESCRIPTION
###### Motivation for this change
Packaging more FOSS chiptune tracker, see https://github.com/NixOS/nixpkgs/issues/81815.

Last proper releases are blocked by the lack of GDC in nixpkgs (usage of legacy D syntax that ldc and dmd refuse to accept). Fortunately, master actually compiles under non-GDC compilers, though the alternative stereo version that the releases are exposing via tags is lacking behind in commits.

If the stereo version is desired as well, I can look into that though.

I patched out references to a function that uses Dlang's `__DATE__`, which would display the date of the build in the top-left corner of the application (i.e., "Mar 15 2020"). My thought behind that was to reduce differences between rebuilds without version updates, though I can drop the patch if you think it's not that big of a deal.

Also packaged the ACME Cross-Assembler, as it's a build-time dependency of the tool that assembles the module data into a C64 file. I haven't extensively tested it, but the assembler itself works fine in CheeseCutter's Makefile, and an assembled SID file sounds okay as well.

cc @fgaz 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
