### PR TITLE
shortwave: init at 1.0.1

### DIFF
--- a/pkgs/applications/audio/shortwave/default.nix
+++ b/pkgs/applications/audio/shortwave/default.nix
@@ -1,0 +1,87 @@
+{ stdenv
+, fetchFromGitLab
+, cargo
+, dbus
+, desktop-file-utils
+, gdk-pixbuf
+, gettext
+, glib
+, gst_all_1
+, gtk3
+, libhandy
+, meson
+, ninja
+, openssl
+, pkg-config
+, python3
+, rust
+, rustc
+, rustPlatform
+, sqlite
+, wrapGAppsHook
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "shortwave";
+  version = "1.0.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
+    repo = "Shortwave";
+    rev = version;
+    sha256 = "13lhlh75vw02vkcknl4nvy0yvpdf0qx811mmyja8bzs4rj1j9kr8";
+  };
+
+  cargoSha256 = "0aph5z54a6i5p8ga5ghhx1c9hjc8zdw5pkv9inmanca0bq3hkdlh";
+
+  nativeBuildInputs = [
+    cargo
+    desktop-file-utils
+    gettext
+    glib # for glib-compile-schemas
+    meson
+    ninja
+    pkg-config
+    python3
+    rustc
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    dbus
+    gdk-pixbuf
+    glib
+    gtk3
+    libhandy
+    openssl
+    sqlite
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+  ]);
+
+  # Don't use buildRustPackage phases, only use it for rust deps setup
+  configurePhase = null;
+  buildPhase = null;
+  checkPhase = null;
+  installPhase = null;
+
+  postPatch = ''
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.gnome.org/World/Shortwave";
+    description = "Find and listen to internet radio stations";
+    longDescription = ''
+      Shortwave is a streaming audio player designed for the GNOME
+      desktop. It is the successor to the older Gradio application.
+    '';
+    maintainers = with maintainers; [ lasandell ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21637,6 +21637,8 @@ in
 
   shfmt = callPackage ../tools/text/shfmt { };
 
+  shortwave = callPackage ../applications/audio/shortwave { };
+
   shotgun = callPackage ../tools/graphics/shotgun {};
 
   shutter = callPackage ../applications/graphics/shutter { };


### PR DESCRIPTION
###### Motivation for this change

Add shortwave as it is intended to replace gradio. More info here: https://blogs.gnome.org/haeckerfelix/2020/03/15/shortwave-1-0-0/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
