### PR TITLE
ripgrep: 11.0.2 -> 12.0.0

### DIFF
--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -1,40 +1,44 @@
-{ stdenv, fetchFromGitHub, rustPlatform, asciidoc, docbook_xsl, libxslt
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, asciidoc
+, docbook_xsl
+, libxslt
+, installShellFiles
 , Security
-, withPCRE2 ? true, pcre2 ? null
+, withPCRE2 ? true
+, pcre2 ? null
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "ripgrep";
-  version = "11.0.2";
+  version = "12.0.0";
 
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = pname;
     rev = version;
-    sha256 = "1iga3320mgi7m853la55xip514a3chqsdi1a1rwv25lr9b1p7vd3";
+    sha256 = "0n4169l662fvg6r4rcfs8n8f92rxndlaqb7k4x63680mra470dbi";
   };
 
-  cargoSha256 = "0lwz661rbm7kwkd6mallxym1pz8ynda5f03ynjfd16vrazy2dj21";
+  cargoSha256 = "01zi9zqdjsgc3im9na511n6w2bmqvm46wryh10fhzc9fnkziqmq3";
 
   cargoBuildFlags = stdenv.lib.optional withPCRE2 "--features pcre2";
 
-  nativeBuildInputs = [ asciidoc docbook_xsl libxslt ];
+  nativeBuildInputs = [ asciidoc docbook_xsl libxslt installShellFiles ];
   buildInputs = (stdenv.lib.optional withPCRE2 pcre2)
-    ++ (stdenv.lib.optional stdenv.isDarwin Security);
+  ++ (stdenv.lib.optional stdenv.isDarwin Security);
 
   preFixup = ''
-    mkdir -p "$out/man/man1"
-    cp target/release/build/ripgrep-*/out/rg.1 "$out/man/man1/"
-
-    mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
-    cp target/release/build/ripgrep-*/out/rg.bash "$out/share/bash-completion/completions/"
-    cp target/release/build/ripgrep-*/out/rg.fish "$out/share/fish/vendor_completions.d/"
-    cp "$src/complete/_rg" "$out/share/zsh/site-functions/"
+    (cd target/release/build/ripgrep-*/out
+    installManPage rg.1
+    installShellCompletion rg.{bash,fish})
+    installShellCompletion --zsh "$src/complete/_rg"
   '';
 
   meta = with stdenv.lib; {
     description = "A utility that combines the usability of The Silver Searcher with the raw speed of grep";
-    homepage = https://github.com/BurntSushi/ripgrep;
+    homepage = "https://github.com/BurntSushi/ripgrep";
     license = with licenses; [ unlicense /* or */ mit ];
     maintainers = with maintainers; [ tailhook globin ma27 ];
     platforms = platforms.all;


### PR DESCRIPTION
https://github.com/BurntSushi/ripgrep/blob/master/CHANGELOG.md#1200-2020-03-15

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
