### PR TITLE
bigbluebutton: init at 2.2.2

### DIFF
--- a/pkgs/servers/bigbluebutton/default.nix
+++ b/pkgs/servers/bigbluebutton/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, gradle }:
+
+stdenv.mkDerivation rec {
+  pname = "bigbluebutton";
+  version = "2.2.2";
+
+  src = fetchFromGitHub {
+    owner = "bigbluebutton";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1rrf0d6hcnz5f6pday3r3pxn9yjgaram3fq260ya4scxcymd416h";
+  };
+
+  nativeBuildInputs = [ gradle ];
+
+  # See the build script:
+  # https://github.com/bigbluebutton/bigbluebutton/blob/develop/bbb.sh
+  buildPhase = ''
+    pushd bigbluebutton-apps
+    gradle --offline resolveDeps
+    gradle --offline clean war deploy
+    popd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Web conferencing system designed for online learning";
+    homepage = "https://bigbluebutton.org/";
+    # There seems to be different licenses in the repo:
+    # https://github.com/bigbluebutton/bigbluebutton/search?q=license&unscoped_q=license
+    #
+    # On the other hand, it is said here that the license is LGPL (which
+    # version?): https://bigbluebutton.org/open-source-license/
+    #
+    # At least these licenses could be found in the source files:
+    license = with licenses; [ gpl3 asl20 lgpl3Plus gpl2Plus mit ];
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15274,6 +15274,8 @@ in
 
   bftpd = callPackage ../servers/ftp/bftpd {};
 
+  bigbluebutton = callPackage ../servers/bigbluebutton { };
+
   bind = callPackage ../servers/dns/bind { };
   dnsutils = bind.dnsutils;
 


### PR DESCRIPTION
###### Motivation for this change

Add BigBlueButton package and NixOS service. Fixes #82737 .

BigBlueButton is a web conferencing system designed for online learning: https://github.com/bigbluebutton/bigbluebutton

**NOTE: This is just a draft PR at the moment.** It looks like it's going to be a massive effort to actually package this. I wanted to open a draft PR so that a) people know that someone is working on this, b) others can join and help, c) discussion and questions can be had on this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
