### PR TITLE
virtualboxExtpack: synchronize version with virtualbox

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -1,8 +1,9 @@
-{fetchurl, lib}:
+{fetchurl, lib, virtualbox}:
 
 with lib;
 
-let version = "6.0.14";
+let
+  inherit (virtualbox) version;
 in
 fetchurl rec {
   name = "Oracle_VM_VirtualBox_Extension_Pack-${version}.vbox-extpack";
@@ -11,7 +12,7 @@ fetchurl rec {
     # Manually sha256sum the extensionPack file, must be hex!
     # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
     # Checksums can also be found at https://www.virtualbox.org/download/hashes/${version}/SHA256SUMS
-    let value = "c8a5cc980c9c94cdac3d94e23cf159c2433aae76b416dbfb5b1a918758f21e63";
+    let value = "3b73798d776ff223ea8025b1a45001762f8d4e5bcd1ea61449773c1249935800";
     in assert (builtins.stringLength value) == 64; value;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Since #82479 the `virtualboxExtpack` version is out of sync with `virtualbox` (`6.0.14` vs `6.1.4`).

This change synchronizes the `virtualboxExtpack` version with the `virtualbox` version.

The next time the packages are not updated in parallel building `virtualboxExtpack` will fail with a hash mismatch and therefore fail fast.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @m-scr @alyssais 