### PR TITLE
Feature/prometheus dont jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1250,10 +1250,6 @@ self: super: {
     '';
   });
 
-  # Version bounds for http-client are too strict:
-  # https://github.com/bitnomial/prometheus/issues/34
-  prometheus = doJailbreak super.prometheus;
-
   # The doctests in universum-1.5.0 are broken.  The doctests in versions of universum after
   # 1.5.0 should be fixed, so this should be able to be removed.
   universum = dontCheck super.universum;


### PR DESCRIPTION
##### Motivation for this change
- `prometheus` no longer needs to be jailbroken. Jailbreaking was added in https://github.com/NixOS/nixpkgs/pull/70956 to overcome issue https://github.com/bitnomial/prometheus/issues/34.
- This issue has since been fixed and so jailbreaking is no longer necessary.

###### Things done

Removed `doJailbreak` override.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).