### PR TITLE
nixos/sympa: fix outgoing emails, update package version

### DIFF
--- a/nixos/modules/services/mail/sympa.nix
+++ b/nixos/modules/services/mail/sympa.nix
@@ -415,7 +415,7 @@ in
       # force-copy static_content so it's up to date with package
       # set permissions for wwsympa which needs write access (...)
       "R  ${dataDir}/static_content    -    -       -        - -"
-      "C  ${dataDir}/static_content    0711 ${user} ${group} - ${pkg}/static_content"
+      "C  ${dataDir}/static_content    0711 ${user} ${group} - ${pkg}/var/lib/sympa/static_content"
       "e  ${dataDir}/static_content/*  0711 ${user} ${group} - -"
 
       "d  /run/sympa                   0755 ${user} ${group} - -"
@@ -497,7 +497,7 @@ in
           -F ${toString cfg.web.fcgiProcs} \
           -P /run/sympa/wwsympa.pid \
           -s /run/sympa/wwsympa.socket \
-          -- ${pkg}/bin/wwsympa.fcgi
+          -- ${pkg}/lib/sympa/cgi/wwsympa.fcgi
         '';
 
       } // commonServiceConfig;
@@ -518,7 +518,7 @@ in
           fastcgi_split_path_info ^(${loc})(.*)$;
 
           fastcgi_param PATH_INFO       $fastcgi_path_info;
-          fastcgi_param SCRIPT_FILENAME ${pkg}/bin/wwsympa.fcgi;
+          fastcgi_param SCRIPT_FILENAME ${pkg}/lib/sympa/cgi/wwsympa.fcgi;
         '';
       }) // {
         "/static-sympa/".alias = "${dataDir}/static_content/";
@@ -550,7 +550,7 @@ in
           args = [
             "flags=hqRu"
             "user=${user}"
-            "argv=${pkg}/bin/queue"
+            "argv=${pkg}/libexec/queue"
             "\${nexthop}"
           ];
         };
@@ -562,7 +562,7 @@ in
           args = [
             "flags=hqRu"
             "user=${user}"
-            "argv=${pkg}/bin/bouncequeue"
+            "argv=${pkg}/libexec/bouncequeue"
             "\${nexthop}"
           ];
         };

--- a/nixos/modules/services/mail/sympa.nix
+++ b/nixos/modules/services/mail/sympa.nix
@@ -25,8 +25,6 @@ let
     StateDirectory = "sympa";
     ProtectHome = true;
     ProtectSystem = "full";
-    ProtectKernelTunables = true;
-    ProtectKernelModules = true;
     ProtectControlGroups = true;
   };
 

--- a/pkgs/servers/mail/sympa/default.nix
+++ b/pkgs/servers/mail/sympa/default.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = [
+    "--enable-fhs"
     "--without-initdir"
     "--without-unitsdir"
     "--without-smrshdir"

--- a/pkgs/servers/mail/sympa/default.nix
+++ b/pkgs/servers/mail/sympa/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, perl, fetchFromGitHub, autoreconfHook
-}:
+{ stdenv, perl, fetchFromGitHub, autoreconfHook, nixosTests }:
 
 let
   dataDir = "/var/lib/sympa";
@@ -64,13 +63,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "sympa";
-  version = "6.2.52";
+  version = "6.2.54";
 
   src = fetchFromGitHub {
     owner = "sympa-community";
     repo = pname;
     rev = version;
-    sha256 = "071kx6ryifs2f6fhfky9g297frzp5584kn444af1vb2imzydsbnh";
+    sha256 = "07wfvr8rrg7pwkl2zglrdri7n42rl9gwrjbaffb8m37wq67s7fca";
   };
 
   configureFlags = [
@@ -105,6 +104,10 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rm -rf "$TMP/bin"
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) sympa;
+  };
 
   meta = with stdenv.lib; {
     description = "Open source mailing list manager";


### PR DESCRIPTION
###### Motivation for this change

* The service has not been able to actually send emails because systemd sandboxing didn't allow it to call `sendmail` setgid wrapper. I probably broke it during the later iterations of #65397 and haven't caught it until now. Shame on me.
* New version [contains various bugfixes](https://github.com/sympa-community/sympa/blob/6.2.54/NEWS.md#6254-2020-02-24), including [CVE-2020-9369](https://nvd.nist.gov/vuln/detail/CVE-2020-9369).
* The `--enable-fhs` configure flag makes the resulting package layout saner, e.g. by not installing perl modules into `$out/bin`. Upstream plans to make this the default eventually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
