### PR TITLE
pythonPackages.IMAPClient: 0.13 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/imapclient/default.nix
+++ b/pkgs/development/python-modules/imapclient/default.nix
@@ -1,32 +1,35 @@
 { stdenv
 , buildPythonPackage
-, fetchurl
-, isPy34
-, isPy35
+, fetchFromGitHub
 , mock
+, six
 }:
 
 buildPythonPackage rec {
   pname = "IMAPClient";
-  version = "0.13";
-  disabled = isPy34 || isPy35;
+  version = "2.1.0";
 
-  src = fetchurl {
-    url = "https://freshfoo.com/projects/IMAPClient/${pname}-${version}.tar.gz";
-    sha256 = "0v7kd1crdbff0rmh4ddm5qszkis6hpk9084qh94al8h7g4y9l3is";
+  src = fetchFromGitHub {
+    owner = "mjs";
+    repo = "imapclient";
+    rev = version;
+    sha256 = "1zc8qj8ify2zygbz255b6fcg7jhprswf008ccwjmbrnj08kh9l4x";
   };
 
-  buildInputs = [ mock ];
-
-  preConfigure = ''
-    sed -i '/distribute_setup/d' setup.py
-    substituteInPlace setup.py --replace "mock==0.8.0" "mock"
+  # fix test failing in python 36
+  postPatch = ''
+    substituteInPlace tests/test_imapclient.py \
+      --replace "if sys.version_info >= (3, 7):" "if sys.version_info >= (3, 6, 4):"
   '';
 
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ mock ];
+
   meta = with stdenv.lib; {
-    homepage = https://imapclient.readthedocs.io/en/2.1.0/;
+    homepage = "https://imapclient.readthedocs.io";
     description = "Easy-to-use, Pythonic and complete IMAP client library";
     license = licenses.bsd3;
+    maintainers = [ maintainers.almac ];
   };
-
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrading IMAPClient - version 0.13 is from 2015. 
Was working on python package extract-msg, and it needed the new version. I imagine it will be the case with anything else that has IMAPClient as a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested for py27, py36, py37 and tested that gmvault builds and runs (has IMAPClient as a dependency).

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
