### PR TITLE
linphone: 3.12.0 -> unstable-2020-03-06

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -1,61 +1,239 @@
-{ stdenv, intltool, pkgconfig, readline, openldap, cyrus_sasl, libupnp
-, zlib, libxml2, gtk2, libnotify, speex, ffmpeg, libX11, libsoup, udev
-, ortp, mediastreamer, sqlite, belle-sip, libosip, libexosip, bzrtp
-, mediastreamer-openh264, bctoolbox, makeWrapper, fetchFromGitHub, cmake
-, libmatroska, bcunit, doxygen, gdk-pixbuf, glib, cairo, pango, mbedtls
-, python, graphviz, belcard, bcg729
-, withGui ? true
+{ bcg729
+, bctoolbox
+, bcunit
+, belcard
+, belle-sip
+, belr
+, bzrtp
+, cairo
+, cmake
+, cyrus_sasl
+, fetchFromGitLab
+, fetchurl
+, ffmpeg
+, gdk-pixbuf
+, glib
+, gnused
+, graphviz
+, gtk2
+, intltool
+, lib
+, libexosip
+, liblinphone
+, libmatroska
+, libnotify
+, libosip
+, libsoup
+, libupnp
+, libX11
+, libxml2
+, makeWrapper
+, mbedtls
+, mediastreamer
+, mediastreamer-openh264
+, mkDerivation
+, openldap
+, ortp
+, pango
+, pkgconfig
+, python
+, qtbase
+, qtgraphicaleffects
+, qtquickcontrols2
+, qttranslations
+, readline
+, speex
+, sqlite
+, stdenv
+, udev
+, zlib
+  # For Minizip 2.2.7:
+, fetchFromGitHub
+, libbsd
 }:
+let
+  # Linphone Desktop requires Minizip 2.2.7. Nixpkgs contains a very old version
+  # from the time when it was part of zlib. The most recent release of Minizip
+  # is currently 2.9.2 but Linphone Desktop didn't work with that. So, even if
+  # we added most recent Minizip version to nixpkgs, probably Minizip 2.2.7 is
+  # only needed here and we shouldn't add this semi-old version to
+  # all-packages.nix. Therefore, just define it here locally.
+  minizip2 = stdenv.mkDerivation rec {
+    pname = "minizip";
+    version = "2.2.7";
 
-stdenv.mkDerivation rec {
-  pname = "linphone";
-  version = "3.12.0";
+    disabled = stdenv.isAarch32;
 
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
+    src = fetchFromGitHub {
+      owner = "nmoinvaz";
+      repo = pname;
+      rev = version;
+      sha256 = "1a88v1gjlflsd17mlrgxh420rpa38q0d17yh9q8j1zzqfrd1azch";
+    };
+
+    nativeBuildInputs = [ cmake pkgconfig ];
+
+    cmakeFlags = [
+      "-DBUILD_SHARED_LIBS=YES"
+    ];
+
+    buildInputs = [
+      zlib
+      libbsd # required in 2.2.7 but not in 2.9.2?
+    ];
+
+    meta = with stdenv.lib; {
+      description = "Compression library implementing the deflate compression method found in gzip and PKZIP";
+      homepage = "https://github.com/nmoinvaz/minizip";
+      license = licenses.zlib;
+      platforms = platforms.unix;
+    };
+  };
+in
+mkDerivation rec {
+  pname = "linphone-desktop";
+  # Latest release is 4.1.1 old and doesn't build with the latest releases of
+  # some of the dependencies so let's use the latest commit.
+  version = "unstable-2020-03-06";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
     repo = pname;
-    rev = version;
-    sha256 = "0az2ywrpx11sqfb4s4r2v726avcjf4k15bvrqj7xvhz7hdndmh0j";
+    rev = "971997e162558d37051f89c9c34bbc240135f704";
+    sha256 = "02ji4r8bpcm2kyisn9d3054m026l33g2574i1ag1cmb2dz2p8i1c";
   };
 
-  cmakeFlags = stdenv.lib.optional withGui [ "-DENABLE_GTK_UI=ON" ];
+  # Without this patch, the build fails with:
+  #
+  #   No rule to make target
+  #   'minizip_OUTPUT/nix/store/...linphone-desktop.../lib/libminizip.so',
+  #
+  # So, the makefile tries to use a full absolute path to the library but does
+  # it incorrectly. As we have installed Minizip properly, it's sufficient to
+  # just use "minizip" and the library is found automatically. If this patched
+  # target_link_libraries line was removed entirely, the build would fail at the
+  # very end when linking minizip.
+  patches = [
+    ./fix_minizip_linking.patch
+  ];
 
+  # See: https://gitlab.linphone.org/BC/public/linphone-desktop/issues/21
   postPatch = ''
-    touch coreapi/liblinphone_gitversion.h
+    substituteInPlace src/app/AppController.cpp \
+      --replace "LINPHONE_QT_GIT_VERSION" "\"${version}\""
   '';
 
+  # TODO: After linphone-desktop and liblinphone split into separate packages,
+  # there might be some build inputs here that aren't needed for
+  # linphone-desktop.
   buildInputs = [
-    readline openldap cyrus_sasl libupnp zlib libxml2 gtk2 libnotify speex ffmpeg libX11
-    mbedtls libsoup udev ortp mediastreamer sqlite belle-sip libosip libexosip
-    bctoolbox libmatroska gdk-pixbuf glib cairo pango bzrtp belcard bcg729
+    bcg729
+    bctoolbox
+    belcard
+    belle-sip
+    belr
+    bzrtp
+    cairo
+    cyrus_sasl
+    ffmpeg
+    gdk-pixbuf
+    glib
+    gtk2
+    libX11
+    libexosip
+    liblinphone
+    libmatroska
+    libnotify
+    libosip
+    libsoup
+    libupnp
+    libxml2
+    mbedtls
+    mediastreamer
+    mediastreamer-openh264
+    minizip2
+    openldap
+    ortp
+    pango
+    qtbase
+    qtgraphicaleffects
+    qtquickcontrols2
+    qttranslations
+    readline
+    speex
+    sqlite
+    udev
+    zlib
   ];
 
   nativeBuildInputs = [
-    intltool pkgconfig makeWrapper cmake bcunit doxygen graphviz
-    (python.withPackages (ps: [ ps.pystache ps.six ]))
+    bcunit
+    cmake
+    gnused
+    graphviz
+    intltool
+    makeWrapper
+    pkgconfig
   ];
 
-  NIX_CFLAGS_COMPILE = [
-    "-Wno-error"
-    "-I${glib.dev}/include/glib-2.0"
-    "-I${glib.out}/lib/glib-2.0/include"
-    "-I${gtk2.dev}/include/gtk-2.0/"
-    "-I${cairo.dev}/include/cairo"
-    "-I${pango.dev}/include/pango-1.0"
-    "-I${gtk2}/lib/gtk-2.0/include"
-    "-DLIBLINPHONE_GIT_VERSION=\"v${version}\""
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+    "-DMINIZIP_INCLUDE_DIRS=${minizip2}/include"
+    "-DMINIZIP_LIBRARIES=minizip"
   ];
 
-  postInstall = ''
-    for i in $(cd $out/bin && ls); do
-      wrapProgram $out/bin/$i --set MEDIASTREAMER_PLUGINS_DIR ${mediastreamer-openh264}/lib/mediastreamer/plugins
-    done
+  # The default install phase fails because the paths are somehow messed up in
+  # the makefiles. The errors were like:
+  #
+  #   CMake Error at cmake_builder/linphone_package/cmake_install.cmake:49 (file):
+  #     file INSTALL cannot find
+  #     "/build/linphone-desktop-.../build/linphone-sdk/desktop//nix/store/.../bin":
+  #     No such file or directory.
+  #
+  # If someone is able to figure out how to fix that, great. For now, just
+  # trying to pick all the relevant files to the output.
+  #
+  # Also, the exec path in linphone.desktop file remains invalid, pointing to
+  # the build directory, after the whole nix build process. So, let's use sed to
+  # manually fix that path.
+  #
+  # In order to find mediastreamer plugins, mediastreamer package was patched to
+  # support an environment variable pointing to the plugin directory. Set that
+  # environment variable by wrapping the Linphone executable.
+  #
+  # Also, some grammar files needed to be copied too from some dependencies. I
+  # suppose if one define a dependency in such a way that its share directory is
+  # found, then this copying would be unnecessary. These missing grammar files
+  # were discovered when linphone crashed at startup and it was run with
+  # --verbose flag. Instead of actually copying these files, create symlinks.
+  #
+  # It is quite likely that there are some other files still missing and
+  # Linphone will randomly crash when it tries to access those files. Then,
+  # those just need to be copied manually below.
+  installPhase = ''
+    mkdir -p $out/bin
+    cp linphone $out/bin/
+    wrapProgram $out/bin/linphone \
+      --set MEDIASTREAMER_PLUGINS_DIR \
+            ${mediastreamer-openh264}/lib/mediastreamer/plugins
+    mkdir -p $out/share/applications
+    sed -i "s@/build/.*/OUTPUT/bin@$out/bin@" linphone.desktop
+    cp linphone.desktop $out/share/applications/
+    cp -r ../assets/icons $out/share/
+    mkdir -p $out/share/belr/grammars
+    ln -s ${belcard}/share/belr/grammars/* $out/share/belr/grammars/
+    ln -s ${liblinphone}/share/belr/grammars/* $out/share/belr/grammars/
+    mkdir -p $out/share/linphone
+    ln -s ${liblinphone}/share/linphone/* $out/share/linphone/
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://www.linphone.org/;
     description = "Open source SIP phone for voice/video calls and instant messaging";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl3;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ jluttine ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/linphone/fix_minizip_linking.patch
+++ b/pkgs/applications/networking/instant-messengers/linphone/fix_minizip_linking.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3ee77441..18ea5c27 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -517,7 +517,7 @@ else()
+             target_link_libraries(${TARGET_NAME} "${MINIZIP_OUTPUT_DIR}/${CMAKE_INSTALL_LIBDIR}/libminizip.dylib")
+             execute_process(COMMAND install_name_tool -id "@executable_path/../Frameworks/libminizip.dylib" "${MINIZIP_OUTPUT_DIR}/${CMAKE_INSTALL_LIBDIR}/libminizip.dylib")
+         elseif(NOT WIN32)
+-            target_link_libraries(${TARGET_NAME} "${MINIZIP_OUTPUT_DIR}/${CMAKE_INSTALL_LIBDIR}/libminizip.so")
++            target_link_libraries(${TARGET_NAME} "minizip")
+         endif()
+     endif()#If (LinphoneCxx_FOUND AND Minizip_FOUND)
+ endif()#If (LinphoneCxx_FOUND)

--- a/pkgs/development/libraries/bctoolbox/default.nix
+++ b/pkgs/development/libraries/bctoolbox/default.nix
@@ -1,27 +1,39 @@
-{ stdenv, fetchFromGitHub, cmake, bcunit, mbedtls }:
+{ bcunit
+, cmake
+, fetchFromGitLab
+, mbedtls
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
   pname = "bctoolbox";
-  version = "0.6.0";
+  version = "4.3.1";
 
   nativeBuildInputs = [ cmake bcunit ];
   buildInputs = [ mbedtls ];
 
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "1cxx243wyzkd4xnvpyqf97n0rjhfckpvw1vhwnbwshq3q6fra909";
+    sha256 = "1y91jcrma4kjqpm6w5ahlygjsyvx7l8zjrjvq7g2n39jmw175cvs";
   };
+
+  # Do not build static libraries
+  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=stringop-truncation" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     inherit version;
     description = "Utilities library for Linphone";
-    homepage = "https://github.com/BelledonneCommunications/bctoolbox";
-    license = stdenv.lib.licenses.gpl2Plus ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://gitlab.linphone.org/BC/public/bctoolbox";
+    # Still using GPLv2 but as the rest of the Linphone projects have switched
+    # to GPLv3, this might too, so check this when bumping the version number.
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ raskin jluttine ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/belcard/default.nix
+++ b/pkgs/development/libraries/belcard/default.nix
@@ -1,24 +1,34 @@
-{ stdenv, cmake, fetchFromGitHub, bctoolbox, belr }:
+{ bctoolbox
+, belr
+, cmake
+, fetchFromGitLab
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
-  baseName = "belcard";
-  version = "1.0.2";
-  name = "${baseName}-${version}";
+  pname = "belcard";
+  version = "4.3.1";
 
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
-    repo = baseName;
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
+    repo = pname;
     rev = version;
-    sha256 = "1pwji83vpsdrfma24rnj3rz1x0a0g6zk3v4xjnip7zf2ys3zcnlk";
+    sha256 = "1w6rbp53cwxr00clp957458x27cgc2y9ylwa5mp812qva7zadmfw";
   };
 
   buildInputs = [ bctoolbox belr ];
   nativeBuildInputs = [ cmake ];
 
-  meta = with stdenv.lib;{
-    description = "Belcard is a C++ library to manipulate VCard standard format";
-    homepage = https://github.com/BelledonneCommunications/belcard;
+  # Do not build static libraries
+  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
+
+  meta = with stdenv.lib; {
+    description = "C++ library to manipulate VCard standard format";
+    homepage = "https://gitlab.linphone.org/BC/public/belcard";
     license = licenses.lgpl21;
     platforms = platforms.all;
+    maintainers = with maintainers; [ jluttine ];
   };
 }

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -1,21 +1,35 @@
-{ stdenv, antlr3_4, libantlr3c, jre, mbedtls, fetchFromGitHub
-  , cmake, zlib, bctoolbox
+{ antlr3_4
+, bctoolbox
+, cmake
+, fetchFromGitLab
+, jre
+, libantlr3c
+, mbedtls
+, stdenv
+, zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "belle-sip";
-  version = "1.6.3";
+  # Using master branch for linphone-desktop caused a chain reaction that many
+  # of its dependencies needed to use master branch too.
+  version = "unstable-2020-02-18";
 
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
     repo = pname;
-    rev = version;
-    sha256 = "0q70db1klvhca1af29bm9paka3gyii5hfbzrj4178gclsg7cj8fk";
+    rev = "0dcb13416eae87edf140771b886aedaf6be8cf60";
+    sha256 = "0pzxk8mkkg6zsnmj1bwggbdjv864psx89gglfm51h8s501kg11fv";
   };
 
   nativeBuildInputs = [ jre cmake ];
 
   buildInputs = [ zlib ];
+
+  # Do not build static libraries
+  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
 
   NIX_CFLAGS_COMPILE = toString [
     "-Wno-error=deprecated-declarations"
@@ -29,9 +43,10 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
 
   meta = with stdenv.lib; {
-    homepage = https://linphone.org/technical-corner/belle-sip;
+    homepage = "https://linphone.org/technical-corner/belle-sip";
     description = "Modern library implementing SIP (RFC 3261) transport, transaction and dialog layers";
-    license = licenses.gpl2;
+    license = licenses.gpl3;
     platforms = platforms.all;
+    maintainers = with maintainers; [ jluttine ];
   };
 }

--- a/pkgs/development/libraries/belr/default.nix
+++ b/pkgs/development/libraries/belr/default.nix
@@ -1,24 +1,35 @@
-{ stdenv, cmake, fetchFromGitHub, bctoolbox }:
+{ bctoolbox
+, cmake
+, fetchFromGitLab
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
-  baseName = "belr";
-  version = "0.1.3";
-  name = "${baseName}-${version}";
+  pname = "belr";
+  # Using master branch for linphone-desktop caused a chain reaction that many
+  # of its dependencies needed to use master branch too.
+  version = "unstable-2020-03-09";
 
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
-    repo = baseName;
-    rev = version;
-    sha256 = "0mf8lsyq1z3b5p47c00lnwc8n7v9nzs1fd2g9c9hnz6fjd2ka44w";
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
+    repo = pname;
+    rev = "326d030ca9db12525c2a6d2a65f386f36f3c2ed5";
+    sha256 = "1cdblb9smncq3al0crqp5651b02k1g6whlw1ib769p61gad0rs3v";
   };
 
   buildInputs = [ bctoolbox ];
   nativeBuildInputs = [ cmake ];
 
-  meta = with stdenv.lib;{
+  # Do not build static libraries
+  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
+
+  meta = with stdenv.lib; {
     description = "Belr is Belledonne Communications' language recognition library";
-    homepage = https://github.com/BelledonneCommunications/belr;
-    license = licenses.lgpl21;
+    homepage = "https://gitlab.linphone.org/BC/public/belr";
+    license = licenses.gpl3;
     platforms = platforms.all;
+    maintainers = with maintainers; [ jluttine ];
   };
 }

--- a/pkgs/development/libraries/bzrtp/default.nix
+++ b/pkgs/development/libraries/bzrtp/default.nix
@@ -1,26 +1,38 @@
-{ stdenv, cmake, fetchFromGitHub, bctoolbox, sqlite }:
+{ bctoolbox
+, cmake
+, fetchFromGitLab
+, sqlite
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
-  baseName = "bzrtp";
-  version = "1.0.6";
-  name = "${baseName}-${version}";
+  pname = "bzrtp";
+  version = "4.3.1";
 
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
-    repo = baseName;
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
+    repo = pname;
     rev = version;
-    sha256 = "0438zzxp82bj5fmvqnwlljkgrz9ab5qm5lgpwwgmg1cp78bp2l45";
+    sha256 = "14fqp6r9rf7z6j5phbsrdxlbjak03hs8kb94b6jgcrcdxrxhy3fy";
   };
 
   buildInputs = [ bctoolbox sqlite ];
   nativeBuildInputs = [ cmake ];
 
+  # Do not build static libraries
+  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
+
   NIX_CFLAGS_COMPILE = "-Wno-error=cast-function-type";
 
   meta = with stdenv.lib; {
     description = "BZRTP is an opensource implementation of ZRTP keys exchange protocol";
-    homepage = https://github.com/BelledonneCommunications/bzrtp;
+    homepage = "https://gitlab.linphone.org/BC/public/bzrtp";
+    # They have switched to GPLv3 on git HEAD so probably the next release will
+    # be GPL3.
     license = licenses.lgpl21;
     platforms = platforms.all;
+    maintainers = with maintainers; [ jluttine ];
   };
 }

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -1,0 +1,150 @@
+{ bcg729
+, bctoolbox
+, bcunit
+, belcard
+, belle-sip
+, belr
+, bzrtp
+, cairo
+, cmake
+, cyrus_sasl
+, doxygen
+, fetchFromGitLab
+, fetchurl
+, ffmpeg
+, gdk-pixbuf
+, git
+, glib
+, graphviz
+, gtk2
+, intltool
+, libexosip
+, libmatroska
+, libnotify
+, libosip
+, libsoup
+, libupnp
+, libX11
+, libxml2
+, lime
+, makeWrapper
+, mbedtls
+, mediastreamer
+, mediastreamer-openh264
+, openldap
+, ortp
+, pango
+, pkgconfig
+, python
+, readline
+, soci
+, speex
+, sqlite
+, stdenv
+, udev
+, xercesc
+, xsd
+, zlib
+}:
+let
+  # Got the following error when building:
+  #
+  #   Your version of Doxygen (1.8.17) is known to malfunction with some of our
+  #   macro definitions, which causes errors while wrapprers generation. Please
+  #   install an older version of Doxygen (< 1.8.17) or disable documentation
+  #   and wrapper generation.
+  #
+  # So, let's then use 1.8.16 version of doxygen in this derivation. Hopefully
+  # this workaround can be removed with some newer release of liblinphone.
+  doxygen_1_8_16 = doxygen.overrideAttrs (
+    oldAttrs: rec {
+      name = "doxygen-1.8.16";
+      src = fetchurl {
+        urls = [
+          "mirror://sourceforge/doxygen/${name}.src.tar.gz" # faster, with https, etc.
+          "http://doxygen.nl/files/${name}.src.tar.gz"
+        ];
+        sha256 = "10iwv8bcz5b5cd85gg8pgn0bmyg04n9hs36xn7ggjjnvynv1z67z";
+      };
+      buildInputs = oldAttrs.buildInputs ++ [ git ];
+    }
+  );
+in
+stdenv.mkDerivation rec {
+  pname = "liblinphone";
+  # Using master branch for linphone-desktop caused a chain reaction that many
+  # of its dependencies needed to use master branch too.
+  version = "unstable-2020-03-20";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
+    repo = pname;
+    rev = "1d762a3e0e304aa579798aed4400d2cee2c1ffa0";
+    sha256 = "0ja38payyqbd8z6q5l5w6hi7xarmfj5021gh0qdk0j832br4c6c3";
+  };
+
+  # Do not build static libraries
+  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
+
+  # TODO: Not sure if all these inputs are actually needed. Most of them were
+  # defined when liblinphone and linphone-desktop weren't separated yet, so some
+  # of them might not be needed for liblinphone alone.
+  buildInputs = [
+    (python.withPackages (ps: [ ps.pystache ps.six ]))
+    bcg729
+    bctoolbox
+    belcard
+    belle-sip
+    belr
+    bzrtp
+    cairo
+    cyrus_sasl
+    ffmpeg
+    gdk-pixbuf
+    git
+    glib
+    gtk2
+    libX11
+    libexosip
+    libmatroska
+    libnotify
+    libosip
+    libsoup
+    libupnp
+    libxml2
+    lime
+    mbedtls
+    mediastreamer
+    openldap
+    ortp
+    pango
+    readline
+    soci
+    speex
+    sqlite
+    udev
+    xercesc
+    xsd
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    bcunit
+    cmake
+    doxygen_1_8_16
+    graphviz
+    intltool
+    makeWrapper
+    pkgconfig
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.linphone.org/technical-corner/liblinphone";
+    description = "Library for SIP calls and instant messaging";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/libraries/lime/default.nix
+++ b/pkgs/development/libraries/lime/default.nix
@@ -1,0 +1,36 @@
+{ bctoolbox
+, belle-sip
+, cmake
+, fetchFromGitLab
+, soci
+, sqlite
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lime";
+  version = "4.3.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
+    repo = pname;
+    rev = version;
+    sha256 = "1ilpp9ai4sah23ngnxisvmwhrv5jkk5f831yp7smpl225z5nv83g";
+  };
+
+  buildInputs = [ bctoolbox soci belle-sip sqlite ];
+  nativeBuildInputs = [ cmake ];
+
+  # Do not build static libraries
+  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
+
+  meta = with stdenv.lib; {
+    description = "End-to-end encryption library for instant messaging";
+    homepage = "http://www.linphone.org/technical-corner/lime";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -1,36 +1,96 @@
-{ stdenv, pkgconfig, intltool, alsaLib, libpulseaudio, speex, gsm
-, libopus, ffmpeg, libX11, libXv, libGLU, libGL, glew, libtheora, libvpx, SDL, libupnp
-, ortp, libv4l, libpcap, srtp, fetchFromGitHub, cmake, bctoolbox, doxygen
-, python, libXext, libmatroska, fetchpatch
+{ alsaLib
+, bctoolbox
+, bzrtp
+, cmake
+, doxygen
+, fetchFromGitLab
+, fetchpatch
+, ffmpeg
+, glew
+, gsm
+, intltool
+, libGL
+, libGLU
+, libX11
+, libXext
+, libXv
+, libmatroska
+, libopus
+, libpcap
+, libpulseaudio
+, libtheora
+, libupnp
+, libv4l
+, libvpx
+, ortp
+, pkgconfig
+, python
+, SDL
+, speex
+, srtp
+, stdenv
 }:
 
 stdenv.mkDerivation rec {
   pname = "mediastreamer2";
-  version = "2.16.1";
+  # Using master branch for linphone-desktop caused a chain reaction that many
+  # of its dependencies needed to use master branch too.
+  version = "unstable-2020-03-20";
 
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
     repo = pname;
-    rev = version;
-    sha256 = "02745bzl2r1jqvdqzyv94fjd4w92zr976la4c4nfvsy52waqah7j";
+    rev = "c5eecb72cb44376d142949051dd0cb7c982608fb";
+    sha256 = "1vp260jxvjlmrmjdl4p23prg4cjln20a7z6zq8dqvfh4iq3ya033";
   };
 
   patches = [
-    (fetchpatch {
-      name = "allow-build-without-git.patch";
-      url = "https://github.com/BelledonneCommunications/mediastreamer2/commit/de3a24b795d7a78e78eab6b974e7ec5abf2259ac.patch";
-      sha256 = "1zqkrab42n4dha0knfsyj4q0wc229ma125gk9grj67ps7r7ipscy";
-    })
+    # Plugins directory is normally fixed during compile time. This patch makes
+    # it possible to set the plugins directory run time with an environment
+    # variable MEDIASTREAMER_PLUGINS_DIR. This makes it possible to construct a
+    # plugin directory with desired plugins and wrap executables so that the
+    # environment variable points to that directory.
     ./plugins_dir.patch
   ];
 
-  nativeBuildInputs = [ pkgconfig intltool cmake doxygen python ];
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    intltool
+    pkgconfig
+    python
+  ];
 
   propagatedBuildInputs = [
-    alsaLib libpulseaudio speex gsm libopus
-    ffmpeg libX11 libXv libGLU libGL glew libtheora libvpx SDL libupnp
-    ortp libv4l libpcap srtp bctoolbox libXext libmatroska
+    alsaLib
+    bctoolbox
+    bzrtp
+    ffmpeg
+    glew
+    gsm
+    libGL
+    libGLU
+    libX11
+    libXext
+    libXv
+    libmatroska
+    libopus
+    libpcap
+    libpulseaudio
+    libtheora
+    libupnp
+    libv4l
+    libvpx
+    ortp
+    SDL
+    speex
+    srtp
   ];
+
+  # Do not build static libraries
+  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
 
   NIX_CFLAGS_COMPILE = toString [
     "-DGIT_VERSION=\"v${version}\""
@@ -43,8 +103,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A powerful and lightweight streaming engine specialized for voice/video telephony applications";
-    homepage = http://www.linphone.org/technical-corner/mediastreamer2;
-    license = licenses.gpl2;
+    homepage = "http://www.linphone.org/technical-corner/mediastreamer2";
+    license = licenses.gpl3;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ jluttine ];
   };
 }

--- a/pkgs/development/libraries/mediastreamer/plugins_dir.patch
+++ b/pkgs/development/libraries/mediastreamer/plugins_dir.patch
@@ -1,24 +1,18 @@
-diff -uNr mediastreamer2/src/base/msfactory.c mediastreamer2-new/src/base/msfactory.c
---- a/src/base/msfactory.c	2015-05-13 16:53:49.801113249 +0200
-+++ b/src/base/msfactory.c	2015-08-26 21:35:44.994724647 +0200
-@@ -630,12 +630,18 @@
+diff --git a/src/base/msfactory.c b/src/base/msfactory.c
+index 14f868e3..2e3445a1 100644
+--- a/src/base/msfactory.c
++++ b/src/base/msfactory.c
+@@ -770,7 +770,12 @@ void ms_factory_uninit_plugins(MSFactory *factory){
  }
  
  void ms_factory_init_plugins(MSFactory *obj) {
+-	if (obj->plugins_dir == NULL) {
 +	char *package_plugins_dir;
- 	if (obj->plugins_dir == NULL) {
-+		package_plugins_dir=getenv("MEDIASTREAMER_PLUGINS_DIR");
-+		if (package_plugins_dir!=NULL){
-+			obj->plugins_dir = ms_strdup(package_plugins_dir);
-+		} else {
- #ifdef PACKAGE_PLUGINS_DIR
--		obj->plugins_dir = ms_strdup(PACKAGE_PLUGINS_DIR);
-+			obj->plugins_dir = ms_strdup(PACKAGE_PLUGINS_DIR);
- #else
--		obj->plugins_dir = ms_strdup("");
-+			obj->plugins_dir = ms_strdup("");
- #endif
-+		}
- 	}
- 	if (strlen(obj->plugins_dir) > 0) {
- 		ms_message("Loading ms plugins from [%s]",obj->plugins_dir);
++	// Force plugin dir from environment variable if set
++	package_plugins_dir = getenv("MEDIASTREAMER_PLUGINS_DIR");
++	if (package_plugins_dir != NULL) {
++		ms_factory_set_plugins_dir(obj, package_plugins_dir);
++	} else if (obj->plugins_dir == NULL) {
+ #ifdef __APPLE__
+ 	char *dir = getPluginsDir();
+ 	if (dir != NULL) {

--- a/pkgs/development/libraries/ortp/default.nix
+++ b/pkgs/development/libraries/ortp/default.nix
@@ -1,15 +1,26 @@
-{ stdenv, cmake, fetchFromGitHub, bctoolbox }:
+{ bctoolbox
+, cmake
+, fetchFromGitLab
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
   pname = "ortp";
-  version = "1.0.2";
+  # Using master branch for linphone-desktop caused a chain reaction that many
+  # of its dependencies needed to use master branch too.
+  version = "unstable-2020-03-17";
 
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
     repo = pname;
-    rev = version;
-    sha256 = "12cwv593bsdnxs0zfcp07vwyk7ghlz2wv7vdbs1ksv293w3vj2rv";
+    rev = "804dfc4f90d1a4301127c7af10a74fd2935dd5d8";
+    sha256 = "1yr8j8am68spyy5d9vna8zcq3qn039mi16cv9jf5n4chs9rxf7xx";
   };
+
+  # Do not build static libraries
+  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=stringop-truncation";
 
@@ -18,8 +29,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A Real-Time Transport Protocol (RFC3550) stack";
-    homepage = https://linphone.org/technical-corner/ortp;
-    license = licenses.gpl2Plus;
+    homepage = "https://linphone.org/technical-corner/ortp";
+    license = licenses.gpl3;
     platforms = platforms.all;
+    maintainers = with maintainers; [ jluttine ];
   };
 }

--- a/pkgs/development/libraries/soci/default.nix
+++ b/pkgs/development/libraries/soci/default.nix
@@ -1,0 +1,31 @@
+{ cmake
+, fetchFromGitHub
+, sqlite
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "soci";
+  version = "4.0.0";
+
+  src = fetchFromGitHub {
+    owner = "SOCI";
+    repo = pname;
+    rev = version;
+    sha256 = "06faswdxd2frqr9xnx6bxc7zwarlzsbdi3bqpz7kwdxsjvq41rnb";
+  };
+
+  # Do not build static libraries
+  cmakeFlags = [ "-DSOCI_STATIC=OFF" ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ sqlite ];
+
+  meta = with stdenv.lib; {
+    description = "Database access library for C++";
+    homepage = "http://soci.sourceforge.net/";
+    license = licenses.boost;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/tools/audio/trx/add_bctoolbox_ldlib.patch
+++ b/pkgs/tools/audio/trx/add_bctoolbox_ldlib.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index ffcd883..c4b4ff7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -12,8 +12,9 @@ CFLAGS += -MMD -Wall
+ LDLIBS_ASOUND ?= -lasound
+ LDLIBS_OPUS ?= -lopus
+ LDLIBS_ORTP ?= -lortp
++LDLIBS_BCTOOLBOX ?= -lbctoolbox
+ 
+-LDLIBS += $(LDLIBS_ASOUND) $(LDLIBS_OPUS) $(LDLIBS_ORTP)
++LDLIBS += $(LDLIBS_ASOUND) $(LDLIBS_OPUS) $(LDLIBS_ORTP) $(LDLIBS_BCTOOLBOX)
+ 
+ .PHONY:		all install dist clean
+ 

--- a/pkgs/tools/audio/trx/default.nix
+++ b/pkgs/tools/audio/trx/default.nix
@@ -2,12 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "trx";
-  version = "0.4";
+  version = "0.5";
 
   src = fetchurl {
     url = "https://www.pogo.org.uk/~mark/trx/releases/${pname}-${version}.tar.gz";
-    sha256 = "1wsrkbqc090px8i9p8awz38znxjcqjb1dzjjdd8xkjmiprayjhkl";
+    sha256 = "1jjgca92nifjhcr3n0fmpfr6f5gxlqyal2wmgdlgd7hx834r1if7";
   };
+
+  # Makefile is currently missing -lbctoolbox so the build fails when linking
+  # the libraries. This patch adds that flag.
+  patches = [
+    ./add_bctoolbox_ldlib.patch
+  ];
 
   buildInputs = [ alsaLib libopus ortp bctoolbox ];
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/tools/misc/bcunit/default.nix
+++ b/pkgs/tools/misc/bcunit/default.nix
@@ -1,22 +1,30 @@
-{stdenv, fetchFromGitHub, cmake}:
+{ cmake
+, fetchFromGitLab
+, stdenv
+}:
+
 stdenv.mkDerivation rec {
-  name = "${baseName}-${version}";
-  baseName = "bcunit";
-  version = "3.0.2";
-  buildInputs = [cmake];
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
-    repo = baseName;
-    rev = version;
-    sha256 = "063yl7kxkix76r49qrj0h1qpz2p538d1yw8aih0x4i47g35k00y7";
+  pname = "bcunit";
+  # Latest release 3.0.2 is missing some functions needed by bctoolbox. See:
+  # https://gitlab.linphone.org/BC/public/bcunit/issues/1
+  version = "unstable-2019-11-19";
+
+  buildInputs = [ cmake ];
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
+    repo = pname;
+    rev = "3c720fbf67dd3c02b0c7011ed4036982b2c93532";
+    sha256 = "1237hpmkls2igp60gdfkbknxpgwvxn1vmv2m41vyl25xw1d3g35w";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     inherit version;
-    description = ''A fork of CUnit test framework'';
-    license = stdenv.lib.licenses.lgpl2Plus;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    description = "A fork of CUnit test framework";
+    homepage = "https://gitlab.linphone.org/BC/public/bcunit";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ raskin jluttine ];
+    platforms = platforms.linux;
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20566,7 +20566,7 @@ in
 
   links2 = callPackage ../applications/networking/browsers/links2 { };
 
-  linphone = callPackage ../applications/networking/instant-messengers/linphone { };
+  linphone = libsForQt5.callPackage ../applications/networking/instant-messengers/linphone { };
 
   linuxsampler = callPackage ../applications/audio/linuxsampler { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20605,6 +20605,8 @@ in
     flavour = "git";
   };
 
+  lime = callPackage ../development/libraries/lime { };
+
   luakit = callPackage ../applications/networking/browsers/luakit {
     inherit (luajitPackages) luafilesystem;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22009,6 +22009,8 @@ in
 
   skanlite = libsForQt5.callPackage ../applications/office/skanlite { };
 
+  soci = callPackage ../development/libraries/soci { };
+
   sonic-lineup = libsForQt5.callPackage ../applications/audio/sonic-lineup { };
 
   sonic-visualiser = libsForQt5.callPackage ../applications/audio/sonic-visualiser { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20562,6 +20562,8 @@ in
 
   libdsk = callPackage ../misc/emulators/libdsk { };
 
+  liblinphone = callPackage ../development/libraries/liblinphone { };
+
   links2 = callPackage ../applications/networking/browsers/links2 { };
 
   linphone = callPackage ../applications/networking/instant-messengers/linphone { };


### PR DESCRIPTION
###### Motivation for this change

Update Linphone as it has seen significant upgrades since 3.12.0.

IIUC, it has split into some library packages, so some nontrivial work needed.

Anyway, this is still work in progress, I'm trying to figure out how to fix the upgrade. I just wanted to open a draft pull request already so people know that this is being worked on (and they can help if they want).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
