### PR TITLE
[ZHF] kicad: don't build versions with 3d on Hydra

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -137,5 +137,9 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ evils kiwi berce ];
     # kicad's cross-platform, not sure what to fill in here
     platforms = with platforms; linux;
+  } // optionalAttrs with3d {
+    # We can't download the 3d models on Hydra - they are a ~1 GiB download and
+    # they occupy ~5 GiB in store.
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/applications/science/electronics/kicad/libraries.nix
+++ b/pkgs/applications/science/electronics/kicad/libraries.nix
@@ -12,8 +12,8 @@
 # };
 with lib;
 let
-  mkLib = name: attrs:
-    stdenv.mkDerivation (
+  mkLib = name:
+    stdenv.mkDerivation
       {
         pname = "kicad-${name}";
         version = "${version}";
@@ -27,16 +27,13 @@ let
         );
         nativeBuildInputs = [ cmake ];
         meta.license = licenses.cc-by-sa-40;
-      } // attrs
-    );
+      };
 in
 {
-  symbols = mkLib "symbols" { };
-  templates = mkLib "templates" { };
-  footprints = mkLib "footprints" { };
-  packages3d = mkLib "packages3d" {
-    hydraPlatforms = []; # this is a ~1 GiB download, occupies ~5 GiB in store
-  };
+  symbols = mkLib "symbols";
+  templates = mkLib "templates";
+  footprints = mkLib "footprints";
+  packages3d = mkLib "packages3d";
 
   # i18n is a special case, not actually a library
   # more a part of kicad proper, but also optional and separate


### PR DESCRIPTION
The hydraPlatforms have to be set on the kicad package itself, that can be
checked using:

    echo ":p { inherit kicad kicad-small kicad-unstable; }" | nix repl ./pkgs/top-level/release.nix

This commit disables build of all kicad variants that require downloading
packages3d, which currently fail on hydra with the "Output limit exceeded"
status. This leaves Hydra with only building the kicad-small, which will allow
us to cache the build of kicad-base as well as all libraries except of
packages3d.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This will stop making Hydra try to build kicad variants that are currently failing.
Some relevant discussion is in #82634

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

#80379