### PR TITLE
alsa-lib: 1.1.9 -> 1.2.2 and new alsa conf packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6305,6 +6305,12 @@
       fingerprint = "92B2 904F D293 C94D C4C9  3E6B BFBA F4C9 75F7 6450";
     }];
   };
+  roastiek = {
+    email = "r.dee.b.b@gmail.com";
+    github = "roastiek";
+    githubId = 422802;
+    name = "Rostislav Beneš";
+  };
   rob = {
     email = "rob.vermaas@gmail.com";
     github = "rbvermaa";

--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, alsa-ucm-conf, alsa-topology-conf }:
 
 stdenv.mkDerivation rec {
-  name = "alsa-lib-1.1.9";
+  name = "alsa-lib-1.2.2";
 
   src = fetchurl {
     url = "mirror://alsa/lib/${name}.tar.bz2";
-    sha256 = "0jwr9g4yxg9gj6xx0sb2r6wrdl8amrjd19hilkrq4rirynp770s8";
+    sha256 = "1v5kb8jyvrpkvvq7dq8hfbmcj68lml97i4s0prxpfx2mh3c57s6q";
   };
 
   patches = [
     ./alsa-plugin-conf-multilib.patch
   ];
 
+  enableParallelBuilding = true;
+
   # Fix pcm.h file in order to prevent some compilation bugs
-  # 2: see http://stackoverflow.com/questions/3103400/how-to-overcome-u-int8-t-vs-uint8-t-issue-efficiently
   postPatch = ''
     sed -i -e 's|//int snd_pcm_mixer_element(snd_pcm_t \*pcm, snd_mixer_t \*mixer, snd_mixer_elem_t \*\*elem);|/\*int snd_pcm_mixer_element(snd_pcm_t \*pcm, snd_mixer_t \*mixer, snd_mixer_elem_t \*\*elem);\*/|' include/pcm.h
+  '';
 
-
-    sed -i -e '1i#include <stdint.h>' include/pcm.h
-    sed -i -e 's/u_int\([0-9]*\)_t/uint\1_t/g' include/pcm.h
+  postInstall = ''
+    ln -s ${alsa-ucm-conf}/share/alsa/{ucm,ucm2} $out/share/alsa
+    ln -s ${alsa-topology-conf}/share/alsa/topology $out/share/alsa
   '';
 
   outputs = [ "out" "dev" ];

--- a/pkgs/os-specific/linux/alsa-topology-conf/default.nix
+++ b/pkgs/os-specific/linux/alsa-topology-conf/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "alsa-topology-conf-${version}";
+  version = "1.2.2";
+
+  src = fetchurl {
+    url = "mirror://alsa/lib/${name}.tar.bz2";
+    sha256 = "09cls485ckdjsp4azhv3nw7chyg3r7zrqgald6yp70f7cysxcwml";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/alsa
+    cp -r topology $out/share/alsa
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.alsa-project.org/;
+    description = "ALSA topology configuration files";
+
+    longDescription = ''
+      The Advanced Linux Sound Architecture (ALSA) provides audio and
+      MIDI functionality to the Linux-based operating system.
+    '';
+
+    license = licenses.bsd3;
+    maintainers = [ maintainers.roastiek ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/alsa-ucm-conf/default.nix
+++ b/pkgs/os-specific/linux/alsa-ucm-conf/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "alsa-ucm-conf-${version}";
+  version = "1.2.2";
+
+  src = fetchurl {
+    url = "mirror://alsa/lib/${name}.tar.bz2";
+    sha256 = "0364fgzdm2qrsqvgqri25gzscbma7yqlv31wz8b1z9c5phlxkgvy";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/alsa
+    cp -r ucm ucm2 $out/share/alsa
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.alsa-project.org/;
+    description = "ALSA Use Case Manager configuration";
+
+    longDescription = ''
+      The Advanced Linux Sound Architecture (ALSA) provides audio and
+      MIDI functionality to the Linux-based operating system.
+    '';
+
+    license = licenses.bsd3;
+    maintainers = [ maintainers.roastiek ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16251,6 +16251,8 @@ in
   alsaOss = callPackage ../os-specific/linux/alsa-oss { };
   alsaTools = callPackage ../os-specific/linux/alsa-tools { };
 
+  alsa-ucm-conf = callPackage ../os-specific/linux/alsa-ucm-conf { };
+
   inherit (callPackage ../misc/arm-trusted-firmware {})
     buildArmTrustedFirmware
     armTrustedFirmwareTools

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16253,6 +16253,8 @@ in
 
   alsa-ucm-conf = callPackage ../os-specific/linux/alsa-ucm-conf { };
 
+  alsa-topology-conf = callPackage ../os-specific/linux/alsa-topology-conf { };
+
   inherit (callPackage ../misc/arm-trusted-firmware {})
     buildArmTrustedFirmware
     armTrustedFirmwareTools


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
alsa-lib is behind upstream and other alsa tools in nixpkgs. This PR adds to new packages `alsa-ucm-conf` and `alsa-topology-conf` to reflect upstream's split to multiple repositories. Their content is linked into alsa-lib `$out/share/alsa` directory, where alsa searches them.

It looks like new alsa-lib is needed by new sof drivers to fully support sound in newer intel notebooks like mine (tested with custom nixos build).
https://bugzilla.redhat.com/show_bug.cgi?id=1772498
https://bugzilla.kernel.org/show_bug.cgi?id=201251

I removed some obsolete seds chaning `u_int` to `uint`. Upstream has fixed this some time ago. And the last remaining is probaly not needed anymore too.

Replaces #74102

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
