### PR TITLE
pdftools.pdfposter init at 0.7.post1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7809,12 +7809,6 @@
     githubId = 3889405;
     name = "vyp";
   };
-  wamserma = {
-    name = "Markus S. Wamser";
-    email = "github-dev@mail2013.wamser.eu";
-    github = "wamserma";
-    githubId = 60148;
-  };
   waynr = {
     name = "Wayne Warren";
     email = "wayne.warren.s@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7809,6 +7809,12 @@
     githubId = 3889405;
     name = "vyp";
   };
+  wamserma = {
+    name = "Markus S. Wamser";
+    email = "github-dev@mail2013.wamser.eu";
+    github = "wamserma";
+    githubId = 60148;
+  };
   waynr = {
     name = "Wayne Warren";
     email = "wayne.warren.s@gmail.com";

--- a/pkgs/development/python-modules/pdfposter/default.nix
+++ b/pkgs/development/python-modules/pdfposter/default.nix
@@ -16,6 +16,5 @@ buildPythonPackage rec {
     homepage = "https://pdfposter.readthedocs.io";
     license = licenses.gpl3;
     maintainers = with maintainers; [ wamserma ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/python-modules/pdfposter/default.nix
+++ b/pkgs/development/python-modules/pdfposter/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Split large pages of a PDF into smaller ones for poster printing";
-    homepage = https://gitlab.com/pdftools/pdfposter;
+    homepage = "https://pdfposter.readthedocs.io";
     license = licenses.gpl3;
     maintainers = with maintainers; [ wamserma ];
     platforms = platforms.all;

--- a/pkgs/development/python-modules/pdfposter/default.nix
+++ b/pkgs/development/python-modules/pdfposter/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, pypdf2 }:
+
+buildPythonPackage rec {
+  pname = "pdftools.pdfposter";
+  version = "0.7.post1";
+
+  propagatedBuildInputs = [ pypdf2 ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0c1avpbr9q53yzq5ar2x485rmp9d0l3z27aham32bg7gplzd7w0j";
+  };
+
+  meta = with stdenv.lib; {
+    description = "pdfposter is much like poster does for Postscript files, but working with PDF.";
+    homepage = https://gitlab.com/pdftools/pdfposter;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ wamserma ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/pdfposter/default.nix
+++ b/pkgs/development/python-modules/pdfposter/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   };
 
   meta = with stdenv.lib; {
-    description = "pdfposter is much like poster does for Postscript files, but working with PDF.";
+    description = "Split large pages of a PDF into smaller ones for poster printing";
     homepage = https://gitlab.com/pdftools/pdfposter;
     license = licenses.gpl3;
     maintainers = with maintainers; [ wamserma ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -992,6 +992,8 @@ in {
 
   pdfminer = callPackage ../development/python-modules/pdfminer_six { };
 
+  pdfposter = callPackage ../development/python-modules/pdfposter { };
+
   pdftotext = callPackage ../development/python-modules/pdftotext { };
 
   pdfx = callPackage ../development/python-modules/pdfx { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

pdfposter is packaged for other distriutions and easy enough to package for NixOS so I can maintain it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
