### PR TITLE
python3Packages.opuslib: init at 3.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7318,6 +7318,12 @@
     githubId = 8547242;
     name = "Stefan Rohrbacher";
   };
+  "thelegy" = {
+    email = "mail+nixos@0jb.de";
+    github = "thelegy";
+    githubId = 3105057;
+    name = "Jan Beinke";
+  };
   thesola10 = {
     email = "thesola10@bobile.fr";
     github = "thesola10";

--- a/pkgs/development/python-modules/opuslib/default.nix
+++ b/pkgs/development/python-modules/opuslib/default.nix
@@ -1,0 +1,39 @@
+{ buildPythonPackage,
+  fetchFromGitHub,
+  isPy27,
+  libopus,
+  nose,
+  stdenv,
+  substituteAll,
+}:
+
+buildPythonPackage rec {
+  pname = "opuslib";
+  version = "3.0.3";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "orion-labs";
+    repo = "opuslib";
+    rev = "92109c528f9f6c550df5e5325ca0fcd4f86b0909";
+    sha256 = "0kd37wimwd1g6c0w5hq2hiiljgbi1zg3rk5prval086khkzq469p";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./opuslib-paths.patch;
+      opusLibPath = "${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  checkInputs = [ nose ];
+
+  meta = with stdenv.lib; {
+    description = "Python bindings to the libopus, IETF low-delay audio codec";
+    homepage = "https://github.com/orion-labs/opuslib";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ thelegy ];
+  };
+}

--- a/pkgs/development/python-modules/opuslib/opuslib-paths.patch
+++ b/pkgs/development/python-modules/opuslib/opuslib-paths.patch
@@ -1,0 +1,26 @@
+diff --git a/opuslib/api/__init__.py b/opuslib/api/__init__.py
+index 323a2a4..4c8a8fe 100644
+--- a/opuslib/api/__init__.py
++++ b/opuslib/api/__init__.py
+@@ -7,20 +7,12 @@
+
+ import ctypes  # type: ignore
+
+-from ctypes.util import find_library  # type: ignore
+-
+ __author__ = 'Никита Кузнецов <self@svartalf.info>'
+ __copyright__ = 'Copyright (c) 2012, SvartalF'
+ __license__ = 'BSD 3-Clause License'
+
+
+-lib_location = find_library('opus')
+-
+-if lib_location is None:
+-    raise Exception(
+-        'Could not find Opus library. Make sure it is installed.')
+-
+-libopus = ctypes.CDLL(lib_location)
++libopus = ctypes.CDLL('@opusLibPath@')
+
+ c_int_pointer = ctypes.POINTER(ctypes.c_int)
+ c_int16_pointer = ctypes.POINTER(ctypes.c_int16)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4629,6 +4629,8 @@ in {
 
   omegaconf = callPackage ../development/python-modules/omegaconf { };
 
+  opuslib = callPackage ../development/python-modules/opuslib { };
+
   orderedset = callPackage ../development/python-modules/orderedset { };
 
   python-multipart = callPackage ../development/python-modules/python-multipart { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
