### PR TITLE
cinnamon.mint-y-icons: init at unstable-2020-03-21

### DIFF
--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -9,6 +9,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   cjs = callPackage ./cjs { };
   nemo = callPackage ./nemo { };
   mint-themes = callPackage ./mint-themes { };
+  mint-y-icons = callPackage ./mint-y-icons { };
   muffin = callPackage ./muffin { };
   xapps = callPackage ./xapps { };
 })

--- a/pkgs/desktops/cinnamon/mint-y-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-y-icons/default.nix
@@ -1,0 +1,46 @@
+{ fetchFromGitHub
+, stdenv
+, gnome3
+, hicolor-icon-theme
+, gtk3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mint-y-icons";
+  version = "unstable-2020-03-21";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = "f169a617bc344cb0b480b2b72f54cdd06af05255";
+    sha256 = "1c2a79ylk363i982czwwqcwc7cw6dyzlqphcypqm6nll7xlafq8s";
+  };
+
+  propagatedUserEnvPkgs = [
+    gnome3.adwaita-icon-theme
+    hicolor-icon-theme
+  ];
+
+  nativeBuildInputs = [
+    gtk3
+  ];
+
+  postFixup =  ''
+    gtk-update-icon-cache $out/share/icons/*
+  '';
+
+  dontDropIconThemeCache = true;
+
+  installPhase = ''
+    mkdir -p $out
+    mv usr/share $out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/mint-y-icons";
+    description = "The Mint-Y icon theme";
+    license = licenses.gpl3; # from debian/copyright
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
