### PR TITLE
epkowa: fix parsing of interpreters

### DIFF
--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -244,6 +244,7 @@ stdenv.mkDerivation rec {
       sha256 = "04y70qjd220dpyh771fiq50lha16pms98mfigwjczdfmx6kpj1jd";
     })
     ./firmware_location.patch
+    ./sscanf.patch
     ];
   patchFlags = [ "-p0" ];
 

--- a/pkgs/misc/drivers/epkowa/sscanf.patch
+++ b/pkgs/misc/drivers/epkowa/sscanf.patch
@@ -1,0 +1,29 @@
+The "%as" verb requests sscanf to allocate a buffer for us. However,
+this use of 'a' has been long deprecated, and gcc doesn't support it
+in this manner when using -std=c99. The modern replacement is "%ms".
+
+Without this change, iscan couldn't read the interpreter file, in turn
+breaking all scanners that require plugins.
+--- backend/cfg-obj.c.orig	2020-03-19 01:27:17.254762077 +0100
++++ backend/cfg-obj.c	2020-03-19 02:01:52.293329873 +0100
+@@ -1026,7 +1026,7 @@
+       char *vendor = NULL;
+       char *model  = NULL;
+ 
+-      sscanf (string, "%*s %as %as", &vendor, &model);
++      sscanf (string, "%*s %ms %ms", &vendor, &model);
+ 
+       if (list_append (_cfg->seen[CFG_KEY_SCSI], info))
+         {
+@@ -1108,10 +1112,10 @@
+       char *library  = NULL;
+       char *firmware = NULL;
+ 
+-      sscanf (string, "%*s %*s %x %x %as %as",
++      sscanf (string, "%*s %*s %x %x %ms %ms",
+               &vendor, &product, &library, &firmware);
+ 
+       if (library && _cfg_have_interpreter (library, firmware)
+           && list_append (_cfg->seen[CFG_KEY_INTERPRETER], info))
+         {
+ 


### PR DESCRIPTION
Building with -std=c99 breaks the obsolete "%as" format string, which
completely breaks the parsing of epkowa interpreters. This means that
no scanner requiring plugins worked.

###### Motivation for this change
Fix support for epkowa/iscan plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
