### PR TITLE
bloop: add blp linking to bloop

### DIFF
--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation {
     chmod +x $out/bloop
     makeWrapper $out/bloop $out/bin/bloop \
       --prefix PATH : ${lib.makeBinPath [ python ]}
+
+    ln -s $out/bin/bloop $out/bin/blp
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

When trying to use Bloop with BSP in Intellij IDEA, I was getting an error:

```
Cannot run program "/nix/store/iskjxr3qbdyq72dzh7kmxjvcxy7zd1lf-user-environment/bin/blp" (in directory "/home/karol/workspace/yields/foundation/registry"): error=2, No such file or directory
```

I'm not sure why blp is called, but I [didn't find any issue](https://youtrack.jetbrains.com/issues/SCL?q=blp) in Intellij. So I assume it's something NixOS related.

My naïve solution was to add link from `bloop` to `bsp`, as in this PR, and it worked flawlessly. I'm not sure at all if it's a good solution, but I've been using it for a couple of days now and it just works.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Pinging @tomahna :)