### PR TITLE
[20.03] qgis: 3.10.1 -> 3.10.4

### DIFF
--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -10,7 +10,7 @@ let
     [ qscintilla-qt5 gdal jinja2 numpy psycopg2
       chardet dateutil pyyaml pytz requests urllib3 pygments pyqt5 sip owslib six ];
 in mkDerivation rec {
-  version = "3.10.1";
+  version = "3.10.4";
   pname = "qgis";
   name = "${pname}-unwrapped-${version}";
 
@@ -18,7 +18,7 @@ in mkDerivation rec {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "0xq0nnp7zdqaihqvh5rsi1129g23vnk5ijkpxfzaggafgmhf5hgz";
+    sha256 = "0d1rsgjgnnq6jgms5bgppz8lkh4518nf90fk0qvxajdfi9j4jn12";
   };
 
   passthru = {

--- a/pkgs/development/libraries/proj/default.nix
+++ b/pkgs/development/libraries/proj/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "proj";
-  version = "6.1.1";
+  version = "6.3.1";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "PROJ";
     rev = version;
-    sha256 = "0w2v2l22kv0xzq5hwl7n8ki6an8vfsr0lg0cdbkwcl4xv889ysma";
+    sha256 = "1ildcp57qsa01kvv2qxd05nqw5mg0wfkksiv9l138dbhp0s7rkxp";
   };
 
   outputs = [ "out" "dev"];

--- a/pkgs/development/python-modules/pyproj/001.proj.patch
+++ b/pkgs/development/python-modules/pyproj/001.proj.patch
@@ -1,47 +1,62 @@
-diff a/pyproj/datadir.py b/pyproj/datadir.py
---- a/pyproj/datadir.py
-+++ b/pyproj/datadir.py
-@@ -52,6 +52,7 @@ def get_data_dir():
-     str: The valid data directory.
-
-     """
-+    return "@proj@/share/proj"
-     # to avoid re-validating
-     global _VALIDATED_PROJ_DATA
+diff -Nur a/pyproj/datadir.py b/pyproj/datadir.py
+--- a/pyproj/datadir.py	2020-03-24 12:53:39.417440608 +0100
++++ b/pyproj/datadir.py	2020-03-24 12:56:19.870089479 +0100
+@@ -66,9 +66,7 @@
      if _VALIDATED_PROJ_DATA is not None:
-diff a/setup.py b/setup.py
---- a/setup.py
-+++ b/setup.py
-@@ -16,7 +16,7 @@ INTERNAL_PROJ_DIR = os.path.join(CURRENT_FILE_PATH, "pyproj", BASE_INTERNAL_PROJ
-
+         return _VALIDATED_PROJ_DATA
+     global _USER_PROJ_DATA
+-    internal_datadir = os.path.join(
+-        os.path.dirname(os.path.abspath(__file__)), "proj_dir", "share", "proj"
+-    )
++    internal_datadir = "@proj@/share/proj"
+     proj_lib_dirs = os.environ.get("PROJ_LIB", "")
+     prefix_datadir = os.path.join(sys.prefix, "share", "proj")
+ 
+diff -Nur a/setup.py b/setup.py
+--- a/setup.py	2020-03-24 12:53:39.415440624 +0100
++++ b/setup.py	2020-03-24 12:52:05.311232522 +0100
+@@ -11,7 +11,7 @@
+ PROJ_MIN_VERSION = parse_version("6.2.0")
+ CURRENT_FILE_PATH = os.path.dirname(os.path.abspath(__file__))
+ BASE_INTERNAL_PROJ_DIR = "proj_dir"
+-INTERNAL_PROJ_DIR = os.path.join(CURRENT_FILE_PATH, "pyproj", BASE_INTERNAL_PROJ_DIR)
++INTERNAL_PROJ_DIR = "@proj@"
+ 
+ 
  def check_proj_version(proj_dir):
-     """checks that the PROJ library meets the minimum version"""
--    proj = os.path.join(proj_dir, "bin", "proj")
-+    proj = "@proj@/bin/proj"
-     proj_ver_bytes = subprocess.check_output(proj, stderr=subprocess.STDOUT)
-     proj_ver_bytes = (proj_ver_bytes.decode("ascii").split()[1]).strip(",")
-     proj_version = parse_version(proj_ver_bytes)
-@@ -33,6 +33,7 @@ def get_proj_dir():
-     """
-     This function finds the base PROJ directory.
-     """
-+    return "@proj@"
-     proj_dir = os.environ.get("PROJ_DIR")
-     if proj_dir is None and os.path.exists(INTERNAL_PROJ_DIR):
-         proj_dir = INTERNAL_PROJ_DIR
-@@ -56,6 +57,7 @@ def get_proj_libdirs(proj_dir):
-     """
-     This function finds the library directories
-     """
-+    return ["@proj@/lib"]
-     proj_libdir = os.environ.get("PROJ_LIBDIR")
-     libdirs = []
-     if proj_libdir is None:
-@@ -77,6 +79,7 @@ def get_proj_incdirs(proj_dir):
-     """
-     This function finds the include directories
-     """
-+    return ["@proj@/include"]
-     proj_incdir = os.environ.get("PROJ_INCDIR")
-     incdirs = []
-     if proj_incdir is None:
+@@ -146,7 +146,7 @@
+     # By default we'll try to get options PROJ_DIR or the local version of proj
+     proj_dir = get_proj_dir()
+     library_dirs = get_proj_libdirs(proj_dir)
+-    include_dirs = get_proj_incdirs(proj_dir)
++    include_dirs = get_proj_incdirs("@projdev@")
+ 
+     # setup extension options
+     ext_options = {
+diff -Nur a/test/conftest.py b/test/conftest.py
+--- a/test/conftest.py	2020-03-24 12:53:39.417440608 +0100
++++ b/test/conftest.py	2020-03-24 23:16:47.373972786 +0100
+@@ -1,6 +1,7 @@
+ import os
+ import shutil
+ import tempfile
++import stat
+ 
+ import pytest
+ 
+@@ -17,6 +18,15 @@
+     with tempfile.TemporaryDirectory() as tmpdir:
+         tmp_data_dir = os.path.join(tmpdir, "proj")
+         shutil.copytree(data_dir, tmp_data_dir)
++
++        # Data copied from the nix store is readonly (causes cleanup problem).
++        # Make it writable.
++        for r, d, files in os.walk(tmp_data_dir):
++            os.chmod(r, os.stat(r).st_mode | stat.S_IWUSR)
++            for f in files:
++                fpath = os.path.join(r, f)
++                os.chmod(fpath, os.stat(fpath).st_mode | stat.S_IWUSR)
++
+         try:
+             os.remove(os.path.join(str(tmp_data_dir), "ntv2_0.gsb"))
+         except OSError:

--- a/pkgs/development/python-modules/pyproj/default.nix
+++ b/pkgs/development/python-modules/pyproj/default.nix
@@ -1,20 +1,22 @@
-{ lib, buildPythonPackage, fetchFromGitHub, python, pkgs, pythonOlder, substituteAll
+{ lib, buildPythonPackage, fetchFromGitHub, python, pkgs, pythonOlder, isPy27, substituteAll
 , aenum
 , cython
 , pytest
 , mock
 , numpy
+, shapely
 }:
 
 buildPythonPackage rec {
   pname = "pyproj";
-  version = "2.2.2";
+  version = "2.6.0";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "pyproj4";
     repo = "pyproj";
     rev = "v${version}rel";
-    sha256 = "0mb0jczgqh3sma69k7237i38h09gxgmvmddls9hpw4f3131f5ax7";
+    sha256 = "0fyggkbr3kp8mlq4c0r8sl5ah58bdg2mj4kzql9p3qyrkcdlgixh";
   };
 
   # force pyproj to use ${pkgs.proj}
@@ -22,13 +24,14 @@ buildPythonPackage rec {
     (substituteAll {
       src = ./001.proj.patch;
       proj = pkgs.proj;
+      projdev = pkgs.proj.dev;
     })
   ];
 
   buildInputs = [ cython pkgs.proj ];
 
   propagatedBuildInputs = [
-    numpy
+    numpy shapely
   ] ++ lib.optional (pythonOlder "3.6") aenum;
 
   checkInputs = [ pytest mock ];
@@ -38,6 +41,9 @@ buildPythonPackage rec {
   checkPhase = ''
     pytest . -k 'not alternative_grid_name \
                  and not transform_wgs84_to_alaska \
+                 and not transformer_group__unavailable \
+                 and not transform_group__missing_best \
+                 and not datum \
                  and not repr' \
             --ignore=test/test_doctest_wrapper.py \
             --ignore=test/test_datadir.py


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is a backport of #83317 to `release-20.03`.

This PR will remove few packages from `python2Packages` set (pyproj and revdeps). The amount of packages removed is fairly limited and since release-20.03 is not released yet, I hope there is still room for it. I would prefer this to ship with 20.03, but can understand if someone prefers to freeze versions as they are, but if we do so we will not be able to port qgis LTR fixes (3.10.*).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
