### PR TITLE
Freeform modules

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -104,7 +104,8 @@ rec {
                 file = def.file;
                 value = setAttrByPath def.prefix def.value;
               }) merged.unmatchedDefns;
-            in declaredConfig._module.freeformType.merge prefix defs;
+            in if defs == [] then {}
+            else declaredConfig._module.freeformType.merge prefix defs;
 
         in if declaredConfig._module.freeformType == null then declaredConfig
           # Because all definitions that had an associated option ended in

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -210,6 +210,27 @@ checkConfigOutput "empty" config.value.foo ./declare-lazyAttrsOf.nix ./attrsOf-c
 checkConfigError 'The option value .* in .* is not of type .*' \
   config.value ./declare-int-unsigned-value.nix ./define-value-list.nix ./define-value-int-positive.nix
 
+## Freeform modules
+# Assigning without a declared option should work
+checkConfigOutput 24 config.value ./freeform-attrsOf.nix ./define-value-string.nix
+# but only if the type matches
+checkConfigError 'The option value .* in .* is not of type .*' config.value ./freeform-attrsOf.nix ./define-value-list.nix
+# and properties should be applied
+checkConfigOutput yes config.value ./freeform-attrsOf.nix ./define-value-string-properties.nix
+# Options should still be declarable, and be able to have a type that doesn't match the freeform type
+checkConfigOutput false config.enable ./freeform-attrsOf.nix ./define-value-string.nix ./declare-enable.nix
+checkConfigOutput 24 config.value ./freeform-attrsOf.nix ./define-value-string.nix ./declare-enable.nix
+# and this should work too with nested values
+checkConfigOutput false config.nest.foo ./freeform-attrsOf.nix ./freeform-nested.nix
+checkConfigOutput bar config.nest.bar ./freeform-attrsOf.nix ./freeform-nested.nix
+# Check whether a declared option can depend on an freeform-typed one
+checkConfigOutput null config.foo ./freeform-attrsOf.nix ./freeform-str-dep-unstr.nix
+checkConfigOutput 24 config.foo ./freeform-attrsOf.nix ./freeform-str-dep-unstr.nix ./define-value-string.nix
+# Check whether an freeform-typed value can depend on a declared option, this can only work with lazyAttrsOf
+checkConfigError 'infinite recursion encountered' config.foo ./freeform-attrsOf.nix ./freeform-unstr-dep-str.nix
+checkConfigError 'The option .* is used but not defined' config.foo ./freeform-lazyAttrsOf.nix ./freeform-unstr-dep-str.nix
+checkConfigOutput 24 config.foo ./freeform-lazyAttrsOf.nix ./freeform-unstr-dep-str.nix ./define-value-string.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -213,6 +213,8 @@ checkConfigError 'The option value .* in .* is not of type .*' \
 ## Freeform modules
 # Assigning without a declared option should work
 checkConfigOutput 24 config.value ./freeform-attrsOf.nix ./define-value-string.nix
+# No freeform assigments shouldn't make it error
+checkConfigOutput '{ }' config ./freeform-attrsOf.nix
 # but only if the type matches
 checkConfigError 'The option value .* in .* is not of type .*' config.value ./freeform-attrsOf.nix ./define-value-list.nix
 # and properties should be applied

--- a/lib/tests/modules/define-value-string-properties.nix
+++ b/lib/tests/modules/define-value-string-properties.nix
@@ -1,0 +1,12 @@
+{ lib, ... }: {
+
+  imports = [{
+    value = lib.mkDefault "def";
+  }];
+
+  value = lib.mkMerge [
+    (lib.mkIf false "nope")
+    "yes"
+  ];
+
+}

--- a/lib/tests/modules/freeform-attrsOf.nix
+++ b/lib/tests/modules/freeform-attrsOf.nix
@@ -1,3 +1,3 @@
 { lib, ... }: {
-  config._module.freeformType = with lib.types; attrsOf (either str (attrsOf str));
+  freeformType = with lib.types; attrsOf (either str (attrsOf str));
 }

--- a/lib/tests/modules/freeform-attrsOf.nix
+++ b/lib/tests/modules/freeform-attrsOf.nix
@@ -1,0 +1,3 @@
+{ lib, ... }: {
+  config._module.freeformType = with lib.types; attrsOf (either str (attrsOf str));
+}

