### PR TITLE
python3Packages.trackpy: 0.4.1 -> 0.4.2, mark broken

### DIFF
--- a/pkgs/development/python-modules/trackpy/default.nix
+++ b/pkgs/development/python-modules/trackpy/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "trackpy";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "soft-matter";
     repo = pname;
     rev = "v${version}";
-    sha256 = "01fdv93f6z16gypmvqnlbjmcih7dmr7a63n5w9swmp11x3if4iyq";
+    sha256 = "16mc22z3104fvygky4gy3gvifjijm42db48v2z1y0fmyf6whi9p6";
   };
 
   propagatedBuildInputs = [
@@ -54,5 +54,6 @@ buildPythonPackage rec {
     homepage = https://github.com/soft-matter/trackpy;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
+    broken = true; # not compatible with latest pandas
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing another package, tried to bump it, but it still failed:

```
        try:
            with warnings.catch_warnings(record=True):
                # We want to silence any warnings about, e.g. moved modules.
                warnings.simplefilter("ignore", Warning)
>               return pickle.load(f)
E               TypeError: _reconstruct: First argument must be a sub-type of ndarray
```
looks like serialization is broken with current pandas.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
