### PR TITLE
kubeval: don't include huge schema to save space in hydra

### DIFF
--- a/pkgs/applications/networking/cluster/kubeval/default.nix
+++ b/pkgs/applications/networking/cluster/kubeval/default.nix
@@ -1,26 +1,5 @@
 { stdenv, lib, fetchFromGitHub, buildGoModule, makeWrapper }:
 
-let
-
-  # Cache schema as a package so network calls are not
-  # necessary at runtime, allowing use in package builds
-  schema = stdenv.mkDerivation {
-    name = "kubeval-schema";
-    src = fetchFromGitHub {
-      owner = "instrumenta";
-      repo = "kubernetes-json-schema";
-      rev = "6a498a60dc68c5f6a1cc248f94b5cd1e7241d699";
-      sha256 = "1y9m2ma3n4h7sf2lg788vjw6pkfyi0fa7gzc870faqv326n6x2jr";
-    };
-
-    installPhase = ''
-      mkdir -p $out/kubernetes-json-schema/master
-      cp -R . $out/kubernetes-json-schema/master
-    '';
-   };
-
-in
-
 buildGoModule rec {
   pname = "kubeval";
   version = "0.14.0";
@@ -32,11 +11,7 @@ buildGoModule rec {
     sha256 = "0kpwk7bv36m3i8vavm1pqc8l611c6l9qbagcc64v6r85qig4w5xv";
   };
 
-  buildInputs = [ makeWrapper ];
-
   modSha256 = "0y9x44y3bchi8xg0a6jmp2rmi8dybkl6qlywb6nj1viab1s8dd4y";
-
-  postFixup = "wrapProgram $out/bin/kubeval --set KUBEVAL_SCHEMA_LOCATION file:///${schema}/kubernetes-json-schema/master";
 
   meta = with lib; {
     description = "Validate your Kubernetes configuration files";

--- a/pkgs/applications/networking/cluster/kubeval/schema.nix
+++ b/pkgs/applications/networking/cluster/kubeval/schema.nix
@@ -1,0 +1,15 @@
+{ fetchFromGitHub }:
+# To cache schema as a package so network calls are not
+# necessary at runtime, allowing use in package builds you can use the following:
+
+#   KUBEVAL_SCHEMA_LOCATION="file:///${kubeval-schema}";
+(fetchFromGitHub {
+  name = "kubeval-schema";
+  owner = "instrumenta";
+  repo = "kubernetes-json-schema";
+  rev = "6a498a60dc68c5f6a1cc248f94b5cd1e7241d699";
+  sha256 = "1y9m2ma3n4h7sf2lg788vjw6pkfyi0fa7gzc870faqv326n6x2jr";
+}) // {
+  # the schema is huge (> 7GB), we don't get any benefit from building int on hydra
+  meta.hydraPlatforms = [];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20128,6 +20128,8 @@ in
 
   kubeval = callPackage ../applications/networking/cluster/kubeval { };
 
+  kubeval-schema = callPackage ../applications/networking/cluster/kubeval/schema.nix { };
+
   kubernetes = callPackage ../applications/networking/cluster/kubernetes {
     go = buildPackages.go_1_13;
   };


### PR DESCRIPTION
kubeval-schema is a huge 7GB repository that we do not want
to build on hydra. Therefore make it optional.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
