### PR TITLE
ocamlPackages.graphics: init at 5.1.0 for OCaml ≥ 4.09 & refactor buildDune2Package

### DIFF
--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -1,6 +1,8 @@
-{ stdenv, ocaml, findlib, dune, opaline }:
+{ stdenv, ocaml, findlib, dune, dune_2, opaline }:
 
 { pname, version, buildInputs ? [], ... }@args:
+
+let Dune = if args.useDune2 or false then dune_2 else dune; in
 
 if args ? minimumOCamlVersion &&
    ! stdenv.lib.versionAtLeast ocaml.version args.minimumOCamlVersion
@@ -29,7 +31,7 @@ stdenv.mkDerivation ({
 
   name = "ocaml${ocaml.version}-${pname}-${version}";
 
-  buildInputs = [ ocaml dune findlib ] ++ buildInputs;
+  buildInputs = [ ocaml Dune findlib ] ++ buildInputs;
 
   meta = (args.meta or {}) // { platforms = args.meta.platforms or ocaml.meta.platforms; };
 

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -11,7 +11,7 @@ let
 in
 
 { stdenv, fetchurl, ncurses, buildEnv
-, libX11, xorgproto, useX11 ? safeX11 stdenv
+, libX11, xorgproto, useX11 ? safeX11 stdenv && !stdenv.lib.versionAtLeast version "4.09"
 , aflSupport ? false
 , flambdaSupport ? false
 }:

--- a/pkgs/development/ocaml-modules/dune-configurator/default.nix
+++ b/pkgs/development/ocaml-modules/dune-configurator/default.nix
@@ -3,6 +3,8 @@
 buildDunePackage rec {
   pname = "dune-configurator";
 
+  useDune2 = true;
+
   inherit (dune_2) src version;
 
   dontAddPrefix = true;

--- a/pkgs/development/ocaml-modules/dune-private-libs/default.nix
+++ b/pkgs/development/ocaml-modules/dune-private-libs/default.nix
@@ -3,6 +3,8 @@
 buildDunePackage rec {
   pname = "dune-private-libs";
 
+  useDune2 = true;
+
   inherit (dune_2) src version;
 
   dontAddPrefix = true;

--- a/pkgs/development/ocaml-modules/eigen/default.nix
+++ b/pkgs/development/ocaml-modules/eigen/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, buildDune2Package, fetchFromGitHub, ctypes, libcxx }:
+{ stdenv, buildDunePackage, fetchFromGitHub, ctypes, libcxx }:
 
-buildDune2Package rec {
+buildDunePackage rec {
   pname = "eigen";
   version = "0.2.0";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "owlbarn";

--- a/pkgs/development/ocaml-modules/graphics/default.nix
+++ b/pkgs/development/ocaml-modules/graphics/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchurl, buildDunePackage, dune-configurator, libX11 }:
+
+buildDunePackage rec {
+
+  pname = "graphics";
+  version = "5.1.0";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/ocaml/graphics/releases/download/${version}/graphics-${version}.tbz";
+    sha256 = "16z997mp0ccilaqqvmz3wp7vx0ghaf4ik9qklgd4piklcl1yv5n5";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ libX11 ];
+
+  meta = {
+    homepage = "https://github.com/ocaml/graphics";
+    description = "A set of portable drawing primitives";
+    license = lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/ocaml-modules/owl-base/default.nix
+++ b/pkgs/development/ocaml-modules/owl-base/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, buildDune2Package, fetchFromGitHub, stdlib-shims }:
+{ stdenv, buildDunePackage, fetchFromGitHub, stdlib-shims }:
 
-buildDune2Package rec {
+buildDunePackage rec {
   pname = "owl-base";
   version = "0.8.0";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner  = "owlbarn";

--- a/pkgs/development/ocaml-modules/owl/default.nix
+++ b/pkgs/development/ocaml-modules/owl/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, buildDune2Package
+, buildDunePackage
 , dune-configurator
 , fetchFromGitHub
 , alcotest
@@ -11,10 +11,10 @@
 , npy
 }:
 
-buildDune2Package rec {
+buildDunePackage rec {
   pname = "owl";
 
-  inherit (owl-base) version src meta;
+  inherit (owl-base) version src meta useDune2;
 
   checkInputs = [ alcotest ];
   buildInputs = [ dune-configurator ];

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -1,9 +1,11 @@
-{ stdenv, buildDune2Package, fetchFromGitHub, ppx_deriving
+{ stdenv, buildDunePackage, fetchFromGitHub, ppx_deriving
 , alcotest, biocaml, gnuplot, lacaml, menhir, owl }:
 
-buildDune2Package rec {
+buildDunePackage rec {
   pname = "phylogenetics";
   version = "unstable-2019-11-15";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner  = "biocaml";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -16,8 +16,6 @@ let
 
     buildDunePackage = callPackage ../build-support/ocaml/dune.nix {};
 
-    buildDune2Package = buildDunePackage.override { dune = dune_2; };
-
     alcotest = callPackage ../development/ocaml-modules/alcotest {};
 
     alcotest-lwt = callPackage ../development/ocaml-modules/alcotest/lwt.nix {};
@@ -232,9 +230,9 @@ let
 
     dune_2 = callPackage ../development/tools/ocaml/dune/2.nix { };
 
-    dune-configurator = callPackage ../development/ocaml-modules/dune-configurator { buildDunePackage = buildDune2Package; };
+    dune-configurator = callPackage ../development/ocaml-modules/dune-configurator { };
 
-    dune-private-libs = callPackage ../development/ocaml-modules/dune-private-libs { buildDunePackage = buildDune2Package; };
+    dune-private-libs = callPackage ../development/ocaml-modules/dune-private-libs { };
 
     earley = callPackage ../development/ocaml-modules/earley { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -347,6 +347,11 @@ let
 
     gmetadom = callPackage ../development/ocaml-modules/gmetadom { };
 
+    graphics =
+    if lib.versionOlder "4.09" ocaml.version
+    then callPackage ../development/ocaml-modules/graphics { }
+    else null;
+
     graphql = callPackage ../development/ocaml-modules/graphql { };
 
     graphql-cohttp = callPackage ../development/ocaml-modules/graphql/cohttp.nix { };


### PR DESCRIPTION
###### Motivation for this change

The initial motivation was to fix `parmap` with OCaml 4.09. At version 1.1, `parmap` depends on `graphics` which is shipped with OCaml < 4.09; when distributed as a separate library, it is built by dune 2 and seems to impose to dependent libraries to use dune 2 as well. This is why I wanted an easy way to select the version of dune.

FTR, here is a possible way to fix `parmap` after this PR:

~~~
--- a/pkgs/development/ocaml-modules/parmap/default.nix
+++ b/pkgs/development/ocaml-modules/parmap/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchzip }:
+{ lib, buildDunePackage, fetchzip, dune-configurator, graphics }:
 
 buildDunePackage rec {
   pname = "parmap";
@@ -9,6 +9,10 @@ buildDunePackage rec {
     sha256 = "13ahqaga1palf0s0dll512cl7k43sllmwvw6r03y70kfmky1j114";
   };
 
+  useDune2 = graphics != null;
+
+  buildInputs = [ graphics ] ++ lib.optional useDune2 dune-configurator;
+
~~~

Updating `parmap` (as done in #82585) is a much simpler way to solve this particular issue.

Nonetheless, I think that getting rid of `buildDune2Package` is a good idea.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
