### PR TITLE
goimapnotify: init at 2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7922,6 +7922,12 @@
     githubId = 895853;
     name = "Frank Doepper";
   };
+  wohanley = {
+    email = "me@wohanley.com";
+    github = "wohanley";
+    githubId = 1322287;
+    name = "William O'Hanley";
+  };
   womfoo = {
     email = "kranium@gikos.net";
     github = "womfoo";

--- a/pkgs/tools/networking/goimapnotify/default.nix
+++ b/pkgs/tools/networking/goimapnotify/default.nix
@@ -1,0 +1,26 @@
+{ buildGoPackage, fetchFromGitLab, lib }:
+
+buildGoPackage rec {
+  pname = "goimapnotify";
+  version = "2.0";
+
+  goPackagePath = "gitlab.com/shackra/goimapnotify";
+
+  src = fetchFromGitLab {
+    owner = "shackra";
+    repo = "goimapnotify";
+    rev = "${version}";
+    sha256 = "1d42gd3m2rkvy985d181dbcm5i3f7xsg2z8z6s4bpvw24pfnzs42";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description =
+      "Execute scripts on IMAP mailbox changes (new/deleted/updated messages) using IDLE";
+    homepage = "https://gitlab.com/shackra/goimapnotify";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wohanley ];
+  };
+}

--- a/pkgs/tools/networking/goimapnotify/deps.nix
+++ b/pkgs/tools/networking/goimapnotify/deps.nix
@@ -1,0 +1,66 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath = "github.com/emersion/go-imap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/emersion/go-imap";
+      rev = "b7db4a2bc5cc04fb568fb036a438da43ee9a9f78";
+      sha256 = "1v5hp02k9rfdq7gqiydz575dw6a991pspynhxypv0fvgh1vgqs0s";
+    };
+  }
+  {
+    goPackagePath = "github.com/emersion/go-imap-idle";
+    fetch = {
+      type = "git";
+      url = "https://github.com/emersion/go-imap-idle";
+      rev = "2af93776db6b042cc1116b0d0af00d7f58eea696";
+      sha256 = "19dh8sryjr3a8f0bgwywiz2fqccxhf4j66sm0w1jkjzh131f3pr7";
+    };
+  }
+  {
+    goPackagePath = "github.com/emersion/go-sasl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/emersion/go-sasl";
+      rev = "7e096a0a6197b89989e8cc31016daa67c8c62051";
+      sha256 = "0mr9nzi4wc3ck730zqfqwmy8wk7d90h80yvvivqnxyfyadqy48kd";
+    };
+  }
+  {
+    goPackagePath = "github.com/konsorten/go-windows-terminal-sequences";
+    fetch = {
+      type = "git";
+      url = "https://github.com/konsorten/go-windows-terminal-sequences";
+      rev = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e";
+      sha256 = "09mn209ika7ciy87xf2x31dq5fnqw39jidgaljvmqxwk7ff1hnx7";
+    };
+  }
+  {
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev = "8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f";
+      sha256 = "1m7ny9jkb98cxqhsp13xa5hnqh1s9f25x04q6arsala4zswsw33c";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "a129542de9ae0895210abff9c95d67a1f33cb93d";
+      sha256 = "13p5q7s25rsvfkk8fcwf432j8djf7bjg7chs296rzlig4vqcdxi4";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "342b2e1fbaa52c93f31447ad2c6abc048c63e475";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -979,6 +979,8 @@ in
 
   glasgow = with python3Packages; toPythonApplication glasgow;
 
+  goimapnotify = callPackage ../tools/networking/goimapnotify { };
+
   gomatrix = callPackage ../applications/misc/gomatrix { };
 
   gucci = callPackage ../tools/text/gucci { };


### PR DESCRIPTION
###### Motivation for this change

goimapnotify is more reliable in my experience than the alternative currently available on nixpkgs, node-imapnotify.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
