### PR TITLE
gtk2-perl: init at 1.24993

### DIFF
--- a/pkgs/development/libraries/gtk2-perl/default.nix
+++ b/pkgs/development/libraries/gtk2-perl/default.nix
@@ -1,0 +1,47 @@
+{stdenv, fetchurl, bash, perl, gtk2, gtk2-x11, perlPackages}:
+
+stdenv.mkDerivation rec {
+  pname = "gtk2-perl";
+  version = "1.24993";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/Gtk2/${version}/Gtk2-${version}.tar.gz";
+    sha256 = "0ry9jfvfgdwzalxcvwsgr7plhk3agx7p40l0fqdf3vrf7ds47i29";
+  };
+
+  enableParallelBuilding = false;
+  doCheck = false;
+
+ perlDeps = [
+    perl
+    perlPackages.ExtUtilsDepends
+    perlPackages.ExtUtilsPkgConfig
+    perlPackages.Pango
+    perlPackages.Glib
+    perlPackages.Cairo
+ ];
+
+  buildInputs = perlDeps ++ [ gtk2 gtk2-x11 ];
+
+  buildPhase = ''
+    tar xvfz $src
+    
+    PERL5LIB=$PERL5LIB
+    export PERL5LIB
+    perl Makefile.PL PREFIX=$out
+    make
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://sourceforge.net/projects/gtk2-perl/";
+    description = "Perl bindings for Gtk+ 2.x";
+    license = licenses.lgpl2;
+    platforms = platforms.all;
+  };
+  
+  inherit perl;
+  inherit (perlPackages) Gtk2;
+  inherit gtk2;
+  inherit gtk2-x11;
+}
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I build this accidentally as I thought I need it for gcstar. So since I ended with a package which might be useful in the future... here it is this PR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
