### PR TITLE
[19.09] openssl: 1.1.1d -> 1.1.1e

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -143,8 +143,8 @@ in {
   };
 
   openssl_1_1 = common {
-    version = "1.1.1d";
-    sha256 = "1whinyw402z3b9xlb3qaxv4b9sk4w1bgh9k0y8df1z4x3yy92fhy";
+    version = "1.1.1e";
+    sha256 = "1gnwlri1dphr5wdzmg9vlhkh6aq2yqgpfkpmffzwjlfb26n62kv9";
     patches = [
       ./1.1/nix-ssl-cert-file.patch
 


### PR DESCRIPTION
###### Motivation for this change

a "Low severity" [0] security issue:

> Fixed an overflow bug in the x64_64 Montgomery squaring procedure used
> in exponentiation with 512-bit moduli (CVE-2019-1551)

[0] https://www.openssl.org/news/vulnerabilities.html#y2019

Note: Since the flux of changes to 19.09 is very low I think targeting the release branch without going through staging is fine. Let me know if you think otherwise.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
