### PR TITLE
nixos/filesender init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -818,6 +818,7 @@
   ./services/web-apps/cryptpad.nix
   ./services/web-apps/documize.nix
   ./services/web-apps/dokuwiki.nix
+  ./services/web-apps/filesender.nix
   ./services/web-apps/frab.nix
   ./services/web-apps/gotify-server.nix
   ./services/web-apps/grocy.nix

--- a/nixos/modules/services/web-apps/filesender.nix
+++ b/nixos/modules/services/web-apps/filesender.nix
@@ -4,11 +4,163 @@ with lib;
 
 let
   cfg = config.services.filesender;
+  fpm = config.services.phpfpm.pools.filesender;
 in {
   options.services.filesender = {
     enable = mkEnableOption "filesender";
+    hostName = mkOption {
+      type = types.str;
+      description = "FQDN for the filesender instance";
+      example = "filesender.mydomain.com";
+    };
+    home = mkOption {
+      type = types.str;
+      default = "/var/lib/filesender";
+      description = "Storage path of Filesender.";
+    };
+    poolSettings = mkOption {
+      type = with types; attrsOf str;
+      default = {
+        "pm" = "dynamic";
+        "pm.max_children" = "32";
+        "pm.start_servers" = "2";
+        "pm.min_spare_servers" = "2";
+        "pm.max_spare_servers" = "4";
+        "pm.max_requests" = "500";
+      };
+      description = ''
+        Options for filesender's PHP pool. See the documentation on <literal>php-fpm.conf</literal> for details on configuration directives.
+      '';
+    };
+    # dbtype = mkOption {
+    #   type = types.enum [ "pgsql" "mysql" ];
+    #   default = "pgsql";
+    #   description = "Database type.";
+    # };
+    # dbname = mkOption {
+    #   type = types.nullOr types.str;
+    #   default = "filesender";
+    #   description = "Database name.";
+    # };
+    # dbuser = mkOption {
+    #   type = types.nullOr types.str;
+    #   default = "filesender";
+    #   description = "Database user.";
+    # };
+    # dbpass = mkOption {
+    #   type = types.nullOr types.str;
+    #   default = null;
+    #   description = ''
+    #     Database password.  Use <literal>dbpassFile</literal> to avoid this
+    #     being world-readable in the <literal>/nix/store</literal>.
+    #   '';
+    # };
+    # dbpassFile = mkOption {
+    #   type = types.nullOr types.str;
+    #   default = null;
+    #   description = ''
+    #     The full path to a file that contains the database password.
+    #   '';
+    # };
+    # dbhost = mkOption {
+    #   type = types.nullOr types.str;
+    #   default = "localhost";
+    #   description = ''
+    #     Database host.
+
+    #     Note: for using Unix authentication with PostgreSQL, this should be
+    #     set to <literal>/run/postgresql</literal>.
+    #   '';
+    # };
   };
 
   config = mkIf cfg.enable {
+
+    systemd.services.filesender-setup = {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "phpfpm-filesender.service" ];
+      script = ''
+        chown filesender:nginx -R ${cfg.home}
+        mkdir -p ${cfg.home}/config
+        mkdir -p ${cfg.home}/tmp
+        mkdir -p ${cfg.home}/files
+        mkdir -p ${cfg.home}/log
+      '';
+      serviceConfig.Type = "oneshot";
+    };
+
+    # Config is read in classes/utils/Config.class.php as:
+    #
+    # $main_config_file = FILESENDER_BASE.'/config/config.php';
+    #
+    # $config_file = FILESENDER_BASE.'/config/'.$virtualhost.'/config.php';
+    #
+    # So, how to handle this in NixOS??
+    #
+    # Patch Config.class.php so that it reads some environment variable instead
+    # of FILESENDER_BASE if given. For instance, FILESENDER_CONFIG_DIR
+
+    services.phpfpm = {
+      pools.filesender = {
+        user = "filesender";
+        group = "nginx";
+        phpEnv = {
+          # FIXME/TODO: Write the config to nix store!!!
+          FILESENDER_CONFIG_DIR = "${cfg.home}/config";
+        };
+        settings = {
+          "listen.owner" = "nginx";
+          "listen.group" = "nginx";
+        } // cfg.poolSettings;
+      };
+    };
+
+    services.nginx = {
+      enable = true;
+      virtualHosts."${cfg.hostName}" = {
+        # TODO: SSL stuff
+        forceSSL = true;
+        enableACME = true;
+        root = "${pkgs.filesender}/www";
+        locations = {
+          "/" = {
+            extraConfig = ''
+              try_files $uri /index.php?args;
+            '';
+          };
+          "~ [^/]\\.php(/|$)" = {
+            extraConfig = ''
+              fastcgi_split_path_info  ^(.+\.php)(/.+)$;
+              fastcgi_pass  unix:${fpm.socket};
+              include ${config.services.nginx.package}/conf/fastcgi.conf;
+              fastcgi_intercept_errors on;
+              fastcgi_param PATH_INFO       $fastcgi_path_info;
+              fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            '';
+          };
+        };
+      };
+    };
+
+    services.postgresql = {
+      enable = true;
+      ensureDatabases = [ "filesender" ];
+      ensureUsers = [
+        {
+          name = "filesender";
+          ensurePermissions = {
+            "DATABASE filesender" = "ALL PRIVILEGES";
+          };
+        }
+      ];
+    };
+
+    users.extraUsers.filesender = {
+      home = "${cfg.home}";
+      # TODO: Should I use system UID defined in nixos/modules/misc/ids.nix?
+      group = "nginx";
+      createHome = true;
+    };
+
   };
 }

