### PR TITLE
buildFHSUserEnv: use -a "$0" in almost last exec

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/default.nix
@@ -20,7 +20,7 @@ let
     shift
 
     source /etc/profile
-    exec ${run} "$@"
+    exec -a "$0" ${run} "$@"
   '';
 
 in runCommandLocal name {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

In a derivation using buildFHSUserEnv, I'd like to support multiple executables in `$out/bin` using a script such as:

```nix
  runScript = writeScript "${name}-wrapper" ''
    arg0="$(basename "$0")"
    for executable in ${lib.concatStringsSep " " (listOfExecutables)}; do
        if [[ "$arg0" == "$executable" ]]; then
            exec -a "$0" ${drvBeingWrapped}/bin/$executable "$@"
        fi
    done
  '';
```

While in the derivation coming out of `buildFHSUserEnv`, I'm putting in `extraInstallCommands`:

```nix
  extraInstallCommands = ''
    for executable in ${lib.concatStringsSep " " (listOfExecutables)}; do
        ln -s $out/bin/${name} $out/bin/$executable
    done
  '';
```

Where `listOfExecutables` is some list I'm controlling via:

```nix
let
  listOfExecutables = [ ..  ];
in
  buildFHSUserEnv rec {
  ...
};
```

The idea is that every executable's name in `listOfExecutables` is linked to the main executable - `$out/bin/${name}` and _that_ executable is calling in turn `runScript`. I'd like `runScript` to know the original `$0` in order to know what real executable inside the FHS environment to call.

Right now, it's impossible to implement this because the FHS' environment is calling `runScript` without `-a "$0"`. This change should fix this (untested).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
