### PR TITLE
crystal: change all crystal programs to use buildCrystalPackage and update pkgs

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/thicket/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/thicket/default.nix
@@ -1,9 +1,12 @@
 { lib
 , fetchFromGitHub
-, crystal
+, crystal_0_33
 }:
 
-crystal.buildCrystalPackage rec {
+let
+  crystal = crystal_0_33;
+
+in crystal.buildCrystalPackage rec {
   pname = "thicket";
   version = "0.1.3";
 
@@ -14,8 +17,13 @@ crystal.buildCrystalPackage rec {
     sha256 = "0hkmmssiwipx373d0zw9a2yn72gqzqzcvwkqbs522m5adz6qmkzw";
   };
 
+  format = "shards";
+
   shardsFile = ./shards.nix;
   crystalBinaries.thicket.src = "src/thicket.cr";
+
+  # there is one test that tries to clone a repo
+  doCheck = false;
 
   meta = with lib; {
     description = "A better one-line git log";

--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -1,53 +1,109 @@
-{ stdenv, lib, crystal, linkFarm, fetchFromGitHub }:
-{ # Generate shards.nix with `nix-shell -p crystal2nix --run crystal2nix` in the projects root
-  shardsFile ? null
+{ stdenv, lib, crystal, shards, git, pkgconfig, which, linkFarm, fetchFromGitHub, installShellFiles }:
+
+{ # Some projects do not include a lock file, so you can pass one
+  lockFile ? null
+  # Generate shards.nix with `nix-shell -p crystal2nix --run crystal2nix` in the projects root
+, shardsFile ? null
+  # We support different builders. To make things more straight forward, make it
+  # user selectable instead of trying to autodetect
+, format ? "make"
+, installManPages ? true
   # Specify binaries to build in the form { foo.src = "src/foo.cr"; }
   # The default `crystal build` options can be overridden with { foo.options = [ "--no-debug" ]; }
-, crystalBinaries ? {}
-, ...
-}@args:
+, crystalBinaries ? { }, ... }@args:
+
+assert (builtins.elem format [ "make" "crystal" "shards" ]);
+
 let
-  mkDerivationArgs = builtins.removeAttrs args [ "shardsFile" "crystalBinaries" ];
+  mkDerivationArgs = builtins.removeAttrs args [
+    "format"
+    "installManPages"
+    "lockFile"
+    "shardsFile"
+    "crystalBinaries"
+  ];
 
   crystalLib = linkFarm "crystal-lib" (lib.mapAttrsToList (name: value: {
     inherit name;
     path = fetchFromGitHub value;
   }) (import shardsFile));
 
-  defaultOptions = [ "--release" "--progress" "--no-debug" "--verbose" ];
+  # we previously had --no-debug here but that is not recommended by upstream
+  defaultOptions = [ "--release" "--progress" "--verbose" ];
 
+  buildDirectly = shardsFile == null || crystalBinaries != { };
 in stdenv.mkDerivation (mkDerivationArgs // {
 
-  configurePhase = args.configurePhase or ''
-    runHook preConfigure
-    ${lib.optionalString (shardsFile != null) "ln -s ${crystalLib} lib"}
-    runHook postConfigure
+  configurePhase = args.configurePhase or lib.concatStringsSep "\n" ([
+    "runHook preConfigure"
+  ] ++ lib.optional (lockFile != null)   "ln -s ${lockFile} ./shard.lock"
+    ++ lib.optional (shardsFile != null) "ln -s ${crystalLib} lib"
+    ++ [ "runHook postConfigure "]);
+
+  CRFLAGS = lib.concatStringsSep " " defaultOptions;
+
+  PREFIX = placeholder "out";
+
+  buildInputs = args.buildInputs or [ ] ++ [ crystal ]
+    ++ lib.optional (format != "crystal") shards;
+
+  nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [ git installShellFiles pkgconfig which ];
+
+  buildPhase = args.buildPhase or (lib.concatStringsSep "\n" ([
+    "runHook preBuild"
+  ] ++ lib.optional (format == "make")
+    ''make ''${buildTargets:-build} $makeFlags''
+  ++ lib.optionals (format == "crystal") (lib.mapAttrsToList (bin: attrs: ''
+        crystal ${lib.escapeShellArgs (["build" "-o" bin
+            (attrs.src or (throw "No source file for crystal binary ${bin} provided"))
+        ] ++ (attrs.options or defaultOptions))}
+      '') crystalBinaries)
+  ++ lib.optional (format == "shards")
+      "shards build --local --production ${lib.concatStringsSep " " defaultOptions}"
+  ++ [ "runHook postBuild" ]));
+
+  installPhase = args.installPhase or (lib.concatStringsSep "\n" ([
+    "runHook preInstall"
+  ] ++ lib.optional (format == "make")
+    ''make ''${installTargets:-install} $installFlags''
+  ++ lib.optionals (format == "crystal") (map (bin: ''
+      install -Dm555 ${lib.escapeShellArgs [ bin "${placeholder "out"}/bin/${bin}" ]}
+    '') (lib.attrNames crystalBinaries))
+  ++ lib.optional (format == "shards")
+      ''install -Dm555 bin/* -t $out/bin''
+  ++ [
+    ''
+      for f in README* *.md LICENSE; do
+        test -f $f && install -Dm444 $f -t $out/share/doc/${args.pname}
+      done
+    ''
+  ] ++ (lib.optional installManPages ''
+      if [ -d man ]; then
+        installManPage man/*.?
+      fi
+  '') ++ [
+    "runHook postInstall"
+  ]));
+
+  doCheck = args.doCheck or true;
+
+  checkPhase = args.checkPhase or (lib.concatStringsSep "\n" ([
+    "runHook preCheck"
+  ] ++ lib.optional (format == "make")
+    ''make ''${checkTarget:-test} $checkFlags''
+  ++ lib.optional (format != "make")
+    ''crystal ''${checkTarget:-spec} $checkFlags''
+  ++ [ "runHook postCheck" ]));
+
+  doInstallCheck = args.doInstallCheck or true;
+
+  installCheckPhase = args.installCheckPhase or ''
+    for f in $out/bin/*; do
+      $f --help
+    done
   '';
 
-  buildInputs = args.buildInputs or [] ++ [ crystal ];
-
-  buildPhase = args.buildPhase or ''
-    runHook preBuild
-    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (bin: attrs: ''
-      crystal ${lib.escapeShellArgs ([
-        "build"
-        "-o" bin
-        (attrs.src or (throw "No source file for crystal binary ${bin} provided"))
-      ] ++ attrs.options or defaultOptions)}
-    '') crystalBinaries)}
-    runHook postBuild
-  '';
-
-  installPhase = args.installPhase or ''
-    runHook preInstall
-    mkdir -p "$out/bin"
-    ${lib.concatMapStringsSep "\n" (bin: ''
-      mv ${lib.escapeShellArgs [ bin "${placeholder "out"}/bin/${bin}" ]}
-    '') (lib.attrNames crystalBinaries)}
-    runHook postInstall
-  '';
-
-  meta = args.meta or {} // {
+  meta = args.meta or { } // {
     platforms = args.meta.platforms or crystal.meta.platforms;
   };
 })

--- a/pkgs/development/compilers/crystal/crystal2nix.nix
+++ b/pkgs/development/compilers/crystal/crystal2nix.nix
@@ -1,4 +1,5 @@
 { lib, crystal, nix-prefetch-git }:
+
 crystal.buildCrystalPackage {
   pname = "crystal2nix";
   version = "unstable-2018-07-31";
@@ -6,11 +7,16 @@ crystal.buildCrystalPackage {
   nixPrefetchGit = "${lib.getBin nix-prefetch-git}/bin/nix-prefetch-git";
   unpackPhase = "substituteAll ${./crystal2nix.cr} crystal2nix.cr";
 
+  format = "crystal";
+
   crystalBinaries.crystal2nix.src = "crystal2nix.cr";
+
+  # it will blow up without a shard.yml file
+  doInstallCheck = false;
 
   meta = with lib; {
     description = "Utility to convert Crystal's shard.lock files to a Nix file";
     license = licenses.mit;
-    maintainers = [ maintainers.manveru ];
+    maintainers = with maintainers; [ manveru ];
   };
 }

--- a/pkgs/development/compilers/mint/default.nix
+++ b/pkgs/development/compilers/mint/default.nix
@@ -1,27 +1,36 @@
-{ lib, fetchFromGitHub, crystal, zlib, openssl, duktape, which, libyaml }:
-crystal.buildCrystalPackage rec {
-  version = "0.7.1";
+{ lib, fetchFromGitHub, crystal_0_33, openssl }:
+
+let crystal = crystal_0_33;
+in crystal.buildCrystalPackage rec {
+  version = "0.9.0";
   pname = "mint";
+
   src = fetchFromGitHub {
     owner = "mint-lang";
     repo = "mint";
     rev = version;
-    sha256 = "18cg96kl4dn89bj6fm3080zzyd1r7rsfi17agdjjayd2v9fgs95l";
+    sha256 = "0y1qr616x7s0pjgih6s1n4wiwb8kn8l1knnzmib6j4jmqax0jhz0";
   };
 
-  buildInputs = [ openssl ];
+  postPatch = ''
+    export HOME=$TMP
+  '';
+
+  format = "shards";
 
   # Update with
   #   nix-shell -p crystal2nix --run crystal2nix
   # with mint's shard.lock file in the current directory
   shardsFile = ./shards.nix;
-  crystalBinaries.mint.src = "src/mint.cr";
 
-  meta = {
+  buildInputs = [ openssl ];
+
+  meta = with lib; {
     description = "A refreshing language for the front-end web";
     homepage = "https://mint-lang.com/";
-    license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ manveru ];
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ manveru ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+    broken = lib.versionOlder crystal.version "0.33";
   };
 }

--- a/pkgs/development/compilers/mint/shards.nix
+++ b/pkgs/development/compilers/mint/shards.nix
@@ -2,26 +2,26 @@
   admiral = {
     owner = "jwaldrip";
     repo = "admiral.cr";
-    rev = "v1.7.3";
-    sha256 = "0b98qjy43wsrc08am7lkhcdsxc7gplf9hcmbvd4p3dw4g107rk91";
+    rev = "v1.9.0";
+    sha256 = "0y8gsh1qz42bc9jawcrn0i49mzzfvf8znmivd8lybapf0f53fblz";
   };
   ameba = {
-    owner = "veelenga";
+    owner = "crystal-ameba";
     repo = "ameba";
-    rev = "v0.10.1";
-    sha256 = "0dcw7px7g0c5pxpdlirhirqzhcc7gdwdfiwb9kgm4x1k74ghjgxq";
+    rev = "v0.12.0";
+    sha256 = "0g68yijbm2j4ig536fwq49d1z7x2iv9kp4g3gjklf5zn1sbqhm12";
   };
   baked_file_system = {
     owner = "schovi";
     repo = "baked_file_system";
-    rev = "v0.9.7";
-    sha256 = "1fi6zag1a6h4xwrfizy01dls3hhraqw0cmpwj7rjv1qcddjgig5z";
+    rev = "v0.9.8";
+    sha256 = "12l375jllg1lxvfh610dz0a39p803xw6q9fxlmnc6hy55i0gm0y3";
   };
   diff = {
     owner = "MakeNowJust";
     repo = "crystal-diff";
-    rev = "51962dc36f9bbb1b926d557f7cb8993a6c73cc63";
-    sha256 = "1nwnsxm8srfw8jg0yfi2v19x6j3dadx62hq0xpxra40qcqz9dbnp";
+    rev = "v1.1.0";
+    sha256 = "1q5q2d5mp1r8c6k5v4755sb3b6awiz85d1j280djzhbd0pggk3z7";
   };
   dotenv = {
     owner = "gdotdesign";
@@ -32,14 +32,14 @@
   exception_page = {
     owner = "crystal-loot";
     repo = "exception_page";
-    rev = "v0.1.2";
-    sha256 = "0j5ishhyriq9p339yaawrmawl9wgmp1paniq30a8d6a0568h3avq";
+    rev = "v0.1.4";
+    sha256 = "0bsp2m89sl0bg9d5szbs1nxyk7yk58rkk24aibr39hhb5zi70pqi";
   };
   kemal = {
     owner = "kemalcr";
     repo = "kemal";
-    rev = "v0.25.1";
-    sha256 = "1334i905xj6vlmp8acyybwwlaxsgmf90b59da7brzpnf28wci782";
+    rev = "v0.26.1";
+    sha256 = "169pwkjmk7x6j8i0rf5rpyk1y0hl7jaf9h6yrq4ha2ag9yq9i8fr";
   };
   kilt = {
     owner = "jeromegn";

--- a/pkgs/development/tools/ameba/default.nix
+++ b/pkgs/development/tools/ameba/default.nix
@@ -1,37 +1,15 @@
-{ stdenv, lib, fetchFromGitHub, crystal, shards }:
+{ stdenv, lib, fetchFromGitHub, crystal }:
 
-stdenv.mkDerivation rec {
+crystal.buildCrystalPackage rec {
   pname = "ameba";
-  version = "0.12.0";
+  version = "0.12.1";
 
   src = fetchFromGitHub {
-    owner  = "crystal-ameba";
-    repo   = "ameba";
-    rev    = "v${version}";
-    sha256 = "0g68yijbm2j4ig536fwq49d1z7x2iv9kp4g3gjklf5zn1sbqhm12";
+    owner = "crystal-ameba";
+    repo = "ameba";
+    rev = "v${version}";
+    sha256 = "0c2j2qki0czkpsqxv75qg95pk9f0w4rqa5ln07rs4bj9dk2lrr3l";
   };
-
-  nativeBuildInputs = [ crystal shards ];
-
-  buildPhase = ''
-    runHook preBuild
-    shards build --release
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 -t $out/bin bin/ameba
-    runHook postInstall
-  '';
-
-  doCheck = true;
-
-  checkPhase = ''
-    runHook preCheck
-    crystal spec
-    runHook postCheck
-  '';
 
   meta = with stdenv.lib; {
     description = "A static code analysis tool for Crystal";

--- a/pkgs/development/tools/build-managers/shards/default.nix
+++ b/pkgs/development/tools/build-managers/shards/default.nix
@@ -1,22 +1,29 @@
-{ stdenv, fetchFromGitHub, crystal, pcre, libyaml, which }:
+{ stdenv, fetchFromGitHub, crystal }:
 
 crystal.buildCrystalPackage rec {
   pname = "shards";
   version = "0.10.0";
 
   src = fetchFromGitHub {
-    owner  = "crystal-lang";
-    repo   = "shards";
-    rev    = "v${version}";
+    owner = "crystal-lang";
+    repo = "shards";
+    rev = "v${version}";
     sha256 = "1bjy3hcdqq8769bx73f3pwn26rnkj23dngyfbw4iv32bw23x1d49";
   };
 
+  # we cannot use `make` here as it would introduce a dependency on itself
+  format = "crystal";
+
   shardsFile = ./shards.nix;
+
   crystalBinaries.shards.src = "./src/shards.cr";
+
+  # tries to execute git which fails spectacularly
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Dependency manager for the Crystal language";
-    license     = licenses.asl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ peterhoeg ];
     inherit (crystal.meta) homepage platforms;
   };

--- a/pkgs/development/tools/icr/default.nix
+++ b/pkgs/development/tools/icr/default.nix
@@ -1,28 +1,30 @@
-{ stdenv, fetchFromGitHub, crystal, shards, which
-, openssl, readline, libyaml }:
+{ stdenv, lib, fetchFromGitHub, crystal, shards, makeWrapper, pkgconfig, which
+, openssl, readline, libyaml, zlib }:
 
-stdenv.mkDerivation rec {
+crystal.buildCrystalPackage rec {
   pname = "icr";
-  version = "0.6.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
-    owner  = "crystal-community";
-    repo   = pname;
-    rev    = "v${version}";
-    sha256 = "0kkdqrxk4f4bqbb84mgjrk9r0fz1hsz95apvjsc49gav4c8xx3mb";
+    owner = "crystal-community";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1bz2bhs6csyg2rhrlknlvaiilq3vq8plxjh1hdxmbrfi3n6c7k5a";
   };
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace /usr/local $out
+  shardsFile = ./shards.nix;
+
+  buildInputs = [ libyaml openssl readline zlib ];
+
+  nativeBuildInputs = [ makeWrapper pkgconfig which ];
+
+  # tests are failing due to our sandbox
+  doCheck = false;
+
+  postFixup = ''
+    wrapProgram $out/bin/icr \
+      --prefix PATH : ${lib.makeBinPath [ crystal shards makeWrapper which ]}
   '';
-
-  buildInputs = [ crystal libyaml openssl readline ];
-
-  nativeBuildInputs = [ shards which ];
-
-  doCheck = true;
-  checkTarget = "test";
 
   meta = with stdenv.lib; {
     description = "Interactive console for the Crystal programming language";

--- a/pkgs/development/tools/icr/shards.nix
+++ b/pkgs/development/tools/icr/shards.nix
@@ -1,0 +1,8 @@
+{
+  readline = {
+    owner = "crystal-lang";
+    repo = "crystal-readline";
+    rev = "0fb7d186da8e1b157998d98d1c96e99699b791eb";
+    sha256 = "1rk27vw3ssldgnfgprwvz2gag02v4g6d6yg56b3sk9w3fn8jyyi8";
+  };
+}

--- a/pkgs/development/tools/scry/default.nix
+++ b/pkgs/development/tools/scry/default.nix
@@ -1,6 +1,8 @@
-{ lib, fetchFromGitHub, crystal }:
+{ lib, fetchFromGitHub, crystal_0_31, coreutils, shards, makeWrapper, which }:
 
-crystal.buildCrystalPackage rec {
+let crystal = crystal_0_31;
+
+in crystal.buildCrystalPackage rec {
   pname = "scry";
   version = "0.8.1";
 
@@ -11,8 +13,26 @@ crystal.buildCrystalPackage rec {
     sha256 = "0ii4k9l3dgm1c9lllc8ni9dar59lrxik0v9iz7gk3d6v62wwnq79";
   };
 
+  # we are already testing for this, so we can ignore the failures
+  postPatch = ''
+    rm spec/scry/executable_spec.cr
+  '';
+
+  format = "crystal";
+
+  nativeBuildInputs = [ makeWrapper ];
+
   shardsFile = ./shards.nix;
+
   crystalBinaries.scry.src = "src/scry.cr";
+
+  postFixup = ''
+    wrapProgram $out/bin/scry \
+      --prefix PATH : ${lib.makeBinPath [ crystal coreutils ]}
+  '';
+
+  # the binary doesn't take any arguments, so this will hang
+  doInstallCheck = false;
 
   meta = with lib; {
     description = "Code analysis server for the Crystal programming language";

--- a/pkgs/development/web/lucky-cli/default.nix
+++ b/pkgs/development/web/lucky-cli/default.nix
@@ -1,0 +1,42 @@
+{ lib, fetchFromGitHub, crystal, makeWrapper, openssl }:
+
+crystal.buildCrystalPackage rec {
+  pname = "lucky-cli";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "luckyframework";
+    repo = "lucky_cli";
+    rev = "v${version}";
+    sha256 = "0n7fgnsivf39bkxpf7xgg9dqkam08axdn1j45wl1n0r4qmfkjs94";
+  };
+
+  # the integration tests will try to clone a remote repos
+  postPatch = ''
+    rm -rf spec/integration
+  '';
+
+  format = "crystal";
+
+  lockFile = ./shard.lock;
+  shardsFile = ./shards.nix;
+
+  crystalBinaries.lucky.src = "src/lucky.cr";
+
+  buildInputs = [ openssl ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/lucky \
+      --prefix PATH : ${lib.makeBinPath [ crystal ]}
+  '';
+
+  meta = with lib; {
+    description =
+      "A Crystal library for creating and running tasks. Also generates Lucky projects";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/web/lucky-cli/shard.lock
+++ b/pkgs/development/web/lucky-cli/shard.lock
@@ -1,0 +1,5 @@
+version: 1.0
+shards:
+  teeplate:
+    github: luckyframework/teeplate
+    version: 0.8.1

--- a/pkgs/development/web/lucky-cli/shards.nix
+++ b/pkgs/development/web/lucky-cli/shards.nix
@@ -1,0 +1,8 @@
+{
+  teeplate = {
+    owner = "luckyframework";
+    repo = "teeplate";
+    rev = "v0.8.1";
+    sha256 = "022jmmg3d2wq2xnhc63afldm9vrcr8xqn43s9i39d7qflrzrfc7v";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8114,9 +8114,7 @@ in
     crystal
     crystal2nix;
 
-  icr = callPackage ../development/tools/icr {
-    openssl = openssl_1_0_2;
-  };
+  icr = callPackage ../development/tools/icr { };
 
   scry = callPackage ../development/tools/scry {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3991,6 +3991,8 @@ in
 
   httplab = callPackage ../tools/networking/httplab { };
 
+  lucky-cli = callPackage ../development/web/lucky-cli { };
+
   partclone = callPackage ../tools/backup/partclone { };
 
   partimage = callPackage ../tools/backup/partimage { };


### PR DESCRIPTION
###### Motivation for this change

See the last comments for more details.

~~The `icr` change is straight forward and only included here to showcase the change in how we build crystal packages.~~

~~The crystal builder will now use a Makefile if one is included by the project, `shards` if we have the required files in place and otherwise build the specified binaries (the old behaviour).~~

Couple of other things to note:
1. we add a few more things to `nativeBuildInputs` that are required by several crystal programs.
2. upstream recommends not building with `--no-debug` so rip that out
3. support copying in a lockfile if the program doesn't have one (`lucky-cli` I'm looking at you)

~~The way I've done the conditionals where we combine bash conditionals with nix conditionals is *very* ugly and I'm not proud of that at all but it works.~~

Cc @manveru as the person we have to thank for having the crystal build infrastructure in the first place.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
