### PR TITLE
unityhub: fix hash

### DIFF
--- a/pkgs/development/tools/unityhub/default.nix
+++ b/pkgs/development/tools/unityhub/default.nix
@@ -17,11 +17,11 @@ appimageTools.wrapType2 rec {
 
   src = fetchurl {
     url = "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage";
-    sha256 = "1rx7ih94ig3pd1yx1d3fpx7zpixq3j5birkpnzkh778qqsdrg0nf";
+    sha256 = "05p5kqbwgqyk2aw2lix5dk1ql16aj6iczxrc63a1l0vj8wrha7z4";
   };
 
   meta = with stdenv.lib; {
-    homepage = https://unity3d.com/;
+    homepage = "https://unity3d.com/";
     description = "Game development tool";
     longDescription = ''
       Popular development platform for creating 2D and 3D multiplatform games


### PR DESCRIPTION
###### Motivation for this change
noticed this:
```
hash mismatch in fixed-output derivation '/nix/store/9cqma387r5qxzgb0yp449bkw6ffaiy0n-UnityHub.AppImage':
  wanted: sha256:1rx7ih94ig3pd1yx1d3fpx7zpixq3j5birkpnzkh778qqsdrg0nf
  got:    sha256:05p5kqbwgqyk2aw2lix5dk1ql16aj6iczxrc63a1l0vj8wrha7z4
```
when reviewing other packages.

Unfortunately they seem to not have distribution methods which have stable URLs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/82757
1 package built:
unityhub
```