### PR TITLE
dnscontrol: init at 3.0.0

### DIFF
--- a/pkgs/applications/networking/dnscontrol/default.nix
+++ b/pkgs/applications/networking/dnscontrol/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, buildGoPackage}:
-  
+
 buildGoPackage rec {
   pname = "dnscontrol";
   version = "3.0.0";
 
   goPackagePath = "github.com/StackExchange/dnscontrol";
 
-   goDeps = ./deps.nix;
+  goDeps = ./deps.nix;
 
   src = fetchFromGitHub {
     owner = "StackExchange";
@@ -14,6 +14,10 @@ buildGoPackage rec {
     rev = "v${version}";
     sha256 = "1j8i4k7bqkqmi6dmc9fxfab49a7qigig72rlbga902lw336p6cc7";
   };
+
+  postInstall = ''
+    rm $bin/bin/{build,convertzone,generate,validate}
+  '';
 
   meta = with stdenv.lib; {
     description = "Synchronize your DNS to multiple providers from a simple DSL";

--- a/pkgs/applications/networking/dnscontrol/default.nix
+++ b/pkgs/applications/networking/dnscontrol/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, buildGoPackage}:
+  
+buildGoPackage rec {
+  pname = "dnscontrol";
+  version = "3.0.0";
+
+  goPackagePath = "github.com/StackExchange/dnscontrol";
+
+   goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "StackExchange";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1j8i4k7bqkqmi6dmc9fxfab49a7qigig72rlbga902lw336p6cc7";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Synchronize your DNS to multiple providers from a simple DSL";
+    homepage = "https://stackexchange.github.io/dnscontrol/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mmahut ];
+  };
+}

--- a/pkgs/applications/networking/dnscontrol/deps.nix
+++ b/pkgs/applications/networking/dnscontrol/deps.nix
@@ -1,0 +1,1236 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev = "335e9e09b93e";
+      sha256 = "1aiglr6d2369nf3s9ig1kc0nixsivcmh7p1fyzkcf6n6ql0p2zsm";
+    };
+  }
+  {
+    goPackagePath = "github.com/Azure/azure-sdk-for-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/azure-sdk-for-go";
+      rev = "v39.1.0";
+      sha256 = "1s0j7gh3d3p157py7v6525c6zs07hdiry97dhg4c8z7ww35wxhj7";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/xgb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/xgb";
+      rev = "27f122750802";
+      sha256 = "18lp2x8f5bljvlz0r7xn744f0c9rywjsb9ifiszqqdcpwhsa0kvj";
+    };
+  }
+  {
+    goPackagePath = "github.com/DisposaBoy/JsonConfigReader";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DisposaBoy/JsonConfigReader";
+      rev = "5ea4d0ddac55";
+      sha256 = "022wzrkf0rni9yb15439w81kj0kb4667zx6n2zq07ysw7lk6ahqz";
+    };
+  }
+  {
+    goPackagePath = "github.com/TomOnTime/utfutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/TomOnTime/utfutil";
+      rev = "09c41003ee1d";
+      sha256 = "01d6w8migw5px19jg0mm7qhsa1ydcz9wvl838nsclfw63x5sy70i";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/kingpin";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/kingpin";
+      rev = "v2.2.6";
+      sha256 = "0mndnv3hdngr3bxp7yxfd47cas4prv98sqw534mx7vp38gd88n5r";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev = "fb15b899a751";
+      sha256 = "1vlasv4dgycydh5wx6jdcvz40zdv90zz1h7836z7lhsi2ymvii26";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev = "f65c72e2690d";
+      sha256 = "04jyqm7m3m01ppfy1f9xk4qvrwvs78q9zml6llyf2b3v5k6b2bbc";
+    };
+  }
+  {
+    goPackagePath = "github.com/andreyvit/diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/andreyvit/diff";
+      rev = "c7f18ee00883";
+      sha256 = "1s4qjkxig5yqahpzfl4xqh4kzi9mymdpkzq6kj3f4dr5dl3hlynr";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/go-metrics";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/go-metrics";
+      rev = "f0300d1749da";
+      sha256 = "13l7c35ps0r27vxfil2w0xhhc7w5rh00awvlmn4cz0a937b9ffpv";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/go-radix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/go-radix";
+      rev = "7fddfc383310";
+      sha256 = "0y8chspn14n9xpsfb9gxnnf819rfpriaz64v81p7873a42kkhxb4";
+    };
+  }
+  {
+    goPackagePath = "github.com/aws/aws-sdk-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev = "v1.29.21";
+      sha256 = "0q97abz6cjj1gf3gfd52gjx39grfhlcjax8306zw9038a8v0nadc";
+    };
+  }
+  {
+    goPackagePath = "github.com/bgentry/speakeasy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bgentry/speakeasy";
+      rev = "v0.1.0";
+      sha256 = "02dfrj0wyphd3db9zn2mixqxwiz1ivnyc5xc7gkz58l5l27nzp8s";
+    };
+  }
+  {
+    goPackagePath = "github.com/billputer/go-namecheap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/billputer/go-namecheap";
+      rev = "0c7adb0710f8";
+      sha256 = "09jkymml6f0nvz7md7s4ayj75xdms77ziz9rkw4kvj7jhv36302p";
+    };
+  }
+  {
+    goPackagePath = "github.com/cenkalti/backoff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cenkalti/backoff";
+      rev = "v2.1.1";
+      sha256 = "1mf4lsl3rbb8kk42x0mrhzzy4ikqy0jf6nxpzhkr02rdgwh6rjk8";
+    };
+  }
+  {
+    goPackagePath = "github.com/census-instrumentation/opencensus-proto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-instrumentation/opencensus-proto";
+      rev = "v0.2.1";
+      sha256 = "19fcx3sc99i5dsklny6r073z5j20vlwn2xqm6di1q3b1xwchzqfj";
+    };
+  }
+  {
+    goPackagePath = "github.com/client9/misspell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/client9/misspell";
+      rev = "v0.3.4";
+      sha256 = "1vwf33wsc4la25zk9nylpbp9px3svlmldkm0bha4hp56jws4q9cs";
+    };
+  }
+  {
+    goPackagePath = "github.com/cpuguy83/go-md2man";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cpuguy83/go-md2man";
+      rev = "v2.0.0";
+      sha256 = "0r1f7v475dxxgzqci1mxfliwadcrk86ippflx9n411325l4g3ghv";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/digitalocean/godo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/digitalocean/godo";
+      rev = "v1.30.0";
+      sha256 = "0z38lg1zd57b5ymxdxhz5rs5rynpzhqmbvm0marhh0v7v9bbk0rx";
+    };
+  }
+  {
+    goPackagePath = "github.com/dimchansky/utfbom";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dimchansky/utfbom";
+      rev = "v1.1.0";
+      sha256 = "06s61wwd32fad1p8qn5blqjd5791avzb13fnqflkkg993adw49ww";
+    };
+  }
+  {
+    goPackagePath = "github.com/dnsimple/dnsimple-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dnsimple/dnsimple-go";
+      rev = "v0.31.0";
+      sha256 = "0i074r3m0bqggmplswymgj6yfzbsrcqw8gn6py9x8g3kyl4si0x0";
+    };
+  }
+  {
+    goPackagePath = "github.com/envoyproxy/go-control-plane";
+    fetch = {
+      type = "git";
+      url = "https://github.com/envoyproxy/go-control-plane";
+      rev = "5f8ba28d4473";
+      sha256 = "1f1s764rd41vd9vgk3r14h1m6fz6pdvxj6fd83q58gxifbc4q5w4";
+    };
+  }
+  {
+    goPackagePath = "github.com/envoyproxy/protoc-gen-validate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/envoyproxy/protoc-gen-validate";
+      rev = "v0.1.0";
+      sha256 = "0kxd3wwh3xwqk0r684hsy281xq4y71cd11d4q2hspcjbnlbwh7cy";
+    };
+  }
+  {
+    goPackagePath = "github.com/exoscale/egoscale";
+    fetch = {
+      type = "git";
+      url = "https://github.com/exoscale/egoscale";
+      rev = "v0.23.0";
+      sha256 = "0dgc08sdvy2cj7yygrlnyp6v9m829h4v0pm3vdsj9yx3bps5v7iy";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "v1.7.0";
+      sha256 = "0v8msvg38r8d1iiq2i5r4xyfx0invhc941kjrsg5gzwvagv55inv";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/structs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/structs";
+      rev = "v1.1.0";
+      sha256 = "1wrhb8wp8zpzggl61lapb627lw8yv281abvr6vqakmf569nswa9q";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-acme/lego";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-acme/lego";
+      rev = "v2.7.2";
+      sha256 = "1137l22jrwk8hvdzjbmfkvd9nllp6sznzy66ngmcsc0ybp19hcry";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-ldap/ldap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ldap/ldap";
+      rev = "v3.0.2";
+      sha256 = "1srb1nkcbs0v1hcdz6j4zhg000h763j83jlklsiwanvbp48y4lhz";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-sql-driver/mysql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-sql-driver/mysql";
+      rev = "v1.5.0";
+      sha256 = "11x0m9yf3kdnf6981182r824psgxwfaqhn3x3in4yiidp0w0hk3v";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-test/deep";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-test/deep";
+      rev = "042da051cf31";
+      sha256 = "08bya0s7m15f5qm1kn2r42g1r4lpq0svpaqr0zaac4hmaxj7vnid";
+    };
+  }
+  {
+    goPackagePath = "github.com/gobwas/glob";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gobwas/glob";
+      rev = "e7a84e9525fe";
+      sha256 = "1v6vjklq06wqddv46ihajahaj1slv0imgaivlxr8bsx59i90js5q";
+    };
+  }
+  {
+    goPackagePath = "github.com/gofrs/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gofrs/uuid";
+      rev = "v3.2.0";
+      sha256 = "1q63mp7bznhfgyw133c0wc0hpcj1cq9bcf7w1f8r6inkcrils1fz";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev = "23def4e6c14b";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/mock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/mock";
+      rev = "v1.3.1";
+      sha256 = "1wnfa8njxdym1qb664dmfnkpm4pmqy22hqjlqpwaaiqhglb5g9d1";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.3.3";
+      sha256 = "1cyyr52yhj3fzrily3rmsbqyj8va4ld75lmry0857m39rgpv8sy1";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev = "v0.0.1";
+      sha256 = "0gp3kkzlm3wh37kgkhbqxq3zx07iqbgis5w9mf4d64h6vjq760is";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/btree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/btree";
+      rev = "v1.0.0";
+      sha256 = "0ba430m9fbnagacp57krgidsyrgp3ycw5r7dj71brgp5r52g82p6";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.4.0";
+      sha256 = "1x5pvl3fb5sbyng7i34431xycnhmx8xx94gq2n19g6p0vz68z2v2";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-github";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-github";
+      rev = "v17.0.0";
+      sha256 = "1kvw95l77a5n5rgal9n1xjh58zxb3a40ij1j722b1h4z8yg9jhg4";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-querystring";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-querystring";
+      rev = "c8c88dbee036";
+      sha256 = "1yckg2052mz7ps1m68wri6kyb5n4g0vx2yf7s0xs9gdqvvscp57l";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/martian";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/martian";
+      rev = "v2.1.0";
+      sha256 = "197hil6vrjk50b9wvwyzf61csid83whsjj6ik8mc9r2lryxlyyrp";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/pprof";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/pprof";
+      rev = "54271f7e092f";
+      sha256 = "14x4ydifz23rzaylggvwbm3dwlv1bc6s0bclmkxck9nbjbqw89vy";
+    };
+  }
+  {
+    goPackagePath = "github.com/googleapis/gax-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gax-go";
+      rev = "v2.0.5";
+      sha256 = "1lxawwngv6miaqd25s3ba0didfzylbwisd2nz7r4gmbmin6jsjrx";
+    };
+  }
+  {
+    goPackagePath = "github.com/gopherjs/gopherjs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gopherjs/gopherjs";
+      rev = "0766667cb4d1";
+      sha256 = "13pfc9sxiwjky2lm1xb3i3lcisn8p6mgjk2d927l7r92ysph8dmw";
+    };
+  }
+  {
+    goPackagePath = "github.com/gopherjs/jquery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gopherjs/jquery";
+      rev = "73f4c7416038";
+      sha256 = "1xhl0k52v3djalnd02a0ph572f85i1szj2x4q3lglkq40j7racd2";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/errwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/errwrap";
+      rev = "v1.0.0";
+      sha256 = "0slfb6w3b61xz04r32bi0a1bygc82rjzhqkxj2si2074wynqnr1c";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-cleanhttp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-cleanhttp";
+      rev = "v0.5.1";
+      sha256 = "07kx3fhryqmaw3czacmm11qwx63js2q8cfq967vphk7xg9q377kk";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-hclog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-hclog";
+      rev = "v0.9.2";
+      sha256 = "0pakba7rdkjgq50r79sbbpavymbyib77cy613wl734mpi30ywrxm";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-immutable-radix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-immutable-radix";
+      rev = "v1.0.0";
+      sha256 = "1v3nmsnk1s8bzpclrhirz7iq0g5xxbw9q5gvrg9ss6w9crs72qr6";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-multierror";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-multierror";
+      rev = "v1.0.0";
+      sha256 = "00nyn8llqzbfm8aflr9kwsvpzi4kv8v45c141v88xskxp5xf6z49";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-plugin";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-plugin";
+      rev = "v1.0.1";
+      sha256 = "0aama8vdyrfzjdhxc1l4cwhmgydl989lywhq3pg3slzjg6r00rda";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-retryablehttp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-retryablehttp";
+      rev = "v0.6.3";
+      sha256 = "1vnhr7yry71jldmmj5gxhq49crhi9vrmqc2i41mycpnva2zd8a0i";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-rootcerts";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-rootcerts";
+      rev = "v1.0.1";
+      sha256 = "0ca5h7vlvrghf24dzh8l6w5px293n173qxfkjxb9kgsl6hsrsl3y";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-sockaddr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-sockaddr";
+      rev = "v1.0.2";
+      sha256 = "0y106nhd3s63lj7h7k21iq0br97h0z9qjrvx028zqcsq9407k9is";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-uuid";
+      rev = "v1.0.1";
+      sha256 = "0jvb88m0rq41bwgirsadgw7mnayl27av3gd2vqa3xvxp3fy0hp5k";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-version";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-version";
+      rev = "v1.1.0";
+      sha256 = "1ykh3jl5zj5a4irkgp5mq936bqkznmf9lp23qk741vh4r5874vi8";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev = "v0.5.1";
+      sha256 = "13f870cvk161bzjj6x41l45r5x9i1z9r2ymwmvm7768kg08zznpy";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/hcl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev = "v1.0.0";
+      sha256 = "0q6ml0qqs0yil76mpn4mdx4lp94id8vbv575qm60jzl1ijcl5i66";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/yamux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/yamux";
+      rev = "2f1d1f20f75d";
+      sha256 = "1fga3p6j2g24ip9qjfwn3nqjr00m4nnjz92app7ms3sz7vgq2a7s";
+    };
+  }
+  {
+    goPackagePath = "github.com/hexonet/go-sdk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hexonet/go-sdk";
+      rev = "v2.2.3";
+      sha256 = "0mgkfrc7qlm4xf1v7kb29p7wq6rmaaha9zv8kwa27r8hjx6qnb8c";
+    };
+  }
+  {
+    goPackagePath = "github.com/jarcoal/httpmock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jarcoal/httpmock";
+      rev = "v1.0.4";
+      sha256 = "1x04i9hhvdxi9xmyf0vbi5azlh7rr4blsq7fbhps8i2gdpga612y";
+    };
+  }
+  {
+    goPackagePath = "github.com/jmespath/go-jmespath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev = "2437e8417af5";
+      sha256 = "1hwcbr7nrlfshwr4hrac8ch8gvfpf07qi72bpqmqi272c67ma89v";
+    };
+  }
+  {
+    goPackagePath = "github.com/jstemmer/go-junit-report";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jstemmer/go-junit-report";
+      rev = "af01ea7f8024";
+      sha256 = "1lp3n94ris12hac02wi31f3whs88lcrzwgdg43a5j6cafg9p1d0s";
+    };
+  }
+  {
+    goPackagePath = "github.com/jtolds/gls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jtolds/gls";
+      rev = "v4.20.0";
+      sha256 = "1k7xd2q2ysv2xsh373qs801v6f359240kx0vrl0ydh7731lngvk6";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty";
+      rev = "v0.1.0";
+      sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.1";
+      sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text";
+      rev = "v0.1.0";
+      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
+    };
+  }
+  {
+    goPackagePath = "github.com/malexdev/utfutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/malexdev/utfutil";
+      rev = "00c8d4a8e7a8";
+      sha256 = "01d6w8migw5px19jg0mm7qhsa1ydcz9wvl838nsclfw63x5sy70i";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "v0.0.9";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.3";
+      sha256 = "06w45aqz2a6yrk25axbly2k5wmsccv8cspb94bfmz4izvw8h927n";
+    };
+  }
+  {
+    goPackagePath = "github.com/miekg/dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/miekg/dns";
+      rev = "v1.1.27";
+      sha256 = "0fpd9alvhzrkb1c31n4lrxlpv1nlhy51w1yg39xxb3mjmrb7lby1";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/cli";
+      rev = "v1.0.0";
+      sha256 = "1i9kmr7rcf10d2hji8h4247hmc0nbairv7a0q51393aw2h1bnwg2";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/copystructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/copystructure";
+      rev = "v1.0.0";
+      sha256 = "05njg92w1088v4yl0js0zdrpfq6k37i9j14mxkr3p90p5yd9rrrr";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "v1.1.0";
+      sha256 = "0ydzkipf28hwj2bfxqmwlww47khyk6d152xax4bnyh60f4lq3nx1";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-testing-interface";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-testing-interface";
+      rev = "v1.0.0";
+      sha256 = "1dl2js8di858bawg7dadlf1qjpkl2g3apziihjyf5imri3znyfpw";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-wordwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-wordwrap";
+      rev = "v1.0.0";
+      sha256 = "1jffbwcr3nnq6c12c5856bwzv2nxjzqk3jwgvxkwi1xhpd2by0bf";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev = "v1.1.2";
+      sha256 = "03bpv28jz9zhn4947saqwi328ydj7f6g6pf1m2d4m5zdh5jlfkrr";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/reflectwalk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/reflectwalk";
+      rev = "v1.0.0";
+      sha256 = "0wzkp0fdx22n8f7y9y37dgmnlrlfsv9zjdb48cbx7rsqsbnny7l0";
+    };
+  }
+  {
+    goPackagePath = "github.com/mjibson/esc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mjibson/esc";
+      rev = "v0.2.0";
+      sha256 = "0ci3bdm01prm114plcwkgzbqn825lh0zc1iqaw3jicjay5sh0bis";
+    };
+  }
+  {
+    goPackagePath = "github.com/namedotcom/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/namedotcom/go";
+      rev = "08470befbe04";
+      sha256 = "00ai7fd74sn4alqmpqsiyczirli50b7m059b6zzg1izy9g4cdd4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/oklog/run";
+    fetch = {
+      type = "git";
+      url = "https://github.com/oklog/run";
+      rev = "v1.0.0";
+      sha256 = "1pbjza4claaj95fpqvvfrysvs10y7dm0pl6qr5lzh6qy1vnhmcgw";
+    };
+  }
+  {
+    goPackagePath = "github.com/ovh/go-ovh";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ovh/go-ovh";
+      rev = "ba5adb4cf014";
+      sha256 = "1rwxib0pn2ni6nfn2sijvb6cd424n95gnqhs21q6mz08n9hnzspy";
+    };
+  }
+  {
+    goPackagePath = "github.com/pascaldekloe/goe";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pascaldekloe/goe";
+      rev = "v0.1.0";
+      sha256 = "1dqd3mfb4z2vmv6pg6fhgvfc53vhndk24wcl9lj1rz02n6m279fq";
+    };
+  }
+  {
+    goPackagePath = "github.com/philhug/opensrs-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/philhug/opensrs-go";
+      rev = "9dfa7433020d";
+      sha256 = "1bjw3llpx5n1srylw08310ch14sz1pw5mban1yakax8606q3dqdf";
+    };
+  }
+  {
+    goPackagePath = "github.com/pierrec/lz4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pierrec/lz4";
+      rev = "v2.0.5";
+      sha256 = "0y5rh7z01zycd59nnjpkqq0ydyjmcg9j1xw15q1i600l9j9g617p";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.9.1";
+      sha256 = "1761pybhc2kqr6v5fm8faj08x9bql8427yqg6vnfv6nhrasx1mwq";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/posener/complete";
+    fetch = {
+      type = "git";
+      url = "https://github.com/posener/complete";
+      rev = "v1.1.1";
+      sha256 = "1nbdiybjizbaxbf5q0xwbq0cjqw4bl6jggvsjzrpif0w86fcjda2";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev = "14fe0d1b01d4";
+      sha256 = "0zdmk6rbbx39cvfz0r59v2jg5sg9yd02b4pds5n5llgvivi99550";
+    };
+  }
+  {
+    goPackagePath = "github.com/renier/xmlrpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/renier/xmlrpc";
+      rev = "ce4a1a486c03";
+      sha256 = "0byvacdwhagva53r2frzqws3f5j7qzigmxzxahpcv300i8pm9i50";
+    };
+  }
+  {
+    goPackagePath = "github.com/robertkrimen/otto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/robertkrimen/otto";
+      rev = "c382bd3c16ff";
+      sha256 = "043y6l647snsz71mdy84s2d3kn22aj6rbqd6c1vd8absvamqhlxa";
+    };
+  }
+  {
+    goPackagePath = "github.com/russross/blackfriday";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev = "v2.0.1";
+      sha256 = "0nlz7isdd4rgnwzs68499hlwicxz34j2k2a0b8jy0y7ycd2bcr5j";
+    };
+  }
+  {
+    goPackagePath = "github.com/ryanuber/columnize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ryanuber/columnize";
+      rev = "v2.1.0";
+      sha256 = "0m9jhagb1k44zfcdai76xdf9vpi3bqdl7p078ffyibmz0z9jfap6";
+    };
+  }
+  {
+    goPackagePath = "github.com/ryanuber/go-glob";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ryanuber/go-glob";
+      rev = "v1.0.0";
+      sha256 = "0mhrjy0iba3jr6bsgy7q50zjr42ar1njn1sb2fvihlkhxgb2ahv2";
+    };
+  }
+  {
+    goPackagePath = "github.com/sergi/go-diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sergi/go-diff";
+      rev = "v1.1.0";
+      sha256 = "0ir8ali2vx0j7pipmlfd6k8c973akyy2nmbjrf008fm800zcp7z2";
+    };
+  }
+  {
+    goPackagePath = "github.com/shurcooL/sanitized_anchor_name";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/sanitized_anchor_name";
+      rev = "v1.0.0";
+      sha256 = "1gv9p2nr46z80dnfjsklc6zxbgk96349sdsxjz05f3z6wb6m5l8f";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/assertions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/assertions";
+      rev = "b2de0cb4f26d";
+      sha256 = "1i7ldgavgl35c7gk25p7bvdr282ckng090zr4ch9mk1705akx09y";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/goconvey";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/goconvey";
+      rev = "68dc04aab96a";
+      sha256 = "1kas5v95fzhr88hg4rjy0vp03y4pzvy3pwwgkfz2yhn5nlj29nk6";
+    };
+  }
+  {
+    goPackagePath = "github.com/softlayer/softlayer-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/softlayer/softlayer-go";
+      rev = "5e1c8cccc730";
+      sha256 = "0jsi0f60gx92qm1n2lcz65v425bbqf59dsr0dw4x1wmychp25mk7";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.0";
+      sha256 = "19ynspzjdynbi85xw06mh8ad5j0qa1vryvxjgvbnyrr8rbm4vd8w";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.5.1";
+      sha256 = "09r89m1wy4cjv2nps1ykp00qjpi0531r07q3s34hr7m6njk4srkl";
+    };
+  }
+  {
+    goPackagePath = "github.com/tdewolff/minify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tdewolff/minify";
+      rev = "v2.3.6";
+      sha256 = "0p4v4ab49lm5y438k5aks06fpiagbjw2j2x7i8jaa273mkgicrbb";
+    };
+  }
+  {
+    goPackagePath = "github.com/tdewolff/parse";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tdewolff/parse";
+      rev = "v2.3.4";
+      sha256 = "00hclphbjgc5vjrqgnclp72v8c45k35vmj84d2a0f7bw8cc88zcd";
+    };
+  }
+  {
+    goPackagePath = "github.com/tdewolff/test";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tdewolff/test";
+      rev = "v1.0.6";
+      sha256 = "12glhjb4cwp6yxwd17rwa6b4gxna3lm01bgc7yn9di58chc7lyh3";
+    };
+  }
+  {
+    goPackagePath = "github.com/tiramiseb/go-gandi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tiramiseb/go-gandi";
+      rev = "e1cf2e430b3a";
+      sha256 = "1m6wzif0dgssh5hzffwqg39789k9nwvj8xaq0d492f0fr14w0nng";
+    };
+  }
+  {
+    goPackagePath = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev = "v2.1.1";
+      sha256 = "0znf7pim7xsl8x6pcgi9vm0px48xrqfkw6ysn4yv6xc2569zpjs1";
+    };
+  }
+  {
+    goPackagePath = "github.com/vultr/govultr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vultr/govultr";
+      rev = "v0.2.0";
+      sha256 = "09103hb2rx93d6vyr54bqdai35d6l5q3klk09k53aqrijp8pycfz";
+    };
+  }
+  {
+    goPackagePath = "go.opencensus.io";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-instrumentation/opencensus-go";
+      rev = "v0.22.0";
+      sha256 = "05jr8gkr2w34i5wwki4zhl5ch0qrgi7cdgag5iy5gpxplhbrvbg9";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "2aa609cf4a9d";
+      sha256 = "1yvis6fqbsd7f356aqyi18f76vnwj3bry6mxqnkvshq4cwrf92il";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/exp";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/exp";
+      rev = "efd6b22b2522";
+      sha256 = "0ysahwb7p6y09izks4ca8nk2w414gmjxzz44l5rmadlvk3k66cgp";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/image";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/image";
+      rev = "0694c2d4d067";
+      sha256 = "0v4rs4xpi7agbdzjw713mp7gzij8z89058s0yfj3276mzlns3zk4";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/lint";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/lint";
+      rev = "959b441ac422";
+      sha256 = "1mgcv5f00pkzsbwnq2y7vqvd1b4lr5a3s47cphh2qv4indfk7pck";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/mobile";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/mobile";
+      rev = "d3739f865fa6";
+      sha256 = "079ck2dyikacnph9s5mf0hrjnqlk6lc8q64dwnyw45w3xbbc50mg";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/mod";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/mod";
+      rev = "v0.2.0";
+      sha256 = "1fp6885dclq77mh73v7i54v2b9llpv4di193zc8vmsbbkkc483cl";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "0de0cce0169b";
+      sha256 = "1db7s5kbzyh2zd5lpv05n7hp8wbwdvgk0wpiwrlnig94mkr0y5aq";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev = "bf48bf16ab8d";
+      sha256 = "1sirdib60zwmh93kf9qrx51r8544k1p9rs5mk0797wibz3m4mrdg";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "cd5d95a43a6e";
+      sha256 = "1nqkyz2y1qvqcma52ijh02s8aiqmkfb95j08f6zcjhbga3ds6hds";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "cb0a6d8edb6c";
+      sha256 = "0xkrf2k6nn1qh64ckrc4rmf1vhkzs0p7f1rnhv4v4pz9mvgh3v6w";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.2";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev = "9d24e82272b4";
+      sha256 = "1f5nkr4vys2vbd8wrwyiq2f5wcaahhpxmia85d1gshcbqjqf8dkb";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "20ab64c0d93f";
+      sha256 = "1gfhw6daabjy771b3c0k0yga18ja50845n648mgagsa441dxvlch";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/xerrors";
+      rev = "9bdfabe68543";
+      sha256 = "1yjfi1bk9xb81lqn85nnm13zz725wazvrx3b50hx19qmwg7a4b0c";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/api";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/google-api-go-client";
+      rev = "v0.20.0";
+      sha256 = "13syr1x33k6mrn5w6l4sgdbzn368w3m60vf6kk2j10fwa45125rg";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.6.5";
+      sha256 = "05hbq4cs7bqw0zl17bx8rzdkszid3nyl92100scg3jjrg70dhm7w";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-genproto";
+      rev = "24fa4b261c55";
+      sha256 = "109zhaqlfd8zkbr1hk6zqbs6vcxfrk64scjwh2nswph05gr0m84d";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev = "v1.27.0";
+      sha256 = "1ijrmgrxyabfn51nm3p9l81iaasq5fg237wnr6mdc4dzsfcg8kd7";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/asn1-ber.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/asn1-ber.v1";
+      rev = "f715ec2f112d";
+      sha256 = "00ixms8x3lrhywbvq5v2sagcqsxa1pcnlk17dp5lnwckv3xg4psb";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "41f04d3bba15";
+      sha256 = "0vfk9czmlxmp6wndq8k17rhnjxal764mxfhrccza7nwlia760pjy";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/ini.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/ini.v1";
+      rev = "v1.42.0";
+      sha256 = "18ywm8zyv091j1pp5mvx8szl7928chk8lw02br6jy568d7rk4xal";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/ns1/ns1-go.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/ns1/ns1-go.v2";
+      rev = "c563826f4cbe";
+      sha256 = "0swpsy0bdkwqlb7i0fgxs55sdfsy7pbnh6a09crhbw5xldvswq5k";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/sourcemap.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/sourcemap.v1";
+      rev = "v1.0.5";
+      sha256 = "08rf2dl13hbnm3fq2cm0nnsspy9fhf922ln23cz5463cv7h62as4";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/square/go-jose.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/square/go-jose.v2";
+      rev = "v2.3.1";
+      sha256 = "11r93g9xrcjqj7qvq8sbd5hy5rnbpmim0vdsp6rbav8gl7wimaa3";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.8";
+      sha256 = "1inf7svydzscwv9fcjd2rm61a4xjk6jkswknybmns2n58shimapw";
+    };
+  }
+  {
+    goPackagePath = "honnef.co/go/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dominikh/go-tools";
+      rev = "ea95bdfd59fc";
+      sha256 = "1763nw7pwpzkvzfnm63dgzcgbq9hwmq5l1nffchnhh77vgkaq4ic";
+    };
+  }
+  {
+    goPackagePath = "rsc.io/binaryregexp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rsc/binaryregexp";
+      rev = "v0.2.0";
+      sha256 = "1kar0myy85waw418zslviwx8846zj0m9cmqkxjx0fvgjdi70nc4b";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2892,6 +2892,8 @@ in
 
   dnscrypt-wrapper = callPackage ../tools/networking/dnscrypt-wrapper { };
 
+  dnscontrol = callPackage ../applications/networking/dnscontrol { };
+
   dnsenum = callPackage ../tools/security/dnsenum { };
 
   dnsmasq = callPackage ../tools/networking/dnsmasq { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
