### PR TITLE
sacd: init at 19.7.16.37

### DIFF
--- a/pkgs/tools/cd-dvd/sacd/default.nix
+++ b/pkgs/tools/cd-dvd/sacd/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sacd";
+  version = "19.7.16.37";
+
+  src = fetchFromGitHub {
+    owner = "Sound-Linux-More";
+    repo = "sacd";
+    rev = version;
+    sha256 = "03s7jr75pzqj1xd41rkgbszlgf9zx6vzhd0nizc05wyf0fxq5xif";
+  };
+
+  patches = [
+    # Makefile prefix, otherwise `/usr` prefix is enforced
+    (fetchpatch {
+      url = "https://github.com/Sound-Linux-More/sacd/pull/1.patch";
+      name = "makefile-prefix.patch";
+      sha256 = "0a7r4x0yqpg6l4vr84dq4wbrypabqm4vvcjv91am068gqjiw6w64";
+    })
+  ];
+
+  makeFlagsArray = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Converts SACD image files, Philips DSDIFF and Sony DSF files to 24-bit high resolution wave files. Handles both DST and DSD streams. ";
+    longDescription = ''
+      Super Audio CD decoder. Converts SACD image files, Philips DSDIFF and Sony DSF files to 24-bit high resolution wave files.
+      Handles both DST and DSD streams.
+    '';
+    homepage = "https://github.com/Sound-Linux-More/sacd";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.doronbehar ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6337,6 +6337,8 @@ in
 
   safecopy = callPackage ../tools/system/safecopy { };
 
+  sacd = callPackage ../tools/cd-dvd/sacd { };
+
   safe = callPackage ../tools/security/safe { };
 
   safe-rm = callPackage ../tools/system/safe-rm { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/Sound-Linux-More/sacd was missing - a very important and useful yet not well known software for converting SACD (super audio compact disk) ISO files to `wav`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
