### PR TITLE
meshlab: 20190129-beta -> 2020.03

### DIFF
--- a/pkgs/applications/graphics/meshlab/default.nix
+++ b/pkgs/applications/graphics/meshlab/default.nix
@@ -7,111 +7,25 @@
 , lib3ds
 , bzip2
 , muparser
+, eigen
+, glew
+, gmp
 , levmar
+, qhull
+, cmake
 }:
 
-let
-  meshlabRev = "25f3d17b1d1d47ddc51179cb955f3027b7638745";
-  vcglibRev = "910da4c3e310f2e6557bd7a39c4f1529e61573e5";
-  # ^ this should be the latest commit in the vcglib devel branch at the time of the meshlab revision
-  # We keep it separate here instead of using the `vcg` nix package because
-  # as of writing, meshlab upstream does not seem to follow a proper
-  # release process, and the other dependencies of `vcg` may no longer
-  # work when we upgrade it for the purpose of meshlab.
+mkDerivation rec {
+  pname = "meshlab";
+  version = "2020.03";
 
-  # Unfixed upstream compile error; see
-  #     https://github.com/cnr-isti-vclab/meshlab/issues/188#issuecomment-364785362
-  # that has with fixed line endings.
-  import_bundle_out_patch = fetchpatch {
-    name = "import_bundle_out.patch";
-    url = "https://aur.archlinux.org/cgit/aur.git/plain/import_bundle_out.patch?h=meshlab-git&id=f7250ea818470f07dc9b86726407091d39c0be6f";
-    sha256 = "1g6nli15i3fjd6jsgkxvb33kzbcv67xjkc3jv9r51lrwlm1ifzxi";
+  src = fetchFromGitHub {
+    owner = "cnr-isti-vclab";
+    repo = "meshlab";
+    rev = "f3568e75c9aed6da8bb105a1c8ac7ebbe00e4536";
+    sha256 = "17g9icgy1w67afxiljzxk94dyhj4f336gjxn0bhppd58xfqh8w4g";
+    fetchSubmodules = true; # for vcglib
   };
-
-  # Reduces amount of vendored libraries, fixes `/linux` vs `linux-g++`
-  # directory name linker errors.
-  external_patch = fetchpatch {
-    name = "external.patch";
-    url = "https://aur.archlinux.org/cgit/aur.git/plain/external.patch?h=meshlab-git&id=f7250ea818470f07dc9b86726407091d39c0be6f";
-    sha256 = "1rxwkxhmxis1420rc1w7dg89gkmym68lpszsq6snl6dzpl3ingsb";
-  };
-  _3ds_patch = fetchpatch {
-    name = "3ds.patch";
-    url = "https://aur.archlinux.org/cgit/aur.git/plain/3ds.patch?h=meshlab-git&id=f7250ea818470f07dc9b86726407091d39c0be6f";
-    sha256 = "1w435b7p1ggi2bzib4yyszmk54drjgpbn8n9mnsk1slsxnp2vmg8";
-  };
-  muparser_patch = fetchpatch {
-    name = "muparser.patch";
-    url = "https://aur.archlinux.org/cgit/aur.git/plain/muparser.patch?h=meshlab-git&id=f7250ea818470f07dc9b86726407091d39c0be6f";
-    sha256 = "1sf7xqwc2j8xxdx2yklwifii9qqgknvx6ahk2hq76mg78ry1nzhq";
-  };
-
-in mkDerivation {
-  name = "meshlab-20190129-beta";
-
-  srcs =
-    [
-      (fetchFromGitHub {
-        owner = "cnr-isti-vclab";
-        repo = "meshlab";
-        rev = meshlabRev;
-        sha256 = "16d2i91hrxvrr5p0k33g3fzis9zp4gsy3n5y2nhafvsgdmaidiij";
-        name = "meshlab-${meshlabRev}";
-      })
-      (fetchFromGitHub {
-        owner = "cnr-isti-vclab";
-        repo = "vcglib";
-        rev = vcglibRev;
-        sha256 = "0xpnjpwpj57hgai184rzyk9lbq6d9vbjzr477dvl5nplpwa420m1";
-        name = "vcglib-${vcglibRev}";
-      })
-    ];
-
-  sourceRoot = "meshlab-${meshlabRev}";
-
-  # Meshlab is not format-security clean; without disabling hardening, we get:
-  #     ../../external/qhull-2003.1/src/io.c:2169:3: error: format not a string literal and no format arguments [-Werror=format-security]
-  #        fprintf(fp, endfmt);
-  #        ^~~~~~~
-  hardeningDisable = [ "format" ];
-
-  enableParallelBuilding = true;
-
-  prePatch =
-    ''
-      # MeshLab has ../vcglib hardcoded everywhere, so move the source dir
-      mv ../vcglib-${vcglibRev} ../vcglib
-
-      # Make all source files writable so that patches can be applied.
-      chmod -R u+w ..
-
-      patch -Np1 --directory=../vcglib -i ${import_bundle_out_patch}
-
-      patch -Np1 -i ${external_patch}
-      # Individual libraries
-      patch -Np1 -i ${_3ds_patch}
-      patch -Np1 -i ${muparser_patch}
-    ''
-    ;
-
-  buildPhase = ''
-    cd src
-    export NIX_LDFLAGS="-rpath $out/opt/meshlab $NIX_LDFLAGS"
-
-    pushd external
-    qmake -recursive $QMAKE_FLAGS external.pro
-    buildPhase
-    popd
-    qmake -recursive $QMAKE_FLAGS meshlab_full.pro
-    buildPhase
-  '';
-
-  installPhase = ''
-    mkdir -p $out/opt/meshlab $out/bin
-    cp -Rv distrib/* $out/opt/meshlab
-    ln -s $out/opt/meshlab/meshlab $out/bin/meshlab
-    ln -s $out/opt/meshlab/meshlabserver $out/bin/meshlabserver
-  '';
 
   buildInputs = [
     libGLU
@@ -121,8 +35,48 @@ in mkDerivation {
     lib3ds
     bzip2
     muparser
+    eigen
+    glew
+    gmp
     levmar
+    qhull
   ];
+
+  nativeBuildInputs = [ cmake ];
+
+  patches = [ ./no-build-date.patch ];
+
+  # MeshLab computes the version based on the build date, remove when https://github.com/cnr-isti-vclab/meshlab/issues/622 is fixed.
+  postPatch = ''
+    substituteAll ${./fix-version.patch} /dev/stdout | patch -p1 --binary
+  '';
+
+  preConfigure = ''
+    substituteAll ${./meshlab.desktop} install/linux/resources/meshlab.desktop
+    cd src
+  '';
+
+  cmakeFlags = [
+    "-DALLOW_BUNDLED_EIGEN=OFF"
+    "-DALLOW_BUNDLED_GLEW=OFF"
+    "-DALLOW_BUNDLED_LIB3DS=OFF"
+    "-DALLOW_BUNDLED_MUPARSER=OFF"
+    "-DALLOW_BUNDLED_QHULL=OFF"
+     # disable when available in nixpkgs
+    "-DALLOW_BUNDLED_OPENCTM=ON"
+    "-DALLOW_BUNDLED_SSYNTH=ON"
+    # some plugins are disabled unless these are on
+    "-DALLOW_BUNDLED_NEWUOA=ON"
+    "-DALLOW_BUNDLED_LEVMAR=ON"
+  ];
+
+  # Meshlab is not format-security clean; without disabling hardening, we get:
+  # src/common/GLLogStream.h:61:37: error: format not a string literal and no format arguments [-Werror=format-security]
+  #  61 |         int chars_written = snprintf(buf, buf_size, f, std::forward<Ts>(ts)...);
+  #     |
+  hardeningDisable = [ "format" ];
+
+  enableParallelBuilding = true;
 
   meta = {
     description = "A system for processing and editing 3D triangular meshes.";

--- a/pkgs/applications/graphics/meshlab/fix-version.patch
+++ b/pkgs/applications/graphics/meshlab/fix-version.patch
@@ -1,0 +1,5 @@
+--- a/src/common/mlapplication.h
++++ b/src/common/mlapplication.h
+@@ -23 +23 @@ public:
+-        return QString::number(compileTimeYear()) + "." + (compileTimeMonth() < 10 ? "0" + QString::number(compileTimeMonth()) : QString::number(compileTimeMonth()));
++        return "@version@";

--- a/pkgs/applications/graphics/meshlab/meshlab.desktop
+++ b/pkgs/applications/graphics/meshlab/meshlab.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=MeshLab
+Version=@version@
+Name[en_GB]=MeshLab
+GenericName=Mesh processing
+GenericName[en_GB]=Mesh processing
+Comment=View and process meshes
+Type=Application
+Exec=@out@/bin/meshlab %U
+TryExec=@out@/bin/meshlab
+Icon=@out@/share/icons/hicolor/meshlab.png
+Terminal=false
+MimeType=model/mesh;application/x-3ds;image/x-3ds;application/sla;
+Categories=Graphics;3DGraphics;Viewer;Qt;
+END_DESKTOP

--- a/pkgs/applications/graphics/meshlab/no-build-date.patch
+++ b/pkgs/applications/graphics/meshlab/no-build-date.patch
@@ -1,0 +1,10 @@
+--- a/src/meshlab/mainwindow_RunTime.cpp
++++ b/src/meshlab/mainwindow_RunTime.cpp
+@@ -3312 +3312 @@ void MainWindow::about()
+-    temp.labelMLName->setText(MeshLabApplication::completeName(MeshLabApplication::HW_ARCHITECTURE(QSysInfo::WordSize))+"   (built on "+__DATE__+")");
++    temp.labelMLName->setText(MeshLabApplication::completeName(MeshLabApplication::HW_ARCHITECTURE(QSysInfo::WordSize)));
+--- a/src/meshlabplugins/filter_plymc/plymc_main.cpp
++++ b/src/meshlabplugins/filter_plymc/plymc_main.cpp
+@@ -121 +121 @@ int main(int argc, char *argv[])
+-  printf(   "\n                  PlyMC "_PLYMC_VER" ("__DATE__")\n"
++  printf(   "\n                  PlyMC "_PLYMC_VER"\n"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
