### PR TITLE
python2Packages.flowlogs-reader: disable for python2

### DIFF
--- a/pkgs/development/python-modules/flowlogs_reader/default.nix
+++ b/pkgs/development/python-modules/flowlogs_reader/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , botocore
 , boto3
 , docutils
@@ -11,6 +12,7 @@
 buildPythonPackage rec {
   pname = "flowlogs_reader";
   version = "2.0.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
while reviewing another package
```
builder for '/nix/store/2ylannhbpbjd0l0h0zlbwr1f3f8q6wl4-python2.7-flowlogs_reader-2.0.0.drv' failed with exit code 1; last 10 log lines:
  adding 'flowlogs_reader-2.0.0.dist-info/top_level.txt'
  adding 'flowlogs_reader-2.0.0.dist-info/RECORD'
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  installing
  Executing pipInstallPhase
  /build/flowlogs_reader-2.0.0/dist /build/flowlogs_reader-2.0.0
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
  Processing ./flowlogs_reader-2.0.0-py2-none-any.whl
  ERROR: Package 'flowlogs-reader' requires a different Python: 2.7.17 not in '>=3.4'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
27 package updated:
prl-tools pyblock qes r8125 r8168 rtlwifi_new sch_cake sch_cake sch_cake sch_cake sch_cake sch_cake sch_cake sch_cake sch_cake sch_cake sch_cake stdenv-linux stdenv-linux stog synfigstudio sysdig sysdig sysdig uclibc-ng v4l2loopback vhba

1 package removed:
python2.7-flowlogs_reader (†20190831)

https://github.com/NixOS/nixpkgs/pull/82869
27 package marked as broken and skipped:
clang-sierraHack-stdenv crossLibcStdenv linuxPackages-libre.sch_cake linuxPackages.sch_cake linuxPackages_4_14.sch_cake linuxPackages_4_4.sysdig linuxPackages_4_9.sysdig linuxPackages_hardened.sch_cake linuxPackages_hardkernel_4_14.prl-tools linuxPackages_hardkernel_4_14.r8125 linuxPackages_hardkernel_4_14.r8168 linuxPackages_hardkernel_4_14.rtlwifi_new linuxPackages_hardkernel_4_14.sch_cake linuxPackages_hardkernel_4_14.sysdig linuxPackages_hardkernel_4_14.v4l2loopback linuxPackages_hardkernel_4_14.vhba linuxPackages_latest-libre.sch_cake linuxPackages_latest_hardened.sch_cake linuxPackages_testing_bcachefs.sch_cake linuxPackages_testing_hardened.sch_cake linuxPackages_xen_dom0.sch_cake linuxPackages_xen_dom0_hardened.sch_cake ocamlPackages.stog python37Packages.pyblock qes synfigstudio uclibcCross
```