### PR TITLE
Revert "fetchzip, fetchgit: cleanup handling of optional features and whitespace"

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, git, cacert }: let
+{stdenvNoCC, git, cacert}: let
   urlToName = url: rev: let
     inherit (stdenvNoCC.lib) removeSuffix splitString last;
     base = last (splitString ":" (baseNameOf (removeSuffix "/" url)));

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -1,5 +1,6 @@
-#!/usr/bin/env bash
-set -eo pipefail
+#! /usr/bin/env bash
+
+set -e -o pipefail
 
 url=
 rev=
@@ -37,17 +38,17 @@ usage(){
     echo  >&2 "syntax: nix-prefetch-git [options] [URL [REVISION [EXPECTED-HASH]]]
 
 Options:
-      --out path         Path where the output would be stored.
-      --url url          Any url understood by 'git clone'.
-      --rev ref          Any sha1 or references (such as refs/heads/master).
-      --hash h           Expected hash.
-      --branch-name      Branch name to check out into.
-      --deepClone        Clone the entire repository.
-      --no-deepClone     Make a shallow clone of just the required ref.
-      --leave-dotGit     Keep the .git directories.
+      --out path      Path where the output would be stored.
+      --url url       Any url understood by 'git clone'.
+      --rev ref       Any sha1 or references (such as refs/heads/master)
+      --hash h        Expected hash.
+      --branch-name   Branch name to check out into
+      --deepClone     Clone the entire repository.
+      --no-deepClone  Make a shallow clone of just the required ref.
+      --leave-dotGit  Keep the .git directories.
       --fetch-submodules Fetch submodules.
-      --builder          Clone as fetchgit does, but url, rev, and out option are mandatory.
-      --quiet            Only print the final json summary.
+      --builder       Clone as fetchgit does, but url, rev, and out option are mandatory.
+      --quiet         Only print the final json summary.
 "
     exit 1
 }

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -5,46 +5,47 @@
 # (e.g. due to minor changes in the compression algorithm, or changes
 # in timestamps).
 
-{ lib, fetchurl, unzip }:
+{ fetchurl, unzip }:
 
-{ name ? "source"
+{ # Optionally move the contents of the unpacked tree up one level.
+  stripRoot ? true
 , url
-  # Optionally move the contents of the unpacked tree up one level.
-, stripRoot ? true
 , extraPostFetch ? ""
+, name ? "source"
 , ... } @ args:
 
 (fetchurl ({
   inherit name;
 
   recursiveHash = true;
+
   downloadToTemp = true;
 
-  postFetch = ''
-    unpackDir="$TMPDIR/unpack"
-    mkdir "$unpackDir"
-    cd "$unpackDir"
+  postFetch =
+    ''
+      unpackDir="$TMPDIR/unpack"
+      mkdir "$unpackDir"
+      cd "$unpackDir"
 
-    renamed="$TMPDIR/${baseNameOf url}"
-    mv "$downloadedFile" "$renamed"
-    unpackFile "$renamed"
-    result=$unpackDir
-  ''
-  # Most src disted tarballs have a parent directory like foo-1.2.3/ to strip
-  + lib.optionalString stripRoot ''
-    if [ $(ls "$unpackDir" | wc -l) != 1 ]; then
-      echo "error: zip file must contain a single file or directory."
-      echo "hint: Pass stripRoot=false; to fetchzip to assume flat list of files."
-      exit 1
-    fi
-    fn=$(cd "$unpackDir" && echo *)
-    result="$unpackDir/$fn"
-  '' + ''
-    mkdir $out
-    mv "$result" "$out"
-  ''
-  + extraPostFetch;
-
+      renamed="$TMPDIR/${baseNameOf url}"
+      mv "$downloadedFile" "$renamed"
+      unpackFile "$renamed"
+    ''
+    + (if stripRoot then ''
+      if [ $(ls "$unpackDir" | wc -l) != 1 ]; then
+        echo "error: zip file must contain a single file or directory."
+        echo "hint: Pass stripRoot=false; to fetchzip to assume flat list of files."
+        exit 1
+      fi
+      fn=$(cd "$unpackDir" && echo *)
+      if [ -f "$unpackDir/$fn" ]; then
+        mkdir $out
+      fi
+      mv "$unpackDir/$fn" "$out"
+    '' else ''
+      mv "$unpackDir" "$out"
+    '') #*/
+    + extraPostFetch;
 } // removeAttrs args [ "stripRoot" "extraPostFetch" ])).overrideAttrs (x: {
   # Hackety-hack: we actually need unzip hooks, too
   nativeBuildInputs = x.nativeBuildInputs ++ [ unzip ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#79581

I merged this ~25 minutes ago, and while most packages appear to be fetching just fine, I see it caused a regression in https://github.com/NixOS/nixpkgs/pull/83377.  Since this was supposed to be a no-op whitespace/option cleanup and is clearly not, I'm reverting it until further testing.  