### PR TITLE
Minor module improvements

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -93,7 +93,11 @@ rec {
             res set._definedNames
         else
           res;
-      result = { inherit options config; };
+      result = {
+        inherit options;
+        config = removeAttrs config [ "_module" ];
+        inherit (config) _module;
+      };
     in result;
 
   # collectModules :: (modulesPath: String) -> (modules: [ Module ]) -> (args: Attrs) -> [ Module ]

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -416,10 +416,9 @@ rec {
     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
     mergedValue =
       if isDefined then
-        foldl' (res: def:
-          if type.check def.value then res
-          else throw "The option value `${showOption loc}' in `${def.file}' is not of type `${type.description}'."
-        ) (type.merge loc defsFinal) defsFinal
+        if all (def: type.check def.value) defsFinal then type.merge loc defsFinal
+        else let firstInvalid = findFirst (def: ! type.check def.value) null defsFinal;
+        in throw "The option value `${showOption loc}' in `${firstInvalid.file}' is not of type `${type.description}'."
       else
         # (nixos-option detects this specific error message and gives it special
         # handling.  If changed here, please change it there too.)

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -299,7 +299,9 @@ rec {
             in
               throw "The option `${showOption loc}' in `${firstOption._file}' is a prefix of options in `${firstNonOption._file}'."
           else
-            mergeModules' loc decls defns
+            if all (def: isAttrs def.value) defns' then mergeModules' loc decls defns
+            else let firstInvalid = findFirst (def: ! isAttrs def.value) null defns';
+            in throw "The option path `${showOption loc}' is an attribute set of options, but it is defined to not be an attribute set in `${firstInvalid.file}'. Did you define its value at the correct and complete path?"
       ))
     // { _definedNames = map (m: { inherit (m) file; names = attrNames m.config; }) configs; };
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -194,6 +194,10 @@ checkConfigOutput "true" config.conditionalWorks ./declare-attrsOf.nix ./attrsOf
 checkConfigOutput "false" config.conditionalWorks ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
 checkConfigOutput "empty" config.value.foo ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
 
+# Check error for when an option set is defined to be a non-attribute set value
+checkConfigError 'The option path .* is an attribute set of options, but it is defined to not be an attribute set in' \
+  config.value ./declare-option-set.nix ./define-value-int-zero.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -198,6 +198,10 @@ checkConfigOutput "empty" config.value.foo ./declare-lazyAttrsOf.nix ./attrsOf-c
 checkConfigError 'The option path .* is an attribute set of options, but it is defined to not be an attribute set in' \
   config.value ./declare-option-set.nix ./define-value-int-zero.nix
 
+# Even with multiple assignments, a type error should be thrown if any of them aren't valid
+checkConfigError 'The option value .* in .* is not of type .*' \
+  config.value ./declare-int-unsigned-value.nix ./define-value-list.nix ./define-value-int-positive.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/declare-option-set.nix
+++ b/lib/tests/modules/declare-option-set.nix
@@ -1,0 +1,3 @@
+{
+  options.value = {};
+}


### PR DESCRIPTION
###### Motivation for this change
Some tiny improvements to the module system:
- Removing `_module` from the evaluation result, this will be very useful for https://github.com/NixOS/nixpkgs/pull/82743, as it means that people won't have to filter out that key manually from every submodule that's used.
- Improving one error message
- Fixing another error message

Ping @roberth

Previous discussion regarding the removal of `_module` is in https://github.com/NixOS/nixpkgs/pull/82461#discussion_r392178468, where @roberth mentioned that he uses it for debugging sometimes. This could still be exposed via an explicit and non-module-internal option specifically for NixOS modules though.

###### Things done

- [x] Implemented tests for the error message bits
- [x] Successfully evaluated my system configs with the `_module` change