### PR TITLE
llvmPackages_10: rc3 -> rc4 -> rc5, polly enabled by default

### DIFF
--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -8,7 +8,7 @@ let
     pname = "clang";
     inherit version;
 
-    src = fetch "clang" "19y2nii0rqq8hf657d331s8rmpddlm5wvcznhdwxkymd0fd5l7vm";
+    src = fetch "clang" "0ap63qhz0j6m63l4njwp055xni4s71dsxqi1w5d2p93hbswaiiw2";
 
     unpackPhase = ''
       unpackFile $src

--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -8,7 +8,7 @@ let
     pname = "clang";
     inherit version;
 
-    src = fetch "clang" "1w7ixr16a9f0g5kv4irvhwq973wn0d418kb0p9rabyfscm05wfmq";
+    src = fetch "clang" "19y2nii0rqq8hf657d331s8rmpddlm5wvcznhdwxkymd0fd5l7vm";
 
     unpackPhase = ''
       unpackFile $src
@@ -36,7 +36,7 @@ let
     ];
 
     patches = [
-      # 10.0.0rc3-only
+      # 10.0.0 only, this should be present in 10.0.1
       ./clang-extension-handling.patch
 
       ./purity.patch

--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation rec {
   pname = "compiler-rt";
   inherit version;
-  src = fetch pname "0s2dzhcvdw50wsw6abksrrc9bqzwa6dp0qfk3bykinj8ah33ljws";
+  src = fetch pname "1g067yx8qz0bmf00b2xqjqaayqj2xvrjp9smms3a16syj9m0hfri";
 
   nativeBuildInputs = [ cmake python3 llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;

--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation rec {
   pname = "compiler-rt";
   inherit version;
-  src = fetch pname "0qv40mv91630l6f75w9g5y6v97s5shz94n82rms12gcd8mir6qp5";
+  src = fetch pname "0s2dzhcvdw50wsw6abksrrc9bqzwa6dp0qfk3bykinj8ah33ljws";
 
   nativeBuildInputs = [ cmake python3 llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;

--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -6,7 +6,7 @@
 
 let
   release_version = "10.0.0";
-  candidate = "rc3";
+  candidate = "rc4";
   version = "10.0.0${candidate}"; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
@@ -14,7 +14,7 @@ let
     inherit sha256;
   };
 
-  clang-tools-extra_src = fetch "clang-tools-extra" "03669c93wzmbmfpv0pyzb7y4z1xc912l95iqywyx01xgdl1xws0r";
+  clang-tools-extra_src = fetch "clang-tools-extra" "0irbb1n31qpwzspizxp2b17m4jnbkh6rlr9bs85q16yc4xr6c781";
 
   tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python3 isl release_version version fetch; });

--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -30,15 +30,10 @@ let
   in {
 
     llvm = callPackage ./llvm.nix { };
-    llvm-polly = callPackage ./llvm.nix { enablePolly = true; };
 
     clang-unwrapped = callPackage ./clang {
       inherit (tools) lld;
       inherit clang-tools-extra_src;
-    };
-    clang-polly-unwrapped = callPackage ./clang {
-      inherit clang-tools-extra_src;
-      llvm = tools.llvm-polly;
     };
 
     llvm-manpages = lowPrio (tools.llvm.override {

--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -6,7 +6,7 @@
 
 let
   release_version = "10.0.0";
-  candidate = "rc4";
+  candidate = "rc5";
   version = "10.0.0${candidate}"; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
@@ -14,7 +14,7 @@ let
     inherit sha256;
   };
 
-  clang-tools-extra_src = fetch "clang-tools-extra" "0irbb1n31qpwzspizxp2b17m4jnbkh6rlr9bs85q16yc4xr6c781";
+  clang-tools-extra_src = fetch "clang-tools-extra" "0x23q70c0xcwdhj0d66nisr8rqq69qcshrbb4si9pxfsm0zs9h3i";
 
   tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python3 isl release_version version fetch; });

--- a/pkgs/development/compilers/llvm/10/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/10/libc++/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "libc++";
   inherit version;
 
-  src = fetch "libcxx" "1j15szimdyihqzz5k1ys40v1vrswa4aaj6ckpqx3gngindi80sdr";
+  src = fetch "libcxx" "0qw85sy3y1mcdrj8yd1j1gmskh0vs4xdgrx80niigizhr7030vxs";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/10/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/10/libc++/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "libc++";
   inherit version;
 
-  src = fetch "libcxx" "1cjxiby8nq95g02rgx08iy86pswpi66b9wmxqjiyga1s92nb19j0";
+  src = fetch "libcxx" "1j15szimdyihqzz5k1ys40v1vrswa4aaj6ckpqx3gngindi80sdr";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/10/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/10/libc++abi.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "libc++abi";
   inherit version;
 
-  src = fetch "libcxxabi" "1xs7dr91qzz7lq9am4q3vcj2jf1gx23ar1jbnhn763011hl94vs0";
+  src = fetch "libcxxabi" "08w3lvg414k2w3ddbdbc979z38l7w1rbnwrxq68mvcrp7zry347a";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;

--- a/pkgs/development/compilers/llvm/10/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/10/libc++abi.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "libc++abi";
   inherit version;
 
-  src = fetch "libcxxabi" "08w3lvg414k2w3ddbdbc979z38l7w1rbnwrxq68mvcrp7zry347a";
+  src = fetch "libcxxabi" "15iclzxjqfjynqxjg8dahyr0gfg83blv9dm7z9hq5ipxw8x2sglf";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;

--- a/pkgs/development/compilers/llvm/10/libunwind.nix
+++ b/pkgs/development/compilers/llvm/10/libunwind.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "libunwind";
   inherit version;
 
-  src = fetch pname "07rp723yldqvr05hmfq7xsa2g6sdw9jiird4r5v9lk112bwb2y1q";
+  src = fetch pname "12c2fh63afav8rfmplfs628r74ksfs8fjls655rwjsrg1hk0gy3l";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/compilers/llvm/10/libunwind.nix
+++ b/pkgs/development/compilers/llvm/10/libunwind.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "libunwind";
   inherit version;
 
-  src = fetch pname "1dm7l75ajnjy6kbg2157v2g5gfia3n47fc56ayryyp2jdvbgprwl";
+  src = fetch pname "07rp723yldqvr05hmfq7xsa2g6sdw9jiird4r5v9lk112bwb2y1q";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/compilers/llvm/10/lld.nix
+++ b/pkgs/development/compilers/llvm/10/lld.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   pname = "lld";
   inherit version;
 
-  src = fetch pname "1w9c9xmzbdnkwgal612hqz2lxj9jgqpfzxr2rllcspmf6v7arvf4";
+  src = fetch pname "1c8s5jcp1h2lvws6dxy7c3a36ic10q6lbmd4i38l3g3irl6dj871";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/10/lld.nix
+++ b/pkgs/development/compilers/llvm/10/lld.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   pname = "lld";
   inherit version;
 
-  src = fetch pname "1c8s5jcp1h2lvws6dxy7c3a36ic10q6lbmd4i38l3g3irl6dj871";
+  src = fetch pname "08zg546872b432qrx49i7k1c2vdq9yjvc7gnrvy2nywv0d2qf9nc";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/10/lldb.nix
+++ b/pkgs/development/compilers/llvm/10/lldb.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (rec {
   pname = "lldb";
   inherit version;
 
-  src = fetch pname "1djjjya2fawkc8fd9x82ijsscz3k6kj9mwdsnpk0yikac167pqaw";
+  src = fetch pname "0swv16n7gm12f399f7hxai1jh89s14h3yg7cci10yaiibpvwk73x";
 
   patches = [ ./lldb-procfs.patch ];
 

--- a/pkgs/development/compilers/llvm/10/lldb.nix
+++ b/pkgs/development/compilers/llvm/10/lldb.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (rec {
   pname = "lldb";
   inherit version;
 
-  src = fetch pname "06qzh13cr20wrd5925698yq696bhl68zbvm7kjxp7c2rx5swxmg8";
+  src = fetch pname "1djjjya2fawkc8fd9x82ijsscz3k6kj9mwdsnpk0yikac167pqaw";
 
   patches = [ ./lldb-procfs.patch ];
 

--- a/pkgs/development/compilers/llvm/10/llvm.nix
+++ b/pkgs/development/compilers/llvm/10/llvm.nix
@@ -17,7 +17,7 @@
 , enablePFM ? !(stdenv.isDarwin
   || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
 )
-, enablePolly ? false
+, enablePolly ? true
 }:
 
 let

--- a/pkgs/development/compilers/llvm/10/llvm.nix
+++ b/pkgs/development/compilers/llvm/10/llvm.nix
@@ -31,8 +31,8 @@ in stdenv.mkDerivation (rec {
   pname = "llvm";
   inherit version;
 
-  src = fetch pname "16mh2n5s7pngc1wlkwp2xnnjpjljm4p6d6ld1646dayr6q8lmi34";
-  polly_src = fetch "polly" "15w5mpl98wldyxjgqjnbh1pb4p9wnrqgik7sq2qi49qp4g1cg5wh";
+  src = fetch pname "1abfi0zqbcwxf68dk00szpjxkcd44589va243af8sg97hljq6709";
+  polly_src = fetch "polly" "1fzg5934km69rwam6vgznk0p4slzhr0icwmj3jibw3p93ppa8k9r";
 
   unpackPhase = ''
     unpackFile $src

--- a/pkgs/development/compilers/llvm/10/llvm.nix
+++ b/pkgs/development/compilers/llvm/10/llvm.nix
@@ -31,8 +31,8 @@ in stdenv.mkDerivation (rec {
   pname = "llvm";
   inherit version;
 
-  src = fetch pname "1pa322iwqg071gxdn5wxri263j6aki6ag36xbdzbyi3g8m8v8jci";
-  polly_src = fetch "polly" "0p9dmv4hxwx4f5k1v4r9b5jp7fbi71ajpmrv3xf3vmp6m4i3r0pc";
+  src = fetch pname "16mh2n5s7pngc1wlkwp2xnnjpjljm4p6d6ld1646dayr6q8lmi34";
+  polly_src = fetch "polly" "15w5mpl98wldyxjgqjnbh1pb4p9wnrqgik7sq2qi49qp4g1cg5wh";
 
   unpackPhase = ''
     unpackFile $src

--- a/pkgs/development/compilers/llvm/10/openmp.nix
+++ b/pkgs/development/compilers/llvm/10/openmp.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   pname = "openmp";
   inherit version;
 
-  src = fetch pname "0axdxar18rvk9r4yx7y55ywqr3070mixag9sg2fcck1jzwfgymjb";
+  src = fetch pname "1qnimi4dypy4r8vpjxcg2rpc9lsvsyi4kl08v51p33657q449syr";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];

--- a/pkgs/development/compilers/llvm/10/openmp.nix
+++ b/pkgs/development/compilers/llvm/10/openmp.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   pname = "openmp";
   inherit version;
 
-  src = fetch pname "1qnimi4dypy4r8vpjxcg2rpc9lsvsyi4kl08v51p33657q449syr";
+  src = fetch pname "0swif1plz7drjha6rdw02b60symsz95w62wxpiygbpdwsmhbbgam";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
 *  rc4 was released.
 *  No reason to keep two separate llvm-version, since polly needs to be enabled to use during compilation (size difference 26MB or ~10% for llvm, but only one llvm and clang is build instead of two). Originally this was done to defer rebuilds (see ed60483257b62c32b5b58c6e91c9c8cd586f77d0)

###### Things done
 *  Updated hashed and version (rc3 -> rc4).
 *  removed non polly build


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
