### PR TITLE
[20.03] texworks: fix qt build

### DIFF
--- a/pkgs/applications/editors/texworks/default.nix
+++ b/pkgs/applications/editors/texworks/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig
-, qt5, libsForQt5, hunspell
+{ mkDerivation, lib, fetchFromGitHub, cmake, pkg-config
+, qtscript, poppler, hunspell
 , withLua ? true, lua
 , withPython ? true, python3 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "texworks";
   version = "0.6.3";
 
@@ -14,15 +14,15 @@ stdenv.mkDerivation rec {
     sha256 = "1ljfl784z7dmh6f1qacqhc6qhcaqdzw033yswbvpvkkck0lsk2mr";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ qt5.qtscript libsForQt5.poppler hunspell ]
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ qtscript poppler hunspell ]
                 ++ lib.optional withLua lua
                 ++ lib.optional withPython python3;
 
   cmakeFlags = lib.optional withLua "-DWITH_LUA=ON"
                ++ lib.optional withPython "-DWITH_PYTHON=ON";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Simple TeX front-end program inspired by TeXShop";
     homepage = http://www.tug.org/texworks/;
     license = licenses.gpl2Plus;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6769,7 +6769,7 @@ in
 
   textadept = callPackage ../applications/editors/textadept { };
 
-  texworks = callPackage ../applications/editors/texworks { };
+  texworks = libsForQt5.callPackage ../applications/editors/texworks { };
 
   thc-hydra = callPackage ../tools/security/thc-hydra { };
 


### PR DESCRIPTION
###### Motivation for this change
backport of https://github.com/NixOS/nixpkgs/pull/82873

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/82917
1 package built:
texworks
```