### PR TITLE
quicklisp: 2017-03-06 -> 2019-02-16 and lispPackages: update distinfo

### DIFF
--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -8,7 +8,7 @@ let lispPackages = rec {
 
   quicklisp = buildLispPackage rec {
     baseName = "quicklisp";
-    version = "2017-03-06";
+    version = "2019-02-16";
 
     buildSystems = [];
 
@@ -17,7 +17,7 @@ let lispPackages = rec {
     src = pkgs.fetchgit {
       url = "https://github.com/quicklisp/quicklisp-client/";
       rev = "refs/tags/version-${version}";
-      sha256 = "11ywk7ggc1axivpbqvrd7m1lxsj4yp38d1h9w1d8i9qnn7zjpqj4";
+      sha256 = "0x9b4vf36n2hh102gqgjxg5f5ymxcr9j5khn4rskjdprfgd8d1y9";
     };
     overrides = x: rec {
       inherit clwrapper;

--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -24,8 +24,8 @@ let lispPackages = rec {
       quicklispdist = pkgs.fetchurl {
         # Will usually be replaced with a fresh version anyway, but needs to be
         # a valid distinfo.txt
-        url = "https://beta.quicklisp.org/dist/quicklisp/2019-07-11/distinfo.txt";
-        sha256 = "0r7ga5gkiy6va1v7a01fnj1yp97pifl9v8fnqpvbiv33dwdvbx2w";
+        url = "https://beta.quicklisp.org/dist/quicklisp/2019-12-27/distinfo.txt";
+        sha256 = "0fz0k7ydmddxvxyid0nkifap21n6bxap602qhqsac2dxglv3i4cs";
       };
       buildPhase = '' true; '';
       postInstall = ''

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''alexandria'';
-  version = ''20190710-git'';
+  version = ''20191227-git'';
 
   description = ''Alexandria is a collection of portable public domain utilities.'';
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/alexandria/2019-07-10/alexandria-20190710-git.tgz'';
-    sha256 = ''0127d5yyq46dpffvr4hla6d3ryiml48mxd2r6cgbg3mgz3b2nr70'';
+    url = ''http://beta.quicklisp.org/archive/alexandria/2019-12-27/alexandria-20191227-git.tgz'';
+    sha256 = ''1vq19i7mcx3dk8vd8l92ld33birs9qhwcs7hbwwphvrwsrxbnd89'';
   };
 
   packageName = "alexandria";
@@ -19,8 +19,8 @@ rec {
 }
 /* (SYSTEM alexandria DESCRIPTION
     Alexandria is a collection of portable public domain utilities. SHA256
-    0127d5yyq46dpffvr4hla6d3ryiml48mxd2r6cgbg3mgz3b2nr70 URL
-    http://beta.quicklisp.org/archive/alexandria/2019-07-10/alexandria-20190710-git.tgz
-    MD5 2b5abc0a266aeafe9029bf26db90b292 NAME alexandria FILENAME alexandria
-    DEPS NIL DEPENDENCIES NIL VERSION 20190710-git SIBLINGS (alexandria-tests)
+    1vq19i7mcx3dk8vd8l92ld33birs9qhwcs7hbwwphvrwsrxbnd89 URL
+    http://beta.quicklisp.org/archive/alexandria/2019-12-27/alexandria-20191227-git.tgz
+    MD5 634105318a9c82a2a2729d0305c91667 NAME alexandria FILENAME alexandria
+    DEPS NIL DEPENDENCIES NIL VERSION 20191227-git SIBLINGS (alexandria-tests)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/anaphora.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/anaphora.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''anaphora'';
-  version = ''20180228-git'';
+  version = ''20191007-git'';
 
   parasites = [ "anaphora/test" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/anaphora/2018-02-28/anaphora-20180228-git.tgz'';
-    sha256 = ''1bd2mvrxdf460wqrmg93lrvrjzvhbxjq8fcpvh24afx6573g2d41'';
+    url = ''http://beta.quicklisp.org/archive/anaphora/2019-10-07/anaphora-20191007-git.tgz'';
+    sha256 = ''0iwfddh3cycjr9vhjnr1ldd5xc3qwqhrp41904s1dvysf99277kv'';
   };
 
   packageName = "anaphora";
@@ -20,8 +20,8 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM anaphora DESCRIPTION The Anaphoric Macro Package from Hell SHA256
-    1bd2mvrxdf460wqrmg93lrvrjzvhbxjq8fcpvh24afx6573g2d41 URL
-    http://beta.quicklisp.org/archive/anaphora/2018-02-28/anaphora-20180228-git.tgz
-    MD5 a884be2d820c0bc7dc59dea7ffd72731 NAME anaphora FILENAME anaphora DEPS
-    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20180228-git SIBLINGS NIL
+    0iwfddh3cycjr9vhjnr1ldd5xc3qwqhrp41904s1dvysf99277kv URL
+    http://beta.quicklisp.org/archive/anaphora/2019-10-07/anaphora-20191007-git.tgz
+    MD5 bfaae44cfb6226f35f0afde335e51ca4 NAME anaphora FILENAME anaphora DEPS
+    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20191007-git SIBLINGS NIL
     PARASITES (anaphora/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/babel.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/babel.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''babel'';
-  version = ''20171227-git'';
+  version = ''20191130-git'';
 
   description = ''Babel, a charset conversion library.'';
 
   deps = [ args."alexandria" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/babel/2017-12-27/babel-20171227-git.tgz'';
-    sha256 = ''166y6j9ma1vxzy5bcwnbi37zwgn2zssx5x1q7zr63kyj2caiw2rf'';
+    url = ''http://beta.quicklisp.org/archive/babel/2019-11-30/babel-20191130-git.tgz'';
+    sha256 = ''0rnb7waq3fi51g2fxrazkyr2fmksqp0syjhni005vzzlbykmkavd'';
   };
 
   packageName = "babel";
@@ -18,10 +18,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM babel DESCRIPTION Babel, a charset conversion library. SHA256
-    166y6j9ma1vxzy5bcwnbi37zwgn2zssx5x1q7zr63kyj2caiw2rf URL
-    http://beta.quicklisp.org/archive/babel/2017-12-27/babel-20171227-git.tgz
-    MD5 8ea39f73873847907a8bb67f99f16ecd NAME babel FILENAME babel DEPS
+    0rnb7waq3fi51g2fxrazkyr2fmksqp0syjhni005vzzlbykmkavd URL
+    http://beta.quicklisp.org/archive/babel/2019-11-30/babel-20191130-git.tgz
+    MD5 80087c99fe351d24e56bb279a62effeb NAME babel FILENAME babel DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME trivial-features FILENAME trivial-features))
-    DEPENDENCIES (alexandria trivial-features) VERSION 20171227-git SIBLINGS
+    DEPENDENCIES (alexandria trivial-features) VERSION 20191130-git SIBLINGS
     (babel-streams babel-tests) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/bordeaux-threads.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/bordeaux-threads.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''bordeaux-threads'';
-  version = ''v0.8.6'';
+  version = ''v0.8.7'';
 
   parasites = [ "bordeaux-threads/test" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/bordeaux-threads/2018-07-11/bordeaux-threads-v0.8.6.tgz'';
-    sha256 = ''1q3b9dbyz02g6iav5rvzml7c8r0iad9j5kipgwkxj0b8qijjzr1y'';
+    url = ''http://beta.quicklisp.org/archive/bordeaux-threads/2019-11-30/bordeaux-threads-v0.8.7.tgz'';
+    sha256 = ''1an8fgam16nyhfninm0gl8k666f93k9j7kwmg43g8qcimyaj3l6w'';
   };
 
   packageName = "bordeaux-threads";
@@ -21,10 +21,10 @@ rec {
 }
 /* (SYSTEM bordeaux-threads DESCRIPTION
     Bordeaux Threads makes writing portable multi-threaded apps simple. SHA256
-    1q3b9dbyz02g6iav5rvzml7c8r0iad9j5kipgwkxj0b8qijjzr1y URL
-    http://beta.quicklisp.org/archive/bordeaux-threads/2018-07-11/bordeaux-threads-v0.8.6.tgz
-    MD5 f959d3902694b1fe6de450a854040f86 NAME bordeaux-threads FILENAME
+    1an8fgam16nyhfninm0gl8k666f93k9j7kwmg43g8qcimyaj3l6w URL
+    http://beta.quicklisp.org/archive/bordeaux-threads/2019-11-30/bordeaux-threads-v0.8.7.tgz
+    MD5 071b427dd047999ffe038a2ef848ac13 NAME bordeaux-threads FILENAME
     bordeaux-threads DEPS
     ((NAME alexandria FILENAME alexandria) (NAME fiveam FILENAME fiveam))
-    DEPENDENCIES (alexandria fiveam) VERSION v0.8.6 SIBLINGS NIL PARASITES
+    DEPENDENCIES (alexandria fiveam) VERSION v0.8.7 SIBLINGS NIL PARASITES
     (bordeaux-threads/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/caveman.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/caveman.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''caveman'';
-  version = ''20181210-git'';
+  version = ''20190813-git'';
 
   description = ''Web Application Framework for Common Lisp'';
 
-  deps = [ args."alexandria" args."anaphora" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."circular-streams" args."cl_plus_ssl" args."cl-annot" args."cl-ansi-text" args."cl-base64" args."cl-colors" args."cl-cookie" args."cl-emb" args."cl-fad" args."cl-ppcre" args."cl-project" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."clack-test" args."clack-v1-compat" args."dexador" args."do-urlencode" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."let-plus" args."local-time" args."map-set" args."marshal" args."md5" args."myway" args."named-readtables" args."nibbles" args."proc-parse" args."prove" args."quri" args."rfc2388" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."usocket" args."xsubseq" ];
+  deps = [ args."alexandria" args."anaphora" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."circular-streams" args."cl_plus_ssl" args."cl-annot" args."cl-ansi-text" args."cl-base64" args."cl-colors" args."cl-cookie" args."cl-emb" args."cl-fad" args."cl-ppcre" args."cl-project" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."clack-test" args."clack-v1-compat" args."dexador" args."dissect" args."do-urlencode" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."let-plus" args."local-time" args."map-set" args."marshal" args."md5" args."myway" args."named-readtables" args."nibbles" args."proc-parse" args."prove" args."quri" args."rfc2388" args."rove" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/caveman/2018-12-10/caveman-20181210-git.tgz'';
-    sha256 = ''04b5dhmdwcwpdcjk4bk25fmqx786k7g3iqsk1xc35kvsxi9ykldf'';
+    url = ''http://beta.quicklisp.org/archive/caveman/2019-08-13/caveman-20190813-git.tgz'';
+    sha256 = ''017b3g3vm28awv8s68rwkwri7yq31a6lgdd7114ziis2a9fq9hyd'';
   };
 
   packageName = "caveman";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM caveman DESCRIPTION Web Application Framework for Common Lisp SHA256
-    04b5dhmdwcwpdcjk4bk25fmqx786k7g3iqsk1xc35kvsxi9ykldf URL
-    http://beta.quicklisp.org/archive/caveman/2018-12-10/caveman-20181210-git.tgz
-    MD5 d3192b79636901bb0676681fc5d05748 NAME caveman FILENAME caveman DEPS
+    017b3g3vm28awv8s68rwkwri7yq31a6lgdd7114ziis2a9fq9hyd URL
+    http://beta.quicklisp.org/archive/caveman/2019-08-13/caveman-20190813-git.tgz
+    MD5 09d7223fd528757eaf1285dd99105ed6 NAME caveman FILENAME caveman DEPS
     ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
      (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -42,7 +42,8 @@ rec {
      (NAME clack-socket FILENAME clack-socket)
      (NAME clack-test FILENAME clack-test)
      (NAME clack-v1-compat FILENAME clack-v1-compat)
-     (NAME dexador FILENAME dexador) (NAME do-urlencode FILENAME do-urlencode)
+     (NAME dexador FILENAME dexador) (NAME dissect FILENAME dissect)
+     (NAME do-urlencode FILENAME do-urlencode)
      (NAME fast-http FILENAME fast-http) (NAME fast-io FILENAME fast-io)
      (NAME flexi-streams FILENAME flexi-streams)
      (NAME http-body FILENAME http-body)
@@ -57,7 +58,8 @@ rec {
      (NAME named-readtables FILENAME named-readtables)
      (NAME nibbles FILENAME nibbles) (NAME proc-parse FILENAME proc-parse)
      (NAME prove FILENAME prove) (NAME quri FILENAME quri)
-     (NAME rfc2388 FILENAME rfc2388) (NAME smart-buffer FILENAME smart-buffer)
+     (NAME rfc2388 FILENAME rfc2388) (NAME rove FILENAME rove)
+     (NAME smart-buffer FILENAME smart-buffer)
      (NAME split-sequence FILENAME split-sequence)
      (NAME static-vectors FILENAME static-vectors)
      (NAME trivial-backtrace FILENAME trivial-backtrace)
@@ -72,14 +74,14 @@ rec {
      chipz chunga circular-streams cl+ssl cl-annot cl-ansi-text cl-base64
      cl-colors cl-cookie cl-emb cl-fad cl-ppcre cl-project cl-reexport
      cl-syntax cl-syntax-annot cl-utilities clack clack-handler-hunchentoot
-     clack-socket clack-test clack-v1-compat dexador do-urlencode fast-http
-     fast-io flexi-streams http-body hunchentoot ironclad jonathan lack
-     lack-component lack-middleware-backtrace lack-util let-plus local-time
-     map-set marshal md5 myway named-readtables nibbles proc-parse prove quri
-     rfc2388 smart-buffer split-sequence static-vectors trivial-backtrace
-     trivial-features trivial-garbage trivial-gray-streams trivial-mimes
-     trivial-types usocket xsubseq)
-    VERSION 20181210-git SIBLINGS
+     clack-socket clack-test clack-v1-compat dexador dissect do-urlencode
+     fast-http fast-io flexi-streams http-body hunchentoot ironclad jonathan
+     lack lack-component lack-middleware-backtrace lack-util let-plus
+     local-time map-set marshal md5 myway named-readtables nibbles proc-parse
+     prove quri rfc2388 rove smart-buffer split-sequence static-vectors
+     trivial-backtrace trivial-features trivial-garbage trivial-gray-streams
+     trivial-mimes trivial-types usocket xsubseq)
+    VERSION 20190813-git SIBLINGS
     (caveman-middleware-dbimanager caveman-test caveman2-db caveman2-test
      caveman2)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-repl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-repl.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-async-repl'';
-  version = ''cl-async-20190307-git'';
+  version = ''cl-async-20191130-git'';
 
   description = ''REPL integration for CL-ASYNC.'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-async" args."cl-async-base" args."cl-async-util" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-async/2019-03-07/cl-async-20190307-git.tgz'';
-    sha256 = ''1sgqdz1dqhknh92l39w67931kml6v9c5yj0brx7lb18l1z76ycw6'';
+    url = ''http://beta.quicklisp.org/archive/cl-async/2019-11-30/cl-async-20191130-git.tgz'';
+    sha256 = ''01kadvflif18f4i2l8iwx9jpg9543hrxagv4ad4q1k9500078vv2'';
   };
 
   packageName = "cl-async-repl";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-async-repl DESCRIPTION REPL integration for CL-ASYNC. SHA256
-    1sgqdz1dqhknh92l39w67931kml6v9c5yj0brx7lb18l1z76ycw6 URL
-    http://beta.quicklisp.org/archive/cl-async/2019-03-07/cl-async-20190307-git.tgz
-    MD5 ead46ad0e709ce26489eb8b239bdbd0e NAME cl-async-repl FILENAME
+    01kadvflif18f4i2l8iwx9jpg9543hrxagv4ad4q1k9500078vv2 URL
+    http://beta.quicklisp.org/archive/cl-async/2019-11-30/cl-async-20191130-git.tgz
+    MD5 3850bc827b4c41b6047b962e3892bcb2 NAME cl-async-repl FILENAME
     cl-async-repl DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -39,5 +39,5 @@ rec {
     (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain cl-async
      cl-async-base cl-async-util cl-libuv cl-ppcre fast-io static-vectors
      trivial-features trivial-gray-streams vom)
-    VERSION cl-async-20190307-git SIBLINGS
+    VERSION cl-async-20191130-git SIBLINGS
     (cl-async-ssl cl-async-test cl-async) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-ssl.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-async-ssl'';
-  version = ''cl-async-20190307-git'';
+  version = ''cl-async-20191130-git'';
 
   description = ''SSL Wrapper around cl-async socket implementation.'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-async" args."cl-async-base" args."cl-async-util" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-async/2019-03-07/cl-async-20190307-git.tgz'';
-    sha256 = ''1sgqdz1dqhknh92l39w67931kml6v9c5yj0brx7lb18l1z76ycw6'';
+    url = ''http://beta.quicklisp.org/archive/cl-async/2019-11-30/cl-async-20191130-git.tgz'';
+    sha256 = ''01kadvflif18f4i2l8iwx9jpg9543hrxagv4ad4q1k9500078vv2'';
   };
 
   packageName = "cl-async-ssl";
@@ -19,9 +19,9 @@ rec {
 }
 /* (SYSTEM cl-async-ssl DESCRIPTION
     SSL Wrapper around cl-async socket implementation. SHA256
-    1sgqdz1dqhknh92l39w67931kml6v9c5yj0brx7lb18l1z76ycw6 URL
-    http://beta.quicklisp.org/archive/cl-async/2019-03-07/cl-async-20190307-git.tgz
-    MD5 ead46ad0e709ce26489eb8b239bdbd0e NAME cl-async-ssl FILENAME
+    01kadvflif18f4i2l8iwx9jpg9543hrxagv4ad4q1k9500078vv2 URL
+    http://beta.quicklisp.org/archive/cl-async/2019-11-30/cl-async-20191130-git.tgz
+    MD5 3850bc827b4c41b6047b962e3892bcb2 NAME cl-async-ssl FILENAME
     cl-async-ssl DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -40,5 +40,5 @@ rec {
     (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain cl-async
      cl-async-base cl-async-util cl-libuv cl-ppcre fast-io static-vectors
      trivial-features trivial-gray-streams vom)
-    VERSION cl-async-20190307-git SIBLINGS
+    VERSION cl-async-20191130-git SIBLINGS
     (cl-async-repl cl-async-test cl-async) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-async'';
-  version = ''20190307-git'';
+  version = ''20191130-git'';
 
   parasites = [ "cl-async-base" "cl-async-util" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."uiop" args."vom" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-async/2019-03-07/cl-async-20190307-git.tgz'';
-    sha256 = ''1sgqdz1dqhknh92l39w67931kml6v9c5yj0brx7lb18l1z76ycw6'';
+    url = ''http://beta.quicklisp.org/archive/cl-async/2019-11-30/cl-async-20191130-git.tgz'';
+    sha256 = ''01kadvflif18f4i2l8iwx9jpg9543hrxagv4ad4q1k9500078vv2'';
   };
 
   packageName = "cl-async";
@@ -20,9 +20,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-async DESCRIPTION Asynchronous operations for Common Lisp. SHA256
-    1sgqdz1dqhknh92l39w67931kml6v9c5yj0brx7lb18l1z76ycw6 URL
-    http://beta.quicklisp.org/archive/cl-async/2019-03-07/cl-async-20190307-git.tgz
-    MD5 ead46ad0e709ce26489eb8b239bdbd0e NAME cl-async FILENAME cl-async DEPS
+    01kadvflif18f4i2l8iwx9jpg9543hrxagv4ad4q1k9500078vv2 URL
+    http://beta.quicklisp.org/archive/cl-async/2019-11-30/cl-async-20191130-git.tgz
+    MD5 3850bc827b4c41b6047b962e3892bcb2 NAME cl-async FILENAME cl-async DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
@@ -37,5 +37,5 @@ rec {
     (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain cl-libuv
      cl-ppcre fast-io static-vectors trivial-features trivial-gray-streams uiop
      vom)
-    VERSION 20190307-git SIBLINGS (cl-async-repl cl-async-ssl cl-async-test)
+    VERSION 20191130-git SIBLINGS (cl-async-repl cl-async-ssl cl-async-test)
     PARASITES (cl-async-base cl-async-util)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-change-case.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-change-case.nix
@@ -1,0 +1,31 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-change-case'';
+  version = ''20191007-git'';
+
+  description = ''Convert strings between camelCase, param-case, PascalCase and more'';
+
+  deps = [ args."cl-ppcre" args."cl-ppcre-unicode" args."cl-unicode" args."flexi-streams" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-change-case/2019-10-07/cl-change-case-20191007-git.tgz'';
+    sha256 = ''097n7bzlsryqh6gbwn3nzi9qdw4jhck4vn3qw41zpc496xfgz9y1'';
+  };
+
+  packageName = "cl-change-case";
+
+  asdFilesToKeep = ["cl-change-case.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-change-case DESCRIPTION
+    Convert strings between camelCase, param-case, PascalCase and more SHA256
+    097n7bzlsryqh6gbwn3nzi9qdw4jhck4vn3qw41zpc496xfgz9y1 URL
+    http://beta.quicklisp.org/archive/cl-change-case/2019-10-07/cl-change-case-20191007-git.tgz
+    MD5 385245df04b1f1514b9fd709a08c4082 NAME cl-change-case FILENAME
+    cl-change-case DEPS
+    ((NAME cl-ppcre FILENAME cl-ppcre)
+     (NAME cl-ppcre-unicode FILENAME cl-ppcre-unicode)
+     (NAME cl-unicode FILENAME cl-unicode)
+     (NAME flexi-streams FILENAME flexi-streams))
+    DEPENDENCIES (cl-ppcre cl-ppcre-unicode cl-unicode flexi-streams) VERSION
+    20191007-git SIBLINGS (cl-change-case-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cookie.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cookie.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-cookie'';
-  version = ''20150804-git'';
+  version = ''20191007-git'';
 
   description = ''HTTP cookie manager'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cl-fad" args."cl-ppcre" args."cl-utilities" args."local-time" args."proc-parse" args."quri" args."split-sequence" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-cookie/2015-08-04/cl-cookie-20150804-git.tgz'';
-    sha256 = ''0llh5d2p7wi5amzpckng1bzmf2bdfdwkfapcdq0znqlzd5bvbby8'';
+    url = ''http://beta.quicklisp.org/archive/cl-cookie/2019-10-07/cl-cookie-20191007-git.tgz'';
+    sha256 = ''1xcb69n3qfp37nwj0mj2whf3yj5xfsgh9sdw6c64gxqkiiq9nfhh'';
   };
 
   packageName = "cl-cookie";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-cookie DESCRIPTION HTTP cookie manager SHA256
-    0llh5d2p7wi5amzpckng1bzmf2bdfdwkfapcdq0znqlzd5bvbby8 URL
-    http://beta.quicklisp.org/archive/cl-cookie/2015-08-04/cl-cookie-20150804-git.tgz
-    MD5 d2c08a71afd47b3ad42e1234ec1a3083 NAME cl-cookie FILENAME cl-cookie DEPS
+    1xcb69n3qfp37nwj0mj2whf3yj5xfsgh9sdw6c64gxqkiiq9nfhh URL
+    http://beta.quicklisp.org/archive/cl-cookie/2019-10-07/cl-cookie-20191007-git.tgz
+    MD5 37595a6705fdd77415b859aea90d30bc NAME cl-cookie FILENAME cl-cookie DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-fad FILENAME cl-fad) (NAME cl-ppcre FILENAME cl-ppcre)
@@ -32,4 +32,4 @@ rec {
     DEPENDENCIES
     (alexandria babel bordeaux-threads cl-fad cl-ppcre cl-utilities local-time
      proc-parse quri split-sequence trivial-features)
-    VERSION 20150804-git SIBLINGS (cl-cookie-test) PARASITES NIL) */
+    VERSION 20191007-git SIBLINGS (cl-cookie-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-dbi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-dbi.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-dbi'';
-  version = ''20190521-git'';
+  version = ''20191007-git'';
 
   description = ''System lacks description'';
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-annot" args."cl-syntax" args."cl-syntax-annot" args."closer-mop" args."dbi" args."named-readtables" args."split-sequence" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz'';
-    sha256 = ''1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg'';
+    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz'';
+    sha256 = ''0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35'';
   };
 
   packageName = "cl-dbi";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-dbi DESCRIPTION System lacks description SHA256
-    1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg URL
-    http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz
-    MD5 ba77d3a955991b406f56cc1a09e71dc2 NAME cl-dbi FILENAME cl-dbi DEPS
+    0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35 URL
+    http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz
+    MD5 bf524c4000468d12627fa419ae412abb NAME cl-dbi FILENAME cl-dbi DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-annot FILENAME cl-annot) (NAME cl-syntax FILENAME cl-syntax)
@@ -32,5 +32,5 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads cl-annot cl-syntax cl-syntax-annot closer-mop
      dbi named-readtables split-sequence trivial-types)
-    VERSION 20190521-git SIBLINGS
+    VERSION 20191007-git SIBLINGS
     (dbd-mysql dbd-postgres dbd-sqlite3 dbi-test dbi) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fad.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fad.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-fad'';
-  version = ''20180430-git'';
+  version = ''20190813-git'';
 
   parasites = [ "cl-fad-test" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-ppcre" args."unit-test" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-fad/2018-04-30/cl-fad-20180430-git.tgz'';
-    sha256 = ''175v6y32q6qpc8axacf8nw44pmsw7a6r476w0f01cp1gwvpis1cs'';
+    url = ''http://beta.quicklisp.org/archive/cl-fad/2019-08-13/cl-fad-20190813-git.tgz'';
+    sha256 = ''0kixjb6cqpcmlac5mh4qjlnhjbww32f3pn89g0cnwvz952y8nlng'';
   };
 
   packageName = "cl-fad";
@@ -20,11 +20,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-fad DESCRIPTION Portable pathname library SHA256
-    175v6y32q6qpc8axacf8nw44pmsw7a6r476w0f01cp1gwvpis1cs URL
-    http://beta.quicklisp.org/archive/cl-fad/2018-04-30/cl-fad-20180430-git.tgz
-    MD5 005c1b7b376fc60dea72574d2acdc704 NAME cl-fad FILENAME cl-fad DEPS
+    0kixjb6cqpcmlac5mh4qjlnhjbww32f3pn89g0cnwvz952y8nlng URL
+    http://beta.quicklisp.org/archive/cl-fad/2019-08-13/cl-fad-20190813-git.tgz
+    MD5 7d0405b44fefccb8a807527249ee2700 NAME cl-fad FILENAME cl-fad DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-ppcre FILENAME cl-ppcre) (NAME unit-test FILENAME unit-test))
     DEPENDENCIES (alexandria bordeaux-threads cl-ppcre unit-test) VERSION
