### PR TITLE
nixos/nixpkgs/lib/strings: add stringToValidNixPath

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -681,16 +681,16 @@ rec {
 
   /* Determines a valid nix store name for a path.
 
-     Type: stringToValidNixPath :: string -> string -> string
+     Type: sanitizeNixPath :: string -> string -> string
 
      Example:
-       stringToValidNixPath "foo_" ".stack/config.yml"
+       sanitizeNixPath "foo_" ".stack/config.yml"
        => "foo_.stackconfig.yml"
-       stringToValidNixPath "  " ".stack/config.yml"
+       sanitizeNixPath "  " ".stack/config.yml"
        => "safePrefix_.stackconfig.yml"
   */
 
-  stringToValidNixPath = prefix: path:
+  sanitizeNixPath = prefix: path:
     let
       safePrefix = if replaceStrings [" "] [""] prefix == "" then "safePrefix_" else prefix;
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -702,7 +702,7 @@ rec {
       unsafeChars = stringToCharacters (replaceStrings safeChars safeCharsEmpty path);
       unsafeCharsEmpty = listToEmptyStrings unsafeChars;
 
-      validPath = replaceStrings unsafeChars unsafeCharsEmpty path;
+      sanitizedPath = replaceStrings unsafeChars unsafeCharsEmpty path;
     in
-      "${safePrefix}${validPath}";
+      "${safePrefix}${sanitizedPath}";
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -127,18 +127,18 @@ runTests {
     expected = [ "2001" "db8" "0" "0042" "" "8a2e" "370" "" ];
   };
 
-  testStringToValidNixPath = {
-    expr = strings.stringToValidNixPath "foo_" ".stack/config.yml";
+  testSanitizeNixPath = {
+    expr = strings.sanitizeNixPath "foo_" ".stack/config.yml";
     expected = "foo_.stackconfig.yml";
   };
 
-  testStringToValidNixPathEmpty = {
-    expr = strings.stringToValidNixPath "" ".test9+8.7=6?5_4^3'2|1/foo.BAZ";
+  testSanitizeNixPathEmpty = {
+    expr = strings.sanitizeNixPath "" ".test9+8.7=6?5_4^3'2|1/foo.BAZ";
     expected = "safePrefix_.test9+8.7=6?5_4321foo.BAZ";
   };
 
-  testStringToValidNixPathEmptySpaces = {
-    expr = strings.stringToValidNixPath "   " ".test9+8.7=6?5_4^3'2|1/FOO.baz";
+  testSanitizeNixPathEmptySpaces = {
+    expr = strings.sanitizeNixPath "   " ".test9+8.7=6?5_4^3'2|1/FOO.baz";
     expected = "safePrefix_.test9+8.7=6?5_4321FOO.baz";
   };
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -127,6 +127,21 @@ runTests {
     expected = [ "2001" "db8" "0" "0042" "" "8a2e" "370" "" ];
   };
 
+  testStringToValidNixPath = {
+    expr = strings.stringToValidNixPath "foo_" ".stack/config.yml";
+    expected = "foo_.stackconfig.yml";
+  };
+
+  testStringToValidNixPathEmpty = {
+    expr = strings.stringToValidNixPath "" ".test9+8.7=6?5_4^3'2|1/foo.BAZ";
+    expected = "safePrefix_.test9+8.7=6?5_4321foo.BAZ";
+  };
+
+  testStringToValidNixPathEmptySpaces = {
+    expr = strings.stringToValidNixPath "   " ".test9+8.7=6?5_4^3'2|1/FOO.baz";
+    expected = "safePrefix_.test9+8.7=6?5_4321FOO.baz";
+  };
+
   testSplitVersionSingle = {
     expr = versions.splitVersion "1";
     expected = [ "1" ];


### PR DESCRIPTION
(This is my first time contributing like this to nixpkgs... please be gentle)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
When using tools like `nixpkgs.lib.attrsets.mapAttrsToList`
and trying to build derivations where nix store file names
are to be created, set attributes like `".stack/config.yml"`
are invalid, so `sanitizeNixPath` cleans them up to allow
them to be created in the nix store.

I did not include `-` as a valid character because of [rycee's reasoning here](https://github.com/rycee/home-manager/blob/b9d4f55228befb6ea5b1888a0e472b40776b3cc8/modules/lib/strings.nix#L9-L11).

If no prefix is provided, the string `safePrefix_` is used.

###### Things done
* adds `strings.sanitizeNixPath`
* adds tests for `strings.sanitizeNixPath`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

* * *

I'm not sure how to run the tests locally and could use some help doing that.
