### PR TITLE
releaseTools: no-op expression cleanup

### DIFF
--- a/pkgs/build-support/release/binary-tarball.nix
+++ b/pkgs/build-support/release/binary-tarball.nix
@@ -51,29 +51,24 @@ stdenv.mkDerivation (
       configureFlags="--prefix=$prefix $configureFlags"
       dontAddPrefix=1
       prefix=$TMPDIR/inst$prefix
-    ''; # */
-
+    '';
 
     doDist = true;
 
-    distPhase =
-      ''
-        mkdir -p $out/tarballs
-        tar cvfj $out/tarballs/''${releaseName:-binary-dist}.tar.bz2 -C $TMPDIR/inst .
-      '';
+    distPhase = ''
+      mkdir -p $out/tarballs
+      tar cvfj $out/tarballs/''${releaseName:-binary-dist}.tar.bz2 -C $TMPDIR/inst .
+    '';
 
+    finalPhase = ''
+      for i in $out/tarballs/*; do
+          echo "file binary-dist $i" >> $out/nix-support/hydra-build-products
+      done
 
-    finalPhase =
-      ''
-        for i in $out/tarballs/*; do
-            echo "file binary-dist $i" >> $out/nix-support/hydra-build-products
-        done
-
-        # Propagate the release name of the source tarball.  This is
-        # to get nice package names in channels.
-        test -n "$releaseName" && (echo "$releaseName" >> $out/nix-support/hydra-release-name)
-      '';
-
+      # Propagate the release name of the source tarball.  This is
+      # to get nice package names in channels.
+      test -n "$releaseName" && (echo "$releaseName" >> $out/nix-support/hydra-release-name)
+    '';
 
     meta = (if args ? meta then args.meta else {}) // {
       description = "Build of a generic binary distribution";

--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -88,7 +88,7 @@ vmTools.runInLinuxImage (stdenv.mkDerivation (
       done
 
       eval "$postInstall"
-    ''; # */
+    '';
 
     meta = (if args ? meta then args.meta else {}) // {
       description = "Deb package for ${diskImage.fullName}";

--- a/pkgs/build-support/release/default.nix
+++ b/pkgs/build-support/release/default.nix
@@ -1,4 +1,4 @@
-{pkgs}:
+{ pkgs }:
 
 with pkgs;
 
@@ -77,7 +77,7 @@ rec {
      its contituents. Channel jobs are a special type of jobs that are
      listed in the channel tab of Hydra and that can be suscribed.
      A tarball of the src attribute is distributed via the channel.
-     
+
      - constituents: a list of derivations on which the channel success depends.
      - name: the channel name that will be used in the hydra interface.
      - src: should point to the root folder of the nix-expressions used by the
@@ -88,7 +88,7 @@ rec {
          name = "my-channel";
          src = ./.;
        };
-     
+
   */
   channel =
     { name, src, constituents ? [], meta ? {}, isNixOS ? true, ... }@args:

--- a/pkgs/build-support/release/maven-build.nix
+++ b/pkgs/build-support/release/maven-build.nix
@@ -11,12 +11,12 @@
 , ...
 } @ args :
 
-let 
+let
   mvnFlags = "-Dmaven.repo.local=$M2_REPO ${if doTest then "" else "-Dmaven.test.skip.exec=true"} ${extraMvnFlags}";
 in
 
 stdenv.mkDerivation ( {
-  inherit name src; 
+  inherit name src;
   phases = "setupPhase unpackPhase patchPhase mvnCompile ${if doTestCompile then "mvnTestCompile mvnTestJar" else ""} ${if doTest then "mvnTest" else ""} ${if doJavadoc then "mvnJavadoc" else ""} ${if doCheckstyle then "mvnCheckstyle" else ""} mvnJar mvnAssembly mvnRelease finalPhase";
 
   setupPhase = ''
@@ -32,15 +32,15 @@ stdenv.mkDerivation ( {
 
   mvnCompile = ''
     mvn compile ${mvnFlags}
-  '';  
+  '';
 
   mvnTestCompile = ''
     mvn test-compile ${mvnFlags}
-  '';  
+  '';
 
   mvnTestJar = ''
     mvn jar:test-jar ${mvnFlags}
-  '';  
+  '';
 
   mvnTest = ''
     mvn test ${mvnFlags}
@@ -53,21 +53,21 @@ stdenv.mkDerivation ( {
       mvn surefire-report:report-only
       echo "report coverage $out/site/surefire-report.html" >> $out/nix-support/hydra-build-products
     fi
-  '';  
+  '';
 
   mvnJavadoc = ''
     mvn javadoc:javadoc ${mvnFlags}
     echo "report javadoc $out/site/apidocs" >> $out/nix-support/hydra-build-products
-  '';  
+  '';
 
   mvnCheckstyle = ''
     mvn checkstyle:checkstyle ${mvnFlags}
     echo "report checkstyle $out/site/checkstyle.html" >> $out/nix-support/hydra-build-products
-  '';  
+  '';
 
   mvnJar = ''
     mvn jar:jar ${mvnFlags}
-  '';  
+  '';
 
   mvnAssembly = ''
     mvn assembly:assembly -Dmaven.test.skip=true ${mvnFlags}
@@ -80,13 +80,13 @@ stdenv.mkDerivation ( {
     releaseName=$(basename $zip .zip)
     releaseName="$releaseName-r${toString src.rev or "0"}"
     cp $zip $out/release/$releaseName.zip
-    
+
     echo "$releaseName" > $out/nix-support/hydra-release-name
 
     ${if doRelease then  ''
     echo "file zip $out/release/$releaseName.zip" >> $out/nix-support/hydra-build-products
     '' else ""}
-  '';  
+  '';
 
   finalPhase = ''
     if [ -d target/site ] ; then
@@ -94,5 +94,5 @@ stdenv.mkDerivation ( {
       echo "report site $out/site" >> $out/nix-support/hydra-build-products
     fi
   '';
-} // args 
+} // args
 )

--- a/pkgs/build-support/release/rpm-build.nix
+++ b/pkgs/build-support/release/rpm-build.nix
@@ -44,7 +44,7 @@ vmTools.buildRPM (
       for rpmdir in $extraRPMs ; do
         echo "file rpm-extra $(ls $rpmdir/rpms/*/*.rpm | grep -v 'src\.rpm' | sort | head -1)" >> $out/nix-support/hydra-build-products
       done
-    ''; # */
+    '';
 
     meta = (if args ? meta then args.meta else {}) // {
       description = "RPM package for ${diskImage.fullName}";


### PR DESCRIPTION
No functional change, was just reading through these and cleaning/sanitizing
them a bit while I'm here.  I'm planning on factoring out some AMI construction logic into a nicer helper function a follow-up.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).