### PR TITLE
i3lock-fancy: Fix wrong path to mktemp

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "00lqsvz1knb8iqy8lnkn3sf4c2c4nzb0smky63qf48m8za5aw9b1";
   };
   patchPhase = ''
-    sed -i -e "s|(mktemp)|(${coreutils}/bin/mktemp)|" i3lock-fancy
+    sed -i -e "s|(mktemp|(${coreutils}/bin/mktemp|" i3lock-fancy
     sed -i -e "s|'rm -f |'${coreutils}/bin/rm -f |" i3lock-fancy
     sed -i -e "s|scrot -z |${scrot}/bin/scrot -z |" i3lock-fancy
     sed -i -e "s|convert |${imagemagick.out}/bin/convert |" i3lock-fancy

--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "00lqsvz1knb8iqy8lnkn3sf4c2c4nzb0smky63qf48m8za5aw9b1";
   };
   patchPhase = ''
-    sed -i -e "s|(mktemp|(${coreutils}/bin/mktemp|" i3lock-fancy
+    sed -i -e "s|mktemp|${coreutils}/bin/mktemp|" i3lock-fancy
     sed -i -e "s|'rm -f |'${coreutils}/bin/rm -f |" i3lock-fancy
     sed -i -e "s|scrot -z |${scrot}/bin/scrot -z |" i3lock-fancy
     sed -i -e "s|convert |${imagemagick.out}/bin/convert |" i3lock-fancy


### PR DESCRIPTION
###### Motivation for this change
mktemp was not correctly replaced in this package. Leading to
"command not found: mktemp" error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
