### PR TITLE
coqPackages.coqhammer: 1.1 → 1.1.1

### DIFF
--- a/pkgs/development/coq-modules/coqhammer/default.nix
+++ b/pkgs/development/coq-modules/coqhammer/default.nix
@@ -3,17 +3,25 @@
 let
   params = {
     "8.8" = {
+      version = "1.1";
       sha256 = "0ms086wp4jmrzyglb8wymchzyflflk01nsfsk4r6qv8rrx81nx9h";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
     };
     "8.9" = {
-      sha256 = "0hmqwsry8ldg4g4hhwg4b84dgzibpdrg1wwsajhlyqfx3fb3n3b5";
+      version = "1.1.1";
+      sha256 = "1knjmz4hr8vlp103j8n4fyb2lfxysnm512gh3m2kp85n6as6fvb9";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
+    };
+    "8.10" = {
+      version = "1.1.1";
+      sha256 = "0b6r7bsygl1axbqybkhkr7zlwcd51ski5ql52994klrrxvjd58df";
     };
   };
   param = params.${coq.coq-version};
 in
 
 stdenv.mkDerivation rec {
-  version = "1.1";
+  inherit (param) version;
   name = "coq${coq.coq-version}-coqhammer-${version}";
 
   src = fetchFromGitHub {
@@ -31,8 +39,8 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ coq ] ++ (with coq.ocamlPackages; [
-    ocaml findlib camlp5
-  ]);
+    ocaml findlib
+  ]) ++ (param.buildInputs or []);
 
   preInstall = ''
     mkdir -p $out/bin


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
