### PR TITLE
[20.03] backport protonvpn cli ng 2.2.0 -> 2.2.2

### DIFF
--- a/pkgs/applications/networking/protonvpn-cli-ng/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli-ng/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "protonvpn-cli-ng";
-  version = "2.2.0";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "protonvpn";
     repo = "protonvpn-cli-ng";
     rev = "v${version}";
-    sha256 = "11fvnnr5p3qdc4y10815jnydcjvxlxwkkq9kvaajg0yszq84rwkz";
+    sha256 = "0ixjb02kj4z79whm1izd8mrn2h0rp9cmw4im1qvp93rahqxdd4n8";
   };
 
   propagatedBuildInputs = (with python3Packages; [
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "Linux command-line client for ProtonVPN";
     homepage = "https://github.com/protonvpn/protonvpn-cli-ng";
-    maintainers = [ maintainers.jtcoolen ];
+    maintainers = [ maintainers.jtcoolen maintainers.jefflabonte ];
     license = licenses.gpl3;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Keep security tool up-to-date

###### Things done

Backport PR #81735

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
