### PR TITLE
pixiecore: init at 2020-03-25

### DIFF
--- a/pkgs/tools/networking/pixiecore/default.nix
+++ b/pkgs/tools/networking/pixiecore/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "pixiecore";
+  version = "2020-03-25";
+  rev = "68743c67a60c18c06cd21fd75143e3e069ca3cfc";
+
+  src = fetchFromGitHub {
+    owner = "danderson";
+    repo = "netboot";
+    inherit rev;
+    sha256 = "14dslmx3gk08h9gqfjw5y27x7d2c6r8ir7mjd7l9ybysagpzr02a";
+  };
+
+  modSha256 = "1waqaglm6f9zy5296z309ppkck2vmydhk9gjnxrgzmhqld5lcq4f";
+  subPackages = [ "cmd/pixiecore" ];
+
+  meta = {
+    description = "A tool to manage network booting of machines";
+    homepage = "https://github.com/danderson/netboot/tree/master/pixiecore";
+    license =  stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ bbigras danderson ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2150,6 +2150,8 @@ in
 
   pueue = callPackage ../applications/misc/pueue { };
 
+  pixiecore = callPackage ../tools/networking/pixiecore {};
+
   pyCA = python3Packages.callPackage ../applications/video/pyca {};
 
   pyznap = python3Packages.callPackage ../tools/backup/pyznap {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is a rebase of #62113 (without the module, I'll do that next). I added the other contributor as a `Co-authored-by`.

package and module requested in #49740

Note that according to https://github.com/danderson/netboot the project is "no longer actively developed". But it still works fine and it's a really useful tool. See https://nixos.wiki/wiki/Netboot

@Lassulus @aanderse @Ekleog 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
