### PR TITLE
nixos/release-combined.nix: fix tested/supportedSystems (master version of #82886)

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -38,99 +38,102 @@ in rec {
     nixpkgs = nixpkgsSrc;
   })) [ "unstable" ];
 
-  tested = pkgs.releaseTools.aggregate {
-    name = "nixos-${nixos.channel.version}";
-    meta = {
-      description = "Release-critical builds for the NixOS channel";
-      maintainers = with pkgs.lib.maintainers; [ eelco fpletz ];
+  tested =
+    let
+      onFullSupported = x: map (system: "${x}.${system}") supportedSystems;
+      onAllSupported = x: map (system: "${x}.${system}") (supportedSystems ++ limitedSupportedSystems);
+      onSystems = systems: x: map (system: "${x}.${system}")
+        (pkgs.lib.intersectLists systems (supportedSystems ++ limitedSupportedSystems));
+    in pkgs.releaseTools.aggregate {
+      name = "nixos-${nixos.channel.version}";
+      meta = {
+        description = "Release-critical builds for the NixOS channel";
+        maintainers = with pkgs.lib.maintainers; [ eelco fpletz ];
+      };
+      constituents = pkgs.lib.concatLists [
+        [ "nixos.channel" ]
+        (onFullSupported "nixos.dummy")
+        (onAllSupported "nixos.iso_minimal")
+        (onSystems ["x86_64-linux"] "nixos.iso_plasma5")
+        (onFullSupported "nixos.manual")
+        (onSystems ["x86_64-linux"] "nixos.ova")
+        (onSystems ["aarch64-linux"] "nixos.sd_image")
+        (onSystems ["x86_64-linux"] "nixos.tests.boot.biosCdrom")
+        (onSystems ["x86_64-linux"] "nixos.tests.boot.biosUsb")
+        (onFullSupported "nixos.tests.boot-stage1")
+        (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiCdrom")
+        (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiUsb")
+        (onSystems ["x86_64-linux"] "nixos.tests.chromium")
+        (onFullSupported "nixos.tests.containers-imperative")
+        (onFullSupported "nixos.tests.containers-ip")
+        (onSystems ["x86_64-linux"] "nixos.tests.docker")
+        (onFullSupported "nixos.tests.ecryptfs")
+        (onFullSupported "nixos.tests.env")
+        (onFullSupported "nixos.tests.firefox-esr")
+        (onFullSupported "nixos.tests.firefox")
+        (onFullSupported "nixos.tests.firewall")
+        (onFullSupported "nixos.tests.fontconfig-default-fonts")
+        (onFullSupported "nixos.tests.gnome3")
+        (onFullSupported "nixos.tests.gnome3-xorg")
+        (onFullSupported "nixos.tests.hibernate")
+        (onFullSupported "nixos.tests.i3wm")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSimple")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSubvolDefault")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSubvols")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.luksroot")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.lvm")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.separateBootFat")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.separateBoot")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.simpleLabels")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.simpleProvided")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.simpleUefiSystemdBoot")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.simple")
+        (onSystems ["x86_64-linux"] "nixos.tests.installer.swraid")
+        (onFullSupported "nixos.tests.ipv6")
+        (onFullSupported "nixos.tests.keymap.azerty")
+        (onFullSupported "nixos.tests.keymap.colemak")
+        (onFullSupported "nixos.tests.keymap.dvorak")
+        (onFullSupported "nixos.tests.keymap.dvp")
+        (onFullSupported "nixos.tests.keymap.neo")
+        (onFullSupported "nixos.tests.keymap.qwertz")
+        (onFullSupported "nixos.tests.lightdm")
+        (onFullSupported "nixos.tests.login")
+        (onFullSupported "nixos.tests.misc")
+        (onFullSupported "nixos.tests.mutableUsers")
+        (onFullSupported "nixos.tests.nat.firewall-conntrack")
+        (onFullSupported "nixos.tests.nat.firewall")
+        (onFullSupported "nixos.tests.nat.standalone")
+        (onFullSupported "nixos.tests.networking.scripted.bond")
+        (onFullSupported "nixos.tests.networking.scripted.bridge")
+        (onFullSupported "nixos.tests.networking.scripted.dhcpOneIf")
+        (onFullSupported "nixos.tests.networking.scripted.dhcpSimple")
+        (onFullSupported "nixos.tests.networking.scripted.loopback")
+        (onFullSupported "nixos.tests.networking.scripted.macvlan")
+        (onFullSupported "nixos.tests.networking.scripted.sit")
+        (onFullSupported "nixos.tests.networking.scripted.static")
+        (onFullSupported "nixos.tests.networking.scripted.vlan")
+        (onFullSupported "nixos.tests.nfs3.simple")
+        (onFullSupported "nixos.tests.nfs4.simple")
+        (onFullSupported "nixos.tests.openssh")
+        (onFullSupported "nixos.tests.pantheon")
+        (onFullSupported "nixos.tests.php.fpm")
+        (onFullSupported "nixos.tests.php.pcre")
+        (onFullSupported "nixos.tests.plasma5")
+        (onFullSupported "nixos.tests.predictable-interface-names.predictableNetworkd")
+        (onFullSupported "nixos.tests.predictable-interface-names.predictable")
+        (onFullSupported "nixos.tests.predictable-interface-names.unpredictableNetworkd")
+        (onFullSupported "nixos.tests.predictable-interface-names.unpredictable")
+        (onFullSupported "nixos.tests.printing")
+        (onFullSupported "nixos.tests.proxy")
+        (onFullSupported "nixos.tests.sddm.default")
+        (onFullSupported "nixos.tests.simple")
+        (onFullSupported "nixos.tests.switchTest")
+        (onFullSupported "nixos.tests.udisks2")
+        (onFullSupported "nixos.tests.xfce")
+        (onSystems ["i686-linux"] "nixos.tests.zfs.installer")
+        (onFullSupported "nixpkgs.emacs")
+        (onFullSupported "nixpkgs.jdk")
+        ["nixpkgs.tarball"]
+      ];
     };
