### PR TITLE
pythonPackages.tensorflow: disable for python2.7 and 3.8+

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -1,7 +1,7 @@
 { stdenv, pkgs, bazel_0, buildBazelPackage, lib, fetchFromGitHub, fetchpatch, symlinkJoin
 , addOpenGLRunpath
 # Python deps
-, buildPythonPackage, isPy3k, pythonOlder, pythonAtLeast, python
+, buildPythonPackage, isPy3k, isPy27, pythonOlder, pythonAtLeast, python
 # Python libraries
 , numpy, tensorflow-tensorboard, backports_weakref, mock, enum34, absl-py
 , future, setuptools, wheel, keras-preprocessing, keras-applications, google-pasta
@@ -348,6 +348,7 @@ let
 
 in buildPythonPackage {
   inherit version pname;
+  disabled = isPy27 || (pythonAtLeast "3.8");
 
   src = bazel-build.python;
 


### PR DESCRIPTION
###### Motivation for this change
tired of my machine taking up 10+ GB of ram, and 30mins to try and build for versions which aren't supported: https://pypi.org/project/tensorflow/1.15.2/#files

```
builder for '/nix/store/a58jmaxxjy9b9sfqjskq0xigl93dlmqp-tensorflow-1.15.2.drv' failed with exit code 37; last 10 log lines:
      Compiling .../core/kernels/matrix_logarithm_op.cc [for host]; 81s local
      Compiling tensorflow/core/kernels/svd_op_float.cc [for host]; 79s local
      Compiling .../core/kernels/svd_op_complex64.cc [for host]; 78s local
      Compiling .../core/kernels/svd_op_complex128.cc [for host]; 76s local
      Compiling .../core/kernels/matrix_exponential_op.cc [for host]; 74s local
      Compiling tensorflow/core/kernels/svd_op_double.cc [for host]; 57s local
      Compiling .../compiler/mlir/lite/ir/tfl_ops.cc [for host]; 50s local ...

  Server terminated abruptly (error code: 14, error message: 'Socket closed', log file: '/build/output/server/jvm.out')
cannot build derivation '/nix/store/hlyighpyvm83cgnn7jzv52m2mw6mkbbw-python3.8-tensorflow-1.15.2.drv': 1 dependencies couldn't be built
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
