### PR TITLE
cinnamon.warpinator: init at 1.0.8

### DIFF
--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -29,4 +29,5 @@ lib.makeScope pkgs.newScope (self: with self; {
   mint-y-icons = callPackage ./mint-y-icons { };
   muffin = callPackage ./muffin { };
   xapps = callPackage ./xapps { };
+  warpinator = callPackage ./warpinator { };
 })

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -1,0 +1,79 @@
+{ fetchFromGitHub
+, stdenv
+, gobject-introspection
+, meson
+, ninja
+, python3
+, gtk3
+, gdk-pixbuf
+, wrapGAppsHook
+, gettext
+, polkit
+, glib
+}:
+
+python3.pkgs.buildPythonApplication rec  {
+  pname = "warpinator";
+  version = "1.0.8";
+
+  format = "other";
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "0n1b50j2w76qnhfj5yg5q2j7fgxr9gbmzpazmbml4q41h8ybcmxm";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    gobject-introspection
+    wrapGAppsHook
+    gettext
+    polkit # for its gettext
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    gdk-pixbuf
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    grpcio-tools
+    protobuf
+    pygobject3
+    setproctitle
+    xapp
+    zeroconf
+    grpcio
+    setuptools
+    cryptography
+    pynacl
+    netifaces
+  ];
+
+  postPatch = ''
+    chmod +x install-scripts/*
+    patchShebangs .
+
+    find . -type f -exec sed -i \
+      -e s,/usr/libexec/warpinator,$out/libexec/warpinator,g \
+      {} +
+  '';
+
+  preFixup = ''
+    # these get loaded via import from bin, so don't need wrapping
+    chmod -x+X $out/libexec/warpinator/*.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/warpinator";
+    description = "Share files across the LAN";
+    license = licenses.gpl3plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

More cinnamon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
