### PR TITLE
python3Packages.py-cpuinfo: 4.0.0 -> 5.0.0

### DIFF
--- a/pkgs/development/python-modules/py-cpuinfo/default.nix
+++ b/pkgs/development/python-modules/py-cpuinfo/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "py-cpuinfo";
-  version = "4.0.0";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
      owner = "workhorsy";
      repo = pname;
      rev = "v${version}";
-     sha256 = "1pp561lj80jnvr2038nrzhmks2akxsbdqxvfrqa6n340x81981lm";
+     sha256 = "0lxl9n6djaz5h1zrb2jca4qwl41c2plxy8chr7yhcxnzg0srddqi";
   };
 
   checkInputs = [
@@ -27,7 +27,14 @@ buildPythonPackage rec {
 
   meta = {
     description = "Get CPU info with pure Python 2 & 3";
-    homepage = https://github.com/workhorsy/py-cpuinfo;
+    longDescription = ''
+      Py-cpuinfo gets CPU info with pure Python and should work without any
+      extra programs or libraries, beyond what your OS provides. It does not
+      require any compilation (C/C++, assembly, etc.) to use and works with
+      Python 2 and 3.
+    '';
+    inherit (src.meta) homepage;
+    changelog = "https://github.com/workhorsy/py-cpuinfo/blob/v${version}/ChangeLog";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ costrouc ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
