### PR TITLE
llvmPackages_10: rc5 -> release

### DIFF
--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -8,7 +8,7 @@ let
     pname = "clang";
     inherit version;
 
-    src = fetch "clang" "0ap63qhz0j6m63l4njwp055xni4s71dsxqi1w5d2p93hbswaiiw2";
+    src = fetch "clang" "08fbxa2a0kr3ni35ckppj0kyvlcyaywrhpqwcdrdy0z900mhcnw8";
 
     unpackPhase = ''
       unpackFile $src

--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation rec {
   pname = "compiler-rt";
   inherit version;
-  src = fetch pname "1g067yx8qz0bmf00b2xqjqaayqj2xvrjp9smms3a16syj9m0hfri";
+  src = fetch pname "0x9c531k6ww21s2mkdwqx1vbdjmx6d4wmfb8gdbj0wqa796sczba";
 
   nativeBuildInputs = [ cmake python3 llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;

--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -6,15 +6,14 @@
 
 let
   release_version = "10.0.0";
-  candidate = "rc5";
-  version = "10.0.0${candidate}"; # differentiating these is important for rc's
+  version = release_version; # differentiating these (variables) is important for rc's
 
   fetch = name: sha256: fetchurl {
-    url = "https://prereleases.llvm.org/${release_version}/${candidate}/${name}-${version}.src.tar.xz";
+    url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-${release_version}/${name}-${version}.src.tar.xz";
     inherit sha256;
   };
 
-  clang-tools-extra_src = fetch "clang-tools-extra" "0x23q70c0xcwdhj0d66nisr8rqq69qcshrbb4si9pxfsm0zs9h3i";
+  clang-tools-extra_src = fetch "clang-tools-extra" "074ija5s2jsdn0k035r2dzmryjmqxdnyg4xwvaqych2bazv8rpxc";
 
   tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python3 isl release_version version fetch; });

--- a/pkgs/development/compilers/llvm/10/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/10/libc++/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "libc++";
   inherit version;
 
-  src = fetch "libcxx" "0qw85sy3y1mcdrj8yd1j1gmskh0vs4xdgrx80niigizhr7030vxs";
+  src = fetch "libcxx" "1isnj78diknh0nvd73mlq8p8g209f9bab2mbysq826bg2wzql3r7";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/10/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/10/libc++abi.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "libc++abi";
   inherit version;
 
-  src = fetch "libcxxabi" "15iclzxjqfjynqxjg8dahyr0gfg83blv9dm7z9hq5ipxw8x2sglf";
+  src = fetch "libcxxabi" "1q8lrbh68a9v4lr88b8xsjpmwx5z96sa5wnkb92xx7ccm1ssq6z7";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD && !stdenv.hostPlatform.isWasm) libunwind;

--- a/pkgs/development/compilers/llvm/10/libunwind.nix
+++ b/pkgs/development/compilers/llvm/10/libunwind.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "libunwind";
   inherit version;
 
-  src = fetch pname "12c2fh63afav8rfmplfs628r74ksfs8fjls655rwjsrg1hk0gy3l";
+  src = fetch pname "09n66dl9cc17d81qflj5h1l4garmhvzfi2lhcb7rx00l8z65xp09";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/compilers/llvm/10/lld.nix
+++ b/pkgs/development/compilers/llvm/10/lld.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   pname = "lld";
   inherit version;
 
-  src = fetch pname "08zg546872b432qrx49i7k1c2vdq9yjvc7gnrvy2nywv0d2qf9nc";
+  src = fetch pname "026pwcbczcg0j5c9h7hxxrn3ki81ia9m9sfn0sy0bvzffv2xg85r";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/10/lldb.nix
+++ b/pkgs/development/compilers/llvm/10/lldb.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (rec {
   pname = "lldb";
   inherit version;
 
-  src = fetch pname "0swv16n7gm12f399f7hxai1jh89s14h3yg7cci10yaiibpvwk73x";
+  src = fetch pname "0ddikvc0kbqlqvsypsm9nhfwmyw4prp4rv49f0bgacyh5ssgq7yx";
 
   patches = [ ./lldb-procfs.patch ];
 

--- a/pkgs/development/compilers/llvm/10/llvm.nix
+++ b/pkgs/development/compilers/llvm/10/llvm.nix
@@ -31,8 +31,8 @@ in stdenv.mkDerivation (rec {
   pname = "llvm";
   inherit version;
 
-  src = fetch pname "1abfi0zqbcwxf68dk00szpjxkcd44589va243af8sg97hljq6709";
-  polly_src = fetch "polly" "1fzg5934km69rwam6vgznk0p4slzhr0icwmj3jibw3p93ppa8k9r";
+  src = fetch pname "1pwgm6cr0xr5a0hrbqs1zvsvvjvy0yq1y47c96804wcs795s90yz";
+  polly_src = fetch "polly" "15sd3dq0w60jsb76pis09lkagj5iy43h9hg4kd9gx5l8cbnsdyrm";
 
   unpackPhase = ''
     unpackFile $src

--- a/pkgs/development/compilers/llvm/10/openmp.nix
+++ b/pkgs/development/compilers/llvm/10/openmp.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   pname = "openmp";
   inherit version;
 
-  src = fetch pname "0swif1plz7drjha6rdw02b60symsz95w62wxpiygbpdwsmhbbgam";
+  src = fetch pname "1ymd13gj07x0b0vxziygm0p41vrq6nsgx837jqg9ll6h8ndg57rv";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];


### PR DESCRIPTION
###### Motivation for this change
LLVM 10.0.0 was released (http://lists.llvm.org/pipermail/llvm-dev/2020-March/140233.html)

@ggreif I fixed the hashes, hopefully you haven't already :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
updated hashes and url for release code
I checked with nix-review, only chromiumDev depends on this, but it doesn't build even without this commit, because of patches.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
