### PR TITLE
psc-package: Stop using haskellPackages to build

### DIFF
--- a/pkgs/development/compilers/purescript/psc-package/default.nix
+++ b/pkgs/development/compilers/purescript/psc-package/default.nix
@@ -1,27 +1,61 @@
-{ haskellPackages, mkDerivation, fetchFromGitHub, lib }:
+# Based on https://github.com/justinwoo/easy-purescript-nix/blob/master/psc-package-simple.nix
+{ stdenv, lib, fetchurl, gmp, zlib, libiconv, darwin, installShellFiles }:
 
-with lib;
+let
+  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
 
-mkDerivation rec {
-  pname = "psc-package";
+in
+stdenv.mkDerivation rec {
+  pname = "psc-package-simple";
+
   version = "0.6.2";
 
-  src = fetchFromGitHub {
-    owner = "purescript";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0536mijma61khldnpbdviq2vvpfzzz7w8bxr59mvr19i10njdq0y";
+  src = if stdenv.isDarwin
+  then fetchurl {
+    url = "https://github.com/purescript/psc-package/releases/download/v0.6.2/macos.tar.gz";
+    sha256 = "17dh3bc5b6ahfyx0pi6n9qnrhsyi83qdynnca6k1kamxwjimpcq1";
+  }
+  else fetchurl {
+    url = "https://github.com/purescript/psc-package/releases/download/v0.6.2/linux64.tar.gz";
+    sha256 = "1zvay9q3xj6yd76w6qyb9la4jaj9zvpf4dp78xcznfqbnbhm1a54";
   };
 
-  isLibrary = false;
-  isExecutable = true;
+  buildInputs = [ gmp zlib ];
+  nativeBuildInputs = [ installShellFiles ];
 
-  executableHaskellDepends = with haskellPackages; [
-    aeson aeson-pretty either errors optparse-applicative
-    system-filepath turtle
-  ];
+  libPath = lib.makeLibraryPath buildInputs;
 
-  description = "A package manager for PureScript based on package sets";
-  license = licenses.bsd3;
-  maintainers = with lib.maintainers; [ Profpatsch ];
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    PSC_PACKAGE=$out/bin/psc-package
+
+    install -D -m555 -T psc-package $PSC_PACKAGE
+    chmod u+w $PSC_PACKAGE
+  '' + lib.optionalString stdenv.isDarwin ''
+    install_name_tool \
+      -change /usr/lib/libSystem.B.dylib ${darwin.Libsystem}/lib/libSystem.B.dylib \
+      -change /usr/lib/libiconv.2.dylib ${libiconv}/libiconv.2.dylib \
+      $PSC_PACKAGE
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    patchelf --interpreter ${dynamic-linker} --set-rpath ${libPath} $PSC_PACKAGE
+  '' + ''
+    chmod u-w $PSC_PACKAGE
+
+    $PSC_PACKAGE --bash-completion-script $PSC_PACKAGE > psc-package.bash
+    $PSC_PACKAGE --fish-completion-script $PSC_PACKAGE > psc-package.fish
+    $PSC_PACKAGE --zsh-completion-script $PSC_PACKAGE > _psc-package
+    installShellCompletion \
+      psc-package.{bash,fish} \
+      --zsh _psc-package
+  '';
+
+  meta = with lib; {
+    description = "A package manager for PureScript based on package sets";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ Profpatsch ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8343,8 +8343,7 @@ in
 
   purescript = callPackage ../development/compilers/purescript/purescript { };
 
-  psc-package = haskell.lib.justStaticExecutables
-    (haskellPackages.callPackage ../development/compilers/purescript/psc-package { });
+  psc-package = callPackage ../development/compilers/purescript/psc-package { };
 
   purescript-psa = nodePackages.purescript-psa;
 


### PR DESCRIPTION
###### Motivation for this change
The current `psc-package` doesn't compile anymore, both becasue it's not compatible with GHC 8.8 and because the version of `base-compat` in `haskellPackages` is newer than what it supports.

The new approach just downloads a prebuilt binary and patches the linker paths. This means we're using the official supported compiler so we match other installations of `psc-package`, at the downside of fewer supported platforms. This was the recommended approach from https://github.com/purescript/psc-package/issues/165.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (with sandbox)
   - [X] macOS (without sandbox)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested one package that depends on this (`nodePackages.insect`). I don't anticipate any issues with dependent packages as this is the same version of `psc-package` as before, so it should behave the same.

CC @Profpatsch
