### PR TITLE
gwyddion: 2.48 -> 2.55 (and add options)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1257,6 +1257,20 @@
     githubId = 5949913;
     name = "Carlos Fernandez Sanz";
   };
+  cge = {
+    email = "cevans@evanslabs.org";
+    github = "cgevans";
+    githubId = 2054509;
+    name = "Constantine Evans";
+    keys = [
+      { longkeyid = "rsa4096/0xB67DB1D20A93A9F9";
+        fingerprint = "32B1 6EE7 DBA5 16DE 526E  4C5A B67D B1D2 0A93 A9F9";
+      }
+      { longkeyid = "rsa4096/0x1A1D58B86AE2AABD";
+        fingerprint = "669C 1D24 5A87 DB34 6BE4  3216 1A1D 58B8 6AE2 AABD";
+      }
+    ];
+  };
   chaduffy = {
     email = "charles@dyfis.net";
     github = "charles-dyfis-net";

--- a/pkgs/applications/science/chemistry/gwyddion/codegen.patch
+++ b/pkgs/applications/science/chemistry/gwyddion/codegen.patch
@@ -1,0 +1,22 @@
+--- gwyddion-2.55.orig/configure	2019-11-04 01:25:31.000000000 -0800
++++ gwyddion-2.55/configure	2020-03-20 18:49:43.860452655 -0700
+@@ -18560,7 +18560,7 @@
+ fi
+   if test "x$embed_pygtk" = xno; then
+     if test "x$PYGTK_CODEGENDIR" = 'x'; then
+-      PYGTK_CODEGENDIR=`$PKG_CONFIG --variable=codegendir pygtk-2.0`
++      PYGTK_CODEGENDIR=`$PKG_CONFIG --variable=codegendir pygobject-2.0`
+     fi
+   else
+     # Some silly OSes want to remove pygtk2.  We can build pygwy without
+--- gwyddion-2.55.orig/configure.ac	2019-11-04 01:25:16.000000000 -0800
++++ gwyddion-2.55/configure.ac	2020-03-20 18:52:55.042724547 -0700
+@@ -270,7 +270,7 @@
+                     [embed_pygtk=yes; pygwy_warn=" (embedded pygtk2)"])
+   if test "x$embed_pygtk" = xno; then
+     if test "x$PYGTK_CODEGENDIR" = 'x'; then
+-      PYGTK_CODEGENDIR=`$PKG_CONFIG --variable=codegendir pygtk-2.0`
++      PYGTK_CODEGENDIR=`$PKG_CONFIG --variable=codegendir pygobject-2.0`
+     fi
+   else
+     # Some silly OSes want to remove pygtk2.  We can build pygwy without

--- a/pkgs/applications/science/chemistry/gwyddion/default.nix
+++ b/pkgs/applications/science/chemistry/gwyddion/default.nix
@@ -1,17 +1,69 @@
-{ stdenv, fetchurl, gtk2, pkgconfig }:
+{ stdenv, fetchurl, gtk2, pkg-config, fftw, file,
+  pythonSupport ? false, pythonPackages ? null,
+  gnome2 ? null,
+  openexrSupport ? true, openexr ? null,
+  libzipSupport ? true, libzip ? null,
+  libxml2Support ? true, libxml2 ? null,
+  libwebpSupport ? true, libwebp ? null,
+  # libXmu is not used if libunique is.
+  libXmuSupport ? false, xorg ? null,
+  libxsltSupport ? true, libxslt ? null,
+  fitsSupport ? true, cfitsio ? null,
+  zlibSupport ? true, zlib ? null,
+  libuniqueSupport ? true, libunique ? null,
+  libpngSupport ? true, libpng ? null,
+  openglSupport ? true
+}:
 
-with stdenv.lib;
+assert openexrSupport -> openexr != null;
+assert libzipSupport -> libzip != null;
+assert libxml2Support -> libxml2 != null;
+assert libwebpSupport -> libwebp != null;
+assert libXmuSupport -> xorg != null;
+assert libxsltSupport -> libxslt != null;
+assert fitsSupport -> cfitsio != null;
+assert zlibSupport -> zlib != null;
+assert libuniqueSupport -> libunique != null;
+assert libpngSupport -> libpng != null;
+assert openglSupport -> gnome2 != null;
+assert pythonSupport -> (pythonPackages != null && gnome2 != null);
 
-let version = "2.48"; in
-stdenv.mkDerivation {
+let
+    inherit (pythonPackages) pygtk pygobject2 python;
+
+in
+
+stdenv.mkDerivation rec {
   pname = "gwyddion";
-  inherit version;
+   version = "2.55";
   src = fetchurl {
-    url = "mirror://sourceforge/gwyddion/files/gwyddion/${version}/gwyddion-${version}.tar.xz";
-    sha256 = "119iw58ac2wn4cas6js8m7r1n4gmmkga6b1y711xzcyjp9hshgwx";
+    url = "mirror://sourceforge/gwyddion/gwyddion-${version}.tar.xz";
+    sha256 = "0l00zszvginpriv12idc0y1x28qmicdmrwkqa007srkxvrdgxwdi";
   };
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk2 ];
+  
+  nativeBuildInputs = [ pkg-config file ];
+  
+  buildInputs = with stdenv.lib;
+    [ gtk2 fftw ] ++
+    optionals openglSupport [gnome2.gtkglext] ++
+    optional openexrSupport openexr ++
+    optional libXmuSupport xorg.libXmu ++
+    optional fitsSupport cfitsio ++
+    optional libpngSupport libpng ++
+    optional libxsltSupport libxslt ++
+    optional libxml2Support libxml2 ++
+    optional libwebpSupport libwebp ++
+    optional zlibSupport zlib ++
+    optional libuniqueSupport libunique ++
+    optional libzipSupport libzip;
+
+  propagatedBuildInputs = with stdenv.lib;
+    optionals pythonSupport [ pygtk pygobject2 python gnome2.gtksourceview ];
+
+  # This patch corrects problems with python support, but should apply cleanly
+  # regardless of whether python support is enabled, and have no effects if
+  # it is disabled.
+  patches = [ ./codegen.patch ];
   meta = {
     homepage = http://gwyddion.net/;
 
@@ -29,5 +81,6 @@ stdenv.mkDerivation {
     '';
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.cge ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2244,6 +2244,11 @@ in {
 
   eth-utils = callPackage ../development/python-modules/eth-utils { };
 
+  gwyddion = disabledIf isPy3k (toPythonModule (pkgs.gwyddion.override {
+    pythonSupport = true;
+    pythonPackages = self;
+  }));
+
   impacket = callPackage ../development/python-modules/impacket { };
 
   jsonlines = callPackage ../development/python-modules/jsonlines { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Gwyddion has a large number of optional dependencies. In this update, those dependencies have been added with options set mostly to true, and an option (default false) for working Python 2.7 support in the program and in Python (but without the gwyutils module) has been added. I have also added myself as a maintainer as no maintainer is currently set.

Upstream has made the gwyutils module intentionally hard to use by placing it outside the Python path, and I'm not sure the best way to fix this, or whether it should be fixed.  I have also not added options for ruby and perl support, as I don't know how that support works (it isn't listed in the configuration summary).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

-  [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)

(Tested both gwyddion (and confirmed no Python support) and python27Packages.gwyddion (and confirmed Python support))

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` 
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
