### PR TITLE
python3Packages.pymumble: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/pymumble/default.nix
+++ b/pkgs/development/python-modules/pymumble/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage,
+  fetchFromGitHub,
+  isPy27,
+  lib,
+  opuslib,
+  protobuf,
+}:
+
+buildPythonPackage rec {
+  pname = "pymumble";
+  version = "0.3.1";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "azlux";
+    repo = "pymumble";
+    rev = "1dd6d6d4df2fdef33202f17e2acf3ba9678a5737";
+    sha256 = "1r1sch8xrpbzffsb72lhp5xjr3ac3xb599n44vsfmaam3xklz6vz";
+  };
+
+  propagatedBuildInputs = [ opuslib protobuf ];
+
+  pythonImportsCheck = [ "pymumble_py3" ];
+
+  meta = with lib; {
+    description = "Python 3 version of pymumble, Mumble library used for multiple uses like making mumble bot.";
+    homepage = "https://github.com/azlux/pymumble";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ thelegy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5060,6 +5060,8 @@ in {
 
   pylint-plugin-utils = callPackage ../development/python-modules/pylint-plugin-utils { };
 
+  pymumble = callPackage ../development/python-modules/pymumble { };
+
   pyomo = callPackage ../development/python-modules/pyomo { };
 
   pyopencl = callPackage ../development/python-modules/pyopencl { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
