### PR TITLE
pythonPackages.flask-appbuilder: 2.1.6 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -25,12 +25,12 @@
 
 buildPythonPackage rec {
   pname = "flask-appbuilder";
-  version = "2.1.6";
+  version = "2.3.0";
 
   src = fetchPypi {
     pname = "Flask-AppBuilder";
     inherit version;
-    sha256 = "a37d7d6a62407a2e0975af5305c795f2fb5c06ecc34e3cf64659d083b1b2dd5f";
+    sha256 = "04bsswi7daaqda01a83rd1f2gq6asii520f9arjf7bsy24pmbprc";
   };
 
   checkInputs = [
@@ -60,12 +60,13 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-   substituteInPlace setup.py \
-     --replace "jsonschema>=3.0.1<4" "jsonschema" \
-     --replace "marshmallow>=2.18.0,<2.20" "marshmallow" \
-     --replace "PyJWT>=1.7.1" "PyJWT" \
-     --replace "Flask-SQLAlchemy>=2.4,<3" "Flask-SQLAlchemy" \
-     --replace "Flask-JWT-Extended>=3.18,<4" "Flask-JWT-Extended"
+    substituteInPlace setup.py \
+      --replace "apispec[yaml]>=1.1.1, <2" "apispec" \
+      --replace "jsonschema>=3.0.1, <4" "jsonschema" \
+      --replace "marshmallow>=2.18.0, <4.0.0" "marshmallow" \
+      --replace "PyJWT>=1.7.1" "PyJWT" \
+      --replace "Flask-SQLAlchemy>=2.4, <3" "Flask-SQLAlchemy" \
+      --replace "Flask-JWT-Extended>=3.18, <4" "Flask-JWT-Extended"
   '';
 
   # majority of tests require network access or mongo
@@ -73,8 +74,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Simple and rapid application development framework, built on top of Flask";
-    homepage = https://github.com/dpgaspar/flask-appbuilder/;
+    homepage = "https://github.com/dpgaspar/flask-appbuilder/";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
While upgrading a separate package, saw ``pythonPackages.flask-appbuilder``  had a new version.
Waiting on #83314 to pass.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