--- a/lib/tests/modules/freeform-lazyAttrsOf.nix
+++ b/lib/tests/modules/freeform-lazyAttrsOf.nix
@@ -1,0 +1,3 @@
+{ lib, ... }: {
+  config._module.freeformType = with lib.types; lazyAttrsOf (either str (lazyAttrsOf str));
+}

--- a/lib/tests/modules/freeform-lazyAttrsOf.nix
+++ b/lib/tests/modules/freeform-lazyAttrsOf.nix
@@ -1,3 +1,3 @@
 { lib, ... }: {
-  config._module.freeformType = with lib.types; lazyAttrsOf (either str (lazyAttrsOf str));
+  freeformType = with lib.types; lazyAttrsOf (either str (lazyAttrsOf str));
 }

--- a/lib/tests/modules/freeform-nested.nix
+++ b/lib/tests/modules/freeform-nested.nix
@@ -1,0 +1,7 @@
+{ lib, ... }: {
+  options.nest.foo = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+  };
+  config.nest.bar = "bar";
+}

--- a/lib/tests/modules/freeform-str-dep-unstr.nix
+++ b/lib/tests/modules/freeform-str-dep-unstr.nix
@@ -1,0 +1,8 @@
+{ lib, config, ... }: {
+  options.foo = lib.mkOption {
+    type = lib.types.nullOr lib.types.str;
+    default = null;
+  };
+
+  config.foo = lib.mkIf (config ? value) config.value;
+}

