### PR TITLE
texworks: fix build

### DIFF
--- a/pkgs/applications/editors/texworks/default.nix
+++ b/pkgs/applications/editors/texworks/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig
-, qt5, libsForQt5, hunspell
+{ mkDerivation, lib, fetchFromGitHub, cmake, pkg-config
+, qtscript, poppler, hunspell
 , withLua ? true, lua
 , withPython ? true, python3 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "texworks";
   version = "0.6.4";
 
@@ -14,15 +14,15 @@ stdenv.mkDerivation rec {
     sha256 = "0d7f23c6c1wj4aii4h5w9piv01qfb69zrd79dvxwydrk99i8gnl4";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ qt5.qtscript libsForQt5.poppler hunspell ]
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ qtscript poppler hunspell ]
                 ++ lib.optional withLua lua
                 ++ lib.optional withPython python3;
 
   cmakeFlags = lib.optional withLua "-DWITH_LUA=ON"
                ++ lib.optional withPython "-DWITH_PYTHON=ON";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Simple TeX front-end program inspired by TeXShop";
     homepage = "http://www.tug.org/texworks/";
     license = licenses.gpl2Plus;

--- a/pkgs/applications/editors/texworks/default.nix
+++ b/pkgs/applications/editors/texworks/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "texworks";
-  version = "0.6.3";
+  version = "0.6.4";
 
   src = fetchFromGitHub {
     owner = "TeXworks";
     repo = "texworks";
     rev = "release-${version}";
-    sha256 = "1ljfl784z7dmh6f1qacqhc6qhcaqdzw033yswbvpvkkck0lsk2mr";
+    sha256 = "0d7f23c6c1wj4aii4h5w9piv01qfb69zrd79dvxwydrk99i8gnl4";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Simple TeX front-end program inspired by TeXShop";
-    homepage = http://www.tug.org/texworks/;
+    homepage = "http://www.tug.org/texworks/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ dotlambda ];
     platforms = with platforms; linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6855,7 +6855,7 @@ in
 
   textadept = callPackage ../applications/editors/textadept { };
 
-  texworks = callPackage ../applications/editors/texworks { };
+  texworks = libsForQt5.callPackage ../applications/editors/texworks { };
 
   thc-hydra = callPackage ../tools/security/thc-hydra { };
 


### PR DESCRIPTION
###### Motivation for this change
closes #82844

gui now opens fine
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/82873
1 package built:
texworks
```