-    20180430-git SIBLINGS NIL PARASITES (cl-fad-test)) */
+    20190813-git SIBLINGS NIL PARASITES (cl-fad-test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fuse.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-fuse.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-fuse'';
-  version = ''20190710-git'';
+  version = ''20191227-git'';
 
   description = ''CFFI bindings to FUSE (Filesystem in user space)'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-utilities" args."iterate" args."trivial-backtrace" args."trivial-features" args."trivial-utf-8" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-fuse/2019-07-10/cl-fuse-20190710-git.tgz'';
-    sha256 = ''1gxah8qwwb9xlvbdy5xxz07hh2hsw7xdrps1n4slhz4x6vyy80li'';
+    url = ''http://beta.quicklisp.org/archive/cl-fuse/2019-12-27/cl-fuse-20191227-git.tgz'';
+    sha256 = ''1yvzixbbwmi87w9zwc1nf2xngxrb3a2q3sp4l2g3751hbd4i0m38'';
   };
 
   packageName = "cl-fuse";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-fuse DESCRIPTION CFFI bindings to FUSE (Filesystem in user space)
-    SHA256 1gxah8qwwb9xlvbdy5xxz07hh2hsw7xdrps1n4slhz4x6vyy80li URL
-    http://beta.quicklisp.org/archive/cl-fuse/2019-07-10/cl-fuse-20190710-git.tgz
-    MD5 5f267e59eb2358b1b6e4e735fb408e6a NAME cl-fuse FILENAME cl-fuse DEPS
+    SHA256 1yvzixbbwmi87w9zwc1nf2xngxrb3a2q3sp4l2g3751hbd4i0m38 URL
+    http://beta.quicklisp.org/archive/cl-fuse/2019-12-27/cl-fuse-20191227-git.tgz
+    MD5 3c6f85db7797a2890d8303d11595100d NAME cl-fuse FILENAME cl-fuse DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
@@ -32,4 +32,4 @@ rec {
     DEPENDENCIES
     (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain
      cl-utilities iterate trivial-backtrace trivial-features trivial-utf-8)
-    VERSION 20190710-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20191227-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-pdf'';
-  version = ''20170830-git'';
+  version = ''20191007-git'';
 
   description = ''Common Lisp PDF Generation Library'';
 
   deps = [ args."iterate" args."uiop" args."zpb-ttf" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-pdf/2017-08-30/cl-pdf-20170830-git.tgz'';
-    sha256 = ''1x4zk6l635f121p1anfd7d807iglyrlhsnmygydw5l49m3h6n08s'';
+    url = ''http://beta.quicklisp.org/archive/cl-pdf/2019-10-07/cl-pdf-20191007-git.tgz'';
+    sha256 = ''0l0hnxysy7dc4wj50nfwn8x7v188vaxvsvk8kl92zb92lfzgw7cd'';
   };
 
   packageName = "cl-pdf";
@@ -18,10 +18,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-pdf DESCRIPTION Common Lisp PDF Generation Library SHA256
-    1x4zk6l635f121p1anfd7d807iglyrlhsnmygydw5l49m3h6n08s URL
-    http://beta.quicklisp.org/archive/cl-pdf/2017-08-30/cl-pdf-20170830-git.tgz
-    MD5 f865503aff50c0a4732a7a4597bdcc25 NAME cl-pdf FILENAME cl-pdf DEPS
+    0l0hnxysy7dc4wj50nfwn8x7v188vaxvsvk8kl92zb92lfzgw7cd URL
+    http://beta.quicklisp.org/archive/cl-pdf/2019-10-07/cl-pdf-20191007-git.tgz
+    MD5 edde2f2da08ec10be65364737ed5fa5c NAME cl-pdf FILENAME cl-pdf DEPS
     ((NAME iterate FILENAME iterate) (NAME uiop FILENAME uiop)
      (NAME zpb-ttf FILENAME zpb-ttf))
-    DEPENDENCIES (iterate uiop zpb-ttf) VERSION 20170830-git SIBLINGS
+    DEPENDENCIES (iterate uiop zpb-ttf) VERSION 20191007-git SIBLINGS
     (cl-pdf-parser) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-postgres'';
-  version = ''postmodern-20190521-git'';
+  version = ''postmodern-20191227-git'';
 
   parasites = [ "cl-postgres/tests" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."fiveam" args."md5" args."split-sequence" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/postmodern/2019-05-21/postmodern-20190521-git.tgz'';
-    sha256 = ''1vphrizbhbs3r5rq4b8dh4149bz11h5xxilragwf4l2i619k3cp5'';
+    url = ''http://beta.quicklisp.org/archive/postmodern/2019-12-27/postmodern-20191227-git.tgz'';
+    sha256 = ''1p44aphx7y0lh018pk2r9w006vinc5yrfrp1m9l9648p2jxiw1c4'';
   };
 
   packageName = "cl-postgres";
@@ -20,13 +20,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-postgres DESCRIPTION Low-level client library for PostgreSQL
-    SHA256 1vphrizbhbs3r5rq4b8dh4149bz11h5xxilragwf4l2i619k3cp5 URL
-    http://beta.quicklisp.org/archive/postmodern/2019-05-21/postmodern-20190521-git.tgz
-    MD5 102567f386757cd52aca500c0c348d90 NAME cl-postgres FILENAME cl-postgres
+    SHA256 1p44aphx7y0lh018pk2r9w006vinc5yrfrp1m9l9648p2jxiw1c4 URL
+    http://beta.quicklisp.org/archive/postmodern/2019-12-27/postmodern-20191227-git.tgz
+    MD5 67b909de432e6414e7832eed18f9ad18 NAME cl-postgres FILENAME cl-postgres
     DEPS
     ((NAME fiveam FILENAME fiveam) (NAME md5 FILENAME md5)
      (NAME split-sequence FILENAME split-sequence)
      (NAME usocket FILENAME usocket))
     DEPENDENCIES (fiveam md5 split-sequence usocket) VERSION
-    postmodern-20190521-git SIBLINGS (postmodern s-sql simple-date) PARASITES
+    postmodern-20191227-git SIBLINGS (postmodern s-sql simple-date) PARASITES
     (cl-postgres/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-prevalence.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-prevalence.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-prevalence'';
-  version = ''20190521-git'';
+  version = ''20191130-git'';
 
   description = ''Common Lisp Prevalence Package'';
 
   deps = [ args."s-sysdeps" args."s-xml" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-prevalence/2019-05-21/cl-prevalence-20190521-git.tgz'';
-    sha256 = ''16j7ccpjdidz1p6mgib06viy966ckxzgkd6xcvg96xmr4hkksljf'';
+    url = ''http://beta.quicklisp.org/archive/cl-prevalence/2019-11-30/cl-prevalence-20191130-git.tgz'';
+    sha256 = ''01pk77nhyv89zd9sf78i0gch9swxlaw3sqnjdnx4329ww6qv2sg4'';
   };
 
   packageName = "cl-prevalence";
@@ -18,10 +18,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-prevalence DESCRIPTION Common Lisp Prevalence Package SHA256
-    16j7ccpjdidz1p6mgib06viy966ckxzgkd6xcvg96xmr4hkksljf URL
-    http://beta.quicklisp.org/archive/cl-prevalence/2019-05-21/cl-prevalence-20190521-git.tgz
-    MD5 6c81a4fe41bd63eef9ff8f4cc41aa6b9 NAME cl-prevalence FILENAME
+    01pk77nhyv89zd9sf78i0gch9swxlaw3sqnjdnx4329ww6qv2sg4 URL
+    http://beta.quicklisp.org/archive/cl-prevalence/2019-11-30/cl-prevalence-20191130-git.tgz
+    MD5 7615cb79ec797a5520941aedc3101390 NAME cl-prevalence FILENAME
     cl-prevalence DEPS
     ((NAME s-sysdeps FILENAME s-sysdeps) (NAME s-xml FILENAME s-xml))
-    DEPENDENCIES (s-sysdeps s-xml) VERSION 20190521-git SIBLINGS
+    DEPENDENCIES (s-sysdeps s-xml) VERSION 20191130-git SIBLINGS
     (cl-prevalence-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-smtp.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-smtp.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-smtp'';
-  version = ''20190710-git'';
+  version = ''20191130-git'';
 
   description = ''Common Lisp smtp client.'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl_plus_ssl" args."cl-base64" args."flexi-streams" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-smtp/2019-07-10/cl-smtp-20190710-git.tgz'';
-    sha256 = ''1bx5jh5vl8slsgrl2w4yv7imiswl8nmknczzyj5bzm1bzk0hx52r'';
+    url = ''http://beta.quicklisp.org/archive/cl-smtp/2019-11-30/cl-smtp-20191130-git.tgz'';
+    sha256 = ''04x1xq1qlsnhl4wdi82l8ds6rl9rzxk72bjf2ja10jay1p6ljvdq'';
   };
 
   packageName = "cl-smtp";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-smtp DESCRIPTION Common Lisp smtp client. SHA256
-    1bx5jh5vl8slsgrl2w4yv7imiswl8nmknczzyj5bzm1bzk0hx52r URL
-    http://beta.quicklisp.org/archive/cl-smtp/2019-07-10/cl-smtp-20190710-git.tgz
-    MD5 f55956a4708d0b4fc2ba181063b73e92 NAME cl-smtp FILENAME cl-smtp DEPS
+    04x1xq1qlsnhl4wdi82l8ds6rl9rzxk72bjf2ja10jay1p6ljvdq URL
+    http://beta.quicklisp.org/archive/cl-smtp/2019-11-30/cl-smtp-20191130-git.tgz
+    MD5 880f09b9fd22e358d1b94a3caf3bd34b NAME cl-smtp FILENAME cl-smtp DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cl+ssl FILENAME cl_plus_ssl)
@@ -35,4 +35,4 @@ rec {
     (alexandria babel bordeaux-threads cffi cl+ssl cl-base64 flexi-streams
      split-sequence trivial-features trivial-garbage trivial-gray-streams
      usocket)
-    VERSION 20190710-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20191130-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-store.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-store.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl-store'';
-  version = ''20180328-git'';
+  version = ''20191130-git'';
 
   parasites = [ "cl-store-tests" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."rt" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-store/2018-03-28/cl-store-20180328-git.tgz'';
-    sha256 = ''1r5fmmpjcshfqv43zv282kjsxxp0imxd2fdpwwcr7y7m256w660n'';
+    url = ''http://beta.quicklisp.org/archive/cl-store/2019-11-30/cl-store-20191130-git.tgz'';
+    sha256 = ''1pybx08w486d3bmn8fc6zxvxyprc3da24kk3wxhkrgh0fi1vmcbc'';
   };
 
   packageName = "cl-store";
@@ -20,8 +20,8 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-store DESCRIPTION Serialization package SHA256
-    1r5fmmpjcshfqv43zv282kjsxxp0imxd2fdpwwcr7y7m256w660n URL
-    http://beta.quicklisp.org/archive/cl-store/2018-03-28/cl-store-20180328-git.tgz
-    MD5 2f8831cb60c0b0575c65e1dbebc07dee NAME cl-store FILENAME cl-store DEPS
-    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20180328-git SIBLINGS NIL
+    1pybx08w486d3bmn8fc6zxvxyprc3da24kk3wxhkrgh0fi1vmcbc URL
+    http://beta.quicklisp.org/archive/cl-store/2019-11-30/cl-store-20191130-git.tgz
+    MD5 d6052274cd0c6a86bfc2de1e4a8a0886 NAME cl-store FILENAME cl-store DEPS
+    ((NAME rt FILENAME rt)) DEPENDENCIES (rt) VERSION 20191130-git SIBLINGS NIL
     PARASITES (cl-store-tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''cl_plus_ssl'';
-  version = ''cl+ssl-20190710-git'';
+  version = ''cl+ssl-20191130-git'';
 
   description = ''Common Lisp interface to OpenSSL.'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."flexi-streams" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl+ssl/2019-07-10/cl+ssl-20190710-git.tgz'';
-    sha256 = ''0lxyd8nryhk9f8gg0fksqf3y5lgbb7f61snsc3qzi5gplkdy0mzv'';
+    url = ''http://beta.quicklisp.org/archive/cl+ssl/2019-11-30/cl+ssl-20191130-git.tgz'';
+    sha256 = ''073ba82xb0jsqlmhv46g7n31j0k2ahw6bw02a51qg77l7wxnms23'';
   };
 
   packageName = "cl+ssl";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl+ssl DESCRIPTION Common Lisp interface to OpenSSL. SHA256
-    0lxyd8nryhk9f8gg0fksqf3y5lgbb7f61snsc3qzi5gplkdy0mzv URL
-    http://beta.quicklisp.org/archive/cl+ssl/2019-07-10/cl+ssl-20190710-git.tgz
-    MD5 fae6e01902964d010ad2565a61a6af2a NAME cl+ssl FILENAME cl_plus_ssl DEPS
+    073ba82xb0jsqlmhv46g7n31j0k2ahw6bw02a51qg77l7wxnms23 URL
+    http://beta.quicklisp.org/archive/cl+ssl/2019-11-30/cl+ssl-20191130-git.tgz
+    MD5 995aaef02ec5112a0de78b2533691629 NAME cl+ssl FILENAME cl_plus_ssl DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME flexi-streams FILENAME flexi-streams)
@@ -31,4 +31,4 @@ rec {
     DEPENDENCIES
     (alexandria babel bordeaux-threads cffi flexi-streams trivial-features
      trivial-garbage trivial-gray-streams uiop)
-    VERSION cl+ssl-20190710-git SIBLINGS (cl+ssl.test) PARASITES NIL) */
+    VERSION cl+ssl-20191130-git SIBLINGS (cl+ssl.test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-handler-hunchentoot.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-handler-hunchentoot.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''clack-handler-hunchentoot'';
-  version = ''clack-20190710-git'';
+  version = ''clack-20191007-git'';
 
   description = ''Clack handler for Hunchentoot.'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-fad" args."cl-ppcre" args."clack-socket" args."flexi-streams" args."hunchentoot" args."md5" args."rfc2388" args."split-sequence" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz'';
-    sha256 = ''1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k'';
+    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
+    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
   };
 
   packageName = "clack-handler-hunchentoot";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-handler-hunchentoot DESCRIPTION Clack handler for Hunchentoot.
-    SHA256 1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k URL
-    http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz
-    MD5 9d8869ca599652d68dd759c8a6adcd3d NAME clack-handler-hunchentoot
+    SHA256 004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
+    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
+    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack-handler-hunchentoot
     FILENAME clack-handler-hunchentoot DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -42,7 +42,7 @@ rec {
      cl-ppcre clack-socket flexi-streams hunchentoot md5 rfc2388 split-sequence
      trivial-backtrace trivial-features trivial-garbage trivial-gray-streams
      usocket)
-    VERSION clack-20190710-git SIBLINGS
+    VERSION clack-20191007-git SIBLINGS
     (clack-handler-fcgi clack-handler-toot clack-handler-wookie clack-socket
      clack-test clack-v1-compat clack t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''clack-socket'';
-  version = ''clack-20190710-git'';
+  version = ''clack-20191007-git'';
 
   description = ''System lacks description'';
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz'';
-    sha256 = ''1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k'';
+    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
+    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
   };
 
   packageName = "clack-socket";
@@ -18,10 +18,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-socket DESCRIPTION System lacks description SHA256
-    1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k URL
-    http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz
-    MD5 9d8869ca599652d68dd759c8a6adcd3d NAME clack-socket FILENAME
-    clack-socket DEPS NIL DEPENDENCIES NIL VERSION clack-20190710-git SIBLINGS
+    004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
+    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
+    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack-socket FILENAME
+    clack-socket DEPS NIL DEPENDENCIES NIL VERSION clack-20191007-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-test clack-v1-compat clack t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-test.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-test.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''clack-test'';
-  version = ''clack-20190710-git'';
+  version = ''clack-20191007-git'';
 
   description = ''Testing Clack Applications.'';
 
-  deps = [ args."alexandria" args."anaphora" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-annot" args."cl-ansi-text" args."cl-base64" args."cl-colors" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."dexador" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."let-plus" args."local-time" args."md5" args."named-readtables" args."nibbles" args."proc-parse" args."prove" args."quri" args."rfc2388" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."usocket" args."xsubseq" ];
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-annot" args."cl-base64" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."dexador" args."dissect" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."local-time" args."md5" args."named-readtables" args."nibbles" args."proc-parse" args."quri" args."rfc2388" args."rove" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz'';
-    sha256 = ''1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k'';
+    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
+    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
   };
 
   packageName = "clack-test";
@@ -18,19 +18,16 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-test DESCRIPTION Testing Clack Applications. SHA256
-    1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k URL
-    http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz
-    MD5 9d8869ca599652d68dd759c8a6adcd3d NAME clack-test FILENAME clack-test
+    004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
+    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
+    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack-test FILENAME clack-test
     DEPS
-    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
-     (NAME babel FILENAME babel)
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
      (NAME cffi-toolchain FILENAME cffi-toolchain) (NAME chipz FILENAME chipz)
      (NAME chunga FILENAME chunga) (NAME cl+ssl FILENAME cl_plus_ssl)
-     (NAME cl-annot FILENAME cl-annot)
-     (NAME cl-ansi-text FILENAME cl-ansi-text)
-     (NAME cl-base64 FILENAME cl-base64) (NAME cl-colors FILENAME cl-colors)
+     (NAME cl-annot FILENAME cl-annot) (NAME cl-base64 FILENAME cl-base64)
      (NAME cl-cookie FILENAME cl-cookie) (NAME cl-fad FILENAME cl-fad)
      (NAME cl-ppcre FILENAME cl-ppcre) (NAME cl-reexport FILENAME cl-reexport)
      (NAME cl-syntax FILENAME cl-syntax)
@@ -38,19 +35,19 @@ rec {
      (NAME cl-utilities FILENAME cl-utilities) (NAME clack FILENAME clack)
      (NAME clack-handler-hunchentoot FILENAME clack-handler-hunchentoot)
      (NAME clack-socket FILENAME clack-socket) (NAME dexador FILENAME dexador)
-     (NAME fast-http FILENAME fast-http) (NAME fast-io FILENAME fast-io)
+     (NAME dissect FILENAME dissect) (NAME fast-http FILENAME fast-http)
+     (NAME fast-io FILENAME fast-io)
      (NAME flexi-streams FILENAME flexi-streams)
      (NAME http-body FILENAME http-body)
      (NAME hunchentoot FILENAME hunchentoot) (NAME ironclad FILENAME ironclad)
      (NAME jonathan FILENAME jonathan) (NAME lack FILENAME lack)
      (NAME lack-component FILENAME lack-component)
      (NAME lack-middleware-backtrace FILENAME lack-middleware-backtrace)
-     (NAME lack-util FILENAME lack-util) (NAME let-plus FILENAME let-plus)
-     (NAME local-time FILENAME local-time) (NAME md5 FILENAME md5)
-     (NAME named-readtables FILENAME named-readtables)
+     (NAME lack-util FILENAME lack-util) (NAME local-time FILENAME local-time)
+     (NAME md5 FILENAME md5) (NAME named-readtables FILENAME named-readtables)
      (NAME nibbles FILENAME nibbles) (NAME proc-parse FILENAME proc-parse)
-     (NAME prove FILENAME prove) (NAME quri FILENAME quri)
-     (NAME rfc2388 FILENAME rfc2388) (NAME smart-buffer FILENAME smart-buffer)
+     (NAME quri FILENAME quri) (NAME rfc2388 FILENAME rfc2388)
+     (NAME rove FILENAME rove) (NAME smart-buffer FILENAME smart-buffer)
      (NAME split-sequence FILENAME split-sequence)
      (NAME static-vectors FILENAME static-vectors)
      (NAME trivial-backtrace FILENAME trivial-backtrace)
@@ -61,17 +58,16 @@ rec {
      (NAME trivial-types FILENAME trivial-types)
      (NAME usocket FILENAME usocket) (NAME xsubseq FILENAME xsubseq))
     DEPENDENCIES
-    (alexandria anaphora babel bordeaux-threads cffi cffi-grovel cffi-toolchain
-     chipz chunga cl+ssl cl-annot cl-ansi-text cl-base64 cl-colors cl-cookie
-     cl-fad cl-ppcre cl-reexport cl-syntax cl-syntax-annot cl-utilities clack
-     clack-handler-hunchentoot clack-socket dexador fast-http fast-io
-     flexi-streams http-body hunchentoot ironclad jonathan lack lack-component
-     lack-middleware-backtrace lack-util let-plus local-time md5
-     named-readtables nibbles proc-parse prove quri rfc2388 smart-buffer
-     split-sequence static-vectors trivial-backtrace trivial-features
-     trivial-garbage trivial-gray-streams trivial-mimes trivial-types usocket
-     xsubseq)
-    VERSION clack-20190710-git SIBLINGS
+    (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain chipz
+     chunga cl+ssl cl-annot cl-base64 cl-cookie cl-fad cl-ppcre cl-reexport
+     cl-syntax cl-syntax-annot cl-utilities clack clack-handler-hunchentoot
+     clack-socket dexador dissect fast-http fast-io flexi-streams http-body
+     hunchentoot ironclad jonathan lack lack-component
+     lack-middleware-backtrace lack-util local-time md5 named-readtables
+     nibbles proc-parse quri rfc2388 rove smart-buffer split-sequence
+     static-vectors trivial-backtrace trivial-features trivial-garbage
+     trivial-gray-streams trivial-mimes trivial-types usocket xsubseq)
+    VERSION clack-20191007-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-socket clack-v1-compat clack
      t-clack-handler-fcgi t-clack-handler-hunchentoot t-clack-handler-toot

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-v1-compat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-v1-compat.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''clack-v1-compat'';
-  version = ''clack-20190710-git'';
+  version = ''clack-20191007-git'';
 
   description = ''System lacks description'';
 
-  deps = [ args."alexandria" args."anaphora" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."circular-streams" args."cl_plus_ssl" args."cl-annot" args."cl-ansi-text" args."cl-base64" args."cl-colors" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."clack-test" args."dexador" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."let-plus" args."local-time" args."marshal" args."md5" args."named-readtables" args."nibbles" args."proc-parse" args."prove" args."quri" args."rfc2388" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."uiop" args."usocket" args."xsubseq" ];
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."circular-streams" args."cl_plus_ssl" args."cl-annot" args."cl-base64" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."clack-test" args."dexador" args."dissect" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."local-time" args."marshal" args."md5" args."named-readtables" args."nibbles" args."proc-parse" args."quri" args."rfc2388" args."rove" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."uiop" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz'';
-    sha256 = ''1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k'';
+    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
+    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
   };
 
   packageName = "clack-v1-compat";
@@ -18,41 +18,40 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-v1-compat DESCRIPTION System lacks description SHA256
-    1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k URL
-    http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz
-    MD5 9d8869ca599652d68dd759c8a6adcd3d NAME clack-v1-compat FILENAME
+    004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
+    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
+    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack-v1-compat FILENAME
     clack-v1-compat DEPS
-    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
-     (NAME babel FILENAME babel)
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
      (NAME cffi-toolchain FILENAME cffi-toolchain) (NAME chipz FILENAME chipz)
      (NAME chunga FILENAME chunga)
      (NAME circular-streams FILENAME circular-streams)
      (NAME cl+ssl FILENAME cl_plus_ssl) (NAME cl-annot FILENAME cl-annot)
-     (NAME cl-ansi-text FILENAME cl-ansi-text)
-     (NAME cl-base64 FILENAME cl-base64) (NAME cl-colors FILENAME cl-colors)
-     (NAME cl-cookie FILENAME cl-cookie) (NAME cl-fad FILENAME cl-fad)
-     (NAME cl-ppcre FILENAME cl-ppcre) (NAME cl-reexport FILENAME cl-reexport)
+     (NAME cl-base64 FILENAME cl-base64) (NAME cl-cookie FILENAME cl-cookie)
+     (NAME cl-fad FILENAME cl-fad) (NAME cl-ppcre FILENAME cl-ppcre)
+     (NAME cl-reexport FILENAME cl-reexport)
      (NAME cl-syntax FILENAME cl-syntax)
      (NAME cl-syntax-annot FILENAME cl-syntax-annot)
      (NAME cl-utilities FILENAME cl-utilities) (NAME clack FILENAME clack)
      (NAME clack-handler-hunchentoot FILENAME clack-handler-hunchentoot)
      (NAME clack-socket FILENAME clack-socket)
      (NAME clack-test FILENAME clack-test) (NAME dexador FILENAME dexador)
-     (NAME fast-http FILENAME fast-http) (NAME fast-io FILENAME fast-io)
+     (NAME dissect FILENAME dissect) (NAME fast-http FILENAME fast-http)
+     (NAME fast-io FILENAME fast-io)
      (NAME flexi-streams FILENAME flexi-streams)
      (NAME http-body FILENAME http-body)
      (NAME hunchentoot FILENAME hunchentoot) (NAME ironclad FILENAME ironclad)
      (NAME jonathan FILENAME jonathan) (NAME lack FILENAME lack)
      (NAME lack-component FILENAME lack-component)
      (NAME lack-middleware-backtrace FILENAME lack-middleware-backtrace)
-     (NAME lack-util FILENAME lack-util) (NAME let-plus FILENAME let-plus)
-     (NAME local-time FILENAME local-time) (NAME marshal FILENAME marshal)
-     (NAME md5 FILENAME md5) (NAME named-readtables FILENAME named-readtables)
+     (NAME lack-util FILENAME lack-util) (NAME local-time FILENAME local-time)
+     (NAME marshal FILENAME marshal) (NAME md5 FILENAME md5)
+     (NAME named-readtables FILENAME named-readtables)
      (NAME nibbles FILENAME nibbles) (NAME proc-parse FILENAME proc-parse)
-     (NAME prove FILENAME prove) (NAME quri FILENAME quri)
-     (NAME rfc2388 FILENAME rfc2388) (NAME smart-buffer FILENAME smart-buffer)
+     (NAME quri FILENAME quri) (NAME rfc2388 FILENAME rfc2388)
+     (NAME rove FILENAME rove) (NAME smart-buffer FILENAME smart-buffer)
      (NAME split-sequence FILENAME split-sequence)
      (NAME static-vectors FILENAME static-vectors)
      (NAME trivial-backtrace FILENAME trivial-backtrace)
@@ -63,17 +62,17 @@ rec {
      (NAME trivial-types FILENAME trivial-types) (NAME uiop FILENAME uiop)
      (NAME usocket FILENAME usocket) (NAME xsubseq FILENAME xsubseq))
     DEPENDENCIES
-    (alexandria anaphora babel bordeaux-threads cffi cffi-grovel cffi-toolchain
-     chipz chunga circular-streams cl+ssl cl-annot cl-ansi-text cl-base64
-     cl-colors cl-cookie cl-fad cl-ppcre cl-reexport cl-syntax cl-syntax-annot
-     cl-utilities clack clack-handler-hunchentoot clack-socket clack-test
-     dexador fast-http fast-io flexi-streams http-body hunchentoot ironclad
-     jonathan lack lack-component lack-middleware-backtrace lack-util let-plus
-     local-time marshal md5 named-readtables nibbles proc-parse prove quri
-     rfc2388 smart-buffer split-sequence static-vectors trivial-backtrace
-     trivial-features trivial-garbage trivial-gray-streams trivial-mimes
-     trivial-types uiop usocket xsubseq)
-    VERSION clack-20190710-git SIBLINGS
+    (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain chipz
+     chunga circular-streams cl+ssl cl-annot cl-base64 cl-cookie cl-fad
+     cl-ppcre cl-reexport cl-syntax cl-syntax-annot cl-utilities clack
+     clack-handler-hunchentoot clack-socket clack-test dexador dissect
+     fast-http fast-io flexi-streams http-body hunchentoot ironclad jonathan
+     lack lack-component lack-middleware-backtrace lack-util local-time marshal
+     md5 named-readtables nibbles proc-parse quri rfc2388 rove smart-buffer
+     split-sequence static-vectors trivial-backtrace trivial-features
+     trivial-garbage trivial-gray-streams trivial-mimes trivial-types uiop
+     usocket xsubseq)
+    VERSION clack-20191007-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-socket clack-test clack t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''clack'';
-  version = ''20190710-git'';
+  version = ''20191007-git'';
 
   description = ''Web application environment for Common Lisp'';
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."nibbles" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz'';
-    sha256 = ''1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k'';
+    url = ''http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz'';
+    sha256 = ''004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w'';
   };
 
   packageName = "clack";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack DESCRIPTION Web application environment for Common Lisp SHA256
