### PR TITLE
ant themes: should not use a fixed output path

### DIFF
--- a/pkgs/data/themes/ant-theme/ant-bloody.nix
+++ b/pkgs/data/themes/ant-theme/ant-bloody.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     gtk-engine-murrine
   ];
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/themes/${themeName}
@@ -25,10 +23,6 @@ stdenv.mkDerivation rec {
     rm -r $out/share/themes/${themeName}/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
     runHook postInstall
   '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "0v5pdhysa2460sh400cpq11smcfsi9g1lbfzx8nj1w5a21d811cz";
 
   meta = with stdenv.lib; {
     description = "Bloody variant of the Ant theme";

--- a/pkgs/data/themes/ant-theme/ant-dracula.nix
+++ b/pkgs/data/themes/ant-theme/ant-dracula.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     gtk-engine-murrine
   ];
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/themes/${themeName}
@@ -25,10 +23,6 @@ stdenv.mkDerivation rec {
     rm -r $out/share/themes/${themeName}/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
     runHook postInstall
   '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1a9mkxfb0zixx8s05h15lhnnzygh2qzc8k2q10i0khx90bf72x14";
 
   meta = with stdenv.lib; {
     description = "Dracula variant of the Ant theme";

--- a/pkgs/data/themes/ant-theme/ant-nebula.nix
+++ b/pkgs/data/themes/ant-theme/ant-nebula.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     gtk-engine-murrine
   ];
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/themes/${themeName}
@@ -25,10 +23,6 @@ stdenv.mkDerivation rec {
     rm -r $out/share/themes/${themeName}/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
     runHook postInstall
   '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1lmlc4fvjnp05gshc0arfysh8r1xxzpzdv3j0bk40mjf3d59814c";
 
   meta = with stdenv.lib; {
     description = "Nebula variant of the Ant theme";

--- a/pkgs/data/themes/ant-theme/ant.nix
+++ b/pkgs/data/themes/ant-theme/ant.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     gtk-engine-murrine
   ];
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/themes/${themeName}
@@ -25,10 +23,6 @@ stdenv.mkDerivation rec {
     rm -r $out/share/themes/${themeName}/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
     runHook postInstall
   '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "07iv4jangqnzrvjr749vl3x31z7dxds51bq1bhz5acbjbwf25wjf";
 
   meta = with stdenv.lib; {
     description = "A flat and light theme with a modern look";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/82833.

See also https://discourse.nixos.org/t/using-fixed-output-paths-for-a-derivation/6338.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).