### PR TITLE
pythonPackages.qiskit-ignis: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/qiskit-ignis/default.nix
+++ b/pkgs/development/python-modules/qiskit-ignis/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, numpy
+, qiskit-terra
+, scipy
+  # Check Inputs
+, pytestCheckHook
+, qiskit-aer
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-ignis";
+  version = "0.2.0";
+
+  disabled = pythonOlder "3.5";
+
+  # Pypi's tarball doesn't contain tests
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = pname;
+    rev = version;
+    sha256 = "08a60xk5dq5wmqc23r4hr2v2nsf9hs0ybz832vbnd6d80dl6izyc";
+  };
+
+  patches = [
+    # Update tests for compatibility with qiskit-aer 0.4 (#342). Remove in version > 0.2.0
+    (fetchpatch {
+      url = "https://github.com/Qiskit/qiskit-ignis/commit/d78c494579f370058e68e360f10149db81b52477.patch";
+      sha256 = "0ygkllf95c0jfvjg7gn399a5fd0wshsjpcn279kj7855m8j306h6";
+    })
+    # Fix statevector test over-eager validation (PR #333)
+    (fetchpatch {
+      url = "https://github.com/Qiskit/qiskit-ignis/commit/7cc8eb2e852b383ea429233fa43d3728931f1707.patch";
+      sha256 = "0mdygykilg4qivdaa731z3y56l3ax4jp1sil9npqv0gn4p03c9g5";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    qiskit-terra
+    scipy
+  ];
+
+  # Tests
+  pythonImportsCheck = [ "qiskit.ignis" ];
+  dontUseSetuptoolsCheck = true;
+  preCheck = ''export HOME=$TMPDIR'';
+  checkInputs = [
+    pytestCheckHook
+    qiskit-aer
+  ];
+
+  meta = with lib; {
+    description = "Qiskit tools for quantum hardware verification, noise characterization, and error correction";
+    homepage = "https://github.com/QISKit/qiskit-ignis";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7062,6 +7062,8 @@ in {
 
   qiskit-ibmq-provider = callPackage ../development/python-modules/qiskit-ibmq-provider { };
 
+  qiskit-ignis = callPackage ../development/python-modules/qiskit-ignis { };
+
   qiskit-terra = callPackage ../development/python-modules/qiskit-terra { };
 
   qasm2image = callPackage ../development/python-modules/qasm2image { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update qiskit according to new upstream package structure (collection of subpackages). This is broken out of #78772.

Waiting on approval of #80662 , will rebase to remove the ``qiskit-aer`` commits when done.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
