### PR TITLE
Conan 1.23.0

### DIFF
--- a/pkgs/development/python-modules/patch-ng/default.nix
+++ b/pkgs/development/python-modules/patch-ng/default.nix
@@ -1,0 +1,22 @@
+{ stdenv
+, buildPythonPackage
+, fetchurl
+}:
+
+buildPythonPackage rec {
+  version = "1.17.2"; # note: `conan` package may require a hardcoded one
+  pname = "patch-ng";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "02nadk70sk51liv0qav88kx8rzfdjc1x52023zayanz44kkcjl2i";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Library to parse and apply unified diffs.";
+    homepage = "https://github.com/conan-io/python-patch";
+    license = licenses.mit;
+    maintainers = with maintainers; [ HaoZeke ];
+  };
+
+}

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -1,5 +1,17 @@
 { lib, python3, git, pkgconfig }:
 
+# Note:
+# Conan has specific dependency demanands; check
+#     https://github.com/conan-io/conan/blob/master/conans/requirements.txt
+#     https://github.com/conan-io/conan/blob/master/conans/requirements_server.txt
+# on the release branch/commit we're packaging.
+#
+# Two approaches are used here to deal with that:
+# Pinning the specific versions it wants in `newPython`,
+# and using `substituteInPlace conans/requirements.txt ...`
+# in `postPatch` to allow newer versions when we know
+# (e.g. from changelogs) that they are compatible.
+
 let newPython = python3.override {
   packageOverrides = self: super: {
     distro = super.distro.overridePythonAttrs (oldAttrs: rec {
@@ -16,20 +28,6 @@ let newPython = python3.override {
         sha256 = "1dv6mjsm67l1razcgmq66riqmsb36wns17mnipqr610v0z0zf5j0";
       };
     });
-    future = super.future.overridePythonAttrs (oldAttrs: rec {
-      version = "0.16.0";
-      src = oldAttrs.src.override {
-        inherit version;
-        sha256 = "1nzy1k4m9966sikp0qka7lirh8sqrsyainyf8rk97db7nwdfv773";
-      };
-    });
-    tqdm = super.tqdm.overridePythonAttrs (oldAttrs: rec {
-      version = "4.28.1";
-      src = oldAttrs.src.override {
-        inherit version;
-        sha256 = "1fyybgbmlr8ms32j7h76hz5g9xc6nf0644mwhc40a0s5k14makav";
-      };
-    });
     pluginbase = super.pluginbase.overridePythonAttrs (oldAttrs: rec {
       version = "0.7";
       src = oldAttrs.src.override {
@@ -41,31 +39,34 @@ let newPython = python3.override {
 };
 
 in newPython.pkgs.buildPythonApplication rec {
-  version = "1.12.3";
+  version = "1.23.0";
   pname = "conan";
 
   src = newPython.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "1cnfy9b57apps4bfai6r67g0mrvgnqa154z9idv0kf93k1nvx53g";
+    sha256 = "06jnmgvzdyxjpcmyj1804mlq6b842jvvbsngsamdy976sqws870g";
   };
 
   propagatedBuildInputs = with newPython.pkgs; [
     bottle
     colorama
+    dateutil
     deprecation
     distro
     fasteners
     future
+    jinja2
     node-semver
-    patch
+    patch-ng
     pluginbase
     pygments
     pyjwt
-    pylint
+    pylint # Not in `requirements.txt` but used in hooks, see https://github.com/conan-io/conan/pull/6152
     pyyaml
     requests
     six
     tqdm
+    urllib3
   ];
 
   checkInputs = [
@@ -81,11 +82,11 @@ in newPython.pkgs.buildPythonApplication rec {
     webtest
   ]);
 
-  checkPhase = ''
-    export HOME=$TMPDIR
-    pytest conans/test/{utils,unittests} \
-      -k 'not SVN and not ToolsNetTest'
-  '';
+  # Conan 1.14.0 has removed all tests from the Pypi source dist:
+  #     https://github.com/conan-io/conan/pull/4713
+  # We have recommended they be added back:
+  #     https://github.com/conan-io/conan/issues/4563#issuecomment-602225083
+  doCheck = false;
 
   postPatch = ''
     substituteInPlace conans/requirements.txt \

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -50,9 +50,22 @@ in newPython.pkgs.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with newPython.pkgs; [
-    colorama deprecation distro fasteners bottle
-    future node-semver patch pygments pluginbase
-    pyjwt pylint pyyaml requests six tqdm
+    bottle
+    colorama
+    deprecation
+    distro
+    fasteners
+    future
+    node-semver
+    patch
+    pluginbase
+    pygments
+    pyjwt
+    pylint
+    pyyaml
+    requests
+    six
+    tqdm
   ];
 
   checkInputs = [

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -88,8 +88,6 @@ in newPython.pkgs.buildPythonApplication rec {
   '';
 
   postPatch = ''
-    substituteInPlace conans/requirements_server.txt \
-      --replace "pluginbase>=0.5, < 1.0" "pluginbase>=0.5"
     substituteInPlace conans/requirements.txt \
       --replace "PyYAML>=3.11, <3.14.0" "PyYAML"
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4764,6 +4764,8 @@ in {
 
   patch = callPackage ../development/python-modules/patch { };
 
+  patch-ng = callPackage ../development/python-modules/patch-ng { };
+
   pathos = callPackage ../development/python-modules/pathos { };
 
   patsy = callPackage ../development/python-modules/patsy { };


### PR DESCRIPTION
###### Motivation for this change

#80379 (Zero Hydra Failures for 20.03) -- conan fails there and on `master` because it does not support GCC >= 9. This newer version does (somehwere around this PR: https://github.com/conan-io/conan/issues/5093).

I've added @HaoZeke as the maintainer of the newly added `patch-ng` dependency, also maintained by the Conan team.

I myself am not a user of Conan nor do I know how to run it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
