### PR TITLE
slack-term: 0.4.1 -> 0.5.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack-term/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack-term/default.nix
@@ -3,7 +3,7 @@
 buildGoPackage rec {
   # https://github.com/erroneousboat/slack-term
   pname = "slack-term";
-  version = "0.4.1";
+  version = "0.5.0";
 
   goPackagePath = "github.com/erroneousboat/slack-term";
 
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "erroneousboat";
     repo = "slack-term";
     rev = "v${version}";
-    sha256 = "1340bq7h31fxykxbxpn6hv7n2hmjf20f8vg5gan9pjf5jaa6kfza";
+    sha256 = "1fbq7bdhy70hlkklppimgdjamnk0v059pg73xm9ax1f4616ki1m6";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

slack-term version 0.5.0 was released
![image](https://user-images.githubusercontent.com/13085980/77123843-8e3cf700-6a41-11ea-9610-dea6c3bd3c7b.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
