### PR TITLE
vollkorn: init at 4.105

### DIFF
--- a/pkgs/data/fonts/vollkorn/default.nix
+++ b/pkgs/data/fonts/vollkorn/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchzip }:
+let
+  version = "4.105";
+in fetchzip rec {
+  name = "vollkorn-${version}";
+
+  url = "http://vollkorn-typeface.com/download/vollkorn-4-105.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -j $downloadedFile \*.ttf   -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.otf   -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.woff  -d $out/share/fonts/woff
+    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2
+    unzip -j $downloadedFile \*.eot   -d $out/share/fonts/EOT
+    unzip -j $downloadedFile {Fontlog,OFL,OFL-FAQ}.txt  -d "$out/share/doc/${name}"
+  '';
+
+  sha256 = "0inm64q7bsg0z9hx5ba1qqcchrg7b3qaqkd4h63392515dnpjks9";
+
+  meta = with lib; {
+    homepage = "http://vollkorn-typeface.com/";
+    description = "The free and healthy typeface for bread and butter use";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rasendubi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7116,6 +7116,8 @@ in
 
   volatility = callPackage ../tools/security/volatility { };
 
+  vollkorn = callPackage ../data/fonts/vollkorn { };
+
   vbetool = callPackage ../tools/system/vbetool { };
 
   vde2 = callPackage ../tools/networking/vde2 { };


### PR DESCRIPTION
###### Motivation for this change
I want to use this font.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
