### PR TITLE
ioping: add support for netdata

### DIFF
--- a/pkgs/tools/system/ioping/default.nix
+++ b/pkgs/tools/system/ioping/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub
+, withNetdata ? false
+}:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "ioping";
@@ -11,9 +15,15 @@ stdenv.mkDerivation rec {
     sha256 = "10bv36bqga8sdifxzywzzpjil7vmy62psirz7jbvlsq1bw71aiid";
   };
 
+  patches = optional withNetdata [
+    # Add support for netdata
+    # https://github.com/koct9i/ioping/pull/41
+    ./ioping-netdata.patch
+  ];
+
   makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "Disk I/O latency measuring tool";
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.unix;

--- a/pkgs/tools/system/ioping/ioping-netdata.patch
+++ b/pkgs/tools/system/ioping/ioping-netdata.patch
@@ -1,0 +1,128 @@
+diff --git a/ioping.1 b/ioping.1
+index 8eaa98e..8fec21e 100644
+--- a/ioping.1
++++ b/ioping.1
+@@ -3,7 +3,7 @@
+ ioping \- simple disk I/O latency monitoring tool
+ .SH SYNOPSYS
+ .SY ioping
+-.OP \-ABCDJLRWGYykq
++.OP \-ABCDJLRWGYykqN
+ .OP \-a count
+ .OP \-c count
+ .OP \-i interval
+@@ -123,6 +123,9 @@ Keep and reuse temporary working file "ioping.tmp" (only for directory target).
+ \fB\-q\fR, \fB\-quiet\fR
+ Suppress periodical human-readable output.
+ .TP
++\fB\-N\fR
++Use output format compatible with netdata.
++.TP
+ \fB\-h\fR, \fB\-help\fR
+ Display help message and exit.
+ .TP
+diff --git a/ioping.c b/ioping.c
+index 76835d2..6abb29d 100644
+--- a/ioping.c
++++ b/ioping.c
+@@ -484,6 +484,7 @@ int fd;
+ void *buf;
+ 
+ int quiet = 0;
++int netdata_output = 0;
+ int batch_mode = 0;
+ int direct = 0;
+ int cached = 0;
+@@ -525,7 +526,7 @@ int json_line = 0;
+ 
+ int exiting = 0;
+ 
+-const char *options = "hvkALRDCWGYBqyi:t:T:w:s:S:c:o:p:P:l:r:a:J";
++const char *options = "hvkALRDCWGYBNqyi:t:T:w:s:S:c:o:p:P:l:r:a:J";
+ 
+ #ifdef HAVE_GETOPT_LONG_ONLY
+ 
+@@ -610,6 +611,7 @@ void usage(void)
+ 			"      -B, -batch                 print final statistics in raw format\n"
+ 			"      -J, -json                  print output in JSON format\n"
+ 			"      -q, -quiet                 suppress human-readable output\n"
++      "      -N                         use output format compatible with netdata\n"
+ 			"      -h, -help                  display this message and exit\n"
+ 			"      -v, -version               display version and exit\n"
+ 			"\n"
+@@ -716,6 +718,9 @@ void parse_options(int argc, char **argv)
+ 			case 'q':
+ 				quiet = 1;
+ 				break;
++      case 'N':
++        netdata_output = 1;
++        break;
+ 			case 'B':
+ 				quiet = 1;
+ 				batch_mode = 1;
+@@ -743,6 +748,19 @@ void parse_options(int argc, char **argv)
+ 	if (optind < argc-1)
+ 		errx(1, "more than one destination specified");
+ 	path = argv[optind];
++
++  if (netdata_output) {
++    if (stop_at_request || custom_deadline || period_request || period_time || custom_deadline || write_read_test)
++      errx(1, "-c, -w, -p, -P, -R, and -G options are incompatible with netdata output (-N)");
++
++    if (interval < NSEC_PER_SEC) {
++      interval = NSEC_PER_SEC;
++      warnx("the minimal interval for netdata is 1 second");
++    } else {
++      interval = roundl(interval / NSEC_PER_SEC) * NSEC_PER_SEC;
++      warnx("round interval to %lld seconds", interval / NSEC_PER_SEC);
++    }
++  }
+ }
+ 
+ #ifdef __linux__
+@@ -1271,6 +1289,34 @@ static void dump_statistics(struct statistics *s) {
+ 			(unsigned long)s->load_time);
+ }
+ 
++void print_netdata(ssize_t ret_size, long long time_now, long long this_time) {
++  static int sent_chart = 0;
++  static long long time_prev = 0;
++
++  fflush(stdout);
++
++  if (!sent_chart) {
++    printf("CHART 'ioping.%s_", path);
++    print_size(ret_size);
++    printf("_%s_latency' '' '%s Latency for %s' microseconds '%s' ioping.latency line 110030 %lld '' ioping.plugin\n"
++         , write_test ? "write" : "read"
++         , write_test ? "Write" : "Read"
++         , path
++         , path
++         , interval / NSEC_PER_SEC);
++    printf("DIMENSION latency '' absolute 1 1000\n");
++    sent_chart = 1;
++  }
++
++  printf("BEGIN 'ioping.%s_", path);
++  print_size(ret_size);
++  printf("_%s_latency' %lld\n", write_test ? "write" : "read", time_prev ? (time_now - time_prev) / 1000 : 0);
++  time_prev = time_now;
++
++  printf("SET latency %lld\n", this_time);
++  printf("END\n");
++}
++
+ static void json_request(size_t io_size, long long io_time, int valid)
+ {
+ 	printf("%s{\n"
+@@ -1610,7 +1656,9 @@ skip_preparation:
+ 
+ 		valid = add_statistics(&part, this_time);
+ 
+-		if (quiet) {
++    if (netdata_output) {
++      print_netdata(ret_size, time_now, this_time);
++    } else if (quiet) {
+ 			/* silence */
+ 		} else if (json) {
+ 			json_request(ret_size, this_time, valid);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add patch to enable work netdata ioping plugin.
The patch is based on PR https://github.com/koct9i/ioping/pull/41

cc @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
