### PR TITLE
pythonPackages.soundcard: init at 0.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5488,6 +5488,11 @@
     githubId = 1538622;
     name = "Michael Reilly";
   };
+  onny = {
+    email = "onny@project-insanity.org";
+    github = "onny";
+    name = "Jonas Heinrich";
+  };
   OPNA2608 = {
     email = "christoph.neidahl@gmail.com";
     github = "OPNA2608";

--- a/pkgs/development/python-modules/soundcard/default.nix
+++ b/pkgs/development/python-modules/soundcard/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, libpulseaudio
+, python3Packages
+, extraLibs ? []
+}:
+
+buildPythonPackage rec {
+  pname = "SoundCard";
+  version = "0.3.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "01050fe3af635a8880b9f0f2461299e7d52f0ba72bbb1eb60ef3ec67e33609c6";
+  };
+
+  #propagatedBuildInputs = [numpy cffi];
+
+  propagatedBuildInputs = with python3Packages; [ numpy cffi ] ++
+    [ libpulseaudio ] ++ extraLibs;
+
+  libpulseaudioPath = stdenv.lib.makeLibraryPath [ libpulseaudio ];
+  ldWrapperSuffix = "--suffix LD_LIBRARY_PATH : \"${libpulseaudioPath}\"";
+  # LC_TIME != C results in locale.Error: unsupported locale setting
+  makeWrapperArgs = [ "--set LC_TIME C" ldWrapperSuffix ]; # libpulseaudio.so is loaded manually
+
+  postInstall = ''
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/${pname}-python-interpreter \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      ${ldWrapperSuffix}
+  '';
+
+  # tests fail
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Play and record audio without resorting to CPython extensions";
+    homepage = "https://github.com/bastibe/SoundCard";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3285,6 +3285,8 @@ in {
 
   samplerate = callPackage ../development/python-modules/samplerate { };
 
+  soundcard = callPackage ../development/python-modules/soundcard { };
+
   ssdeep = callPackage ../development/python-modules/ssdeep { };
 
   ssdp = callPackage ../development/python-modules/ssdp { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Module is missing but still has some issues. When running a script which uses soundcard module, the depended module cffi throws following error:
```
Traceback (most recent call last):
  File "recognition.py", line 1, in <module>
    import soundcard as sc
  File "/nix/store/ln7n0w4lim2zi585cn1bb2v65zsipvfx-python3-3.7.6-env/lib/python3.7/site-packages/soundcard/__init__.py", line 4, in <module>
    from soundcard.pulseaudio import *
  File "/nix/store/ln7n0w4lim2zi585cn1bb2v65zsipvfx-python3-3.7.6-env/lib/python3.7/site-packages/soundcard/pulseaudio.py", line 16, in <module>
    _pa = _ffi.dlopen('pulse')
  File "/nix/store/ln7n0w4lim2zi585cn1bb2v65zsipvfx-python3-3.7.6-env/lib/python3.7/site-packages/cffi/api.py", line 150, in dlopen
    lib, function_cache = _make_ffi_library(self, name, flags)
  File "/nix/store/ln7n0w4lim2zi585cn1bb2v65zsipvfx-python3-3.7.6-env/lib/python3.7/site-packages/cffi/api.py", line 832, in _make_ffi_library
    backendlib = _load_backend_lib(backend, libname, flags)
  File "/nix/store/ln7n0w4lim2zi585cn1bb2v65zsipvfx-python3-3.7.6-env/lib/python3.7/site-packages/cffi/api.py", line 827, in _load_backend_lib
    raise OSError(msg)
OSError: ctypes.util.find_library() did not manage to locate a library called 'pulse'
```
So I'm not sure how I could include libpulse in this case. I already tried to include hacks from i3pystatus to somehow wrap libpulseaudio path into the app :/ https://github.com/NixOS/nixpkgs/blob/6d4f3311d4b5662e2703cfd3278fd78bd972a56c/pkgs/applications/window-managers/i3/pystatus.nix#L27

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