--- a/lib/tests/modules/freeform-unstr-dep-str.nix
+++ b/lib/tests/modules/freeform-unstr-dep-str.nix
@@ -1,0 +1,8 @@
+{ lib, config, ... }: {
+  options.value = lib.mkOption {
+    type = lib.types.nullOr lib.types.str;
+    default = null;
+  };
+
+  config.foo = lib.mkIf (config.value != null) config.value;
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -486,9 +486,15 @@ rec {
           else value
         ) defs;
 
+        freeformType = (evalModules {
+          inherit modules specialArgs;
+          args.name = "‹name›";
+        })._module.freeformType;
+
       in
       mkOptionType rec {
         name = "submodule";
+        description = freeformType.description or name;
         check = x: isAttrs x || isFunction x || path.check x;
         merge = loc: defs:
           (evalModules {

--- a/nixos/doc/manual/development/freeform-modules.xml
+++ b/nixos/doc/manual/development/freeform-modules.xml
@@ -1,0 +1,68 @@
+<section xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xi="http://www.w3.org/2001/XInclude"
+        version="5.0"
+        xml:id="sec-freeform-modules">
+ <title>Freeform modules</title>
+ <para>
+  Freeform modules allow you to define values for option paths that have not been declared explicitly. This can be used to add attribute-specific types to what would otherwise have to be <literal>attrsOf</literal> options in order to accept all attribute names.
+ </para>
+ <para>
+  This feature can be enabled by using the attribute <literal>freeformType</literal> to define a freeform type. By doing this, all assignments without an associated option will be merged using the freeform type and combined into the resulting <literal>config</literal> set. Since this feature nullifies name checking for entire option trees, it is only recommended for use in submodules.
+ </para>
+ <example xml:id="ex-freeform-module">
+  <title>Freeform submodule</title>
+  <para>
+   The following shows a submodule assigning a freeform type that allows arbitrary attributes with <literal>str</literal> values below <literal>settings</literal>, but also declares an option for the <literal>settings.port</literal> attribute to have it type-checked and assign a default value. See <xref linkend="ex-settings-typed-attrs"/> for a more complete example.
+  </para>
+ <programlisting>
+{ lib, config, ... }: {
+
+  options.settings = lib.mkOption {
+    type = lib.types.submodule {
+
+      freeformType = with lib.types; attrsOf str;
+
+      # We want this attribute to be checked for the correct type
+      options.port = lib.mkOption {
+        type = lib.types.port;
+        # Declaring the option also allows defining a default value
+        default = 8080;
+      };
+
+    };
+  };
+}
+ </programlisting>
+ <para>
+  And the following shows what such a module then allows
+ </para>
+ <programlisting>
+{
+  # Not a declared option, but the freeform type allows this
+  settings.logLevel = "debug";
+
+  # Not allowed because the the freeform type only allows strings
+  # settings.enable = true;
+
+  # Allowed because there is a port option declared
+  settings.port = 80;
+
+  # Not allowed because the port option doesn't allow strings
+  # settings.port = "443";
+}
+ </programlisting>
+ </example>
+ <note>
+  <para>
+   Freeform attributes cannot depend on other attributes of the same set without infinite recursion:
+<programlisting>
+{
+  # This throws infinite recursion encountered
+  settings.logLevel = lib.mkIf (config.settings.port == 80) "debug";
+}
+</programlisting>
+   To prevent this, declare options for all attributes that need to depend on others. For above example this means to declare <literal>logLevel</literal> to be an option.
+  </para>
+ </note>
+</section>

--- a/nixos/doc/manual/development/settings-options.xml
+++ b/nixos/doc/manual/development/settings-options.xml
@@ -137,7 +137,7 @@ in {
       description = ''
         Configuration for foo, see
         &lt;link xlink:href="https://example.com/docs/foo"/&gt;
-        for supported values.
+        for supported settings.
       '';
     };
   };
@@ -167,13 +167,50 @@ in {
 
     # We know that the `user` attribute exists because we set a default value
     # for it above, allowing us to use it without worries here
-    users.users.${cfg.settings.user} = {}
+    users.users.${cfg.settings.user} = {};
 
     # ...
   };
 }
 </programlisting>
    </example>
+   <section xml:id="sec-settings-attrs-options">
+    <title>Option declarations for attributes</title>
+    <para>
+     Some <literal>settings</literal> attributes may deserve some extra care. They may need a different type, default or merging behavior, or they are essential options that should show their documentation in the manual. This can be done using <xref linkend='sec-freeform-modules'/>.
+     <example xml:id="ex-settings-typed-attrs">
+      <title>Declaring a type-checked <literal>settings</literal> attribute</title>
+      <para>
+       We extend above example using freeform modules to declare an option for the port, which will enforce it to be a valid integer and make it show up in the manual.
+      </para>
+<programlisting>
+settings = lib.mkOption {
+  type = lib.types.submodule {
+
+    freeformType = settingsFormat.type;
+
+    # Declare an option for the port such that the type is checked and this option
+    # is shown in the manual.
+    options.port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = ''
+        Which port this service should listen on.
+      '';
+    };
+
+  };
+  default = {};
+  description = ''
+    Configuration for Foo, see
+    &lt;link xlink:href="https://example.com/docs/foo"/&gt;
+    for supported values.
+  '';
+};
+</programlisting>
+     </example>
+    </para>
+   </section>
  </section>
 
 </section>

--- a/nixos/doc/manual/development/writing-modules.xml
+++ b/nixos/doc/manual/development/writing-modules.xml
@@ -183,5 +183,6 @@ in {
  <xi:include href="meta-attributes.xml" />
  <xi:include href="importing-modules.xml" />
  <xi:include href="replace-modules.xml" />
+ <xi:include href="freeform-modules.xml" />
  <xi:include href="settings-options.xml" />
 </chapter>


### PR DESCRIPTION
###### Motivation for this change
This implement freeform modules, which are like a combination between `types.submodule` and `types.attrsOf`: The options declared with the submodule are type-checked, while the others are combined using a freeform type. This has been a desired feature in multiple occasions now:
- This will simplify NixOS/rfcs#42 drastically, making the process of declaring options corresponding to `settings` values very conventional.
- Type checking for nixpkgs' `config` argument, as previously attempted in https://github.com/NixOS/nixpkgs/pull/57123 and https://github.com/NixOS/nixpkgs/pull/80582, will now be possible in a sane way.

How it looks like (updated for latest version) (evaluate with `nix-instantiate --eval --strict example.nix -A config`)
```nix
with import ./lib; evalModules {
  modules = [{
    options.settings = mkOption {
      default = {};
      type = with types; submodule {
        # All values that don't have an associated option have to be of this type
        freeformType = attrsOf int;

        options.port = mkOption {
          type = port;
          default = 80;
          description = "The port to use.";
        };
      };
    };

    # Works, even though foo isn't declared as an option
    config.settings.foo = 10;

    # error: The option value `settings.port' in `example.nix' is not of type
    # `16 bit unsigned integer; between 0 and 65535 (both inclusive)'.
    #config.settings.port = "not-a-port";

    ## Overrides default value
    config.settings.port = 8080;
  }];
}

```

Ping @roberth @Ma27 @rycee @Profpatsch @oxij

###### TODO

- [x] Write tests
- [x] Potentially separate orthogonal changes into a separate PR
- [x] Write docs
- [x] Check how this affects performance -> The current implementation is slower than it could be when many freeform values are defined, but since the number of them per module evaluation is expected to be rather low, I'll leave it at this for now.