### PR TITLE
netdata: fix load go.d.plugin

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -47,7 +47,7 @@ in stdenv.mkDerivation rec {
 
   postInstall = ''
     ln -s ${go-d-plugin.bin}/lib/netdata/conf.d/* $out/lib/netdata/conf.d
-    ln -s ${go-d-plugin.bin}/bin/godplugind $out/libexec/netdata/plugins.d/go.d.plugin
+    ln -s ${go-d-plugin.bin}/bin/godplugin $out/libexec/netdata/plugins.d/go.d.plugin
   '' + optionalString (!stdenv.isDarwin) ''
     # rename this plugin so netdata will look for setuid wrapper
     mv $out/libexec/netdata/plugins.d/apps.plugin \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixed load god plugin
```
2020-03-19 17:37:24: netdata INFO  : PLUGINSD[go.d] : connected to '/nix/store/ai9y6r76157n4jv08y7k7s6by3xayzqa-netdata-1.20.0/libexec/netdata/plugins.d/go.d.plugin' running on pid 803
2020-03-19 17:37:24: netdata INFO  : PLUGINSD[charts.d] : connected to '/nix/store/ai9y6r76157n4jv08y7k7s6by3xayzqa-netdata-1.20.0/libexec/netdata/plugins.d/charts.d.plugin' running on pid 804
sh: /nix/store/ai9y6r76157n4jv08y7k7s6by3xayzqa-netdata-1.20.0/libexec/netdata/plugins.d/go.d.plugin: No such file or directory
2020-03-19 17:37:24: netdata ERROR : PLUGINSD[go.d] : read failed: end of file
2020-03-19 17:37:24: netdata ERROR : PLUGINSD[go.d] : '/nix/store/ai9y6r76157n4jv08y7k7s6by3xayzqa-netdata-1.20.0/libexec/netdata/plugins.d/go.d.plugin' (pid 803) disconnected after 0 successful data collections (ENDs).
2020-03-19 17:37:24: netdata ERROR : PLUGINSD[go.d] : child pid 803 exited with code 127.
2020-03-19 17:37:24: netdata ERROR : PLUGINSD[go.d] : '/nix/store/ai9y6r76157n4jv08y7k7s6by3xayzqa-netdata-1.20.0/libexec/netdata/plugins.d/go.d.plugin' (pid 803) exited with error code 127 and haven't collected any data. Disabling it.
2020-03-19 17:37:24: netdata INFO  : PLUGINSD[go.d] : thread with task id 786 finished
```
cc @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
