### PR TITLE
znapzend: 0.18.0 -> 0.20.0

### DIFF
--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -372,6 +372,41 @@ in
         and <citerefentry><refentrytitle>zfs</refentrytitle><manvolnum>8</manvolnum></citerefentry>
         for more info.
       '';
+      features.sendRaw = mkEnableOption ''
+        sendRaw feature which adds the options <literal>-w</literal> to the
+        <command>zfs send</command> command. For encrypted source datasets this
+        instructs zfs not to decrypt before sending which results in a remote
+        backup that can't be read without the encryption key/passphrase, useful
+        when the remote isn't fully trusted or not physically secure. This
+        option must be used consistently, raw incrementals cannot be based on
+        non-raw snapshots and vice versa.
+      '';
+      features.skipIntermediates = mkEnableOption ''
+        Enable the skipIntermediates feature to send a single increment
+        between latest common snapshot and the newly made one. It may skip
+        several source snaps if the destination was offline for some time, and
+        it should skip snapshots not managed by znapzend. Normally for online
+        destinations, the new snapshot is sent as soon as it is created on the
+        source, so there are no automatic increments to skip.
+      '';
+      features.lowmemRecurse = mkEnableOption ''
+        use lowmemRecurse on systems where you have too many datasets, so a
+        recursive listing of attributes to find backup plans exhausts the
+        memory available to <command>znapzend</command>: instead, go the slower
+        way to first list all impacted dataset names, and then query their
+        configs one by one.
+      '';
+      features.zfsGetType = mkEnableOption ''
+        use zfsGetType if your <command>zfs get</command> supports a
+        <literal>-t</literal> argument for filtering by dataset type at all AND
+        lists properties for snapshots by default when recursing, so that there
+        is too much data to process while searching for backup plans.
+        If these two conditions apply to your system, the time needed for a
+        <literal>--recursive</literal> search for backup plans can literally
+        differ by hundreds of times (depending on the amount of snapshots in
+        that dataset tree... and a decent backup plan will ensure you have a lot
+        of those), so you would benefit from requesting this feature.
+      '';
     };
   };
 

--- a/pkgs/tools/backup/znapzend/default.nix
+++ b/pkgs/tools/backup/znapzend/default.nix
@@ -1,27 +1,28 @@
-{ stdenv, fetchFromGitHub, fetchurl, perl, perlPackages, wget, autoconf, automake }:
+{ stdenv, fetchFromGitHub, fetchurl, perl, perlPackages, wget, autoconf, automake, autoreconfHook }:
 
 let
