### PR TITLE
vdr-xineliboutput fix build and 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/applications/video/vdr/xineliboutput/default.nix
+++ b/pkgs/applications/video/vdr/xineliboutput/default.nix
@@ -4,16 +4,15 @@
 , libX11, libXext, libXrender, libXrandr
 , makeWrapper
 }: let
-  name = "vdr-xineliboutput-2.1.0";
-
   makeXinePluginPath = l: lib.concatStringsSep ":" (map (p: "${p}/lib/xine/plugins") l);
 
-  self =  stdenv.mkDerivation {
-    inherit name;
+  self =  stdenv.mkDerivation rec {
+    pname = "vdr-xineliboutput";
+    version = "2.2.0";
 
     src = fetchurl {
-      url = "mirror://sourceforge/project/xineliboutput/xineliboutput/${name}/${name}.tgz";
-      sha256 = "1phrxpaz8li7z0qy241spawalhcmwkv5hh3gdijbv4h7mm899yba";
+      url = "mirror://sourceforge/project/xineliboutput/xineliboutput/${pname}-${version}/${pname}-${version}.tgz";
+      sha256 = "0a24hs5nr7ncf51c5agyfn1xrvb4p70y3i0s6dlyyd9bwbfjldns";
     };
 
     postPatch = ''

--- a/pkgs/applications/video/vdr/xineliboutput/default.nix
+++ b/pkgs/applications/video/vdr/xineliboutput/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, lib, vdr
 , libav, libcap, libvdpau
-, xineLib, libjpeg, libextractor, mesa, libGLU
+, xineLib, libjpeg, libextractor, libglvnd, libGLU
 , libX11, libXext, libXrender, libXrandr
 , makeWrapper
 }: let
@@ -15,6 +15,12 @@
       url = "mirror://sourceforge/project/xineliboutput/xineliboutput/${name}/${name}.tgz";
       sha256 = "1phrxpaz8li7z0qy241spawalhcmwkv5hh3gdijbv4h7mm899yba";
     };
+
+    postPatch = ''
+      # pkg-config is called with opengl, which do not contain needed glx symbols
+      substituteInPlace configure \
+        --replace "X11  opengl" "X11  gl"
+    '';
 
     # configure don't accept argument --prefix
     dontAddPrefix = true;
@@ -40,13 +46,13 @@
       libcap
       libextractor
       libjpeg
+      libglvnd
       libGLU
       libvdpau
       libXext
       libXrandr
       libXrender
       libX11
-      mesa
       vdr
       xineLib
     ];


### PR DESCRIPTION
###### Motivation for this change
The package was broken. Additional updated to 2.2.0.
I will cherry pick this fix for nixos-20.03 when this PR is merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
