### PR TITLE
fitnesstrax: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6537,6 +6537,12 @@
     githubId = 2347889;
     name = "Sauyon Lee";
   };
+  savannidgerinel = {
+    email = "savanni@luminescent-dreams.com";
+    github = "savannidgerinel";
+    githubId = 8534888;
+    name = "Savanni D'Gerinel";
+  };
   sb0 = {
     email = "sb@m-labs.hk";
     github = "sbourdeauducq";
@@ -8326,12 +8332,6 @@
     github = "xavierzwirtz";
     githubId = 474343;
     name = "Xavier Zwirtz";
-  };
-  savannidgerinel = {
-    email = "savanni@luminescent-dreams.com";
-    github = "savannidgerinel";
-    githubId = 8534888;
-    name = "Savanni D'Gerinel";
   };
 }
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8332,7 +8332,7 @@
     github = "savannidgerinel";
     githubId = 8534888;
     name = "Savanni D'Gerinel";
-  }
+  };
 }
 
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8327,6 +8327,12 @@
     githubId = 474343;
     name = "Xavier Zwirtz";
   };
+  savannidgerinel = {
+    email = "savanni@luminescent-dreams.com";
+    github = "savannidgerinel";
+    githubId = 8534888;
+    name = "Savanni D'Gerinel";
+  }
 }
 
 

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -7,13 +7,13 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  name = "fitnesstrax";
+  pname = "fitnesstrax";
   version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "luminescent-dreams";
     repo = "fitnesstrax";
-    rev = "${name}-${version}";
+    rev = "${pname}-${version}";
     sha256 = "1k6zhnbs0ggx7q0ig2abcnzprsgrychlpvsh6d36dw6mr8zpfkp7";
   };
 

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
     gtk3
   ];
 
