### PR TITLE
GNOME fixes

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-initial-setup/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-initial-setup/default.nix
@@ -32,7 +32,6 @@
 , tzdata
 , yelp
 , libgnomekbd
-, malcontent
 }:
 
 stdenv.mkDerivation rec {
@@ -75,7 +74,6 @@ stdenv.mkDerivation rec {
     polkit
     webkitgtk
     libnma
-    malcontent
   ];
 
   patches = [
@@ -89,6 +87,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dcheese=disabled"
     "-Dibus=disabled"
+    "-Dparental_controls=disabled"
     "-Dvendor-conf-file=${./vendor.conf}"
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -43,6 +43,7 @@ in stdenv.mkDerivation rec {
 
     # recording
     gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
 
     # not declared at build time, but typelib is needed at runtime

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -85,6 +85,13 @@ in stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/gnome-shell/commit/72c4f148ef88b4bffb2106b99434da5c05c0bb64.patch";
       sha256 = "RBA+JHz4ZvmbJZMnGNieD6D5LONRgFU4iOFIMQQ2kHQ=";
     })
+
+    # Fix Telepathy chat integration.
+    # https://gitlab.gnome.org/GNOME/gnome-shell/issues/2449
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-shell/commit/766288eec1bd3bd50dfc4ddf410c2b507187e603.patch";
+      sha256 = "Cp6xLohCM0gmMxtyYjSukS2oV60Khmxf4iQd9EDAlIc=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Fixing few issues I noticed while using GNOME 3.36.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
