### PR TITLE
mojave-gtk-theme: 2020-02-20 -> 2020-03-19

### DIFF
--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchFromGitHub, fetchurl, gtk_engines, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, fetchurl, glib, gtk-engine-murrine, gtk_engines, inkscape, optipng, sassc, which }:
 
 stdenv.mkDerivation rec {
   pname = "mojave-gtk-theme";
-  version = "2020-02-20";
+  version = "2020-03-19";
 
   srcs = [
     (fetchFromGitHub {
       owner = "vinceliuice";
       repo = pname;
       rev = version;
-      sha256 = "0fbpjfdx53g4qicr97jl1dssykjwwca9xzrfyh53dmd81vr6znpy";
+      sha256 = "1f120sx092i56q4dx2b8d3nnn9pdw67656446nw702rix7zc5jpx";
     })
     (fetchurl {
       url = "https://github.com/vinceliuice/Mojave-gtk-theme/raw/11741a99d96953daf9c27e44c94ae50a7247c0ed/macOS_Mojave_Wallpapers.tar.xz";
@@ -19,12 +19,32 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "source";
 
+  nativeBuildInputs = [ glib inkscape optipng sassc which ];
+
   buildInputs = [ gtk_engines ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
-  installPhase = ''
+  postPatch = ''
     patchShebangs .
+
+    for f in render-assets.sh \
+             src/assets/gtk-2.0/render-assets.sh \
+             src/assets/gtk-3.0/common-assets/render-assets.sh \
+             src/assets/gtk-3.0/windows-assets/render-assets.sh \
+             src/assets/metacity-1/render-assets.sh \
+             src/assets/xfwm4/render-assets.sh
+    do
+      substituteInPlace $f \
+        --replace /usr/bin/inkscape ${inkscape}/bin/inkscape \
+        --replace /usr/bin/optipng ${optipng}/bin/optipng
+    done
+
+    # Shut up inkscape's warnings
+    export HOME="$NIX_BUILD_ROOT"
+  '';
+
+  installPhase = ''
     name= ./install.sh -d $out/share/themes
     install -D -t $out/share/wallpapers ../"macOS Mojave Wallpapers"/*
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [2020-03-19](https://github.com/vinceliuice/Mojave-gtk-theme/releases/tag/2020-03-19)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).