### PR TITLE
lib/modules: Test the ability for config to depend on options for compatibility

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -185,6 +185,11 @@ checkConfigError 'The option .* defined in .* does not exist' config.enable ./di
 # Check that imports can depend on derivations
 checkConfigOutput "true" config.enable ./import-from-store.nix
 
+# Check that configs can be conditional on option existence
+checkConfigOutput true config.enable ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix
+checkConfigOutput 360 config.value ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix
+checkConfigOutput 7 config.value ./define-option-dependently.nix ./declare-int-positive-value.nix
+
 # Check attrsOf and lazyAttrsOf. Only lazyAttrsOf should be lazy, and only
 # attrsOf should work with conditional definitions
 # In addition, lazyAttrsOf should honor an options emptyValue

--- a/lib/tests/modules/define-option-dependently.nix
+++ b/lib/tests/modules/define-option-dependently.nix
@@ -1,0 +1,16 @@
+{ lib, options, ... }:
+
+# Some modules may be distributed separately and need to adapt to other modules
+# that are distributed and versioned separately.
+{
+
+  # Always defined, but the value depends on the presence of an option.
+  config = {
+    value = if options ? enable then 360 else 7;
+  } 
+  # Only define if possible.
+  // lib.optionalAttrs (options ? enable) {
+    enable = true;
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

Prepare for a decentralized future with flakes, where modules will need to adapt to their neighbors, about which those modules can not make too many assumptions. Supporting two releases of NixOS may be impossible at times for flakes if they can't read the `options` variable.

Additionally, this provides a partial solutions to the expression problem as applied to separately distributed modules.

```
Feature interactions: where to get the code?

               Core features     Feature A

Core features  nixpkgs/nixos     Flake A

Feature B      Flake B           ???
```

Without this feature, `???` will always have to be a separate module that users have to turn on manually to make the interaction between `Feature A` and `Feature B` not break.

With this feature, `???` can be packaged by either `Flake A` or `Flake B`, ensuring that the interaction between the features is always dealt with.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Used this in a real-life separately distributed NixOS module
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
