### PR TITLE
nerdfonts: expand capabilities

### DIFF
--- a/doc/builders/packages/nerdfonts.xml
+++ b/doc/builders/packages/nerdfonts.xml
@@ -1,0 +1,16 @@
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="sec-nerdfonts">
+ <title>Nerd Fonts</title>
+
+ <para>
+  Nerd Fonts can be built to install the patched fonts from the repository:
+<programlisting>super.nerdfonts.override {
+  fonts = [ "FiraMono" "Hermit" ];
+};</programlisting>
+  or patch existing fonts given their derivation
+<programlisting>super.nerdfonts.override {
+  patchFontDrvs = [ hermit ibm-plex ];
+};</programlisting>
+ </para>
+</section>

--- a/pkgs/data/fonts/nerdfonts/default.nix
+++ b/pkgs/data/fonts/nerdfonts/default.nix
@@ -1,26 +1,42 @@
-{ stdenv, fetchFromGitHub, which, withFont ? "" }:
+{ lib, stdenv, fetchFromGitHub
+, which, fonts ? []
+, patchFontDrvs ? [], patchFlags ? [ "mono" "windows" "complete" "careful" ], fontforge ? null }:
+
+assert patchFontDrvs != [] -> fontforge != null;
 
 stdenv.mkDerivation rec {
-  version = "2.1.0";
   pname = "nerdfonts";
+  version = "2.1.0";
+
   src = fetchFromGitHub {
     owner = "ryanoasis";
     repo = "nerd-fonts";
     rev = version;
     sha256 = "1la79y16k9rwcl2zsxk73c0kgdms2ma43kpjfqnq5jlbfdj0niwg";
   };
-  dontPatchShebangs = true;
-  buildInputs = [ which ];
+
+  nativeBuildInputs = [ which fontforge ];
+
   patchPhase = ''
     patchShebangs install.sh
     sed -i -e 's|font_dir="\$HOME/.local/share/fonts|font_dir="$out/share/fonts/truetype|g' install.sh
   '';
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    ./install.sh ${withFont}
+
+  ffPatcher = "fontforge -script font-patcher ${lib.concatMapStringsSep " " (flag: "--${flag}") patchFlags}";
+
+  installPhase = lib.concatMapStringsSep "\n" (drv: ''
+    find ${drv.out}/share/fonts -name '*.otf' \
+      -exec $ffPatcher --outputdir $out/share/fonts/opentype --extension otf "{}" \;
+    find ${drv.out}/share/fonts -name '*.ttf' \
+      -exec $ffPatcher --outputdir $out/share/fonts/truetype --extension ttf "{}" \;
+  '') patchFontDrvs + lib.optionalString (fonts != null) ''
+    ./install.sh ${lib.concatStringsSep " " fonts}
+
+    mkdir -p $out/share/fonts/opentype
+    find $out/share/fonts -name '*.otf' -exec mv "{}" $out/share/fonts/opentype \;
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = ''
       Nerd Fonts is a project that attempts to patch as many developer targeted
       and/or used fonts as possible. The patch is to specifically add a high


### PR DESCRIPTION
Allow patching of fonts from derivation outputs
Fix output path of *.otf files

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
