### PR TITLE
ghc: update bootstrap 8.6.3 -> 8.6.5, add aarch64 support

### DIFF
--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -24,22 +24,23 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "8.6.3";
+  version = "8.6.5";
 
   name = "ghc-${version}-binary";
 
+  # https://downloads.haskell.org/~ghc/8.6.5/
   src = fetchurl ({
     i686-linux = {
-      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-deb8-linux.tar.xz";
-      sha256 = "0bw8a7fxcbskf93rb4m542ff66vrmx5i5kj77qx37cbhijx70w5m";
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-deb9-linux.tar.xz";
+      sha256 = "1p2h29qghql19ajk755xa0yxkn85slbds8m9n5196ris743vkp8w";
     };
     x86_64-linux = {
-      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-deb8-linux.tar.xz";
-      sha256 = "1m9gaga2pzi2cx5gvasg0rx1dlvr68gmi20l67652kag6xjsa719";
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-deb9-linux.tar.xz";
+      sha256 = "1pqlx6rdjs2110g0y1i9f8x18lmdizibjqd15f5xahcz39hgaxdw";
     };
     x86_64-darwin = {
       url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
-      sha256 = "1hbzk57v45176kxcx848p5jn5p1xbp2129ramkbzsk6plyhnkl3r";
+      sha256 = "0s9188vhhgf23q3rjarwhbr524z6h2qga5xaaa2pma03sfqvvhfz";
     };
   }.${stdenv.hostPlatform.system}
     or (throw "cannot bootstrap GHC on this platform"));

--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -1,12 +1,15 @@
 { stdenv
 , fetchurl, perl, gcc
 , ncurses5, gmp, glibc, libiconv
+, llvmPackages
 }:
 
 # Prebuilt only does native
 assert stdenv.targetPlatform == stdenv.hostPlatform;
 
 let
+  useLLVM = !stdenv.targetPlatform.isx86;
+
   libPath = stdenv.lib.makeLibraryPath ([
     ncurses5 gmp
   ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
@@ -38,6 +41,10 @@ stdenv.mkDerivation rec {
       url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-deb9-linux.tar.xz";
       sha256 = "1pqlx6rdjs2110g0y1i9f8x18lmdizibjqd15f5xahcz39hgaxdw";
     };
+    aarch64-linux = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-aarch64-ubuntu18.04-linux.tar.xz";
+      sha256 = "11n7l2a36i5vxzzp85la2555q4m34l747g0pnmd81cp46y85hlhq";
+    };
     x86_64-darwin = {
       url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
       sha256 = "0s9188vhhgf23q3rjarwhbr524z6h2qga5xaaa2pma03sfqvvhfz";
@@ -46,6 +53,7 @@ stdenv.mkDerivation rec {
     or (throw "cannot bootstrap GHC on this platform"));
 
   nativeBuildInputs = [ perl ];
+  propagatedBuildInputs = stdenv.lib.optionals useLLVM [ llvmPackages.llvm ];
 
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
   # the final install location/
@@ -169,5 +177,5 @@ stdenv.mkDerivation rec {
   };
 
   meta.license = stdenv.lib.licenses.bsd3;
-  meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
+  meta.platforms = ["x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
 }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -4,7 +4,7 @@ let
   # These are attributes in compiler and packages that don't support integer-simple.
   integerSimpleExcludes = [
     "ghc822Binary"
-    "ghc863Binary"
+    "ghc865Binary"
     "ghc844"
     "ghcjs"
     "ghcjs86"
@@ -42,7 +42,7 @@ in {
 
     ghc822Binary = callPackage ../development/compilers/ghc/8.2.2-binary.nix { };
 
-    ghc863Binary = callPackage ../development/compilers/ghc/8.6.3-binary.nix { };
+    ghc865Binary = callPackage ../development/compilers/ghc/8.6.5-binary.nix { };
 
     ghc844 = callPackage ../development/compilers/ghc/8.4.4.nix {
       bootPkgs = packages.ghc822Binary;
@@ -57,31 +57,31 @@ in {
       llvmPackages = pkgs.llvmPackages_6;
     };
     ghc881 = callPackage ../development/compilers/ghc/8.8.1.nix {
-      bootPkgs = packages.ghc863Binary;
+      bootPkgs = packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_7;
       llvmPackages = pkgs.llvmPackages_7;
     };
     ghc882 = callPackage ../development/compilers/ghc/8.8.2.nix {
-      bootPkgs = packages.ghc863Binary;
+      bootPkgs = packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_7;
       llvmPackages = pkgs.llvmPackages_7;
     };
     ghc883 = callPackage ../development/compilers/ghc/8.8.3.nix {
-      bootPkgs = packages.ghc863Binary;
+      bootPkgs = packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_7;
       llvmPackages = pkgs.llvmPackages_7;
     };
     ghc8101 = callPackage ../development/compilers/ghc/8.10.1.nix {
-      bootPkgs = packages.ghc863Binary;
+      bootPkgs = packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_9;
       llvmPackages = pkgs.llvmPackages_9;
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
-      bootPkgs = packages.ghc863Binary;
+      bootPkgs = packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_6;
       llvmPackages = pkgs.llvmPackages_6;
@@ -117,9 +117,9 @@ in {
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
       packageSetConfig = bootstrapPackageSet;
     };
-    ghc863Binary = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc863Binary;
-      ghc = bh.compiler.ghc863Binary;
+    ghc865Binary = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc865Binary;
+      ghc = bh.compiler.ghc865Binary;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.6.x.nix { };
       packageSetConfig = bootstrapPackageSet;
     };


### PR DESCRIPTION
###### Motivation for this change

GHC on Aarch64.

I'm not in the loop with how the haskell infrastructure works in nixpkgs, I just require ghc to build my system for things like pandoc and nix-diff. I assume aarch64 was omitted from ghc863Binary due to the [upstream 8.6.3 release][] not to having an appropriate tarball. The [upstream 8.6.5 release][] includes `ghc-8.6.5-aarch64-ubuntu18.04-linux.tar.xz`.

[upstream 8.6.3 release]: https://downloads.haskell.org/~ghc/8.6.3 
[upstream 8.6.5 release]: https://downloads.haskell.org/~ghc/8.6.5 

With these changes, I can build ghc 8.8.3 on aarch64. I split out the commit for the version change and the aarch64 support to make it easier to read.

Related: #80355 -- contains the same llvm logic as here for `propagatedBuildInputs`
Related: #80176 -- issue for this and #80355

cc @marcweber @kosmikus @peti (maintainers of ghc)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
