### PR TITLE
python3Packages.openwrt-luci-rpc: init at 1.1.2

### DIFF
--- a/pkgs/development/python-modules/openwrt-luci-rpc/default.nix
+++ b/pkgs/development/python-modules/openwrt-luci-rpc/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, click
+, requests
+, packaging
+}:
+
+with lib;
+
+buildPythonPackage rec {
+  pname = "openwrt-luci-rpc";
+  version = "1.1.2";
+
+  srcs = fetchPypi {
+    inherit pname version;
+    sha256 = "144bw7w1xvpdkad5phflpkl15ih5pvi19799wmvfv8mj1dn1yjhp";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "requests==2.21.0" "requests"
+    substituteInPlace setup.py --replace "packaging==19.1" "packaging"
+  '';
+
+  propagatedBuildInputs = [ click requests packaging ];
+
+  meta = {
+    description = ''
+      Python3 module for interacting with the OpenWrt Luci RPC interface.
+      Supports 15.X & 17.X & 18.X or newer releases of OpenWrt.
+    '';
+    homepage = "https://github.com/fbradyirl/openwrt-luci-rpc";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matt-snider ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6987,6 +6987,8 @@ in {
 
   pyemd  = callPackage ../development/python-modules/pyemd { };
 
+  openwrt-luci-rpc = disabledIf (!isPy3k) (callPackage ../development/python-modules/openwrt-luci-rpc { });
+
   pulp  = callPackage ../development/python-modules/pulp { };
 
   behave = callPackage ../development/python-modules/behave { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Currently home-assistant does not install extra components for [openwrt luci][hass-luci-component] because [openwrt-luci-rpc][openwrt-luci-rpc] hasn't yet been packaged yet. This means that it is missing from the output when [parse-requirements.py][parse-requirements] runs.

Question: should I be running `parse-requirements.py` or is it run automatically at some point?

[hass-luci-component]: https://github.com/NixOS/nixpkgs/blob/473366f5cabfbbc5ed1be4477c90ffe5b30e772c/pkgs/servers/home-assistant/component-packages.nix#L430
[parse-requirements]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/home-assistant/parse-requirements.py
[openwrt-luci-rpc]: https://github.com/fbradyirl/openwrt-luci-rpc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

