### PR TITLE
lib/options: Only recurse into visible sub options

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -159,7 +159,7 @@ rec {
           let ss = opt.type.getSubOptions opt.loc;
           in if ss != {} then optionAttrSetToDocList' opt.loc ss else [];
       in
-        [ docOption ] ++ subOptions) (collect isOption options);
+        [ docOption ] ++ optionals docOption.visible subOptions) (collect isOption options);
 
 
   /* This function recursively removes all derivation attributes from


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/82862, which was introduced with https://github.com/NixOS/nixpkgs/pull/78135

Confirmed this works with a `config.nix` like this:
```nix
{ pkgs, config, lib, ... }: with lib;
{

  imports = [
    (lib.mkRenamedOptionModule [ "oldoldoldold" ] [ "newnewnewnew" ])
  ];

  options.newnewnewnew = lib.mkOption {
    type = types.attrsOf (types.submodule {
      options.subsubsubsub = lib.mkOption {
        type = types.str;
        default = "test";
        description = "hello";
      };
    });
    default = {};
    description = "bar";
  };

  config.documentation.nixos.includeAllModules = true;

  config.boot.loader.grub.device = "nodev";
  config.fileSystems."/".device = "test";
}
```

Then building the manual and opening it:
```
$ nix-build nixos --arg configuration ./config.nix -A config.system.build.manual.manualHTML
$ xdg-open result/share/doc/nixos/options.html
```

And then searching for the string `subsubsubsub`. Before this PR it would occur once under `oldoldoldold.<name>.subsubsubsub` and once under `newnewnewnew.<name>.subsubsubsub`, but only the latter of which is present after this PR.