### PR TITLE
ansible: Use overridePythonAttrs to get the right name attribute

### DIFF
--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -5,7 +5,7 @@ rec {
 
   ansible_2_9 = python3Packages.toPythonApplication python3Packages.ansible;
 
-  ansible_2_8 = with python3Packages; toPythonApplication (python3Packages.ansible.overrideAttrs(old: rec {
+  ansible_2_8 = python3Packages.toPythonApplication (python3Packages.ansible.overridePythonAttrs (old: rec {
     pname = "ansible";
     version = "2.8.7";
 
@@ -15,7 +15,7 @@ rec {
     };
   }));
 
-  ansible_2_7 = with python3Packages; toPythonApplication (ansible.overrideAttrs(old: rec {
+  ansible_2_7 = python3Packages.toPythonApplication (python3Packages.ansible.overridePythonAttrs (old: rec {
     pname = "ansible";
     version = "2.7.15";
 
@@ -25,7 +25,7 @@ rec {
     };
   }));
 
-  ansible_2_6 = with python3Packages; toPythonApplication (ansible.overrideAttrs(old: rec {
+  ansible_2_6 = python3Packages.toPythonApplication (python3Packages.ansible.overridePythonAttrs (old: rec {
     pname = "ansible";
     version = "2.6.20";
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #83105.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
