### PR TITLE
pkgs.varnish: pkgs.varnish63 -> pkgs.varnish60

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -2,7 +2,7 @@
 , python3, makeWrapper }:
 
 let
-  common = { version, sha256, extraNativeBuildInputs ? [] }:
+  common = { version, sha256 }:
     stdenv.mkDerivation rec {
       pname = "varnish";
       inherit version;
@@ -30,12 +30,15 @@ let
 
       outputs = [ "out" "dev" "man" ];
 
+      doCheck = true;
+
       meta = with stdenv.lib; {
         description = "Web application accelerator also known as a caching HTTP reverse proxy";
         homepage = https://www.varnish-cache.org;
         license = licenses.bsd2;
         maintainers = with maintainers; [ fpletz ];
         platforms = platforms.unix;
+        broken = versionAtLeast version "6.2"; # tests crash with core dump
       };
     };
 in

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7373,7 +7373,7 @@ in
     varnish62Packages
     varnish63Packages;
 
-  varnishPackages = varnish63Packages;
+  varnishPackages = varnish60Packages;
   varnish = varnishPackages.varnish;
 
   hitch = callPackage ../servers/hitch { };


### PR DESCRIPTION
because `pkgs.varnish62` and `pkgs.varnish63` are broken (and might need to be removed from 20.03 as not yet ready)

partial backport of https://github.com/NixOS/nixpkgs/pull/82514