### PR TITLE
gitAndTools.git-machete: 2.13.5 -> 2.13.6

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonApplication rec {
   pname = "git-machete";
-  version = "2.13.5";
+  version = "2.13.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ll5l1f3vcib9a8qsqm8bfzz4g4q1dnr389x7x26kl13n6a50wib";
+    sha256 = "0n07gm05676vgfh6vlym59jwwzym9xmibhr0zpf0drlx02fr47qy";
   };
 
   nativeBuildInputs = [ installShellFiles pbr ];
@@ -25,7 +25,7 @@ buildPythonApplication rec {
 
   meta = with lib; {
     homepage = https://github.com/VirtusLab/git-machete;
-    description = "Git repository organizer and rebase workflow automation tool";
+    description = "Git repository organizer and rebase/merge workflow automation tool";
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = [ maintainers.blitz ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest upstream version

###### Things done
 * [ ]  Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
 * Built on platform(s)

   * [x]  NixOS
   * [ ]  macOS
   * [ ]  other Linux distributions
 * [ ]  Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
 * [ ]  Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
 * [x]  Tested execution of all binary files (usually in `./result/bin/`)
 * [ ]  Determined the impact on package closure size (by running `nix path-info -S` before and after)
 * [ ]  Ensured that relevant documentation is up to date
 * [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
cc @worldofpeace @tfc @jtraue