### PR TITLE
treewide: fix redirected urls (again)

### DIFF
--- a/pkgs/applications/audio/MMA/default.nix
+++ b/pkgs/applications/audio/MMA/default.nix
@@ -61,7 +61,7 @@
 
   meta = {
     description = "Creates MIDI tracks for a soloist to perform over from a user supplied file containing chords";
-    homepage =  https://www.mellowood.ca/mma/index.html;
+    homepage =  "https://www.mellowood.ca/mma/index.html";
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/audio/MMA/default.nix
+++ b/pkgs/applications/audio/MMA/default.nix
@@ -61,7 +61,7 @@
 
   meta = {
     description = "Creates MIDI tracks for a soloist to perform over from a user supplied file containing chords";
-    homepage =  http://www.mellowood.ca/mma/index.html;
+    homepage =  https://www.mellowood.ca/mma/index.html;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/audio/traverso/default.nix
+++ b/pkgs/applications/audio/traverso/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Cross-platform multitrack audio recording and audio editing suite";
-    homepage = https://traverso-daw.org/;
+    homepage = "https://traverso-daw.org/";
     license = with licenses; [ gpl2Plus lgpl21Plus ];
     platforms = platforms.all;
     maintainers = with maintainers; [ coconnor ];

--- a/pkgs/applications/audio/traverso/default.nix
+++ b/pkgs/applications/audio/traverso/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   version = "0.49.6";
 
   src = fetchurl {
-    url = "http://traverso-daw.org/traverso-0.49.6.tar.gz";
+    url = "https://traverso-daw.org/traverso-0.49.6.tar.gz";
     sha256 = "12f7x8kw4fw1j0xkwjrp54cy4cv1ql0zwz2ba5arclk4pf6bhl7q";
   };
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Cross-platform multitrack audio recording and audio editing suite";
-    homepage = http://traverso-daw.org/;
+    homepage = https://traverso-daw.org/;
     license = with licenses; [ gpl2Plus lgpl21Plus ];
     platforms = platforms.all;
     maintainers = with maintainers; [ coconnor ];

--- a/pkgs/applications/editors/flpsed/default.nix
+++ b/pkgs/applications/editors/flpsed/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "WYSIWYG PostScript annotator";
-    homepage = https://flpsed.org/flpsed.html;
+    homepage = "https://flpsed.org/flpsed.html";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ];

--- a/pkgs/applications/editors/flpsed/default.nix
+++ b/pkgs/applications/editors/flpsed/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "WYSIWYG PostScript annotator";
-    homepage = http://flpsed.org/flpsed.html;
+    homepage = https://flpsed.org/flpsed.html;
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ];

--- a/pkgs/applications/misc/devilspie2/default.nix
+++ b/pkgs/applications/misc/devilspie2/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       positioned at a specific screen position, or position a window
       on a specific workspace.
     '';
