### PR TITLE
ripcord: make version overriding easier by allowing version and hash …

### DIFF
--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -6,11 +6,12 @@
 mkDerivation rec {
   pname = "ripcord";
   version = "0.4.24";
+  imageHash = "0rscmnwxvbdl0vfx1pz7x5gxs9qsjk905zmcad4f330j5l5m227z";
 
   src = let
     appimage = fetchurl {
       url = "https://cancel.fm/dl/Ripcord-${version}-x86_64.AppImage";
-      sha256 = "0rscmnwxvbdl0vfx1pz7x5gxs9qsjk905zmcad4f330j5l5m227z";
+      sha256 = "${imageHash}";
       name = "${pname}-${version}.AppImage";
     };
   in appimageTools.extract {
@@ -31,21 +32,21 @@ mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out
-    cp -r ${src}/{qt.conf,translations,twemoji.ripdb} $out
+    cp -r $src/{qt.conf,translations,twemoji.ripdb} $out
 
     for size in 16 32 48 64 72 96 128 192 256 512 1024; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -resize "$size"x"$size" ${src}/Ripcord_Icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/ripcord.png
+      convert -resize "$size"x"$size" $src/Ripcord_Icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/ripcord.png
     done
 
     desktop-file-install --dir $out/share/applications \
       --set-key Exec --set-value ripcord \
       --set-key Icon --set-value ripcord \
       --set-key Comment --set-value "${meta.description}" \
-      ${src}/Ripcord.desktop
+      $src/Ripcord.desktop
     mv $out/share/applications/Ripcord.desktop $out/share/applications/ripcord.desktop
 
-    install -Dm755 ${src}/Ripcord $out/Ripcord
+    install -Dm755 $src/Ripcord $out/Ripcord
     patchelf --replace-needed libsodium.so.18 libsodium.so $out/Ripcord
     makeQtWrapper $out/Ripcord $out/bin/ripcord \
       --run "cd $out" \


### PR DESCRIPTION
…overrides

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Tried to override to version 0.4.24 before the PR was merged, failed due to `${src}` in installPhase, and was a pain anyway due to `sha256` being nested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
