### PR TITLE
Revert "nixos-container: use systemd-run instead of nsenter"

### DIFF
--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -9,6 +9,7 @@ use Getopt::Long qw(:config gnu_getopt);
 use Cwd 'abs_path';
 use Time::HiRes;
 
+my $nsenter = "@utillinux@/bin/nsenter";
 my $su = "@su@";
 
 # Ensure a consistent umask.
@@ -319,10 +320,9 @@ sub restartContainer {
 # Run a command in the container.
 sub runInContainer {
     my @args = @_;
-
-    exec("systemd-run", "--machine", $containerName, "--pty", "--quiet", "--", @args);
-
-    die "cannot run ‘systemd-run’: $!\n";
+    my $leader = getLeader;
+    exec($nsenter, "-t", $leader, "-m", "-u", "-i", "-n", "-p", "--", @args);
+    die "cannot run ‘nsenter’: $!\n";
 }
 
 # Remove a directory while recursively unmounting all mounted filesystems within


### PR DESCRIPTION

###### Motivation for this change

:warning: Please note that I'll only revert this on `release-20.03` for now to get rid of the regression within the `container`-backend of `nixops`. After merging this, an issue should be opened to track further changes (to use the original commit without further regressions on 20.09).

----

This reverts commit 7cb100b6833e020d4a4b25c3766cfde507e763e6.

This appears to break at least the `container`-backend of `nixops`: when
running `switch-to-configuration` within `nixos-container run`, the
running `systemd`-instance gets reloaded which appears to kill the
`systemd-run` command and causes `nixos-container run` to hang.

The full issue is reported in the original PR[1].

[1] https://github.com/NixOS/nixpkgs/pull/67332#issuecomment-604145869

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
