### PR TITLE
pyexiv2: 0.3.2 -> 2.1.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1126,7 +1126,7 @@ in {
 
   pydy = callPackage ../development/python-modules/pydy { };
 
-  pyexiv2 = disabledIf isPy3k (toPythonModule (callPackage ../development/python-modules/pyexiv2 {}));
+  pyexiv2 = callPackage ../development/python-modules/pyexiv2 {};
 
   py3exiv2 = callPackage ../development/python-modules/py3exiv2 { };
 


### PR DESCRIPTION
###### Motivation for this change
pyexiv2 has been broken for quite a while, but since then it has been rewritten. It no longer has a Boost dependency and now only works on Python 3 (formerly, it only worked on Python 2.)

Only one package depends on pyexiv2, jbrout. However, it is old and broken, so I made a PR to remove it in #82770.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
