### PR TITLE
pythonPackages.opensimplex: init at 2.0

### DIFF
--- a/pkgs/development/python-modules/opensimplex/default.nix
+++ b/pkgs/development/python-modules/opensimplex/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "opensimplex";
+  version = "0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0aqpksbwf52s3w2adz467df474prcqxazdq6nic63kdf1zhjpwak";
+  };
+
+  # Error "make: *** No rule to make target 'test'.  Stop."
+  doCheck = false;
+
+  checkPhase = ''
+    make test
+    make benchmark
+  '';
+
+  meta = with lib; {
+    description = "Python port of Kurt Spencer's OpenSimplex Noise functions for 2D, 3D and 4D.";
+    homepage = "https://github.com/lmas/opensimplex";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mrmebelman ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2287,6 +2287,8 @@ in {
     pythonPackages = self;
   });
 
+  opensimplex = callPackage ../development/python-modules/opensimplex { };
+
   opentracing = callPackage ../development/python-modules/opentracing { };
 
   openidc-client = callPackage ../development/python-modules/openidc-client {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Problems
Unfortunately, I haven't been able to run the tests, it says `make: *** No rule to make target 'test'.  Stop.` when I do it as the documentation says, and cannot find the 
"tests/samples.json.gz" file when I try to test it with setuptools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
