### PR TITLE
[20.03] memcached: 1.5.22 -> 1.6.2

### DIFF
--- a/pkgs/servers/memcached/default.nix
+++ b/pkgs/servers/memcached/default.nix
@@ -1,23 +1,13 @@
-{stdenv, fetchurl, fetchpatch, cyrus_sasl, libevent}:
+{stdenv, fetchurl, cyrus_sasl, libevent}:
 
 stdenv.mkDerivation rec {
-  version = "1.5.22";
+  version = "1.6.2";
   pname = "memcached";
 
   src = fetchurl {
     url = "https://memcached.org/files/${pname}-${version}.tar.gz";
-    sha256 = "14qzbxgz40j4yhi3lzrsdjd6kyy3zwv9c8kw11kj6njp42fpxd62";
+    sha256 = "12qn8m0jdvdckz53m2akrvixbrn64g5kv6r4hl5vx286qhc02wh6";
   };
-
-  patches = [
-    # Fixes compilation error on Darwin due to redeclaration of
-    # htonll. The fix should appear in 1.5.23.
-    # https://github.com/memcached/memcached/issues/598
-    (fetchpatch {
-      url = "https://github.com/memcached/memcached/commit/95c67710aaf5cfe188d94b510faef8c66d6f5604.diff";
-      sha256 = "0ab5l24p4n4fpx78ilmg7jvs9nl84pdza90jbpbx3ns5n23pqbfs";
-    })
-  ];
 
   configureFlags = [
      "ac_cv_c_endian=${if stdenv.hostPlatform.isBigEndian then "big" else "little"}"
@@ -32,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A distributed memory object caching system";
     repositories.git = https://github.com/memcached/memcached.git;
-    homepage = http://memcached.org/;
+    homepage = "http://memcached.org/";
     license = licenses.bsd3;
     maintainers = [ maintainers.coconnor ];
     platforms = platforms.linux ++ platforms.darwin;


### PR DESCRIPTION
###### Motivation for this change
fixes remote DoS/possibly code execution, as described in
https://github.com/memcached/memcached/issues/629

backport of 58a491aa801aab83ed8eed28fce211a185689236

cc @grahamc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
