### PR TITLE
pythonPackages.arrow: 0.15.4 -> 0.15.5

### DIFF
--- a/pkgs/development/python-modules/arrow/default.nix
+++ b/pkgs/development/python-modules/arrow/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "arrow";
-  version = "0.15.4";
+  version = "0.15.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e1a318a4c0b787833ae46302c02488b6eeef413c6a13324b3261ad320f21ec1e";
+    sha256 = "0yq2bld2bjxddmg9zg4ll80pb32rkki7xyhgnrqnkxy5w9jf942k";
   };
 
   checkPhase = ''
@@ -25,7 +25,8 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Python library for date manipulation";
-    license     = "apache";
+    homepage = "https://arrow.readthedocs.io/";
+    license = licenses.asl20;
     maintainers = with maintainers; [ thoughtpolice ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bump pythonPackages.arrow version.

Requirement for upcoming ``qiskit-ibmq-provider`` package #83320.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
**NOTE: ``nixpkgs-review wip`` didn't find any dependent packages**, though there obviously are. I was able to find/build most of the dependencies manually. Partial list of dependent packages (think I got everything, but not 100% sure):
* topydo
* buku
* rapid-photo-downloader
* pythonPackages.django-q
* pythonPackages.jinja2_time
* pythonPackages.stravalib
* backblaze-b2
* pythonPackages.rainbowstream
* pythonPackages.construct
* pythonPackages.ics
* bonfire

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
