### PR TITLE
rpcs3: 0.0.6-8187-790962425 -> 0.0.8-9300-341fdf7eb

### DIFF
--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, lib, fetchgit, cmake, pkgconfig, git
-, qt5, openal, glew, vulkan-loader, libpng, ffmpeg, libevdev, python27
+{ mkDerivation, lib, fetchgit, cmake, pkgconfig, git
+, qtbase, qtquickcontrols, openal, glew, vulkan-loader, libpng, ffmpeg, libevdev, python3
 , pulseaudioSupport ? true, libpulseaudio
 , waylandSupport ? true, wayland
 , alsaSupport ? true, alsaLib
 }:
 
 let
-  majorVersion = "0.0.6";
-  gitVersion = "8187-790962425"; # echo $(git rev-list HEAD --count)-$(git rev-parse --short HEAD)
+  majorVersion = "0.0.8";
+  gitVersion = "9300-341fdf7eb"; # echo $(git rev-list HEAD --count)-$(git rev-parse --short HEAD)
 in
-stdenv.mkDerivation {
+mkDerivation {
   pname = "rpcs3";
   version = "${majorVersion}-${gitVersion}";
 
   src = fetchgit {
     url = "https://github.com/RPCS3/rpcs3";
-    rev = "790962425cfb893529f72b3ef0dd1424fcc42973";
-    sha256 = "154ys29b9xdws3bp4b7rb3kc0h9hd49g2yf3z9268cdq8aclahaa";
+    rev = "341fdf7eb14763fd06e2eab9a4b2b8f1adf9fdbd";
+    sha256 = "1qx97zkkjl6bmv5rhfyjqynbz0v8h40b2wxqnl59g287wj0yk3y1";
   };
 
   preConfigure = ''
@@ -36,14 +36,14 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake pkgconfig git ];
 
   buildInputs = [
-    qt5.qtbase qt5.qtquickcontrols openal glew vulkan-loader libpng ffmpeg libevdev python27
+    qtbase qtquickcontrols openal glew vulkan-loader libpng ffmpeg libevdev python3
   ] ++ lib.optional pulseaudioSupport libpulseaudio
     ++ lib.optional alsaSupport alsaLib
     ++ lib.optional waylandSupport wayland;
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "PS3 emulator/debugger";
     homepage = "https://rpcs3.net/";
     maintainers = with maintainers; [ abbradar nocent ];


### PR DESCRIPTION
###### Motivation for this change
Resolves https://github.com/NixOS/nixpkgs/issues/82954

See: https://github.com/NixOS/nixpkgs/issues/65399

Took the chance to update the version as well as the Qt build stuff.

While there is a tagged 0.0.9 release, it requires a Qt version >= 5.14 and the latest version we seem to package is 5.12.

cc @dali99. Build was tested and emulator starts up, not intensely tested because I don't have the required images to run anything with it. Maybe you could give that a shot?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  575256384 -> 402994504
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
