### PR TITLE
mesa: restore OpenCL support.

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -182,8 +182,7 @@ stdenv.mkDerivation {
 
     if [ -n "$(shopt -s nullglob; echo "$out"/lib/lib*_mesa*)" ]; then
       # Move other drivers to a separate output
-      mv -t $drivers/lib \
-        $out/lib/lib*_mesa*
+      mv -t $drivers/lib $out/lib/lib*_mesa*
     fi
 
     if [ -n "$(shopt -s nullglob; echo "$out"/lib/libMesaOpenCL*)" ]; then

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -239,10 +239,10 @@ stdenv.mkDerivation {
     done
   '';
 
-  NIX_CFLAGS_COMPILE =
-    optionals stdenv.isDarwin ["-fno-common"]
-    ++ [ "-UPIPE_SEARCH_DIR"
-         "-DPIPE_SEARCH_DIR=\"${placeholder "drivers"}/lib/gallium-pipe\"" ];
+  NIX_CFLAGS_COMPILE = optionals stdenv.isDarwin ["-fno-common"] ++ [ 
+    "-UPIPE_SEARCH_DIR"
+    "-DPIPE_SEARCH_DIR=\"${placeholder "drivers"}/lib/gallium-pipe\"" 
+  ];
 
   passthru = {
     inherit libdrm;

--- a/pkgs/development/libraries/mesa/opencl.patch
+++ b/pkgs/development/libraries/mesa/opencl.patch
@@ -1,0 +1,69 @@
+diff --git a/meson_options.txt b/meson_options.txt
+index 2d39d13b6ad..995231cd7c8 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -18,6 +18,12 @@
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ 
++option(
++  'clang-libdir',
++  type : 'string',
++  value : '',
++  description : 'Locations to search for clang libraries.'
++)
+ option(
+   'platforms',
+   type : 'array',
+diff --git a/src/gallium/targets/opencl/meson.build b/src/gallium/targets/opencl/meson.build
+index dedd8ab7647..ac0e470a142 100644
+--- a/src/gallium/targets/opencl/meson.build
++++ b/src/gallium/targets/opencl/meson.build
+@@ -30,6 +30,7 @@ if with_ld_version_script
+ endif
+ 
+ llvm_libdir = dep_llvm.get_configtool_variable('libdir')
++clang_libdir = get_option('clang-libdir')
+ opencl_libname = with_opencl_icd ? 'MesaOpenCL' : 'OpenCL'
+ 
+ polly_dep = null_dep
+@@ -60,19 +61,19 @@ else
+ endif
+ if not (dep_clang.found() and dep_clang_usable)
+   dep_clang = [
+-    cpp.find_library('clangCodeGen', dirs : llvm_libdir),
+-    cpp.find_library('clangFrontendTool', dirs : llvm_libdir),
+-    cpp.find_library('clangFrontend', dirs : llvm_libdir),
+-    cpp.find_library('clangDriver', dirs : llvm_libdir),
+-    cpp.find_library('clangSerialization', dirs : llvm_libdir),
+-    cpp.find_library('clangParse', dirs : llvm_libdir),
+-    cpp.find_library('clangSema', dirs : llvm_libdir),
+-    cpp.find_library('clangAnalysis', dirs : llvm_libdir),
+-    cpp.find_library('clangAST', dirs : llvm_libdir),
+-    cpp.find_library('clangASTMatchers', dirs : llvm_libdir),
+-    cpp.find_library('clangEdit', dirs : llvm_libdir),
+-    cpp.find_library('clangLex', dirs : llvm_libdir),
+-    cpp.find_library('clangBasic', dirs : llvm_libdir),
++    cpp.find_library('clangCodeGen', dirs : clang_libdir),
++    cpp.find_library('clangFrontendTool', dirs : clang_libdir),
++    cpp.find_library('clangFrontend', dirs : clang_libdir),
++    cpp.find_library('clangDriver', dirs : clang_libdir),
++    cpp.find_library('clangSerialization', dirs : clang_libdir),
++    cpp.find_library('clangParse', dirs : clang_libdir),
++    cpp.find_library('clangSema', dirs : clang_libdir),
++    cpp.find_library('clangAnalysis', dirs : clang_libdir),
++    cpp.find_library('clangAST', dirs : clang_libdir),
++    cpp.find_library('clangASTMatchers', dirs : clang_libdir),
++    cpp.find_library('clangEdit', dirs : clang_libdir),
++    cpp.find_library('clangLex', dirs : clang_libdir),
++    cpp.find_library('clangBasic', dirs : clang_libdir),
+     polly_dep, polly_isl_dep,
+   ]
+   # check clang once more
+@@ -110,5 +111,6 @@ if with_opencl_icd
+     output : 'mesa.icd',
+     install : true,
+     install_dir : join_paths(get_option('sysconfdir'), 'OpenCL', 'vendors'),
++    install_dir : join_paths(get_option('prefix'), 'etc', 'OpenCL', 'vendors'),
+   )
+ endif


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is a first shot at addressing #62933.  In practice, OpenCL support should probably be hidden behind an option, because it takes up a significant chunk of space (requires a full LLVM at run-time).

Currently I put all the OpenCL stuff in the `drivers` output, because at least `mesa.icd` needs to be available via `/run/opengl-driver`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