-    homepage = https://www.gusnan.se/devilspie2/;
+    homepage = "https://www.gusnan.se/devilspie2/";
     license = licenses.gpl3;
     maintainers = [ maintainers.ebzzry ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/devilspie2/default.nix
+++ b/pkgs/applications/misc/devilspie2/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       positioned at a specific screen position, or position a window
       on a specific workspace.
     '';
-    homepage = http://www.gusnan.se/devilspie2/;
+    homepage = https://www.gusnan.se/devilspie2/;
     license = licenses.gpl3;
     maintainers = [ maintainers.ebzzry ];
     platforms = platforms.linux;

--- a/pkgs/applications/radio/gqrx/default.nix
+++ b/pkgs/applications/radio/gqrx/default.nix
@@ -38,7 +38,7 @@ mkDerivation rec {
       including Funcube Dongle Pro/Pro+, rtl-sdr, HackRF, and Universal
       Software Radio Peripheral (USRP) devices.
     '';
-    homepage = https://gqrx.dk/;
+    homepage = "https://gqrx.dk/";
     # Some of the code comes from the Cutesdr project, with a BSD license, but
     # it's currently unknown which version of the BSD license that is.
     license = licenses.gpl3Plus;

--- a/pkgs/applications/radio/gqrx/default.nix
+++ b/pkgs/applications/radio/gqrx/default.nix
@@ -38,7 +38,7 @@ mkDerivation rec {
       including Funcube Dongle Pro/Pro+, rtl-sdr, HackRF, and Universal
       Software Radio Peripheral (USRP) devices.
     '';
-    homepage = http://gqrx.dk/;
+    homepage = https://gqrx.dk/;
     # Some of the code comes from the Cutesdr project, with a BSD license, but
     # it's currently unknown which version of the BSD license that is.
     license = licenses.gpl3Plus;

--- a/pkgs/applications/video/vokoscreen/default.nix
+++ b/pkgs/applications/video/vokoscreen/default.nix
@@ -40,7 +40,7 @@ mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Simple GUI screencast recorder, using ffmpeg";
-    homepage = "http://linuxecke.volkoh.de/vokoscreen/vokoscreen.html";
+    homepage = "https://linuxecke.volkoh.de/vokoscreen/vokoscreen.html";
     longDescription = ''
       vokoscreen is an easy to use screencast creator to record
       educational videos, live recordings of browser, installation,

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool glib exo libXtst xorgproto libxfce4util libxfce4ui xfce4-panel xfconf gtk2 hicolor-icon-theme ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "CPU graph show for Xfce panel";
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-dict-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-dict-plugin.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel xfconf gtk2 ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Dictionary plugin for Xfce panel";
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel xfconf gtk2 ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Embed arbitrary app windows on Xfce panel";
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-eyes-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-eyes-plugin.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel xfconf gtk2 ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Eyes following you!";
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-fsguard-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-fsguard-plugin.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel xfconf gtk2 ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Filesystem monitor";
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-genmon-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-genmon-plugin.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel xfconf gtk2 ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Cyclically spawns a command and captures its output";
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${pname}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${pname}";
     description = "Hardware monitor plugin for the XFCE4 panel";
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     xfconf gtk2 exo gnutls libgcrypt ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Mailwatch plugin for Xfce panel";
     platforms = platforms.linux;
     maintainers = [ ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     xfconf gtk2 exo ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "MPD plugin for Xfce panel";
     platforms = platforms.linux;
     maintainers = [ ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel xfconf gtk2 libunique ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Sticky notes plugin for Xfce panel";
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${pname}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${pname}";
     description = "A panel plug-in for different sensors using acpi, lm_sensors and hddtemp";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel gtk2 ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "System load plugin for Xfce panel";
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "A simple XFCE panel plugin that lets the user run an alarm at a specified time or at the end of a specified countdown period";
     platforms = platforms.linux;
     license = licenses.gpl2;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Weather plugin for the Xfce desktop environment";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    homepage = "https://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Set of two plugins which allows you to put the maximized window title and windows buttons on the panel";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -57,7 +57,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A strongly-typed functional programming language that compiles to JavaScript";
-    homepage = https://www.purescript.org/;
+    homepage = "https://www.purescript.org/";
     license = licenses.bsd3;
     maintainers = [ maintainers.justinwoo maintainers.mbbx6spp ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -57,7 +57,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A strongly-typed functional programming language that compiles to JavaScript";
-    homepage = http://www.purescript.org/;
+    homepage = https://www.purescript.org/;
     license = licenses.bsd3;
     maintainers = [ maintainers.justinwoo maintainers.mbbx6spp ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage    = https://www.openldap.org/;
+    homepage = "https://www.openldap.org/";
     description = "An open source implementation of the Lightweight Directory Access Protocol";
     license = licenses.openldap;
     maintainers = with maintainers; [ lovek323 ];

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage    = http://www.openldap.org/;
+    homepage    = https://www.openldap.org/;
     description = "An open source implementation of the Lightweight Directory Access Protocol";
     license = licenses.openldap;
     maintainers = with maintainers; [ lovek323 ];

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -41,7 +41,7 @@ let src = fetchFromGitHub {
     pname = "ppx_tools";
     meta = with stdenv.lib; {
       description = "Tools for authors of ppx rewriters";
-      homepage = https://www.lexifi.com/ppx_tools;
+      homepage = "https://www.lexifi.com/ppx_tools";
       license = licenses.mit;
       maintainers = with maintainers; [ vbgl ];
     };

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -41,7 +41,7 @@ let src = fetchFromGitHub {
     pname = "ppx_tools";
     meta = with stdenv.lib; {
       description = "Tools for authors of ppx rewriters";
-      homepage = http://www.lexifi.com/ppx_tools;
+      homepage = https://www.lexifi.com/ppx_tools;
       license = licenses.mit;
       maintainers = with maintainers; [ vbgl ];
     };

--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -79,7 +79,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
-    homepage = "http://github.com/quantumlib/cirq";
+    homepage = "https://github.com/quantumlib/cirq";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };

--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Video editing with Python";
-    homepage = https://zulko.github.io/moviepy/;
+    homepage = "https://zulko.github.io/moviepy/";
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Video editing with Python";
-    homepage = http://zulko.github.io/moviepy/;
+    homepage = https://zulko.github.io/moviepy/;
     license = licenses.mit;
   };
 

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -67,10 +67,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Package and build manager for D applications and libraries";
-    homepage = https://code.dlang.org/;
+    homepage = "https://code.dlang.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ ThomasMader ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }
-

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Package and build manager for D applications and libraries";
-    homepage = http://code.dlang.org/;
+    homepage = https://code.dlang.org/;
     license = licenses.mit;
     maintainers = with maintainers; [ ThomasMader ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];

--- a/pkgs/misc/emulators/vbam/default.nix
+++ b/pkgs/misc/emulators/vbam/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     description = "A merge of the original Visual Boy Advance forks";
     license = licenses.gpl2;
     maintainers = with maintainers; [ lassulus ];
-    homepage = https://vba-m.com/;
+    homepage = "https://vba-m.com/";
     platforms = stdenv.lib.platforms.linux;
     badPlatforms = [ "aarch64-linux" ];
   };

--- a/pkgs/misc/emulators/vbam/default.nix
+++ b/pkgs/misc/emulators/vbam/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     description = "A merge of the original Visual Boy Advance forks";
     license = licenses.gpl2;
     maintainers = with maintainers; [ lassulus ];
-    homepage = http://vba-m.com/;
+    homepage = https://vba-m.com/;
     platforms = stdenv.lib.platforms.linux;
     badPlatforms = [ "aarch64-linux" ];
   };

--- a/pkgs/misc/frescobaldi/default.nix
+++ b/pkgs/misc/frescobaldi/default.nix
@@ -28,7 +28,7 @@ buildPythonApplication rec {
   ];
 
   meta = with lib; {
-    homepage = https://frescobaldi.org/;
+    homepage = "https://frescobaldi.org/";
     description = ''Frescobaldi is a LilyPond sheet music text editor'';
     longDescription = ''
       Powerful text editor with syntax highlighting and automatic completion, 

--- a/pkgs/misc/frescobaldi/default.nix
+++ b/pkgs/misc/frescobaldi/default.nix
@@ -28,7 +28,7 @@ buildPythonApplication rec {
   ];
 
   meta = with lib; {
-    homepage = http://frescobaldi.org/;
+    homepage = https://frescobaldi.org/;
     description = ''Frescobaldi is a LilyPond sheet music text editor'';
     longDescription = ''
       Powerful text editor with syntax highlighting and automatic completion, 

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -18,7 +18,7 @@ let
   apparmor-version = apparmor-series + "." + apparmor-patchver;
 
   apparmor-meta = component: with stdenv.lib; {
-    homepage = https://apparmor.net/;
+    homepage = "https://apparmor.net/";
     description = "A mandatory access control system - ${component}";
     license = licenses.gpl2;
     maintainers = with maintainers; [ phreedom thoughtpolice joachifm ];

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -18,7 +18,7 @@ let
   apparmor-version = apparmor-series + "." + apparmor-patchver;
 
   apparmor-meta = component: with stdenv.lib; {
-    homepage = http://apparmor.net/;
+    homepage = https://apparmor.net/;
     description = "A mandatory access control system - ${component}";
     license = licenses.gpl2;
     maintainers = with maintainers; [ phreedom thoughtpolice joachifm ];


### PR DESCRIPTION
Ran the same script as #78265.
Additionally, manually replaced `http://goodies.xfce.org`
with https.

@ryantm: Maybe we could integrate this behaviour in @r-ryantm?
