### PR TITLE
qmidiarp: init at 0.6.5

### DIFF
--- a/pkgs/applications/audio/qmidiarp/default.nix
+++ b/pkgs/applications/audio/qmidiarp/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, fetchgit
+, automake
+, autoreconfHook
+, lv2
+, pkg-config
+, qt5
+, alsaLib
+, libjack2
+}:
+
+stdenv.mkDerivation rec {
+  name = "qmidiarp";
+  version = "0.6.5";
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/qmidiarp/code";
+    sha256 = "1g2143gzfbihqr2zi3k2v1yn1x3mwfbb2khmcd4m4cq3hcwhhlx9";
+    rev = "qmidiarp-0.6.5";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    alsaLib
+    lv2
+    libjack2
+  ] ++ (with qt5; [
+    qttools
+  ]);
+
+  meta = with stdenv.lib; {
+    description = "An advanced MIDI arpeggiator";
+    longDescription = ''
+      An advanced MIDI arpeggiator, programmable step sequencer and LFO for Linux.
+      It can hold any number of arpeggiator, sequencer, or LFO modules running in
+      parallel.
+    '';
+
+    homepage = "http://qmidiarp.sourceforge.net";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sjfloat ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21266,6 +21266,8 @@ in
 
   qmetro = callPackage ../applications/misc/qmetro { };
 
+  qmidiarp = callPackage ../applications/audio/qmidiarp {};
+
   qmidinet = libsForQt5.callPackage ../applications/audio/qmidinet { };
 
   qmidiroute = callPackage ../applications/audio/qmidiroute { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Introduction of qmidiarp app.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` *New pkg, no dependents.*
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
