### PR TITLE
tamgamp.lv2: init at  unstable-2020-05-14

### DIFF
--- a/pkgs/applications/audio/tamgamp.lv2/default.nix
+++ b/pkgs/applications/audio/tamgamp.lv2/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchFromGitHub, pkg-config, lv2, zita-resampler }:
+
+stdenv.mkDerivation rec {
+  pname = "tamgamp.lv2";
+  version = "unstable-2020-06-14";
+
+  src = fetchFromGitHub {
+    owner = "sadko4u";
+    repo = pname;
+    rev = "426da74142fcb6b7687a35b2b1dda3392e171b92";
+    sha256 = "0dqsnim7v79rx13bkkh143gqz0xg26cpf6ya3mrwwprpf5hns2bp";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ lv2 zita-resampler ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sadko4u/tamgamp.lv2";
+    description = "Guitar amplifier simulator";
+    longDescription = ''
+       Tamgamp (Pronouncement: "Damage Amp") is an LV2 guitar amp simulator that provides two plugins:
+
+        - Tamgamp - a plugin based on Guitarix DK Builder simulated chains.
+        - TamgampGX - a plugin based on tuned Guitarix internal amplifiers implementation.
+
+       The reference to the original Guitarix project: https://guitarix.org/
+
+       It simulates the set of the following guitar amplifiers:
+
+       - Fender Princeton Reverb-amp AA1164 (without reverb module)
+       - Fender Twin Reverb-Amp AA769 (Normal channel, bright off)
+       - Fender Twin Reverb-Amp AA769 (Vibrato channel, bright on)
+       - Marshall JCM-800 High-gain input
+       - Marshall JCM-800 Low-gain input
+       - Mesa/Boogie DC3 preamplifier (lead channel)
+       - Mesa/Boogie DC3 preamplifier (rhythm channel)
+       - Mesa Dual Rectifier preamplifier (orange channel, less gain)
+       - Mesa Dual Rectifier preamplifier (red channel, more gain)
+       - Peavey 5150II crunch channel
+       - Peavey 5150II lead channel
+       - VOX AC-30 Brilliant channel
+       - VOX AC-30 normal channel
+     '';
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+    license = licenses.lgpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22922,6 +22922,8 @@ in
 
   tambura = callPackage ../applications/audio/tambura { };
 
+  tamgamp.lv2 = callPackage ../applications/audio/tamgamp.lv2 { };
+
   tanka = callPackage ../applications/networking/cluster/tanka { };
 
   teams = callPackage ../applications/networking/instant-messengers/teams { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