-    1642myknfaajcyqllnhn9s17yb6dbj1yh9wmg1kbplwq9c3yjs7k URL
-    http://beta.quicklisp.org/archive/clack/2019-07-10/clack-20190710-git.tgz
-    MD5 9d8869ca599652d68dd759c8a6adcd3d NAME clack FILENAME clack DEPS
+    004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
+    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
+    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack FILENAME clack DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME ironclad FILENAME ironclad) (NAME lack FILENAME lack)
@@ -31,7 +31,7 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads ironclad lack lack-component
      lack-middleware-backtrace lack-util nibbles uiop)
-    VERSION 20190710-git SIBLINGS
+    VERSION 20191007-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-socket clack-test clack-v1-compat
      t-clack-handler-fcgi t-clack-handler-hunchentoot t-clack-handler-toot

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''closer-mop'';
-  version = ''20190710-git'';
+  version = ''20191227-git'';
 
   description = ''Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.'';
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/closer-mop/2019-07-10/closer-mop-20190710-git.tgz'';
-    sha256 = ''0zh53f4jffzjl8ix9dks0shqcxnsj830a34iqgmz3prq8rwba0gx'';
+    url = ''http://beta.quicklisp.org/archive/closer-mop/2019-12-27/closer-mop-20191227-git.tgz'';
+    sha256 = ''12qkaadpbj946ln17xp5cjahd9jkbwv9j51rvk3q9kqmsm0r1r9l'';
   };
 
   packageName = "closer-mop";