-  # when upgrade znapzend, check versions of Perl libs here: https://github.com/oetiker/znapzend/blob/master/PERL_MODULES
-  Mojolicious-6-46 = perlPackages.buildPerlPackage rec {
+  # when upgrade znapzend, check versions of Perl libs here: https://github.com/oetiker/znapzend/blob/master/cpanfile
+  # pinned versions are listed at https://github.com/oetiker/znapzend/blob/master/thirdparty/cpanfile-5.26.1.snapshot
+  Mojolicious-8-35 = perlPackages.buildPerlPackage rec {
     pname = "Mojolicious";
-    version = "6.46";
+    version = "8.35";
     src = fetchurl {
       url = "mirror://cpan/authors/id/S/SR/SRI/${pname}-${version}.tar.gz";
-      sha256 = "0i3axmx4506fx5gms148pj65x6ys7flaz1aqjd8hd9zfkd8pzdfr";
+      sha256 = "1bll0ahh5v1y3x0ql29klwsa68cj46wzqc385srsnn2m8kh2ak8h";
     };
   };
-  MojoIOLoopForkCall-0-17 = perlPackages.buildPerlModule rec {
+  MojoIOLoopForkCall-0-20 = perlPackages.buildPerlModule rec {
     pname = "Mojo-IOLoop-ForkCall";
-    version = "0.17";
+    version = "0.20";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JB/JBERGER/${pname}-${version}.tar.gz";
-      sha256 = "090qxz1nbah2qxvfg4whl6yp6q03qkx7a42751iai521nk1yavc8";
+      sha256 = "19pih5x0ayxs2m8j29qwdpi6ky3w4ghv6vrmax3ix9r59hj6569b";
     };
-    propagatedBuildInputs = [ perlPackages.IOPipely Mojolicious-6-46 ];
+    propagatedBuildInputs = [ perlPackages.IOPipely Mojolicious-8-35 ];
   };
 
-  version = "0.18.0";
-  checksum = "1nlvw56viwgafma506slywfg54z6009jmzc9q6wljgr6mqfmmchd";
+  version = "0.20.0";
+  checksum = "15lb5qwksa508m9bj6d3n4rrjpakfaas9qxspg408bcqfp7pqjw3";
 in
 stdenv.mkDerivation {
   pname = "znapzend";
@@ -34,9 +35,9 @@ stdenv.mkDerivation {
     sha256 = checksum;
   };
 
-  buildInputs = [ wget perl MojoIOLoopForkCall-0-17 perlPackages.TAPParserSourceHandlerpgTAP ];
+  buildInputs = [ wget perl MojoIOLoopForkCall-0-20 perlPackages.TAPParserSourceHandlerpgTAP ];
 
-  nativeBuildInputs = [ autoconf automake ];
+  nativeBuildInputs = [ autoconf automake autoreconfHook ];
 
   preConfigure = ''
     sed -i 's/^SUBDIRS =.*$/SUBDIRS = lib/' Makefile.am
@@ -55,23 +56,23 @@ stdenv.mkDerivation {
   postInstall = ''
     substituteInPlace $out/bin/znapzend --replace "${perl}/bin/perl" \
       "${perl}/bin/perl \
-      -I${Mojolicious-6-46}/${perl.libPrefix} \
+      -I${Mojolicious-8-35}/${perl.libPrefix} \
       -I${perlPackages.TAPParserSourceHandlerpgTAP}/${perl.libPrefix} \
-      -I${MojoIOLoopForkCall-0-17}/${perl.libPrefix} \
+      -I${MojoIOLoopForkCall-0-20}/${perl.libPrefix} \
       -I${perlPackages.IOPipely}/${perl.libPrefix} \
       "
     substituteInPlace $out/bin/znapzendzetup --replace "${perl}/bin/perl" \
       "${perl}/bin/perl \
-      -I${Mojolicious-6-46}/${perl.libPrefix} \
+      -I${Mojolicious-8-35}/${perl.libPrefix} \
       -I${perlPackages.TAPParserSourceHandlerpgTAP}/${perl.libPrefix} \
-      -I${MojoIOLoopForkCall-0-17}/${perl.libPrefix} \
+      -I${MojoIOLoopForkCall-0-20}/${perl.libPrefix} \
       -I${perlPackages.IOPipely}/${perl.libPrefix} \
       "
     substituteInPlace $out/bin/znapzendztatz --replace "${perl}/bin/perl" \
       "${perl}/bin/perl \
-      -I${Mojolicious-6-46}/${perl.libPrefix} \
+      -I${Mojolicious-8-35}/${perl.libPrefix} \
       -I${perlPackages.TAPParserSourceHandlerpgTAP}/${perl.libPrefix} \
-      -I${MojoIOLoopForkCall-0-17}/${perl.libPrefix} \
+      -I${MojoIOLoopForkCall-0-20}/${perl.libPrefix} \
       -I${perlPackages.IOPipely}/${perl.libPrefix} \
       "
   '';


### PR DESCRIPTION
###### Motivation for this change
* update to latest znapzend version which supports `sendRaw` features (encrypted backups)

###### Things done
I tested this on "my laptop" :tm: :) I use native ZFS encryption and with `sendRaw` feature enabled I get properly generated backups that I can mount only by specifying the encryption passphrase. 

Is there any other scenario that I should use to test this?

This is my `configuration.nix` snippet:
```nix
  services.znapzend = {
    enable = true;
    autoCreation = true;
    pure = true;
    features.sendRaw = true;
    zetup = {
      "rpool/HOME" = {
        plan = "4hour=>15min,2day=>1hour,7day=>1day,3week=>1week";
        enable = true;
        destinations = {
          local = {
            dataset = "backup/HOME";
            plan = "4hour=>15min,4day=>1hour,1week=>1day,1year=>1week,10year=>1month";
          };
        };
      };
      "rpool/NIXOS" = {
        plan = "1day=>1hour,7day=>1day,3week=>1week";
        enable = true;
        destinations = {
          local = {
            dataset = "backup/NIXOS";
            plan = "4days=>1hour,1week=>1day,1year=>1week,10year=>1month";
          };
        };
      };
    };
  };

```

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
