### PR TITLE
xp-pen-g430: init at 20190820

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3235,6 +3235,12 @@
       fingerprint = "7311 2700 AB4F 4CDF C68C  F6A5 79C3 C47D C652 EA54";
     }];
   };
+  ivar = {
+    email = "ivar.scholten@protonmail.com";
+    github = "IvarWithoutBones";
+    githubId = 41924494;
+    Name = "Ivar";
+  };
   ivegotasthma = {
     email = "ivegotasthma@protonmail.com";
     github = "ivegotasthma";

--- a/pkgs/misc/drivers/xp-pen-g430/default.nix
+++ b/pkgs/misc/drivers/xp-pen-g430/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchzip, autoPatchelfHook, libusb1, libX11, libXtst, qtbase, wrapQtAppsHook, libglvnd }:
+stdenv.mkDerivation rec {
+  pname = "xp-pen-G430";
+  version = "20190820";
+
+  src = fetchzip {
+    url = "https://download01.xp-pen.com/file/2019/08/Linux%20Beta%20Driver(${version}).zip";
+    sha256 = "091kfqxxj90pdmwncgfl8ldi70pdhwryh3cls30654983m8cgnby";
+  } + /Linux_Pentablet_V1.3.0.0.tar.gz;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libusb1
+    libX11
+    libXtst
+    qtbase
+    libglvnd
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp {Pentablet_Driver,config.xml} "$out"/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.xp-pen.com/download-46.html";
+    description = "Driver for the XP-PEN G430 drawing tablet";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26339,6 +26339,8 @@ in
 
   bcompare = libsForQt5.callPackage ../applications/version-management/bcompare {};
 
+  xp-pen-g430 = libsForQt5.callPackage ../misc/drivers/xp-pen-g430 {};
+
   qmk_firmware = callPackage ../development/misc/qmk_firmware {
     avrgcc = pkgsCross.avr.buildPackages.gcc;
     avrbinutils = pkgsCross.avr.buildPackages.binutils;


### PR DESCRIPTION
###### Motivation for this change
This is a useful driver package for people with the xp-pen g430 drawing tablet.
Review was done over at #76180

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
