### PR TITLE
[19.09] nextcloud: 16.0.8 -> 16.0.9

### DIFF
--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nextcloud";
-  version = "16.0.8";
+  version = "16.0.9";
 
   src = fetchurl {
     url = "https://download.nextcloud.com/server/releases/${pname}-${version}.tar.bz2";
-    sha256 = "0c5z46936pxsmh5isgj5d8pcj1sy9hcqdi55awz5axs7h5cvabr5";
+    sha256 = "0ds9awn4fqjizf4pz35aa9rg1pf3mrghbbp2wyyzb73zk0n10dg1";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
https://nextcloud.com/security/advisory/?id=nC-SA-2020-015

~~I'm not sure if Nextcloud 16.0.9 already fixes this~~. Their advisory says it should be fixed by 16.0.10, but the advisory is dated from 2020-02-07, and 16.0.9 was released at 2020-03-13.

I also opened https://github.com/nextcloud/server/issues/19976 upstream for clarification, ~~we should probably still update to this version no matter if it fixes the issue or not.~~

TLDR: This was indeed a typo upstream. Adressed in https://github.com/nextcloud/security-advisories/pull/21

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
