### PR TITLE
netease-cloud-music: do not set QT_AUTO_SCREEN_SCALE_FACTOR

### DIFF
--- a/pkgs/applications/audio/netease-cloud-music/default.nix
+++ b/pkgs/applications/audio/netease-cloud-music/default.nix
@@ -68,7 +68,6 @@ in stdenv.mkDerivation rec {
 
     wrapProgram $out/bin/netease-cloud-music \
       --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
-      --set QT_AUTO_SCREEN_SCALE_FACTOR 1 \
       --set QCEF_INSTALL_PATH "${deepin.qcef}/lib/qcef"
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
It is not a good idea to set QT_AUTO_SCREEN_SCALE_FACTOR in packages. Users may want to cusomize the scale (i.e. set QT_SCALE in the session) and set scales in package will lead to unexpected results.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
