### PR TITLE
aws-sam-cli: update cookiecutter version to 1.7.0 since 1.6.0 doesn't exists anymore

### DIFF
--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -15,7 +15,7 @@ let
       });
 
       cookiecutter = super.cookiecutter.overridePythonAttrs (oldAttrs: rec {
-        version = "1.6.0";
+        version = "1.7.0";
         src = oldAttrs.src.override {
           inherit version;
           sha256 = "0glsvaz8igi2wy1hsnhm9fkn6560vdvdixzvkq6dn20z3hpaa5hk";


### PR DESCRIPTION
###### Motivation for this change
Repairing aws-sam-cli installation.
Current nix package reference cookiecutter version 1.6.0 that's doesn't exist. 1.7.0 is now the only dependency. 
It fixes the package for me 
Tested it with 

nix-env -f path/to/forked/pkgs -i aws-sam-cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
