### PR TITLE
jemalloc450: enable to default option disable-initial-exec-tls

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12353,7 +12353,7 @@ in
 
   jemalloc = callPackage ../development/libraries/jemalloc { };
 
-  jemalloc450 = callPackage ../development/libraries/jemalloc/jemalloc450.nix { };
+  jemalloc450 = callPackage ../development/libraries/jemalloc/jemalloc450.nix { disableInitExecTls = true; };
 
   jose = callPackage ../development/libraries/jose { };
 
@@ -15875,7 +15875,7 @@ in
   mariadb = callPackage ../servers/sql/mariadb {
     # As per mariadb's cmake, "static jemalloc_pic.a can only be used up to jemalloc 4".
     # https://jira.mariadb.org/browse/MDEV-15034
-    jemalloc = jemalloc450.override ({ disableInitExecTls = true; });
+    jemalloc = jemalloc450;
     inherit (darwin) cctools;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
If use `environment.memoryAllocator.provider = "jemalloc";` service mariadb crashed

```
200316  8:15:47 [ERROR] mysqld got signal 11 ;
This could be because you hit a bug. It is also possible that this binary
or one of the libraries it was linked against is corrupt, improperly built,
or misconfigured. This error can also be caused by malfunctioning hardware.

To report this bug, see https://mariadb.com/kb/en/reporting-bugs

We will try our best to scrape up some info that will hopefully help
diagnose the problem, but since we have already crashed,
something is definitely wrong and this may fail.

Server version: 10.3.22-MariaDB-log
key_buffer_size=16777216
read_buffer_size=2097152
max_used_connections=0
max_threads=65537
thread_count=6
It is possible that mysqld could use up to
key_buffer_size + (read_buffer_size + sort_buffer_size)*max_threads = 268479022 K  bytes of memory
Hope that's ok; if not, decrease some variables in the equation.

Thread pointer: 0x70fb51115b88
Attempting backtrace. You can use the following information to find out
where mysqld died. If you see no messages after this, something went
terribly wrong...
stack_bottom = 0x70fbf15aad28 thread_stack 0x49000
/nix/store/ljfk18bib2h3ir1hif6rpq8slqw4rbzn-mariadb-server-10.3.22/bin/mysqld(my_print_stacktrace+0x29)[0x638370d6ae49]
/nix/store/ljfk18bib2h3ir1hif6rpq8slqw4rbzn-mariadb-server-10.3.22/bin/mysqld(handle_fatal_signal+0x53d)[0x63837085b10d]
/nix/store/9rabxvqbv0vgjmydiv59wkz768b5fmbc-glibc-2.30/lib/libpthread.so.0(+0x12f70)[0x70fbf3d88f70]
/nix/store/6hy3n14bm4f8jld1bnvr5lxzssmbh3vi-malloc-provider-jemalloc/lib/libjemalloc.so(+0x7ce5a)[0x70fbf40bce5a]
/nix/store/6hy3n14bm4f8jld1bnvr5lxzssmbh3vi-malloc-provider-jemalloc/lib/libjemalloc.so(+0x14366)[0x70fbf4054366]
/nix/store/6hy3n14bm4f8jld1bnvr5lxzssmbh3vi-malloc-provider-jemalloc/lib/libjemalloc.so(_ZdlPvm+0xe)[0x70fbf40c1cbe]
/nix/store/ljfk18bib2h3ir1hif6rpq8slqw4rbzn-mariadb-server-10.3.22/bin/mysqld(_ZN11MDL_context27release_locks_stored_beforeE17enum_mdl_durationP10MDL_ticket+0x37)[0x638370768d47]
/nix/store/ljfk18bib2h3ir1hif6rpq8slqw4rbzn-mariadb-server-10.3.22/bin/mysqld(_Z21mysql_execute_commandP3THD+0x4895)[0x63837067c0d5]
/nix/store/ljfk18bib2h3ir1hif6rpq8slqw4rbzn-mariadb-server-10.3.22/bin/mysqld(_Z11mysql_parseP3THDPcjP12Parser_statebb+0x1f4)[0x63837067feb4]
/nix/store/ljfk18bib2h3ir1hif6rpq8slqw4rbzn-mariadb-server-10.3.22/bin/mysqld(+0x5df260)[0x638370680260]
/nix/store/ljfk18bib2h3ir1hif6rpq8slqw4rbzn-mariadb-server-10.3.22/bin/mysqld(_Z19do_handle_bootstrapP3THD+0xc2)[0x638370680752]
/nix/store/ljfk18bib2h3ir1hif6rpq8slqw4rbzn-mariadb-server-10.3.22/bin/mysqld(handle_bootstrap+0x35)[0x638370680825]
/nix/store/9rabxvqbv0vgjmydiv59wkz768b5fmbc-glibc-2.30/lib/libpthread.so.0(+0x7edd)[0x70fbf3d7dedd]
/nix/store/9rabxvqbv0vgjmydiv59wkz768b5fmbc-glibc-2.30/lib/libc.so.6(clone+0x3f)[0x70fbf34d9a4f]

Trying to get some variables.
Some pointers may be invalid and cause the dump to abort.
Query (0x70fb4de22ba0): insert into help_category (help_category_id,name,parent_category_id,url) values (1,'Geographic',0,'');
Connection ID (thread ID): 6
Status: NOT_KILLED

Optimizer switch: index_merge=on,index_merge_union=on,index_merge_sort_union=on,index_merge_intersection=on,index_merge_sort_intersection=off,engine_condition_pushdown=off,index_condition_pushdown=on,derived_merge=on,derived_with_keys=on,firstmatch=on,loosescan=on,materialization=on,in_to_exists=on,semijoin=on,partial_match_rowid_merge=on,partial_match_table_scan=on,subquery_cache=on,mrr=off,mrr_cost_based=off,mrr_sort_keys=off,outer_join_with_cache=on,semijoin_with_cache=on,join_cache_incremental=on,join_cache_hashed=on,join_cache_bka=on,optimize_join_buffer_size=off,table_elimination=on,extended_keys=on,exists_to_in=on,orderby_uses_equalities=on,condition_pushdown_for_derived=on,split_materialized=on

The manual page at http://dev.mysql.com/doc/mysql/en/crashing.html contains
information that should help you find out what is causing the crash.
Writing a core file...
Working directory at /var/data/db/mysql
Resource Limits:
Limit                     Soft Limit           Hard Limit           Units
Max cpu time              unlimited            unlimited            seconds
Max file size             unlimited            unlimited            bytes
Max data size             unlimited            unlimited            bytes
Max stack size            8388608              unlimited            bytes
Max core file size        unlimited            unlimited            bytes
Max resident set          unlimited            unlimited            bytes
Max processes             7911                 7911                 processes
Max open files            5151                 5151                 files
Max locked memory         65536                65536                bytes
Max address space         unlimited            unlimited            bytes
Max file locks            unlimited            unlimited            locks
Max pending signals       7911                 7911                 signals
Max msgqueue size         819200               819200               bytes
Max nice priority         0                    0
Max realtime priority     0                    0
Max realtime timeout      unlimited            unlimited            us
Core pattern: |/nix/store/isjw585167wip2jwk9l38ir3fyvafq5d-systemd-243.7/lib/systemd/systemd-coredump %P %u %g %s %t %c %h
```

cc @flokli @aanderse

Updated PR
Latest changes need to correct load TokuDB plugin:
```
      ### TokuDB
      malloc-lib = ${pkgs.jemalloc450}/lib/libjemalloc.so
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
