### PR TITLE
nixos: Fix pkgs exporting

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -61,7 +61,7 @@ in rec {
     args = extraArgs;
     specialArgs =
       { modulesPath = builtins.toString ../modules; } // specialArgs;
-  }) config options;
+  }) config options _module;
 
   # These are the extra arguments passed to every module.  In
   # particular, Nixpkgs is passed through the "pkgs" argument.
@@ -69,5 +69,5 @@ in rec {
     inherit baseModules extraModules modules;
   };
 
-  inherit (config._module.args) pkgs;
+  inherit (_module.args) pkgs;
 }


### PR DESCRIPTION
###### Motivation for this change
This needs adjustment after dcdd232939232d04c1132b4cc242dd3dac44be8c from https://github.com/NixOS/nixpkgs/pull/82751

Discovered thanks to the report by @samueldr 

###### Things done

- [x] Checked that `nix-instantiate --eval '<nixpkgs/nixos>' -A pkgs` now works