### PR TITLE
darktable, wireshark: Fix documentation installation directory

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_USERMANUAL=False"
+    "-DCMAKE_INSTALL_DOCDIR=share/doc/${pname}"
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     "-DUSE_COLORD=OFF"
     "-DUSE_KWALLET=OFF"

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -12,10 +12,10 @@ with stdenv.lib;
 let
   version = "3.2.2";
   variant = if withQt then "qt" else "cli";
+  pname = "wireshark-${variant}";
 
 in stdenv.mkDerivation {
-  pname = "wireshark-${variant}";
-  inherit version;
+  inherit pname version;
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
@@ -28,6 +28,7 @@ in stdenv.mkDerivation {
     "-DENABLE_APPLICATION_BUNDLE=${if withQt && stdenv.isDarwin then "ON" else "OFF"}"
     # Fix `extcap` and `plugins` paths. See https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16444
     "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_DOCDIR=share/doc/${pname}"
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fixes documentation directory. Before the documentation files for these packages would end up directly inside `/share/doc` and now they are placed in `/share/doc/${pname}`.