### PR TITLE
weechat-notify-send: init at 0.9

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -7,6 +7,8 @@
 
   weechat-matrix = python3Packages.callPackage ./weechat-matrix { };
 
+  weechat-notify-send = python3Packages.callPackage ./weechat-notify-send { };
+
   wee-slack = callPackage ./wee-slack { };
 
   weechat-autosort = callPackage ./weechat-autosort { };

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-notify-send/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-notify-send/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, libnotify }:
+
+stdenv.mkDerivation rec {
+  pname = "weechat-notify-send";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "s3rvac";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1693b7axm9ls5p7hm6kq6avddsisi491khr5irvswr5lpizvys6a";
+  };
+
+  passthru.scripts = [ "notify_send.py" ];
+
+  dontBuild = true;
+  doCheck = false;
+
+  installPhase = ''
+    install -D notify_send.py $out/share/notify_send.py
+    substituteInPlace $out/share/notify_send.py \
+      --replace "'notify-send'" "'${libnotify}/bin/notify-send'"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A WeeChat script that sends highlight and message notifications through notify-send";
+    homepage = "https://github.com/s3rvac/weechat-notify-srnd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tobim ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Send desktop notifications from weechat via libnotify.

https://github.com/s3rvac/weechat-notify-send

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
