### PR TITLE
onedrive: 2.3.13 -> 2.4.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -108,6 +108,11 @@
       <link linkend="opt-security.duosec.integrationKey">security.duosec.integrationKey</link>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      The package <package>onedrive</package> needs the end user to reauthorize the client for all the accounts. Details <link xlink:href="https://github.com/abraunegg/onedrive/issues/835">here</link>.  
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/applications/networking/sync/onedrive/default.nix
+++ b/pkgs/applications/networking/sync/onedrive/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "onedrive";
-  version = "2.3.13";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "abraunegg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0bcsrfh1g7bdlcp0zjn6np88qzpn5frv61lzxz9b2ayxf7wyybvi";
+    sha256 = "12cc1i6ygrky4dm42frlsysyjn74qjqg9w19m17fgblagdh66q04";
   };
 
   nativeBuildInputs = [ dmd pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Upgrade

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
