### PR TITLE
volctl: 0.6.2 -> 0.6.3

### DIFF
--- a/pkgs/tools/audio/volctl/default.nix
+++ b/pkgs/tools/audio/volctl/default.nix
@@ -2,13 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "volctl";
-  version = "0.6.2";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "buzz";
     repo = pname;
     rev = version;
-    sha256 = "1bqq5mrpi7qxzl37z6fj67pqappjmwhi8d8db95j3lmf16svm2xk";
+    sha256 = "0rppqc5wiqxd83z2mgvhi6gdx7yhy9wnav1dbbi1wvm7lzw6fnil";
   };
 
   nativeBuildInputs = [
@@ -28,14 +28,6 @@ pythonPackages.buildPythonApplication rec {
 
   strictDeps = false;
 
-  postPatch = ''
-    # The user can set a mixer application in the preferences. The
-    # default is pavucontrol. Do not hard code its path and hope it
-    # can be found in $PATH.
-
-    substituteInPlace volctl/app.py --replace /usr/bin/pavucontrol pavucontrol
-  '';
-
   preBuild = ''
     export LD_LIBRARY_PATH=${libpulseaudio}/lib
   '';
@@ -50,7 +42,7 @@ pythonPackages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "PulseAudio enabled volume control featuring per-app sliders";
-    homepage = https://buzz.github.io/volctl/;
+    homepage = "https://buzz.github.io/volctl/";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [0.6.3](https://github.com/buzz/volctl/releases/tag/0.6.3)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).