### PR TITLE
Tiny doc fix: Update git clone command example

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -369,7 +369,7 @@ automatically select the right version of GHC and other build tools to build,
 test and execute apps in an existing project downloaded from somewhere on the
 Internet. Pass the `--nix` flag to any `stack` command to do so, e.g.
 ```shell
-git clone --recursive https://github.com/yesodweb/wai
+git clone --recurse-submodules https://github.com/yesodweb/wai.git
 cd wai
 stack --nix build
 ```


### PR DESCRIPTION
`--recursive` has been replaced by `--recurse-submodules`