### PR TITLE
libgpiod: add support for Python bindings

### DIFF
--- a/pkgs/development/libraries/libgpiod/default.nix
+++ b/pkgs/development/libraries/libgpiod/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, autoreconfHook, autoconf-archive, pkgconfig, kmod, enable-tools ? true }:
+{ lib, stdenv, fetchurl, autoreconfHook, autoconf-archive, pkgconfig, kmod
+, enable-tools ? true
+, enablePython ? false, python3, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "libgpiod";
@@ -9,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1r337ici2nvi9v2h33nf3b7nisirc4s8p31cpv1cg8jbzn3wi15g";
   };
 
-  buildInputs = [ kmod ];
+  buildInputs = [ kmod ] ++ lib.optionals enablePython [ python3 ncurses ];
   nativeBuildInputs = [
     autoconf-archive
     pkgconfig
@@ -20,9 +22,9 @@ stdenv.mkDerivation rec {
     "--enable-tools=${if enable-tools then "yes" else "no"}"
     "--enable-bindings-cxx"
     "--prefix=${placeholder "out"}"
-  ];
+  ] ++ lib.optional enablePython "--enable-bindings-python";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "C library and tools for interacting with the linux GPIO character device";
     longDescription = ''
       Since linux 4.8 the GPIO sysfs interface is deprecated. User space should use

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4149,6 +4149,11 @@ in {
     inherit (pkgs.linuxPackages) nvidia_x11;
   };
 
+  libgpiod = disabledIf (!isPy3k) (toPythonModule (pkgs.libgpiod.override {
+    enablePython = true;
+    python3 = python;
+  }));
+
   libkeepass = callPackage ../development/python-modules/libkeepass { };
 
   librepo = pipe pkgs.librepo [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds support for building the Python bindings to libgpiod.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @expipiplus1 