### PR TITLE
pythonPackages.python-baseconv: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/python-baseconv/default.nix
+++ b/pkgs/development/python-modules/python-baseconv/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+}:
+buildPythonPackage rec {
+  pname = "python-baseconv";
+  version = "1.2.2";
+
+  src = fetchPypi {
+    inherit pname version ;
+    sha256 = "0539f8bd0464013b05ad62e0a1673f0ac9086c76b43ebf9f833053527cd9931b";
+  };
+
+  pythonImportsCheck = [ "baseconv" ];
+
+  meta = with lib; {
+    description = "Python module to convert numbers from base 10 integers to base X strings and back again";
+    homepage = "https://github.com/semente/python-baseconv";
+    license = licenses.psfl;
+    maintainers = with maintainers; [ rakesh4g ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -904,6 +904,8 @@ in {
     mpi = pkgs.openmpi;
   };
 
+  python-baseconv = callPackage ../development/python-modules/python-baseconv { };
+
   pycognito = callPackage ../development/python-modules/pycognito { };
 
   python-mpv-jsonipc = callPackage ../development/python-modules/python-mpv-jsonipc { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
pythonPackages.python-baseconv: init at 1.2.2
needed by py-multibase https://github.com/NixOS/nixpkgs/pull/83276

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
