### PR TITLE
nixos-rebuild: support --upgrade-all and document --upgrade

### DIFF
--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -52,10 +52,18 @@
     <option>build-vm-with-bootloader</option>
    </arg>
     </group>
-   <sbr />
-   <arg>
-    <option>--upgrade</option>
-   </arg>
+    <sbr />
+
+    <arg>
+      <group choice='req'>
+        <arg choice='plain'>
+          <option>--upgrade</option>
+        </arg>
+        <arg choice='plain'>
+          <option>--upgrade-all</option>
+        </arg>
+      </group>
+    </arg>
 
    <arg>
     <option>--install-bootloader</option>
@@ -334,9 +342,23 @@
     <term>
      <option>--upgrade</option>
     </term>
+    <term>
+     <option>--upgrade-all</option>
+    </term>
     <listitem>
-     <para>
-      Fetch the latest version of NixOS from the NixOS channel.
+      <para>
+        Update the root user's channel named <literal>nixos</literal>
+        before rebuilding the system.
+      </para>
+      <para>
+        In addition to the <literal>nixos</literal> channel, the root
+        user's channels which have a file named
+        <literal>.update-on-nixos-rebuild</literal> in their base
+        directory will also be updated.
+      </para>
+      <para>
+        Passing <option>--upgrade-all</option> updates all of the root
+        user's channels.
      </para>
     </listitem>
    </varlistentry>

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -22,6 +22,7 @@ buildNix=1
 fast=
 rollback=
 upgrade=
+upgrade_all=
 repair=
 profile=/nix/var/nix/profiles/system
 buildHost=
@@ -53,6 +54,10 @@ while [ "$#" -gt 0 ]; do
         ;;
       --upgrade)
         upgrade=1
+        ;;
+      --upgrade-all)
+        upgrade=1
+        upgrade_all=1
         ;;
       --repair)
         repair=1
@@ -221,15 +226,22 @@ if [ "$action" = switch -o "$action" = boot -o "$action" = test ]; then
 fi
 
 
-# If ‘--upgrade’ is given, run ‘nix-channel --update nixos’.
+# If ‘--upgrade’ or `--upgrade-all` is given,
+# run ‘nix-channel --update nixos’.
 if [[ -n $upgrade && -z $_NIXOS_REBUILD_REEXEC && -z $flake ]]; then
-    nix-channel --update nixos
+    # If --upgrade-all is passed, or there are other channels that
+    # contain a file called ".update-on-nixos-rebuild", update them as
+    # well. Also upgrade the nixos channel.
 
-    # If there are other channels that contain a file called
-    # ".update-on-nixos-rebuild", update them as well.
     for channelpath in /nix/var/nix/profiles/per-user/root/channels/*; do
-        if [ -e "$channelpath/.update-on-nixos-rebuild" ]; then
-            nix-channel --update "$(basename "$channelpath")"
+        channel_name=$(basename "$channelpath")
+
+        if [[ "$channel_name" == "nixos" ]]; then
+            nix-channel --update "$channel_name"
+        elif [ -e "$channelpath/.update-on-nixos-rebuild" ]; then
+            nix-channel --update "$channel_name"
+        elif [[ -n $upgrade_all ]] ; then
+            nix-channel --update "$channel_name"
         fi
     done
 fi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