@@ -19,7 +19,7 @@ rec {
 }
 /* (SYSTEM closer-mop DESCRIPTION
     Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.
-    SHA256 0zh53f4jffzjl8ix9dks0shqcxnsj830a34iqgmz3prq8rwba0gx URL
-    http://beta.quicklisp.org/archive/closer-mop/2019-07-10/closer-mop-20190710-git.tgz
-    MD5 5ebb554f9f7ba7f0d9dc6584806c8a0e NAME closer-mop FILENAME closer-mop
-    DEPS NIL DEPENDENCIES NIL VERSION 20190710-git SIBLINGS NIL PARASITES NIL) */
+    SHA256 12qkaadpbj946ln17xp5cjahd9jkbwv9j51rvk3q9kqmsm0r1r9l URL
+    http://beta.quicklisp.org/archive/closer-mop/2019-12-27/closer-mop-20191227-git.tgz
+    MD5 67dda2ff56690bb8eec6131983605031 NAME closer-mop FILENAME closer-mop
+    DEPS NIL DEPENDENCIES NIL VERSION 20191227-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clss.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clss.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''clss'';
-  version = ''20190710-git'';
+  version = ''20191130-git'';
 
   description = ''A DOM tree searching engine based on CSS selectors.'';
 
   deps = [ args."array-utils" args."documentation-utils" args."plump" args."trivial-indent" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clss/2019-07-10/clss-20190710-git.tgz'';
-    sha256 = ''1gvnvwjrvinp8545gzav108pzrh00wx3vx2v7l6z18a80kn0h9vs'';
+    url = ''http://beta.quicklisp.org/archive/clss/2019-11-30/clss-20191130-git.tgz'';
+    sha256 = ''0cbjzsc90fpa8zqv5s0ri7ncbv6f8azgbbfsxswqfphbibkcpcka'';
   };
 
   packageName = "clss";
@@ -18,11 +18,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clss DESCRIPTION A DOM tree searching engine based on CSS selectors.
-    SHA256 1gvnvwjrvinp8545gzav108pzrh00wx3vx2v7l6z18a80kn0h9vs URL
-    http://beta.quicklisp.org/archive/clss/2019-07-10/clss-20190710-git.tgz MD5
-    c5a918fe272b71af7c4b6e71a7faad46 NAME clss FILENAME clss DEPS
+    SHA256 0cbjzsc90fpa8zqv5s0ri7ncbv6f8azgbbfsxswqfphbibkcpcka URL
+    http://beta.quicklisp.org/archive/clss/2019-11-30/clss-20191130-git.tgz MD5
+    9910677b36df00f3046905a9b84122a9 NAME clss FILENAME clss DEPS
     ((NAME array-utils FILENAME array-utils)
      (NAME documentation-utils FILENAME documentation-utils)
      (NAME plump FILENAME plump) (NAME trivial-indent FILENAME trivial-indent))
     DEPENDENCIES (array-utils documentation-utils plump trivial-indent) VERSION
-    20190710-git SIBLINGS NIL PARASITES NIL) */
+    20191130-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clx.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clx.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''clx'';
-  version = ''20190521-git'';
+  version = ''20191130-git'';
 
   parasites = [ "clx/test" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."fiasco" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clx/2019-05-21/clx-20190521-git.tgz'';
-    sha256 = ''0rsais9nsz4naf50wp2iirxfj84rdmbdxivfh3496rsi2ji7j8qs'';
+    url = ''http://beta.quicklisp.org/archive/clx/2019-11-30/clx-20191130-git.tgz'';
+    sha256 = ''1fyh34hrx4p4kf5mijrmgl66hy7yjh9y43ilxck5q378291yk8dj'';
   };
 
   packageName = "clx";
@@ -21,8 +21,8 @@ rec {
 }
 /* (SYSTEM clx DESCRIPTION
     An implementation of the X Window System protocol in Lisp. SHA256
-    0rsais9nsz4naf50wp2iirxfj84rdmbdxivfh3496rsi2ji7j8qs URL
-    http://beta.quicklisp.org/archive/clx/2019-05-21/clx-20190521-git.tgz MD5
-    afcd581193237d3202a4fbcc1f0622c3 NAME clx FILENAME clx DEPS
-    ((NAME fiasco FILENAME fiasco)) DEPENDENCIES (fiasco) VERSION 20190521-git
+    1fyh34hrx4p4kf5mijrmgl66hy7yjh9y43ilxck5q378291yk8dj URL
+    http://beta.quicklisp.org/archive/clx/2019-11-30/clx-20191130-git.tgz MD5
+    61e86a60727732df62c9fa383535fc89 NAME clx FILENAME clx DEPS
+    ((NAME fiasco FILENAME fiasco)) DEPENDENCIES (fiasco) VERSION 20191130-git
     SIBLINGS NIL PARASITES (clx/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/command-line-arguments.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/command-line-arguments.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''command-line-arguments'';
-  version = ''20190710-git'';
+  version = ''20191227-git'';
 
   description = ''small library to deal with command-line arguments'';
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/command-line-arguments/2019-07-10/command-line-arguments-20190710-git.tgz'';
-    sha256 = ''1221nraxk55mwgf6pilhzg5lh98jd0nxrdn2mj1zczj88im01733'';
+    url = ''http://beta.quicklisp.org/archive/command-line-arguments/2019-12-27/command-line-arguments-20191227-git.tgz'';
+    sha256 = ''1846v22mdi8qfavp9wcp7spic6gcmlrbd6g3l0f3crssqza0asgf'';
   };
 
   packageName = "command-line-arguments";
@@ -19,8 +19,8 @@ rec {
 }
 /* (SYSTEM command-line-arguments DESCRIPTION
     small library to deal with command-line arguments SHA256
-    1221nraxk55mwgf6pilhzg5lh98jd0nxrdn2mj1zczj88im01733 URL
-    http://beta.quicklisp.org/archive/command-line-arguments/2019-07-10/command-line-arguments-20190710-git.tgz
-    MD5 77b361a7f4b3b73a88c3a95c7bbffa98 NAME command-line-arguments FILENAME
-    command-line-arguments DEPS NIL DEPENDENCIES NIL VERSION 20190710-git
+    1846v22mdi8qfavp9wcp7spic6gcmlrbd6g3l0f3crssqza0asgf URL
+    http://beta.quicklisp.org/archive/command-line-arguments/2019-12-27/command-line-arguments-20191227-git.tgz
+    MD5 3ed82e1536b55fc0b7abc79626631aab NAME command-line-arguments FILENAME
+    command-line-arguments DEPS NIL DEPENDENCIES NIL VERSION 20191227-git
     SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-mysql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-mysql.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''dbd-mysql'';
-  version = ''cl-dbi-20190521-git'';
+  version = ''cl-dbi-20191007-git'';
 
   description = ''Database driver for MySQL.'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-annot" args."cl-mysql" args."cl-syntax" args."cl-syntax-annot" args."closer-mop" args."dbi" args."named-readtables" args."split-sequence" args."trivial-features" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz'';
-    sha256 = ''1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg'';
+    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz'';
+    sha256 = ''0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35'';
   };
 
   packageName = "dbd-mysql";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbd-mysql DESCRIPTION Database driver for MySQL. SHA256
-    1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg URL
-    http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz
-    MD5 ba77d3a955991b406f56cc1a09e71dc2 NAME dbd-mysql FILENAME dbd-mysql DEPS
+    0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35 URL
+    http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz
+    MD5 bf524c4000468d12627fa419ae412abb NAME dbd-mysql FILENAME dbd-mysql DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cl-annot FILENAME cl-annot)
@@ -35,5 +35,5 @@ rec {
     (alexandria babel bordeaux-threads cffi cl-annot cl-mysql cl-syntax
      cl-syntax-annot closer-mop dbi named-readtables split-sequence
      trivial-features trivial-types)
-    VERSION cl-dbi-20190521-git SIBLINGS
+    VERSION cl-dbi-20191007-git SIBLINGS
     (cl-dbi dbd-postgres dbd-sqlite3 dbi-test dbi) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-postgres.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''dbd-postgres'';
-  version = ''cl-dbi-20190521-git'';
+  version = ''cl-dbi-20191007-git'';
 
   description = ''Database driver for PostgreSQL.'';
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-annot" args."cl-postgres" args."cl-syntax" args."cl-syntax-annot" args."closer-mop" args."dbi" args."md5" args."named-readtables" args."split-sequence" args."trivial-garbage" args."trivial-types" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz'';
-    sha256 = ''1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg'';
+    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz'';
+    sha256 = ''0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35'';
   };
 
   packageName = "dbd-postgres";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbd-postgres DESCRIPTION Database driver for PostgreSQL. SHA256
-    1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg URL
-    http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz
-    MD5 ba77d3a955991b406f56cc1a09e71dc2 NAME dbd-postgres FILENAME
+    0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35 URL
+    http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz
+    MD5 bf524c4000468d12627fa419ae412abb NAME dbd-postgres FILENAME
     dbd-postgres DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -37,5 +37,5 @@ rec {
     (alexandria bordeaux-threads cl-annot cl-postgres cl-syntax cl-syntax-annot
      closer-mop dbi md5 named-readtables split-sequence trivial-garbage
      trivial-types usocket)
-    VERSION cl-dbi-20190521-git SIBLINGS
+    VERSION cl-dbi-20191007-git SIBLINGS
     (cl-dbi dbd-mysql dbd-sqlite3 dbi-test dbi) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-sqlite3.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-sqlite3.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''dbd-sqlite3'';
-  version = ''cl-dbi-20190521-git'';
+  version = ''cl-dbi-20191007-git'';
 
   description = ''Database driver for SQLite3.'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-annot" args."cl-syntax" args."cl-syntax-annot" args."closer-mop" args."dbi" args."iterate" args."named-readtables" args."split-sequence" args."sqlite" args."trivial-features" args."trivial-garbage" args."trivial-types" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz'';
-    sha256 = ''1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg'';
+    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz'';
+    sha256 = ''0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35'';
   };
 
   packageName = "dbd-sqlite3";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbd-sqlite3 DESCRIPTION Database driver for SQLite3. SHA256
-    1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg URL
-    http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz
-    MD5 ba77d3a955991b406f56cc1a09e71dc2 NAME dbd-sqlite3 FILENAME dbd-sqlite3
+    0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35 URL
+    http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz
+    MD5 bf524c4000468d12627fa419ae412abb NAME dbd-sqlite3 FILENAME dbd-sqlite3
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -39,5 +39,5 @@ rec {
     (alexandria babel bordeaux-threads cffi cl-annot cl-syntax cl-syntax-annot
      closer-mop dbi iterate named-readtables split-sequence sqlite
      trivial-features trivial-garbage trivial-types uiop)
-    VERSION cl-dbi-20190521-git SIBLINGS
+    VERSION cl-dbi-20191007-git SIBLINGS
     (cl-dbi dbd-mysql dbd-postgres dbi-test dbi) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''dbi'';
-  version = ''cl-20190521-git'';
+  version = ''cl-20191007-git'';
 
   description = ''Database independent interface for Common Lisp'';
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-annot" args."cl-syntax" args."cl-syntax-annot" args."closer-mop" args."named-readtables" args."split-sequence" args."trivial-types" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz'';
-    sha256 = ''1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg'';
+    url = ''http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz'';
+    sha256 = ''0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35'';
   };
 
   packageName = "dbi";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbi DESCRIPTION Database independent interface for Common Lisp
-    SHA256 1q0hhgxnd91v020zh9ivlmzhzz5ald6q1bm5i5cawzh0xfyfhhvg URL
-    http://beta.quicklisp.org/archive/cl-dbi/2019-05-21/cl-dbi-20190521-git.tgz
-    MD5 ba77d3a955991b406f56cc1a09e71dc2 NAME dbi FILENAME dbi DEPS
+    SHA256 0xsg0xqq88wsx6wf8nllfd0mk356bw2qw3c5c31rfj41wz5vpx35 URL
+    http://beta.quicklisp.org/archive/cl-dbi/2019-10-07/cl-dbi-20191007-git.tgz
+    MD5 bf524c4000468d12627fa419ae412abb NAME dbi FILENAME dbi DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-annot FILENAME cl-annot) (NAME cl-syntax FILENAME cl-syntax)
@@ -32,5 +32,5 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads cl-annot cl-syntax cl-syntax-annot closer-mop
      named-readtables split-sequence trivial-types)
-    VERSION cl-20190521-git SIBLINGS
+    VERSION cl-20191007-git SIBLINGS
     (cl-dbi dbd-mysql dbd-postgres dbd-sqlite3 dbi-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''dexador'';
-  version = ''20190521-git'';
+  version = ''20191007-git'';
 
   description = ''Yet another HTTP client for Common Lisp'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-utilities" args."fast-http" args."fast-io" args."flexi-streams" args."local-time" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/dexador/2019-05-21/dexador-20190521-git.tgz'';
-    sha256 = ''15v475xvawp3vhbw3kkvxq8z98j6i7h9fi4mkicn5mylx2j3z1mk'';
+    url = ''http://beta.quicklisp.org/archive/dexador/2019-10-07/dexador-20191007-git.tgz'';
+    sha256 = ''1q0anlgbg5gbk9ifynnn6dd894d9hvjsrd45jjklkjabhywgizk7'';
   };
 
   packageName = "dexador";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dexador DESCRIPTION Yet another HTTP client for Common Lisp SHA256
-    15v475xvawp3vhbw3kkvxq8z98j6i7h9fi4mkicn5mylx2j3z1mk URL
-    http://beta.quicklisp.org/archive/dexador/2019-05-21/dexador-20190521-git.tgz
-    MD5 4e405ba1b7721c2d62bc315ec31af0fe NAME dexador FILENAME dexador DEPS
+    1q0anlgbg5gbk9ifynnn6dd894d9hvjsrd45jjklkjabhywgizk7 URL
+    http://beta.quicklisp.org/archive/dexador/2019-10-07/dexador-20191007-git.tgz
+    MD5 aa1c435f809a794610fe599987cb73a8 NAME dexador FILENAME dexador DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
@@ -48,4 +48,4 @@ rec {
      fast-http fast-io flexi-streams local-time proc-parse quri smart-buffer
      split-sequence static-vectors trivial-features trivial-garbage
      trivial-gray-streams trivial-mimes usocket xsubseq)
-    VERSION 20190521-git SIBLINGS (dexador-test) PARASITES NIL) */
+    VERSION 20191007-git SIBLINGS (dexador-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dissect.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dissect.nix
@@ -1,0 +1,25 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''dissect'';
+  version = ''20190710-git'';
+
+  description = ''A lib for introspecting the call stack and active restarts.'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/dissect/2019-07-10/dissect-20190710-git.tgz'';
+    sha256 = ''15h653gbi9iybns0ll8rhjr7diwwnq4g9wf51f6d9846nl1v424b'';
+  };
+
+  packageName = "dissect";
+
+  asdFilesToKeep = ["dissect.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM dissect DESCRIPTION
+    A lib for introspecting the call stack and active restarts. SHA256
+    15h653gbi9iybns0ll8rhjr7diwwnq4g9wf51f6d9846nl1v424b URL
+    http://beta.quicklisp.org/archive/dissect/2019-07-10/dissect-20190710-git.tgz
+    MD5 fb0e90e86fe4c184c08d19c1ef61d4e4 NAME dissect FILENAME dissect DEPS NIL
+    DEPENDENCIES NIL VERSION 20190710-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/drakma.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/drakma.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''drakma'';
-  version = ''v2.0.5'';
+  version = ''v2.0.7'';
 
   description = ''Full-featured http/https client based on usocket'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-ppcre" args."flexi-streams" args."puri" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/drakma/2019-05-21/drakma-v2.0.5.tgz'';
-    sha256 = ''14bqvdr1f5ms6kxdgran57qk43g9c37ia7ni1z3afdkbv8wp2lyj'';
+    url = ''http://beta.quicklisp.org/archive/drakma/2019-11-30/drakma-v2.0.7.tgz'';
+    sha256 = ''1r0sh0nsx7fq24yybazjw8n7grk1b85l52x523axwchnnaj58kzw'';
   };
 
   packageName = "drakma";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM drakma DESCRIPTION Full-featured http/https client based on usocket
