### PR TITLE
ffado: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -33,8 +33,7 @@ mkDerivation rec {
 
   prePatch = ''
     substituteInPlace ./support/tools/ffado-diag.in \
-      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace 'stdout ("uname", "-r").rstrip ()' '"${kernel.modDirVersion}"'
+      --replace /lib/modules/ "/run/booted-system/kernel-modules/lib/modules/"
   '';
 
   patches = [

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -91,7 +91,7 @@ mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.ffado.org;
+    homepage = "http://www.ffado.org";
     description = "FireWire audio drivers";
     license = licenses.gpl3;
     maintainers = with maintainers; [ goibhniu michojel ];

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -1,20 +1,41 @@
-{ stdenv, fetchurl, scons, pkgconfig, which, makeWrapper, python3
-, libraw1394, libconfig, libavc1394, libiec61883, libxmlxx3
+{ stdenv
+, mkDerivation
+, dbus
+, dbus_cplusplus
+, desktop-file-utils
+, fetchurl
 , glibmm
-, dbus, dbus_cplusplus
+, kernel
+, libavc1394
+, libconfig
+, libiec61883
+, libraw1394
+, libxmlxx3
+, pkgconfig
+, python3
+, scons
+, which
+, wrapQtAppsHook
 }:
 
 let
   inherit (python3.pkgs) pyqt5 dbus-python;
   python = python3.withPackages (pkgs: with pkgs; [ pyqt5 dbus-python ]);
-in stdenv.mkDerivation rec {
+in
+mkDerivation rec {
   pname = "ffado";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchurl {
     url = "http://www.ffado.org/files/libffado-${version}.tgz";
-    sha256 = "0byr3kv58d1ryy60vr69fd868zlfkvl2gq9hl94dqdn485l9pq9y";
+    sha256 = "09dxy6fkfnvzk45lpr74hkqymii8a45jzlq6054f3jz65m8qvj3d";
   };
+
+  prePatch = ''
+    substituteInPlace ./support/tools/ffado-diag.in \
+      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace 'stdout ("uname", "-r").rstrip ()' '"${kernel.modDirVersion}"'
+  '';
 
   patches = [
     # fix installing metainfo file
@@ -23,13 +44,13 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "bin" "dev" ];
 
-  nativeBuildInputs = [ scons pkgconfig which makeWrapper python pyqt5 ];
+  nativeBuildInputs = [ desktop-file-utils scons pkgconfig which python pyqt5 wrapQtAppsHook ];
 
   prefixKey = "PREFIX=";
   sconsFlags = [
     "DEBUG=False"
     "ENABLE_ALL=True"
-    "BUILD_TESTS=False"
+    "BUILD_TESTS=True"
     "WILL_DEAL_WITH_XDG_MYSELF=True"
     "BUILD_MIXER=True"
     "UDEVDIR=${placeholder "out"}/lib/udev/rules.d"
@@ -40,29 +61,41 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    libraw1394
-    libconfig
-    libavc1394
-    libiec61883
     dbus
     dbus_cplusplus
+    glibmm
+    libavc1394
+    libconfig
+    libiec61883
+    libraw1394
     libxmlxx3
     python
-    glibmm
   ];
 
   enableParallelBuilding = true;
+  dontWrapQtApps = true;
 
   postInstall = ''
+    desktop="$bin/share/applications/ffado-mixer.desktop"
+    install -DT -m 444 support/xdg/ffado.org-ffadomixer.desktop $desktop
+    substituteInPlace "$desktop" \
+      --replace Exec=ffado-mixer "Exec=$bin/bin/ffado-mixer" \
+      --replace hi64-apps-ffado ffado-mixer
+    install -DT -m 444 support/xdg/hi64-apps-ffado.png "$bin/share/icons/hicolor/64x64/apps/ffado-mixer.png"
+
     # prevent build tools from leaking into closure
     echo 'See `nix-store --query --tree ${placeholder "out"}`.' > $out/lib/libffado/static_info.txt
+  '';
+
+  preFixup = ''
+    wrapQtApp $bin/bin/ffado-mixer
   '';
 
   meta = with stdenv.lib; {
     homepage = http://www.ffado.org;
     description = "FireWire audio drivers";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ goibhniu ];
+    maintainers = with maintainers; [ goibhniu michojel ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16383,7 +16383,9 @@ in
 
   fatrace = callPackage ../os-specific/linux/fatrace { };
 
-  ffado = callPackage ../os-specific/linux/ffado { };
+  ffado = libsForQt5.callPackage ../os-specific/linux/ffado {
+    inherit (pkgs.linuxPackages) kernel;
+  };
   libffado = ffado;
 
   fbterm = callPackage ../os-specific/linux/fbterm { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bumped version and did some fixes to binaries.

- fixed broken ffado-diag (hardcoded kernel module paths)
- fixed ffado-mixer (broken Qt5)
- enabled ffado-test
- added desktop file for ffado-mixer
- formatted using [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] ffado-diag
  - [x] ffado-test
  - [x] ffado-mixer
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).