### PR TITLE
alt-ergo: 2.3.0 → 2.3.1

### DIFF
--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -1,26 +1,48 @@
-{ fetchurl, stdenv, which, dune, ocamlPackages }:
+{ fetchurl, lib, which, ocamlPackages }:
 
-stdenv.mkDerivation rec {
+let
   pname = "alt-ergo";
-  version = "2.3.0";
+  version = "2.3.1";
 
   src = fetchurl {
     url    = "https://alt-ergo.ocamlpro.com/download_manager.php?target=${pname}-${version}.tar.gz";
     name   = "${pname}-${version}.tar.gz";
-    sha256 = "1ycr3ff0gacq1aqzs16n6swgfniwpim0m7rvhcam64kj0a80c6bz";
+    sha256 = "124n836alqm13245hcnxixzc6a15rip919shfflvxqnl617mkmhg";
   };
 
-  buildInputs = [ dune which ] ++ (with ocamlPackages; [
-    ocaml findlib camlzip lablgtk menhir num ocplib-simplex psmt2-frontend seq zarith
-  ]);
-
   preConfigure = "patchShebangs ./configure";
+
+  nativeBuildInputs = [ which ];
+
+in
+
+let alt-ergo-lib = ocamlPackages.buildDunePackage rec {
+  pname = "alt-ergo-lib";
+  inherit version src preConfigure nativeBuildInputs;
+  configureFlags = pname;
+  propagatedBuildInputs = with ocamlPackages; [ num ocplib-simplex zarith ];
+}; in
+
+let alt-ergo-parsers = ocamlPackages.buildDunePackage rec {
+  pname = "alt-ergo-parsers";
+  inherit version src preConfigure nativeBuildInputs;
+  configureFlags = pname;
+  buildInputs = with ocamlPackages; [ menhir ];
+  propagatedBuildInputs = [ alt-ergo-lib ] ++ (with ocamlPackages; [ camlzip psmt2-frontend ]);
+}; in
+
+ocamlPackages.buildDunePackage {
+
+  inherit pname version src preConfigure nativeBuildInputs;
+
+  configureFlags = pname;
+
+  buildInputs = [ alt-ergo-parsers ocamlPackages.menhir ];
 
   meta = {
     description = "High-performance theorem prover and SMT solver";
     homepage    = "https://alt-ergo.ocamlpro.com/";
-    license     = stdenv.lib.licenses.ocamlpro_nc;
-    platforms   = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    license     = lib.licenses.ocamlpro_nc;
+    maintainers = [ lib.maintainers.thoughtpolice ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Current package is broken (wrong hash).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
