### PR TITLE
[20.03] virtualbox: 6.0.14 -> 6.1.4

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -21,8 +21,8 @@ let
   buildType = "release";
   # Remember to change the extpackRev and version in extpack.nix and
   # guest-additions/default.nix as well.
-  main = "036x2mvkk22lbg72cz6pik9z538j1ag6mmwjjmfikgrq1i7v24jy";
-  version = "6.0.14";
+  main = "59f8f5774473f593e3eb5940e2a337e0674bcd9854164b2578fd43f896260c99";
+  version = "6.1.4";
 
   iasl' = iasl.overrideAttrs (old: rec {
     inherit (old) pname;
@@ -89,6 +89,7 @@ in stdenv.mkDerivation {
 
   patches =
      optional enableHardening ./hardened.patch
+  ++ [ ./extra_symbols.patch ]
      # When hardening is enabled, we cannot use wrapQtApp to ensure that VirtualBoxVM sees
      # the correct environment variables needed for Qt to work, specifically QT_PLUGIN_PATH.
      # This is because VirtualBoxVM would detect that it is wrapped that and refuse to run,
@@ -102,26 +103,6 @@ in stdenv.mkDerivation {
     })
   ++ [
     ./qtx11extras.patch
-    # Kernel 5.4 fix, should be fixed with next upstream release
-    # https://www.virtualbox.org/ticket/18945
-    (fetchpatch {
-      name = "kernel-5.4-fix-1.patch";
-      url = "https://www.virtualbox.org/changeset/81586/vbox?format=diff";
-      sha256 = "0zbkc9v65pkdmjik53x29g39qyf7narkhpwpx5n1n1bfqnhf0k1r";
-      stripLen = 1;
-    })
-    (fetchpatch {
-      name = "kernel-5.4-fix-2.patch";
-      url = "https://www.virtualbox.org/changeset/81587/vbox?format=diff";
-      sha256 = "1j98cqxj8qlqwaqr4mvwwbkmchw8jmygjwgzz82gix7fj76j2y9c";
-      stripLen = 1;
-    })
-    (fetchpatch {
-      name = "kernel-5.4-fix-3.patch";
-      url = "https://www.virtualbox.org/changeset/81649/vbox?format=diff";
-      sha256 = "1d6p5k5dgzmjglqfkbcbvpn1x3wxila30q4gcbb7pxwfgclaw2hk";
-      stripLen = 1;
-    })
   ];
 
   postPatch = ''

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -1,8 +1,9 @@
-{fetchurl, lib}:
+{fetchurl, lib, virtualbox}:
 
 with lib;
 
-let version = "6.0.14";
+let
+  inherit (virtualbox) version;
 in
 fetchurl rec {
   name = "Oracle_VM_VirtualBox_Extension_Pack-${version}.vbox-extpack";
@@ -11,7 +12,7 @@ fetchurl rec {
     # Manually sha256sum the extensionPack file, must be hex!
     # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
     # Checksums can also be found at https://www.virtualbox.org/download/hashes/${version}/SHA256SUMS
-    let value = "c8a5cc980c9c94cdac3d94e23cf159c2433aae76b416dbfb5b1a918758f21e63";
+    let value = "3b73798d776ff223ea8025b1a45001762f8d4e5bcd1ea61449773c1249935800";
     in assert (builtins.stringLength value) == 64; value;
 
   meta = {

--- a/pkgs/applications/virtualization/virtualbox/extra_symbols.patch
+++ b/pkgs/applications/virtualization/virtualbox/extra_symbols.patch
@@ -1,0 +1,21 @@
+diff --git a/src/VBox/HostDrivers/linux/Makefile b/src/VBox/HostDrivers/linux/Makefile
+index 6e44129b..e68ce128 100644
+--- a/src/VBox/HostDrivers/linux/Makefile
++++ b/src/VBox/HostDrivers/linux/Makefile
+@@ -95,13 +95,13 @@ vboxpci: vboxdrv
+ install:
+ 	@$(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) -C vboxdrv install
+ 	@if [ -d vboxnetflt ]; then \
+-	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) -C vboxnetflt install; \
++		$(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) KBUILD_EXTRA_SYMBOLS=$(abspath vboxnetflt/Module.symvers) -C vboxnetflt install; \
+ 	fi
+ 	@if [ -d vboxnetadp ]; then \
+-	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) -C vboxnetadp install; \
++	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) KBUILD_EXTRA_SYMBOLS=$(abspath vboxnetadp/Module.symvers) -C vboxnetadp install; \
+ 	fi
+ 	@if [ -d vboxpci ]; then \
+-	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) -C vboxpci install; \
++	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) KBUILD_EXTRA_SYMBOLS=$(abspath vboxpci/Module.symvers) -C vboxpci install; \
+ 	fi
+ 
+ else

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, lib, patchelf, cdrkit, kernel, which, makeWrapper
-, zlib, xorg, dbus, virtualbox, dos2unix, fetchpatch, findutils, patchutils }:
+, zlib, xorg, dbus, virtualbox}:
 
 let
   version = virtualbox.version;
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "1c9ysx0fhxxginmp607b4fk74dvlr32n6w52gawm06prf4xg90nb";
+    sha256 = "e2846a7576cce1b92a7c0744f41eaac750248d6e31dfca5c45d5766648b394c7";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
@@ -43,67 +43,9 @@ in stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace src/vboxguest-${version}/vboxvideo/vbox_ttm.c \
       --replace "<ttm/" "<drm/ttm/"
