### PR TITLE
patch-shebangs.sh: fix error messages to go to stderr, not '0' file

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -42,7 +42,7 @@ patchShebangs() {
     local newInterpreterLine
 
     if [ $# -eq 0 ]; then
-        echo "No arguments supplied to patchShebangs" >0
+        echo "No arguments supplied to patchShebangs" >&2
         return 0
     fi
 
@@ -66,7 +66,7 @@ patchShebangs() {
             # - options: something starting with a '-'
             # - environment variables: foo=bar
             if $(echo "$arg0" | grep -q -- "^-.*\|.*=.*"); then
-                echo "$f: unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)" >0
+                echo "$f: unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)" >&2
                 exit 1
             fi
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`patch-shebangs.sh` displays error messages when it's called without arguments, and when it can't handle a shebang line it finds.  However, these error messages are being written to a `0` file rather than stdout or stderr, so these error messages never appear in build logs, and a build will simply fail with for example:

    ...
    patching script interpreter paths in /nix/store/...-shebangs-error-test
    builder for '/nix/store/...-shebangs-error-test.drv' failed with exit code 1
    error: build of '/nix/store/...-shebangs-error-test.drv' failed

without showing the cause of the failure.  This change sends the error messages to stderr instead.

I've tested this change by building the `shebangs-error-test.nix` on before and after the change applied to staging, and ensured that the error message appeared with the change applied.  This looks like it will force lots of rebuilds, since some `bootstrap-stage0` and `bootstrap-stage1` rebuilds were triggered just for this test build.  I'm also attempting to build the NixOS boot.nix test, but because of the rebuilds, this might take a while.

...Unless a `0` file has some significance somewhere and I'm simply not aware of it!

shebangs-error-test.nix:

    with import ./. {};
    let
      script = writeScript "foo" ''
        #!/usr/bin/env -S python3 -u
        print("Hello, world!")
      '';
    in
    stdenv.mkDerivation {
      name = "shebangs-error-test";
      unpackPhase = "true";
      installPhase = ''
        mkdir -p $out/bin
        cp ${script} $out/bin/foo
      '';
    }

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