-  cargoSha256 = "1inzpsj2329svd955axr7ja3gqs7h2kikksdffppkf600mqh4xl4";
+  cargoSha256 = "1xgyyxd2kz21xan0pk7rbxiym90s7m2qrzg2ddilcszva60bxdd9";
 
   postInstall = ''
     mkdir -p $out/share/glib-2.0/schemas

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage rec {
     cairo
     glib
     gdk-pixbuf
-    gtkd
     gtk3
   ];
 

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -1,14 +1,15 @@
 { pkgs
-, fetchFromGitHub
-, stdenv
-, rustPlatform
 , atk
-, gnome2
 , cairo
-, glib
+, fetchFromGitHub
 , gdk-pixbuf
-, gtkd
+, glib
+, gnome2
 , gtk3
+, gtkd
+, lib
+, rustPlatform
+, stdenv
 , wrapGAppsHook
 }:
 rustPlatform.buildRustPackage rec {
@@ -46,6 +47,6 @@ rustPlatform.buildRustPackage rec {
     description = "Privacy-first fitness tracking";
     homepage = "https://github.com/luminescent-dreams/fitnesstrax";
     license = licenses.bsd3;
-    maintainers = [ mantainers.savannidgerinel ];
+    maintainers = with lib.maintainers; [ savannidgerinel ];
   };
 }

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -1,31 +1,38 @@
-{ pkgs,
-  fetchFromGitHub ? pkgs.fetchFromGitHub,
-  stdenv ? pkgs.stdenv,
-  rustPlatform ? pkgs.rustPlatform,
-  wrapGAppsHook ? pkgs.wrapGAppsHook,
+{ pkgs
+, fetchFromGitHub
+, stdenv
+, rustPlatform
+, atk
+, gnome2
+, cairo
+, glib
+, gdk_pixbuf
+, gtkd
+, gtk3
+, wrapGAppsHook
 }:
 rustPlatform.buildRustPackage rec {
-  name = "fitnesstrax-${version}";
+  name = "fitnesstrax";
   version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "luminescent-dreams";
     repo = "fitnesstrax";
-    rev = "516a9e48978ac0f90bbbeade34d626211ccb78a3";
+    rev = "0.1.0";
     sha256 = "1k6zhnbs0ggx7q0ig2abcnzprsgrychlpvsh6d36dw6mr8zpfkp7";
   };
 
-  nativeBuildInputs = [
-    pkgs.glib
-    pkgs.atk
-    pkgs.gnome2.pango
-    pkgs.cairo
-    pkgs.glib
-    pkgs.gdk_pixbuf
-    pkgs.gtkd
-    pkgs.gtk3
-    wrapGAppsHook
-    ];
+  buildInputs = [
+    atk
+    gnome2.pango
+    cairo
+    glib
+    gdk_pixbuf
+    gtkd
+    gtk3
+  ];
+
+  nativeBuildInputs = [ wrapGAppsHook ];
 
   cargoSha256 = "0p0d72njx5m2v6x94sxc2ldjipl4j3cw876shbdq7ghkjjkxv93m";
 
@@ -33,10 +40,10 @@ rustPlatform.buildRustPackage rec {
     mkdir -p $out/share/glib-2.0/schemas
     cp -r $src/share/* $out/share/
     glib-compile-schemas $out/share/glib-2.0/schemas
-    '';
+  '';
 
   meta = with stdenv.lib; {
-    description = "Privacy-first fitness tracking. Your health, your data, your machine.";
+    description = "Privacy-first fitness tracking";
     homepage = "https://github.com/luminescent-dreams/fitnesstrax";
     license = licenses.bsd3;
     maintainers = [ "savanni@luminescent-dreams.com" ];

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "luminescent-dreams";
     repo = "fitnesstrax";
-    rev = "fitnesstrax-0.1.0";
+    rev = "${pname}-${version}";
     sha256 = "1k6zhnbs0ggx7q0ig2abcnzprsgrychlpvsh6d36dw6mr8zpfkp7";
   };
 

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -1,17 +1,11 @@
-{ pkgs
-, atk
-, cairo
-, fetchFromGitHub
-, gdk-pixbuf
+{ fetchFromGitHub
 , glib
-, gnome2
 , gtk3
-, gtkd
 , lib
 , rustPlatform
-, stdenv
 , wrapGAppsHook
 }:
+
 rustPlatform.buildRustPackage rec {
   name = "fitnesstrax";
   version = "0.1.0";
@@ -23,16 +17,14 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1k6zhnbs0ggx7q0ig2abcnzprsgrychlpvsh6d36dw6mr8zpfkp7";
   };
 
-  buildInputs = [
-    atk
-    gnome2.pango
-    cairo
-    glib
-    gdk-pixbuf
-    gtk3
+  nativeBuildInputs = [
+    wrapGAppsHook
   ];
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  buildInputs = [
+    glib
+    gtk3
+  ];
 
   cargoSha256 = "1inzpsj2329svd955axr7ja3gqs7h2kikksdffppkf600mqh4xl4";
 
@@ -42,10 +34,10 @@ rustPlatform.buildRustPackage rec {
     glib-compile-schemas $out/share/glib-2.0/schemas
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Privacy-first fitness tracking";
     homepage = "https://github.com/luminescent-dreams/fitnesstrax";
     license = licenses.bsd3;
-    maintainers = with lib.maintainers; [ savannidgerinel ];
+    maintainers = with maintainers; [ savannidgerinel ];
   };
 }

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "luminescent-dreams";
     repo = "fitnesstrax";
-    rev = "${pname}-${version}";
+    rev = "${name}-${version}";
     sha256 = "1k6zhnbs0ggx7q0ig2abcnzprsgrychlpvsh6d36dw6mr8zpfkp7";
   };
 

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -6,7 +6,7 @@
 , gnome2
 , cairo
 , glib
-, gdk_pixbuf
+, gdk-pixbuf
 , gtkd
 , gtk3
 , wrapGAppsHook
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     gnome2.pango
     cairo
     glib
-    gdk_pixbuf
+    gdk-pixbuf
     gtkd
     gtk3
   ];
@@ -46,6 +46,6 @@ rustPlatform.buildRustPackage rec {
     description = "Privacy-first fitness tracking";
     homepage = "https://github.com/luminescent-dreams/fitnesstrax";
     license = licenses.bsd3;
-    maintainers = [ "savanni@luminescent-dreams.com" ];
+    maintainers = [ mantainers.savannidgerinel ];
   };
 }

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -1,0 +1,44 @@
+{ pkgs,
+  fetchFromGitHub ? pkgs.fetchFromGitHub,
+  stdenv ? pkgs.stdenv,
+  rustPlatform ? pkgs.rustPlatform,
+  wrapGAppsHook ? pkgs.wrapGAppsHook,
+}:
+rustPlatform.buildRustPackage rec {
+  name = "fitnesstrax-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "luminescent-dreams";
+    repo = "fitnesstrax";
+    rev = "516a9e48978ac0f90bbbeade34d626211ccb78a3";
+    sha256 = "1k6zhnbs0ggx7q0ig2abcnzprsgrychlpvsh6d36dw6mr8zpfkp7";
+  };
+
+  nativeBuildInputs = [
+    pkgs.glib
+    pkgs.atk
+    pkgs.gnome2.pango
+    pkgs.cairo
+    pkgs.glib
+    pkgs.gdk_pixbuf
+    pkgs.gtkd
+    pkgs.gtk3
+    wrapGAppsHook
+    ];
+
+  cargoSha256 = "0p0d72njx5m2v6x94sxc2ldjipl4j3cw876shbdq7ghkjjkxv93m";
+
+  postInstall = ''
+    mkdir -p $out/share/glib-2.0/schemas
+    cp -r $src/share/* $out/share/
+    glib-compile-schemas $out/share/glib-2.0/schemas
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Privacy-first fitness tracking. Your health, your data, your machine.";
+    homepage = "https://github.com/luminescent-dreams/fitnesstrax";
+    license = licenses.bsd3;
+    maintainers = [ "savanni@luminescent-dreams.com" ];
+  };
+}

--- a/pkgs/applications/misc/fitnesstrax/default.nix
+++ b/pkgs/applications/misc/fitnesstrax/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "luminescent-dreams";
     repo = "fitnesstrax";
-    rev = "0.1.0";
+    rev = "fitnesstrax-0.1.0";
     sha256 = "1k6zhnbs0ggx7q0ig2abcnzprsgrychlpvsh6d36dw6mr8zpfkp7";
   };
 
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ wrapGAppsHook ];
 
-  cargoSha256 = "0p0d72njx5m2v6x94sxc2ldjipl4j3cw876shbdq7ghkjjkxv93m";
+  cargoSha256 = "1inzpsj2329svd955axr7ja3gqs7h2kikksdffppkf600mqh4xl4";
 
   postInstall = ''
     mkdir -p $out/share/glib-2.0/schemas

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -947,7 +947,7 @@ in
 
   libfx2 = with python3Packages; toPythonApplication fx2;
 
-  fitnesstrax = callPackage ../applications/misc/fitnesstrax/default.nix { pkgs = pkgs; };
+  fitnesstrax = callPackage ../applications/misc/fitnesstrax/default.nix { };
 
   fxlinuxprintutil = callPackage ../tools/misc/fxlinuxprintutil { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -947,6 +947,8 @@ in
 
   libfx2 = with python3Packages; toPythonApplication fx2;
 
+  fitnesstrax = callPackage ../applications/misc/fitnesstrax/default.nix { pkgs = pkgs; };
+
   fxlinuxprintutil = callPackage ../tools/misc/fxlinuxprintutil { };
 
   genymotion = callPackage ../development/mobile/genymotion { };


### PR DESCRIPTION
###### Motivation for this change

This adds a fitness tracking application that I am developing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
