### PR TITLE
pythonPackages.py-multibase: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/py-multibase/default.nix
+++ b/pkgs/development/python-modules/py-multibase/default.nix
@@ -1,0 +1,46 @@
+{ buildPythonPackage
+, fetchPypi
+, isPy27
+, lib
+, morphys
+, pytest
+, pytestrunner
+, python-baseconv
+, six
+}:
+buildPythonPackage rec {
+  pname = "py-multibase";
+  version = "1.0.1";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version ;
+    sha256 = "6ed706ea321b487ba82e4172a9c82d61dacd675c865f576a937a94bca1a23443";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "[pytest]" ""
+    substituteInPlace setup.cfg --replace "python_classes = *TestCase" ""
+  '';
+
+  nativeBuildInputs = [
+    pytestrunner
+  ];
+
+  propagatedBuildInputs = [
+    morphys
+    six
+    python-baseconv
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  meta = with lib; {
+    description = "Multibase is a protocol for distinguishing base encodings and other simple string encodings";
+    homepage = "https://github.com/multiformats/py-multibase";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rakesh4g ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1129,6 +1129,8 @@ in {
 
   py-lru-cache = callPackage ../development/python-modules/py-lru-cache { };
 
+  py-multibase = callPackage ../development/python-modules/py-multibase { };
+
   py-multihash = callPackage ../development/python-modules/py-multihash { };
 
   py-radix = callPackage ../development/python-modules/py-radix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
pythonPackages.py-multibase: init at 1.0.1
**DependsOn :**: https://github.com/NixOS/nixpkgs/pull/83275 
https://github.com/NixOS/nixpkgs/pull/83202

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
