### PR TITLE
buildRustCrate: don't sort link flags

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -172,7 +172,7 @@ in ''
      set +e
      EXTRA_BUILD=$(sed -n "s/^cargo:rustc-flags=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ' | sort -u)
      EXTRA_FEATURES=$(sed -n "s/^cargo:rustc-cfg=\(.*\)/--cfg \1/p" target/build/${crateName}.opt | tr '\n' ' ')
-     EXTRA_LINK=$(sed -n "s/^cargo:rustc-link-lib=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ' | sort -u)
+     EXTRA_LINK=$(sed -n "s/^cargo:rustc-link-lib=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ')
      EXTRA_LINK_SEARCH=$(sed -n "s/^cargo:rustc-link-search=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ' | sort -u)
 
      for env in $(sed -n "s/^cargo:rustc-env=\(.*\)/\1/p" target/build/${crateName}.opt); do

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -105,11 +105,6 @@ setup_link_paths() {
   done
 
   if [[ -e target/link ]]; then
-     sort -u target/link.final > target/link.final.sorted
-     mv target/link.final.sorted target/link.final
-     sort -u target/link > target/link.sorted
-     mv target/link.sorted target/link
-
      tr '\n' ' ' < target/link > target/link_
      LINK=$(cat target/link_)
   fi


### PR DESCRIPTION
Linkage order is significant and sorting can result in link errors.

This was tested (and the corresponding issue was discovered) by building nix-du with crate2nix.

nix-review reports only one compilation failure which seems unrelated (it's not a linker error)
```
builder for '/nix/store/ap83imyisrrq33caq1l86hf6ldsxbfy3-rust_url-1.6.0.drv' failed with exit code 1; last 10 log lines:
      |      -- lifetime `'a` defined here
  260 |     fn as_mut_string(&mut self) -> &mut String { &mut self.url.serialization }
  261 |     fn finish(self) -> &'a mut ::Url { self.url }
      |                                        ^^^^^^^^ - here, drop of `self` needs exclusive access to `*self.url`, because the type `UrlQuery<'_>` implements the `Drop` trait
      |                                        |
      |                                        returning this value requires that `*self.url` is borrowed for `'a`
  
  error: aborting due to previous error
  
  For more information about this error, try `rustc --explain E0713`.
cannot build derivation '/nix/store/xklj28hy7fx8rhrdx8dqyyzqg7g323hf-rust_serde_urlencoded-0.5.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/zl4qhhdm4ndwgjjdlh5x9fcgdz7yvx8z-rust_reqwest-0.9.5.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/dnywhrwcwjisfs16ns49sk23naq8wvnz-rust_cargo-download-0.1.2.drv': 3 dependencies couldn't be built
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
