### PR TITLE
rmtrash: init at 1.13

### DIFF
--- a/pkgs/tools/misc/rmtrash/default.nix
+++ b/pkgs/tools/misc/rmtrash/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper
+, trash-cli, coreutils, which, getopt }:
+
+stdenv.mkDerivation rec {
+  pname = "rmtrash";
+  version = "1.13";
+
+  src = fetchFromGitHub {
+    owner = "PhrozenByte";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04a9c65wnkq1fj8qhdsdbps88xjbp7rn6p27y25v47kaysvrw01j";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    for f in rm{,dir}trash; do
+      install -D ./$f $out/bin/$f
+      wrapProgram $out/bin/$f \
+        --prefix PATH : ${lib.makeBinPath [ trash-cli coreutils which getopt ]}
+    done
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/PhrozenByte/rmtrash";
+    description = "trash-put made compatible with GNUs rm and rmdir";
+    longDescription = ''
+      Put files (and directories) in trash using the `trash-put` command in a
+      way that is, otherwise as `trash-put` itself, compatible to GNUs `rm`
+      and `rmdir`.
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ peelz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6276,6 +6276,8 @@ in
 
   rlwrap = callPackage ../tools/misc/rlwrap { };
 
+  rmtrash = callPackage ../tools/misc/rmtrash { };
+
   rockbox_utility = libsForQt5.callPackage ../tools/misc/rockbox-utility { };
 
   rosegarden = libsForQt5.callPackage ../applications/audio/rosegarden { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
