### PR TITLE
[19.09] Revert 1.1.1e update and apply CVE-2019-1551 patch

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -151,6 +151,17 @@ in {
       (if stdenv.hostPlatform.isDarwin
        then ./1.1/use-etc-ssl-certs-darwin.patch
        else ./1.1/use-etc-ssl-certs.patch)
+
+      # not able to use fetchpatch here: infinite recursion
+      # CVE-2019-1551 patches
+      (fetchurl {
+        url = "https://github.com/openssl/openssl/commit/75d8b191a0940db110e84844fea0b023fbf07ca4.patch";
+        sha256 = "0rqwiyhb6avgyg97rbms8n6pd3v3y4zzla3v7kkwly8iixcjpx35";
+      })
+      (fetchurl {
+        url = "https://github.com/openssl/openssl/commit/69f98d55165526f2e5547f3b22ecedca21ea88a7.patch";
+        sha256 = "0xi6zlgc46k8yl43h0zsdaz5j4kk9h0ypyrgiaaks31jhj4cqf8g";
+      })
     ];
     withDocs = true;
   };

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -143,8 +143,8 @@ in {
   };
 
   openssl_1_1 = common {
-    version = "1.1.1e";
-    sha256 = "1gnwlri1dphr5wdzmg9vlhkh6aq2yqgpfkpmffzwjlfb26n62kv9";
+    version = "1.1.1d";
+    sha256 = "1whinyw402z3b9xlb3qaxv4b9sk4w1bgh9k0y8df1z4x3yy92fhy";
     patches = [
       ./1.1/nix-ssl-cert-file.patch
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

openssl 1.1.1e introduces breaking changes in its EOF handling. Applying only the security patch and nothing else to avoid risk of breakage.

Submitting to release-19.09 not staging-19.09, because it's broken anyway. Not submitting to other branches because I think the other branches should simply use 1.1.1e instead of bothering with patching process.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (also built `pyopenssl`, but I'm not going to rebuild the whole world)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
