### PR TITLE
python3.pkgs.rpy2: fix tests with pandas 1.x, 3.2.5 -> 3.2.6

### DIFF
--- a/pkgs/development/python-modules/rpy2/default.nix
+++ b/pkgs/development/python-modules/rpy2/default.nix
@@ -1,6 +1,7 @@
 { lib
 , python
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
 , isPyPy
 , R
@@ -68,6 +69,14 @@ buildPythonPackage rec {
       # R_LIBS_SITE is used by the nix r package to point to the installed R libraries.
       # This patch sets R_LIBS_SITE when rpy2 is imported.
       ./rpy2-3.x-r-libs-site.patch
+
+      # pandas 1.x compatibility, already merged upstream
+      # https://github.com/rpy2/rpy2/issues/636
+      (fetchpatch {
+        name = "pandas-1.x.patch";
+        url = "https://github.com/rpy2/rpy2/commit/fbd060e364b70012e8d26cc74df04ee53f769379.patch";
+        sha256 = "19rdqydwjmqg25ibmsbx7lggrr9fsyjn283zgvz1wj4iyfjwp1za";
+      })
     ];
     postPatch = ''
       substituteInPlace 'rpy2/rinterface_lib/embedded.py' --replace '@NIX_R_LIBS_SITE@' "$R_LIBS_SITE"

--- a/pkgs/development/python-modules/rpy2/default.nix
+++ b/pkgs/development/python-modules/rpy2/default.nix
@@ -25,13 +25,13 @@
 }:
 
 buildPythonPackage rec {
-    version = "3.2.5";
+    version = "3.2.6";
     pname = "rpy2";
 
     disabled = isPyPy;
     src = fetchPypi {
       inherit version pname;
-      sha256 = "0pnk363klic4smb3jnkm4lnh984c2cpqzawrg2j52hgy8k1bgyrk";
+      sha256 = "1p990cqx3p2pd1rc9wn66m56wahaq8dlr88frz49vb7nv4zw4a8q";
     };
 
     buildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The `python3.pkgs.rpy2` build was broken by a recent update to `pandas`. A fix is already upstream and just needs to be backported. While I'm at it I also included a version bump to the latest released version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
