### PR TITLE
tailscale: init at 0.97-0 [backport 19.09]

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3979,6 +3979,12 @@
     githubId = 1269099;
     name = "Marius Bakke";
   };
+  mbaillie = {
+    email = "martin@baillie.email";
+    github = "martinbaillie";
+    githubId = 613740;
+    name = "Martin Baillie";
+  };
   mbbx6spp = {
     email = "me@susanpotter.net";
     github = "mbbx6spp";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -704,6 +704,7 @@
   ./services/networking/syncthing.nix
   ./services/networking/syncthing-relay.nix
   ./services/networking/syncplay.nix
+  ./services/networking/tailscale.nix
   ./services/networking/tcpcrypt.nix
   ./services/networking/teamspeak3.nix
   ./services/networking/tedicross.nix

--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.tailscale;
+in {
+  meta.maintainers = with maintainers; [ danderson mbaillie ];
+
+  options.services.tailscale = {
+    enable = mkEnableOption "Tailscale client daemon";
+
+    port = mkOption {
+      type = types.port;
+      default = 41641;
+      description = "The port to listen on for tunnel traffic (0=autoselect).";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.tailscale = {
+      description = "Tailscale client daemon";
+
+      after = [ "network-pre.target" ];
+      wants = [ "network-pre.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      unitConfig = {
+        StartLimitIntervalSec = 0;
+        StartLimitBurst = 0;
+      };
+
+      serviceConfig = {
+        ExecStart =
+          "${pkgs.tailscale}/bin/tailscaled --port ${toString cfg.port}";
+
+        RuntimeDirectory = "tailscale";
+        RuntimeDirectoryMode = 755;
+
+        StateDirectory = "tailscale";
+        StateDirectoryMode = 700;
+
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -96,6 +96,7 @@ let
 
       export GOCACHE=$TMPDIR/go-cache
       export GOPATH="$TMPDIR/go"
+      export GOSUMDB=off
       export GOPROXY=file://${go-modules}
 
       runHook postConfigure

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, iptables, iproute }:
+
+buildGoModule rec {
+  pname = "tailscale";
+  version = "0.96-33";
+
+  src = fetchFromGitHub {
+    owner = "tailscale";
+    repo = "tailscale";
+    rev = "19cc4f8b8ecfdc16136d8489a1c2b899f556fda7";
+    sha256 = "0kcf3mz7fs15dm1dnkvrmdkm3agrl1zlg9ngb7cwfmvkkw1rkl6i";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  CGO_ENABLED = 0;
+
+  goPackagePath = "tailscale.com";
+  modSha256 = "1pjqfzw411k6kw8hqf56irnlhnl8947p1ad8yd84zvqqpzfs3jmz";
+  subPackages = [ "cmd/tailscale" "cmd/tailscaled" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/tailscaled --prefix PATH : ${
+      lib.makeBinPath [ iproute iptables ]
+    }
+  '';
+
+  meta = with lib; {
+    homepage = "https://tailscale.com";
+    description = "The node agent for Tailscale, a mesh VPN built on WireGuard";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ danderson mbaillie ];
+  };
+}

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "tailscale";
-  version = "0.96-33";
+  version = "0.97-0";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "19cc4f8b8ecfdc16136d8489a1c2b899f556fda7";
-    sha256 = "0kcf3mz7fs15dm1dnkvrmdkm3agrl1zlg9ngb7cwfmvkkw1rkl6i";
+    rev = "dd14b658a2f42a3b4d78682e4f4f82f730262c5c";
+    sha256 = "0ckjqhj99c25h8xgyfkrd19nw5w4a7972nvba9r5faw5micjs02n";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -16,7 +16,7 @@ buildGoModule rec {
   CGO_ENABLED = 0;
 
   goPackagePath = "tailscale.com";
-  modSha256 = "1pjqfzw411k6kw8hqf56irnlhnl8947p1ad8yd84zvqqpzfs3jmz";
+  modSha256 = "0anpakcqz4irwxnm0iwm7wqzh84kv3yxxdvyr38154pbd0ys5pa2";
   subPackages = [ "cmd/tailscale" "cmd/tailscaled" ];
 
   postInstall = ''

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -2,12 +2,12 @@
 
 buildGoModule rec {
   pname = "tailscale";
-  version = "0.97-0";
+  version = "0.97";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "dd14b658a2f42a3b4d78682e4f4f82f730262c5c";
+    rev = "v${version}";
     sha256 = "0ckjqhj99c25h8xgyfkrd19nw5w4a7972nvba9r5faw5micjs02n";
   };
 

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -1,6 +1,6 @@
-{ lib, buildGoModule, fetchFromGitHub, makeWrapper, iptables, iproute }:
+{ lib, buildGo113Module, fetchFromGitHub, makeWrapper, iptables, iproute }:
 
-buildGoModule rec {
+buildGo113Module rec {
   pname = "tailscale";
   version = "0.97";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15254,6 +15254,8 @@ in
 
   syncserver = callPackage ../servers/syncserver { };
 
+  tailscale = callPackage ../servers/tailscale { };
+
   thanos = callPackage ../servers/monitoring/thanos { };
 
   inherit (callPackages ../servers/http/tomcat { })


### PR DESCRIPTION
###### Motivation for this change

Tailscale is a new package+nixos module, merged recently in master. I would like to backport it to 19.09, selfishly so that I can install Tailscale on my NixOS servers.

It's not clear if this is okay or not. I backported the pppd module I created into 19.09 late last year, and back then the reasoning was: it's a "leaf" config, so it only risks breaking something if you explicitly decide to enable it. Therefore the risk was low to other 19.09 users.

I think the same reasoning applies here: the tailscale package is a "leaf" package that creates binaries (not libs), and the nixos module does nothing unless you explicitly opt-in. So, this should be completely safe to backport.

The only policy I could find was in the NixOS manual, where it says RMs decide what bugs & features should be backported. So, @disassembler and @lheckemann, I think this is your decision.

There are 4 commits in this PR: 3 cherrypicks, and 1 19.09-only change.
 1. Cherrypick https://github.com/NixOS/nixpkgs/commit/c5733e7a0933b62144e17947176ebd2e871b4616 to fix `buildGo113Module` (otherwise it can't build anything)
 2. Cherrypick https://github.com/NixOS/nixpkgs/commit/6e055c9f4a3734e1d1b8e9f55be68e6743bf59d3 (tailscale pkg+module init)
 3. Cherrypick https://github.com/NixOS/nixpkgs/commit/1e593070cdd8953f2c4f661535684d7aa8783441 (pkg version bump to fix a severe bug)
 4. Change the pkg to use `buildGo113Module` instead of `buildGoModule`, because 19.09 defaults to Go 1.12 and Tailscale requires >=1.13.

Of note: even though `buildGo113Module` exists in 19.09, this would be the 1st and only package that uses it in 19.09 (that's why it was broken without anyone noticing).

So, um, there. That's all the information on this change. Hopefully that helps you decide if this is acceptable to backport or not. I would like to document some general guidelines for this for future maintainers (because nobody was sure if this is okay or not), so I anxiously await your feedback :)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
