### PR TITLE
python: propagate makeWrapper arguments

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -34,7 +34,8 @@ with pkgs;
         isPyPy = lib.hasInfix "pypy" interpreter;
 
         buildEnv = callPackage ./wrapper.nix { python = self; inherit (pythonPackages) requiredPythonModules; };
-        withPackages = import ./with-packages.nix { inherit buildEnv pythonPackages;};
+        withPackages = import ./with-packages.nix { inherit buildEnv pythonPackages; };
+
         pkgs = pythonPackages;
         interpreter = "${self}/bin/${executable}";
         inherit executable implementation libPrefix pythonVersion sitePackages;

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -63,6 +63,12 @@ in rec {
       };
     } ./pip-install-hook.sh) {};
 
+  propagateWrapperArgsHook = callPackage ({ }:
+    makeSetupHook {
+      name = "propagate-wrapper-args";
+      deps = [ ];
+    } ./propagate-wrapper-args.sh) {};
+
   pytestCheckHook = callPackage ({ pytest }:
     makeSetupHook {
       name = "pytest-check-hook";

--- a/pkgs/development/interpreters/python/hooks/propagate-wrapper-args.sh
+++ b/pkgs/development/interpreters/python/hooks/propagate-wrapper-args.sh
@@ -1,0 +1,33 @@
+# Hook that propagates wrapper arguments up to the
+# python interpreter buildEnv environment.
+echo "Sourcing propagate-wrapper-args.sh"
+
+storeWrapperArgsHook() {
+    # Store the arguments for use by other derivations
+    # and the python interpreter derivation.
+    echo "Executing propagateWrapperArgsHook"
+
+    mkdir -p "$out/nix-support"
+    if [ ${#qtWrapperArgs[@]} -ne 0 ]; then
+        printf '%s\n' "${qtWrapperArgs[@]}" >> "$out/nix-support/make-wrapper-args"
+    fi
+    if [ ${#gappsWrapperArgs[@]} -ne 0 ]; then
+        printf '%s\n' "${gappsWrapperArgs[@]}" >> "$out/nix-support/make-wrapper-args"
+    fi
+    if [ ${#makeWrapperArgs[@]} -ne 0 ]; then
+        printf '%s\n' "${makeWrapperArgs[@]}" >> "$out/nix-support/make-wrapper-args"
+    fi
+}
+
+loadWrapperArgsHook() {
+    # Load the arguments from all the dependencies.
+    # Note: this hook *must* run after storeWrapperArgsHook to
+    # avoid an exponential duplication of the wrapper arguments.
+    for path in $propagatedBuildInputs "$@"; do
+        if [ -f "$path/nix-support/make-wrapper-args" ]; then
+            makeWrapperArgs+=$(cat "$path/nix-support/make-wrapper-args")
+        fi
+    done
+}
+
+postFixupHooks+=(storeWrapperArgsHook loadWrapperArgsHook)

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -14,6 +14,7 @@
 , flitBuildHook
 , pipBuildHook
 , pipInstallHook
+, propagateWrapperArgsHook
 , pythonCatchConflictsHook
 , pythonImportsCheckHook
 , pythonNamespacesHook
@@ -113,6 +114,7 @@ let
       ensureNewerSourcesForZipFilesHook  # move to wheel installer (pip) or builder (setuptools, flit, ...)?
       pythonRecompileBytecodeHook  # Remove when solved https://github.com/NixOS/nixpkgs/issues/81441
       pythonRemoveTestsDirHook
+      propagateWrapperArgsHook
     ] ++ lib.optionals catchConflicts [
       setuptools pythonCatchConflictsHook
     ] ++ lib.optionals removeBinBytecode [

--- a/pkgs/development/python-modules/matplotlib/2.nix
+++ b/pkgs/development/python-modules/matplotlib/2.nix
@@ -3,10 +3,10 @@
 , freetype, libpng, pkgconfig, mock, pytz, pygobject3, gobject-introspection, functools32, subprocess32
 , fetchpatch
 , enableGhostscript ? false, ghostscript ? null, gtk3
-, enableGtk3 ? false, cairo
+, enableGtk3 ? false, cairo, wrapGAppsHook ? null
 # darwin has its own "MacOSX" backend
 , enableTk ? !stdenv.isDarwin, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
-, enableQt ? false, pyqt4
+, enableQt ? false, pyqt4 ? null, wrapQtAppsHook ? null
 , Cocoa
 , pythonOlder
 }:
@@ -43,7 +43,9 @@ buildPythonPackage rec {
 
   buildInputs = [ which sphinx ]
     ++ stdenv.lib.optional enableGhostscript ghostscript
-    ++ stdenv.lib.optional stdenv.isDarwin [ Cocoa ];
+    ++ stdenv.lib.optional stdenv.isDarwin Cocoa
+    ++ stdenv.lib.optional enableQt wrapQtAppsHook
+    ++ stdenv.lib.optional enableGtk3 wrapGAppsHook;
 
   propagatedBuildInputs =
     [ cycler dateutil nose numpy pyparsing tornado freetype kiwisolver

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -3,10 +3,10 @@
 , freetype, libpng, pkgconfig, mock, pytz, pygobject3, gobject-introspection
 , certifi, pillow
 , enableGhostscript ? true, ghostscript ? null, gtk3
-, enableGtk3 ? false, cairo
+, enableGtk3 ? false, cairo ? null, wrapGAppsHook ? null
 # darwin has its own "MacOSX" backend
 , enableTk ? !stdenv.isDarwin, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
-, enableQt ? false, pyqt5 ? null
+, enableQt ? false, pyqt5 ? null, wrapQtAppsHook ? null
 , Cocoa
 , pythonOlder
 }:
@@ -32,7 +32,9 @@ buildPythonPackage rec {
 
   XDG_RUNTIME_DIR = "/tmp";
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ]
+    ++ stdenv.lib.optional enableQt wrapQtAppsHook
+    ++ stdenv.lib.optional enableGtk3 wrapGAppsHook;
 
   buildInputs = [ which sphinx ]
     ++ stdenv.lib.optional enableGhostscript ghostscript

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -114,6 +114,7 @@ in {
     flitBuildHook
     pipBuildHook
     pipInstallHook
+    propagateWrapperArgsHook
     pytestCheckHook
     pythonCatchConflictsHook
     pythonImportsCheckHook

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3542,6 +3542,7 @@ in {
     stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
     inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
     inherit (pkgs) pkgconfig;
+    inherit (pkgs.qt5) wrapQtAppsHook;
   };
 
   matrix-client = callPackage ../development/python-modules/matrix-client { };


### PR DESCRIPTION
###### Motivation for this change
Python libraries that have runtime dependencies, like Qt and GTK
libraries, are currently not working. These are not included in
the interpreter wrapper and no mechanism exist to do so automatically.

This commit adds a `nix-support/make-wrapper-args` file that stores
the makeWrapper arguments of a python derivation (created with
buildPythonPackage). The arguments are loaded from python.buildEnv
when creating the Python environment and passed to the makeWrapper
invocation.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [ ] Tested compilation of all pkgs that depend on this change: obviously not.
- [x] Tested the wrapping is working for `pythonPackages.matplotlib` with Qt
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This should fix issues #25351 #80147 #39637