### PR TITLE
foldingathome: Make FAHControl be able to start the FAHViewer

### DIFF
--- a/pkgs/applications/science/misc/foldingathome/control.nix
+++ b/pkgs/applications/science/misc/foldingathome/control.nix
@@ -1,6 +1,7 @@
 { stdenv
 , autoPatchelfHook
 , dpkg
+, fahviewer
 , fetchurl
 , makeWrapper
 , python2
@@ -32,7 +33,7 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  buildInputs = [ python ];
+  buildInputs = [ fahviewer python ];
 
   doBuild = false;
 
@@ -45,6 +46,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     sed -e 's|/usr/bin|$out/bin|g' -i $out/share/applications/FAHControl.desktop
     wrapProgram "$out/bin/FAHControl" \
+      --suffix PATH : "${fahviewer.outPath}/bin" \
       --set PYTHONPATH "$out/lib/python2.7/dist-packages"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The command to run when clicking the button is configurable, but by default it
tries to run `FAHViewer`. To make this work the executable needs to be in the `PATH`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
