### PR TITLE
epkowa: add the GT-S650 plugin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1925,6 +1925,12 @@
     githubId = 126339;
     name = "Domen Kozar";
   };
+  dominikh = {
+    email = "dominik@honnef.co";
+    github = "dominikh";
+    githubId = 39825;
+    name = "Dominik Honnef";
+  };
   doronbehar = {
     email = "me@doronbehar.com";
     github = "doronbehar";

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -153,6 +153,39 @@ let plugins = {
 
     meta = common_meta // { description = "iscan esci s80 plugin for "+passthru.hw; };
   };
+  s650 = stdenv.mkDerivation rec {
+    name = "iscan-gt-s650-bundle";
+    version = "2.30.4";
+
+    src = fetchurl {
+      urls = [
+        "https://download2.ebz.epson.net/iscan/plugin/gt-s650/rpm/x64/iscan-gt-s650-bundle-${version}.x64.rpm.tar.gz"
+        "https://web.archive.org/web/https://download2.ebz.epson.net/iscan/plugin/gt-s650/rpm/x64/iscan-gt-s650-bundle-${version}.x64.rpm.tar.gz"
+      ];
+      sha256 = "1ffddf488c5fc1eb39452499951bd13a2dc1971980c0551176076c81af363038";
+    };
+
+    nativeBuildInputs = [ autoPatchelfHook rpm ];
+
+    installPhase = ''
+      cd plugins
+      ${rpm}/bin/rpm2cpio iscan-plugin-gt-s650-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      mkdir $out
+      cp -r usr/share $out
+      cp -r usr/lib64 $out/lib
+      mv $out/share/iscan $out/share/esci
+      mv $out/lib/iscan $out/lib/esci
+      '';
+
+    passthru = {
+      registrationCommand = ''
+        $registry --add interpreter usb 0x04b8 0x013c "$plugin/lib/esci/libiscan-plugin-gt-s650 $plugin/share/esci/esfw010c.bin"
+        $registry --add interpreter usb 0x04b8 0x013d "$plugin/lib/esci/libiscan-plugin-gt-s650 $plugin/share/esci/esfw010c.bin"
+        '';
+      hw = "GT-S650, Perfection V19, Perfection V39";
+    };
+    meta = common_meta // { description = "iscan GT-S650 for "+passthru.hw; };
+  };
   network = stdenv.mkDerivation rec {
     pname = "iscan-nt-bundle";
     # for the version, look for the driver of XP-750 in the search page

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -311,6 +311,6 @@ stdenv.mkDerivation rec {
       Supported hardware: at least :
     '' +
     stdenv.lib.concatStringsSep ", " (stdenv.lib.mapAttrsToList (name: value: value.passthru.hw) plugins);
-    maintainers = with stdenv.lib.maintainers; [ symphorien ];
+    maintainers = with stdenv.lib.maintainers; [ symphorien dominikh ];
   };
 }

--- a/pkgs/misc/drivers/epkowa/firmware_location.patch
+++ b/pkgs/misc/drivers/epkowa/firmware_location.patch
@@ -8,12 +8,13 @@ set this environment variable. Instead, we patch iscan to set this variable
 before loading libesci-interpreter-gt-f720.so.
 --- backend/channel-usb.c.orig	2017-08-14 11:24:27.669582456 +0200
 +++ backend/channel-usb.c	2017-08-14 11:31:40.509010897 +0200
-@@ -169,6 +169,9 @@
+@@ -169,6 +169,10 @@
  {
    SANE_Status s;
  
 +  setenv("ESCI_FIRMWARE_DIR", NIX_ESCI_PREFIX, 1);
 +  setenv("ISCAN_FW_DIR", NIX_ESCI_PREFIX, 1);
++  setenv("ISCAN_FIRMWARE_DIR", NIX_ESCI_PREFIX, 1);
 +
    s = sanei_usb_open (self->name, &self->fd);
  


### PR DESCRIPTION
This plugin adds support for the GT-S650, Perfection V19 and
Perfection V39 scanners. I've tested it personally with an Epson
Perfection V39.

This plugin uses the ISCAN_FIRMWARE_DIR environment variable, not
ISCAN_FW_DIR. A quick grep didn't find any use of ISCAN_FW_DIR in the
currently packaged plugins, but a quick Google suggests that this
variable does (or at least used to) exist, so I'm not touching it.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
