### PR TITLE
[20.03] pythonPackages.mkl-service: 2.1.0 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/mkl-service/default.nix
+++ b/pkgs/development/python-modules/mkl-service/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "mkl-service";
-  version = "2.1.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "IntelPython";
     repo = "mkl-service";
     rev = "v${version}";
-    sha256 = "1bnpgx629rxqf0yhn0jn68ypj3dqv6njc3981j1g8j8rsm5lycrn";
+    sha256 = "1b4dkkl439rfaa86ywzc2zf9ifawhvdlaiqcg0il83cn5bzs7g5z";
   };
 
   MKLROOT = mkl;


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/83172

Simple python module with no reverse dependencies, and newer version adds some
AVX-512 support that'd be good to have on 20.03.

(cherry picked from commit bd42541989bdf62428c7551c07a2cf04e1c05baa)