### PR TITLE
terraform-providers.lxd: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2748,6 +2748,12 @@
     githubId = 3217744;
     name = "Peter Ferenczy";
   };
+  gila = {
+    email = "jeffry.molanus@gmail.com";
+    github = "gila";
+    githubId = 15957973;
+    name = "Jeffry Molanus";
+  };
   gilligan = {
     email = "tobias.pflug@gmail.com";
     github = "gilligan";

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -33,5 +33,6 @@ in
     gandi = callPackage ./gandi {};
     ibm = callPackage ./ibm {};
     libvirt = callPackage ./libvirt {};
+    lxd = callPackage ./lxd {};
     ansible = callPackage ./ansible {};
   } // lib.mapAttrs (n: v: toDrv v) list

--- a/pkgs/applications/networking/cluster/terraform-providers/lxd/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/lxd/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "terraform-provider-lxd";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "sl1pm4t";
+    repo = "terraform-provider-lxd";
+    rev = "v${version}";
+    sha256 = "1k54021178zybh9dqly2ly8ji9x5rka8dn9xd6rv7gkcl5w3y6fv";
+  };
+
+  modSha256 = "1h95ng9by3i3v15s1ws1fv86a47vglivn42xbffdy94s108g0908";
+
+  postBuild = "mv ../go/bin/terraform-provider-lxd{,_v${version}}";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sl1pm4t/terraform-provider-lxd";
+    description = "Terraform provider for lxd";
+    platforms = platforms.linux;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ gila ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -480,6 +480,7 @@ mapAliases ({
   telnet = inetutils; # added 2018-05-15
   terraform-provider-ibm = terraform-providers.ibm; # added 2018-09-28
   terraform-provider-libvirt = terraform-providers.libvirt; # added 2018-09-28
+  terraform-provider-lxd = terraform-providers.lxd; # added 2020-03-16
   terraform-provider-nixos = terraform-providers.nixos; # added 2018-09-28
   tesseract_4 = tesseract4; # added 2018-12-19
   testdisk-photorec = throw "This package was a duplicate, please use testdisk or testdisk-qt instead"; # added 2019-10-13


### PR DESCRIPTION
###### Motivation for this change

This adds support for terraform-provider-lxd

###### Things done

Used the provider to setup an LXD k8s cluster and it seems to work just fine. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
