### PR TITLE
python: add use-pkgs-prefix option to update script

### DIFF
--- a/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
+++ b/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
@@ -315,11 +315,11 @@ def _update(path, target):
         return False
 
 
-def _commit(path, pname, old_version, new_version, **kwargs):
+def _commit(path, pname, old_version, new_version, pkgs_prefix="python: ", **kwargs):
     """Commit result.
     """
 
-    msg = f'python: {pname}: {old_version} -> {new_version}'
+    msg = f'{pkgs_prefix}{pname}: {old_version} -> {new_version}'
 
     try:
         subprocess.check_call([GIT, 'add', path])
@@ -337,6 +337,7 @@ def main():
     parser.add_argument('package', type=str, nargs='+')
     parser.add_argument('--target', type=str, choices=SEMVER.keys(), default='major')
     parser.add_argument('--commit', action='store_true', help='Create a commit for each package update')
+    parser.add_argument('--use-pkgs-prefix', action='store_true', help='Use python3Packages.${pname}: instead of python: ${pname}: when making commits')
 
     args = parser.parse_args()
     target = args.target
@@ -347,17 +348,23 @@ def main():
 
     # Use threads to update packages concurrently
     with Pool() as p:
-        results = list(p.map(lambda pkg: _update(pkg, target), packages))
+        results = list(filter(bool, p.map(lambda pkg: _update(pkg, target), packages)))
 
     logging.info("Finished updating packages.")
+
+    commit_options = {}
+    if args.use_pkgs_prefix:
+        logging.info("Using python3Packages. prefix for commits")
+        commit_options["pkgs_prefix"] = "python3Packages."
 
     # Commits are created sequentially.
     if args.commit:
         logging.info("Committing updates...")
-        list(map(lambda x: _commit(**x), filter(bool, results)))
+        # list forces evaluation
+        list(map(lambda x: _commit(**x, **commit_options), results))
         logging.info("Finished committing updates")
 
-    count = sum(map(bool, results))
+    count = len(results)
     logging.info("{} package(s) updated".format(count))
 
 


### PR DESCRIPTION
###### Motivation for this change
before the colon should specify the installable path

`python: pname: ...` -> `pythonPackages.pname: ...`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
