### PR TITLE
[20.03] haskellPackages.binary-strict: 0.4.8.4 -> 0.4.8.5

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3238,7 +3238,6 @@ broken-packages:
   - binary-protocol
   - binary-protocol-zmq
   - binary-streams
-  - binary-strict
   - binary-typed
   - bind-marshal
   - binding-gtk
@@ -4562,7 +4561,6 @@ broken-packages:
   - ethereum-analyzer-webui
   - ethereum-client-haskell
   - ethereum-merkle-patricia-db
-  - eths-rlp
   - euler-tour-tree
   - euphoria
   - eurofxref
@@ -10105,7 +10103,6 @@ broken-packages:
   - vk-aws-route53
   - VKHS
   - voicebase
-  - vorbiscomment
   - vowpal-utils
   - voyeur
   - vpq
@@ -10208,7 +10205,6 @@ broken-packages:
   - webdriver-w3c
   - WeberLogic
   - webfinger-client
-  - webify
   - webkit-javascriptcore
   - Webrexp
   - webserver


### PR DESCRIPTION


###### Motivation for this change

I want to use `webify` on `nixos-20.03`.

###### Things done

I basically backported the bump that happened in ea1aae15ae62c59641cfb84f1138a8a0d3b365e2.

This fixes the build, also of

- eths-rlp
- vorbiscomment
- webify

which depend on binary-strict. Everything else that depends on binary-strict remains broken, so this commit shouldn't break anything that wasn't broken yet.

I know that I edit `hackage-packages.nix`, which shouldn't be touched by hand. But I'd still propose this, as

- this doesn't break anything (at least on `x86_64-linux`)
- If hackage-packages ever gets regenerated, it will include the bump anyway.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
