### PR TITLE
[19.09 unblock] grafana: Drop Frostman from maintainers

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -38,7 +38,7 @@ buildGoPackage rec {
     description = "Gorgeous metric viz, dashboards & editors for Graphite, InfluxDB & OpenTSDB";
     license = licenses.asl20;
     homepage = "https://grafana.com";
-    maintainers = with maintainers; [ offline fpletz willibutz globin ma27 Frostman ];
+    maintainers = with maintainers; [ offline fpletz willibutz globin ma27 ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
@Frostman is not in maintainers-list.nix on 19.09.
This fails the build of the `channel` and `tarball` jobs on the small
jobset.

Follow-up of #83102