### PR TITLE
elmPackages.elmi-to-json: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/development/compilers/elm/packages/elmi-to-json.nix
+++ b/pkgs/development/compilers/elm/packages/elmi-to-json.nix
@@ -5,11 +5,11 @@
 }:
 mkDerivation {
   pname = "elmi-to-json";
-  version = "1.2.0";
+  version = "1.3.0";
   src = fetchgit {
-    url = "https://github.com/stoeffel/elmi-to-json.git";
-    sha256 = "1kxai87h2g0749yq0fkxwk3xaavydraaivhnavbwr62q2hw4wrj7";
-    rev = "af08ceafe742a252f1f1f3c229b0ce3b3e00084d";
+    url = "https://github.com/stoeffel/elmi-to-json";
+    sha256 = "11j56vcyhijkwi9hzggkwwmxlhzhgm67ab2m7kxkhcbbqgpasa8n";
+    rev = "ae40d1aa1e3d6878f2af514e611d44890e7abc1e";
     fetchSubmodules = true;
   };
   isLibrary = true;


### PR DESCRIPTION
**This also fixes elmPackages.elm-test**

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
