### PR TITLE
zsh-powerlevel10k: v1.3.0 → v1.4.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "gitstatus";
-  version = "unstable-2020-03-06";
+  version = "unstable-2020-03-15";
 
   src = fetchFromGitHub {
     owner = "romkatv";

--- a/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "powerlevel10k";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "powerlevel10k";
     rev = "v${version}";
-    sha256 = "1w2iy9anc3cxb5kffrdz8knml8nsl6v3lcrdsigfzfp0zignb4cw";
+    sha256 = "03v8qlblgdazbm16gwr87blm5nxizza61f8w6hjyhgrx51ly9ln5";
   };
 
   patches = [


### PR DESCRIPTION
##### Motivation for this change

New upstream release.

https://github.com/romkatv/powerlevel10k/releases/tag/v1.4.0

Also updates gitstatus which is used in powerlevel10k.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@maralorn @flokli 