### PR TITLE
[20.03] protonvpn-cli-ng: 2.2.0 -> 2.2.2

### DIFF
--- a/pkgs/applications/networking/protonvpn-cli-ng/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli-ng/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, lib, fetchFromGitHub, python3Packages, openvpn, dialog }:
+{ lib, fetchFromGitHub, python3Packages, openvpn, dialog, iptables }:
 
 python3Packages.buildPythonApplication rec {
-  name = "protonvpn-cli-ng";
+  pname = "protonvpn-cli-ng";
   version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "protonvpn";
-    repo = "protonvpn-cli-ng";
+    repo = "${pname}";
     rev = "v${version}";
     sha256 = "0ixjb02kj4z79whm1izd8mrn2h0rp9cmw4im1qvp93rahqxdd4n8";
   };
@@ -19,15 +19,16 @@ python3Packages.buildPythonApplication rec {
     ]) ++ [
       dialog
       openvpn
+      iptables
     ];
 
   # No tests
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Linux command-line client for ProtonVPN";
     homepage = "https://github.com/protonvpn/protonvpn-cli-ng";
-    maintainers = [ maintainers.jtcoolen maintainers.jefflabonte ];
+    maintainers = with maintainers; [ jtcoolen jefflabonte ];
     license = licenses.gpl3;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
Some changes were made after final review of the package. There was a
missing runtime dependency that was discovered after merge of the
backport

(cherry picked from commit 9fe4a634c1f3171b356d2fe986deab1b2d5ceda4)
Reason: The dependency can make the package work or not

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Make sure the package works for everybody

###### Things done

Backport from PR #81735

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
