### PR TITLE
elmPackages.elm-instrument: remove patch

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -52,14 +52,6 @@ let
             }));
 
             elm-instrument = justStaticExecutables (overrideCabal (self.callPackage ./packages/elm-instrument.nix {}) (drv: {
-              patches = [(
-                # GHC 8.8.1 and Cabal >= 1.25.0 support
-                # https://github.com/zwilias/elm-instrument/pull/3
-                fetchpatch {
-                  url = "https://github.com/turboMaCk/elm-instrument/commit/4272db2aea742c8b54509e536fa4f35d04f95da5.patch";
-                  sha256 = "1d1lc43lp3x5jfhlyb1b7na7nj1g1i1vc1np26pcisg9c2s7gjz6";
-                }
-              )];
               prePatch = ''
                 sed "s/desc <-.*/let desc = \"${drv.version}\"/g" Setup.hs --in-place
               '';

--- a/pkgs/development/compilers/elm/packages/elm-instrument.nix
+++ b/pkgs/development/compilers/elm/packages/elm-instrument.nix
@@ -3,15 +3,15 @@
 , fetchgit, filepath, free, HUnit, indents, json, mtl
 , optparse-applicative, parsec, process, QuickCheck, quickcheck-io
 , split, stdenv, tasty, tasty-golden, tasty-hunit, tasty-quickcheck
-, text, elm
+, text
 }:
 mkDerivation {
   pname = "elm-instrument";
   version = "0.0.7";
   src = fetchgit {
-    url = "https://github.com/zwilias/elm-instrument.git";
-    sha256 = "14yfzwsyvgc6rzn19sdmwk2mc1vma9hcljnmjnmlig8mp0271v56";
-    rev = "31b527e405a6afdb25bb87ad7bd14f979e65cff7";
+    url = "https://github.com/zwilias/elm-instrument";
+    sha256 = "167d7l2547zxdj7i60r6vazznd9ichwc0bqckh3vrh46glkz06jv";
+    rev = "63e15bb5ec5f812e248e61b6944189fa4a0aee4e";
     fetchSubmodules = true;
   };
   isLibrary = true;


### PR DESCRIPTION
PR is merged to master so patch is no longer needed (provided we use commit from master)

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

