### PR TITLE
clementine: fix broken symlink

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -125,7 +125,7 @@ let
 
       mkdir -p $out/share
       for dir in applications icons kde4; do
-        ln -s "$free/share/$dir" "$out/share/$dir"
+        ln -s "${free}/share/$dir" "$out/share/$dir"
       done
     '';
     enableParallelBuilding = true;


### PR DESCRIPTION

###### Motivation for this change
Prevents installing clementineUnfree with other things in the same profile: https://github.com/NixOS/nixpkgs/issues/82685

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
