### PR TITLE
ocamlPackages.camlp5: 7.10 → 7.11

### DIFF
--- a/pkgs/applications/science/logic/hol_light/default.nix
+++ b/pkgs/applications/science/logic/hol_light/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runtimeShell, fetchFromGitHub, ocaml, num, camlp5 }:
+{ stdenv, runtimeShell, fetchFromGitHub, fetchpatch, ocaml, num, camlp5 }:
 
 let
   load_num =
@@ -29,6 +29,11 @@ stdenv.mkDerivation {
     rev    = "5c91b2ded8a66db571824ecfc18b4536c103b23e";
     sha256 = "0sxsk8z08ba0q5aixdyczcx5l29lb51ba4ip3d2fry7y604kjsx6";
   };
+
+  patches = [(fetchpatch {
+    url = https://salsa.debian.org/ocaml-team/hol-light/-/raw/master/debian/patches/0004-Fix-compilation-with-camlp5-7.11.patch;
+    sha256 = "180qmxbrk3vb1ix7j77hcs8vsar91rs11s5mm8ir5352rz7ylicr";
+  })];
 
   buildInputs = [ ocaml camlp5 ];
   propagatedBuildInputs = [ num ];

--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation {
 
-  name = "camlp5-7.10";
+  name = "camlp5-7.11";
 
   src = fetchzip {
-    url = "https://github.com/camlp5/camlp5/archive/rel710.tar.gz";
-    sha256 = "1a1lgsc8350afdwmsznsys7m0c0cks4nw6irqz2f92g8g4vkk9b7";
+    url = "https://github.com/camlp5/camlp5/archive/rel711.tar.gz";
+    sha256 = "1s1f9i0r0czxlbnsaz4kvs2ahknmqxcm5ypl75g7scjcbl0an2x4";
   };
 
   buildInputs = [ ocaml ];


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.09.1 and 4.10.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
