### PR TITLE
roboto-slab: 2016-01-11 -> 2.000

### DIFF
--- a/pkgs/data/fonts/roboto-slab/default.nix
+++ b/pkgs/data/fonts/roboto-slab/default.nix
@@ -1,51 +1,28 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
-let
-  # last commit on the directory containing the fonts in the upstream repository
-  commit = "883939708704a19a295e0652036369d22469e8dc";
-in
 stdenv.mkDerivation {
   pname = "roboto-slab";
-  version = "2016-01-11";
+  version = "2.000";
 
-  srcs = [
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotoslab/RobotoSlab-Regular.ttf";
-      sha256 = "04180b5zk2nzll1rrgx8f1i1za66pk6pbrp0iww2xypjqra5zahk";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotoslab/RobotoSlab-Bold.ttf";
-      sha256 = "0ayl2hf5j33vixxfa7051hzjjxnx8zhag3rr0mmmnxpsn7md44ms";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotoslab/RobotoSlab-Light.ttf";
-      sha256 = "09riqgj9ixqjdb3mkzbs799cgmnp3ja3d6izlqkhpkfm52sgafqm";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotoslab/RobotoSlab-Thin.ttf";
-      sha256 = "1hd0m7lxhr261a4s2nb572ari6v53w2yd8yjr9i534iqfl4jcbsf";
-    })
-  ];
-
-  sourceRoot = "./";
-
-  unpackCmd = ''
-    ttfName=$(basename $(stripHash $curSrc))
-    cp $curSrc ./$ttfName
-  '';
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "robotoslab";
+    rev = "baeeba45e0c3ccdcfb6a70dc564785941aafef5d";
+    sha256 = "1v6z0a2xgwgf9dyj62sriy8ckwpbwlxkki6gfax1f4h4livvzpdn";
+  };
 
   installPhase = ''
     mkdir -p $out/share/fonts/truetype
-    cp -a *.ttf $out/share/fonts/truetype/
+    cp -a fonts/static/*.ttf $out/share/fonts/truetype/
   '';
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "0imhvisjzi0rvn32hn04kngca4szx0j39h4c4zs7ryb4wdca76q9";
+  outputHash = "0g663npi5lkvwcqafd4cjrm90ph0nv1lig7d19xzfymnj47qpj8x";
 
-  meta = {
-    homepage = https://www.google.com/fonts/specimen/Roboto+Slab;
-    description = "Google Roboto Slab fonts";
+  meta = with stdenv.lib; {
+    homepage = "https://www.google.com/fonts/specimen/Roboto+Slab";
+    description = "Roboto Slab Typeface by Google";
     longDescription = ''
       Roboto has a dual nature. It has a mechanical skeleton and the forms
       are largely geometric. At the same time, the font features friendly
@@ -57,8 +34,8 @@ stdenv.mkDerivation {
       This is the Roboto Slab family, which can be used alongside the normal
       Roboto family and the Roboto Condensed family.
     '';
-    license = stdenv.lib.licenses.asl20;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- use the version from the ttf file
- source is the [github repository for the font](https://github.com/googlefonts/robotoslab)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).