### PR TITLE
[19.09] gitlab: 12.8.6 -> 12.8.7 (#82838)

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,11 +1,11 @@
 {
-  "version": "12.8.6",
-  "repo_hash": "0plcigppmg6ckmq8myj3m9adshdvqj7czx8fms71bsa9zx060wib",
+  "version": "12.8.7",
+  "repo_hash": "15dw8v5184500jm823wv920li3ishwk8k2dhxl1w8209x53nbqgj",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.8.6-ee",
+  "rev": "v12.8.7-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "12.8.6",
+    "GITALY_SERVER_VERSION": "12.8.7",
     "GITLAB_PAGES_VERSION": "1.16.0",
     "GITLAB_SHELL_VERSION": "11.0.0",
     "GITLAB_WORKHORSE_VERSION": "8.21.0"

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -19,14 +19,14 @@ let
       };
   };
 in buildGoPackage rec {
-  version = "12.8.6";
+  version = "12.8.7";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "1rf9qmyjllkwkyi7la1dzyjh0z9sw21zdzihd7v9ngwqssfk5zfk";
+    sha256 = "1sb11xavckzm70m27xcwbv4a1iaicxkh1hv2zi4brlcj5ia2rky4";
   };
 
   # Fix a check which assumes that hook files are writeable by their


### PR DESCRIPTION
###### Motivation for this change
https://about.gitlab.com/releases/2020/03/16/gitlab-12-8-7-released/
Backport of #82838

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
