### PR TITLE
page: init at 2.3.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6497,6 +6497,12 @@
     githubId = 766350;
     name = "Richard Zetterberg";
   };
+  s1341 = {
+    email = "s1341@shmarya.net";
+    name = "Shmarya Rubenstein";
+    github = "s1341";
+    githubId = 5682183;
+  };
   samdoshi = {
     email = "sam@metal-fish.co.uk";
     github = "samdoshi";

--- a/pkgs/tools/misc/page/default.nix
+++ b/pkgs/tools/misc/page/default.nix
@@ -1,0 +1,32 @@
+{ lib, rustPlatform, fetchFromGitHub, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "page";
+  version = "2.3.4";
+
+  src = fetchFromGitHub {
+    owner = "I60R";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xcbnl8fbdfdmcbv5d7v830aa3vfhg7nlf768rbrfd5a0970pllh";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    completions_dir=$(find "target" -name "shell_completions" -type d -printf "%T+\t%p\n" | sort | awk 'NR==1{print $2}')
+
+    installShellCompletion --bash $completions_dir/page.bash
+    installShellCompletion --fish $completions_dir/page.fish
+    installShellCompletion --zsh $completions_dir/_page
+  '';
+
+  cargoSha256 = "0ckfmqi6jvbvj99vbdp798mmy6gc54254n32br0ri842b04i26qf";
+
+  meta = with lib; {
+    description = "Use neovim as pager";
+    homepage = "https://github.com/I60R/page";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.s1341 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5701,6 +5701,8 @@ in
 
   padthv1 = libsForQt5.callPackage ../applications/audio/padthv1 { };
 
+  page = callPackage ../tools/misc/page { };
+  
   pagmo2 = callPackage ../development/libraries/pagmo2 { };
 
   pakcs = callPackage ../development/compilers/pakcs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add the page utility, which is a pager using nvim's :terminal feature. 

See #82948 82948

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
