### PR TITLE
pythonPackages.pynanoleaf: init at 0.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5505,6 +5505,12 @@
     githubId = 101514;
     name = "Orivej Desh";
   };
+  oro = {
+    email = "marco@orovecchia.at";
+    github = "oro";
+    githubId = 357005;
+    name = "Marco Orovecchia";
+  };
   osener = {
     email = "ozan@ozansener.com";
     github = "osener";

--- a/pkgs/development/python-modules/pynanoleaf/default.nix
+++ b/pkgs/development/python-modules/pynanoleaf/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k, requests }:
+
+buildPythonPackage rec {
+  pname = "pynanoleaf";
+  version = "0.0.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2ced000e3c37f4e2ce0ea177d924af71c97007de9e4fd0ef37dcd7b4a6d1b622";
+  };
+
+  disabled = !isPy3k;
+
+  propagatedBuildInputs = [ requests ];
+
+  # pynanoleaf does not contain tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "pynanoleaf"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Oro/pynanoleaf";
+    description = "A Python3 wrapper for the Nanoleaf API, capable of controlling both Nanoleaf Aurora and Nanoleaf Canvas";
+    license = licenses.mit;
+    maintainers = with maintainers; [ oro ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -496,7 +496,7 @@
     "n26" = ps: with ps; [ ]; # missing inputs: n26
     "nad" = ps: with ps; [ ]; # missing inputs: nad_receiver
     "namecheapdns" = ps: with ps; [ defusedxml];
-    "nanoleaf" = ps: with ps; [ ]; # missing inputs: pynanoleaf
+    "nanoleaf" = ps: with ps; [ pynanoleaf];
     "neato" = ps: with ps; [ pybotvac];
     "nederlandse_spoorwegen" = ps: with ps; [ ]; # missing inputs: nsapi
     "nello" = ps: with ps; [ ]; # missing inputs: pynello

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1185,6 +1185,8 @@ in {
 
   pymsgbox = callPackage ../development/python-modules/pymsgbox { };
 
+  pynanoleaf = callPackage ../development/python-modules/pynanoleaf { };
+
   pynisher = callPackage ../development/python-modules/pynisher { };
 
   pyparser = callPackage ../development/python-modules/pyparser { };


### PR DESCRIPTION
###### Motivation for this change
Nanoleaf connectivity for Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
