### PR TITLE
[19.09] opensmtpd: mark as insecure due to CVE-2020-8794 / #80978

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     platforms = platforms.linux;
     maintainers = with maintainers; [ rickynils obadz ekleog ];
+    knownVulnerabilities = [ "CVE-2020-8794 / NixOS PR #80978 has not been backported. Upgrade to NixOS 20.03." ];
   };
   passthru.tests = {
     basic-functionality-and-dovecot-interaction = nixosTests.opensmtpd;

--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     platforms = platforms.linux;
     maintainers = with maintainers; [ rickynils obadz ekleog ];
-    knownVulnerabilities = [ "CVE-2020-8794 / NixOS PR #80978 has not been backported. Upgrade to NixOS 20.03." ];
+    knownVulnerabilities = [ "CVE-2020-8794" ];
   };
   passthru.tests = {
     basic-functionality-and-dovecot-interaction = nixosTests.opensmtpd;


### PR DESCRIPTION
Security critical fix #80978 was never backported to 19.09. This marks the package as vulnerable.