### PR TITLE
libsidplayfp: 1.8.7 -> 2.0.4, sidplayfp: 1.4.4 -> 2.0.2, fix API options

### DIFF
--- a/pkgs/applications/audio/sidplayfp/default.nix
+++ b/pkgs/applications/audio/sidplayfp/default.nix
@@ -1,18 +1,36 @@
-{ stdenv, fetchurl, pkgconfig, libsidplayfp }:
+{ stdenv
+, lib
+, fetchurl
+, pkgconfig
+, libsidplayfp
+, alsaSupport ? stdenv.hostPlatform.isLinux
+, alsaLib
+, pulseSupport ? stdenv.hostPlatform.isLinux
+, libpulseaudio
+}:
 
+assert alsaSupport -> alsaLib != null;
+assert pulseSupport -> libpulseaudio != null;
+let
+  inherit (lib) optional;
+  inherit (lib.versions) majorMinor;
+in
 stdenv.mkDerivation rec {
-  version = "1.4.4";
   pname = "sidplayfp";
+  version = "2.0.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/sidplay-residfp/sidplayfp/1.4/${pname}-${version}.tar.gz";
-    sha256 = "0arsrg3f0fsinal22qjmj3r6500bcbgqnx26fsz049ldl716kz1m";
+    url = "mirror://sourceforge/sidplay-residfp/sidplayfp/${majorMinor version}/${pname}-${version}.tar.gz";
+    sha256 = "1s2dfs9z1hwarpfzawg11wax9nh0zcqx4cafwq7iysckyg4scz4k";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ]
+    ++ optional alsaSupport alsaLib
+    ++ optional pulseSupport libpulseaudio;
+
   buildInputs = [ libsidplayfp ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A SID player using libsidplayfp";
     homepage = "https://sourceforge.net/projects/sidplay-residfp/";
     license = with licenses; [ gpl2Plus ];

--- a/pkgs/development/libraries/libsidplayfp/default.nix
+++ b/pkgs/development/libraries/libsidplayfp/default.nix
@@ -1,34 +1,41 @@
-{ stdenv, fetchurl, pkgconfig
-, docSupport ? true, doxygen ? null, graphviz ? null }:
+{ stdenv
+, lib
+, fetchurl
+, pkgconfig
+, docSupport ? true
+, doxygen ? null
+, graphviz ? null
+}:
 
 assert docSupport -> doxygen != null && graphviz != null;
-
+let
+  inherit (lib) optionals optionalString;
+  inherit (lib.versions) majorMinor;
+in
 stdenv.mkDerivation rec {
   pname = "libsidplayfp";
-  major = "1";
-  minor = "8";
-  level = "7";
-  version = "${major}.${minor}.${level}";
+  version = "2.0.4";
 
   src = fetchurl {
-    url = "mirror://sourceforge/sidplay-residfp/${pname}/${major}.${minor}/${pname}-${version}.tar.gz";
-    sha256 = "14k1sbdcbhykwfcadq5lbpnm9xp2r7vs7fyi84h72g89y8pjg0da";
+    url = "mirror://sourceforge/sidplay-residfp/${pname}/${majorMinor version}/${pname}-${version}.tar.gz";
+    sha256 = "0d866czmnmhnhb2j37rlrdphjdi2b75kak9barm9xqwg2z0nmmhz";
   };
 
   nativeBuildInputs = [ pkgconfig ]
-    ++ stdenv.lib.optionals docSupport [ doxygen graphviz ];
+    ++ optionals docSupport [ doxygen graphviz ];
 
   installTargets = [ "install" ]
-    ++ stdenv.lib.optionals docSupport [ "doc" ];
+    ++ optionals docSupport [ "doc" ];
 
-  outputs = [ "out" ] ++ stdenv.lib.optionals docSupport [ "doc" ];
+  outputs = [ "out" ]
+    ++ optionals docSupport [ "doc" ];
 
-  postInstall = stdenv.lib.optionalString docSupport ''
+  postInstall = optionalString docSupport ''
     mkdir -p $doc/share/doc/libsidplayfp
     mv docs/html $doc/share/doc/libsidplayfp/
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A library to play Commodore 64 music derived from libsidplay2";
     homepage = "https://sourceforge.net/projects/sidplay-residfp/";
     license = with licenses; [ gpl2Plus ];


### PR DESCRIPTION
###### Motivation for this change
New versions available.

`sidplayfp` would only try to use OSS for playback, fixed that.

cc @RamKromberg @dezgeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
I haven't tested `stilview` in the sidplayfp package, don't know how to use that
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
sidplayfp: 34679176 -> 74860048
libsidplayfp: 34491888 -> 39865888
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
