### PR TITLE
pythonPackages.variants: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/variants/default.nix
+++ b/pkgs/development/python-modules/variants/default.nix
@@ -1,0 +1,32 @@
+{ buildPythonPackage
+, fetchPypi
+, pytestrunner
+, setuptools_scm
+, pytest
+, lib
+}:
+buildPythonPackage rec {
+  pname = "variants";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version ;
+    sha256 = "511f75b4cf7483c27e4d86d9accf2b5317267900c166d17636beeed118929b90";
+  };
+
+  nativeBuildInputs = [
+    pytestrunner
+    setuptools_scm
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+  
+  meta = with lib; {
+    description = "Library providing syntactic sugar for creating variant forms of a canonical function";
+    homepage = "https://github.com/python-variants/variants";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rakesh4g ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5807,6 +5807,8 @@ in {
 
   user-agents = callPackage ../development/python-modules/user-agents { };
 
+  variants = callPackage ../development/python-modules/variants { };
+
   verboselogs = callPackage ../development/python-modules/verboselogs { };
 
   vega_datasets = callPackage ../development/python-modules/vega_datasets { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
pythonPackages.variants: init at 0.2.0
Needed by py-multihash https://github.com/NixOS/nixpkgs/pull/83203

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
