### PR TITLE
xfce4-netload-plugin wrong decription patch

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin/default.nix
@@ -10,6 +10,6 @@ mkXfceDerivation rec {
   buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
 
   meta = {
-    description = "Battery plugin for Xfce panel";
+    description = "Internet load speed plugin for Xfce panel";
   };
 }

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin/default.nix
@@ -10,6 +10,6 @@ mkXfceDerivation rec {
   buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
 
   meta = {
-    description = "Internet load speed plugin for Xfce panel";
+    description = "Internet load speed plugin for Xfce4 panel";
   };
 }


### PR DESCRIPTION
- [n ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [y ] NixOS
   - [n ] macOS
   - [n ] other Linux distributions
- [n ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [n ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [n ] Tested execution of all binary files (usually in `./result/bin/`)
- [n ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [y ] Ensured that relevant documentation is up to date
- [y ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Panel plugin xfce4-netload-plugin has wrong description that says "Battery plugin for Xfce panel" but its not actually battery plugin. The patch I've sent fixes that mistake