### PR TITLE
update-users-groups.pl: use atomic write_file

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -16,7 +16,7 @@ my $gidMap = -e $gidMapFile ? decode_json(read_file($gidMapFile)) : {};
 
 sub updateFile {
     my ($path, $contents, $perms) = @_;
-    write_file("$path.tmp", { binmode => ':utf8', perms => $perms // 0644 }, $contents);
+    write_file("$path.tmp", { binmode => ':utf8', perms => $perms // 0644, atomic => 1 }, $contents);
     rename("$path.tmp", $path) or die;
 }
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This should prevent critical files from being overwritten by `update-users-groups.pl` in case something goes wrong when writing. Also in that script there are a lot of: `FIXME: acquire lock.` - comments which won't be solved by this, but at least mitigated to a point that parallel writes from an other source will not corrupt the file.

From the [doc](https://metacpan.org/pod/File::Slurp):

> * atomic
>
> The atomic option is a boolean option, defaulted to false (0). Setting this option to true (1) will cause the file to be be written to in an atomic fashion. A temporary file name is created using "tempfile" in File::Temp. After the file is closed it is renamed to the original file name (and rename is an atomic operation on most OSes). If the program using this were to crash in the middle of this, then the temporary file could be left behind.

With this pull request I am patching something that stumbled upon today. I am **not** familiar with this part of nixos. I believe this change makes sense, but at the same time I have my concerns. By opening this PR i would like to open the discussion around several open points I am not fully able to answer myself:

- Does this improve the current situation?
- Where do temporary files get written and is it safe to do so in this script?
- ...


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [x]  login.nix
  - [x]  mutable-users.nix
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
