### PR TITLE
pydf: install man page and default config file

### DIFF
--- a/pkgs/applications/misc/pydf/default.nix
+++ b/pkgs/applications/misc/pydf/default.nix
@@ -9,6 +9,12 @@ python3Packages.buildPythonPackage rec {
     sha256 = "7f47a7c3abfceb1ac04fc009ded538df1ae449c31203962a1471a4eb3bf21439";
   };
 
+  postInstall = ''
+    mkdir -p $out/share/man/man1 $out/share/pydf
+    install -t $out/share/pydf -m 444 pydfrc
+    install -t $out/share/man/man1 -m 444 pydf.1
+  '';
+
   meta = with stdenv.lib; {
     description = "colourised df(1)-clone";
     homepage = http://kassiopeia.juls.savba.sk/~garabik/software/pydf/;


### PR DESCRIPTION
This makes the pydf derivation install the package's man page and default config
file, so that `man pydf` works and the user has a default config file to work
from.  This default config file is placed in `share/pydf/` and isn't read by
default; pydf still looks in `/etc` and `$HOME` instead.  (The file is identical
to the defaults in the executable itself except for additional colours applied
to the `full_fs_colour` setting.)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - Not applicable.
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - The difference in closure size as reported by `path-info -S` is 5408 (bytes?).
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