-    
-    echo ${lib.escapeShellArgs patches} | \
-      ${findutils}/bin/xargs -n1 ${patchutils}/bin/lsdiff --strip=1 --addprefix=src/vboxguest-${version}/ | \
-      ${findutils}/bin/xargs ${dos2unix}/bin/dos2unix
   '';
 
   patchFlags = [ "-p1" "-d" "src/vboxguest-${version}" ];
-  # Kernel 5.4 fix, should be fixed with next upstream release
-  # https://www.virtualbox.org/ticket/18945
-  patches = lib.concatLists (lib.mapAttrsToList (changeset: args:
-    map (arg:
-      fetchpatch ({
-        name = "kernel-5.4-fix-${changeset}.patch";
-        url = "https://www.virtualbox.org/changeset/${changeset}/vbox?format=diff";
-      } // arg)) args) {
-        "81586" = [{
-          sha256 = "126z67x6vy65w6jlqbh4z4f1cffxnycwb69vns0154bawbsbxsiw";
-          stripLen = 5;
-          extraPrefix = "vboxguest/";
-        }];
-        "81587" = [
-          {
-            sha256 = "0simzswnl0wvnc2i9gixz99rfc7lxk1nrnskksrlrrl9hqnh0lva";
-            stripLen = 5;
-            extraPrefix = "vboxsf/";
-            includes = [ "*/the-linux-kernel.h" ];
-          }
-          {
-            sha256 = "0a8r9h3x3lcjq2fykgqhdaykp00rnnkbxz8xnxg847zgvca15y02";
-            stripLen = 5;
-            extraPrefix = "vboxguest/";
-            includes = [ "*/the-linux-kernel.h" ];
-          }
-        ];
-        "81649" = [
-          {
-            sha256 = "1p1skxlvqigydxr4sk7w51lpk7nxg0d9lppq39sdnfmgi1z0h0sc";
-            stripLen = 2;
-            extraPrefix = "vboxguest/";
-            includes = [ "*/cdefs.h" ];
-          }
-          {
-            sha256 = "1j060ggdnndyjdhkfvs15306gl7g932sim9xjmx2mnx8gjdmg37f";
-            stripLen = 2;
-            extraPrefix = "vboxsf/";
-            includes = [ "*/cdefs.h" ];
-          }
-          {
-            sha256 = "060h3a5k2yklbvlg0hyg4x87xrg37cvv3rjb67xizlwvlyy6ykkg";
-            stripLen = 5;
-            extraPrefix = "vboxguest/";
-            includes = [ "*/thread2-r0drv-linux.c" ];
-          }
-          {
-            sha256 = "0cxlkf7cy751gl8dgzr7vkims1kmx5pgzsrxyk8w18zyp5nk9glw";
-            stripLen = 7;
-            extraPrefix = "vboxvideo/";
-            includes = [ "*/vbox_*.c" ];
-          }
-        ];
-      });
 
   unpackPhase = ''
     ${if stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux" then ''
@@ -162,7 +104,7 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     # Install kernel modules.
     cd src/vboxguest-${version}
-    make install INSTALL_MOD_PATH=$out
+    make install INSTALL_MOD_PATH=$out KBUILD_EXTRA_SYMBOLS=$PWD/vboxsf/Module.symvers
     cd ../..
 
     # Install binaries

--- a/pkgs/applications/virtualization/virtualbox/hardened.patch
+++ b/pkgs/applications/virtualization/virtualbox/hardened.patch
@@ -75,32 +75,6 @@ index ce0f288..6193108 100644
              return supR3HardenedSetError3(VERR_SUPLIB_WRITE_NON_SYS_GROUP, pErrInfo,
                                            "An unknown (and thus untrusted) group has write access to '", pszPath,
                                            "' and we therefore cannot trust the directory content or that of any subdirectory");
-diff --git a/src/VBox/Main/src-server/MachineImpl.cpp b/src/VBox/Main/src-server/MachineImpl.cpp
-index 320c569..9bfe41f 100644
---- a/src/VBox/Main/src-server/MachineImpl.cpp
-+++ b/src/VBox/Main/src-server/MachineImpl.cpp
-@@ -7543,7 +7543,7 @@ HRESULT Machine::i_launchVMProcess(IInternalSessionControl *aControl,
-
-     /* get the path to the executable */
-     char szPath[RTPATH_MAX];
--    RTPathAppPrivateArch(szPath, sizeof(szPath) - 1);
-+    RTStrCopy(szPath, sizeof(szPath) - 1, "/run/wrappers/bin");
-     size_t cchBufLeft = strlen(szPath);
-     szPath[cchBufLeft++] = RTPATH_DELIMITER;
-     szPath[cchBufLeft] = 0;
-diff --git a/src/VBox/Main/src-server/NetworkServiceRunner.cpp b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
-index 1e38d99..5e43dda 100644
---- a/src/VBox/Main/src-server/NetworkServiceRunner.cpp
-+++ b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
-@@ -85,7 +85,7 @@ int NetworkServiceRunner::start(bool aKillProcOnStop)
-
-     /* get the path to the executable */
-     char exePathBuf[RTPATH_MAX];
--    const char *exePath = RTProcGetExecutablePath(exePathBuf, RTPATH_MAX);
-+    const char *exePath = RTProcGetSuidPath(exePathBuf, RTPATH_MAX);
-     char *substrSl = strrchr(exePathBuf, '/');
-     char *substrBs = strrchr(exePathBuf, '\\');
-     char *suffix = substrSl ? substrSl : substrBs;
 diff --git a/src/VBox/Main/src-server/generic/NetIf-generic.cpp b/src/VBox/Main/src-server/generic/NetIf-generic.cpp
 index 98dc91a..43a819f 100644
 --- a/src/VBox/Main/src-server/generic/NetIf-generic.cpp
@@ -180,3 +154,29 @@ index 2aab645..9795f21 100644
 
  RTR3DECL(const char *) RTProcShortName(void)
  {
+diff --git a/src/VBox/Main/src-server/NetworkServiceRunner.cpp b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
+index 2e57690..3272c84 100644
+--- a/src/VBox/Main/src-server/NetworkServiceRunner.cpp
++++ b/src/VBox/Main/src-server/NetworkServiceRunner.cpp
+@@ -188,7 +188,7 @@ int NetworkServiceRunner::start(bool aKillProcessOnStop)
+      * ASSUME it is relative to the directory that holds VBoxSVC.
+      */
+     char szExePath[RTPATH_MAX];
+-    AssertReturn(RTProcGetExecutablePath(szExePath, RTPATH_MAX), VERR_FILENAME_TOO_LONG);
++    AssertReturn(RTProcGetSuidPath(szExePath, RTPATH_MAX), VERR_FILENAME_TOO_LONG);
+     RTPathStripFilename(szExePath);
+     int vrc = RTPathAppend(szExePath, sizeof(szExePath), m->pszProcName);
+     AssertLogRelRCReturn(vrc, vrc);
+diff --git a/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp b/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp
+index 2991d3a7..d042a08b 100644
+--- a/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp
++++ b/src/VBox/Main/src-all/MachineLaunchVMCommonWorker.cpp
+@@ -90,7 +90,7 @@ int MachineLaunchVMCommonWorker(const Utf8Str &aNameOrId,
+ 
+     /* Get the path to the executable directory w/ trailing slash: */
+     char szPath[RTPATH_MAX];
+-    int vrc = RTPathAppPrivateArch(szPath, sizeof(szPath));
++    int vrc = RTStrCopy(szPath, sizeof(szPath) - 1, "/run/wrappers/bin");
+     AssertRCReturn(vrc, vrc);
+     size_t cbBufLeft = RTPathEnsureTrailingSeparator(szPath, sizeof(szPath));
+     AssertReturn(cbBufLeft > 0, VERR_FILENAME_TOO_LONG);


### PR DESCRIPTION
Update Virtualbox to its latest version. This allows compilation against
kernel >= 5.4 to succeed without further patches (see #74260, build
would fail for linux-5.5.5 to 5.5.9).

(cherry picked from commit 3132c237b181244f3c5d128e5195f538ddffb38e)

###### Motivation for this change
This would allow 20.03 users to use kernels >= 5.4 and still be able to run Virtualbox (maybe very likely, given Linux 5.4 gpu hang issues). Backports #82479 and #82774.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
