### PR TITLE
zenith: init at 0.8.0

### DIFF
--- a/pkgs/tools/system/zenith/default.nix
+++ b/pkgs/tools/system/zenith/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "zenith";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "bvaisvil";
+    repo = pname;
+    rev = version;
+    sha256 = "1m709mnhhjs30s91542rhri3xbzsb3kw8zablvn11rwp2iq1lxxx";
+  };
+
+  cargoSha256 = "1j6pww4mpssnr9zsbfy74llv7336kjrif1qiph998b82qj63vdlg";
+
+  meta = with stdenv.lib; {
+    description = "Sort of like top or htop but with zoom-able charts, network, and disk usage";
+    homepage = "https://github.com/bvaisvil/zenith";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bbigras ];
+    platforms = platforms.x86;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7780,6 +7780,8 @@ in
 
   zdelta = callPackage ../tools/compression/zdelta { };
 
+  zenith = callPackage ../tools/system/zenith {};
+
   zerotierone = callPackage ../tools/networking/zerotierone { };
 
   zerofree = callPackage ../tools/filesystems/zerofree { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/1x1i6fsqfgs7sa3934imxx1wsclxa2aw-zenith-0.7.5	  34.6M