### PR TITLE
[20.03] pythonPackages.flake8-future-import: 0.4.5 -> 0.4.6 and fix build

### DIFF
--- a/pkgs/development/python-modules/flake8-future-import/default.nix
+++ b/pkgs/development/python-modules/flake8-future-import/default.nix
@@ -1,30 +1,27 @@
-{ lib, fetchFromGitHub, buildPythonPackage, fetchpatch, flake8, six }:
+{ lib, isPy27, fetchFromGitHub, buildPythonPackage, fetchpatch, flake8, six }:
 
 buildPythonPackage rec {
   pname = "flake8-future-import";
-  version = "0.4.5";
+  version = "0.4.6";
 
   # PyPI tarball doesn't include the test suite
   src = fetchFromGitHub {
     owner = "xZise";
     repo = "flake8-future-import";
     rev = version;
-    sha256 = "00fpxa6g8cabybnciwnpsbg60zhgydc966jgwyyggw1pcg0frdqr";
+    sha256 = "00q8n15xdnvqj454arn7xxksyrzh0dw996kjyy7g9rdk0rf8x82z";
   };
-
-  patches = [
-    # Add Python 3.7 support. Remove with the next release
-    (fetchpatch {
-      url = https://github.com/xZise/flake8-future-import/commit/cace194a44d3b95c9c1ed96640bae49183acca04.patch;
-      sha256 = "17pkqnh035j5s5c53afs8bk49bq7lnmdwqp5k7izx7sw80z73p9r";
-    })
-  ];
 
   propagatedBuildInputs = [ flake8 six ];
 
-  meta = {
-    homepage = https://github.com/xZise/flake8-future-import;
+  # Upstream disables this test case naturally on python 3, but it also fails
+  # inside NixPkgs for python 2. Since it's going to be deleted, we just skip it
+  # on py2 as well.
+  patches = lib.optionals isPy27 [ ./skip-test.patch ];
+
+  meta = with lib; {
     description = "A flake8 extension to check for the imported __future__ modules to make it easier to have a consistent code base";
-    license = lib.licenses.mit;
+    homepage = "https://github.com/xZise/flake8-future-import";
+    license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/flake8-future-import/skip-test.patch
+++ b/pkgs/development/python-modules/flake8-future-import/skip-test.patch
@@ -1,0 +1,13 @@
+diff --git a/test_flake8_future_import.py b/test_flake8_future_import.py
+index 84fde59..345f23f 100644
+--- a/test_flake8_future_import.py
++++ b/test_flake8_future_import.py
+@@ -230,7 +230,7 @@ class TestBadSyntax(TestCaseBase):
+     """Test using various bad syntax examples from Python's library."""
+ 
+ 
+-@unittest.skipIf(sys.version_info[:2] >= (3, 7), 'flake8 supports up to 3.6')
++@unittest.skip("Has issue with installed path for flake8 in python2")
+ class Flake8TestCase(TestCaseBase):
+ 
+     """


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/83170

ZHF: #80379

(cherry picked from commit e9979380cf325912ccbd2c945a7963d667f1b76d)


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).