### PR TITLE
python3Packages.cufflinks: 0.16 -> 0.17.3

### DIFF
--- a/pkgs/development/python-modules/cufflinks/default.nix
+++ b/pkgs/development/python-modules/cufflinks/default.nix
@@ -3,7 +3,7 @@
 , colorlover
 , ipython
 , ipywidgets
-, nose
+, pytest
 , numpy
 , pandas
 , six
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "cufflinks";
-  version = "0.16";
+  version = "0.17.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "163lag5g4micpqm3m4qy9b5r06a7pw45nq80x4skxc7dcrly2ygd";
+    sha256 = "0i56062k54dlg5iz3qyl1ykww62mpkp8jr4n450h0c60dm0b7ha8";
   };
 
   propagatedBuildInputs = [
@@ -30,24 +30,12 @@ buildPythonPackage rec {
     statsmodels
   ];
 
-  patches = [
-    # Plotly 4 compatibility. Remove with next release, assuming it gets merged.
-    (fetchpatch {
-      url = "https://github.com/santosjorge/cufflinks/pull/202/commits/e291dce14181858cb457404adfdaf2624b6d0594.patch";
-      sha256 = "1l0dahwqn3cxg49v3i3amwi80dmx2bi5zrazmgzpwsfargmk2kd1";
-    })
-  ];
+  checkInputs = [ pytest ];
 
-  # in plotly4+, the plotly.plotly module was moved to chart-studio.plotly
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "plotly>=3.0.0,<4.0.0a0" "chart-studio"
-  '';
-
-  checkInputs = [ nose ];
-
+  # ignore tests which are incompatible with pandas>=1.0
+  # https://github.com/santosjorge/cufflinks/issues/236
   checkPhase = ''
-    nosetests -xv tests.py
+    pytest tests.py -k 'not bar_row'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing another package

the "production code" has already been updated for pandas>=1.0, but some of the tests still use removed attributes
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[3 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/82880
3 package built:
python27Packages.cufflinks python37Packages.cufflinks python38Packages.cufflinks
```