### PR TITLE
python3Packages.dipy: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/dipy/default.nix
+++ b/pkgs/development/python-modules/dipy/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, packaging
+, pytest
+, cython
+, numpy
+, scipy
+, h5py
+, nibabel
+}:
+
+buildPythonPackage rec {
+  pname = "dipy";
+  version = "1.1.1";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner  = "dipy";
+    repo   = pname;
+    rev    = version;
+    sha256 = "08abx0f4li6ya62ilc59miw4mk6wndizahyylxhgcrpacb6ydw28";
+  };
+
+  nativeBuildInputs = [ cython packaging ];
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    h5py
+    nibabel
+  ];
+
+  checkInputs = [ pytest ];
+
+  # disable tests for now due to:
+  #   - some tests require data download (see dipy/dipy/issues/2092);
+  #   - running the tests manually causes a multiprocessing hang;
+  #   - import weirdness when running the tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "dipy"
+    "dipy.core"
+    "dipy.direction"
+    "dipy.tracking"
+    "dipy.reconst"
+    "dipy.io"
+    "dipy.viz"
+    "dipy.boots"
+    "dipy.data"
+    "dipy.utils"
+    "dipy.segment"
+    "dipy.sims"
+    "dipy.stats"
+    "dipy.denoise"
+    "dipy.workflows"
+    "dipy.nn"
+  ];
+
+  meta = with lib; {
+    homepage = "https://dipy.org/";
+    description = "Diffusion imaging toolkit for Python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -619,6 +619,8 @@ in {
 
   diofant = callPackage ../development/python-modules/diofant { };
 
+  dipy = callPackage ../development/python-modules/dipy { };
+
   docrep = callPackage ../development/python-modules/docrep { };
 
   dominate = callPackage ../development/python-modules/dominate { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @lheckemann @drewrisinger 