### PR TITLE
visidata: add setuptools

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -1,5 +1,16 @@
-{ buildPythonApplication, lib, fetchFromGitHub
-, dateutil, pyyaml, openpyxl, xlrd, h5py, fonttools, lxml, pandas, pyshp
+{ buildPythonApplication
+, lib
+, fetchFromGitHub
+, dateutil
+, pyyaml
+, openpyxl
+, xlrd
+, h5py
+, fonttools
+, lxml
+, pandas
+, pyshp
+, setuptools
 }:
 buildPythonApplication rec {
   pname = "visidata";
@@ -12,16 +23,26 @@ buildPythonApplication rec {
     sha256 = "19gs8i6chrrwibz706gib5sixx1cjgfzh7v011kp3izcrn524mc0";
   };
 
-  propagatedBuildInputs = [dateutil pyyaml openpyxl xlrd h5py fonttools
-    lxml pandas pyshp ];
+  propagatedBuildInputs = [
+    dateutil
+    pyyaml
+    openpyxl
+    xlrd
+    h5py
+    fonttools
+    lxml
+    pandas
+    pyshp
+    setuptools
+  ];
 
   doCheck = false;
 
   meta = {
     inherit version;
     description = "Interactive terminal multitool for tabular data";
-    license = lib.licenses.gpl3 ;
-    maintainers = [lib.maintainers.raskin];
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
     homepage = "http://visidata.org/";
   };


### PR DESCRIPTION
and ran nixpkgs-fmt.

This allows to access visidata's help via ctrl+H since right now this results in:
`ModuleNotFoundError: No module named 'pkg_resources'`

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
