### PR TITLE
tut: init at 0.0.2

### DIFF
--- a/pkgs/applications/misc/tut/default.nix
+++ b/pkgs/applications/misc/tut/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "tut";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "RasmusLindroth";
+    repo = pname;
+    rev = version;
+    sha256 = "0c44mgkmjnfpf06cj63i6mscxcsm5cipm0l4n6pjxhc7k3qhgsfw";
+  };
+
+  modSha256 = "02xwf4l7860mfdbk8jikpf2g4p5ck760qnv1ka4qhxzizqqgcizv";
+
+  meta = with stdenv.lib; {
+    description = "TUI for Mastodon";
+    homepage = "https://github.com/RasmusLindroth/tut";
+    license = licenses.mit;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7082,6 +7082,8 @@ in
 
   turses = callPackage ../applications/networking/instant-messengers/turses { };
 
+  tut = callPackage ../applications/misc/tut { };
+
   oysttyer = callPackage ../applications/networking/instant-messengers/oysttyer { };
 
   twilight = callPackage ../tools/graphics/twilight {


### PR DESCRIPTION
Just saw this on reddit... if someone could give me a pointer with the error below... I'd finish this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
$ nix-build -A tut
these derivations will be built:
  /nix/store/nmfz3rqvag3p1a509wx0rrbn4q1ggk3r-tut-0.0.2.drv 
building '/nix/store/nmfz3rqvag3p1a509wx0rrbn4q1ggk3r-tut-0.0.2.drv'...
unpacking sources
unpacking source archive /nix/store/fb13jd7gmk6dji255h3iigkr64hfd3vq-source
source root is source
patching sources
configuring       
building                    
go/src/github.com/RasmusLindroth/tut/config.go:6:2: cannot find package "github.com/gdamore/tcell" in any of:
        /nix/store/nha5hv6zzdixkdp6icz8319ylk0ii60n-go-1.14/share/go/src/github.com/gdamore/tcell (from $GOROOT)
        /build/go/src/github.com/gdamore/tcell (from $GOPATH)
go/src/github.com/RasmusLindroth/tut/config.go:7:2: cannot find package "github.com/kyoh86/xdg" in any of:
        /nix/store/nha5hv6zzdixkdp6icz8319ylk0ii60n-go-1.14/share/go/src/github.com/kyoh86/xdg (from $GOROOT)
        /build/go/src/github.com/kyoh86/xdg (from $GOPATH)
go/src/github.com/RasmusLindroth/tut/account.go:8:2: cannot find package "github.com/mattn/go-mastodon" in any of:
        /nix/store/nha5hv6zzdixkdp6icz8319ylk0ii60n-go-1.14/share/go/src/github.com/mattn/go-mastodon (from $GOROOT)
        /build/go/src/github.com/mattn/go-mastodon (from $GOPATH)
go/src/github.com/RasmusLindroth/tut/util.go:14:2: cannot find package "github.com/microcosm-cc/bluemonday" in any of:
        /nix/store/nha5hv6zzdixkdp6icz8319ylk0ii60n-go-1.14/share/go/src/github.com/microcosm-cc/bluemonday (from $GOROOT)
        /build/go/src/github.com/microcosm-cc/bluemonday (from $GOPATH)
go/src/github.com/RasmusLindroth/tut/account.go:9:2: cannot find package "github.com/pelletier/go-toml" in any of:
        /nix/store/nha5hv6zzdixkdp6icz8319ylk0ii60n-go-1.14/share/go/src/github.com/pelletier/go-toml (from $GOROOT)
        /build/go/src/github.com/pelletier/go-toml (from $GOPATH)             
go/src/github.com/RasmusLindroth/tut/app.go:5:2: cannot find package "github.com/rivo/tview" in any of:
        /nix/store/nha5hv6zzdixkdp6icz8319ylk0ii60n-go-1.14/share/go/src/github.com/rivo/tview (from $GOROOT)
        /build/go/src/github.com/rivo/tview (from $GOPATH)
go/src/github.com/RasmusLindroth/tut/util.go:16:2: cannot find package "golang.org/x/net/html" in any of:
        /nix/store/nha5hv6zzdixkdp6icz8319ylk0ii60n-go-1.14/share/go/src/golang.org/x/net/html (from $GOROOT)
        /build/go/src/golang.org/x/net/html (from $GOPATH)                                                             
builder for '/nix/store/nmfz3rqvag3p1a509wx0rrbn4q1ggk3r-tut-0.0.2.drv' failed with exit code 1
error: build of '/nix/store/nmfz3rqvag3p1a509wx0rrbn4q1ggk3r-tut-0.0.2.drv' failed
```