### PR TITLE
qgnomeplatform: hardcode gsettings schemas

### DIFF
--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -1,4 +1,16 @@
-{ mkDerivation, lib, fetchFromGitHub, pkgconfig, gtk3, qtbase, qmake, qtx11extras, pantheon }:
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, pkgconfig
+, gtk3
+, glib
+, qtbase
+, qmake
+, qtx11extras
+, pantheon
+, substituteAll
+, gsettings-desktop-schemas
+}:
 
 mkDerivation rec {
   pname = "qgnomeplatform";
@@ -11,12 +23,21 @@ mkDerivation rec {
     sha256 = "0fb1mzs6sx76bl7f0z2xhc0jq6y1c55jrw1v3na8577is6g5ji0a";
   };
 
+  patches = [
+    # Hardcode GSettings schema path to avoid crashes from missing schemas
+    (substituteAll {
+      src = ./hardcode-gsettings.patch;
+      gds_gsettings_path = glib.getSchemaPath gsettings-desktop-schemas;
+    })
+  ];
+
   nativeBuildInputs = [
     pkgconfig
     qmake
   ];
 
   buildInputs = [
+    glib
     gtk3
     qtbase
     qtx11extras

--- a/pkgs/development/libraries/qgnomeplatform/hardcode-gsettings.patch
+++ b/pkgs/development/libraries/qgnomeplatform/hardcode-gsettings.patch
@@ -1,0 +1,24 @@
+diff --git a/common/gnomehintssettings.cpp b/common/gnomehintssettings.cpp
+index 9860e57..40fa6ec 100644
+--- a/common/gnomehintssettings.cpp
++++ b/common/gnomehintssettings.cpp
+@@ -80,9 +80,17 @@ void gtkMessageHandler(const gchar *log_domain,
+ GnomeHintsSettings::GnomeHintsSettings()
+     : QObject(0)
+     , m_usePortal(checkUsePortalSupport())
+-    , m_gnomeDesktopSettings(g_settings_new("org.gnome.desktop.wm.preferences"))
+-    , m_settings(g_settings_new("org.gnome.desktop.interface"))
+ {
++    g_autoptr(GSettingsSchemaSource) schemaSource = nullptr;
++    g_autoptr(GSettingsSchema) gnomeDesktopSchema = nullptr;
++    g_autoptr(GSettingsSchema) settingsSchema = nullptr;
++
++    schemaSource = g_settings_schema_source_new_from_directory("@gds_gsettings_path@", g_settings_schema_source_get_default(), true, nullptr);
++    gnomeDesktopSchema = g_settings_schema_source_lookup(schemaSource, "org.gnome.desktop.wm.preferences", false);
++    m_gnomeDesktopSettings = g_settings_new_full(gnomeDesktopSchema, nullptr, nullptr);
++    settingsSchema = g_settings_schema_source_lookup(schemaSource, "org.gnome.desktop.interface", false);
++    m_settings = g_settings_new_full(settingsSchema, nullptr, nullptr);
++
+     gtk_init(nullptr, nullptr);
+ 
+     // Set log handler to suppress false GtkDialog warnings


### PR DESCRIPTION
Fixes #81866

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
