### PR TITLE
vim-plugins: Add --debug flag to update.py.

### DIFF
--- a/pkgs/misc/vim-plugins/update.py
+++ b/pkgs/misc/vim-plugins/update.py
@@ -407,6 +407,12 @@ def parse_args():
         default=DEFAULT_OUT,
         help="Filename to save generated nix code",
     )
+    parser.add_argument(
+        "--sync",
+        dest="sync",
+        action="store_true",
+        help="Fetch plugins synchronously. This can be useful for debugging."
+    )
 
     return parser.parse_args()
 
@@ -421,10 +427,11 @@ def main() -> None:
     prefetch_with_cache = functools.partial(prefetch, cache=cache)
 
     try:
-        # synchronous variant for debugging
-        # results = list(map(prefetch_with_cache, plugin_names))
-        pool = Pool(processes=30)
-        results = pool.map(prefetch_with_cache, plugin_names)
+        if args.sync:
+            results = list(map(prefetch_with_cache, plugin_names))
+        else:
+            pool = Pool(processes=30)
+            results = pool.map(prefetch_with_cache, plugin_names)
     finally:
         cache.store()
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I don't know how anybody is able to use this pooling so many github requests simultaneously. Github has always rate-banned me for doing stuff like this, even synchronously if it's too fast. At least with this flag one doesn't have to edit update.py to toggle this behavior.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
