### PR TITLE
ocamlPackages.gnuplot: 0.5.3 → 0.7

### DIFF
--- a/pkgs/development/ocaml-modules/gnuplot/default.nix
+++ b/pkgs/development/ocaml-modules/gnuplot/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, buildDunePackage, fetchFromBitbucket, gnuplot, core }:
+{ lib, buildDunePackage, fetchFromGitHub, gnuplot, iso8601 }:
 
 buildDunePackage rec {
   pname = "gnuplot";
-  version = "0.5.3";
+  version = "0.7";
 
-  src = fetchFromBitbucket {
-    owner  = "ogu";
-    repo   = "${pname}-ocaml";
-    rev    = "release-${version}";
-    sha256 = "00sn9g46pj8pfh7faiyxg3pfhq7w9knafyabjr464bh6qz5kiin3";
+  minimumOCamlVersion = "4.03";
+
+  src = fetchFromGitHub {
+    owner  = "c-cube";
+    repo   = "ocaml-${pname}";
+    rev    = "v${version}";
+    sha256 = "02pzi3lb57ysrdsba743s3vmnapjbxgq8ynlzpxbbs6cn1jj6ch9";
   };
 
-  propagatedBuildInputs = [ core gnuplot ];
+  propagatedBuildInputs = [ gnuplot iso8601 ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     inherit (src.meta) homepage;
     description = "Ocaml bindings to Gnuplot";
     maintainers = [ maintainers.bcdarwin ];

--- a/pkgs/development/ocaml-modules/ocaml-r/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-r/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchFromGitHub, buildDunePackage, pkg-config, configurator, stdio, R }:
+
+buildDunePackage rec {
+  pname = "ocaml-r";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "pveber";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09gljccwjsw9693m1hm9hcyvgp3p2fvg3cfn18yyidpc2f81a4fy";
+  };
+
+  # Without the following patch, stub generation fails with:
+  # > Fatal error: exception (Failure "not supported: osVersion")
+  preConfigure = ''
+    substituteInPlace stubgen/stubgen.ml --replace  \
+    'failwithf "not supported: %s" name ()' \
+    'sprintf "(* not supported: %s *)" name'
+  '';
+
+  buildInputs = [ configurator pkg-config R stdio ];
+
+  meta = {
+    description = "OCaml bindings for the R interpreter";
+    inherit (src.meta) homepage;
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.bcdarwin ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -1,23 +1,23 @@
 { stdenv, buildDunePackage, fetchFromGitHub, ppx_deriving
-, alcotest, biocaml, gnuplot, lacaml, menhir, owl }:
+, alcotest, biocaml, gnuplot, lacaml, menhir, ocaml-r, owl, printbox }:
 
 buildDunePackage rec {
   pname = "phylogenetics";
-  version = "unstable-2019-11-15";
+  version = "unstable-2020-01-05";
 
   useDune2 = true;
 
   src = fetchFromGitHub {
     owner  = "biocaml";
     repo   = pname;
-    rev    = "91c03834db065cf4a86f33affbb9cfd216defc9f";
-    sha256 = "0i9m0633a6a724as35ix8z3p1gj267cl0hmqrpw4qfq39zxmgnxb";
+    rev    = "b55ef7d7322bd822be26d21339945d45487fb547";
+    sha256 = "0hzfjhs5w3a7hlzxs739k5ik3k1xn3dzyzziid765s74f638n4hj";
   };
 
   minimumOCamlVersion = "4.08";  # e.g., uses Float.min
 
   checkInputs = [ alcotest ];
-  propagatedBuildInputs = [ biocaml gnuplot lacaml menhir owl ppx_deriving ];
+  propagatedBuildInputs = [ biocaml gnuplot lacaml menhir ocaml-r owl ppx_deriving printbox ];
 
   doCheck = false;  # many tests require bppsuite
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -615,6 +615,8 @@ let
 
     pgocaml_ppx = callPackage ../development/ocaml-modules/pgocaml/ppx.nix {};
 
+    ocaml-r = callPackage ../development/ocaml-modules/ocaml-r { };
+
     ocaml-sat-solvers = callPackage ../development/ocaml-modules/ocaml-sat-solvers { };
 
     ocamlscript = callPackage ../development/tools/ocaml/ocamlscript { };


### PR DESCRIPTION
###### Motivation for this change

Drop dependency of ocaml-gnuplot on the `core` library.

The `phylogenetics` package must be updated for compatibility with ocaml-gnuplot (cc @bcdarwin).

Updated phylogenetics depends on ocaml-r, which is thus packaged in this PR too.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
