### PR TITLE
vimPlugins.vim-pandoc: fix startup

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -112,6 +112,21 @@ self: super: {
     '';
   });
 
+  vim-pandoc = super.vim-pandoc.overrideAttrs(old: {
+    patches = (super.patches or []) ++ [
+      # Fix a failure on startup, which breaks the rplugin manifest generation
+      # https://github.com/vim-pandoc/vim-pandoc/pull/363#issuecomment-599080366
+      (fetchpatch {
+        name = "fix-fdetect.patch";
+        url = "https://github.com/vim-pandoc/vim-pandoc/commit/da4c0b0325c1bfad20f7cfd15abb53943fe22fc4.patch";
+        revert = true;
+        # For some reason that part was already reverted upstream.
+        excludes = ["ftdetect/pandoc.vim"];
+        sha256 = "10nykgsqpxx5hlagk83khjl8p58zx7z3bcryzinv5vv52wlqkq5p";
+      })
+    ];
+  });
+
   clighter8 = super.clighter8.overrideAttrs(old: {
     preFixup = ''
       sed "/^let g:clighter8_libclang_path/s|')$|${llvmPackages.clang.cc.lib}/lib/libclang.so')|" \


### PR DESCRIPTION
###### Motivation for this change

`vim-pandoc` fails on startup, which breaks building my neovim configuration.

This will cause some pain on the next package set update (since the patch will fail to apply), but I don't know how we could handle this better. I'll keep an eye on (and subscribed to) the upstream issue and remove the patch when possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
