### PR TITLE
python3Packages.xdg: init at 4.0.1

### DIFF
--- a/pkgs/development/python-modules/clikit/default.nix
+++ b/pkgs/development/python-modules/clikit/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "clikit";
-  version = "0.4.1";
+  version = "0.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8ae4766b974d7b1983e39d501da9a0aadf118a907a0c9b50714d027c8b59ea81";
+    sha256 = "0glppxx0pyppjcigzs8h16srlbxb6nci0282xfy3ayvwbq8pwbbf";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pastel/default.nix
+++ b/pkgs/development/python-modules/pastel/default.nix
@@ -1,24 +1,21 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pytest }:
+{ lib, buildPythonPackage, fetchPypi, poetry, pytest }:
 
 buildPythonPackage rec {
   pname = "pastel";
-  version = "0.1.0";
+  version = "0.2.0";
 
-  # No tests in PyPi tarball
-  src = fetchFromGitHub {
-    owner = "sdispater";
-    repo = "pastel";
-    rev = version;
-    sha256 = "1b4ag7jr7j0sxly5g29imdq8g0d4ixhbck55dblr45mlsidydx0s";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dnaw44ss10i10z4ksy0xljknvjap7rb7g0b8p6yzm5x4g2my5a6";
   };
 
   checkInputs = [ pytest ];
   checkPhase = ''
-    pytest tests -sq
+    pytest
   '';
 
   meta = with lib; {
-    homepage = https://github.com/sdispater/pastel;
+    homepage = "https://github.com/sdispater/pastel";
     description = "Bring colors to your terminal";
     license = licenses.mit;
     maintainers = with maintainers; [ jakewaksbaum ];

--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -36,7 +36,7 @@ in buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0y528095njf28isbcp5iwbf12j67xhxnrkac93pws0zy133v7kc1";
+    sha256 = "02h387k0xssvv78yy82pcpknpq4w5ym2in1zl8cg9r5wljl5w6cf";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/xdg/default.nix
+++ b/pkgs/development/python-modules/xdg/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27
+, clikit
+, poetry
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  version = "4.0.1";
+  pname = "xdg";
+  disabled = isPy27;
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "srstevenson";
+    repo = pname;
+    rev = version;
+    sha256 = "13kgnbwam6wmdbig0m98vmyjcqrp0j62nmfknb6prr33ns2nxbs2";
+  };
+
+  nativeBuildInputs = [ poetry ];
+
+  propagatedBuildInputs = [
+    clikit
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "XDG Base Directory Specification for Python";
+    homepage = "https://github.com/srstevenson/xdg";
+    license = licenses.isc;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3943,6 +3943,8 @@ in {
 
   colored = callPackage ../development/python-modules/colored { };
 
+  xdg = callPackage ../development/python-modules/xdg { };
+
   xdis = callPackage ../development/python-modules/xdis { };
 
   xnd = callPackage ../development/python-modules/xnd { };


### PR DESCRIPTION
###### Motivation for this change
one of the scripts at work required this. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/83389
21 package marked as broken and skipped:
octave-jit octoprint php72Packages-unit.php_excel php72Packages.php_excel php73Packages-unit.php_excel php73Packages.php_excel php74Packages-unit.couchbase php74Packages-unit.pcs php74Packages-unit.php_excel php74Packages.couchbase php74Packages.php_excel python27Packages.habanero python27Packages.handout python27Packages.hass-nabucasa python37Packages.notify python37Packages.pasteScript python37Packages.pyblock python38Packages.notify python38Packages.pasteScript python38Packages.pyblock qes

16 package built:
python27Packages.cleo python27Packages.clikit python27Packages.pastel python27Packages.poetry python37Packages.aria2p python37Packages.cleo python37Packages.clikit python37Packages.pastel python37Packages.poetry python37Packages.xdg python38Packages.aria2p python38Packages.cleo python38Packages.clikit python38Packages.pastel python38Packages.poetry python38Packages.xdg
```