### PR TITLE
improve robustness of various Rust packages

### DIFF
--- a/pkgs/applications/blockchains/zcash/librustzcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/librustzcash/default.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   installPhase = ''
     mkdir -p $out/lib
-    cp target/release/librustzcash.a $out/lib/
+    cp $releaseDir/librustzcash.a $out/lib/
     mkdir -p $out/include
     cp librustzcash/include/librustzcash.h $out/include/
   '';

--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -95,7 +95,7 @@ rustPlatform.buildRustPackage rec {
   installPhase = ''
     runHook preInstall
 
-    install -D target/release/alacritty $out/bin/alacritty
+    install -D $releaseDir/alacritty $out/bin/alacritty
 
   '' + (
     if stdenv.isDarwin then ''

--- a/pkgs/applications/networking/dyndns/cfdyndns/default.nix
+++ b/pkgs/applications/networking/dyndns/cfdyndns/default.nix
@@ -19,7 +19,7 @@ buildRustPackage rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -p target/release/cfdyndns $out/bin/
+    cp -p $releaseDir/cfdyndns $out/bin/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl, darwin }:
+{ stdenv, fetchFromGitHub, installShellFiles, rustPlatform, pkgconfig, openssl, darwin }:
 
 with rustPlatform;
 
@@ -15,7 +15,7 @@ buildRustPackage rec {
 
   cargoSha256 = "0vcg2pl0s329fr8p23pwdx2jy7qahbr7n337ib61f69aaxi1xmq0";
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig installShellFiles ];
   buildInputs = [ openssl ]
   ++ stdenv.lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
@@ -23,8 +23,7 @@ buildRustPackage rec {
 
   outputs = [ "out" "man" ];
   preFixup = ''
-    mkdir -p "$man/man/man1"
-    cp target/release/build/git-ignore-*/out/git-ignore.1 "$man/man/man1/"
+    installManPage $releaseDir/build/git-ignore-*/out/git-ignore.1
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/rust/racerd/default.nix
+++ b/pkgs/development/tools/rust/racerd/default.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -p target/release/racerd $out/bin/
+    cp -p $releaseDir/racerd $out/bin/
     wrapProgram $out/bin/racerd --set-default RUST_SRC_PATH "$RUST_SRC_PATH"
   '';
 

--- a/pkgs/tools/misc/broot/default.nix
+++ b/pkgs/tools/misc/broot/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     # install shell completion files
-    OUT_DIR=target/release/build/broot-*/out
+    OUT_DIR=$releaseDir/build/broot-*/out
 
     installShellCompletion --bash $OUT_DIR/{br,broot}.bash
     installShellCompletion --fish $OUT_DIR/{br,broot}.fish

--- a/pkgs/tools/misc/fd/default.nix
+++ b/pkgs/tools/misc/fd/default.nix
@@ -18,9 +18,8 @@ rustPlatform.buildRustPackage rec {
   preFixup = ''
     installManPage "$src/doc/fd.1"
 
-    (cd target/release/build/fd-find-*/out
-    installShellCompletion fd.{bash,fish}
-    installShellCompletion --zsh _fd)
+    installShellCompletion $releaseDir/build/fd-find-*/out/fd.{bash,fish}
+    installShellCompletion --zsh $releaseDir/build/fd-find-*/out/_fd
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/lsd/default.nix
+++ b/pkgs/tools/misc/lsd/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
   postInstall = ''
-    installShellCompletion target/release/build/lsd-*/out/{_lsd,lsd.{bash,fish}}
+    installShellCompletion $releaseDir/build/lsd-*/out/{_lsd,lsd.{bash,fish}}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/networking/tox-node/default.nix
+++ b/pkgs/tools/networking/tox-node/default.nix
@@ -24,7 +24,7 @@ buildRustPackage rec {
   installPhase = ''
     runHook preInstall
 
-    install -D target/release/tox-node $out/bin/tox-node
+    install -D $releaseDir/tox-node $out/bin/tox-node
 
     runHook postInstall
   '';

--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -30,9 +30,9 @@ rustPlatform.buildRustPackage rec {
   ++ (stdenv.lib.optional stdenv.isDarwin Security);
 
   preFixup = ''
-    (cd target/release/build/ripgrep-*/out
-    installManPage rg.1
-    installShellCompletion rg.{bash,fish})
+    installManPage $releaseDir/build/ripgrep-*/out/rg.1
+
+    installShellCompletion $releaseDir/build/ripgrep-*/out/rg.{bash,fish}
     installShellCompletion --zsh "$src/complete/_rg"
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Some cleanup in preparation for https://github.com/NixOS/nixpkgs/pull/82342.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@Ma27 I cherry-picked your `librustzcash` fix and reworded the commit message to slightly decouple it from https://github.com/NixOS/nixpkgs/pull/82342.

I built and ran all of these packages by running `{binary} --help`. They all displayed their help flags at least (except for `cfdyndns`, which panicked without some env vars set).

@bhipple A few of the packages that showed up in `git grep target/release` actually need it (or, at least, don't benefit from it being changed to `$releaseDir`). Just figured I'd let you know why I left out `ycmd` and `vdirsyncer`.