### PR TITLE
tasty-tap: fix failing build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1254,13 +1254,6 @@ self: super: {
   # https://github.com/bitnomial/prometheus/issues/34
   prometheus = doJailbreak super.prometheus;
 
-  # Tasty-tap tests are out-of-date with TAP format
-  # https://github.com/MichaelXavier/tasty-tap/issues/2
-  tasty-tap = appendPatch super.tasty-tap (pkgs.fetchpatch {
-    url = https://patch-diff.githubusercontent.com/raw/MichaelXavier/tasty-tap/pull/3.diff;
-    sha256 = "0l8zbc56dy8ilxl3k49aiknmfhgpcg3jhs72lh3dk51d0a09d9sv";
-  });
-
   # The doctests in universum-1.5.0 are broken.  The doctests in versions of universum after
   # 1.5.0 should be fixed, so this should be able to be removed.
   universum = dontCheck super.universum;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9837,7 +9837,6 @@ broken-packages:
   - tasty-laws
   - tasty-lens
   - tasty-stats
-  - tasty-tap
   - tateti-tateti
   - Taxonomy
   - TaxonomyTools


### PR DESCRIPTION
###### Motivation for this change

`tasty-tap` was failing to build because the changes in the patch it was trying to apply had already been released. Removed the patch and marked the package unbroken.

See https://github.com/NixOS/nixpkgs/pull/71017 for the history.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
