### PR TITLE
php: Clean up php derivation

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -10,8 +10,6 @@
 , makeWrapper, callPackage
 }:
 
-with lib;
-
 let
   generic =
   { version
@@ -51,17 +49,17 @@ let
   , gmpSupport ? config.php.gmp or true
   , ztsSupport ? (config.php.zts or false) || (apxs2Support)
   , calendarSupport ? config.php.calendar or true
-  , sodiumSupport ? (config.php.sodium or true) && (versionAtLeast version "7.2")
+  , sodiumSupport ? (config.php.sodium or true) && (lib.versionAtLeast version "7.2")
   , tidySupport ? (config.php.tidy or false)
-  , argon2Support ? (config.php.argon2 or true) && (versionAtLeast version "7.2")
-  , libzipSupport ? (config.php.libzip or true) && (versionAtLeast version "7.2")
+  , argon2Support ? (config.php.argon2 or true) && (lib.versionAtLeast version "7.2")
+  , libzipSupport ? (config.php.libzip or true) && (lib.versionAtLeast version "7.2")
   , phpdbgSupport ? config.php.phpdbg or true
   , cgiSupport ? config.php.cgi or true
   , cliSupport ? config.php.cli or true
   , pharSupport ? config.php.phar or true
   , xmlrpcSupport ? (config.php.xmlrpc or false) && (libxml2Support)
   , cgotoSupport ? config.php.cgoto or false
-  , valgrindSupport ? (config.php.valgrind or true) && (versionAtLeast version "7.2")
+  , valgrindSupport ? (config.php.valgrind or true) && (lib.versionAtLeast version "7.2")
   , ipv6Support ? config.php.ipv6 or true
   , pearSupport ? (config.php.pear or true) && (libxml2Support)
   }: stdenv.mkDerivation {
@@ -74,79 +72,79 @@ let
     nativeBuildInputs = [ autoconf automake bison file flex libtool pkgconfig re2c ];
 
     buildInputs = [ ]
-      ++ optional (versionOlder version "7.3") pcre
-      ++ optional (versionAtLeast version "7.3") pcre2
-      ++ optional (versionAtLeast version "7.4") oniguruma
-      ++ optional withSystemd systemd
-      ++ optionals imapSupport [ uwimap openssl pam ]
-      ++ optionals curlSupport [ curl openssl ]
-      ++ optionals ldapSupport [ openldap openssl ]
-      ++ optionals gdSupport [ gd freetype libXpm libjpeg libpng libwebp ]
-      ++ optionals opensslSupport [ openssl openssl.dev ]
-      ++ optional apxs2Support apacheHttpd
-      ++ optional (ldapSupport && stdenv.isLinux) cyrus_sasl
-      ++ optional zlibSupport zlib
-      ++ optional libxml2Support libxml2
-      ++ optional readlineSupport readline
-      ++ optional sqliteSupport sqlite
-      ++ optional postgresqlSupport postgresql
-      ++ optional pdo_odbcSupport unixODBC
-      ++ optional pdo_pgsqlSupport postgresql
-      ++ optional gmpSupport gmp
-      ++ optional gettextSupport gettext
-      ++ optional intlSupport icu
-      ++ optional xslSupport libxslt
-      ++ optional bz2Support bzip2
-      ++ optional sodiumSupport libsodium
-      ++ optional tidySupport html-tidy
-      ++ optional argon2Support libargon2
-      ++ optional libzipSupport libzip
-      ++ optional valgrindSupport valgrind;
+      ++ lib.optional (lib.versionOlder version "7.3") pcre
+      ++ lib.optional (lib.versionAtLeast version "7.3") pcre2
+      ++ lib.optional (lib.versionAtLeast version "7.4") oniguruma
+      ++ lib.optional withSystemd systemd
+      ++ lib.optionals imapSupport [ uwimap openssl pam ]
+      ++ lib.optionals curlSupport [ curl openssl ]
+      ++ lib.optionals ldapSupport [ openldap openssl ]
+      ++ lib.optionals gdSupport [ gd freetype libXpm libjpeg libpng libwebp ]
+      ++ lib.optionals opensslSupport [ openssl openssl.dev ]
+      ++ lib.optional apxs2Support apacheHttpd
+      ++ lib.optional (ldapSupport && stdenv.isLinux) cyrus_sasl
+      ++ lib.optional zlibSupport zlib
+      ++ lib.optional libxml2Support libxml2
+      ++ lib.optional readlineSupport readline
+      ++ lib.optional sqliteSupport sqlite
+      ++ lib.optional postgresqlSupport postgresql
+      ++ lib.optional pdo_odbcSupport unixODBC
+      ++ lib.optional pdo_pgsqlSupport postgresql
+      ++ lib.optional gmpSupport gmp
+      ++ lib.optional gettextSupport gettext
+      ++ lib.optional intlSupport icu
+      ++ lib.optional xslSupport libxslt
+      ++ lib.optional bz2Support bzip2
+      ++ lib.optional sodiumSupport libsodium
+      ++ lib.optional tidySupport html-tidy
+      ++ lib.optional argon2Support libargon2
+      ++ lib.optional libzipSupport libzip
+      ++ lib.optional valgrindSupport valgrind;
 
-    CXXFLAGS = optionalString stdenv.cc.isClang "-std=c++11";
+    CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
 
     configureFlags = [ "--with-config-file-scan-dir=/etc/php.d" ]
-      ++ optionals (versionOlder version "7.3") [ "--with-pcre-regex=${pcre.dev}" "PCRE_LIBDIR=${pcre}" ]
-      ++ optionals (versions.majorMinor version == "7.3") [ "--with-pcre-regex=${pcre2.dev}" "PCRE_LIBDIR=${pcre2}" ]
-      ++ optionals (versionAtLeast version "7.4") [ "--with-external-pcre=${pcre2.dev}" "PCRE_LIBDIR=${pcre2}" ]
-      ++ optional stdenv.isDarwin "--with-iconv=${libiconv}"
-      ++ optional withSystemd "--with-fpm-systemd"
-      ++ optionals imapSupport [
+      ++ lib.optionals (lib.versionOlder version "7.3") [ "--with-pcre-regex=${pcre.dev}" "PCRE_LIBDIR=${pcre}" ]
+      ++ lib.optionals (lib.versions.majorMinor version == "7.3") [ "--with-pcre-regex=${pcre2.dev}" "PCRE_LIBDIR=${pcre2}" ]
+      ++ lib.optionals (lib.versionAtLeast version "7.4") [ "--with-external-pcre=${pcre2.dev}" "PCRE_LIBDIR=${pcre2}" ]
+      ++ lib.optional stdenv.isDarwin "--with-iconv=${libiconv}"
+      ++ lib.optional withSystemd "--with-fpm-systemd"
+      ++ lib.optionals imapSupport [
         "--with-imap=${uwimap}"
         "--with-imap-ssl"
       ]
-      ++ optionals ldapSupport [
+      ++ lib.optionals ldapSupport [
         "--with-ldap=/invalid/path"
         "LDAP_DIR=${openldap.dev}"
         "LDAP_INCDIR=${openldap.dev}/include"
         "LDAP_LIBDIR=${openldap.out}/lib"
       ]
-      ++ optional (ldapSupport && stdenv.isLinux) "--with-ldap-sasl=${cyrus_sasl.dev}"
-      ++ optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
-      ++ optional embedSupport "--enable-embed"
-      ++ optional curlSupport "--with-curl=${curl.dev}"
-      ++ optional zlibSupport "--with-zlib=${zlib.dev}"
-      ++ optional (libxml2Support && (versionOlder version "7.4")) "--with-libxml-dir=${libxml2.dev}"
-      ++ optional (!libxml2Support) [
+      ++ lib.optional (ldapSupport && stdenv.isLinux) "--with-ldap-sasl=${cyrus_sasl.dev}"
+      ++ lib.optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
+      ++ lib.optional embedSupport "--enable-embed"
+      ++ lib.optional curlSupport "--with-curl=${curl.dev}"
+      ++ lib.optional zlibSupport "--with-zlib=${zlib.dev}"
+      ++ lib.optional (libxml2Support && (lib.versionOlder version "7.4")) "--with-libxml-dir=${libxml2.dev}"
+      ++ lib.optional (!libxml2Support) [
         "--disable-dom"
-        (if (versionOlder version "7.4") then "--disable-libxml" else "--without-libxml")
+        (if (lib.versionOlder version "7.4") then "--disable-libxml" else "--without-libxml")
         "--disable-simplexml"
         "--disable-xml"
         "--disable-xmlreader"
         "--disable-xmlwriter"
         "--without-pear"
       ]
-      ++ optional pcntlSupport "--enable-pcntl"
-      ++ optional readlineSupport "--with-readline=${readline.dev}"
-      ++ optional sqliteSupport "--with-pdo-sqlite=${sqlite.dev}"
-      ++ optional postgresqlSupport "--with-pgsql=${postgresql}"
-      ++ optional pdo_odbcSupport "--with-pdo-odbc=unixODBC,${unixODBC}"
-      ++ optional pdo_pgsqlSupport "--with-pdo-pgsql=${postgresql}"
-      ++ optional (pdo_mysqlSupport && mysqlndSupport) "--with-pdo-mysql=mysqlnd"
-      ++ optional (mysqliSupport && mysqlndSupport) "--with-mysqli=mysqlnd"
-      ++ optional (pdo_mysqlSupport || mysqliSupport) "--with-mysql-sock=/run/mysqld/mysqld.sock"
-      ++ optional bcmathSupport "--enable-bcmath"
-      ++ optionals (gdSupport && versionAtLeast version "7.4") [
+      ++ lib.optional pcntlSupport "--enable-pcntl"
+      ++ lib.optional readlineSupport "--with-readline=${readline.dev}"
+      ++ lib.optional sqliteSupport "--with-pdo-sqlite=${sqlite.dev}"
+      ++ lib.optional postgresqlSupport "--with-pgsql=${postgresql}"
+      ++ lib.optional pdo_odbcSupport "--with-pdo-odbc=unixODBC,${unixODBC}"
+      ++ lib.optional pdo_pgsqlSupport "--with-pdo-pgsql=${postgresql}"
+      ++ lib.optional (pdo_mysqlSupport && mysqlndSupport) "--with-pdo-mysql=mysqlnd"
+      ++ lib.optional (mysqliSupport && mysqlndSupport) "--with-mysqli=mysqlnd"
+      ++ lib.optional (pdo_mysqlSupport || mysqliSupport) "--with-mysql-sock=/run/mysqld/mysqld.sock"
+      ++ lib.optional bcmathSupport "--enable-bcmath"
+      ++ lib.optionals (gdSupport && lib.versionAtLeast version "7.4") [
         "--enable-gd"
         "--with-external-gd=${gd.dev}"
         "--with-webp=${libwebp}"
@@ -154,7 +152,7 @@ let
         "--with-xpm=${libXpm.dev}"
         "--with-freetype=${freetype.dev}"
         "--enable-gd-jis-conv"
-      ] ++ optionals (gdSupport && versionOlder version "7.4") [
+      ] ++ lib.optionals (gdSupport && lib.versionOlder version "7.4") [
         "--with-gd=${gd.dev}"
         "--with-webp-dir=${libwebp}"
         "--with-jpeg-dir=${libjpeg.dev}"
@@ -163,36 +161,36 @@ let
         "--with-xpm-dir=${libXpm.dev}"
         "--enable-gd-jis-conv"
       ]
-      ++ optional gmpSupport "--with-gmp=${gmp.dev}"
-      ++ optional soapSupport "--enable-soap"
-      ++ optional socketsSupport "--enable-sockets"
-      ++ optional opensslSupport "--with-openssl"
-      ++ optional mbstringSupport "--enable-mbstring"
-      ++ optional gettextSupport "--with-gettext=${gettext}"
-      ++ optional intlSupport "--enable-intl"
-      ++ optional exifSupport "--enable-exif"
-      ++ optional xslSupport "--with-xsl=${libxslt.dev}"
-      ++ optional bz2Support "--with-bz2=${bzip2.dev}"
-      ++ optional (zipSupport && (versionOlder version "7.4")) "--enable-zip"
-      ++ optional (zipSupport && (versionAtLeast version "7.4")) "--with-zip"
-      ++ optional ftpSupport "--enable-ftp"
-      ++ optional fpmSupport "--enable-fpm"
-      ++ optional ztsSupport "--enable-maintainer-zts"
-      ++ optional calendarSupport "--enable-calendar"
-      ++ optional sodiumSupport "--with-sodium=${libsodium.dev}"
-      ++ optional tidySupport "--with-tidy=${html-tidy}"
-      ++ optional argon2Support "--with-password-argon2=${libargon2}"
-      ++ optional (libzipSupport && (versionOlder version "7.4")) "--with-libzip=${libzip.dev}"
-      ++ optional phpdbgSupport "--enable-phpdbg"
-      ++ optional (!phpdbgSupport) "--disable-phpdbg"
-      ++ optional (!cgiSupport) "--disable-cgi"
-      ++ optional (!cliSupport) "--disable-cli"
-      ++ optional (!pharSupport) "--disable-phar"
-      ++ optional xmlrpcSupport "--with-xmlrpc"
-      ++ optional cgotoSupport "--enable-re2c-cgoto"
-      ++ optional valgrindSupport "--with-valgrind=${valgrind.dev}"
-      ++ optional (!ipv6Support) "--disable-ipv6"
-      ++ optional (pearSupport && libxml2Support) "--with-pear=$(out)/lib/php/pear";
+      ++ lib.optional gmpSupport "--with-gmp=${gmp.dev}"
+      ++ lib.optional soapSupport "--enable-soap"
+      ++ lib.optional socketsSupport "--enable-sockets"
+      ++ lib.optional opensslSupport "--with-openssl"
+      ++ lib.optional mbstringSupport "--enable-mbstring"
+      ++ lib.optional gettextSupport "--with-gettext=${gettext}"
+      ++ lib.optional intlSupport "--enable-intl"
+      ++ lib.optional exifSupport "--enable-exif"
+      ++ lib.optional xslSupport "--with-xsl=${libxslt.dev}"
+      ++ lib.optional bz2Support "--with-bz2=${bzip2.dev}"
+      ++ lib.optional (zipSupport && (lib.versionOlder version "7.4")) "--enable-zip"
+      ++ lib.optional (zipSupport && (lib.versionAtLeast version "7.4")) "--with-zip"
+      ++ lib.optional ftpSupport "--enable-ftp"
+      ++ lib.optional fpmSupport "--enable-fpm"
+      ++ lib.optional ztsSupport "--enable-maintainer-zts"
+      ++ lib.optional calendarSupport "--enable-calendar"
+      ++ lib.optional sodiumSupport "--with-sodium=${libsodium.dev}"
+      ++ lib.optional tidySupport "--with-tidy=${html-tidy}"
+      ++ lib.optional argon2Support "--with-password-argon2=${libargon2}"
+      ++ lib.optional (libzipSupport && (lib.versionOlder version "7.4")) "--with-libzip=${libzip.dev}"
+      ++ lib.optional phpdbgSupport "--enable-phpdbg"
+      ++ lib.optional (!phpdbgSupport) "--disable-phpdbg"
+      ++ lib.optional (!cgiSupport) "--disable-cgi"
+      ++ lib.optional (!cliSupport) "--disable-cli"
+      ++ lib.optional (!pharSupport) "--disable-phar"
+      ++ lib.optional xmlrpcSupport "--with-xmlrpc"
+      ++ lib.optional cgotoSupport "--enable-re2c-cgoto"
+      ++ lib.optional valgrindSupport "--with-valgrind=${valgrind.dev}"
+      ++ lib.optional (!ipv6Support) "--disable-ipv6"
+      ++ lib.optional (pearSupport && libxml2Support) "--with-pear=$(out)/lib/php/pear";
 
     hardeningDisable = [ "bindnow" ];
 
@@ -215,7 +213,7 @@ let
       if test -f $src/genfiles; then
         ./genfiles
       fi
-    '' + optionalString stdenv.isDarwin ''
+    '' + lib.optionalString stdenv.isDarwin ''
       substituteInPlace configure --replace "-lstdc++" "-lc++"
     '';
 
@@ -239,7 +237,7 @@ let
 
     meta = with stdenv.lib; {
       description = "An HTML-embedded scripting language";
-      homepage = https://www.php.net/;
+      homepage = "https://www.php.net/";
       license = licenses.php301;
       maintainers = with maintainers; [ globin etu ma27 ];
       platforms = platforms.all;
@@ -257,7 +255,7 @@ let
     passthru.buildEnv = { exts ? (_: []), extraConfig ? "" }: let
       extraInit = writeText "custom-php.ini" ''
         ${extraConfig}
-        ${concatMapStringsSep "\n" (ext: let
+        ${lib.concatMapStringsSep "\n" (ext: let
           extName = lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
           type = "${lib.optionalString (ext.zendExtension or false) "zend_"}extension";
         in ''
@@ -283,7 +281,7 @@ in {
     sha256 = "18sjvl67z5a2x5s2a36g6ls1r3m4hbrsw52hqr2qsgfvg5dkm5bw";
 
     # https://bugs.php.net/bug.php?id=76826
-    extraPatches = optional stdenv.isDarwin ./php72-darwin-isfinite.patch;
+    extraPatches = lib.optional stdenv.isDarwin ./php72-darwin-isfinite.patch;
   };
 
   php73 = generic' {
@@ -291,7 +289,7 @@ in {
     sha256 = "0g84hws15s8gh8iq4h6q747dyfazx47vh3da3whz8d80x83ibgld";
 
     # https://bugs.php.net/bug.php?id=76826
-    extraPatches = optional stdenv.isDarwin ./php73-darwin-isfinite.patch;
+    extraPatches = lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;
   };
 
   php74 = generic' {

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -3,7 +3,7 @@
 , autoconf, automake, bison, file, flex, libtool, pkgconfig, re2c
 , libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pcre, pcre2, sqlite
-, libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, unixODBC
+, libxslt, bzip2, icu, openldap, cyrus_sasl, unixODBC
 , uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium, html-tidy, libargon2
 , gd, freetype, libXpm, libjpeg, libpng, libwebp
 , libzip, valgrind, oniguruma, symlinkJoin, writeText
@@ -20,7 +20,6 @@ let
   , withSystemd ? config.php.systemd or stdenv.isLinux
   , imapSupport ? config.php.imap or (!stdenv.isDarwin)
   , ldapSupport ? config.php.ldap or true
-  , mhashSupport ? config.php.mhash or false
   , mysqlndSupport ? config.php.mysqlnd or true
   , mysqliSupport ? (config.php.mysqli or true) && (mysqlndSupport)
   , pdo_mysqlSupport ? (config.php.pdo_mysql or true) && (mysqlndSupport)
@@ -45,7 +44,6 @@ let
   , intlSupport ? config.php.intl or true
   , exifSupport ? config.php.exif or true
   , xslSupport ? config.php.xsl or false
-  , mcryptSupport ? (config.php.mcrypt or true) && (versionOlder version "7.2")
   , bz2Support ? config.php.bz2 or false
   , zipSupport ? config.php.zip or true
   , ftpSupport ? config.php.ftp or true
@@ -66,10 +64,7 @@ let
   , valgrindSupport ? (config.php.valgrind or true) && (versionAtLeast version "7.2")
   , ipv6Support ? config.php.ipv6 or true
   , pearSupport ? (config.php.pear or true) && (libxml2Support)
-  }:
-  let
-    libmcrypt' = libmcrypt.override { disablePosixThreads = true; };
-  in stdenv.mkDerivation {
+  }: stdenv.mkDerivation {
     pname = "php";
 
     inherit version;
@@ -90,7 +85,6 @@ let
       ++ optionals opensslSupport [ openssl openssl.dev ]
       ++ optional apxs2Support apacheHttpd
       ++ optional (ldapSupport && stdenv.isLinux) cyrus_sasl
-      ++ optional mhashSupport libmhash
       ++ optional zlibSupport zlib
       ++ optional libxml2Support libxml2
       ++ optional readlineSupport readline
@@ -102,7 +96,6 @@ let
       ++ optional gettextSupport gettext
       ++ optional intlSupport icu
       ++ optional xslSupport libxslt
-      ++ optional mcryptSupport libmcrypt'
       ++ optional bz2Support bzip2
       ++ optional sodiumSupport libsodium
       ++ optional tidySupport html-tidy
@@ -131,7 +124,6 @@ let
       ++ optional (ldapSupport && stdenv.isLinux) "--with-ldap-sasl=${cyrus_sasl.dev}"
       ++ optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
       ++ optional embedSupport "--enable-embed"
-      ++ optional mhashSupport "--with-mhash"
       ++ optional curlSupport "--with-curl=${curl.dev}"
       ++ optional zlibSupport "--with-zlib=${zlib.dev}"
       ++ optional (libxml2Support && (versionOlder version "7.4")) "--with-libxml-dir=${libxml2.dev}"
@@ -180,7 +172,6 @@ let
       ++ optional intlSupport "--enable-intl"
       ++ optional exifSupport "--enable-exif"
       ++ optional xslSupport "--with-xsl=${libxslt.dev}"
-      ++ optional mcryptSupport "--with-mcrypt=${libmcrypt'}"
       ++ optional bz2Support "--with-bz2=${bzip2.dev}"
       ++ optional (zipSupport && (versionOlder version "7.4")) "--enable-zip"
       ++ optional (zipSupport && (versionAtLeast version "7.4")) "--with-zip"


### PR DESCRIPTION
###### Motivation for this change
I'm on this mission to clean up the PHP package, so I have done #82348 as a starting point to get a more modular setup.

This PR doesn't actually change the result of any version of PHP that we support. It's just a clean up to make the file easier to work with.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
