### PR TITLE
ocaml: 4.09.0 → 4.09.1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.09.nix
+++ b/pkgs/development/compilers/ocaml/4.09.nix
@@ -1,6 +1,9 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "09";
-  patch_version = "0";
-  sha256 = "1v3z5ar326f3hzvpfljg4xj8b9lmbrl53fn57yih1bkbx3gr3yzj";
+  patch_version = "1";
+  sha256 = "1aq5505lpa39garky2icgfv4c7ylpx3j623cz9bsz5c466d2kqls";
+
+  # Breaks build with Clang
+  hardeningDisable = [ "strictoverflow" ];
 }


### PR DESCRIPTION
###### Motivation for this change

Bugfix release: https://inbox.ocaml.org/caml-list/92fddd1b-3791-4f5d-0edb-f886fc0385ca@inria.fr/T/#u

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
