### PR TITLE
buildGoModule: enable strictDeps

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -33,7 +33,9 @@ in buildGoPackage rec {
 
   goPackagePath = "github.com/openshift/origin";
 
-  buildInputs = [ which rsync go-bindata kerberos clang ];
+  buildInputs = [ kerberos ];
+
+  nativeBuildInputs = [ which rsync go-bindata clang ];
 
   patchPhase = ''
     patchShebangs ./hack

--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -17,10 +17,8 @@ in buildGoModule rec {
   modSha256 = "127xrah6xxrvc224g5dxn432sagrssx8v7phzapcsdajsnmagq6x";
 
   nativeBuildInputs = [
-    go
     scdoc
     python3.pkgs.wrapPython
-    notmuch
   ];
 
   patches = [
@@ -31,7 +29,7 @@ in buildGoModule rec {
     python3.pkgs.colorama
   ];
 
-  buildInputs = [ python3 perl ];
+  buildInputs = [ python3 notmuch ];
 
   GOFLAGS="-tags=notmuch";
 

--- a/pkgs/applications/networking/p2p/magnetico/default.nix
+++ b/pkgs/applications/networking/p2p/magnetico/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   modSha256 = "1h9fij8mxlxfw7kxix00n10fkhkvmf8529fxbk1n30cxc1bs2szf";
 
-  buildInputs = [ go-bindata ];
+  nativeBuildInputs = [ go-bindata ];
   buildPhase = ''
     make magneticow magneticod
   '';

--- a/pkgs/applications/virtualization/gvisor/containerd-shim.nix
+++ b/pkgs/applications/virtualization/gvisor/containerd-shim.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildGoModule, go-bindata }:
+{ lib, fetchFromGitHub, buildGoModule }:
 
 buildGoModule rec {
   name = "gvisor-containerd-shim-${version}";

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -208,6 +208,8 @@ let
       find $out/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
     '';
 
+    strictDeps = true;
+
     disallowedReferences = lib.optional (!allowGoReference) go;
 
     passthru = passthru // { inherit go go-modules modSha256; };

--- a/pkgs/servers/documize-community/default.nix
+++ b/pkgs/servers/documize-community/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   modSha256 = "1z0v7n8klaxcqv7mvzf3jzgrp78zb4yiibx899ppk6i5qnj4xiv0";
 
-  buildInputs = [ go-bindata-assetfs go-bindata ];
+  nativeBuildInputs = [ go-bindata go-bindata-assetfs ];
 
   subPackages = [ "edition/community.go" ];
 

--- a/pkgs/servers/imgproxy/default.nix
+++ b/pkgs/servers/imgproxy/default.nix
@@ -13,11 +13,9 @@ buildGoModule rec {
 
   modSha256 = "0kgd8lwcdns3skvd4bj4z85mq6hkk79mb0zzwky0wqxni8f73s6w";
 
-  buildInputs = [
-    gobject-introspection
-    pkg-config
-    vips
-  ];
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gobject-introspection vips ];
 
   preBuild = ''
     export CGO_LDFLAGS_ALLOW='-(s|w)'

--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -14,8 +14,11 @@ buildGoPackage rec {
   };
 
   goPackagePath = "github.com/gravitational/teleport";
+
   subPackages = [ "tool/tctl" "tool/teleport" "tool/tsh" ];
-  buildInputs = [ zip ];
+
+  nativeBuildInputs = [ zip ];
+
   postBuild = ''
     pushd .
     cd $NIX_BUILD_TOP/go/src/github.com/gravitational/teleport
@@ -27,7 +30,7 @@ buildGoPackage rec {
     cd $NIX_BUILD_TOP/go/bin
     zip -q -A teleport
     popd
-    '';
+  '';
 
   dontStrip = true;
 


### PR DESCRIPTION
This will improve cross compiling in the long run.
See also https://github.com/NixOS/nixpkgs/pull/82786

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