-    SHA256 14bqvdr1f5ms6kxdgran57qk43g9c37ia7ni1z3afdkbv8wp2lyj URL
-    http://beta.quicklisp.org/archive/drakma/2019-05-21/drakma-v2.0.5.tgz MD5
-    85316671dd8ada170b85af82ed97ce8e NAME drakma FILENAME drakma DEPS
+    SHA256 1r0sh0nsx7fq24yybazjw8n7grk1b85l52x523axwchnnaj58kzw URL
+    http://beta.quicklisp.org/archive/drakma/2019-11-30/drakma-v2.0.7.tgz MD5
+    f166498aaed67f726060e9e997df10a3 NAME drakma FILENAME drakma DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME chipz FILENAME chipz)
@@ -36,4 +36,4 @@ rec {
     (alexandria babel bordeaux-threads cffi chipz chunga cl+ssl cl-base64
      cl-ppcre flexi-streams puri split-sequence trivial-features
      trivial-garbage trivial-gray-streams usocket)
-    VERSION v2.0.5 SIBLINGS (drakma-test) PARASITES NIL) */
+    VERSION v2.0.7 SIBLINGS (drakma-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap-peg.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap-peg.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''esrap-peg'';
-  version = ''20170403-git'';
+  version = ''20191007-git'';
 
   description = ''A wrapper around Esrap to allow generating Esrap grammars from PEG definitions'';
 
   deps = [ args."alexandria" args."cl-unification" args."esrap" args."iterate" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/esrap-peg/2017-04-03/esrap-peg-20170403-git.tgz'';
-    sha256 = ''123pl1p87f8llpzs19abn5idivl4b5mxrc9rflqirbsz3gyc8wl9'';
+    url = ''http://beta.quicklisp.org/archive/esrap-peg/2019-10-07/esrap-peg-20191007-git.tgz'';
+    sha256 = ''0285ngcm73rpzmr0ydy6frps2b4q6n4jymjv3ncwsh81x5blfvis'';
   };
 
   packageName = "esrap-peg";
@@ -19,11 +19,11 @@ rec {
 }
 /* (SYSTEM esrap-peg DESCRIPTION
     A wrapper around Esrap to allow generating Esrap grammars from PEG definitions
-    SHA256 123pl1p87f8llpzs19abn5idivl4b5mxrc9rflqirbsz3gyc8wl9 URL
-    http://beta.quicklisp.org/archive/esrap-peg/2017-04-03/esrap-peg-20170403-git.tgz
-    MD5 0d31f9c82d88ad11ee3d309128e7803c NAME esrap-peg FILENAME esrap-peg DEPS
+    SHA256 0285ngcm73rpzmr0ydy6frps2b4q6n4jymjv3ncwsh81x5blfvis URL
+    http://beta.quicklisp.org/archive/esrap-peg/2019-10-07/esrap-peg-20191007-git.tgz
+    MD5 48d87d3118febeefc23ca3a8dda36fc0 NAME esrap-peg FILENAME esrap-peg DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME cl-unification FILENAME cl-unification) (NAME esrap FILENAME esrap)
      (NAME iterate FILENAME iterate))
-    DEPENDENCIES (alexandria cl-unification esrap iterate) VERSION 20170403-git
+    DEPENDENCIES (alexandria cl-unification esrap iterate) VERSION 20191007-git
     SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''esrap'';
-  version = ''20190521-git'';
+  version = ''20191227-git'';
 
   parasites = [ "esrap/tests" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."fiveam" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/esrap/2019-05-21/esrap-20190521-git.tgz'';
-    sha256 = ''0kbb05735yhkh2vply6hdk2jn43s8pym8j6jqip13qyaaiax6w5q'';
+    url = ''http://beta.quicklisp.org/archive/esrap/2019-12-27/esrap-20191227-git.tgz'';
+    sha256 = ''0614lb8iyraihx2m81manlyd3x89snsn9a1mihlil85piswdbiv8'';
   };
 
   packageName = "esrap";
@@ -21,9 +21,9 @@ rec {
 }
 /* (SYSTEM esrap DESCRIPTION
     A Packrat / Parsing Grammar / TDPL parser for Common Lisp. SHA256
-    0kbb05735yhkh2vply6hdk2jn43s8pym8j6jqip13qyaaiax6w5q URL
-    http://beta.quicklisp.org/archive/esrap/2019-05-21/esrap-20190521-git.tgz
-    MD5 401362d64d644f02824de03697435883 NAME esrap FILENAME esrap DEPS
+    0614lb8iyraihx2m81manlyd3x89snsn9a1mihlil85piswdbiv8 URL
+    http://beta.quicklisp.org/archive/esrap/2019-12-27/esrap-20191227-git.tgz
+    MD5 8dd58ffc605bba6eec614bdea573978b NAME esrap FILENAME esrap DEPS
     ((NAME alexandria FILENAME alexandria) (NAME fiveam FILENAME fiveam))
-    DEPENDENCIES (alexandria fiveam) VERSION 20190521-git SIBLINGS NIL
+    DEPENDENCIES (alexandria fiveam) VERSION 20191227-git SIBLINGS NIL
     PARASITES (esrap/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fast-http.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fast-http.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''fast-http'';
-  version = ''20180831-git'';
+  version = ''20191007-git'';
 
   description = ''A fast HTTP protocol parser in Common Lisp'';
 
   deps = [ args."alexandria" args."babel" args."cl-utilities" args."flexi-streams" args."proc-parse" args."smart-buffer" args."trivial-features" args."trivial-gray-streams" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fast-http/2018-08-31/fast-http-20180831-git.tgz'';
-    sha256 = ''1827ra8nkjh5ghg2hn96w3zs8n1lvqzbf8wmzrcs8yky3l0m4qrm'';
+    url = ''http://beta.quicklisp.org/archive/fast-http/2019-10-07/fast-http-20191007-git.tgz'';
+    sha256 = ''00qnl56cfss2blm4pp03dwv84bmkyd0kbarhahclxbn8f7pgwf32'';
   };
 
   packageName = "fast-http";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM fast-http DESCRIPTION A fast HTTP protocol parser in Common Lisp
-    SHA256 1827ra8nkjh5ghg2hn96w3zs8n1lvqzbf8wmzrcs8yky3l0m4qrm URL
-    http://beta.quicklisp.org/archive/fast-http/2018-08-31/fast-http-20180831-git.tgz
-    MD5 d5e839f204b2dd78a390336572d1ee65 NAME fast-http FILENAME fast-http DEPS
+    SHA256 00qnl56cfss2blm4pp03dwv84bmkyd0kbarhahclxbn8f7pgwf32 URL
+    http://beta.quicklisp.org/archive/fast-http/2019-10-07/fast-http-20191007-git.tgz
+    MD5 fd43be4dd72fd9bda5a3ecce87104c97 NAME fast-http FILENAME fast-http DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cl-utilities FILENAME cl-utilities)
      (NAME flexi-streams FILENAME flexi-streams)
@@ -32,4 +32,4 @@ rec {
     DEPENDENCIES
     (alexandria babel cl-utilities flexi-streams proc-parse smart-buffer
      trivial-features trivial-gray-streams xsubseq)
-    VERSION 20180831-git SIBLINGS (fast-http-test) PARASITES NIL) */
+    VERSION 20191007-git SIBLINGS (fast-http-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiasco.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiasco.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''fiasco'';
-  version = ''20190307-git'';
+  version = ''20191130-git'';
 
   parasites = [ "fiasco-self-tests" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/fiasco/2019-03-07/fiasco-20190307-git.tgz'';
-    sha256 = ''0ffnkfnj4ayvzsxb2h04xaypgxg3fbar07f6rvlbncdckm9q5jk3'';
+    url = ''http://beta.quicklisp.org/archive/fiasco/2019-11-30/fiasco-20191130-git.tgz'';
+    sha256 = ''0jpxzrac8kzb34b9n5zyh3wcz0wghxd7pq8xwxp87yg6c3927sl0'';
   };
 
   packageName = "fiasco";
@@ -21,10 +21,10 @@ rec {
 }
 /* (SYSTEM fiasco DESCRIPTION
     A Common Lisp test framework that treasures your failures, logical continuation of Stefil.
-    SHA256 0ffnkfnj4ayvzsxb2h04xaypgxg3fbar07f6rvlbncdckm9q5jk3 URL
-    http://beta.quicklisp.org/archive/fiasco/2019-03-07/fiasco-20190307-git.tgz
-    MD5 7cc0c66f865d44974c8d682346b5f6d5 NAME fiasco FILENAME fiasco DEPS
+    SHA256 0jpxzrac8kzb34b9n5zyh3wcz0wghxd7pq8xwxp87yg6c3927sl0 URL
+    http://beta.quicklisp.org/archive/fiasco/2019-11-30/fiasco-20191130-git.tgz
+    MD5 235809b661c89fed1c4ca4ba3e4f3606 NAME fiasco FILENAME fiasco DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams))
-    DEPENDENCIES (alexandria trivial-gray-streams) VERSION 20190307-git
+    DEPENDENCIES (alexandria trivial-gray-streams) VERSION 20191130-git
     SIBLINGS NIL PARASITES (fiasco-self-tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/http-body.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/http-body.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''http-body'';
-  version = ''20181210-git'';
+  version = ''20190813-git'';
 
   description = ''HTTP POST data parser for Common Lisp'';
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-annot" args."cl-ppcre" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."fast-http" args."fast-io" args."flexi-streams" args."jonathan" args."named-readtables" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."trivial-types" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/http-body/2018-12-10/http-body-20181210-git.tgz'';
-    sha256 = ''170w8rcabf72yq2w9a8134n1sgy7mgirkdj9fzwbr29gqv93plcz'';
+    url = ''http://beta.quicklisp.org/archive/http-body/2019-08-13/http-body-20190813-git.tgz'';
+    sha256 = ''1mc4xinqnvjr7cdyaywdb5lv9k34pal7lhp6f9a660r1rbxybvy8'';
   };
 
   packageName = "http-body";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM http-body DESCRIPTION HTTP POST data parser for Common Lisp SHA256
-    170w8rcabf72yq2w9a8134n1sgy7mgirkdj9fzwbr29gqv93plcz URL
-    http://beta.quicklisp.org/archive/http-body/2018-12-10/http-body-20181210-git.tgz
-    MD5 9699bbb11386c6e4d5cf35bea30dbf7f NAME http-body FILENAME http-body DEPS
+    1mc4xinqnvjr7cdyaywdb5lv9k34pal7lhp6f9a660r1rbxybvy8 URL
+    http://beta.quicklisp.org/archive/http-body/2019-08-13/http-body-20190813-git.tgz
+    MD5 d46ac52643ae7dc148438f84a8107a79 NAME http-body FILENAME http-body DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
      (NAME cffi-toolchain FILENAME cffi-toolchain)
@@ -46,4 +46,4 @@ rec {
      jonathan named-readtables proc-parse quri smart-buffer split-sequence
      static-vectors trivial-features trivial-gray-streams trivial-types
      xsubseq)
-    VERSION 20181210-git SIBLINGS (http-body-test) PARASITES NIL) */
+    VERSION 20190813-git SIBLINGS (http-body-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''ironclad'';
-  version = ''v0.46'';
+  version = ''v0.47'';
 
   parasites = [ "ironclad/tests" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."nibbles" args."rt" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/ironclad/2019-07-10/ironclad-v0.46.tgz'';
-    sha256 = ''1bcqz7z30dpr9rz5wg94bbq93swn6lxqj60rn9f5q0fryn9na3l2'';
+    url = ''http://beta.quicklisp.org/archive/ironclad/2019-10-07/ironclad-v0.47.tgz'';
+    sha256 = ''1aczr4678jxz9kvzvwfdbgdbqhihsbj1nz6j2qflc9sdr6hx24rk'';
   };
 
   packageName = "ironclad";
@@ -21,11 +21,11 @@ rec {
 }
 /* (SYSTEM ironclad DESCRIPTION
     A cryptographic toolkit written in pure Common Lisp SHA256
-    1bcqz7z30dpr9rz5wg94bbq93swn6lxqj60rn9f5q0fryn9na3l2 URL
-    http://beta.quicklisp.org/archive/ironclad/2019-07-10/ironclad-v0.46.tgz
-    MD5 23f67c2312723bdaf1ff78898d2354c7 NAME ironclad FILENAME ironclad DEPS
+    1aczr4678jxz9kvzvwfdbgdbqhihsbj1nz6j2qflc9sdr6hx24rk URL
+    http://beta.quicklisp.org/archive/ironclad/2019-10-07/ironclad-v0.47.tgz
+    MD5 b82d370b037422fcaf8953857f03b5f6 NAME ironclad FILENAME ironclad DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME nibbles FILENAME nibbles) (NAME rt FILENAME rt))
-    DEPENDENCIES (alexandria bordeaux-threads nibbles rt) VERSION v0.46
+    DEPENDENCIES (alexandria bordeaux-threads nibbles rt) VERSION v0.47
     SIBLINGS (ironclad-text) PARASITES (ironclad/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''lack-component'';
-  version = ''lack-20190521-git'';
+  version = ''lack-20191007-git'';
 
   description = ''System lacks description'';
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lack/2019-05-21/lack-20190521-git.tgz'';
-    sha256 = ''0ng1k5jq7icfi8c8r3wqj3qrqkh2lyav5ab6mf3l5y4bfwbil593'';
+    url = ''http://beta.quicklisp.org/archive/lack/2019-10-07/lack-20191007-git.tgz'';
+    sha256 = ''1pjvsk1hc0n6aki393mg2z0dd0xwbkm4pmdph78jlk683158an5s'';
   };
 
   packageName = "lack-component";
@@ -18,10 +18,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-component DESCRIPTION System lacks description SHA256
-    0ng1k5jq7icfi8c8r3wqj3qrqkh2lyav5ab6mf3l5y4bfwbil593 URL
-    http://beta.quicklisp.org/archive/lack/2019-05-21/lack-20190521-git.tgz MD5
-    7d7321550f0795e998c7afe4498e7a40 NAME lack-component FILENAME
-    lack-component DEPS NIL DEPENDENCIES NIL VERSION lack-20190521-git SIBLINGS
+    1pjvsk1hc0n6aki393mg2z0dd0xwbkm4pmdph78jlk683158an5s URL
+    http://beta.quicklisp.org/archive/lack/2019-10-07/lack-20191007-git.tgz MD5
+    bce7a6b5aefb5bfd3fbeb782dda7748f NAME lack-component FILENAME
+    lack-component DEPS NIL DEPENDENCIES NIL VERSION lack-20191007-git SIBLINGS
     (lack-middleware-accesslog lack-middleware-auth-basic
      lack-middleware-backtrace lack-middleware-csrf lack-middleware-mount
      lack-middleware-session lack-middleware-static lack-request lack-response

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''lack-middleware-backtrace'';
-  version = ''lack-20190521-git'';
+  version = ''lack-20191007-git'';
 
   description = ''System lacks description'';
 
   deps = [ args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lack/2019-05-21/lack-20190521-git.tgz'';
-    sha256 = ''0ng1k5jq7icfi8c8r3wqj3qrqkh2lyav5ab6mf3l5y4bfwbil593'';
+    url = ''http://beta.quicklisp.org/archive/lack/2019-10-07/lack-20191007-git.tgz'';
+    sha256 = ''1pjvsk1hc0n6aki393mg2z0dd0xwbkm4pmdph78jlk683158an5s'';
   };
 
   packageName = "lack-middleware-backtrace";
@@ -18,11 +18,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-middleware-backtrace DESCRIPTION System lacks description
-    SHA256 0ng1k5jq7icfi8c8r3wqj3qrqkh2lyav5ab6mf3l5y4bfwbil593 URL
-    http://beta.quicklisp.org/archive/lack/2019-05-21/lack-20190521-git.tgz MD5
-    7d7321550f0795e998c7afe4498e7a40 NAME lack-middleware-backtrace FILENAME
+    SHA256 1pjvsk1hc0n6aki393mg2z0dd0xwbkm4pmdph78jlk683158an5s URL
+    http://beta.quicklisp.org/archive/lack/2019-10-07/lack-20191007-git.tgz MD5
+    bce7a6b5aefb5bfd3fbeb782dda7748f NAME lack-middleware-backtrace FILENAME
     lack-middleware-backtrace DEPS ((NAME uiop FILENAME uiop)) DEPENDENCIES
-    (uiop) VERSION lack-20190521-git SIBLINGS
+    (uiop) VERSION lack-20191007-git SIBLINGS
     (lack-component lack-middleware-accesslog lack-middleware-auth-basic
      lack-middleware-csrf lack-middleware-mount lack-middleware-session
      lack-middleware-static lack-request lack-response lack-session-store-dbi

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''lack-util'';
-  version = ''lack-20190521-git'';
+  version = ''lack-20191007-git'';
 
   description = ''System lacks description'';
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."nibbles" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lack/2019-05-21/lack-20190521-git.tgz'';
-    sha256 = ''0ng1k5jq7icfi8c8r3wqj3qrqkh2lyav5ab6mf3l5y4bfwbil593'';
+    url = ''http://beta.quicklisp.org/archive/lack/2019-10-07/lack-20191007-git.tgz'';
+    sha256 = ''1pjvsk1hc0n6aki393mg2z0dd0xwbkm4pmdph78jlk683158an5s'';
   };
 
   packageName = "lack-util";
@@ -18,14 +18,14 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-util DESCRIPTION System lacks description SHA256
-    0ng1k5jq7icfi8c8r3wqj3qrqkh2lyav5ab6mf3l5y4bfwbil593 URL
-    http://beta.quicklisp.org/archive/lack/2019-05-21/lack-20190521-git.tgz MD5
-    7d7321550f0795e998c7afe4498e7a40 NAME lack-util FILENAME lack-util DEPS
+    1pjvsk1hc0n6aki393mg2z0dd0xwbkm4pmdph78jlk683158an5s URL
+    http://beta.quicklisp.org/archive/lack/2019-10-07/lack-20191007-git.tgz MD5
+    bce7a6b5aefb5bfd3fbeb782dda7748f NAME lack-util FILENAME lack-util DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME ironclad FILENAME ironclad) (NAME nibbles FILENAME nibbles))
     DEPENDENCIES (alexandria bordeaux-threads ironclad nibbles) VERSION
-    lack-20190521-git SIBLINGS
+    lack-20191007-git SIBLINGS
     (lack-component lack-middleware-accesslog lack-middleware-auth-basic
      lack-middleware-backtrace lack-middleware-csrf lack-middleware-mount
      lack-middleware-session lack-middleware-static lack-request lack-response

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''lack'';
-  version = ''20190521-git'';
+  version = ''20191007-git'';
 
   description = ''A minimal Clack'';
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack-component" args."lack-util" args."nibbles" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/lack/2019-05-21/lack-20190521-git.tgz'';
-    sha256 = ''0ng1k5jq7icfi8c8r3wqj3qrqkh2lyav5ab6mf3l5y4bfwbil593'';
+    url = ''http://beta.quicklisp.org/archive/lack/2019-10-07/lack-20191007-git.tgz'';
+    sha256 = ''1pjvsk1hc0n6aki393mg2z0dd0xwbkm4pmdph78jlk683158an5s'';
   };
 
   packageName = "lack";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack DESCRIPTION A minimal Clack SHA256
-    0ng1k5jq7icfi8c8r3wqj3qrqkh2lyav5ab6mf3l5y4bfwbil593 URL
-    http://beta.quicklisp.org/archive/lack/2019-05-21/lack-20190521-git.tgz MD5
-    7d7321550f0795e998c7afe4498e7a40 NAME lack FILENAME lack DEPS
+    1pjvsk1hc0n6aki393mg2z0dd0xwbkm4pmdph78jlk683158an5s URL
+    http://beta.quicklisp.org/archive/lack/2019-10-07/lack-20191007-git.tgz MD5
+    bce7a6b5aefb5bfd3fbeb782dda7748f NAME lack FILENAME lack DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME ironclad FILENAME ironclad)
@@ -28,7 +28,7 @@ rec {
      (NAME lack-util FILENAME lack-util) (NAME nibbles FILENAME nibbles))
     DEPENDENCIES
     (alexandria bordeaux-threads ironclad lack-component lack-util nibbles)
-    VERSION 20190521-git SIBLINGS
+    VERSION 20191007-git SIBLINGS
     (lack-component lack-middleware-accesslog lack-middleware-auth-basic
      lack-middleware-backtrace lack-middleware-csrf lack-middleware-mount
      lack-middleware-session lack-middleware-static lack-request lack-response

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/let-plus.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/let-plus.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''let-plus'';
-  version = ''20171130-git'';
+  version = ''20191130-git'';
 
   parasites = [ "let-plus/tests" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."anaphora" args."lift" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/let-plus/2017-11-30/let-plus-20171130-git.tgz'';
-    sha256 = ''1v8rp3ab6kp6v5kl58gi700wjs4qgmkxxkmhx2a1i6b2z934xkx7'';
+    url = ''http://beta.quicklisp.org/archive/let-plus/2019-11-30/let-plus-20191130-git.tgz'';
+    sha256 = ''0zj0fgb7lvczgpz4jq8q851p77kma7ikn7hd2jk2c37iv4nmz29p'';
   };
 
   packageName = "let-plus";
@@ -20,10 +20,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM let-plus DESCRIPTION Destructuring extension of LET*. SHA256
-    1v8rp3ab6kp6v5kl58gi700wjs4qgmkxxkmhx2a1i6b2z934xkx7 URL
-    http://beta.quicklisp.org/archive/let-plus/2017-11-30/let-plus-20171130-git.tgz
-    MD5 cd92097d436a513e7d0eac535617ca08 NAME let-plus FILENAME let-plus DEPS
+    0zj0fgb7lvczgpz4jq8q851p77kma7ikn7hd2jk2c37iv4nmz29p URL
+    http://beta.quicklisp.org/archive/let-plus/2019-11-30/let-plus-20191130-git.tgz
+    MD5 1b8d1660ed67852ea31cad44a6fc15d0 NAME let-plus FILENAME let-plus DEPS
     ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
      (NAME lift FILENAME lift))
-    DEPENDENCIES (alexandria anaphora lift) VERSION 20171130-git SIBLINGS NIL
+    DEPENDENCIES (alexandria anaphora lift) VERSION 20191130-git SIBLINGS NIL
     PARASITES (let-plus/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/log4cl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/log4cl.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''log4cl'';
-  version = ''20190107-git'';
+  version = ''20191007-git'';
 
   parasites = [ "log4cl/syslog" "log4cl/test" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."stefil" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/log4cl/2019-01-07/log4cl-20190107-git.tgz'';
-    sha256 = ''0c5gsmz69jby5hmcl4igf1sh6xkwh8bx2jz6kd2gcnqjwq37h46p'';
+    url = ''http://beta.quicklisp.org/archive/log4cl/2019-10-07/log4cl-20191007-git.tgz'';
+    sha256 = ''0i4i4ahw13fzka8ixasv292y59ljyzl4i6k6gmkrhxxbm6cdq1na'';
   };
 
   packageName = "log4cl";
@@ -20,11 +20,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM log4cl DESCRIPTION System lacks description SHA256
-    0c5gsmz69jby5hmcl4igf1sh6xkwh8bx2jz6kd2gcnqjwq37h46p URL
-    http://beta.quicklisp.org/archive/log4cl/2019-01-07/log4cl-20190107-git.tgz
-    MD5 ecfa1f67902c776f46d192acd55f628c NAME log4cl FILENAME log4cl DEPS
+    0i4i4ahw13fzka8ixasv292y59ljyzl4i6k6gmkrhxxbm6cdq1na URL
+    http://beta.quicklisp.org/archive/log4cl/2019-10-07/log4cl-20191007-git.tgz
+    MD5 11cdcd9da0ede86092886a055b186861 NAME log4cl FILENAME log4cl DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME stefil FILENAME stefil))
-    DEPENDENCIES (alexandria bordeaux-threads stefil) VERSION 20190107-git
+    DEPENDENCIES (alexandria bordeaux-threads stefil) VERSION 20191007-git
     SIBLINGS (log4cl-examples log4slime) PARASITES (log4cl/syslog log4cl/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/metabang-bind.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/metabang-bind.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''metabang-bind'';
-  version = ''20171130-git'';
+  version = ''20191130-git'';
 
   description = ''Bind is a macro that generalizes multiple-value-bind, let, let*, destructuring-bind, structure and slot accessors, and a whole lot more.'';
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/metabang-bind/2017-11-30/metabang-bind-20171130-git.tgz'';
-    sha256 = ''0mjcg4281qljjwzq80r9j7nhvccf5k1069kzk2vljvvm2ai21j1a'';
+    url = ''http://beta.quicklisp.org/archive/metabang-bind/2019-11-30/metabang-bind-20191130-git.tgz'';
+    sha256 = ''0w4hk94wpfxxznl2xvasnwla7v9i8hrixa1b0r5ngph3n0hq48ci'';
   };
 
   packageName = "metabang-bind";
@@ -19,8 +19,8 @@ rec {
 }
 /* (SYSTEM metabang-bind DESCRIPTION
     Bind is a macro that generalizes multiple-value-bind, let, let*, destructuring-bind, structure and slot accessors, and a whole lot more.
-    SHA256 0mjcg4281qljjwzq80r9j7nhvccf5k1069kzk2vljvvm2ai21j1a URL
-    http://beta.quicklisp.org/archive/metabang-bind/2017-11-30/metabang-bind-20171130-git.tgz
-    MD5 dfd06d3929c2f48ccbe1d00cdf9995a7 NAME metabang-bind FILENAME
-    metabang-bind DEPS NIL DEPENDENCIES NIL VERSION 20171130-git SIBLINGS
+    SHA256 0w4hk94wpfxxznl2xvasnwla7v9i8hrixa1b0r5ngph3n0hq48ci URL
+    http://beta.quicklisp.org/archive/metabang-bind/2019-11-30/metabang-bind-20191130-git.tgz
+    MD5 b0845abb1eadb83e33e91c8d4ad88d2f NAME metabang-bind FILENAME
+    metabang-bind DEPS NIL DEPENDENCIES NIL VERSION 20191130-git SIBLINGS
     (metabang-bind-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/proc-parse.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/proc-parse.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''proc-parse'';
-  version = ''20160318-git'';
+  version = ''20190813-git'';
 
   description = ''Procedural vector parser'';
 
   deps = [ args."alexandria" args."babel" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/proc-parse/2016-03-18/proc-parse-20160318-git.tgz'';
-    sha256 = ''00261w269w9chg6r3sh8hg8994njbsai1g3zni0whm2dzxxq6rnl'';
+    url = ''http://beta.quicklisp.org/archive/proc-parse/2019-08-13/proc-parse-20190813-git.tgz'';
+    sha256 = ''126l7mqxjcgw2limddgrdq63cdhwkhaxabxl9l0bjadf92nczg0j'';
   };
 
   packageName = "proc-parse";
@@ -18,11 +18,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM proc-parse DESCRIPTION Procedural vector parser SHA256
-    00261w269w9chg6r3sh8hg8994njbsai1g3zni0whm2dzxxq6rnl URL
-    http://beta.quicklisp.org/archive/proc-parse/2016-03-18/proc-parse-20160318-git.tgz
-    MD5 5e43f50284fa70c448a3df12d1eea2ea NAME proc-parse FILENAME proc-parse
+    126l7mqxjcgw2limddgrdq63cdhwkhaxabxl9l0bjadf92nczg0j URL
+    http://beta.quicklisp.org/archive/proc-parse/2019-08-13/proc-parse-20190813-git.tgz
+    MD5 99bdce79943071267c6a877d8de246c5 NAME proc-parse FILENAME proc-parse
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME trivial-features FILENAME trivial-features))
-    DEPENDENCIES (alexandria babel trivial-features) VERSION 20160318-git
+    DEPENDENCIES (alexandria babel trivial-features) VERSION 20190813-git
     SIBLINGS (proc-parse-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/quri.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/quri.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''quri'';
-  version = ''20190521-git'';
+  version = ''20191130-git'';
 
   description = ''Yet another URI library for Common Lisp'';
 
   deps = [ args."alexandria" args."babel" args."cl-utilities" args."split-sequence" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/quri/2019-05-21/quri-20190521-git.tgz'';
-    sha256 = ''1khhdhn1isszii52xaibn6m4hv4sm5j2v0vgc2rp1x05xds9rzs2'';
+    url = ''http://beta.quicklisp.org/archive/quri/2019-11-30/quri-20191130-git.tgz'';
+    sha256 = ''00j71xf4c81w4lby22w2nm508djj36z4v4g3k5qsw16ylf92pkbs'';
   };
 
   packageName = "quri";
@@ -18,13 +18,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM quri DESCRIPTION Yet another URI library for Common Lisp SHA256
-    1khhdhn1isszii52xaibn6m4hv4sm5j2v0vgc2rp1x05xds9rzs2 URL
-    http://beta.quicklisp.org/archive/quri/2019-05-21/quri-20190521-git.tgz MD5
-    c2e37013c3b8e109aeb009719e9492ac NAME quri FILENAME quri DEPS
+    00j71xf4c81w4lby22w2nm508djj36z4v4g3k5qsw16ylf92pkbs URL
+    http://beta.quicklisp.org/archive/quri/2019-11-30/quri-20191130-git.tgz MD5
+    4a3e8d2ebe459ea731738650c2c5bf56 NAME quri FILENAME quri DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cl-utilities FILENAME cl-utilities)
      (NAME split-sequence FILENAME split-sequence)
      (NAME trivial-features FILENAME trivial-features))
     DEPENDENCIES
     (alexandria babel cl-utilities split-sequence trivial-features) VERSION
-    20190521-git SIBLINGS (quri-test) PARASITES NIL) */
+    20191130-git SIBLINGS (quri-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
@@ -1,0 +1,29 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''rove'';
+  version = ''20191007-git'';
+
+  description = ''Yet another testing framework intended to be a successor of Prove'';
+
+  deps = [ args."bordeaux-threads" args."dissect" args."trivial-gray-streams" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/rove/2019-10-07/rove-20191007-git.tgz'';
+    sha256 = ''0ngklk69rn13qgsy9h07sqfqzyl1wqsfrp7izx6whgs62bm0vixa'';
+  };
+
+  packageName = "rove";
+
+  asdFilesToKeep = ["rove.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM rove DESCRIPTION
+    Yet another testing framework intended to be a successor of Prove SHA256
+    0ngklk69rn13qgsy9h07sqfqzyl1wqsfrp7izx6whgs62bm0vixa URL
+    http://beta.quicklisp.org/archive/rove/2019-10-07/rove-20191007-git.tgz MD5
+    7ce5d3b0b423f8b68665bbcc51cf18a1 NAME rove FILENAME rove DEPS
+    ((NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME dissect FILENAME dissect)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams))
+    DEPENDENCIES (bordeaux-threads dissect trivial-gray-streams) VERSION
+    20191007-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''serapeum'';
-  version = ''20190710-git'';
+  version = ''20191227-git'';
 
   description = ''Utilities beyond Alexandria.'';
 
   deps = [ args."alexandria" args."bordeaux-threads" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."optima" args."parse-declarations-1_dot_0" args."parse-number" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-file-size" args."trivial-garbage" args."trivial-macroexpand-all" args."type-i" args."uiop" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/serapeum/2019-07-10/serapeum-20190710-git.tgz'';
-    sha256 = ''1yvpv8808q24r4fbi2apks12b94az41if2ny1i1ddv9h00vzvpy5'';
+    url = ''http://beta.quicklisp.org/archive/serapeum/2019-12-27/serapeum-20191227-git.tgz'';
+    sha256 = ''1d1yyzj1m0fqlr6dvq7njmkl1zdkj00jbd09l281971qwhfhmarr'';
   };
 
   packageName = "serapeum";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM serapeum DESCRIPTION Utilities beyond Alexandria. SHA256
-    1yvpv8808q24r4fbi2apks12b94az41if2ny1i1ddv9h00vzvpy5 URL
-    http://beta.quicklisp.org/archive/serapeum/2019-07-10/serapeum-20190710-git.tgz
-    MD5 60e2073fccc750d5b56a7e0814756e1c NAME serapeum FILENAME serapeum DEPS
+    1d1yyzj1m0fqlr6dvq7njmkl1zdkj00jbd09l281971qwhfhmarr URL
+    http://beta.quicklisp.org/archive/serapeum/2019-12-27/serapeum-20191227-git.tgz
+    MD5 dabf40eb6c6af7509da66450790cbf4e NAME serapeum FILENAME serapeum DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME closer-mop FILENAME closer-mop)
@@ -58,4 +58,4 @@ rec {
      string-case trivia trivia.balland2006 trivia.level0 trivia.level1
      trivia.level2 trivia.quasiquote trivia.trivial trivial-cltl2
      trivial-file-size trivial-garbage trivial-macroexpand-all type-i uiop)
-    VERSION 20190710-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20191227-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''simple-date'';
-  version = ''postmodern-20190521-git'';
+  version = ''postmodern-20191227-git'';
 
   parasites = [ "simple-date/postgres-glue" "simple-date/tests" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."cl-postgres" args."fiveam" args."md5" args."usocket" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/postmodern/2019-05-21/postmodern-20190521-git.tgz'';
-    sha256 = ''1vphrizbhbs3r5rq4b8dh4149bz11h5xxilragwf4l2i619k3cp5'';
+    url = ''http://beta.quicklisp.org/archive/postmodern/2019-12-27/postmodern-20191227-git.tgz'';
+    sha256 = ''1p44aphx7y0lh018pk2r9w006vinc5yrfrp1m9l9648p2jxiw1c4'';
   };
 
   packageName = "simple-date";
@@ -20,12 +20,12 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM simple-date DESCRIPTION System lacks description SHA256
-    1vphrizbhbs3r5rq4b8dh4149bz11h5xxilragwf4l2i619k3cp5 URL
-    http://beta.quicklisp.org/archive/postmodern/2019-05-21/postmodern-20190521-git.tgz
-    MD5 102567f386757cd52aca500c0c348d90 NAME simple-date FILENAME simple-date
+    1p44aphx7y0lh018pk2r9w006vinc5yrfrp1m9l9648p2jxiw1c4 URL
+    http://beta.quicklisp.org/archive/postmodern/2019-12-27/postmodern-20191227-git.tgz
+    MD5 67b909de432e6414e7832eed18f9ad18 NAME simple-date FILENAME simple-date
     DEPS
     ((NAME cl-postgres FILENAME cl-postgres) (NAME fiveam FILENAME fiveam)
      (NAME md5 FILENAME md5) (NAME usocket FILENAME usocket))
     DEPENDENCIES (cl-postgres fiveam md5 usocket) VERSION
-    postmodern-20190521-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
+    postmodern-20191227-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
     (simple-date/postgres-glue simple-date/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/sqlite.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/sqlite.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''sqlite'';
-  version = ''cl-20130615-git'';
+  version = ''cl-20190813-git'';
 
-  description = ''System lacks description'';
+  description = ''CL-SQLITE package is an interface to the SQLite embedded relational database engine.'';
 
   deps = [ args."alexandria" args."babel" args."cffi" args."iterate" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-sqlite/2013-06-15/cl-sqlite-20130615-git.tgz'';
-    sha256 = ''0db1fvvnsrnxmp272ycnl2kwhymjwrimr8z4djvjlg6cvjxk6lqh'';
+    url = ''http://beta.quicklisp.org/archive/cl-sqlite/2019-08-13/cl-sqlite-20190813-git.tgz'';
+    sha256 = ''07zla2h7i7ggmzsyj33f12vpxvcbbvq6x022c2dy13flx8a83rmk'';
   };
 
   packageName = "sqlite";
@@ -17,12 +17,13 @@ rec {
   asdFilesToKeep = ["sqlite.asd"];
   overrides = x: x;
 }
-/* (SYSTEM sqlite DESCRIPTION System lacks description SHA256
-    0db1fvvnsrnxmp272ycnl2kwhymjwrimr8z4djvjlg6cvjxk6lqh URL
-    http://beta.quicklisp.org/archive/cl-sqlite/2013-06-15/cl-sqlite-20130615-git.tgz
-    MD5 93be7c68f587d830941be55f2c2f1c8b NAME sqlite FILENAME sqlite DEPS
+/* (SYSTEM sqlite DESCRIPTION
+    CL-SQLITE package is an interface to the SQLite embedded relational database engine.
+    SHA256 07zla2h7i7ggmzsyj33f12vpxvcbbvq6x022c2dy13flx8a83rmk URL
+    http://beta.quicklisp.org/archive/cl-sqlite/2019-08-13/cl-sqlite-20190813-git.tgz
+    MD5 2269773eeb4a101ddd3b33f0f7e05e76 NAME sqlite FILENAME sqlite DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi) (NAME iterate FILENAME iterate)
      (NAME trivial-features FILENAME trivial-features))
     DEPENDENCIES (alexandria babel cffi iterate trivial-features) VERSION
-    cl-20130615-git SIBLINGS NIL PARASITES NIL) */
+    cl-20190813-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-vectors.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-vectors.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''static-vectors'';
-  version = ''v1.8.3'';
+  version = ''v1.8.4'';
 
   parasites = [ "static-vectors/test" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."fiveam" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/static-vectors/2017-10-19/static-vectors-v1.8.3.tgz'';
-    sha256 = ''084690v6xldb9xysgc4hg284j0j9ppxldz4gxwmfin1dzxq0g6xk'';
+    url = ''http://beta.quicklisp.org/archive/static-vectors/2019-11-30/static-vectors-v1.8.4.tgz'';
+    sha256 = ''07z3nrsf5ds5iqilpi8awfk5flgy0k58znnn94xlx82hznw4hwxp'';
   };
 
   packageName = "static-vectors";
@@ -21,9 +21,9 @@ rec {
 }
 /* (SYSTEM static-vectors DESCRIPTION
     Create vectors allocated in static memory. SHA256
-    084690v6xldb9xysgc4hg284j0j9ppxldz4gxwmfin1dzxq0g6xk URL
-    http://beta.quicklisp.org/archive/static-vectors/2017-10-19/static-vectors-v1.8.3.tgz
-    MD5 cbad9e34904eedde61cd4cddcca6de29 NAME static-vectors FILENAME
+    07z3nrsf5ds5iqilpi8awfk5flgy0k58znnn94xlx82hznw4hwxp URL
+    http://beta.quicklisp.org/archive/static-vectors/2019-11-30/static-vectors-v1.8.4.tgz
+    MD5 401085c3ec0edc3ab47409e5a4b534c7 NAME static-vectors FILENAME
     static-vectors DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
@@ -32,4 +32,4 @@ rec {
      (NAME trivial-features FILENAME trivial-features))
     DEPENDENCIES
     (alexandria babel cffi cffi-grovel cffi-toolchain fiveam trivial-features)
-    VERSION v1.8.3 SIBLINGS NIL PARASITES (static-vectors/test)) */
+    VERSION v1.8.4 SIBLINGS NIL PARASITES (static-vectors/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''str'';
-  version = ''cl-20190710-git'';
+  version = ''cl-20191227-git'';
 
   description = ''Modern, consistent and terse Common Lisp string manipulation library.'';
 
-  deps = [ args."cl-ppcre" ];
+  deps = [ args."cl-change-case" args."cl-ppcre" args."cl-ppcre-unicode" args."cl-unicode" args."flexi-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/cl-str/2019-07-10/cl-str-20190710-git.tgz'';
-    sha256 = ''1mlnrj9g1d7zbpq6c4vhyw0idhvbm55zpzrbc8iiyv0dzijk70l9'';
+    url = ''http://beta.quicklisp.org/archive/cl-str/2019-12-27/cl-str-20191227-git.tgz'';
+    sha256 = ''0dakksvrd6s96szwhwd89i0hy9mjff2vck30bdnvb6prkwg2c2g6'';
   };
 
   packageName = "str";
@@ -19,8 +19,14 @@ rec {
 }
 /* (SYSTEM str DESCRIPTION
     Modern, consistent and terse Common Lisp string manipulation library.
-    SHA256 1mlnrj9g1d7zbpq6c4vhyw0idhvbm55zpzrbc8iiyv0dzijk70l9 URL
-    http://beta.quicklisp.org/archive/cl-str/2019-07-10/cl-str-20190710-git.tgz
-    MD5 d3c72394ea33291347d8c825c153c143 NAME str FILENAME str DEPS
-    ((NAME cl-ppcre FILENAME cl-ppcre)) DEPENDENCIES (cl-ppcre) VERSION
-    cl-20190710-git SIBLINGS (str.test) PARASITES NIL) */
+    SHA256 0dakksvrd6s96szwhwd89i0hy9mjff2vck30bdnvb6prkwg2c2g6 URL
+    http://beta.quicklisp.org/archive/cl-str/2019-12-27/cl-str-20191227-git.tgz
+    MD5 b2800b32209061b274432c7e699d92b4 NAME str FILENAME str DEPS
+    ((NAME cl-change-case FILENAME cl-change-case)
+     (NAME cl-ppcre FILENAME cl-ppcre)
+     (NAME cl-ppcre-unicode FILENAME cl-ppcre-unicode)
+     (NAME cl-unicode FILENAME cl-unicode)
+     (NAME flexi-streams FILENAME flexi-streams))
+    DEPENDENCIES
+    (cl-change-case cl-ppcre cl-ppcre-unicode cl-unicode flexi-streams) VERSION
+    cl-20191227-git SIBLINGS (str.test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''stumpwm'';
-  version = ''20190710-git'';
+  version = ''20191227-git'';
 
   description = ''A tiling, keyboard driven window manager'';
 
   deps = [ args."alexandria" args."cl-ppcre" args."clx" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/stumpwm/2019-07-10/stumpwm-20190710-git.tgz'';
-    sha256 = ''10msx6a7s28aqkdz6x847n5jhg9sykvx96p3gh2pq1ab71wq1l3w'';
+    url = ''http://beta.quicklisp.org/archive/stumpwm/2019-12-27/stumpwm-20191227-git.tgz'';
+    sha256 = ''1dlw4y1mpsmgx7r0mdiccvnv56xpbq0rigyb2n04kq4hkp7zj6rm'';
   };
 
   packageName = "stumpwm";
@@ -18,10 +18,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM stumpwm DESCRIPTION A tiling, keyboard driven window manager SHA256
-    10msx6a7s28aqkdz6x847n5jhg9sykvx96p3gh2pq1ab71wq1l3w URL
-    http://beta.quicklisp.org/archive/stumpwm/2019-07-10/stumpwm-20190710-git.tgz
-    MD5 7956cf3486c586f137b75f8b8c0e677c NAME stumpwm FILENAME stumpwm DEPS
+    1dlw4y1mpsmgx7r0mdiccvnv56xpbq0rigyb2n04kq4hkp7zj6rm URL
+    http://beta.quicklisp.org/archive/stumpwm/2019-12-27/stumpwm-20191227-git.tgz
+    MD5 247f56ddbdc8bdf4cf087a467ddce6f6 NAME stumpwm FILENAME stumpwm DEPS
     ((NAME alexandria FILENAME alexandria) (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME clx FILENAME clx))
-    DEPENDENCIES (alexandria cl-ppcre clx) VERSION 20190710-git SIBLINGS
+    DEPENDENCIES (alexandria cl-ppcre clx) VERSION 20191227-git SIBLINGS
     (stumpwm-tests) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/swap-bytes.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/swap-bytes.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''swap-bytes'';
-  version = ''v1.1'';
+  version = ''v1.2'';
 
   parasites = [ "swap-bytes/test" ];
 
@@ -10,8 +10,8 @@ rec {
   deps = [ args."fiveam" args."trivial-features" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/swap-bytes/2016-09-29/swap-bytes-v1.1.tgz'';
-    sha256 = ''0snwbfplqhg1y4y4m7lgvksg1hs0sygfikz3rlbkfl4gwg8pq8ky'';
+    url = ''http://beta.quicklisp.org/archive/swap-bytes/2019-11-30/swap-bytes-v1.2.tgz'';
+    sha256 = ''05g37m4cpsszh16jz7kiscd6m6l66ms73f3s6s94i56c49jfxdy8'';
   };
 
   packageName = "swap-bytes";
@@ -20,11 +20,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM swap-bytes DESCRIPTION Optimized byte-swapping primitives. SHA256
-    0snwbfplqhg1y4y4m7lgvksg1hs0sygfikz3rlbkfl4gwg8pq8ky URL
-    http://beta.quicklisp.org/archive/swap-bytes/2016-09-29/swap-bytes-v1.1.tgz
-    MD5 dda8b3b0a4e345879e80a3cc398667bb NAME swap-bytes FILENAME swap-bytes
+    05g37m4cpsszh16jz7kiscd6m6l66ms73f3s6s94i56c49jfxdy8 URL
+    http://beta.quicklisp.org/archive/swap-bytes/2019-11-30/swap-bytes-v1.2.tgz
+    MD5 eea516d7fdbe20bc963a6708c225d719 NAME swap-bytes FILENAME swap-bytes
     DEPS
     ((NAME fiveam FILENAME fiveam)
      (NAME trivial-features FILENAME trivial-features))
-    DEPENDENCIES (fiveam trivial-features) VERSION v1.1 SIBLINGS NIL PARASITES
+    DEPENDENCIES (fiveam trivial-features) VERSION v1.2 SIBLINGS NIL PARASITES
     (swap-bytes/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''trivia'';
-  version = ''20190710-git'';
+  version = ''20191227-git'';
 
   description = ''NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase'';
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."iterate" args."lisp-namespace" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz'';
-    sha256 = ''0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic'';
+    url = ''http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz'';
+    sha256 = ''1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q'';
   };
 
   packageName = "trivia";
@@ -19,9 +19,9 @@ rec {
 }
 /* (SYSTEM trivia DESCRIPTION
     NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase
-    SHA256 0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic URL
-    http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz
-    MD5 f17ca476901eaff8d3e5d32de23b7447 NAME trivia FILENAME trivia DEPS
+    SHA256 1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q URL
+    http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz
+    MD5 645f0e0fcf57ab37ebd4f0a1b7b05854 NAME trivia FILENAME trivia DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
      (NAME introspect-environment FILENAME introspect-environment)
@@ -37,7 +37,7 @@ rec {
     (alexandria closer-mop introspect-environment iterate lisp-namespace
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION 20190710-git SIBLINGS
+    VERSION 20191227-git SIBLINGS
     (trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level1 trivia.level2 trivia.ppcre trivia.quasiquote trivia.test
      trivia.trivial)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_balland2006.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_balland2006.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''trivia_dot_balland2006'';
-  version = ''trivia-20190710-git'';
+  version = ''trivia-20191227-git'';
 
   description = ''Optimizer for Trivia based on (Balland 2006)'';
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."iterate" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz'';
-    sha256 = ''0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic'';
+    url = ''http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz'';
+    sha256 = ''1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q'';
   };
 
   packageName = "trivia.balland2006";
@@ -19,9 +19,9 @@ rec {
 }
 /* (SYSTEM trivia.balland2006 DESCRIPTION
     Optimizer for Trivia based on (Balland 2006) SHA256
-    0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic URL
-    http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz
-    MD5 f17ca476901eaff8d3e5d32de23b7447 NAME trivia.balland2006 FILENAME
+    1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q URL
+    http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz
+    MD5 645f0e0fcf57ab37ebd4f0a1b7b05854 NAME trivia.balland2006 FILENAME
     trivia_dot_balland2006 DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -37,7 +37,7 @@ rec {
     (alexandria closer-mop introspect-environment iterate lisp-namespace
      trivia.level0 trivia.level1 trivia.level2 trivia.trivial trivial-cltl2
      type-i)
-    VERSION trivia-20190710-git SIBLINGS
+    VERSION trivia-20191227-git SIBLINGS
     (trivia trivia.benchmark trivia.cffi trivia.level0 trivia.level1
      trivia.level2 trivia.ppcre trivia.quasiquote trivia.test trivia.trivial)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level0.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level0.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''trivia_dot_level0'';
-  version = ''trivia-20190710-git'';
+  version = ''trivia-20191227-git'';
 
   description = ''Bootstrapping Pattern Matching Library for implementing Trivia'';
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz'';
-    sha256 = ''0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic'';
+    url = ''http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz'';
+    sha256 = ''1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q'';
   };
 
   packageName = "trivia.level0";
@@ -19,11 +19,11 @@ rec {
 }
 /* (SYSTEM trivia.level0 DESCRIPTION
     Bootstrapping Pattern Matching Library for implementing Trivia SHA256
-    0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic URL
-    http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz
-    MD5 f17ca476901eaff8d3e5d32de23b7447 NAME trivia.level0 FILENAME
+    1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q URL
+    http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz
+    MD5 645f0e0fcf57ab37ebd4f0a1b7b05854 NAME trivia.level0 FILENAME
     trivia_dot_level0 DEPS ((NAME alexandria FILENAME alexandria)) DEPENDENCIES
-    (alexandria) VERSION trivia-20190710-git SIBLINGS
+    (alexandria) VERSION trivia-20191227-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level1
      trivia.level2 trivia.ppcre trivia.quasiquote trivia.test trivia.trivial)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level1.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level1.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''trivia_dot_level1'';
-  version = ''trivia-20190710-git'';
+  version = ''trivia-20191227-git'';
 
   description = ''Core patterns of Trivia'';
 
   deps = [ args."alexandria" args."trivia_dot_level0" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz'';
-    sha256 = ''0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic'';
+    url = ''http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz'';
+    sha256 = ''1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q'';
   };
 
   packageName = "trivia.level1";
@@ -18,13 +18,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM trivia.level1 DESCRIPTION Core patterns of Trivia SHA256
-    0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic URL
-    http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz
-    MD5 f17ca476901eaff8d3e5d32de23b7447 NAME trivia.level1 FILENAME
+    1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q URL
+    http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz
+    MD5 645f0e0fcf57ab37ebd4f0a1b7b05854 NAME trivia.level1 FILENAME
     trivia_dot_level1 DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME trivia.level0 FILENAME trivia_dot_level0))
-    DEPENDENCIES (alexandria trivia.level0) VERSION trivia-20190710-git
+    DEPENDENCIES (alexandria trivia.level0) VERSION trivia-20191227-git
     SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level2 trivia.ppcre trivia.quasiquote trivia.test trivia.trivial)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level2.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''trivia_dot_level2'';
-  version = ''trivia-20190710-git'';
+  version = ''trivia-20191227-git'';
 
   description = ''NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase'';
 
   deps = [ args."alexandria" args."closer-mop" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz'';
-    sha256 = ''0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic'';
+    url = ''http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz'';
+    sha256 = ''1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q'';
   };
 
   packageName = "trivia.level2";
@@ -19,9 +19,9 @@ rec {
 }
 /* (SYSTEM trivia.level2 DESCRIPTION
     NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase
-    SHA256 0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic URL
-    http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz
-    MD5 f17ca476901eaff8d3e5d32de23b7447 NAME trivia.level2 FILENAME
+    SHA256 1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q URL
+    http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz
+    MD5 645f0e0fcf57ab37ebd4f0a1b7b05854 NAME trivia.level2 FILENAME
     trivia_dot_level2 DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -32,7 +32,7 @@ rec {
     DEPENDENCIES
     (alexandria closer-mop lisp-namespace trivia.level0 trivia.level1
      trivial-cltl2)
-    VERSION trivia-20190710-git SIBLINGS
+    VERSION trivia-20191227-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level1 trivia.ppcre trivia.quasiquote trivia.test trivia.trivial)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''trivia_dot_quasiquote'';
-  version = ''trivia-20190710-git'';
+  version = ''trivia-20191227-git'';
 
   description = ''fare-quasiquote extension for trivia'';
 
   deps = [ args."alexandria" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-readtable" args."fare-utils" args."lisp-namespace" args."named-readtables" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz'';
-    sha256 = ''0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic'';
+    url = ''http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz'';
+    sha256 = ''1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q'';
   };
 
   packageName = "trivia.quasiquote";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM trivia.quasiquote DESCRIPTION fare-quasiquote extension for trivia
-    SHA256 0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic URL
-    http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz
-    MD5 f17ca476901eaff8d3e5d32de23b7447 NAME trivia.quasiquote FILENAME
+    SHA256 1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q URL
+    http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz
+    MD5 645f0e0fcf57ab37ebd4f0a1b7b05854 NAME trivia.quasiquote FILENAME
     trivia_dot_quasiquote DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -38,7 +38,7 @@ rec {
     (alexandria closer-mop fare-quasiquote fare-quasiquote-readtable fare-utils
      lisp-namespace named-readtables trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2)
-    VERSION trivia-20190710-git SIBLINGS
+    VERSION trivia-20191227-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level1 trivia.level2 trivia.ppcre trivia.test trivia.trivial)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
@@ -1,7 +1,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''trivia_dot_trivial'';
-  version = ''trivia-20190710-git'';
+  version = ''trivia-20191227-git'';
 
   description = ''Base level system of Trivia with a trivial optimizer.
  Systems that intend to enhance Trivia should depend on this package, not the TRIVIA system,
@@ -10,8 +10,8 @@ rec {
   deps = [ args."alexandria" args."closer-mop" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz'';
-    sha256 = ''0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic'';
+    url = ''http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz'';
+    sha256 = ''1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q'';
   };
 
   packageName = "trivia.trivial";
@@ -23,9 +23,9 @@ rec {
     Base level system of Trivia with a trivial optimizer.
  Systems that intend to enhance Trivia should depend on this package, not the TRIVIA system,
  in order to avoid the circular dependency.
-    SHA256 0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic URL
-    http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz
-    MD5 f17ca476901eaff8d3e5d32de23b7447 NAME trivia.trivial FILENAME
+    SHA256 1hn6klc2jlh2qhlc4zr9fi02kqlyfyh5bkcgirql1m06g4j8qi4q URL
+    http://beta.quicklisp.org/archive/trivia/2019-12-27/trivia-20191227-git.tgz
+    MD5 645f0e0fcf57ab37ebd4f0a1b7b05854 NAME trivia.trivial FILENAME
     trivia_dot_trivial DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -37,7 +37,7 @@ rec {
     DEPENDENCIES
     (alexandria closer-mop lisp-namespace trivia.level0 trivia.level1
      trivia.level2 trivial-cltl2)
-    VERSION trivia-20190710-git SIBLINGS
+    VERSION trivia-20191227-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level1 trivia.level2 trivia.ppcre trivia.quasiquote trivia.test)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-indent.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-indent.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''trivial-indent'';
-  version = ''20190710-git'';
+  version = ''20191007-git'';
 
   description = ''A very simple library to allow indentation hints for SWANK.'';
 
   deps = [ ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/trivial-indent/2019-07-10/trivial-indent-20190710-git.tgz'';
-    sha256 = ''00s35j8cf1ivwc1l55wprx1a78mvnxaz6innwwb3jan1sl3caycx'';
+    url = ''http://beta.quicklisp.org/archive/trivial-indent/2019-10-07/trivial-indent-20191007-git.tgz'';
+    sha256 = ''0v5isxg6lfbgcpmndb3c515d7bswhwqgjm97li85w39krnw1bfmv'';
   };
 
   packageName = "trivial-indent";
@@ -19,8 +19,8 @@ rec {
 }
 /* (SYSTEM trivial-indent DESCRIPTION
     A very simple library to allow indentation hints for SWANK. SHA256
-    00s35j8cf1ivwc1l55wprx1a78mvnxaz6innwwb3jan1sl3caycx URL
-    http://beta.quicklisp.org/archive/trivial-indent/2019-07-10/trivial-indent-20190710-git.tgz
-    MD5 a5026ac3d68e02fce100761e546a0d77 NAME trivial-indent FILENAME
-    trivial-indent DEPS NIL DEPENDENCIES NIL VERSION 20190710-git SIBLINGS NIL
+    0v5isxg6lfbgcpmndb3c515d7bswhwqgjm97li85w39krnw1bfmv URL
+    http://beta.quicklisp.org/archive/trivial-indent/2019-10-07/trivial-indent-20191007-git.tgz
+    MD5 d0489ff824d58c03b5c2a9b16279f583 NAME trivial-indent FILENAME
+    trivial-indent DEPS NIL DEPENDENCIES NIL VERSION 20191007-git SIBLINGS NIL
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/type-i.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/type-i.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''type-i'';
-  version = ''20190521-git'';
+  version = ''20191227-git'';
 
   description = ''Type Inference Utility on Fundamentally 1-arg Predicates'';
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/type-i/2019-05-21/type-i-20190521-git.tgz'';
-    sha256 = ''1d79g3vd8s387rqagrkf1nmxax6kq32j1ddjrnx7ly08ib6aca99'';
+    url = ''http://beta.quicklisp.org/archive/type-i/2019-12-27/type-i-20191227-git.tgz'';
+    sha256 = ''0f8q6klqjgz1kdyhisfkk07izvgs04jchlv2kl3srjxfr5dj5jl5'';
   };
 
   packageName = "type-i";
@@ -19,9 +19,9 @@ rec {
 }
 /* (SYSTEM type-i DESCRIPTION
     Type Inference Utility on Fundamentally 1-arg Predicates SHA256
-    1d79g3vd8s387rqagrkf1nmxax6kq32j1ddjrnx7ly08ib6aca99 URL
-    http://beta.quicklisp.org/archive/type-i/2019-05-21/type-i-20190521-git.tgz
-    MD5 9906855a0650f93186f37e162429e58b NAME type-i FILENAME type-i DEPS
+    0f8q6klqjgz1kdyhisfkk07izvgs04jchlv2kl3srjxfr5dj5jl5 URL
+    http://beta.quicklisp.org/archive/type-i/2019-12-27/type-i-20191227-git.tgz
+    MD5 af344179d3f97b836d1e3106f8d1c306 NAME type-i FILENAME type-i DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
      (NAME introspect-environment FILENAME introspect-environment)
@@ -34,4 +34,4 @@ rec {
     DEPENDENCIES
     (alexandria closer-mop introspect-environment lisp-namespace trivia.level0
      trivia.level1 trivia.level2 trivia.trivial trivial-cltl2)
-    VERSION 20190521-git SIBLINGS (type-i.test) PARASITES NIL) */
+    VERSION 20191227-git SIBLINGS (type-i.test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/usocket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/usocket.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''usocket'';
-  version = ''0.8.2'';
+  version = ''0.8.3'';
 
   description = ''Universal socket library for Common Lisp'';
 
   deps = [ args."split-sequence" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/usocket/2019-07-10/usocket-0.8.2.tgz'';
-    sha256 = ''0g5niqwzh4y6f25lnjx1qyzl0yg906zq2sy7ck67f7bcmc79w8zm'';
+    url = ''http://beta.quicklisp.org/archive/usocket/2019-12-27/usocket-0.8.3.tgz'';
+    sha256 = ''19gl72r9jqms8slzn7i7bww2cqng9mhiqqhhccadlrx2xv6d3lm7'';
   };
 
   packageName = "usocket";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM usocket DESCRIPTION Universal socket library for Common Lisp SHA256
-    0g5niqwzh4y6f25lnjx1qyzl0yg906zq2sy7ck67f7bcmc79w8zm URL
-    http://beta.quicklisp.org/archive/usocket/2019-07-10/usocket-0.8.2.tgz MD5
-    0218443cd70b675d9b09c1bf09cd9da4 NAME usocket FILENAME usocket DEPS
+    19gl72r9jqms8slzn7i7bww2cqng9mhiqqhhccadlrx2xv6d3lm7 URL
+    http://beta.quicklisp.org/archive/usocket/2019-12-27/usocket-0.8.3.tgz MD5
+    b1103034f32565487ab3b6eb92c0ca2b NAME usocket FILENAME usocket DEPS
     ((NAME split-sequence FILENAME split-sequence)) DEPENDENCIES
-    (split-sequence) VERSION 0.8.2 SIBLINGS (usocket-server usocket-test)
+    (split-sequence) VERSION 0.8.3 SIBLINGS (usocket-server usocket-test)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/woo.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/woo.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''woo'';
-  version = ''20190710-git'';
+  version = ''20191130-git'';
 
   description = ''An asynchronous HTTP server written in Common Lisp'';
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-utilities" args."clack-socket" args."fast-http" args."fast-io" args."flexi-streams" args."lev" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."swap-bytes" args."trivial-features" args."trivial-gray-streams" args."trivial-utf-8" args."vom" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/woo/2019-07-10/woo-20190710-git.tgz'';
-    sha256 = ''16fxk75bfb6g3998wqra93a7w4n0yqqi1i8w8dx8yiyy9yb7jij5'';
+    url = ''http://beta.quicklisp.org/archive/woo/2019-11-30/woo-20191130-git.tgz'';
+    sha256 = ''18pw094i6damqsjx0v9jymvib0dhlr5s5bly1dphfnvfz5czs6j2'';
   };
 
   packageName = "woo";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM woo DESCRIPTION An asynchronous HTTP server written in Common Lisp
-    SHA256 16fxk75bfb6g3998wqra93a7w4n0yqqi1i8w8dx8yiyy9yb7jij5 URL
-    http://beta.quicklisp.org/archive/woo/2019-07-10/woo-20190710-git.tgz MD5
-    f35b65dec09276f08c4ca532d077a7a9 NAME woo FILENAME woo DEPS
+    SHA256 18pw094i6damqsjx0v9jymvib0dhlr5s5bly1dphfnvfz5czs6j2 URL
+    http://beta.quicklisp.org/archive/woo/2019-11-30/woo-20191130-git.tgz MD5
+    a876d194ed1ccb7439e3f3b6da63760e NAME woo FILENAME woo DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
@@ -43,4 +43,4 @@ rec {
      cl-utilities clack-socket fast-http fast-io flexi-streams lev proc-parse
      quri smart-buffer split-sequence static-vectors swap-bytes
      trivial-features trivial-gray-streams trivial-utf-8 vom xsubseq)
-    VERSION 20190710-git SIBLINGS (clack-handler-woo woo-test) PARASITES NIL) */
+    VERSION 20191130-git SIBLINGS (clack-handler-woo woo-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/wookie.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/wookie.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''wookie'';
-  version = ''20181018-git'';
+  version = ''20191130-git'';
 
   description = ''An evented webserver for Common Lisp.'';
 
   deps = [ args."alexandria" args."babel" args."blackbird" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chunga" args."cl-async" args."cl-async-base" args."cl-async-ssl" args."cl-async-util" args."cl-fad" args."cl-libuv" args."cl-ppcre" args."cl-utilities" args."do-urlencode" args."fast-http" args."fast-io" args."flexi-streams" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" args."xsubseq" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/wookie/2018-10-18/wookie-20181018-git.tgz'';
-    sha256 = ''0z7v7fg9dm6g4kdvfi588vnfh0dv2knb0z3rf5a9fw8yrvckifdq'';
+    url = ''http://beta.quicklisp.org/archive/wookie/2019-11-30/wookie-20191130-git.tgz'';
+    sha256 = ''13f9fi7yv28lag79z03jrnm7aih2x5zwvh4hw9cadw75956975d2'';
   };
 
   packageName = "wookie";
@@ -18,9 +18,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM wookie DESCRIPTION An evented webserver for Common Lisp. SHA256
-    0z7v7fg9dm6g4kdvfi588vnfh0dv2knb0z3rf5a9fw8yrvckifdq URL
-    http://beta.quicklisp.org/archive/wookie/2018-10-18/wookie-20181018-git.tgz
-    MD5 91e350e5aca3c3a5c56371bff8f754ae NAME wookie FILENAME wookie DEPS
+    13f9fi7yv28lag79z03jrnm7aih2x5zwvh4hw9cadw75956975d2 URL
+    http://beta.quicklisp.org/archive/wookie/2019-11-30/wookie-20191130-git.tgz
+    MD5 5e5d6537637312919fd528bb1d0c1eba NAME wookie FILENAME wookie DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME blackbird FILENAME blackbird)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -48,4 +48,4 @@ rec {
      cl-fad cl-libuv cl-ppcre cl-utilities do-urlencode fast-http fast-io
      flexi-streams proc-parse quri smart-buffer split-sequence static-vectors
      trivial-features trivial-gray-streams vom xsubseq)
-    VERSION 20181018-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20191130-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xembed.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xembed.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''xembed'';
-  version = ''clx-20190307-git'';
+  version = ''clx-20191130-git'';
 
   description = ''An implementation of the XEMBED protocol that integrates with CLX.'';
 
   deps = [ args."clx" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/clx-xembed/2019-03-07/clx-xembed-20190307-git.tgz'';
-    sha256 = ''1a0yy707qdb7sw20lavmhlass3n3ds2pn52jxdkrvpgg358waf3j'';
+    url = ''http://beta.quicklisp.org/archive/clx-xembed/2019-11-30/clx-xembed-20191130-git.tgz'';
+    sha256 = ''1ik5gxzhn9j7827jg6g8rk2wa5jby11n2db24y6wrf0ldnbpj7jd'';
   };
 
   packageName = "xembed";
@@ -19,8 +19,8 @@ rec {
 }
 /* (SYSTEM xembed DESCRIPTION
     An implementation of the XEMBED protocol that integrates with CLX. SHA256
-    1a0yy707qdb7sw20lavmhlass3n3ds2pn52jxdkrvpgg358waf3j URL
-    http://beta.quicklisp.org/archive/clx-xembed/2019-03-07/clx-xembed-20190307-git.tgz
-    MD5 04304f828ea8970b6f5301fe78ed8e10 NAME xembed FILENAME xembed DEPS
-    ((NAME clx FILENAME clx)) DEPENDENCIES (clx) VERSION clx-20190307-git
+    1ik5gxzhn9j7827jg6g8rk2wa5jby11n2db24y6wrf0ldnbpj7jd URL
+    http://beta.quicklisp.org/archive/clx-xembed/2019-11-30/clx-xembed-20191130-git.tgz
+    MD5 11d35eeb734c0694005a5e5cec4cad22 NAME xembed FILENAME xembed DEPS
+    ((NAME clx FILENAME clx)) DEPENDENCIES (clx) VERSION clx-20191130-git
     SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/yason.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/yason.nix
@@ -1,15 +1,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = ''yason'';
-  version = ''v0.7.6'';
+  version = ''v0.7.8'';
 
   description = ''JSON parser/encoder'';
 
   deps = [ args."alexandria" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = ''http://beta.quicklisp.org/archive/yason/2016-02-08/yason-v0.7.6.tgz'';
-    sha256 = ''00gfn14bvnw0in03y5m2ssgvhy3ppf5a3s0rf7mf4rq00c5ifchk'';
+    url = ''http://beta.quicklisp.org/archive/yason/2019-12-27/yason-v0.7.8.tgz'';
+    sha256 = ''11d51i2iw4nxsparwbh3s6w9zyms3wi0z0fprwz1d3sqlf03j6f1'';
   };
 
   packageName = "yason";
@@ -18,10 +18,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM yason DESCRIPTION JSON parser/encoder SHA256
-    00gfn14bvnw0in03y5m2ssgvhy3ppf5a3s0rf7mf4rq00c5ifchk URL
-    http://beta.quicklisp.org/archive/yason/2016-02-08/yason-v0.7.6.tgz MD5
-    79de5d242c5e9ce49dfda153d5f442ec NAME yason FILENAME yason DEPS
+    11d51i2iw4nxsparwbh3s6w9zyms3wi0z0fprwz1d3sqlf03j6f1 URL
+    http://beta.quicklisp.org/archive/yason/2019-12-27/yason-v0.7.8.tgz MD5
+    7c3231635aa494f1721273713ea8c56a NAME yason FILENAME yason DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams))
-    DEPENDENCIES (alexandria trivial-gray-streams) VERSION v0.7.6 SIBLINGS NIL
+    DEPENDENCIES (alexandria trivial-gray-streams) VERSION v0.7.8 SIBLINGS NIL
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -17,6 +17,18 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "cl-change-case" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-change-case" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-change-case.nix {
+         inherit fetchurl;
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "cl-ppcre-unicode" = quicklisp-to-nix-packages."cl-ppcre-unicode";
+           "cl-unicode" = quicklisp-to-nix-packages."cl-unicode";
+           "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
+       }));
+
+
   "type-i" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."type-i" or (x: {}))
@@ -747,6 +759,17 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "rove" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."rove" or (x: {}))
+       (import ./quicklisp-to-nix-output/rove.nix {
+         inherit fetchurl;
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "dissect" = quicklisp-to-nix-packages."dissect";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
+       }));
+
+
   "rfc2388" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."rfc2388" or (x: {}))
@@ -859,13 +882,20 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "dissect" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."dissect" or (x: {}))
+       (import ./quicklisp-to-nix-output/dissect.nix {
+         inherit fetchurl;
+       }));
+
+
   "clack-test" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."clack-test" or (x: {}))
        (import ./quicklisp-to-nix-output/clack-test.nix {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "anaphora" = quicklisp-to-nix-packages."anaphora";
            "babel" = quicklisp-to-nix-packages."babel";
            "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
            "cffi" = quicklisp-to-nix-packages."cffi";
@@ -875,9 +905,7 @@ let quicklisp-to-nix-packages = rec {
            "chunga" = quicklisp-to-nix-packages."chunga";
            "cl_plus_ssl" = quicklisp-to-nix-packages."cl_plus_ssl";
            "cl-annot" = quicklisp-to-nix-packages."cl-annot";
-           "cl-ansi-text" = quicklisp-to-nix-packages."cl-ansi-text";
            "cl-base64" = quicklisp-to-nix-packages."cl-base64";
-           "cl-colors" = quicklisp-to-nix-packages."cl-colors";
            "cl-cookie" = quicklisp-to-nix-packages."cl-cookie";
            "cl-fad" = quicklisp-to-nix-packages."cl-fad";
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
@@ -889,6 +917,7 @@ let quicklisp-to-nix-packages = rec {
            "clack-handler-hunchentoot" = quicklisp-to-nix-packages."clack-handler-hunchentoot";
            "clack-socket" = quicklisp-to-nix-packages."clack-socket";
            "dexador" = quicklisp-to-nix-packages."dexador";
+           "dissect" = quicklisp-to-nix-packages."dissect";
            "fast-http" = quicklisp-to-nix-packages."fast-http";
            "fast-io" = quicklisp-to-nix-packages."fast-io";
            "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
@@ -900,15 +929,14 @@ let quicklisp-to-nix-packages = rec {
            "lack-component" = quicklisp-to-nix-packages."lack-component";
            "lack-middleware-backtrace" = quicklisp-to-nix-packages."lack-middleware-backtrace";
            "lack-util" = quicklisp-to-nix-packages."lack-util";
-           "let-plus" = quicklisp-to-nix-packages."let-plus";
            "local-time" = quicklisp-to-nix-packages."local-time";
            "md5" = quicklisp-to-nix-packages."md5";
            "named-readtables" = quicklisp-to-nix-packages."named-readtables";
            "nibbles" = quicklisp-to-nix-packages."nibbles";
            "proc-parse" = quicklisp-to-nix-packages."proc-parse";
-           "prove" = quicklisp-to-nix-packages."prove";
            "quri" = quicklisp-to-nix-packages."quri";
            "rfc2388" = quicklisp-to-nix-packages."rfc2388";
+           "rove" = quicklisp-to-nix-packages."rove";
            "smart-buffer" = quicklisp-to-nix-packages."smart-buffer";
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "static-vectors" = quicklisp-to-nix-packages."static-vectors";
@@ -1313,7 +1341,11 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."str" or (x: {}))
        (import ./quicklisp-to-nix-output/str.nix {
          inherit fetchurl;
+           "cl-change-case" = quicklisp-to-nix-packages."cl-change-case";
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "cl-ppcre-unicode" = quicklisp-to-nix-packages."cl-ppcre-unicode";
+           "cl-unicode" = quicklisp-to-nix-packages."cl-unicode";
+           "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
        }));
 
 
@@ -2355,7 +2387,6 @@ let quicklisp-to-nix-packages = rec {
        (import ./quicklisp-to-nix-output/clack-v1-compat.nix {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "anaphora" = quicklisp-to-nix-packages."anaphora";
            "babel" = quicklisp-to-nix-packages."babel";
            "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
            "cffi" = quicklisp-to-nix-packages."cffi";
@@ -2366,9 +2397,7 @@ let quicklisp-to-nix-packages = rec {
            "circular-streams" = quicklisp-to-nix-packages."circular-streams";
            "cl_plus_ssl" = quicklisp-to-nix-packages."cl_plus_ssl";
            "cl-annot" = quicklisp-to-nix-packages."cl-annot";
-           "cl-ansi-text" = quicklisp-to-nix-packages."cl-ansi-text";
            "cl-base64" = quicklisp-to-nix-packages."cl-base64";
-           "cl-colors" = quicklisp-to-nix-packages."cl-colors";
            "cl-cookie" = quicklisp-to-nix-packages."cl-cookie";
            "cl-fad" = quicklisp-to-nix-packages."cl-fad";
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
@@ -2381,6 +2410,7 @@ let quicklisp-to-nix-packages = rec {
            "clack-socket" = quicklisp-to-nix-packages."clack-socket";
            "clack-test" = quicklisp-to-nix-packages."clack-test";
            "dexador" = quicklisp-to-nix-packages."dexador";
+           "dissect" = quicklisp-to-nix-packages."dissect";
            "fast-http" = quicklisp-to-nix-packages."fast-http";
            "fast-io" = quicklisp-to-nix-packages."fast-io";
            "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
@@ -2392,16 +2422,15 @@ let quicklisp-to-nix-packages = rec {
            "lack-component" = quicklisp-to-nix-packages."lack-component";
            "lack-middleware-backtrace" = quicklisp-to-nix-packages."lack-middleware-backtrace";
            "lack-util" = quicklisp-to-nix-packages."lack-util";
-           "let-plus" = quicklisp-to-nix-packages."let-plus";
            "local-time" = quicklisp-to-nix-packages."local-time";
            "marshal" = quicklisp-to-nix-packages."marshal";
            "md5" = quicklisp-to-nix-packages."md5";
            "named-readtables" = quicklisp-to-nix-packages."named-readtables";
            "nibbles" = quicklisp-to-nix-packages."nibbles";
            "proc-parse" = quicklisp-to-nix-packages."proc-parse";
-           "prove" = quicklisp-to-nix-packages."prove";
            "quri" = quicklisp-to-nix-packages."quri";
            "rfc2388" = quicklisp-to-nix-packages."rfc2388";
+           "rove" = quicklisp-to-nix-packages."rove";
            "smart-buffer" = quicklisp-to-nix-packages."smart-buffer";
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "static-vectors" = quicklisp-to-nix-packages."static-vectors";
@@ -3060,6 +3089,7 @@ let quicklisp-to-nix-packages = rec {
            "clack-test" = quicklisp-to-nix-packages."clack-test";
            "clack-v1-compat" = quicklisp-to-nix-packages."clack-v1-compat";
            "dexador" = quicklisp-to-nix-packages."dexador";
+           "dissect" = quicklisp-to-nix-packages."dissect";
            "do-urlencode" = quicklisp-to-nix-packages."do-urlencode";
            "fast-http" = quicklisp-to-nix-packages."fast-http";
            "fast-io" = quicklisp-to-nix-packages."fast-io";
@@ -3084,6 +3114,7 @@ let quicklisp-to-nix-packages = rec {
            "prove" = quicklisp-to-nix-packages."prove";
            "quri" = quicklisp-to-nix-packages."quri";
            "rfc2388" = quicklisp-to-nix-packages."rfc2388";
+           "rove" = quicklisp-to-nix-packages."rove";
            "smart-buffer" = quicklisp-to-nix-packages."smart-buffer";
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "static-vectors" = quicklisp-to-nix-packages."static-vectors";


### PR DESCRIPTION
###### Motivation for this change
Updated quicklisp and the `distinfo.txt` to the newest versions.  
I hope it's ok to do this both in one pr.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
