### PR TITLE
notable: use .desktop file from AppImage

### DIFF
--- a/pkgs/applications/misc/notable/default.nix
+++ b/pkgs/applications/misc/notable/default.nix
@@ -3,13 +3,23 @@
 let
   pname = "notable";
   version = "1.8.4";
-in
-appimageTools.wrapType2 rec {
+  sha256 = "0rvz8zwsi62kiq89pv8n2wh9h5yb030kvdr1vf65xwqkhqcrzrby";
+
   name = "${pname}-${version}";
+
   src = fetchurl {
     url = "https://github.com/notable/notable/releases/download/v${version}/Notable-${version}.AppImage";
-    sha256 = "0rvz8zwsi62kiq89pv8n2wh9h5yb030kvdr1vf65xwqkhqcrzrby";
+    inherit sha256;
   };
+
+  appimageContents = appimageTools.extract {
+    inherit name src;
+  };
+
+in
+appimageTools.wrapType2 rec {
+
+  inherit name src;
 
   profile = ''
     export LC_ALL=C.UTF-8
@@ -18,7 +28,14 @@ appimageTools.wrapType2 rec {
 
   multiPkgs = null; # no 32bit needed
   extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [ p.at-spi2-atk p.at-spi2-core ];
-  extraInstallCommands = "mv $out/bin/{${name},${pname}}";
+  extraInstallCommands = ''
+    mv $out/bin/{${name},${pname}}
+    install -m 444 -D ${appimageContents}/notable.desktop $out/share/applications/notable.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/1024x1024/apps/notable.png \
+      $out/share/icons/hicolor/1024x1024/apps/notable.png
+    substituteInPlace $out/share/applications/notable.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
 
   meta = with lib; {
     description = "The markdown-based note-taking app that doesn't suck";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

App lacked integration for Desktop Environments. Added build steps to extract `.desktop` file and icon from AppImage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
