### PR TITLE
monero-gui: 0.15.0.1 -> 0.15.0.4

### DIFF
--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -1,36 +1,35 @@
-{ stdenv, wrapQtAppsHook, makeDesktopItem, fetchFromGitHub
-, qtbase, qmake, qtmultimedia, qttools
-, qtgraphicaleffects, qtdeclarative
-, qtlocation, qtquickcontrols, qtquickcontrols2
-, qtwebchannel, qtwebengine, qtx11extras, qtxmlpatterns
+{ stdenv, wrapQtAppsHook, makeDesktopItem
+, fetchFromGitHub, qmake, qttools, pkgconfig
+, qtbase, qtdeclarative, qtgraphicaleffects
+, qtmultimedia, qtxmlpatterns
+, qtquickcontrols, qtquickcontrols2
 , monero, unbound, readline, boost, libunwind
-, libsodium, pcsclite, zeromq, cppzmq, pkgconfig
-, hidapi, randomx
+, libsodium, pcsclite, zeromq, cppzmq
+, hidapi, libusb, protobuf, randomx
 }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.15.0.1";
+  version = "0.15.0.4";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "08j8kkncdn57xql0bhmlzjpjkdfhqbpda1p07r797q8qi0nl4w8n";
+    sha256 = "12m5fgnxkr11q2arx1m5ccpxqm5ljcvm6l547dwqn297zs5jim4z";
   };
 
   nativeBuildInputs = [ qmake pkgconfig wrapQtAppsHook ];
 
   buildInputs = [
-    qtbase qtmultimedia qtgraphicaleffects
-    qtdeclarative qtlocation
-    qtquickcontrols qtquickcontrols2
-    qtwebchannel qtwebengine qtx11extras
-    qtxmlpatterns monero unbound readline
+    qtbase qtdeclarative qtgraphicaleffects
+    qtmultimedia qtquickcontrols qtquickcontrols2
+    qtxmlpatterns
+    monero unbound readline
     boost libunwind libsodium pcsclite zeromq
-    cppzmq hidapi randomx
+    cppzmq hidapi libusb protobuf randomx
   ];
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=format-security" ];

--- a/pkgs/applications/blockchains/monero-gui/move-log-file.patch
+++ b/pkgs/applications/blockchains/monero-gui/move-log-file.patch
@@ -1,15 +1,14 @@
-diff --git a/main.cpp b/main.cpp
-index a51568d..5a9f683 100644
---- a/main.cpp
-+++ b/main.cpp
-@@ -152,7 +152,9 @@ int main(int argc, char *argv[])
+diff --git a/src/main/main.cpp b/src/main/main.cpp
+index c5210e5f..45794d72 100644
+--- a/src/main/main.cpp
++++ b/src/main/main.cpp
+@@ -220,6 +220,9 @@ int main(int argc, char *argv[])
      QCommandLineOption logPathOption(QStringList() << "l" << "log-file",
          QCoreApplication::translate("main", "Log to specified file"),
          QCoreApplication::translate("main", "file"));
--
 +    logPathOption.setDefaultValue(
 +        QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
 +        + "/monero-wallet-gui.log");
-     parser.addOption(logPathOption);
-     parser.addHelpOption();
-     parser.process(app);
+ 
+     QCommandLineOption testQmlOption("test-qml");
+     testQmlOption.setFlags(QCommandLineOption::HiddenFromHelp);

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -2,7 +2,7 @@
 , cmake, pkgconfig
 , boost, miniupnpc, openssl, unbound, cppzmq
 , zeromq, pcsclite, readline, libsodium, hidapi
-, python3Packages, randomx, rapidjson
+, pythonProtobuf, randomx, rapidjson, libusb
 , CoreData, IOKit, PCSC
 }:
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     boost miniupnpc openssl unbound
     cppzmq zeromq pcsclite readline
     libsodium hidapi randomx rapidjson
-    python3Packages.protobuf
+    pythonProtobuf libusb
   ] ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit CoreData PCSC ];
 
   cmakeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22969,10 +22969,12 @@ in
 
   monero = callPackage ../applications/blockchains/monero {
     inherit (darwin.apple_sdk.frameworks) CoreData IOKit PCSC;
+    pythonProtobuf = python3Packages.protobuf.override { protobuf = protobuf3_10; };
   };
 
   monero-gui = libsForQt5.callPackage ../applications/blockchains/monero-gui {
     boost = boost16x;
+    protobuf = protobuf3_10;
   };
 
   masari = callPackage ../applications/blockchains/masari.nix { boost = boost165; };


### PR DESCRIPTION
###### Motivation for this change
Fix #82154

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested GUI and daemon syncronisation
- [x] Tested compilation of all pkgs that depend on this change (monero, monero-gui)
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