-    constituents = [
-      "nixos.channel"
-      "nixos.dummy.x86_64-linux"
-      "nixos.iso_minimal.aarch64-linux"
-      "nixos.iso_minimal.i686-linux"
-      "nixos.iso_minimal.x86_64-linux"
-      "nixos.iso_plasma5.x86_64-linux"
-      "nixos.manual.x86_64-linux"
-      "nixos.ova.x86_64-linux"
-      "nixos.sd_image.aarch64-linux"
-      "nixos.tests.boot.biosCdrom.x86_64-linux"
-      "nixos.tests.boot.biosUsb.x86_64-linux"
-      "nixos.tests.boot-stage1.x86_64-linux"
-      "nixos.tests.boot.uefiCdrom.x86_64-linux"
-      "nixos.tests.boot.uefiUsb.x86_64-linux"
-      "nixos.tests.chromium.x86_64-linux"
-      "nixos.tests.containers-imperative.x86_64-linux"
-      "nixos.tests.containers-ip.x86_64-linux"
-      "nixos.tests.docker.x86_64-linux"
-      "nixos.tests.ecryptfs.x86_64-linux"
-      "nixos.tests.env.x86_64-linux"
-      "nixos.tests.firefox-esr.x86_64-linux"
-      "nixos.tests.firefox.x86_64-linux"
-      "nixos.tests.firewall.x86_64-linux"
-      "nixos.tests.fontconfig-default-fonts.x86_64-linux"
-      "nixos.tests.gnome3.x86_64-linux"
-      "nixos.tests.gnome3-xorg.x86_64-linux"
-      "nixos.tests.hibernate.x86_64-linux"
-      "nixos.tests.i3wm.x86_64-linux"
-      "nixos.tests.installer.btrfsSimple.x86_64-linux"
-      "nixos.tests.installer.btrfsSubvolDefault.x86_64-linux"
-      "nixos.tests.installer.btrfsSubvols.x86_64-linux"
-      "nixos.tests.installer.luksroot.x86_64-linux"
-      "nixos.tests.installer.lvm.x86_64-linux"
-      "nixos.tests.installer.separateBootFat.x86_64-linux"
-      "nixos.tests.installer.separateBoot.x86_64-linux"
-      "nixos.tests.installer.simpleLabels.x86_64-linux"
-      "nixos.tests.installer.simpleProvided.x86_64-linux"
-      "nixos.tests.installer.simpleUefiSystemdBoot.x86_64-linux"
-      "nixos.tests.installer.simple.x86_64-linux"
-      "nixos.tests.installer.swraid.x86_64-linux"
-      "nixos.tests.ipv6.x86_64-linux"
-      "nixos.tests.keymap.azerty.x86_64-linux"
-      "nixos.tests.keymap.colemak.x86_64-linux"
-      "nixos.tests.keymap.dvorak.x86_64-linux"
-      "nixos.tests.keymap.dvp.x86_64-linux"
-      "nixos.tests.keymap.neo.x86_64-linux"
-      "nixos.tests.keymap.qwertz.x86_64-linux"
-      "nixos.tests.lightdm.x86_64-linux"
-      "nixos.tests.login.x86_64-linux"
-      "nixos.tests.misc.x86_64-linux"
-      "nixos.tests.mutableUsers.x86_64-linux"
-      "nixos.tests.nat.firewall-conntrack.x86_64-linux"
-      "nixos.tests.nat.firewall.x86_64-linux"
-      "nixos.tests.nat.standalone.x86_64-linux"
-      "nixos.tests.networking.scripted.bond.x86_64-linux"
-      "nixos.tests.networking.scripted.bridge.x86_64-linux"
-      "nixos.tests.networking.scripted.dhcpOneIf.x86_64-linux"
-      "nixos.tests.networking.scripted.dhcpSimple.x86_64-linux"
-      "nixos.tests.networking.scripted.loopback.x86_64-linux"
-      "nixos.tests.networking.scripted.macvlan.x86_64-linux"
-      "nixos.tests.networking.scripted.sit.x86_64-linux"
-      "nixos.tests.networking.scripted.static.x86_64-linux"
-      "nixos.tests.networking.scripted.vlan.x86_64-linux"
-      "nixos.tests.nfs3.simple.x86_64-linux"
-      "nixos.tests.nfs4.simple.x86_64-linux"
-      "nixos.tests.openssh.x86_64-linux"
-      "nixos.tests.pantheon.x86_64-linux"
-      "nixos.tests.php.fpm.x86_64-linux"
-      "nixos.tests.php.pcre.x86_64-linux"
-      "nixos.tests.plasma5.x86_64-linux"
-      "nixos.tests.predictable-interface-names.predictableNetworkd.x86_64-linux"
-      "nixos.tests.predictable-interface-names.predictable.x86_64-linux"
-      "nixos.tests.predictable-interface-names.unpredictableNetworkd.x86_64-linux"
-      "nixos.tests.predictable-interface-names.unpredictable.x86_64-linux"
-      "nixos.tests.printing.x86_64-linux"
-      "nixos.tests.proxy.x86_64-linux"
-      "nixos.tests.sddm.default.x86_64-linux"
-      "nixos.tests.simple.x86_64-linux"
-      "nixos.tests.switchTest.x86_64-linux"
-      "nixos.tests.udisks2.x86_64-linux"
-      "nixos.tests.xfce.x86_64-linux"
-      "nixos.tests.zfs.installer.i686-linux"
-      "nixpkgs.emacs.x86_64-linux"
-      "nixpkgs.jdk.x86_64-linux"
-      "nixpkgs.tarball"
-    ];
-  };
-
 }

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -75,7 +75,7 @@ in rec {
         (onFullSupported "nixos.tests.fontconfig-default-fonts")
         (onFullSupported "nixos.tests.gnome3")
         (onFullSupported "nixos.tests.gnome3-xorg")
-        (onFullSupported "nixos.tests.hibernate")
+        (onSystems ["x86_64-linux"] "nixos.tests.hibernate")
         (onFullSupported "nixos.tests.i3wm")
         (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSimple")
         (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSubvolDefault")


### PR DESCRIPTION
This properly supports the `supportedSystems` and
`limitedSupportedSystems` arguments of `release-combined.nix`.
Previously, evaluation would fail if `x86_64-linux` was not part either
of those, since the tested job always referenced the `x86_64-linux`
nixos tests (which won't exist in an aarch64-only eval).

Since the hydra configuration for the jobset`trunk-combined` has both
`aarch64-linux` and `x86_64-linux` as supported systems, this will make
aarch64 be part of the tested job on that jobset.

This is the version of #82886 for master.