### PR TITLE
maintainers/teams: add gnome team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -21,4 +21,13 @@ with lib.maintainers; {
     members = [ jtojnar worldofpeace ];
     scope = "Maintain Freedesktop.org packages for graphical desktop.";
   };
+
+  gnome = {
+    members = [
+      hedning
+      jtojnar
+      worldofpeace
+    ];
+    scope = "Maintain GNOME desktop environment and platform.";
+  };
 }

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -18,7 +18,7 @@ lib.makeScope pkgs.newScope (self: with self; {
     in
       lib.filter (x: !(builtins.elem (lib.getName x) namesToRemove)) packages;
 
-  maintainers = with pkgs.lib.maintainers; [ lethalman jtojnar hedning worldofpeace ];
+  maintainers = lib.teams.gnome.members;
 
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };


### PR DESCRIPTION
###### Motivation for this change
`gnome3.maintainers` attribute always felt like a hack and [now](https://github.com/NixOS/nixpkgs/pull/72125) we finally have a place to put a groups of maintainers.

Also remove @lethalman, as they are no longer available.

For now, let’s just create the team, we will handle the tree-wide switch later, after we complete #81626 
