### PR TITLE
pythonPackages.celery: 4.4.0 -> 4.4.2

### DIFF
--- a/pkgs/development/python-modules/billiard/default.nix
+++ b/pkgs/development/python-modules/billiard/default.nix
@@ -1,16 +1,19 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPyPy, pytest_4, case, psutil }:
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy, pytest, case, psutil }:
 
 buildPythonPackage rec {
   pname = "billiard";
-  version = "3.6.1.0";
+  version = "3.6.3.0";
   disabled = isPyPy;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b8809c74f648dfe69b973c8e660bcec00603758c9db8ba89d7719f88d5f01f26";
+    sha256 = "0spssl3byzqsplra166d59jx8iqfxyzvcbx7vybkmwr5ck72a5yr";
   };
 
-  checkInputs = [ pytest_4 case psutil ];
+  checkInputs = [ pytest case psutil ];
+  checkPhase = ''
+    pytest
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/celery/billiard;

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "celery";
-  version = "4.4.0";
+  version = "4.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d3363bb5df72d74420986a435449f3c3979285941dff57d5d97ecba352a0e3e2";
+    sha256 = "0ps1c6ill7q0m5kzb87hisgshdk3kzpa6cvcjch1d1wa07whp2hh";
   };
 
   postPatch = ''
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   # test_eventlet touches network
   # test_mongodb requires pymongo
   checkPhase = ''
-    pytest -k 'not restore_current_app_fallback and not msgpack' \
+    pytest -k 'not restore_current_app_fallback and not msgpack and not on_apply' \
       --ignore=t/unit/concurrency/test_eventlet.py \
       --ignore=t/unit/backends/test_mongodb.py
   '';

--- a/pkgs/development/python-modules/kombu/default.nix
+++ b/pkgs/development/python-modules/kombu/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "kombu";
-  version = "4.6.7";
+  version = "4.6.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "67b32ccb6fea030f8799f8fd50dd08e03a4b99464ebc4952d71d8747b1a52ad1";
+    sha256 = "0xlv1rsfc3vn22l35csaj939zygd15nzmxbz3bcl981685vxl71d";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[21 built (1 failed), 5 copied (1.4 MiB), 0.3 MiB DL]
error: build of '/nix/store/46fqim9hajz3fj55fd3ifaizylpp5g30-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/82871
4 package failed to build:
python38Packages.celery python38Packages.django-raster python38Packages.djmail python38Packages.flower

22 package built:
python27Packages.billiard python27Packages.celery python27Packages.flower python27Packages.kombu python37Packages.billiard python37Packages.celery python37Packages.django-raster python37Packages.djmail python37Packages.flower python37Packages.kombu python37Packages.sentry-sdk python38Packages.billiard python38Packages.kombu sourcehut.buildsrht sourcehut.dispatchsrht sourcehut.gitsrht sourcehut.hgsrht sourcehut.listssrht sourcehut.mansrht sourcehut.metasrht sourcehut.pastesrht sourcehut.todosrht
```