### PR TITLE
vscode-extensions.ms-python.python: 2020.2.64397 -> 2020.3.69010

### DIFF
--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -1,18 +1,18 @@
 { lib, stdenv, fetchurl, vscode-utils, extractNuGet
 , icu, curl, openssl, lttng-ust, autoPatchelfHook
-, pythonUseFixed ? false, python  # When `true`, the python default setting will be fixed to specified.
-                                  # Use version from `PATH` for default setting otherwise.
-                                  # Defaults to `false` as we expect it to be project specific most of the time.
-, ctagsUseFixed ? true, ctags     # When `true`, the ctags default setting will be fixed to specified.
-                                  # Use version from `PATH` for default setting otherwise.
-                                  # Defaults to `true` as usually not defined on a per projet basis.
+, python3
+, pythonUseFixed ? false       # When `true`, the python default setting will be fixed to specified.
+                               # Use version from `PATH` for default setting otherwise.
+                               # Defaults to `false` as we expect it to be project specific most of the time.
+, ctagsUseFixed ? true, ctags  # When `true`, the ctags default setting will be fixed to specified.
+                               # Use version from `PATH` for default setting otherwise.
+                               # Defaults to `true` as usually not defined on a per projet basis.
 }:
 
-assert pythonUseFixed -> null != python;
 assert ctagsUseFixed -> null != ctags;
 
 let
-  pythonDefaultsTo = if pythonUseFixed then "${python}/bin/python" else "python";
+  pythonDefaultsTo = if pythonUseFixed then "${python3}/bin/python" else "python";
   ctagsDefaultsTo = if ctagsUseFixed then "${ctags}/bin/ctags" else "ctags";
 
   # The arch tag comes from 'PlatformName' defined here:
@@ -23,14 +23,14 @@ let
     else throw "Only x86_64 Linux and Darwin are supported.";
 
   languageServerSha256 = {
-    linux-x64 = "10qwi8lih5i6216d1vqsmviab73ha0d3zdvircrgrydkf0d4ancd";
-    osx-x64 = "08gjxs0bjhz5a9l35vvgwnvzshsyyqiqvb5hxv6w0k2ajgv5z7av";
+    linux-x64 = "1pmj5pb4xylx4gdx4zgmisn0si59qx51n2m1bh7clv29q6biw05n";
+    osx-x64 = "0ishiy1z9dghj4ryh95vy8rw0v7q4birdga2zdb4a8am31wmp94b";
   }.${arch};
 
   # version is languageServerVersion in the package.json
   languageServer = extractNuGet rec {
     name = "Python-Language-Server";
-    version = "0.4.127";
+    version = "0.5.30";
 
     src = fetchurl {
       url = "https://pvsc.azureedge.net/python-language-server-stable/${name}-${arch}.${version}.nupkg";
@@ -41,8 +41,8 @@ in vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2020.2.64397";
-    sha256 = "1kwyc5ycz1276i2zbw93mpq59y2py6kj71gvhzya8xvm184jk07a";
+    version = "2020.3.69010";
+    sha256 = "1dg8wfc3yl0msg6c9ccbvwc78f559109slsagi0lgnbc40v6v24b";
   };
 
   buildInputs = [
@@ -54,6 +54,11 @@ in vscode-utils.buildVscodeMarketplaceExtension {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    python3.pkgs.wrapPython
+  ];
+
+  pythonPath = with python3.pkgs; [
+    setuptools
   ];
 
   postPatch = ''
@@ -70,6 +75,8 @@ in vscode-utils.buildVscodeMarketplaceExtension {
     mkdir -p "$out/$installPrefix/languageServer.${languageServer.version}"
     cp -R --no-preserve=ownership ${languageServer}/* "$out/$installPrefix/languageServer.${languageServer.version}"
     chmod -R +wx "$out/$installPrefix/languageServer.${languageServer.version}"
+
+    patchPythonScript "$out/$installPrefix/pythonFiles/lib/python/isort/main.py"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
