### PR TITLE
Build MELPA package sets without null packages

### DIFF
--- a/pkgs/applications/editors/emacs-modes/libgenerated.nix
+++ b/pkgs/applications/editors/emacs-modes/libgenerated.nix
@@ -61,8 +61,9 @@ in {
         pname = builtins.replaceStrings [ "@" ] [ "at" ] ename;
         broken = ! isNull error;
       in
-      lib.nameValuePair ename (if hasSource then (
-        self.callPackage ({ melpaBuild, fetchurl, ... }@pkgargs:
+      if hasSource then
+        lib.nameValuePair ename (
+          self.callPackage ({ melpaBuild, fetchurl, ... }@pkgargs:
           melpaBuild {
             inherit pname;
             ename = ename;
@@ -85,6 +86,8 @@ in {
             };
           }
         ) {}
-      ) else null);
+      )
+    else
+      null;
 
 }

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -42,7 +42,9 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
   }: let
 
     inherit (import ./libgenerated.nix lib self) melpaDerivation;
-    super = lib.listToAttrs (map (melpaDerivation variant) (lib.importJSON archiveJson));
+    super = lib.listToAttrs (builtins.filter (s: s != null)
+                                             (map (melpaDerivation variant)
+                                                  (lib.importJSON archiveJson)));
 
     overrides = rec {
       shared = rec {
@@ -268,10 +270,6 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
 
         # Map legacy renames from emacs2nix since code generation was ported to emacs lisp
         _0blayout = super."0blayout";
-        _0xc = super."0xc";
-        _2048-game = super."2048-game";
-        _4clojure = super."4clojure";
-        at = super."@";
         desktop-plus = super."desktop+";
         ghub-plus = super."ghub+";
         git-gutter-plus = super."git-gutter+";
@@ -282,10 +280,6 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
         markdown-mode-plus = super."markdown-mode+";
         package-plus = super."package+";
         rect-plus = super."rect+";
-        term-plus = super."term+";
-        term-plus-key-intercept = super."term+key-intercept";
-        term-plus-mux = super."term+mux";
-        xml-plus = super."xml+";
       };
 
       stable = shared // {
@@ -413,6 +407,16 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
         });
         # Legacy alias
         emacs-libvterm = unstable.vterm;
+
+        # Map legacy renames from emacs2nix since code generation was ported to emacs lisp
+        _0xc = super."0xc";
+        _2048-game = super."2048-game";
+        _4clojure = super."4clojure";
+        at = super."@";
+        term-plus = super."term+";
+        term-plus-key-intercept = super."term+key-intercept";
+        term-plus-mux = super."term+mux";
+        xml-plus = super."xml+";
 
         w3m = super.w3m.override (args: {
           melpaBuild = drv: args.melpaBuild (drv // {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The current algorithm creates attributes with null values for packages
with no source in a variant of MELPA. Though will satify dependencies
they produce no files, and though a build that transitively depends on
one them will be successful, Emacs won't find them and any code
depending on them won't work.

The solution with minimal code change would have been filtering the
list of results from melpaDerivation by comparing the value against
null, but that leads to an infinite recursion.

This commit also moves legacy renames from the shared to the unstable
set, as the corresponding null value elements won't exist in the
stable set anymore.

The test used for the problem was:

>  $ nix-build --show-trace ./default.nix -A emacs26Packages.melpaStablePackages.findr
>  error: expression does not evaluate to a derivation (or a set or list of those)

The expected output, obtained with this commit is:

>  $ nix-build --show-trace ./default.nix -A emacs26Packages.melpaStablePackages.findr
>  error: attribute 'findr' in selection path 'emacs26Packages.melpaStablePackages.findr' not found

###### Merging into other branches

This can be cleanly merged into [release-20.03](/NixOS/nixpkgs/tree/release-20.03), merging into an older branch will need to be done by cherry picking.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
