### PR TITLE
Fix GCC compilation on MacOS 10.15

### DIFF
--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -10,3 +10,35 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 '' + lib.optionalString (lib.versionOlder version "7" && (langJava || langGo)) ''
   export lib=$out;
 ''
+
+# NOTE 2020/3/18: This environment variable prevents configure scripts from
+# detecting the presence of aligned_alloc on Darwin.  There are many facts that
+# collectively make this fix necessary:
+#  - Nix uses a fixed set of standard library headers on all MacOS systems,
+#    regardless of their actual version.  (Nix uses version 10.12 headers.)
+#  - Nix uses the native standard library binaries for the build system.  That
+#    means the standard library binaries may not exactly match the standard
+#    library headers.
+#  - The aligned_alloc procedure is present in MacOS 10.15 (Catalina), but not
+#    in earlier versions.  Therefore on Catalina systems, aligned_alloc is
+#    linkable (i.e. present in the binary libraries) but not present in the
+#    headers.
+#  - Configure scripts detect a procedure's existence by checking whether it is
+#    linkable.  They do not check whether it is present in the headers.
+#  - GCC throws an error during compilation because aligned_alloc is not
+#    defined in the headers---even though the linker can see it.
+#
+# This fix would not be necessary if ANY of the above were false:
+#  - If Nix used native headers for each different MacOS version, aligned_alloc
+#    would be in the headers on Catalina.
+#  - If Nix used the same libary binaries for each MacOS version, aligned_alloc
+#    would not be in the library binaries.
+#  - If Catalina did not include aligned_alloc, this wouldn't be a problem.
+#  - If the configure scripts looked for header presence as well as
+#    linkability, they would see that aligned_alloc is missing.
+#  - If GCC allowed implicit declaration of symbols, it would not fail during
+#    compilation even if the configure scripts did not check header presence.
+#
++ lib.optionalString (hostPlatform.isDarwin) ''
+  export ac_cv_func_aligned_alloc=no
+''


### PR DESCRIPTION
###### Motivation for this change

Fix #73319 (GCC libstdc++ does not compile on MacOS 10.15 Catalina).

I left a comment in the diff with details about the fix.

This is a "quick-n-dirty" fix: there may be other derivations that suffer from the same issue, and this won't do anything to help them. The right change is probably going to be somewhere in the Darwin stdenv code, but I don't understand it well enough to know what to do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
