### PR TITLE
osu-lazer: Init at 2020.306.0

### DIFF
--- a/pkgs/games/osu-lazer/create-deps.sh
+++ b/pkgs/games/osu-lazer/create-deps.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# 1. create a log with dotnet list osu.sln package > mypackage-restore.log
+# 2. then call ./create-deps.sh mypackage-restore.log
+
+urlbase="https://www.nuget.org/api/v2/package"
+cat << EOL
+{ fetchurl }: let
+
+  fetchNuGet = { name, version, sha256 }: fetchurl {
+    inherit sha256;
+    url = "$urlbase/\${name}/\${version}";
+  };
+
+in [
+EOL
+IFS=''
+while read -r line; do
+  if echo "$line" | grep -q "> "; then
+    name=$(echo "$line" | grep -o -P "[a-zA-Z.]{2,}")
+    version=$(echo "$line" | grep -o -P "(\d+.\d+.\d+)" | head -1)
+    sha256=$(nix-prefetch-url "$urlbase/$name/$version" 2>/dev/null)
+    cat << EOL
+
+  (fetchNuGet {
+    name = "$name";
+    version = "$version";
+    sha256 = "$sha256";
+  })
+EOL
+  fi
+done < "$1"
+cat << EOL
+
+]
+EOL

--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -1,0 +1,69 @@
+{ dotnet-sdk_3
+, fetchFromGitHub
+, fetchurl
+, ffmpeg-full
+, libGL
+, icu
+, Nuget
+, openssl
+, SDL2
+, shared-mime-info
+, stdenv }:
+
+let
+  deps = import ./deps.nix { inherit fetchurl; }; in
+with stdenv;
+mkDerivation rec {
+  pname = "osu-lazer";
+  version = "2020.306.0";
+
+  src = fetchFromGitHub {
+    owner = "ppy";
+    repo = "osu";
+    rev = "${version}";
+    sha256 = "0m2ygyrl26xhzrd8l617k11rr8cbbh38i8jsphkfpcnqsmxk661w";
+  };
+  
+  buildInputs = [ dotnet-sdk_3 ffmpeg-full icu libGL Nuget openssl SDL2 shared-mime-info ];
+  
+  patchPhase = ''
+    for f in $(find . -iname "*.csproj"); do
+      sed -i '/Include="Microsoft.SourceLink.GitHub"/d' $f
+    done
+  '';
+  
+  buildPhase = ''
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
+    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+    export HOME=$PWD/home 
+    export LD_LIBRARY_PATH=${lib.strings.makeLibraryPath [ icu openssl SDL2 ]}
+
+    # disable default-source so nuget does not try to download from online-repo
+    nuget sources Disable -Name "nuget.org"
+    # add all dependencies to a source called 'nixos'
+    for package in ${toString deps}; do
+      nuget add $package -Source nixos
+    done 
+
+    dotnet restore --source nixos osu.sln
+    dotnet build osu.Desktop --runtime linux-x64 \
+                             --configuration Release \
+                             --no-restore \
+                             --output build
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r build/* $out/bin
+  '';
+
+  meta = {
+    homepage = "https://osu.ppy.sh/home";
+    description = "The bestest free-to-win rhythm game";
+    license = with lib.licenses; [ cc-by-nc-40 mit ];
+    maintainers = with lib.maintainers; [ skykanin ];
+    # platforms = with lib.platforms; [ darwin linux ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+  };
+  
+}

--- a/pkgs/games/osu-lazer/deps.nix
+++ b/pkgs/games/osu-lazer/deps.nix
@@ -1,0 +1,418 @@
+{ fetchurl }: let
+
+  fetchNuGet = { name, version, sha256 }: fetchurl {
+    inherit sha256;
+    url = "https://www.nuget.org/api/v2/package/${name}/${version}";
+  };
+
+in [
+
+  (fetchNuGet {
+    name = "Humanizer";
+    version = "2.7.9";
+    sha256 = "01197gpk6m5djbh0nw6hgx5vgcimq826frr6397g84i1gm0lkij2";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Sqlite";
+    version = "2.2.6";
+    sha256 = "0z8k5ns841imaqha5abb1ka0rsfzy90k6qkrvix11sp6k9i7lsam";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Sqlite.Core";
+    version = "2.2.6";
+    sha256 = "0jzqw4672mzxjvzas09sl0zyzzayfgkv003a7bw5g2gjyiphf630";
+  })
+
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "12.0.3";
+    sha256 = "17dzl305d835mzign8r15vkmav2hq8l6g7942dfjpnzr17wwl89x";
+  })
+
+  (fetchNuGet {
+    name = "NUnit";
+    version = "3.12.0";
+    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+  })
+
+  (fetchNuGet {
+    name = "ppy.osu.Framework";
+    version = "2020.305.0";
+    sha256 = "0ia09ckwr3qv9qvfyl05bmg77sqv18z0c70yhvhk5ldpsrpragj9";
+  })
+
+  (fetchNuGet {
+    name = "ppy.osu.Game.Resources";
+    version = "2020.304.0";
+    sha256 = "125x0m17v2czr2cakwlqnfja6kvxzw6ivschr1f11w5kskv13i3y";
+  })
+
+  (fetchNuGet {
+    name = "Sentry";
+    version = "2.1.0";
+    sha256 = "14dsr6fgysn8w2mj179i2klb72b7lbmsk99zlqcqic054j641ccr";
+  })
+
+  (fetchNuGet {
+    name = "SharpCompress";
+    version = "0.24.0";
+    sha256 = "13bzq8ggipr5254654l2ndm6jdxj9ggandy01gpjxnjwy4jhaz9p";
+  })
+
+  (fetchNuGet {
+    name = "System.ComponentModel.Annotations";
+    version = "4.7.0";
+    sha256 = "06x1m46ddxj0ng28d7gry9gjkqdg2kp89jyf480g5gznyybbs49z";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Appveyor.TestLogger";
+    version = "2.0.0";
+    sha256 = "1x2hizldz5wlnjybp115r7npmqw0i9mdpq38wdlibrlq1338g0s9";
+  })
+
+  (fetchNuGet {
+    name = "DeepEqual";
+    version = "2.0.0";
+    sha256 = "11j9a6ld7fn10w0i34c9vbw0h51r9wwyzg87b76rjhw050svbk71";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.5.0";
+    sha256 = "19f5bvzci5mmfz81jwc4dax4qdf7w4k67n263383mn8mawf22bfq";
+  })
+
+  (fetchNuGet {
+    name = "NUnit";
+    version = "3.12.0";
+    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+  })
+
+  (fetchNuGet {
+    name = "NUnit3TestAdapter";
+    version = "3.15.1";
+    sha256 = "1nhpvzxbxgymmkb3bd5ci40rg8k71bfx2ghbgc99znvnvhf2034y";
+  })
+
+  (fetchNuGet {
+    name = "DiscordRichPresence";
+    version = "1.0.150";
+    sha256 = "0qmbi4sccia3w80q8xfvj3bw62nvz047wq198n2b2aflkf47bq79";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Design";
+    version = "2.2.6";
+    sha256 = "0kjjkh1yfb56wnkmciqzfn9vymqfjap364y5amia0lmqmhfz8g7f";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Sqlite";
+    version = "2.2.6";
+    sha256 = "0z8k5ns841imaqha5abb1ka0rsfzy90k6qkrvix11sp6k9i7lsam";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "4.7.0";
+    sha256 = "0bx21jjbs7l5ydyw4p6cn07chryxpmchq2nl5pirzz4l3b0q4dgs";
+  })
+
+  (fetchNuGet {
+    name = "ppy.squirrel.windows";
+    version = "1.9.0.4";
+    sha256 = "1m8shcmgs0fs225qd0navr1qr6csqjin9sg2x0d7xpfk04nd2hi7";
+  })
+
+  (fetchNuGet {
+    name = "System.IO.Packaging";
+    version = "4.7.0";
+    sha256 = "1vivvf158ilcpp6bq70zyafimi0lng546b34csmjb09k19wgxpiv";
+  })
+
+  (fetchNuGet {
+    name = "Appveyor.TestLogger";
+    version = "2.0.0";
+    sha256 = "1x2hizldz5wlnjybp115r7npmqw0i9mdpq38wdlibrlq1338g0s9";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.5.0";
+    sha256 = "19f5bvzci5mmfz81jwc4dax4qdf7w4k67n263383mn8mawf22bfq";
+  })
+
+  (fetchNuGet {
+    name = "NUnit";
+    version = "3.12.0";
+    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+  })
+
+  (fetchNuGet {
+    name = "NUnit3TestAdapter";
+    version = "3.15.1";
+    sha256 = "1nhpvzxbxgymmkb3bd5ci40rg8k71bfx2ghbgc99znvnvhf2034y";
+  })
+
+  (fetchNuGet {
+    name = "Appveyor.TestLogger";
+    version = "2.0.0";
+    sha256 = "1x2hizldz5wlnjybp115r7npmqw0i9mdpq38wdlibrlq1338g0s9";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.5.0";
+    sha256 = "19f5bvzci5mmfz81jwc4dax4qdf7w4k67n263383mn8mawf22bfq";
+  })
+
+  (fetchNuGet {
+    name = "NUnit";
+    version = "3.12.0";
+    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+  })
+
+  (fetchNuGet {
+    name = "NUnit3TestAdapter";
+    version = "3.15.1";
+    sha256 = "1nhpvzxbxgymmkb3bd5ci40rg8k71bfx2ghbgc99znvnvhf2034y";
+  })
+
+  (fetchNuGet {
+    name = "Appveyor.TestLogger";
+    version = "2.0.0";
+    sha256 = "1x2hizldz5wlnjybp115r7npmqw0i9mdpq38wdlibrlq1338g0s9";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.5.0";
+    sha256 = "19f5bvzci5mmfz81jwc4dax4qdf7w4k67n263383mn8mawf22bfq";
+  })
+
+  (fetchNuGet {
+    name = "NUnit";
+    version = "3.12.0";
+    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+  })
+
+  (fetchNuGet {
+    name = "NUnit3TestAdapter";
+    version = "3.15.1";
+    sha256 = "1nhpvzxbxgymmkb3bd5ci40rg8k71bfx2ghbgc99znvnvhf2034y";
+  })
+
+  (fetchNuGet {
+    name = "Appveyor.TestLogger";
+    version = "2.0.0";
+    sha256 = "1x2hizldz5wlnjybp115r7npmqw0i9mdpq38wdlibrlq1338g0s9";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.5.0";
+    sha256 = "19f5bvzci5mmfz81jwc4dax4qdf7w4k67n263383mn8mawf22bfq";
+  })
+
+  (fetchNuGet {
+    name = "NUnit";
+    version = "3.12.0";
+    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+  })
+
+  (fetchNuGet {
+    name = "NUnit3TestAdapter";
+    version = "3.15.1";
+    sha256 = "1nhpvzxbxgymmkb3bd5ci40rg8k71bfx2ghbgc99znvnvhf2034y";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "4.7.0";
+    sha256 = "0bx21jjbs7l5ydyw4p6cn07chryxpmchq2nl5pirzz4l3b0q4dgs";
+  })
+
+  (fetchNuGet {
+    name = "Appveyor.TestLogger";
+    version = "2.0.0";
+    sha256 = "1x2hizldz5wlnjybp115r7npmqw0i9mdpq38wdlibrlq1338g0s9";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "2.9.8";
+    sha256 = "14krjfmvxph21hiw29p3849gydqyr8v541ibgc3833j8rw74mkxr";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "2.9.8";
+    sha256 = "15zv982rln15ds8z2hkpmx04njdg0cmmf1xnb9v1v7cxxf7yxx27";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.5.0";
+    sha256 = "19f5bvzci5mmfz81jwc4dax4qdf7w4k67n263383mn8mawf22bfq";
+  })
+
+  (fetchNuGet {
+    name = "NUnit";
+    version = "3.12.0";
+    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+  })
+
+  (fetchNuGet {
+    name = "NUnit3TestAdapter";
+    version = "3.15.1";
+    sha256 = "1nhpvzxbxgymmkb3bd5ci40rg8k71bfx2ghbgc99znvnvhf2034y";
+  })
+
+]

--- a/pkgs/games/osu-lazer/mypackage-restore.log
+++ b/pkgs/games/osu-lazer/mypackage-restore.log
@@ -1,0 +1,119 @@
+Project 'osu.Game' has the following package references
+   [netstandard2.1]: 
+   Top-level Package                                Requested    Resolved  
+   > Humanizer                                      2.7.9        2.7.9     
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8        2.9.8     
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8        2.9.8     
+   > Microsoft.EntityFrameworkCore.Sqlite           2.2.6        2.2.6     
+   > Microsoft.EntityFrameworkCore.Sqlite.Core      2.2.6        2.2.6     
+   > Newtonsoft.Json                                12.0.3       12.0.3    
+   > NUnit                                          3.12.0       3.12.0    
+   > ppy.osu.Framework                              2020.305.0   2020.305.0
+   > ppy.osu.Game.Resources                         2020.304.0   2020.304.0
+   > Sentry                                         2.1.0        2.1.0     
+   > SharpCompress                                  0.24.0       0.24.0    
+   > System.ComponentModel.Annotations              4.7.0        4.7.0     
+
+Project 'osu.Game.Rulesets.Osu' has the following package references
+   [netstandard2.1]: 
+   Top-level Package                                Requested   Resolved
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+
+Project 'osu.Game.Rulesets.Catch' has the following package references
+   [netstandard2.1]: 
+   Top-level Package                                Requested   Resolved
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+
+Project 'osu.Game.Rulesets.Taiko' has the following package references
+   [netstandard2.1]: 
+   Top-level Package                                Requested   Resolved
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+
+Project 'osu.Game.Rulesets.Mania' has the following package references
+   [netstandard2.1]: 
+   Top-level Package                                Requested   Resolved
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+
+Project 'osu.Game.Tests' has the following package references
+   [netcoreapp3.1]: 
+   Top-level Package                                Requested   Resolved
+   > Appveyor.TestLogger                            2.0.0       2.0.0   
+   > DeepEqual                                      2.0.0       2.0.0   
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+   > Microsoft.NET.Test.Sdk                         16.5.0      16.5.0  
+   > NUnit                                          3.12.0      3.12.0  
+   > NUnit3TestAdapter                              3.15.1      3.15.1  
+
+Project 'osu.Desktop' has the following package references
+   [netcoreapp3.1]: 
+   Top-level Package                                Requested   Resolved
+   > DiscordRichPresence                            1.0.150     1.0.150 
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+   > Microsoft.EntityFrameworkCore.Design           2.2.6       2.2.6   
+   > Microsoft.EntityFrameworkCore.Sqlite           2.2.6       2.2.6   
+   > Microsoft.Win32.Registry                       4.7.0       4.7.0   
+   > ppy.squirrel.windows                           1.9.0.4     1.9.0.4 
+   > System.IO.Packaging                            4.7.0       4.7.0   
+
+Project 'osu.Game.Rulesets.Catch.Tests' has the following package references
+   [netcoreapp3.1]: 
+   Top-level Package                                Requested   Resolved
+   > Appveyor.TestLogger                            2.0.0       2.0.0   
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+   > Microsoft.NET.Test.Sdk                         16.5.0      16.5.0  
+   > NUnit                                          3.12.0      3.12.0  
+   > NUnit3TestAdapter                              3.15.1      3.15.1  
+
+Project 'osu.Game.Rulesets.Mania.Tests' has the following package references
+   [netcoreapp3.1]: 
+   Top-level Package                                Requested   Resolved
+   > Appveyor.TestLogger                            2.0.0       2.0.0   
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+   > Microsoft.NET.Test.Sdk                         16.5.0      16.5.0  
+   > NUnit                                          3.12.0      3.12.0  
+   > NUnit3TestAdapter                              3.15.1      3.15.1  
+
+Project 'osu.Game.Rulesets.Taiko.Tests' has the following package references
+   [netcoreapp3.1]: 
+   Top-level Package                                Requested   Resolved
+   > Appveyor.TestLogger                            2.0.0       2.0.0   
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+   > Microsoft.NET.Test.Sdk                         16.5.0      16.5.0  
+   > NUnit                                          3.12.0      3.12.0  
+   > NUnit3TestAdapter                              3.15.1      3.15.1  
+
+Project 'osu.Game.Rulesets.Osu.Tests' has the following package references
+   [netcoreapp3.1]: 
+   Top-level Package                                Requested   Resolved
+   > Appveyor.TestLogger                            2.0.0       2.0.0   
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+   > Microsoft.NET.Test.Sdk                         16.5.0      16.5.0  
+   > NUnit                                          3.12.0      3.12.0  
+   > NUnit3TestAdapter                              3.15.1      3.15.1  
+
+Project 'osu.Game.Tournament' has the following package references
+   [netstandard2.1]: 
+   Top-level Package                                Requested   Resolved
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+   > Microsoft.Win32.Registry                       4.7.0       4.7.0   
+
+Project 'osu.Game.Tournament.Tests' has the following package references
+   [netcoreapp3.1]: 
+   Top-level Package                                Requested   Resolved
+   > Appveyor.TestLogger                            2.0.0       2.0.0   
+   > Microsoft.CodeAnalysis.BannedApiAnalyzers      2.9.8       2.9.8   
+   > Microsoft.CodeAnalysis.FxCopAnalyzers          2.9.8       2.9.8   
+   > Microsoft.NET.Test.Sdk                         16.5.0      16.5.0  
+   > NUnit                                          3.12.0      3.12.0  
+   > NUnit3TestAdapter                              3.15.1      3.15.1  

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5768,6 +5768,8 @@ in
 
   ostree = callPackage ../tools/misc/ostree { };
 
+  osu-lazer = callPackage ../games/osu-lazer { Nuget = dotnetPackages.Nuget; };
+
   otfcc = callPackage ../tools/misc/otfcc { };
 
   otpw = callPackage ../os-specific/linux/otpw { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add the [osu-lazer](osu.ppy.sh/) rythm game to nixpkgs

###### Issues that need to be resolved
Since there isn't easy way to package dotnet packages I've been relying on [this](https://github.com/NixOS/nixpkgs/blob/5ea0258458118ce531a0d66c77e2d6179bdce516/pkgs/servers/nosql/eventstore/default.nix) package heavily for reference, but I'm still having some [issues](https://discourse.nixos.org/t/dotnet-package-build-access-to-the-path-homeless-shelter-dotnet-is-denied-error/6181/3?u=skykanin) with restoring packages. I'm still not quite sure what file I should be parsing to retrieve the nuget package dependencies for [osu](https://github.com/ppy/osu/).

- [ ] `create-deps.sh` doesn't properly parse the names of some packages (as a temp fix I've added them manually)
- [ ] running `dotnet list osu.sln package > mypackage-restore.log` and then `./create-deps.sh mypackage-restore.log > deps.nix` creates duplicate nuget package entries in `deps.nix`
- [ ]  `nix-build -A osu-lazer` [complains](https://pastebin.com/8n9kRF8x) about missing packages 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
