### PR TITLE
gtk-gnutella: 1.1.14 -> 1.1.15

### DIFF
--- a/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
+++ b/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
@@ -1,37 +1,58 @@
-{ stdenv, fetchurl, fetchpatch, bison, pkgconfig, gettext, desktop-file-utils
-, glib, gtk2, libxml2, libbfd, zlib, binutils, gnutls
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, bison
+, pkgconfig
+, gettext
+, desktop-file-utils
+, glib
+, gtk2
+, libxml2
+, libbfd
+, zlib
+, binutils
+, gnutls
+, enableGui ? true
 }:
 
 stdenv.mkDerivation rec {
   pname = "gtk-gnutella";
-  version = "1.1.14";
+  # NOTE: Please remove hardeningDisable on the next release, see:
+  # https://sourceforge.net/p/gtk-gnutella/bugs/555/#5c19
+  version = "1.1.15";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0sljjha4anfz1r1xq1c6qnnkjv62ld56p7xgj4bsi6lqmq1azvii";
+  src = fetchFromGitHub {
+    owner = "gtk-gnutella";
+    repo = "gtk-gnutella";
+    rev = "v${version}";
+    sha256 = "1g7w6ywwp2g4qdgmfqkrl1rldk1b4rx50yb7h75hh15mh6nr159r";
   };
 
-  patches = [
-    (fetchpatch {
-      # Avoid namespace conflict with glibc 2.28 'statx' struct / remove after v1.1.14
-      url = "https://github.com/gtk-gnutella/gtk-gnutella/commit/e4205a082eb32161e28de81f5cba8095eea8ecc7.patch";
-      sha256 = "0ffkw2cw2b2yhydii8jm40vd40p4xl224l8jvhimg02lgs3zfbca";
-    })
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/gtk-gnutella/raw/f30/f/gtk-gnutella-1.1.14-endian.patch";
-      sha256 = "19q4lq8msknfz4mkbjdqmmgld16p30j2yx371p8spmr19q5i0sfn";
-    })
+  nativeBuildInputs = [
+    bison
+    desktop-file-utils
+    gettext
+    pkgconfig
   ];
-
-  postPatch = ''
-    substituteInPlace Makefile.SH --replace "@exit 0" "@echo done"
-  '';
-
-  nativeBuildInputs = [ bison desktop-file-utils gettext pkgconfig ];
-  buildInputs = [ binutils glib gnutls gtk2 libbfd libxml2 zlib ];
+  buildInputs = [
+    glib
+    gnutls
+    libbfd
+    libxml2
+    zlib
+  ]
+  ++
+    stdenv.lib.optionals (enableGui) [ gtk2 ]
+  ;
 
   configureScript = "./build.sh";
-  configureFlags = [ "--configure-only" ];
+  configureFlags = [
+    "--configure-only"
+    # See https://sourceforge.net/p/gtk-gnutella/bugs/555/
+    "--disable-malloc"
+  ]
+    ++ stdenv.lib.optionals (!enableGui) [ "--topless" ]
+  ;
 
   hardeningDisable = [ "bindnow" "fortify" "pic" "relro" ];
 
@@ -45,6 +66,7 @@ stdenv.mkDerivation rec {
     description = "A GTK Gnutella client, optimized for speed and scalability";
     homepage = "http://gtk-gnutella.sourceforge.net/"; # Code: https://github.com/gtk-gnutella/gtk-gnutella
     changelog = "https://raw.githubusercontent.com/gtk-gnutella/gtk-gnutella/v${version}/ChangeLog";
+    maintainers = [ maintainers.doronbehar ];
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update gnutella and fix something in our build, see discussion with upstream: https://sourceforge.net/p/gtk-gnutella/bugs/555/ .

###### Things done

- [X] Switch to `fetchFromGitHub`.
- [X] Remove old patches now applied in 1.1.15.
- [X] Disable use of upstream's `malloc` implementation to fix https://sourceforge.net/p/gtk-gnutella/bugs/555/ .
- [X] Add myself as maintainer.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
