### PR TITLE
elmPackages.elm-instrument: Init at 0.0.7

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -42,12 +42,30 @@ let
               doCheck = false;
               jailbreak = true;
             }));
+
             elmi-to-json = justStaticExecutables (overrideCabal (self.callPackage ./packages/elmi-to-json.nix {}) (drv: {
               prePatch = ''
                 substituteInPlace package.yaml --replace "- -Werror" ""
                 hpack
               '';
               jailbreak = true;
+            }));
+
+            elm-instrument = justStaticExecutables (overrideCabal (self.callPackage ./packages/elm-instrument.nix {}) (drv: {
+              patches = [(
+                # GHC 8.8.1 and Cabal >= 1.25.0 support
+                # https://github.com/zwilias/elm-instrument/pull/3
+                fetchpatch {
+                  url = "https://github.com/turboMaCk/elm-instrument/commit/4272db2aea742c8b54509e536fa4f35d04f95da5.patch";
+                  sha256 = "1d1lc43lp3x5jfhlyb1b7na7nj1g1i1vc1np26pcisg9c2s7gjz6";
+                }
+              )];
+              prePatch = ''
+                sed "s/desc <-.*/let desc = \"${drv.version}\"/g" Setup.hs --in-place
+              '';
+              jailbreak = true;
+              # Tests are failing because of missing instances for Eq and Show type classes
+              doCheck = false;
             }));
 
             inherit fetchElmDeps;

--- a/pkgs/development/compilers/elm/packages/elm-instrument.nix
+++ b/pkgs/development/compilers/elm/packages/elm-instrument.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, ansi-terminal, ansi-wl-pprint, base, binary
+, bytestring, Cabal, cmark, containers, directory, elm-format
+, fetchgit, filepath, free, HUnit, indents, json, mtl
+, optparse-applicative, parsec, process, QuickCheck, quickcheck-io
+, split, stdenv, tasty, tasty-golden, tasty-hunit, tasty-quickcheck
+, text, elm
+}:
+mkDerivation {
+  pname = "elm-instrument";
+  version = "0.0.7";
+  src = fetchgit {
+    url = "https://github.com/zwilias/elm-instrument.git";
+    sha256 = "14yfzwsyvgc6rzn19sdmwk2mc1vma9hcljnmjnmlig8mp0271v56";
+    rev = "31b527e405a6afdb25bb87ad7bd14f979e65cff7";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  setupHaskellDepends = [ base Cabal directory filepath process ];
+  libraryHaskellDepends = [
+    ansi-terminal ansi-wl-pprint base binary bytestring containers
+    directory filepath free indents json mtl optparse-applicative
+    parsec process split text
+  ];
+  executableHaskellDepends = [ base ];
+  testHaskellDepends = [
+    base cmark containers elm-format HUnit mtl parsec QuickCheck
+    quickcheck-io split tasty tasty-golden tasty-hunit tasty-quickcheck
+    text
+  ];
+  homepage = "http://elm-lang.org";
+  description = "Instrumentation library for Elm";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
Init [elm-instrument](https://github.com/zwilias/elm-instrument/pull/3)

* This package is not that useful on its own but it's a first logical step for packaging [elm-coverage](https://github.com/zwilias/elm-coverage)
* [PR to upstream](https://github.com/zwilias/elm-instrument/pull/3) we're currently using as a patch

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @domenkozar this is part 1/2 of bringing elm-coverage in. I think doing it one by one will result in clearer diff in PRs. Alternatively I can continue on node.js side within this PR.