### PR TITLE
weechatScripts.wee-slack: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/wee-slack/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/wee-slack/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wee-slack";
-  version = "2.4.0";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     repo = "wee-slack";
     owner = "wee-slack";
     rev = "v${version}";
-    sha256 = "0h425ln5vv76zv41dccapyfbl8qmmflbpwmrd26knqyj8k24zfpr";
+    sha256 = "0sxgi5fg8qvzqmxy7sdma6v0wj93xwh21av10n8nxvdskacw5dxz";
   };
 
   patches = [
@@ -19,13 +19,19 @@ stdenv.mkDerivation rec {
         paths = with python3Packages; [ websocket_client six ];
       }}/${python3Packages.python.sitePackages}";
     })
+    ./hardcode-json-file-path.patch
   ];
+
+  postPatch = ''
+    substituteInPlace wee_slack.py --subst-var out
+  '';
 
   passthru.scripts = [ "wee_slack.py" ];
 
   installPhase = ''
     mkdir -p $out/share
     cp wee_slack.py $out/share/wee_slack.py
+    install -D -m 0444 weemoji.json $out/share/wee-slack/weemoji.json
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/irc/weechat/scripts/wee-slack/hardcode-json-file-path.patch
+++ b/pkgs/applications/networking/irc/weechat/scripts/wee-slack/hardcode-json-file-path.patch
@@ -1,0 +1,12 @@
+--- a/wee_slack.py
++++ b/wee_slack.py
+@@ -4560,8 +4560,7 @@
+ 
+ def load_emoji():
+     try:
+-        DIR = w.info_get('weechat_dir', '')
+-        with open('{}/weemoji.json'.format(DIR), 'r') as ef:
++        with open('@out@/share/wee-slack/weemoji.json', 'r') as ef:
+             emojis = json.loads(ef.read())
+             if 'emoji' in emojis:
+                 print_error('The weemoji.json file is in an old format. Please update it.')


### PR DESCRIPTION
###### Motivation for this change

Version bump. The changes are listed on [the GitHub release page](https://github.com/wee-slack/wee-slack/releases/tag/v2.5.0).

wee-slack now (optionally) depends on a data file called weemoji.json
that allows it to translate between Slack emoji names (like
"slight_smile") and Unicode codepoints. For convenience, the derivation
now installs this file and patches the script so that the user doesn't
need to do any extra configuration to use it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @WilliButz 