### PR TITLE
Fix dependent option sets

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -299,9 +299,7 @@ rec {
             in
               throw "The option `${showOption loc}' in `${firstOption._file}' is a prefix of options in `${firstNonOption._file}'."
           else
-            if all (def: isAttrs def.value) defns' then mergeModules' loc decls defns
-            else let firstInvalid = findFirst (def: ! isAttrs def.value) null defns';
-            in throw "The option path `${showOption loc}' is an attribute set of options, but it is defined to not be an attribute set in `${firstInvalid.file}'. Did you define its value at the correct and complete path?"
+            mergeModules' loc decls defns
       ))
     // { _definedNames = map (m: { inherit (m) file; names = attrNames m.config; }) configs; };
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -189,6 +189,9 @@ checkConfigOutput "true" config.enable ./import-from-store.nix
 checkConfigOutput true config.enable ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix
 checkConfigOutput 360 config.value ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix
 checkConfigOutput 7 config.value ./define-option-dependently.nix ./declare-int-positive-value.nix
+checkConfigOutput true config.set.enable ./define-option-dependently-nested.nix ./declare-enable-nested.nix ./declare-int-positive-value-nested.nix
+checkConfigOutput 360 config.set.value ./define-option-dependently-nested.nix ./declare-enable-nested.nix ./declare-int-positive-value-nested.nix
+checkConfigOutput 7 config.set.value ./define-option-dependently-nested.nix ./declare-int-positive-value-nested.nix
 
 # Check attrsOf and lazyAttrsOf. Only lazyAttrsOf should be lazy, and only
 # attrsOf should work with conditional definitions

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -199,9 +199,6 @@ checkConfigOutput "true" config.conditionalWorks ./declare-attrsOf.nix ./attrsOf
 checkConfigOutput "false" config.conditionalWorks ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
 checkConfigOutput "empty" config.value.foo ./declare-lazyAttrsOf.nix ./attrsOf-conditional-check.nix
 
-# Check error for when an option set is defined to be a non-attribute set value
-checkConfigError 'The option path .* is an attribute set of options, but it is defined to not be an attribute set in' \
-  config.value ./declare-option-set.nix ./define-value-int-zero.nix
 
 # Even with multiple assignments, a type error should be thrown if any of them aren't valid
 checkConfigError 'The option value .* in .* is not of type .*' \

--- a/lib/tests/modules/declare-enable-nested.nix
+++ b/lib/tests/modules/declare-enable-nested.nix
@@ -1,0 +1,14 @@
+{ lib, ... }:
+
+{
+  options.set = {
+    enable = lib.mkOption {
+      default = false;
+      example = true;
+      type = lib.types.bool;
+      description = ''
+        Some descriptive text
+      '';
+    };
+  };
+}

--- a/lib/tests/modules/declare-int-positive-value-nested.nix
+++ b/lib/tests/modules/declare-int-positive-value-nested.nix
@@ -1,0 +1,9 @@
+{ lib, ... }:
+
+{
+  options.set = {
+    value = lib.mkOption {
+      type = lib.types.ints.positive;
+    };
+  };
+}

--- a/lib/tests/modules/declare-option-set.nix
+++ b/lib/tests/modules/declare-option-set.nix
@@ -1,3 +1,0 @@
-{
-  options.value = {};
-}

--- a/lib/tests/modules/define-option-dependently-nested.nix
+++ b/lib/tests/modules/define-option-dependently-nested.nix
@@ -1,0 +1,16 @@
+{ lib, options, ... }:
+
+# Some modules may be distributed separately and need to adapt to other modules
+# that are distributed and versioned separately.
+{
+
+  # Always defined, but the value depends on the presence of an option.
+  config.set = {
+    value = if options ? set.enable then 360 else 7;
+  }
+  # Only define if possible.
+  // lib.optionalAttrs (options ? set.enable) {
+    enable = true;
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change
As I learned from a report from @arcnmx, 15c873b486347e7861c64fb0b5a7852be9fc82e4 from https://github.com/NixOS/nixpkgs/pull/82751 gives infinite recursion for option-dependent configuration with `optionalAttrs`, but only with *nested* option sets. https://github.com/NixOS/nixpkgs/pull/82802 only added tests for the non-nested case, which is why currently all tests still pass.

In this PR I revert the problematic commit and extend @roberth's tests to check for nested options as well, which would fail if the commit wasn't reverted.

###### Things done

- [x] Ran ./modules.sh successfully