### PR TITLE
flips: init at unstable-2020-10-02

### DIFF
--- a/pkgs/tools/compression/flips/default.nix
+++ b/pkgs/tools/compression/flips/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, gtk3, libdivsufsort, pkg-config, wrapGAppsHook }:
+
+stdenv.mkDerivation {
+  pname = "flips";
+  version = "unstable-2020-10-02";
+
+  src = fetchFromGitHub {
+    owner = "Alcaro";
+    repo = "Flips";
+    rev = "5a3d2012b8ea53ae777c24b8ac4edb9a6bdb9761";
+    sha256 = "1ksh9j1n5z8b78yd7gjxswndsqnb1azp84xk4rc0p7zq127l0fyy";
+  };
+
+  nativeBuildInputs = [ pkg-config wrapGAppsHook ];
+  buildInputs = [ gtk3 libdivsufsort ];
+  patches = [ ./use-system-libdivsufsort.patch ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  buildPhase = "./make.sh";
+
+  meta = with stdenv.lib; {
+    description = "A patcher for IPS and BPS files";
+    homepage = "https://github.com/Alcaro/Flips";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.xfix ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/compression/flips/use-system-libdivsufsort.patch
+++ b/pkgs/tools/compression/flips/use-system-libdivsufsort.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index c9d8b6d..9d66b0b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -79,9 +79,7 @@ endif
+ MOREFLAGS := $(CFLAGS_$(TARGET))
+ 
+ 
+-DIVSUF := libdivsufsort-2.0.1
+-SOURCES += $(DIVSUF)/lib/divsufsort.c $(DIVSUF)/lib/sssort.c $(DIVSUF)/lib/trsort.c
+-MOREFLAGS += -I$(DIVSUF)/include -DHAVE_CONFIG_H -D__STDC_FORMAT_MACROS
++MOREFLAGS += -ldivsufsort
+ 
+ ifeq ($(TARGET),gtk)
+   CFLAGS_G += -fopenmp

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3742,6 +3742,8 @@ in
 
   flamegraph = callPackage ../development/tools/flamegraph { };
 
+  flips = callPackage ../tools/compression/flips { };
+
   flvtool2 = callPackage ../tools/video/flvtool2 { };
 
   fmbt = callPackage ../development/tools/fmbt {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding a package I'm going to use for ROM hacking purposes (and probably nobody else, but that ain't stopping me).

Update: "probably nobody else" turned out to be wrong, considering https://github.com/NixOS/nixpkgs/pull/94508 was created.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
