### PR TITLE
zoneminder: Path Fix

### DIFF
--- a/pkgs/servers/zoneminder/default.nix
+++ b/pkgs/servers/zoneminder/default.nix
@@ -115,7 +115,8 @@ in stdenv.mkDerivation rec {
 
     for f in misc/*.policy.in \
              scripts/*.pl* \
-             scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in ; do
+             scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in \
+             scripts/ZoneMinder/lib/ZoneMinder/Event.pm.in; do
       substituteInPlace $f \
         --replace '/usr/bin/perl' '${perlBin}' \
         --replace '/bin:/usr/bin' "$out/bin:${lib.makeBinPath [ coreutils procps psmisc ]}"

--- a/pkgs/servers/zoneminder/default.nix
+++ b/pkgs/servers/zoneminder/default.nix
@@ -116,7 +116,7 @@ in stdenv.mkDerivation rec {
     for f in misc/*.policy.in \
              scripts/*.pl* \
              scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in \
-             scripts/ZoneMinder/lib/ZoneMinder/Event.pm.in; do
+             scripts/ZoneMinder/lib/ZoneMinder/Event.pm; do
       substituteInPlace $f \
         --replace '/usr/bin/perl' '${perlBin}' \
         --replace '/bin:/usr/bin' "$out/bin:${lib.makeBinPath [ coreutils procps psmisc ]}"


### PR DESCRIPTION
Event.pm calls /bin/rm by absolute path which was not patched by nixpkgs, due to that zoneminder installs using nixos would not delete events, whether from server or zmaudit.pl

###### Motivation for this change
Fix for #83260 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