--- a/nixos/modules/services/web-apps/filesender.nix
+++ b/nixos/modules/services/web-apps/filesender.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.filesender;
+in {
+  options.services.filesender = {
+    enable = mkEnableOption "filesender";
+  };
+
+  config = mkIf cfg.enable {
+  };
+}

--- a/pkgs/servers/filesender/default.nix
+++ b/pkgs/servers/filesender/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "filesender";
+  version = "2.15";
+
+  src = fetchFromGitHub {
+    owner = "filesender";
+    repo = pname;
+    rev = "master-filesender-${version}";
+    sha256 = "0b53rv5i44cqc94im15ampigj9s5p0i3yzq7gqxkxfw6d5l688bp";
+  };
+
+  installPhase = ''
+    mkdir -p $out/
+    cp -R . $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Web application for sending large files to other users";
+    homepage = "https://filesender.org/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/servers/web-apps/filesender/config_dir.patch
+++ b/pkgs/servers/web-apps/filesender/config_dir.patch
@@ -1,0 +1,56 @@
+diff --git a/classes/utils/Config.class.php b/classes/utils/Config.class.php
+index d11d9b19..70926b5f 100644
+--- a/classes/utils/Config.class.php
++++ b/classes/utils/Config.class.php
+@@ -116,7 +116,7 @@ class Config
+         }
+         
+         // Check if main config exists
+-        $main_config_file = FILESENDER_BASE.'/config/config.php';
++        $main_config_file = CONFIG_DIR.'/config.php';
+         if (!file_exists($main_config_file)) {
+             throw new ConfigFileMissingException($main_config_file);
+         }
+@@ -136,7 +136,7 @@ class Config
+ 
+ 
+         // load password file if it is there
+-        $pass_config_file = FILESENDER_BASE.'/config/config-passwords.php';
++        $pass_config_file = CONFIG_DIR.'/config-passwords.php';
+         if (file_exists($pass_config_file)) {
+             $config = array();
+             include_once($pass_config_file);
+@@ -153,7 +153,7 @@ class Config
+                 throw new ConfigBadParameterException('virtualhost');
+             }
+             
+-            $config_file = FILESENDER_BASE.'/config/'.$virtualhost.'/config.php';
++            $config_file = CONFIG_DIR.'/'.$virtualhost.'/config.php';
+             if (!file_exists($config_file)) {
+                 throw new ConfigFileMissingException($config_file);
+             } // Should exist even if empty
+diff --git a/includes/ConfigValidation.php b/includes/ConfigValidation.php
+index 5c1e7f61..59d5259d 100644
+--- a/includes/ConfigValidation.php
++++ b/includes/ConfigValidation.php
+@@ -33,7 +33,7 @@
+ // Require environment (fatal)
+ if(!defined('FILESENDER_BASE')) die('Missing environment');
+ 
+-if(!file_exists(FILESENDER_BASE.'/config/config.php'))
++if(!file_exists(CONFIG_DIR.'/config.php'))
+     die('Configuration file not found');
+ 
+ ConfigValidator::addCheck('site_url', 'string');
+diff --git a/includes/init.php b/includes/init.php
+index ba7fa82f..3e294890 100644
+--- a/includes/init.php
++++ b/includes/init.php
+@@ -35,6 +35,7 @@ if(PHP_INT_SIZE !== 8) {
+ }
+ 
+ define('FILESENDER_BASE', dirname( __DIR__ ));
++define('CONFIG_DIR', getenv('FILESENDER_CONFIG_DIR', true) ?: (FILESENDER_BASE.'/config'));
+ 
+ // Include classes autoloader
+ require_once(FILESENDER_BASE.'/classes/autoload.php');

--- a/pkgs/servers/web-apps/filesender/default.nix
+++ b/pkgs/servers/web-apps/filesender/default.nix
@@ -11,6 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "0b53rv5i44cqc94im15ampigj9s5p0i3yzq7gqxkxfw6d5l688bp";
   };
 
+  patches = [
+    # Filesender searches for the configuration in the same directory tree as
+    # the other source code. This patch makes it possible to define a different
+    # location for the configuration directory so the NixOS service can write
+    # the configuration without modifying the entire package.
+    ./config_dir.patch
+  ];
+
   installPhase = ''
     mkdir -p $out/
     cp -R . $out/

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15370,6 +15370,8 @@ in
 
   felix_remoteshell = callPackage ../servers/felix/remoteshell.nix { };
 
+  filesender = callPackage ../servers/filesender { };
+
   fingerd_bsd = callPackage ../servers/fingerd/bsd-fingerd { };
 
   firebird = callPackage ../servers/firebird { icu = null; /*stdenv = gcc5Stdenv;*/ };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15370,7 +15370,7 @@ in
 
   felix_remoteshell = callPackage ../servers/felix/remoteshell.nix { };
 
-  filesender = callPackage ../servers/filesender { };
+  filesender = callPackage ../servers/web-apps/filesender { };
 
   fingerd_bsd = callPackage ../servers/fingerd/bsd-fingerd { };
 


### PR DESCRIPTION
###### Motivation for this change

Add Filesender package and NixOS service: https://filesender.org/

This is work in progress at the moment, that's why it's a draft PR. I wanted to open it anyway immediately so others can see that it's being worked on and it can be discussed here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
