### PR TITLE
drush: build with php73

### DIFF
--- a/pkgs/development/tools/misc/drush/default.nix
+++ b/pkgs/development/tools/misc/drush/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     sha256 = "07gbjd7m1fj5dmavr0z20vkqwx1cz2522sj9022p257jifj1yl76";
   };
 
-  buildInputs = [ php which makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     # install libraries

--- a/pkgs/development/tools/misc/drush/default.nix
+++ b/pkgs/development/tools/misc/drush/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, php, which, makeWrapper, bash, coreutils, ncurses }:
+{ stdenv, fetchurl, php73, which, makeWrapper, bash, coreutils, ncurses }:
 
 stdenv.mkDerivation rec {
   name = "drush-6.1.0";
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out"
     cp -r . "$out/src"
     mkdir "$out/bin"
-    wrapProgram "$out/src/drush" --prefix PATH : "${stdenv.lib.makeBinPath [ which php bash coreutils ncurses ]}"
+    wrapProgram "$out/src/drush" --prefix PATH : "${stdenv.lib.makeBinPath [ which php73 bash coreutils ncurses ]}"
     ln -s "$out/src/drush" "$out/bin/drush"
   '';
 }


### PR DESCRIPTION
###### Motivation for this change
when `drush` is wrapped with php 7.4, it complains with a deprecation warning, that swallows all legit output:

```
> drush uli
Deprecated function: Array and string offset access syntax with curly braces is   [error]
 deprecated in include_once() (line 20 of
/var/www/…/htdocs/includes/file.phar.inc).
```

This happens on a fully up2date Drupal 7 installation.
    
Use php7.3 when invoking drush.

Also, fix some `buildInputs` / `nativeBuildInputs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
