### PR TITLE
qxmledit: init at 0.9.15

### DIFF
--- a/pkgs/applications/editors/qxmledit/default.nix
+++ b/pkgs/applications/editors/qxmledit/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub,
+  qmake, qtbase, qtxmlpatterns, qtsvg, qtscxml, qtquick1, libGLU }:
+
+stdenv.mkDerivation rec {
+  name = "qxmledit-${version}" ;
+  version = "0.9.15" ;
+  src = fetchFromGitHub ( stdenv.lib.importJSON ./qxmledit.json ) ;
+  nativeBuildInputs = [ qmake ] ;
+  buildInputs = [ qtbase qtxmlpatterns qtsvg qtscxml qtquick1 libGLU ] ;
+  qmakeFlags = [ "CONFIG+=release" ] ;
+  outputs = [ "out" "doc" ] ;
+
+  preConfigure = ''
+export QXMLEDIT_INST_DATA_DIR="$out/share/data"
+export QXMLEDIT_INST_TRANSLATIONS_DIR="$out/share/i18n"
+export QXMLEDIT_INST_INCLUDE_DIR="$out/include"
+export QXMLEDIT_INST_DIR="$out/bin"
+export QXMLEDIT_INST_LIB_DIR="$out/lib"
+export QXMLEDIT_INST_DOC_DIR="$doc"
+'';
+
+  meta = with stdenv.lib; {
+    description = "Simple XML editor based on qt libraries" ;
+    homepage = https://sourceforge.net/projects/qxmledit;
+    license = licenses.lgpl2;
+    platforms = platforms.all;
+  } ;
+}

--- a/pkgs/applications/editors/qxmledit/default.nix
+++ b/pkgs/applications/editors/qxmledit/default.nix
@@ -11,13 +11,13 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "doc" ] ;
 
   preConfigure = ''
-export QXMLEDIT_INST_DATA_DIR="$out/share/data"
-export QXMLEDIT_INST_TRANSLATIONS_DIR="$out/share/i18n"
-export QXMLEDIT_INST_INCLUDE_DIR="$out/include"
-export QXMLEDIT_INST_DIR="$out/bin"
-export QXMLEDIT_INST_LIB_DIR="$out/lib"
-export QXMLEDIT_INST_DOC_DIR="$doc"
-'';
+    export QXMLEDIT_INST_DATA_DIR="$out/share/data"
+    export QXMLEDIT_INST_TRANSLATIONS_DIR="$out/share/i18n"
+    export QXMLEDIT_INST_INCLUDE_DIR="$out/include"
+    export QXMLEDIT_INST_DIR="$out/bin"
+    export QXMLEDIT_INST_LIB_DIR="$out/lib"
+    export QXMLEDIT_INST_DOC_DIR="$doc"
+  '';
 
   meta = with stdenv.lib; {
     description = "Simple XML editor based on qt libraries" ;

--- a/pkgs/applications/editors/qxmledit/qxmledit.json
+++ b/pkgs/applications/editors/qxmledit/qxmledit.json
@@ -1,0 +1,6 @@
+{
+    "owner": "lbellonda",
+    "repo": "qxmledit",
+    "rev": "6136dca50ceb3b4447c91a7a18dcf84785ea11d1",
+    "sha256": "1wcnphalwf0a5gz9r44jgk8wcv1w2qipbwjkbzkra2kxanxns834"
+}

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -150,6 +150,7 @@ let
       qtserialport = callPackage ../modules/qtserialport.nix {};
       qtspeech = callPackage ../modules/qtspeech.nix {};
       qtsvg = callPackage ../modules/qtsvg.nix {};
+      qtscxml = callPackage ../modules/qtscxml.nix {};
       qttools = callPackage ../modules/qttools.nix {};
       qttranslations = callPackage ../modules/qttranslations.nix {};
       qtvirtualkeyboard = callPackage ../modules/qtvirtualkeyboard.nix {};

--- a/pkgs/development/libraries/qt-5/modules/qtscxml.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtscxml.nix
@@ -1,0 +1,7 @@
+{ qtModule, qtbase, qtdeclarative }:
+
+qtModule {
+  name = "qtscxml";
+  qtInputs = [ qtbase qtdeclarative ];
+  outputs = [ "out" "dev" "bin" ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10757,6 +10757,8 @@ in
 
   qtcreator = libsForQt5.callPackage ../development/tools/qtcreator { };
 
+  qxmledit = libsForQt5.callPackage ../applications/editors/qxmledit {} ;
+
   r10k = callPackage ../tools/system/r10k { };
 
   inherit (callPackages ../development/tools/analysis/radare2 ({


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add editor to the codebase

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
