### PR TITLE
aws-sam-cli: fix depency and update

### DIFF
--- a/pkgs/development/python-modules/aws-lambda-builders/default.nix
+++ b/pkgs/development/python-modules/aws-lambda-builders/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "aws-lambda-builders";
-  version = "0.7.0";
+  version = "0.8.0";
 
   # No tests available in PyPI tarball
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-lambda-builders";
     rev = "v${version}";
-    sha256 = "0g133yxh3bgvdjcpar65x5pyx2bcx0kg173rbq5iwmmpw388f47a";
+    sha256 = "1akiv92cd7ciky0aay94lh9azr73jajn0x0x6ywaf3qm5c4hyvys";
   };
 
   # Package is not compatible with Python 3.5

--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "aws-sam-translator";
-  version = "1.20.1";
+  version = "1.21.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "17n7kajqf35g0bxqd30jpm2vq275l3b45l77lfh6r9llpkd1zxnx";
+    sha256 = "0diyqiwas9fhkj7p5hm08lvkd5h9yn9zqilwww2av04mclfk82ij";
   };
 
   # Tests are not included in the PyPI package

--- a/pkgs/development/python-modules/jmespath/default.nix
+++ b/pkgs/development/python-modules/jmespath/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "jmespath";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c";
+    sha256 = "1nf2ipzvigspy17r16dpkhzn1bqdmlak162rm8dy4wri2n6mr9fc";
   };
 
   buildInputs = [ nose ];

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -30,11 +30,11 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "0.43.0";
+  version = "0.44.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0v852636chil5n4cjqjvh29hhik881pkljs64jy5jiznbrph9ryr";
+    sha256 = "0r3m41xjmg8m2jwsqwc9kdkcs3xbz8dsl240ybwbnr7rp29pnirf";
   };
 
   # Tests are not included in the PyPI package
@@ -50,6 +50,7 @@ buildPythonApplication rec {
     docker
     flask
     idna
+    jmespath
     pathlib2
     requests
     serverlessrepo
@@ -65,11 +66,9 @@ buildPythonApplication rec {
   # fix over-restrictive version bounds
   postPatch = ''
     substituteInPlace requirements/base.txt \
-      --replace "requests==2.20.1" "requests==2.22.0" \
       --replace "serverlessrepo==0.1.9" "serverlessrepo~=0.1.9" \
-      --replace "six~=1.11.0" "six~=1.12.0" \
       --replace "python-dateutil~=2.6, <2.8.1" "python-dateutil~=2.6" \
-      --replace "PyYAML~=3.12" "PyYAML~=5.1"
+      --replace "tomlkit==0.5.8" "tomlkit~=0.5.8" \
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Fixes and updates aws-sam-cli, which had failed since 511ebca3a3c18452ec4bdff51d1ab28de59c5973 because of the strict tomlkit dependecy: https://hydra.nixos.org/build/113853232. From what I could gather from `nixpkgs-review wip`, this update, especially the jmespath bump, didn't affect other packages. All the failures I saw were because of other reasons.

Tested the cli with a new lambda, saw no problems. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
