### PR TITLE
python.pkgs.httpretty: disable flaky test suite

### DIFF
--- a/pkgs/development/python-modules/httpretty/default.nix
+++ b/pkgs/development/python-modules/httpretty/default.nix
@@ -18,6 +18,10 @@ buildPythonPackage rec {
   pname = "httpretty";
   version = "0.9.7";
 
+  # drop this for version > 0.9.7
+  # Flaky tests: https://github.com/gabrielfalcao/HTTPretty/pull/394
+  doCheck = stdenv.lib.versionAtLeast version "0.9.8";
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "66216f26b9d2c52e81808f3e674a6fb65d4bf719721394a1a9be926177e55fbe";


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There are some tests that fail occasionally because the current date
(with second precision) occurs in the output. This is fixed upstream.
I've made this conditional since python updates are often done in an
automated fashion and tests should be re-enabled after the next update.
This avoids the need for human intervention (except for a clean up at
some point in the future).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
