### PR TITLE
gcc: move .dll.a* outputs to $lib

### DIFF
--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -216,6 +216,7 @@ postInstall() {
     moveToOutput "${targetConfig+$targetConfig/}lib/lib*.so*" "$lib"
     moveToOutput "${targetConfig+$targetConfig/}lib/lib*.la"  "$lib"
     moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dylib" "$lib"
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dll.a" "$lib"
     moveToOutput "share/gcc-*/python" "$lib"
 
     for i in "$lib/${targetConfig}"/lib/*.{la,py}; do


### PR DESCRIPTION
These are expected to be here for Windows compilation. The change in
e1831ebea3bcb415800a74fe458f802e63549e1c didn’t move these
correctly (while still patching the search paths).

https://hydra.nixos.org/build/114202790

/cc @lopsided98 

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
