### PR TITLE
kotatogram-desktop: 1.1.5 -> 1.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -1,32 +1,28 @@
 { mkDerivation, lib, fetchFromGitHub, pkg-config, python3, cmake, ninja
-, qtbase, qtimageformats, enchant, xdg_utils, ffmpeg, openalSoft, lzma
-, lz4, xxHash, zlib, minizip, openssl, libtgvoip, range-v3
+, qtbase, qtimageformats, libsForQt5, hunspell, xdg_utils, ffmpeg, openalSoft
+, lzma, lz4, xxHash, zlib, minizip, openssl, libtgvoip, microsoft_gsl, tl-expected
+, range-v3
 }:
 
 with lib;
 
 mkDerivation rec {
   pname = "kotatogram-desktop";
-  version = "1.1.5";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "kotatogram";
     repo = "kotatogram-desktop";
     rev = "k${version}";
-    sha256 = "1j5wn3k1mr2c39szmyzm0pf720jmbllcaj40p2ydx0p3lir1s760";
+    sha256 = "00pdx3cjhrihf7ihhmszcf159jrzn1bcx20vwiiizs5r1qk8l210";
     fetchSubmodules = true;
   };
-
-  postPatch = ''
-    substituteInPlace Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp \
-      --replace '"libenchant-2.so.2"' '"${enchant}/lib/libenchant-2.so.2"'
-  '';
 
   nativeBuildInputs = [ pkg-config python3 cmake ninja ];
 
   buildInputs = [
-    qtbase qtimageformats ffmpeg openalSoft lzma lz4 xxHash
-    zlib minizip openssl enchant libtgvoip range-v3
+    qtbase qtimageformats ffmpeg openalSoft lzma lz4 xxHash libsForQt5.libdbusmenu
+    zlib minizip openssl hunspell libtgvoip microsoft_gsl tl-expected range-v3
   ];
 
   qtWrapperArgs = [
@@ -35,8 +31,8 @@ mkDerivation rec {
 
   cmakeFlags = [
     "-DTDESKTOP_API_TEST=ON"
-    "-DTDESKTOP_DISABLE_GTK_INTEGRATION=ON"
     "-DDESKTOP_APP_USE_PACKAGED_RLOTTIE=OFF"
+    "-DDESKTOP_APP_USE_PACKAGED_VARIANT=OFF"
   ];
 
   meta = {

--- a/pkgs/development/libraries/libtgvoip/default.nix
+++ b/pkgs/development/libraries/libtgvoip/default.nix
@@ -6,13 +6,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "libtgvoip";
-  version = "unstable-2020-01-21";
+  version = "unstable-2020-03-02";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "libtgvoip";
-    rev = "ade4434f1c6efabecc3b548ca1f692f8d103d22a";
-    sha256 = "1bhnx3sknadx7a4qk9flh356kffb02xx32grj7cj7ik4rarccgp0";
+    rev = "e422d2a80546a32ab7166a9b1058bacfc5daeefc";
+    sha256 = "0n6f7215k74039j0zmicjzhj6f45mq6fvkrwzyzibcrv87ib17fc";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
