### PR TITLE
cryptomator: init at 1.5.13

### DIFF
--- a/pkgs/tools/security/cryptomator/default.nix
+++ b/pkgs/tools/security/cryptomator/default.nix
@@ -1,0 +1,91 @@
+{ lib, stdenv, fetchFromGitHub
+, autoPatchelfHook
+, fuse, packer
+, maven, jdk, jre, makeWrapper, glib, wrapGAppsHook
+}:
+
+let
+  pname = "cryptomator";
+  version = "1.5.13";
+
+  src = fetchFromGitHub {
+    owner = "cryptomator";
+    repo = "cryptomator";
+    rev = version;
+    sha256 = "1s9jl3nl6yfjzmilz9b8azk8592nd39xflzfdf38v6s4iiq86r8j";
+  };
+
+  icons = fetchFromGitHub {
+    owner = "cryptomator";
+    repo = "cryptomator-linux";
+    rev = version;
+    sha256 = "1x6h6wp6yxnj576874xj3d2jm8jmb7918wprqvlz4sryxhlcssa7";
+  };
+
+  # perform fake build to make a fixed-output derivation out of the files downloaded from maven central (120MB)
+  deps = stdenv.mkDerivation {
+    name = "cryptomator-${version}-deps";
+    inherit src;
+
+    nativeBuildInputs = [ jdk maven ];
+
+    buildPhase = ''
+      cd main
+      while mvn -Prelease package -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
+        echo "timeout, restart maven to continue downloading"
+      done
+    '';
+
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+    installPhase = ''
+      find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete
+      find $out/.m2 -type f -iname '*.pom' -exec sed -i -e 's/\r\+$//' {} \;
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "06q8bqdz3c4i84wxl9z5861zwdsw8jzcvsbgxqrnh8rwi7500sa7";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname version src;
+
+  buildPhase = ''
+    cd main
+    mvn -Prelease package --offline -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/ $out/usr/share/cryptomator/libs/
+
+    cp buildkit/target/libs/* buildkit/target/linux-libs/* $out/usr/share/cryptomator/libs/
+
+    makeWrapper ${jre}/bin/java $out/bin/cryptomator \
+      --add-flags "-classpath '$out/usr/share/cryptomator/libs/*'" \
+      --add-flags "-Dcryptomator.settingsPath='~/.config/Cryptomator/settings.json'" \
+      --add-flags "-Dcryptomator.ipcPortPath='~/.config/Cryptomator/ipcPort.bin'" \
+      --add-flags "-Dcryptomator.logDir='~/.local/share/Cryptomator/logs'" \
+      --add-flags "-Dcryptomator.mountPointsDir='~/.local/share/Cryptomator/mnt'" \
+      --add-flags "-Djdk.gtk.version=3" \
+      --add-flags "-Xss20m" \
+      --add-flags "-Xmx512m" \
+      --add-flags "org.cryptomator.launcher.Cryptomator" \
+      --prefix PATH : "$out/usr/share/cryptomator/libs/:${lib.makeBinPath [ jre glib ]}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ fuse ]}" \
+      --set JAVA_HOME "${jre.home}"
+
+    # install desktop entry and icons
+    cp -r ${icons}/resources/appimage/AppDir/usr $out/
+  '';
+
+  nativeBuildInputs = [ autoPatchelfHook maven makeWrapper wrapGAppsHook jdk ];
+  buildInputs = [ fuse packer jre glib ];
+
+  meta = with lib; {
+    description = "Free client-side encryption for your cloud files";
+    homepage = "https://cryptomator.org";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ bachp ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18888,6 +18888,8 @@ in
 
   criu = callPackage ../os-specific/linux/criu { };
 
+  cryptomator = callPackage ../tools/security/cryptomator { };
+
   cryptsetup = callPackage ../os-specific/linux/cryptsetup { };
 
   cramfsprogs = callPackage ../os-specific/linux/cramfsprogs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Package the [cryptomator](https://cryptomator.org/) encryption utilitiy.

Closes #75684

###### Things done

The current version can be started from the command line and is packaged from source.
It doesn't include a desktop file to launch it. But i think this can be added later.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
