### PR TITLE
uefitool: update

### DIFF
--- a/pkgs/tools/system/uefitool/variants.nix
+++ b/pkgs/tools/system/uefitool/variants.nix
@@ -3,8 +3,8 @@ let
   common = opts: libsForQt5.callPackage (import ./common.nix opts) {};
 in rec {
   new-engine = common rec {
-    version = "A56";
-    sha256 = "0sxmjkrwcchxg2qmcjsw2vr42s7cdcg2fxkwb8axq2r2z23465gp";
+    version = "A57";
+    sha256 = "0algfdlxfjs582hsqmagbcmw06p8qlh0k5xczfkscs3prdn2vm7n";
     installFiles = [ "UEFITool/UEFITool" "UEFIFind/UEFIFind" "UEFIExtract/UEFIExtract" ];
   };
   old-engine = common rec {

--- a/pkgs/tools/system/uefitool/variants.nix
+++ b/pkgs/tools/system/uefitool/variants.nix
@@ -8,8 +8,8 @@ in rec {
     installFiles = [ "UEFITool/UEFITool" "UEFIFind/UEFIFind" "UEFIExtract/UEFIExtract" ];
   };
   old-engine = common rec {
-    version = "0.27.0";
-    sha256 = "1i1p823qld927p4f1wcphqcnivb9mq7fi5xmzibxc3g9zzgnyc2h";
+    version = "0.28.0";
+    sha256 = "1n2hd2dysi5bv2iyq40phh1jxc48gdwzs414vfbxvcharcwapnja";
     installFiles = [ "UEFITool" "UEFIReplace/UEFIReplace" "UEFIPatch/UEFIPatch" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
New upstream releases:
- https://github.com/LongSoft/UEFITool/releases/tag/A57
- https://github.com/LongSoft/UEFITool/releases/tag/0.28.0

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).