### PR TITLE
tailscale: init at 0.97-0 [20.03 backport]

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4506,6 +4506,12 @@
     githubId = 1269099;
     name = "Marius Bakke";
   };
+  mbaillie = {
+    email = "martin@baillie.email";
+    github = "martinbaillie";
+    githubId = 613740;
+    name = "Martin Baillie";
+  };
   mbbx6spp = {
     email = "me@susanpotter.net";
     github = "mbbx6spp";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -723,6 +723,7 @@
   ./services/networking/syncthing.nix
   ./services/networking/syncthing-relay.nix
   ./services/networking/syncplay.nix
+  ./services/networking/tailscale.nix
   ./services/networking/tcpcrypt.nix
   ./services/networking/teamspeak3.nix
   ./services/networking/tedicross.nix

--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.tailscale;
+in {
+  meta.maintainers = with maintainers; [ danderson mbaillie ];
+
+  options.services.tailscale = {
+    enable = mkEnableOption "Tailscale client daemon";
+
+    port = mkOption {
+      type = types.port;
+      default = 41641;
+      description = "The port to listen on for tunnel traffic (0=autoselect).";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.tailscale = {
+      description = "Tailscale client daemon";
+
+      after = [ "network-pre.target" ];
+      wants = [ "network-pre.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      unitConfig = {
+        StartLimitIntervalSec = 0;
+        StartLimitBurst = 0;
+      };
+
+      serviceConfig = {
+        ExecStart =
+          "${pkgs.tailscale}/bin/tailscaled --port ${toString cfg.port}";
+
+        RuntimeDirectory = "tailscale";
+        RuntimeDirectoryMode = 755;
+
+        StateDirectory = "tailscale";
+        StateDirectoryMode = 700;
+
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, iptables, iproute }:
+
+buildGoModule rec {
+  pname = "tailscale";
+  version = "0.96-33";
+
+  src = fetchFromGitHub {
+    owner = "tailscale";
+    repo = "tailscale";
+    rev = "19cc4f8b8ecfdc16136d8489a1c2b899f556fda7";
+    sha256 = "0kcf3mz7fs15dm1dnkvrmdkm3agrl1zlg9ngb7cwfmvkkw1rkl6i";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  CGO_ENABLED = 0;
+
+  goPackagePath = "tailscale.com";
+  modSha256 = "1pjqfzw411k6kw8hqf56irnlhnl8947p1ad8yd84zvqqpzfs3jmz";
+  subPackages = [ "cmd/tailscale" "cmd/tailscaled" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/tailscaled --prefix PATH : ${
+      lib.makeBinPath [ iproute iptables ]
+    }
+  '';
+
+  meta = with lib; {
+    homepage = "https://tailscale.com";
+    description = "The node agent for Tailscale, a mesh VPN built on WireGuard";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ danderson mbaillie ];
+  };
+}

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "tailscale";
-  version = "0.96-33";
+  version = "0.97-0";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "19cc4f8b8ecfdc16136d8489a1c2b899f556fda7";
-    sha256 = "0kcf3mz7fs15dm1dnkvrmdkm3agrl1zlg9ngb7cwfmvkkw1rkl6i";
+    rev = "dd14b658a2f42a3b4d78682e4f4f82f730262c5c";
+    sha256 = "0ckjqhj99c25h8xgyfkrd19nw5w4a7972nvba9r5faw5micjs02n";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -16,7 +16,7 @@ buildGoModule rec {
   CGO_ENABLED = 0;
 
   goPackagePath = "tailscale.com";
-  modSha256 = "1pjqfzw411k6kw8hqf56irnlhnl8947p1ad8yd84zvqqpzfs3jmz";
+  modSha256 = "0anpakcqz4irwxnm0iwm7wqzh84kv3yxxdvyr38154pbd0ys5pa2";
   subPackages = [ "cmd/tailscale" "cmd/tailscaled" ];
 
   postInstall = ''

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -2,12 +2,12 @@
 
 buildGoModule rec {
   pname = "tailscale";
-  version = "0.97-0";
+  version = "0.97";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "dd14b658a2f42a3b4d78682e4f4f82f730262c5c";
+    rev = "v${version}";
     sha256 = "0ckjqhj99c25h8xgyfkrd19nw5w4a7972nvba9r5faw5micjs02n";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15865,6 +15865,8 @@ in
 
   syncserver = callPackage ../servers/syncserver { };
 
+  tailscale = callPackage ../servers/tailscale { };
+
   thanos = callPackage ../servers/monitoring/thanos { };
 
   inherit (callPackages ../servers/http/tomcat { })


### PR DESCRIPTION
###### Motivation for this change

New package+module, just landed in master. The package and module are both leaves, nothing depends on them, so it should be very safe to add.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
