### PR TITLE
pythonPackages.qiskit-ibmq-provider: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/arrow/default.nix
+++ b/pkgs/development/python-modules/arrow/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "arrow";
-  version = "0.15.4";
+  version = "0.15.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e1a318a4c0b787833ae46302c02488b6eeef413c6a13324b3261ad320f21ec1e";
+    sha256 = "0yq2bld2bjxddmg9zg4ll80pb32rkki7xyhgnrqnkxy5w9jf942k";
   };
 
   checkPhase = ''

--- a/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
@@ -2,6 +2,7 @@
 , pythonOlder
 , buildPythonPackage
 , fetchFromGitHub
+, arrow
 , nest-asyncio
 , qiskit-terra
 , requests
@@ -15,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-ibmq-provider";
-  version = "0.4.5";
+  version = "0.5.0";
 
   disabled = pythonOlder "3.6";
 
@@ -23,10 +24,11 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "148x3x1gk6l7nrqdllglq6ywh70k4747ybkx0bn25k3gmxd57y03";
+    sha256 = "1jhgsfspmry0qk7jkcryn4225j2azys3rm99agk6mh0jzwrvx4am";
   };
 
   propagatedBuildInputs = [
+    arrow
     nest-asyncio
     qiskit-terra
     requests

--- a/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+, nest-asyncio
+, qiskit-terra
+, requests
+, requests_ntlm
+, websockets
+  # check inputs
+, pytestCheckHook
+, vcrpy
+, pproxy
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-ibmq-provider";
+  version = "0.4.5";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = pname;
+    rev = version;
+    sha256 = "148x3x1gk6l7nrqdllglq6ywh70k4747ybkx0bn25k3gmxd57y03";
+  };
+
+  propagatedBuildInputs = [
+    nest-asyncio
+    qiskit-terra
+    requests
+    requests_ntlm
+    websockets
+  ];
+
+  # websockets seems to be pinned b/c in v8+ it drops py3.5 support. Not an issue here (usually py3.7+, and disabled for older py3.6)
+  prePatch = ''
+    substituteInPlace requirements.txt --replace "websockets>=7,<8" "websockets"
+    substituteInPlace setup.py --replace "websockets>=7,<8" "websockets"
+  '';
+
+  # Most tests require credentials to run on IBMQ
+  checkInputs = [ pytestCheckHook vcrpy pproxy ];
+  dontUseSetuptoolsCheck = true;
+  pythonImportsCheck = [ "qiskit.providers.ibmq" ];
+  disabledTests = [ "test_old_api_url" "test_non_auth_url" "test_non_auth_url_with_hub" ];  # tests require internet connection
+  # skip tests that require IBMQ credentials, vs failing.
+  preCheck = ''
+    pushd /build/source  # run pytest from /build vs $out
+    substituteInPlace test/decorators.py --replace "Exception('Could not locate valid credentials.')" "SkipTest('No IBMQ Credentials provided for tests')"
+  '';
+  postCheck = ''
+    popd
+  '';
+
+  meta = with lib; {
+    description = "Qiskit provider for accessing the quantum devices and simulators at IBMQ";
+    homepage = "https://github.com/Qiskit/qiskit-ibmq-provider";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7052,6 +7052,8 @@ in {
 
   qiskit = callPackage ../development/python-modules/qiskit { };
 
+  qiskit-ibmq-provider = callPackage ../development/python-modules/qiskit-ibmq-provider { };
+
   qiskit-terra = callPackage ../development/python-modules/qiskit-terra { };
 
   qasm2image = callPackage ../development/python-modules/qasm2image { };


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Qiskit Provider for accessing the quantum devices and simulators at IBMQ.

Requirement of qiskit package. Update qiskit according to new upstream package structure (collection of subpackages). This is broken out of #78772.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
