### PR TITLE
termius: init at 5.6.1

### DIFF
--- a/pkgs/applications/networking/termius/default.nix
+++ b/pkgs/applications/networking/termius/default.nix
@@ -1,0 +1,67 @@
+{ atomEnv
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, makeDesktopItem
+, makeWrapper
+, stdenv
+, udev
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "termius";
+  version = "5.6.1";
+
+  src = fetchurl {
+    url = "https://deb.termius.com/pool/main/t/termius-app/termius-app_${version}_amd64.deb";
+    sha256 = "1b67163b8e4b71a5e9087acc0a70e4ed0a6147f1846ac755e24e6c529b477d92";
+  };
+
+  desktopItem = makeDesktopItem {
+    categories = "Network;";
+    comment = "The SSH client that works on Desktop and Mobile";
+    desktopName = "Termius";
+    exec = "termius-app";
+    genericName = "Cross-platform SSH client";
+    icon = "termius-app";
+    name = "termius-app";
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontPatchELF = true;
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg makeWrapper wrapGAppsHook ];
+
+  buildInputs = atomEnv.packages;
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp -R "opt" "$out"
+    cp -R "usr/share" "$out/share"
+    chmod -R g-w "$out"
+    # Desktop file
+    mkdir -p "$out/share/applications"
+    cp "${desktopItem}/share/applications/"* "$out/share/applications"
+  '';
+
+  runtimeDependencies = [ udev.lib ];
+
+  postFixup = ''
+    makeWrapper $out/opt/Termius/termius-app $out/bin/termius-app \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform SSH client with cloud data sync and more";
+    homepage = "https://termius.com/";
+    downloadPage = "https://termius.com/linux/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ filalex77 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Termius is a SSH client that works on desktop and mobile. Termius securely syncs data across all your devices and is available for free thanks to github student pack.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
