### PR TITLE
pjsip: 2.9 → 2.10

### DIFF
--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, openssl, libsamplerate, alsaLib }:
+{ stdenv, fetchFromGitHub, openssl, libsamplerate, alsaLib }:
 
 stdenv.mkDerivation rec {
   pname = "pjsip";
-  version = "2.9";
+  version = "2.10";
 
-  src = fetchurl {
-    url = "https://www.pjsip.org/release/${version}/pjproject-${version}.tar.bz2";
-    sha256 = "0dm6l8fypkimmzvld35zyykbg957cm5zb4ny3lchgv68amwfz1fi";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "pjproject";
+    rev = version;
+    sha256 = "1aklicpgwc88578k03i5d5cm5h8mfm7hmx8vfprchbmaa2p8f4z0";
   };
 
   patches = [ ./fix-aarch64.patch ];


### PR DESCRIPTION
###### Motivation for this change

New features: https://github.com/pjsip/pjproject/releases/tag/2.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
