### PR TITLE
discourse: init at 2.4.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -818,6 +818,7 @@
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/codimd.nix
   ./services/web-apps/cryptpad.nix
+  ./services/web-apps/discourse.nix
   ./services/web-apps/documize.nix
   ./services/web-apps/dokuwiki.nix
   ./services/web-apps/frab.nix

--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -1,0 +1,471 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.discourse;
+  dataDir = "/var/lib/discourse";
+  user = "discourse";
+  group = "discourse";
+  baseUrl = "${if cfg.web.https then "https" else "http"}://${cfg.hostName}";
+
+  configGenerator = c: concatStrings (flip mapAttrsToList c (key: val: "${key} = ${val}\n"));
+  mainConfig = pkgs.writeText "discourse.conf" (configGenerator cfg.settings);
+
+  webConfig = pkgs.writeText "site_settings.yml" (builtins.toJSON cfg.web.settings);
+
+  dcEnv = {
+    RAILS_ENV = "production";
+    RAILS_ROOT = dataDir;
+    UNICORN_WORKERS = toString cfg.web.workers;
+  };
+
+  mailEnv = {
+    DISCOURSE_API_USER = cfg.mail.apiUser;
+    DISCOURSE_API_KEY = cfg.mail.apiKeyFile;
+    DISCOURSE_BASE_URL = baseUrl;
+  };
+
+  dcServiceConfig = {
+    Type = "simple";
+    Restart = "always";
+
+    User = user;
+    Group = group;
+
+    StateDirectory = "discourse";
+    WorkingDirectory = dataDir;
+    ProtectHome = true;
+    ProtectSystem = "full";
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectControlGroups = true;
+  };
+
+  discourse-bundler = pkgs.stdenv.mkDerivation {
+    name = "discourse-bundler";
+    buildInputs = [ pkgs.makeWrapper ];
+    dontBuild = true;
+    dontUnpack = true;
+    installPhase = ''
+      makeWrapper ${cfg.package.rubyEnv}/bin/bundler $out/bin/discourse-bundler \
+        ${concatStrings (mapAttrsToList (name: value: "--set ${name} '${value}' ") dcEnv)} \
+        --set PATH '${lib.makeBinPath [ pkgs.coreutils pkgs.procps pkgs.gnugrep pkgs.nodePackages.uglify-js pkgs.which pkgs.brotli pkgs.gzip ]}:$PATH'
+    '';
+  };
+in
+{
+  ###### interface
+
+  options.services.discourse = with types; {
+    enable = mkEnableOption "Enable Discourse forum";
+
+    hostName = mkOption {
+      type = str;
+      description = "Hostname running this forum.";
+      example = "forum.example.org";
+    };
+
+    package = mkOption {
+      type = package;
+      description = ''
+        Discourse package for the service to use.
+      '';
+      default = pkgs.discourse;
+      defaultText = "pkgs.discourse";
+    };
+
+    settings = mkOption {
+      type = attrsOf (oneOf [ str int bool ]);
+      default = {};
+      example = {
+        db_connect_timeout = 5;
+      };
+      description = ''
+        Additional Discourse configuration attributes.
+
+        Use to override <link xlink:href="https://github.com/discourse/discourse/blob/master/config/discourse_defaults.conf">Discourse defaults</link>.
+      '';
+    };
+
+    database = {
+      host = mkOption {
+        type = nullOr str;
+        default = null;
+        description = ''
+          Database host address.
+
+          Use <literal>null</literal> when using
+          <option>services.discourse.database.createLocally</option>.
+        '';
+      };
+
+      socket = mkOption {
+        type = nullOr str;
+        default = null;
+        description = "UNIX Domain socket to use to connect to database.";
+        example = "/run/postgres";
+      };
+
+      port = mkOption {
+        type = nullOr port;
+        default = null;
+        description = "Database port. Use <literal>null</literal> for default port.";
+      };
+
+      name = mkOption {
+        type = str;
+        default = "discourse";
+        defaultText = ''"discourse"'';
+        description = ''
+          Database name.
+        '';
+      };
+
+      user = mkOption {
+        type = nullOr str;
+        default = user;
+        description = "Database user. The system user name is used as a default.";
+      };
+
+      passwordFile = mkOption {
+        type = nullOr path;
+        default = null;
+        example = "/run/keys/discourse-dbpassword";
+        description = ''
+          A file containing the password for <option>services.discourse.database.user</option>.
+        '';
+      };
+
+      createLocally = mkOption {
+        type = bool;
+        default = true;
+        description = "Whether to create a local database automatically.";
+      };
+    };
+
+    mail = {
+      enable = mkEnableOption "Enable Discourse mail processing";
+
+      package = mkOption {
+        type = package;
+        description = ''
+          Discourse mail-receiver package for the service to use.
+        '';
+        default = pkgs.discourse-mail-receiver;
+        defaultText = "pkgs.discourse-mail-receiver";
+      };
+
+      domains = mkOption {
+        type = listOf str;
+        default = [ cfg.hostName ];
+        example = literalExample ''
+          [ "mail.example.org" ]
+        '';
+        description = ''
+          List of mail server domains this instances handles.
+
+          Defaults to singleton with
+          <option>services.discourse.hostName</option>.
+        '';
+      };
+
+      apiUser = mkOption {
+        type = str;
+        default = "system";
+        description = ''
+          User whose identity and permissions will be
+          used to make requests to Discourse API.
+        '';
+      };
+
+      apiKeyFile = mkOption {
+        type = path;
+        example = "/run/keys/discourse-mailer-api-key";
+        description = ''
+          The file containing API key which will be used
+          to authenticate to Discourse in order to submit mail.
+        '';
+      };
+    };
+
+    web = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = "Enable nginx integration";
+      };
+
+      https = mkOption {
+        type = bool;
+        default = true;
+        description = ''
+          Whether to use HTTPS. When nginx integration is enabled,
+          this option forces SSL and enables ACME.
+        '';
+      };
+
+      settings = mkOption {
+        type = attrsOf (oneOf [ str int bool ]);
+        default = {};
+        example = {
+          title = "My Discourse";
+          site_description = "Example site";
+          short_site_description = "NixOS rocks";
+          contact_email = "devnull@example.org";
+          contact_url = "http://example.org/contact";
+        };
+        description = ''
+          Additional Discourse configuration attributes for web front-end.
+          These can be overriden via web interface as well, settings provided
+          here are used as defaults.
+
+          Use to override <link xlink:href="https://github.com/discourse/discourse/blob/master/config/site_settings.yml">front-end defaults</link>.
+        '';
+      };
+
+      workers = mkOption {
+        type = int;
+        default = 4;
+        description = ''
+          Number of Unicorn workers to spawn.
+        '';
+      };
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    assertions = [
+      { assertion = cfg.database.createLocally -> cfg.database.user == user;
+        message = "services.discourse.database.user must be set to ${user} if services.discourse.database.createLocally is set to true";
+      }
+      { assertion = cfg.database.createLocally -> cfg.database.passwordFile == null;
+        message = "a password cannot be specified if services.discourse.database.createLocally is set to true";
+      }
+    ];
+
+    services.discourse.settings = (mapAttrs (_: v: mkDefault v) {
+      hostname = cfg.hostName;
+      db_name = cfg.database.name;
+    }
+    // (optionalAttrs (cfg.database.user != null) {
+      db_user = cfg.database.user;
+    })
+    // (optionalAttrs (cfg.database.socket != null) {
+      db_socket = cfg.database.socket;
+    })
+    // (optionalAttrs cfg.database.createLocally {
+      db_socket = "/run/postgresql";
+    })
+    // (optionalAttrs (cfg.database.host != null) {
+      db_host = cfg.database.host;
+    }));
+
+    environment.systemPackages = [
+      discourse-bundler
+    ];
+
+    users.users.${user} = {
+      description = "Discourse forum user";
+      group = group;
+      home = dataDir;
+      createHome = false;
+      isSystemUser = true;
+    };
+
+    users.groups.${group} = {};
+
+    systemd.services.discourse = {
+      description = "Discourse forum (rails application)";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "postgresql.service" "redis.service" ];
+      requires = [ "discourse-sidekiq.service" ];
+
+      environment = dcEnv;
+
+      path = with pkgs; [
+        imagemagick
+        coreutils # nice
+        procps # ps
+        git # pointless
+      ];
+
+      serviceConfig = dcServiceConfig // {
+        TimeoutStartSec = "6min"; # due to discourse-pre
+        ExecStart = "${cfg.package}/share/discourse/bin/unicorn -E production -c ${dataDir}/config/unicorn.conf.rb";
+        ExecStartPre =
+          let
+            script = pkgs.writeScript "discourse-pre" ''
+              #!${pkgs.runtimeShell}
+              cp -f ${mainConfig} ${dataDir}/config/discourse.conf
+              chown ${user}:${group} ${dataDir}/config/discourse.conf
+
+              ${optionalString (cfg.database.passwordFile != null) ''
+                chmod u+w ${dataDir}/config/discourse.conf
+                echo -n "db_passwd = " >> ${dataDir}/config/discourse.conf
+                cat ${cfg.database.passwordFile} >> ${dataDir}/config/discourse.conf
+              ''}
+
+              ${pkgs.yq}/bin/yq -s '.[0] * .[1]' \
+                ${dataDir}/config/site_settings.yml \
+                ${webConfig} \
+                > ${dataDir}/config/site_settings.yml.merged
+
+              mv ${dataDir}/config/site_settings.yml{,.defaults}
+              mv ${dataDir}/config/site_settings.yml{.merged,}
+              chown ${user}:${group} ${dataDir}/config/site_settings.yml
+
+              ${pkgs.sudo}/bin/sudo -E -u ${user} \
+                ${discourse-bundler}/bin/discourse-bundler \
+                exec rake db:migrate &> log/db-migrate.log
+
+              # sadly we need to compile assets in Pre
+              # as it requires database connection
+              # XXX: assets:precompile needed
+              ${pkgs.sudo}/bin/sudo -u ${user} \
+                ${discourse-bundler}/bin/discourse-bundler \
+                exec rake assets:precompile:css --trace \
+                 &> log/assets.log
+
+              # HAXXX
+              chmod +w ${dataDir}/tmp/ember-rails/*.js || true
+              # sed -i 's/config.autoloader = :zeitwerk/config.autoloader = :classic/g' ${dataDir}/config/application.rb
+            '';
+          in
+            "!${script}";
+      };
+    };
+
+   systemd.services.discourse-sidekiq = {
+      description = "Discourse job queue";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "discourse.service" ];
+      environment = dcEnv;
+      path = with pkgs; [
+        procps # ps
+      ];
+      serviceConfig = dcServiceConfig // {
+        ExecStart = "${discourse-bundler}/bin/discourse-bundler exec sidekiq";
+      };
+    };
+
+    services.postgresql = optionalAttrs cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        { name = cfg.database.user;
+          ensurePermissions = {
+            "DATABASE ${cfg.database.name}" = "ALL PRIVILEGES";
+          };
+        }
+      ];
+    };
+
+    # The postgresql module doesn't currently support concepts like
+    # objects owners and extensions; for now we tack on what's needed
+    # here.
+    systemd.services.postgresql.postStart = mkAfter (optionalString cfg.database.createLocally ''
+      set -eu
+
+      $PSQL '${cfg.database.name}' -tAc "CREATE EXTENSION IF NOT EXISTS hstore"
+      $PSQL '${cfg.database.name}' -tAc "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+    '');
+
+    services.redis.enable = mkDefault true;
+
+    services.postfix = mkIf cfg.mail.enable {
+      enable = true;
+
+      relayDomains = cfg.mail.domains;
+      transport = concatMapStringsSep "\n"
+        (dom: "${dom} discourse:") cfg.mail.domains;
+      config = {
+        smtpd_recipient_restrictions = "check_policy_service unix:private/policy";
+      };
+      masterConfig = {
+        "discourse" = {
+          type = "unix";
+          privileged = true;
+          chroot = false;
+          command = "pipe";
+          args = [
+            "user=nobody:nogroup"
+            "argv=${cfg.mail.package}/bin/receive-mail"
+            "\${recipient}"
+          ];
+        };
+        "policy" = {
+          type = "unix";
+          privileged = true;
+          chroot = false;
+          command = "spawn";
+          args = [
+            "user=nobody:nogroup"
+            "argv=${cfg.mail.package}/bin/discourse-smtp-fast-rejection"
+          ];
+        };
+      };
+    };
+
+    systemd.services.postfix.after = optionals
+      cfg.mail.enable [ "discourse-mail-init.service" ];
+
+    systemd.services.discourse-mail-init = mkIf cfg.mail.enable {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "discourse.service" ];
+
+      script = ''
+        apiKey="$(<'${cfg.mail.apiKeyFile}')"
+        echo '${ builtins.toJSON mailEnv }' | ${pkgs.jq}/bin/jq ".DISCOURSE_API_KEY=\"$apiKey\"" \
+          > ${dataDir}/mail-receiver-environment.json
+
+        chown postfix ${dataDir}/mail-receiver-environment.json
+        chmod 400 ${dataDir}/mail-receiver-environment.json
+      '';
+      serviceConfig.Type = "oneshot";
+    };
+
+    systemd.tmpfiles.rules = [
+      "C  ${dataDir} -    ${user} - - ${cfg.package}/share/discourse"
+      "Z  ${dataDir} 0751 ${user} - -"
+      "Z  ${dataDir}/public 0751 ${user} nginx -"
+    ];
+
+    services.nginx = mkIf (cfg.web.enable) {
+      enable = true;
+      upstreams.discourse.servers."127.0.0.1:3000" = {};
+      virtualHosts.${cfg.hostName} = {
+        forceSSL = cfg.web.https;
+        enableACME = cfg.web.https;
+        locations = {
+          "/" = {
+            root = "${dataDir}/public";
+            tryFiles = "$uri @discourse";
+          };
+
+          "@discourse" = {
+            proxyPass = "http://discourse";
+            extraConfig = ''
+              proxy_set_header Host $host;
+              proxy_set_header X-Request-Start "t=''${msec}";
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-Host $http_host;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+            '';
+          };
+
+        };
+      };
+    };
+
+  };
+
+  meta.maintainers = with maintainers; [ sorki ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -66,6 +66,7 @@ in
   couchdb = handleTest ./couchdb.nix {};
   deluge = handleTest ./deluge.nix {};
   dhparams = handleTest ./dhparams.nix {};
+  discourse = handleTestOn ["x86_64-linux"] ./discourse.nix {};
   dnscrypt-proxy2 = handleTestOn ["x86_64-linux"] ./dnscrypt-proxy2.nix {};
   docker = handleTestOn ["x86_64-linux"] ./docker.nix {};
   docker-containers = handleTestOn ["x86_64-linux"] ./docker-containers.nix {};

--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -7,9 +7,15 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     {
       virtualisation.memorySize = 1024;
       virtualisation.diskSize = 2 * 1024;
+
+      # discourse doesn't like when mail domain is localhost
+      networking.extraHosts = ''
+        127.0.0.1 discourse.xmpl
+      '';
+
       services.discourse = {
         enable = true;
-        hostName = "localhost";
+        hostName = "discourse.xmpl";
         database = {
           name = "discourse";
           createLocally = true;
@@ -26,9 +32,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     start_all()
 
     machine.wait_for_unit("discourse.service")
-
-    machine.sleep(60)
-
-    assert "Discourse Setup" in machine.succeed("curl -v -L http://localhost/")
+    machine.wait_for_open_port("3000")
+    assert "Discourse Setup" in machine.succeed("curl -v -L http://discourse.xmpl/")
   '';
 })

--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -1,0 +1,34 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "discourse";
+  meta.maintainers = with lib.maintainers; [ sorki ];
+
+  machine =
+    { ... }:
+    {
+      virtualisation.memorySize = 1024;
+      virtualisation.diskSize = 2 * 1024;
+      services.discourse = {
+        enable = true;
+        hostName = "localhost";
+        database = {
+          name = "discourse";
+          createLocally = true;
+        };
+        web = {
+          enable = true;
+          https = false;
+          workers = 1;
+        };
+      };
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("discourse.service")
+
+    machine.sleep(60)
+
+    assert "Discourse Setup" in machine.succeed("curl -v -L http://localhost/")
+  '';
+})

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -5,6 +5,7 @@
 , bundlerEnv
 , defaultGemConfig
 , v8
+, nixosTests
 }:
 
 let
@@ -49,11 +50,12 @@ in stdenv.mkDerivation rec {
     sha256 = "1nfvfrlbimfhi2dfsk4y6pbv1rbxxwkbnazm9br5cfiikc54zv3b";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   buildInputs = [
     rubyEnv
     rubyEnv.wrappedRuby
     rubyEnv.bundler
-    makeWrapper
   ];
 
   postPatch = ''
@@ -69,6 +71,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     inherit rubyEnv;
+    inherit (nixosTests) discourse;
   };
 
   meta = with lib; {

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -1,0 +1,82 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, bundlerEnv
+, defaultGemConfig
+, v8
+}:
+
+let
+  rubyEnv = bundlerEnv {
+    name = "discourse-env";
+
+    # XXX: Gemfile.lock needs to be patched with due to bundix expecting bundler 1.x
+    # https://github.com/NixOS/nixpkgs/issues/68089
+    # perl -i -p0e 's/BUNDLED WITH.*2.*$/BUNDLED WITH\n   1.17.2/s' $out/Gemfile.lock
+
+    # afterwards generate gemset.nix from repo checkout using
+    # $ nix-shell -p bundix
+    # $ bundix
+
+    gemdir  = ./rubyEnv;
+    gemset   = ./rubyEnv/gemset.nix;
+
+    # Bundler groups available in this environment
+    groups = ["assets" "default" "development" "test"];
+
+    gemConfig = defaultGemConfig // {
+      mini_racer = attrs: {
+        buildInputs = [ v8 ];
+        dontBuild = false;
+        # force v8 check to use C++
+        postPatch = ''
+          substituteInPlace ext/mini_racer_extension/extconf.rb \
+            --replace "Libv8.configure_makefile" \
+                      "with_cflags(\"-x c++\") do Libv8.configure_makefile end"
+        '';
+      };
+    };
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "discourse";
+  version = "2.4.1";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse";
+    rev = "v${version}";
+    sha256 = "1nfvfrlbimfhi2dfsk4y6pbv1rbxxwkbnazm9br5cfiikc54zv3b";
+  };
+
+  buildInputs = [
+    rubyEnv
+    rubyEnv.wrappedRuby
+    rubyEnv.bundler
+    makeWrapper
+  ];
+
+  postPatch = ''
+    sed -i 's~CREATE EXTENSION IF NOT EXISTS hstore~~'  db/migrate/20120924182000_add_hstore_extension.rb
+    sed -i 's~CREATE EXTENSION IF NOT EXISTS hstore~~'  db/migrate/20120921162512_add_meta_data_to_forum_threads.rb
+    sed -i 's~CREATE EXTENSION IF NOT EXISTS pg_trgm~~' db/migrate/20130315180637_enable_trigram_support.rb
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp -r . $out/share/discourse
+  '';
+
+  passthru = {
+    inherit rubyEnv;
+  };
+
+  meta = with lib; {
+    homepage = "https://www.discourse.org/";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sorki ];
+    license = licenses.gpl2;
+    description = "A platform for community discussion";
+    longDescription = "Discourse is the 100% open source discussion platform built for the next decade of the Internet.";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/mail-receiver.nix
+++ b/pkgs/servers/web-apps/discourse/mail-receiver.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, ruby
+, makeWrapper
+}:
+stdenv.mkDerivation rec {
+  pname = "mail-receiver";
+  version = "4.0.1";
+
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "17rqvj0z5fy928wx0pmdnay89f24y0gjrj215bjpfy2lnf5n5h67";
+  };
+
+  buildInputs = [ makeWrapper ];
+  dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace discourse-smtp-fast-rejection \
+      --replace "require 'mail_receiver/fast_rejection'" \
+                "require_relative '../lib/mail_receiver/fast_rejection'" \
+      --replace "/etc/postfix/" \
+                "/var/lib/discourse/"
+
+    substituteInPlace receive-mail \
+      --replace "require 'mail_receiver/discourse_mail_receiver'" \
+                "require_relative '../lib/mail_receiver/discourse_mail_receiver'" \
+      --replace "/etc/postfix/" \
+                "/var/lib/discourse/"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a lib $out/
+    cp discourse-smtp-fast-rejection receive-mail $out/bin
+    wrapProgram $out/bin/discourse-smtp-fast-rejection --prefix PATH : ${ruby}/bin
+    wrapProgram $out/bin/receive-mail --prefix PATH : ${ruby}/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/discourse/mail-receiver/";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sorki ];
+    # XXX: this is not explicitely stated in repo, ask upstream
+    license = licenses.gpl2;
+    description = "Discourse mail receiver Postfix helpers";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/mail-receiver.nix
+++ b/pkgs/servers/web-apps/discourse/mail-receiver.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "17rqvj0z5fy928wx0pmdnay89f24y0gjrj215bjpfy2lnf5n5h67";
   };
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
   dontBuild = true;
 
   postPatch = ''

--- a/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+# if there is a super emergency and rubygems is playing up, try
+#source 'http://production.cf.rubygems.org'
+
+gem 'bootsnap', require: false, platform: :mri
+
+def rails_master?
+  ENV["RAILS_MASTER"] == '1'
+end
+
+if rails_master?
+  gem 'arel', git: 'https://github.com/rails/arel.git'
+  gem 'rails', git: 'https://github.com/rails/rails.git'
+else
+  # NOTE: Until rubygems gives us optional dependencies we are stuck with this needing to be explicit
+  # this allows us to include the bits of rails we use without pieces we do not.
+  #
+  # To issue a rails update bump the version number here
+  gem 'actionmailer', '6.0.1'
+  gem 'actionpack', '6.0.1'
+  gem 'actionview', '6.0.1'
+  gem 'activemodel', '6.0.1'
+  gem 'activerecord', '6.0.1'
+  gem 'activesupport', '6.0.1'
+  gem 'railties', '6.0.1'
+  gem 'sprockets-rails'
+end
+
+# TODO: At the moment Discourse does not work with Sprockets 4, we would need to correct internals
+# This is a desired upgrade we should get to.
+gem 'sprockets', '3.7.2'
+
+# this will eventually be added to rails,
+# allows us to precompile all our templates in the unicorn master
+gem 'actionview_precompiler', require: false
+
+gem 'seed-fu'
+
+gem 'mail', require: false
+gem 'mini_mime'
+gem 'mini_suffix'
+
+gem 'redis'
+
+# This is explicitly used by Sidekiq and is an optional dependency.
+# We tell Sidekiq to use the namespace "sidekiq" which triggers this
+# gem to be used. There is no explicit dependency in sidekiq cause
+# redis namespace support is optional
+# We already namespace stuff in DiscourseRedis, so we should consider
+# just using a single implementation in core vs having 2 namespace implementations
+gem 'redis-namespace'
+
+# NOTE: AM serializer gets a lot slower with recent updates
+# we used an old branch which is the fastest one out there
+# are long term goal here is to fork this gem so we have a
+# better maintained living fork
+gem 'active_model_serializers', '~> 0.8.3'
+
+gem 'onebox'
+
+gem 'http_accept_language', require: false
+
+# Ember related gems need to be pinned cause they control client side
+# behavior, we will push these versions up when upgrading ember
+gem 'ember-rails', '0.18.5'
+gem 'discourse-ember-source', '~> 3.12.2'
+gem 'ember-handlebars-template', '0.8.0'
+
+gem 'barber'
+
+gem 'message_bus'
+
+gem 'rails_multisite'
+
+gem 'fast_xs', platform: :mri
+
+# may move to xorcist post: https://github.com/fny/xorcist/issues/4
+gem 'fast_xor', platform: :mri
+
+gem 'fastimage'
+
+gem 'aws-sdk-s3', require: false
+gem 'aws-sdk-sns', require: false
+gem 'excon', require: false
+gem 'unf', require: false
+
+gem 'email_reply_trimmer'
+
+# Forked until https://github.com/toy/image_optim/pull/162 is merged
+# https://github.com/discourse/image_optim
+gem 'discourse_image_optim', require: 'image_optim'
+gem 'multi_json'
+gem 'mustache'
+gem 'nokogiri'
+gem 'css_parser', require: false
+
+gem 'omniauth'
+gem 'omniauth-facebook'
+gem 'omniauth-twitter'
+gem 'omniauth-instagram'
+gem 'omniauth-github'
+
+gem 'omniauth-oauth2', require: false
+
+gem 'omniauth-google-oauth2'
+
+gem 'oj'
+gem 'pg'
+gem 'mini_sql'
+gem 'pry-rails', require: false
+gem 'r2', require: false
+gem 'rake'
+
+gem 'thor', require: false
+gem 'diffy', require: false
+gem 'rinku'
+gem 'sanitize'
+gem 'sidekiq'
+gem 'mini_scheduler'
+
+# for sidekiq web
+gem 'tilt', require: false
+
+gem 'execjs', require: false
+gem 'mini_racer'
+
+# TODO: determine why highline is being held back and upgrade to latest
+gem 'highline', '~> 1.7.0', require: false
+
+# TODO: Upgrading breaks Sidekiq Web
+# This is a bit of a hornets nest cause in an ideal world we much prefer
+# if Sidekiq reused session and CSRF mitigation with Discourse on the
+# _forum_session cookie instead of a rack.session cookie
+gem 'rack', '2.0.8'
+
+gem 'rack-protection' # security
+gem 'cbor', require: false
+gem 'cose', require: false
+gem 'addressable'
+
+# Gems used only for assets and not required in production environments by default.
+# Allow everywhere for now cause we are allowing asset debugging in production
+group :assets do
+  gem 'uglifier'
+  gem 'rtlit', require: false # for css rtling
+end
+
+group :test do
+  gem 'webmock', require: false
+  gem 'fakeweb', require: false
+  gem 'minitest', require: false
+  gem 'simplecov', require: false
+  gem "test-prof"
+end
+
+group :test, :development do
+  gem 'rspec'
+  gem 'mock_redis'
+  gem 'listen', require: false
+  gem 'certified', require: false
+  gem 'fabrication', require: false
+
+  # TODO: upgrading to 1.10.1 cause it breaks our test suite.
+  # We want our test suite fixed though to support this upgrade.
+  gem 'mocha', '1.8.0', require: false
+
+  gem 'rb-fsevent', require: RUBY_PLATFORM =~ /darwin/i ? 'rb-fsevent' : false
+
+  # TODO determine if we can update this to 0.10, API changes happened
+  # we would like to upgrade it if possible
+  gem 'rb-inotify', '~> 0.9', require: RUBY_PLATFORM =~ /linux/i ? 'rb-inotify' : false
+
+  # TODO once 4.0.0 is released upgrade to it, at time of writing 3.9.0 is latest
+  gem 'rspec-rails', '4.0.0.beta2', require: false
+
+  gem 'shoulda-matchers', require: false
+  gem 'rspec-html-matchers'
+  gem 'pry-nav'
+  gem 'byebug', require: ENV['RM_INFO'].nil?, platform: :mri
+  gem 'rubocop', require: false
+  gem "rubocop-discourse", require: false
+  gem 'parallel_tests'
+end
+
+group :development do
+  gem 'ruby-prof', require: false, platform: :mri
+  gem 'bullet', require: !!ENV['BULLET']
+  gem 'better_errors', platform: :mri
+  gem 'binding_of_caller'
+  gem 'yaml-lint'
+  gem 'annotate'
+end
+
+# this is an optional gem, it provides a high performance replacement
+# to String#blank? a method that is called quite frequently in current
+# ActiveRecord, this may change in the future
+gem 'fast_blank', platform: :mri
+
+# this provides a very efficient lru cache
+gem 'lru_redux'
+
+gem 'htmlentities', require: false
+
+# IMPORTANT: mini profiler monkey patches, so it better be required last
+#  If you want to amend mini profiler to do the monkey patches in the railties
+#  we are open to it. by deferring require to the initializer we can configure discourse installs without it
+
+gem 'flamegraph', require: false
+gem 'rack-mini-profiler', require: false
+
+gem 'unicorn', require: false, platform: :mri
+gem 'puma', require: false
+gem 'rbtrace', require: false, platform: :mri
+gem 'gc_tracer', require: false, platform: :mri
+
+# required for feed importing and embedding
+gem 'ruby-readability', require: false
+
+gem 'stackprof', require: false, platform: :mri
+gem 'memory_profiler', require: false, platform: :mri
+
+gem 'cppjieba_rb', require: false
+
+gem 'lograge', require: false
+gem 'logstash-event', require: false
+gem 'logstash-logger', require: false
+gem 'logster'
+
+# NOTE: later versions of sassc are causing a segfault, possibly dependent on processer architecture
+# and until resolved should be locked at 2.0.1
+gem 'sassc', '2.0.1', require: false
+gem "sassc-rails"
+
+gem 'rotp', require: false
+gem 'rqrcode'
+
+gem 'rubyzip', require: false
+
+gem 'sshkey', require: false
+
+gem 'rchardet', require: false
+gem 'lz4-ruby', require: false, platform: :mri
+
+if ENV["IMPORT"] == "1"
+  gem 'mysql2'
+  gem 'redcarpet'
+
+  # NOTE: in import mode the version of sqlite can matter a lot, so we stick it to a specific one
+  gem 'sqlite3', '~> 1.3', '>= 1.3.13'
+  gem 'ruby-bbcode-to-md', git: 'https://github.com/nlalonde/ruby-bbcode-to-md'
+  gem 'reverse_markdown'
+  gem 'tiny_tds'
+  gem 'csv'
+end
+
+gem 'webpush', require: false
+gem 'colored2', require: false
+gem 'maxminddb'

--- a/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
@@ -1,0 +1,551 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionmailer (6.0.1)
+      actionpack (= 6.0.1)
+      actionview (= 6.0.1)
+      activejob (= 6.0.1)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (6.0.1)
+      actionview (= 6.0.1)
+      activesupport (= 6.0.1)
+      rack (~> 2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionview (6.0.1)
+      activesupport (= 6.0.1)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    actionview_precompiler (0.2.2)
+      actionview (>= 6.0.a)
+    active_model_serializers (0.8.4)
+      activemodel (>= 3.0)
+    activejob (6.0.1)
+      activesupport (= 6.0.1)
+      globalid (>= 0.3.6)
+    activemodel (6.0.1)
+      activesupport (= 6.0.1)
+    activerecord (6.0.1)
+      activemodel (= 6.0.1)
+      activesupport (= 6.0.1)
+    activesupport (6.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.1.0)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
+    ast (2.4.0)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.272.0)
+    aws-sdk-core (3.89.1)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.29.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.60.2)
+      aws-sdk-core (~> 3, >= 3.83.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-sns (1.21.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+    barber (0.12.2)
+      ember-source (>= 1.0, < 3.1)
+      execjs (>= 1.2, < 3)
+    better_errors (2.5.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
+    bootsnap (1.4.6)
+      msgpack (~> 1.0)
+    builder (3.2.4)
+    bullet (6.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
+    byebug (11.1.1)
+    cbor (0.5.9.6)
+    certified (1.0.0)
+    chunky_png (1.3.11)
+    coderay (1.1.2)
+    colored2 (3.1.2)
+    concurrent-ruby (1.1.6)
+    connection_pool (2.2.2)
+    cose (0.11.0)
+      cbor (~> 0.5.9)
+      openssl-signature_algorithm (~> 0.3.0)
+    cppjieba_rb (0.3.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    crass (1.0.6)
+    css_parser (1.7.1)
+      addressable
+    debug_inspector (0.0.3)
+    diff-lcs (1.3)
+    diffy (3.3.0)
+    discourse-ember-source (3.12.2.0)
+    discourse_image_optim (0.26.2)
+      exifr (~> 1.2, >= 1.2.2)
+      fspath (~> 3.0)
+      image_size (~> 1.5)
+      in_threads (~> 1.3)
+      progress (~> 3.0, >= 3.0.1)
+    docile (1.3.2)
+    email_reply_trimmer (0.1.12)
+    ember-data-source (3.0.2)
+      ember-source (>= 2, < 3.0)
+    ember-handlebars-template (0.8.0)
+      barber (>= 0.11.0)
+      sprockets (>= 3.3, < 4.1)
+    ember-rails (0.18.5)
+      active_model_serializers
+      ember-data-source (>= 1.0.0.beta.5)
+      ember-handlebars-template (>= 0.1.1, < 1.0)
+      ember-source (>= 1.1.0)
+      jquery-rails (>= 1.0.17)
+      railties (>= 3.1)
+    ember-source (2.18.2)
+    erubi (1.9.0)
+    excon (0.72.0)
+    execjs (2.7.0)
+    exifr (1.3.6)
+    fabrication (2.21.0)
+    fakeweb (1.3.0)
+    faraday (0.17.3)
+      multipart-post (>= 1.2, < 3)
+    fast_blank (1.0.0)
+    fast_xor (1.1.3)
+      rake
+      rake-compiler
+    fast_xs (0.8.0)
+    fastimage (2.1.7)
+    ffi (1.12.2)
+    flamegraph (0.9.5)
+    fspath (3.1.2)
+    gc_tracer (1.5.1)
+    globalid (0.4.2)
+      activesupport (>= 4.2.0)
+    guess_html_encoding (0.0.11)
+    hashdiff (1.0.0)
+    hashie (3.6.0)
+    highline (1.7.10)
+    hkdf (0.3.0)
+    htmlentities (4.3.4)
+    http_accept_language (2.1.1)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    image_size (1.5.0)
+    in_threads (1.5.4)
+    jaro_winkler (1.5.4)
+    jmespath (1.4.0)
+    jquery-rails (4.3.5)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    jwt (2.2.1)
+    kgio (2.11.3)
+    libv8 (7.3.492.27.1)
+    listen (3.2.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+    logstash-event (1.2.02)
+    logstash-logger (0.26.1)
+      logstash-event (~> 1.2)
+    logster (2.6.3)
+    loofah (2.4.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    lru_redux (1.1.0)
+    lz4-ruby (0.3.3)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
+    maxminddb (0.1.22)
+    memory_profiler (0.9.14)
+    message_bus (2.2.3)
+      rack (>= 1.1.3)
+    metaclass (0.0.4)
+    method_source (0.9.2)
+    mini_mime (1.0.2)
+    mini_portile2 (2.4.0)
+    mini_racer (0.2.9)
+      libv8 (>= 6.9.411)
+    mini_scheduler (0.12.2)
+      sidekiq
+    mini_sql (0.2.4)
+    mini_suffix (0.3.0)
+      ffi (~> 1.9)
+    minitest (5.14.0)
+    mocha (1.8.0)
+      metaclass (~> 0.0.1)
+    mock_redis (0.22.0)
+    msgpack (1.3.3)
+    multi_json (1.14.1)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    mustache (1.1.1)
+    nio4r (2.5.2)
+    nokogiri (1.10.8)
+      mini_portile2 (~> 2.4.0)
+    nokogumbo (2.0.2)
+      nokogiri (~> 1.8, >= 1.8.4)
+    oauth (0.5.4)
+    oauth2 (1.4.2)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    oj (3.10.2)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-facebook (6.0.0)
+      omniauth-oauth2 (~> 1.2)
+    omniauth-github (1.4.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
+    omniauth-google-oauth2 (0.8.0)
+      jwt (>= 2.0)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.6)
+    omniauth-instagram (1.3.0)
+      omniauth (~> 1)
+      omniauth-oauth2 (~> 1)
+    omniauth-oauth (1.1.0)
+      oauth
+      omniauth (~> 1.0)
+    omniauth-oauth2 (1.6.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.9)
+    omniauth-twitter (1.4.0)
+      omniauth-oauth (~> 1.1)
+      rack
+    onebox (1.9.26)
+      addressable (~> 2.7.0)
+      htmlentities (~> 4.3)
+      multi_json (~> 1.11)
+      mustache
+      nokogiri (~> 1.7)
+      sanitize
+    openssl-signature_algorithm (0.3.0)
+    optimist (3.0.0)
+    parallel (1.19.1)
+    parallel_tests (2.31.0)
+      parallel
+    parser (2.7.0.2)
+      ast (~> 2.4.0)
+    pg (1.2.2)
+    progress (3.5.2)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-nav (0.3.0)
+      pry (>= 0.9.10, < 0.13.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
+    public_suffix (4.0.3)
+    puma (4.3.1)
+      nio4r (~> 2.0)
+    r2 (0.2.7)
+    rack (2.0.8)
+    rack-mini-profiler (1.1.6)
+      rack (>= 1.2.0)
+    rack-protection (2.0.8.1)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
+    rails_multisite (2.0.7)
+      activerecord (> 4.2, < 7)
+      railties (> 4.2, < 7)
+    railties (6.0.1)
+      actionpack (= 6.0.1)
+      activesupport (= 6.0.1)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.20.3, < 2.0)
+    rainbow (3.0.0)
+    raindrops (0.19.1)
+    rake (13.0.1)
+    rake-compiler (1.1.0)
+      rake
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rbtrace (0.4.11)
+      ffi (>= 1.0.6)
+      msgpack (>= 0.4.3)
+      optimist (>= 3.0.0)
+    rchardet (1.8.0)
+    redis (4.1.3)
+    redis-namespace (1.7.0)
+      redis (>= 3.0.4)
+    request_store (1.5.0)
+      rack (>= 1.4)
+    rexml (3.2.4)
+    rinku (2.0.6)
+    rotp (5.1.0)
+      addressable (~> 2.5)
+    rqrcode (1.1.2)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 0.1)
+    rqrcode_core (0.1.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-html-matchers (0.9.2)
+      nokogiri (~> 1)
+      rspec (>= 3.0.0.a, < 4)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-rails (4.0.0.beta2)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.8)
+      rspec-expectations (~> 3.8)
+      rspec-mocks (~> 3.8)
+      rspec-support (~> 3.8)
+    rspec-support (3.9.2)
+    rtlit (0.0.5)
+    rubocop (0.80.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-discourse (1.0.2)
+      rubocop (>= 0.69.0)
+    ruby-prof (1.3.0)
+    ruby-progressbar (1.10.1)
+    ruby-readability (0.7.0)
+      guess_html_encoding (>= 0.0.4)
+      nokogiri (>= 1.6.0)
+    rubyzip (2.2.0)
+    safe_yaml (1.0.5)
+    sanitize (5.1.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.8.0)
+      nokogumbo (~> 2.0)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
+    seed-fu (2.3.9)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
+    shoulda-matchers (4.3.0)
+      activesupport (>= 4.2.0)
+    sidekiq (6.0.5)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
+    simplecov (0.18.3)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.1)
+    sprockets (3.7.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.2.1)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+    sshkey (2.0.0)
+    stackprof (0.2.15)
+    test-prof (0.11.3)
+    thor (1.0.1)
+    thread_safe (0.3.6)
+    tilt (2.0.10)
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
+    uglifier (4.2.0)
+      execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
+    unicode-display_width (1.6.1)
+    unicorn (5.5.3)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
+    uniform_notifier (1.13.0)
+    webmock (3.8.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    webpush (1.0.0)
+      hkdf (~> 0.2)
+      jwt (~> 2.0)
+    yaml-lint (0.0.10)
+    zeitwerk (2.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actionmailer (= 6.0.1)
+  actionpack (= 6.0.1)
+  actionview (= 6.0.1)
+  actionview_precompiler
+  active_model_serializers (~> 0.8.3)
+  activemodel (= 6.0.1)
+  activerecord (= 6.0.1)
+  activesupport (= 6.0.1)
+  addressable
+  annotate
+  aws-sdk-s3
+  aws-sdk-sns
+  barber
+  better_errors
+  binding_of_caller
+  bootsnap
+  bullet
+  byebug
+  cbor
+  certified
+  colored2
+  cose
+  cppjieba_rb
+  css_parser
+  diffy
+  discourse-ember-source (~> 3.12.2)
+  discourse_image_optim
+  email_reply_trimmer
+  ember-handlebars-template (= 0.8.0)
+  ember-rails (= 0.18.5)
+  excon
+  execjs
+  fabrication
+  fakeweb
+  fast_blank
+  fast_xor
+  fast_xs
+  fastimage
+  flamegraph
+  gc_tracer
+  highline (~> 1.7.0)
+  htmlentities
+  http_accept_language
+  listen
+  lograge
+  logstash-event
+  logstash-logger
+  logster
+  lru_redux
+  lz4-ruby
+  mail
+  maxminddb
+  memory_profiler
+  message_bus
+  mini_mime
+  mini_racer
+  mini_scheduler
+  mini_sql
+  mini_suffix
+  minitest
+  mocha (= 1.8.0)
+  mock_redis
+  multi_json
+  mustache
+  nokogiri
+  oj
+  omniauth
+  omniauth-facebook
+  omniauth-github
+  omniauth-google-oauth2
+  omniauth-instagram
+  omniauth-oauth2
+  omniauth-twitter
+  onebox
+  parallel_tests
+  pg
+  pry-nav
+  pry-rails
+  puma
+  r2
+  rack (= 2.0.8)
+  rack-mini-profiler
+  rack-protection
+  rails_multisite
+  railties (= 6.0.1)
+  rake
+  rb-fsevent
+  rb-inotify (~> 0.9)
+  rbtrace
+  rchardet
+  redis
+  redis-namespace
+  rinku
+  rotp
+  rqrcode
+  rspec
+  rspec-html-matchers
+  rspec-rails (= 4.0.0.beta2)
+  rtlit
+  rubocop
+  rubocop-discourse
+  ruby-prof
+  ruby-readability
+  rubyzip
+  sanitize
+  sassc (= 2.0.1)
+  sassc-rails
+  seed-fu
+  shoulda-matchers
+  sidekiq
+  simplecov
+  sprockets (= 3.7.2)
+  sprockets-rails
+  sshkey
+  stackprof
+  test-prof
+  thor
+  tilt
+  uglifier
+  unf
+  unicorn
+  webmock
+  webpush
+  yaml-lint
+
+BUNDLED WITH
+   1.17.2

--- a/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
@@ -1,0 +1,2223 @@
+{
+  actionmailer = {
+    dependencies = ["actionpack" "actionview" "activejob" "mail" "rails-dom-testing"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vzl15jrjkygnpbk867l6nxs06q5lyis7cqaqz7b2mjal4pyh4lr";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  actionpack = {
+    dependencies = ["actionview" "activesupport" "rack" "rack-test" "rails-dom-testing" "rails-html-sanitizer"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ch6mcmzx3avzb1s9mnlzf1k87ms24k3ji9i4ywvsmjga59lrfg5";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  actionview = {
+    dependencies = ["activesupport" "builder" "erubi" "rails-dom-testing" "rails-html-sanitizer"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vdihh2mylzbhaljq9jrg9c7j1imamn68y4z7ghlg80jrmfj5j6a";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  actionview_precompiler = {
+    dependencies = ["actionview"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n7qh2dv70x00q8sck4zlchspkmwg5lv8a114ys6zy8jidy3mc4i";
+      type = "gem";
+    };
+    version = "0.2.2";
+  };
+  active_model_serializers = {
+    dependencies = ["activemodel"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0k3mgia2ahh7mbk30hjq9pzqbk0kh281s91kq2z6p555nv9y6l3k";
+      type = "gem";
+    };
+    version = "0.8.4";
+  };
+  activejob = {
+    dependencies = ["activesupport" "globalid"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0smffh3ppnd6hzd4v16xzw22j0g781b7sysj1bbkg5l3qbhdmaqc";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  activemodel = {
+    dependencies = ["activesupport"];
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "14gh2phxpnmadr9vs9v2ks9v8ilz5gaxgjspmyayddg0hq4f5q60";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  activerecord = {
+    dependencies = ["activemodel" "activesupport"];
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0sq1pqrhdbiij9kf3vliywas046dipjb5z8pdcv95qjcnwzkpkfm";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  activesupport = {
+    dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo" "zeitwerk"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "190xv21yz03zz8nlfly557ir859jr5zkwi89naziy65hskdnkw1s";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  addressable = {
+    dependencies = ["public_suffix"];
+    groups = ["default" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fvchp2rhp2rmigx7qglf69xvjqvzq7x0g49naliw29r2bz656sy";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  annotate = {
+    dependencies = ["activerecord" "rake"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18sx2b157i6qcj0xa00ksnaqzdkwd72pzbdvzgd8p3fsipmf8lji";
+      type = "gem";
+    };
+    version = "3.1.0";
+  };
+  ast = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "184ssy3w93nkajlz2c70ifm79jp3j737294kbc5fjw69v1w0n9x7";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  aws-eventstream = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "100g77a5ixg4p5zwq77f28n2pdkk0y481f7v83qrlmnj22318qq6";
+      type = "gem";
+    };
+    version = "1.0.3";
+  };
+  aws-partitions = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cwihbj6z4c3pzw33zqk67z88478asksn1ffj3k8favp48chfll7";
+      type = "gem";
+    };
+    version = "1.272.0";
+  };
+  aws-sdk-core = {
+    dependencies = ["aws-eventstream" "aws-partitions" "aws-sigv4" "jmespath"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06ds6bdd1q4pdbw99ravwh51qp8n285psy2lrc8is6gvn3pzv4gr";
+      type = "gem";
+    };
+    version = "3.89.1";
+  };
+  aws-sdk-kms = {
+    dependencies = ["aws-sdk-core" "aws-sigv4"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "191qnrpg9qhwj24pisha28fwqx30sqkj75ibgpqcf4q389l3a2gw";
+      type = "gem";
+    };
+    version = "1.29.0";
+  };
+  aws-sdk-s3 = {
+    dependencies = ["aws-sdk-core" "aws-sdk-kms" "aws-sigv4"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pblkq7rw465w08hs2xy6v7w10x9n004hk43yqzswqxirki68ldz";
+      type = "gem";
+    };
+    version = "1.60.2";
+  };
+  aws-sdk-sns = {
+    dependencies = ["aws-sdk-core" "aws-sigv4"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vfyn7hc21qgarhrfghyw3qi550656834b51n5vnginraryk6ji8";
+      type = "gem";
+    };
+    version = "1.21.0";
+  };
+  aws-sigv4 = {
+    dependencies = ["aws-eventstream"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1dfc8i5cxjwlvi4b665lbpbwvks8a6wfy3vfmwr3pjdmxwdmc2cs";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  barber = {
+    dependencies = ["ember-source" "execjs"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07rnlbh7kgamcbnl1sqlcdrjj8src4qc687klqq4a3vqq2slnscx";
+      type = "gem";
+    };
+    version = "0.12.2";
+  };
+  better_errors = {
+    dependencies = ["coderay" "erubi" "rack"];
+    groups = ["development"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mq43k4szfgcdanhdwacyp7yvldl76m9arhdj9n0x25dmbdzp2yn";
+      type = "gem";
+    };
+    version = "2.5.1";
+  };
+  binding_of_caller = {
+    dependencies = ["debug_inspector"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05syqlks7463zsy1jdfbbdravdhj9hpj5pv2m74blqpv8bq4vv5g";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  bootsnap = {
+    dependencies = ["msgpack"];
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bz62p9vc7lcrmzhiz4pf7myww086mq287cw3jjj7fyc7jhmamw0";
+      type = "gem";
+    };
+    version = "1.4.6";
+  };
+  builder = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "045wzckxpwcqzrjr353cxnyaxgf0qg22jh00dcx7z38cys5g1jlr";
+      type = "gem";
+    };
+    version = "3.2.4";
+  };
+  bullet = {
+    dependencies = ["activesupport" "uniform_notifier"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18ifwnvn13755qkfigapyj5bflpby3phxzbb7x5336d0kzv5k7d9";
+      type = "gem";
+    };
+    version = "6.1.0";
+  };
+  byebug = {
+    groups = ["development" "test"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18a9wlwvwxi86nldj56jbk6pwx3rd8l5xi6p8ap24p169h9m8wc4";
+      type = "gem";
+    };
+    version = "11.1.1";
+  };
+  cbor = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0511idr8xps9625nh3kxr68sdy6l3xy2kcz7r57g47fxb1v18jj3";
+      type = "gem";
+    };
+    version = "0.5.9.6";
+  };
+  certified = {
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1706p6p0a8adyvd943af2a3093xakvislgffw3v9dvp7j07dyk5a";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  chunky_png = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "124najs9prqzrzk49h53kap992rmqxj0wni61z2hhsn7mwmgdp9d";
+      type = "gem";
+    };
+    version = "1.3.11";
+  };
+  coderay = {
+    groups = ["default" "development" "test"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15vav4bhcc2x3jmi3izb11l4d9f3xv8hp2fszb7iqmpsccv1pz4y";
+      type = "gem";
+    };
+    version = "1.1.2";
+  };
+  colored2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jlbqa9q4mvrm73aw9mxh23ygzbjiqwisl32d8szfb5fxvbjng5i";
+      type = "gem";
+    };
+    version = "3.1.2";
+  };
+  concurrent-ruby = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "094387x4yasb797mv07cs3g6f08y56virc2rjcpb1k79rzaj3nhl";
+      type = "gem";
+    };
+    version = "1.1.6";
+  };
+  connection_pool = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lflx29mlznf1hn0nihkgllzbj8xp5qasn8j7h838465pi399k68";
+      type = "gem";
+    };
+    version = "2.2.2";
+  };
+  cose = {
+    dependencies = ["cbor" "openssl-signature_algorithm"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1j59fqy453pasms746jjh41kr5pa4n88xvjq6jn6adkdcdm5c812";
+      type = "gem";
+    };
+    version = "0.11.0";
+  };
+  cppjieba_rb = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sslff7yy8jvp4rcn1b6jn9v0d3iibb68i79shgd94rs2yq8k117";
+      type = "gem";
+    };
+    version = "0.3.3";
+  };
+  crack = {
+    dependencies = ["safe_yaml"];
+    groups = ["default" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0abb0fvgw00akyik1zxnq7yv391va148151qxdghnzngv66bl62k";
+      type = "gem";
+    };
+    version = "0.4.3";
+  };
+  crass = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pfl5c0pyqaparxaqxi6s4gfl21bdldwiawrc0aknyvflli60lfw";
+      type = "gem";
+    };
+    version = "1.0.6";
+  };
+  css_parser = {
+    dependencies = ["addressable"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04c4dl8cm5rjr50k9qa6yl9r05fk9zcb1zxh0y0cdahxlsgcydfw";
+      type = "gem";
+    };
+    version = "1.7.1";
+  };
+  debug_inspector = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vxr0xa1mfbkfcrn71n7c4f2dj7la5hvphn904vh20j3x4j5lrx0";
+      type = "gem";
+    };
+    version = "0.0.3";
+  };
+  diff-lcs = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18w22bjz424gzafv6nzv98h0aqkwz3d9xhm7cbr1wfbyas8zayza";
+      type = "gem";
+    };
+    version = "1.3";
+  };
+  diffy = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qhx743lcx61r2d3925jk61c6r8clfjmpf5g93cdy5sq00ig76lh";
+      type = "gem";
+    };
+    version = "3.3.0";
+  };
+  discourse-ember-source = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "03kpcp0m1pjwv2r812q9f16r5cvsiqlcf4j95dn22r03p0kh5nqr";
+      type = "gem";
+    };
+    version = "3.12.2.0";
+  };
+  discourse_image_optim = {
+    dependencies = ["exifr" "fspath" "image_size" "in_threads" "progress"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11nqmga5ygxyhjmsc07gsa0fwwyhdpwi20yyr4fnh263xs1xylvv";
+      type = "gem";
+    };
+    version = "0.26.2";
+  };
+  docile = {
+    groups = ["default" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qrwiyagxzl8zlx3dafb0ay8l14ib7imb2rsmx70i5cp420v8gif";
+      type = "gem";
+    };
+    version = "1.3.2";
+  };
+  email_reply_trimmer = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pnirdmkh7cpss5vvlh7rbmihcx72mjpsb4y1bjil64ig433lpm1";
+      type = "gem";
+    };
+    version = "0.1.12";
+  };
+  ember-data-source = {
+    dependencies = ["ember-source"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1803nh3knvwl12h63jd48qvbbrp42yy291wcb35960daklip0fd8";
+      type = "gem";
+    };
+    version = "3.0.2";
+  };
+  ember-handlebars-template = {
+    dependencies = ["barber" "sprockets"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wxj3vi4xs3vjxrdbzi4j4w6vv45r5dkz2rg2ldid3p8dp3irlf4";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  ember-rails = {
+    dependencies = ["active_model_serializers" "ember-data-source" "ember-handlebars-template" "ember-source" "jquery-rails" "railties"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "059qrwjlq6zba8g86y3mkav95vzr8hadvn6sajvid1vn6bgj31lb";
+      type = "gem";
+    };
+    version = "0.18.5";
+  };
+  ember-source = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0sixy30ym9j2slhlr0lfq943g958w8arlb0lsizh59iv1w5gmxxy";
+      type = "gem";
+    };
+    version = "2.18.2";
+  };
+  erubi = {
+    groups = ["default" "development" "test"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nwzxnqhr31fn7nbqmffcysvxjdfl3bhxi0bld5qqhcnfc1xd13x";
+      type = "gem";
+    };
+    version = "1.9.0";
+  };
+  excon = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vhc5c16i8zrm3d98ppsnw514d7jvwdg0wk60kc9i1xw3797qkkd";
+      type = "gem";
+    };
+    version = "0.72.0";
+  };
+  execjs = {
+    groups = ["assets" "default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yz55sf2nd3l666ms6xr18sm2aggcvmb8qr3v53lr4rir32y1yp1";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  exifr = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0q2abhiyvgfv23i0izbskjxcqaxiw9bfg6s57qgn4li4yxqpwpfg";
+      type = "gem";
+    };
+    version = "1.3.6";
+  };
+  fabrication = {
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1z2v6j3dlv6laldky9364696d1wcg3smz5h9zm6ax0d404hpl4n6";
+      type = "gem";
+    };
+    version = "2.21.0";
+  };
+  fakeweb = {
+    groups = ["test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1a09z9nb369bvwpghncgd5y4f95lh28w0q258srh02h22fz9dj8y";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+  faraday = {
+    dependencies = ["multipart-post"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13aghksmni2sl15y7wfpx6k5l3lfd8j9gdyqi6cbw6jgc7bqyyn2";
+      type = "gem";
+    };
+    version = "0.17.3";
+  };
+  fast_blank = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16s1ilyvwzmkcgmklbrn0c2pch5n02vf921njx0bld4crgdr6z56";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  fast_xor = {
+    dependencies = ["rake" "rake-compiler"];
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n1p3bvvj92p38rgddrnxyhbxp1jlx6ky4r3fdzva8jg3z3wlpli";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  fast_xs = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1iydzaqmvqq7ncxkr182aybkk6xap0cb2w9amr73vbdxi2qf3wjz";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  fastimage = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06lgsy1zdkhhgd9w1c0nb7v9d38mljwz13n6gi3acbzkhz1sf642";
+      type = "gem";
+    };
+    version = "2.1.7";
+  };
+  ffi = {
+    groups = ["default" "development" "test"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10lfhahnnc91v63xpvk65apn61pib086zha3z5sp1xk9acfx12h4";
+      type = "gem";
+    };
+    version = "1.12.2";
+  };
+  flamegraph = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1p785nmhdzbwj0qpxn5fzrmr4kgimcds83v4f95f387z6w3050x6";
+      type = "gem";
+    };
+    version = "0.9.5";
+  };
+  fspath = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xcxikkrjv8ws328nn5ax5pyfjs8pn7djg1hks7qyb3yp6prpb5m";
+      type = "gem";
+    };
+    version = "3.1.2";
+  };
+  gc_tracer = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yv3mp8lx74lfzs04fd5h4g89209iwhzpc407y35p7cmzgx6a4kv";
+      type = "gem";
+    };
+    version = "1.5.1";
+  };
+  globalid = {
+    dependencies = ["activesupport"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zkxndvck72bfw235bd9nl2ii0lvs5z88q14706cmn702ww2mxv1";
+      type = "gem";
+    };
+    version = "0.4.2";
+  };
+  guess_html_encoding = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16700fk6kmif3q3kpc1ldhy3nsc9pkxlgl8sqhznff2zjj5lddna";
+      type = "gem";
+    };
+    version = "0.0.11";
+  };
+  hashdiff = {
+    groups = ["default" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18jqpbvidrlnq3xf0hkdbs00607jgz35lry6gjw4bcxgh52am2mk";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  hashie = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13bdzfp25c8k51ayzxqkbzag3wj5gc1jd8h7d985nsq6pn57g5xh";
+      type = "gem";
+    };
+    version = "3.6.0";
+  };
+  highline = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01ib7jp85xjc4gh4jg0wyzllm46hwv8p0w1m4c75pbgi41fps50y";
+      type = "gem";
+    };
+    version = "1.7.10";
+  };
+  hkdf = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04fixg0a51n4vy0j6c1hvisa2yl33m3jrrpxpb5sq6j511vjriil";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  htmlentities = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nkklqsn8ir8wizzlakncfv42i32wc0w9hxp00hvdlgjr7376nhj";
+      type = "gem";
+    };
+    version = "4.3.4";
+  };
+  http_accept_language = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0d0nlfz9vm4jr1l6q0chx4rp2hrnrfbx3gadc1dz930lbbaz0hq0";
+      type = "gem";
+    };
+    version = "2.1.1";
+  };
+  i18n = {
+    dependencies = ["concurrent-ruby"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jwrd1l4mxz06iyx6053lr6hz2zy7ah2k3ranfzisvych5q19kwm";
+      type = "gem";
+    };
+    version = "1.8.2";
+  };
+  image_size = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zrn2mqaf1kk548wn1y35i1a6kwh3320q62m929kn9m8sqpy4fk7";
+      type = "gem";
+    };
+    version = "1.5.0";
+  };
+  in_threads = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m71806p1gm4kxiz4gvkyr8qip16hifn2kdf926jz44jj6kc6bbs";
+      type = "gem";
+    };
+    version = "1.5.4";
+  };
+  jaro_winkler = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1y8l6k34svmdyqxya3iahpwbpvmn3fswhwsvrz0nk1wyb8yfihsh";
+      type = "gem";
+    };
+    version = "1.5.4";
+  };
+  jmespath = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d4wac0dcd1jf6kc57891glih9w57552zgqswgy74d1xhgnk0ngf";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  jquery-rails = {
+    dependencies = ["rails-dom-testing" "railties" "thor"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wr6302mvj701skpy5iap4zdnjk6k77cvdjr6xw8bil2lsv5zvqq";
+      type = "gem";
+    };
+    version = "4.3.5";
+  };
+  jwt = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01zg1vp3lyl3flyjdkrcc93ghf833qgfgh2p1biqfhkzz11r129c";
+      type = "gem";
+    };
+    version = "2.2.1";
+  };
+  kgio = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ai6bzlvxbzpdl466p1qi4dlhx8ri2wcrp6x1l19y3yfs3a29rng";
+      type = "gem";
+    };
+    version = "2.11.3";
+  };
+  libv8 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jivcckillfvd4n2jnsnnlf93z3gpvqbwsczs0fvv9hc90zpj7yh";
+      type = "gem";
+    };
+    version = "7.3.492.27.1";
+  };
+  listen = {
+    dependencies = ["rb-fsevent" "rb-inotify"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1w923wmdi3gyiky0asqdw5dnh3gcjs2xyn82ajvjfjwh6sn0clgi";
+      type = "gem";
+    };
+    version = "3.2.1";
+  };
+  lograge = {
+    dependencies = ["actionpack" "activesupport" "railties" "request_store"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vrjm4yqn5l6q5gsl72fmk95fl6j9z1a05gzbrwmsm3gp1a1bgac";
+      type = "gem";
+    };
+    version = "0.11.2";
+  };
+  logstash-event = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bk7fhhryjxp1klr3hq6i6srrc21wl4p980bysjp0w66z9hdr9w9";
+      type = "gem";
+    };
+    version = "1.2.02";
+  };
+  logstash-logger = {
+    dependencies = ["logstash-event"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nh0jgz4rl46axqb9l0fa866kh34wb7yf11qc3j30xhprdqb8yjp";
+      type = "gem";
+    };
+    version = "0.26.1";
+  };
+  logster = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1aysr9a4f2dnbbvm1jclrahz8gslcxj1q5b5y2hzq9ld3mn682is";
+      type = "gem";
+    };
+    version = "2.6.3";
+  };
+  loofah = {
+    dependencies = ["crass" "nokogiri"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g7ps9m3s14cajhxrfgbzahv9i3gy47s4hqrv3mpybpj5cyr0srn";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  lru_redux = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yxghzg7476sivz8yyr9nkak2dlbls0b89vc2kg52k0nmg6d0wgf";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  lz4-ruby = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12fymsvcb9kw6ycyfzc8b9svriq0afqf1qnl121xrz8c4gpfa6q1";
+      type = "gem";
+    };
+    version = "0.3.3";
+  };
+  mail = {
+    dependencies = ["mini_mime"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00wwz6ys0502dpk8xprwcqfwyf3hmnx6lgxaiq6vj43mkx43sapc";
+      type = "gem";
+    };
+    version = "2.7.1";
+  };
+  maxminddb = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zlhqilyggiryywgswfi624bv10qnkm66hggmg79vvgv73j3p4sh";
+      type = "gem";
+    };
+    version = "0.1.22";
+  };
+  memory_profiler = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04ivhv1bilwqm33jv28gar2vwzsichb5nipaq395d3axabv8qmfy";
+      type = "gem";
+    };
+    version = "0.9.14";
+  };
+  message_bus = {
+    dependencies = ["rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pmj53frgffshbi1vpgbk8g98fsv1cmad357qs7wfdsg83wlycyp";
+      type = "gem";
+    };
+    version = "2.2.3";
+  };
+  metaclass = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hp99y2b1nh0nr8pc398n3f8lakgci6pkrg4bf2b2211j1f6hsc5";
+      type = "gem";
+    };
+    version = "0.0.4";
+  };
+  method_source = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pviwzvdqd90gn6y7illcdd9adapw8fczml933p5vl739dkvl3lq";
+      type = "gem";
+    };
+    version = "0.9.2";
+  };
+  mini_mime = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1axm0rxyx3ss93wbmfkm78a6x03l8y4qy60rhkkiq0aza0vwq3ha";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
+  mini_portile2 = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15zplpfw3knqifj9bpf604rb3wc1vhq6363pd6lvhayng8wql5vy";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  mini_racer = {
+    dependencies = ["libv8"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zi36qcg5qj4g1c11vwmc7lknjihirrmc6yxi6q8j6v4lfnyjbyg";
+      type = "gem";
+    };
+    version = "0.2.9";
+  };
+  mini_scheduler = {
+    dependencies = ["sidekiq"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0whdxzqssb7mfw3lhbckfd2wxyyhxwh1m3z434glzcv40fqxdzlp";
+      type = "gem";
+    };
+    version = "0.12.2";
+  };
+  mini_sql = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0010rl8bmp1y88bh8jqqxh0dssy6vbs4z68wb3jcz1975zzmx480";
+      type = "gem";
+    };
+    version = "0.2.4";
+  };
+  mini_suffix = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bxd1fgzb20gvfvhbkrxym9fr7skm5x6fzvqfg4a0jijb34ww50h";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  minitest = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0g73x65hmjph8dg1h3rkzfg7ys3ffxm35hj35grw75fixmq53qyz";
+      type = "gem";
+    };
+    version = "5.14.0";
+  };
+  mocha = {
+    dependencies = ["metaclass"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12aglpiq1h18j5a4rlwvnsvnsi2f3407v5xm59lgcg3ymlyak4al";
+      type = "gem";
+    };
+    version = "1.8.0";
+  };
+  mock_redis = {
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1dwm7vv9xwzig0zy9wm6n9bcg1lsnkxil21nk1h7imqsnz8hm4gy";
+      type = "gem";
+    };
+    version = "0.22.0";
+  };
+  msgpack = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lva6bkvb4mfa0m3bqn4lm4s4gi81c40jvdcsrxr6vng49q9daih";
+      type = "gem";
+    };
+    version = "1.3.3";
+  };
+  multi_json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xy54mjf7xg41l8qrg1bqri75agdqmxap9z466fjismc1rn2jwfr";
+      type = "gem";
+    };
+    version = "1.14.1";
+  };
+  multi_xml = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lmd4f401mvravi1i1yq7b2qjjli0yq7dfc4p1nj5nwajp7r6hyj";
+      type = "gem";
+    };
+    version = "0.6.0";
+  };
+  multipart-post = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zgw9zlwh2a6i1yvhhc4a84ry1hv824d6g2iw2chs3k5aylpmpfj";
+      type = "gem";
+    };
+    version = "2.1.1";
+  };
+  mustache = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1l0p4wx15mi3wnamfv92ipkia4nsx8qi132c6g51jfdma3fiz2ch";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  nio4r = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gnmvbryr521r135yz5bv8354m7xn6miiapfgpg1bnwsvxz8xj6c";
+      type = "gem";
+    };
+    version = "2.5.2";
+  };
+  nokogiri = {
+    dependencies = ["mini_portile2"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yi8j8hwrlc3rg5v3w52gxndmwifyk7m732q9yfbal0qajqbh1h8";
+      type = "gem";
+    };
+    version = "1.10.8";
+  };
+  nokogumbo = {
+    dependencies = ["nokogiri"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0sxjnpjvrn10gdmfw2dimhch861lz00f28hvkkz0b1gc2rb65k9s";
+      type = "gem";
+    };
+    version = "2.0.2";
+  };
+  oauth = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zszdg8q1b135z7l7crjj234k4j0m347hywp5kj6zsq7q78pw09y";
+      type = "gem";
+    };
+    version = "0.5.4";
+  };
+  oauth2 = {
+    dependencies = ["faraday" "jwt" "multi_json" "multi_xml" "rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15i9z4j5pcjkr30lkcd79xzbr4kpmy0bqgwa436fqyqk646fv036";
+      type = "gem";
+    };
+    version = "1.4.2";
+  };
+  oj = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zbpfrmdmjj1k4bwyw8z41jakckziqv476hgw0b778mhsj3m1ff5";
+      type = "gem";
+    };
+    version = "3.10.2";
+  };
+  omniauth = {
+    dependencies = ["hashie" "rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1p16h1rp8by05k8gfw17xjhgwp60dk8qmj1xalv1n23kmxfsxb1x";
+      type = "gem";
+    };
+    version = "1.9.0";
+  };
+  omniauth-facebook = {
+    dependencies = ["omniauth-oauth2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vvmg0c3faqlfav8i2albc114hjcj8zd68kyand3cd20slidj4cw";
+      type = "gem";
+    };
+    version = "6.0.0";
+  };
+  omniauth-github = {
+    dependencies = ["omniauth" "omniauth-oauth2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xbk0dbxqfpyfb33ghz6vrlz3m6442rp18ryf13gwzlnifcawhlb";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  omniauth-google-oauth2 = {
+    dependencies = ["jwt" "omniauth" "omniauth-oauth2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17pgqasl048irs2c6w6g57zvk0ygb5ml1krwir4qi4b6y53zyr55";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  omniauth-instagram = {
+    dependencies = ["omniauth" "omniauth-oauth2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07vgcjsl2q3zcpvkzsq4nx0blxnklb1dp9va4dj9sw8jk3v5w3ap";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+  omniauth-oauth = {
+    dependencies = ["oauth" "omniauth"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n5vk4by7hkyc09d9blrw2argry5awpw4gbw1l4n2s9b3j4qz037";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  omniauth-oauth2 = {
+    dependencies = ["oauth2" "omniauth"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11mi36l9d97r77q99jnafdc1yaa0a9wahhpp7dj7ank8q52g7g79";
+      type = "gem";
+    };
+    version = "1.6.0";
+  };
+  omniauth-twitter = {
+    dependencies = ["omniauth-oauth" "rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0r5j65hkpgzhvvbs90id3nfsjgsad6ymzggbm7zlaxvnrmvnrk65";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  onebox = {
+    dependencies = ["addressable" "htmlentities" "multi_json" "mustache" "nokogiri" "sanitize"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1syk5p77ang6ys2dyxci0qbah43zaj8w11qb5xn62vbi1sc319rb";
+      type = "gem";
+    };
+    version = "1.9.26";
+  };
+  openssl-signature_algorithm = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04lna7i0m3yyahrwf7y0sjcy3k0zgj2m5b046l6vnrag53p06h0h";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  optimist = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05jxrp3nbn5iilc1k7ir90mfnwc5abc9h78s5rpm3qafwqxvcj4j";
+      type = "gem";
+    };
+    version = "3.0.0";
+  };
+  parallel = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12jijkap4akzdv11lm08dglsc8jmc87xcgq6947i1s3qb69f4zn2";
+      type = "gem";
+    };
+    version = "1.19.1";
+  };
+  parallel_tests = {
+    dependencies = ["parallel"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0r7hnf676m6jh42kimganrg9wlcsgwrpf7bmx1z5p01prqnv5i7c";
+      type = "gem";
+    };
+    version = "2.31.0";
+  };
+  parser = {
+    dependencies = ["ast"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "145lv6rbbnbddbk79l10kadycjq05vyrzq5d733zswmypshpq6ni";
+      type = "gem";
+    };
+    version = "2.7.0.2";
+  };
+  pg = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1r01bqqhnk272dsyhg3cqx6j0aiwbcdnrwp7vxzc969mb5dgnnrl";
+      type = "gem";
+    };
+    version = "1.2.2";
+  };
+  progress = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pm3bv5n8c8j0vfm7wghd7xf6yq4m068cksxjldmna11qi0h0s8s";
+      type = "gem";
+    };
+    version = "3.5.2";
+  };
+  pry = {
+    dependencies = ["coderay" "method_source"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00rm71x0r1jdycwbs83lf9l6p494m99asakbvqxh8rz7zwnlzg69";
+      type = "gem";
+    };
+    version = "0.12.2";
+  };
+  pry-nav = {
+    dependencies = ["pry"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fbvr7g8dh80bhshzzarxw2qvylm5rh7fbxa4pr9ddja9bwkjj3f";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  pry-rails = {
+    dependencies = ["pry"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cf4ii53w2hdh7fn8vhqpzkymmchjbwij4l3m7s6fsxvb9bn51j6";
+      type = "gem";
+    };
+    version = "0.3.9";
+  };
+  public_suffix = {
+    groups = ["default" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1c6kq6s13idl2036b5lch8r7390f8w82cal8hcp4ml76fm2vdac7";
+      type = "gem";
+    };
+    version = "4.0.3";
+  };
+  puma = {
+    dependencies = ["nio4r"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0v6zai6sinw5r1lchm278mm3dr8x5vi8pwmybwv9lz1kz02fk2g3";
+      type = "gem";
+    };
+    version = "4.3.1";
+  };
+  r2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wk0p55zp3l96xy5ps28b33dn5z0jwsjl74bwfdn6z81pzjs5sfk";
+      type = "gem";
+    };
+    version = "0.2.7";
+  };
+  rack = {
+    groups = ["default" "development" "test"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1id0jsslx1ipv0pbqjfn7mjbb2vx2xybk7qypq59a17163xp30gr";
+      type = "gem";
+    };
+    version = "2.0.8";
+  };
+  rack-mini-profiler = {
+    dependencies = ["rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zpklq5835y8224vavq739b1ylgmfm10cdr8cl0vqph54ycq5gsx";
+      type = "gem";
+    };
+    version = "1.1.6";
+  };
+  rack-protection = {
+    dependencies = ["rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zyj97bfr1shfgwk4ddmdbw0mdkm4qdyh9s1hl0k7accf3kxx1yi";
+      type = "gem";
+    };
+    version = "2.0.8.1";
+  };
+  rack-test = {
+    dependencies = ["rack"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rh8h376mx71ci5yklnpqqn118z3bl67nnv5k801qaqn1zs62h8m";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  rails-dom-testing = {
+    dependencies = ["activesupport" "nokogiri"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lfq2a7kp2x64dzzi5p4cjcbiv62vxh9lyqk2f0rqq3fkzrw8h5i";
+      type = "gem";
+    };
+    version = "2.0.3";
+  };
+  rails-html-sanitizer = {
+    dependencies = ["loofah"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1icpqmxbppl4ynzmn6dx7wdil5hhq6fz707m9ya6d86c7ys8sd4f";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+  rails_multisite = {
+    dependencies = ["activerecord" "railties"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qrnqk4glqssh0vp9d22jh019h8idpv2d4j0aa2gzywkz14i9fmi";
+      type = "gem";
+    };
+    version = "2.0.7";
+  };
+  railties = {
+    dependencies = ["actionpack" "activesupport" "method_source" "rake" "thor"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xs082hz441x93fzc5x0zkspvi7cjmbs31cwfznk4hnwv3dwrm05";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  rainbow = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bb2fpjspydr6x0s8pn1pqkzmxszvkfapv0p4627mywl7ky4zkhk";
+      type = "gem";
+    };
+    version = "3.0.0";
+  };
+  raindrops = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zjja00mzgx2lddb7qrn14k7qrnwhf4bpmnlqj78m1pfxh7svync";
+      type = "gem";
+    };
+    version = "0.19.1";
+  };
+  rake = {
+    groups = ["default" "development" "test"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0w6qza25bq1s825faaglkx1k6d59aiyjjk3yw3ip5sb463mhhai9";
+      type = "gem";
+    };
+    version = "13.0.1";
+  };
+  rake-compiler = {
+    dependencies = ["rake"];
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0l4hg21v0phfrfsc2hilgmwvn2imxr0byqh8dv16bya1s5d3km0q";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  rb-fsevent = {
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lm1k7wpz69jx7jrc92w3ggczkjyjbfziq5mg62vjnxmzs383xx8";
+      type = "gem";
+    };
+    version = "0.10.3";
+  };
+  rb-inotify = {
+    dependencies = ["ffi"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jm76h8f8hji38z3ggf4bzi8vps6p7sagxn3ab57qc0xyga64005";
+      type = "gem";
+    };
+    version = "0.10.1";
+  };
+  rbtrace = {
+    dependencies = ["ffi" "msgpack" "optimist"];
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lwsq08i0aj8na5q5ba3gg02sx3wl58fi6m52svl5p7cy56ycdwi";
+      type = "gem";
+    };
+    version = "0.4.11";
+  };
+  rchardet = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1isj1b3ywgg2m1vdlnr41lpvpm3dbyarf1lla4dfibfmad9csfk9";
+      type = "gem";
+    };
+    version = "1.8.0";
+  };
+  redis = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08v2y91q1pmv12g9zsvwj66w3s8j9d82yrmxgyv4y4gz380j3wyh";
+      type = "gem";
+    };
+    version = "4.1.3";
+  };
+  redis-namespace = {
+    dependencies = ["redis"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wb4x8bg2d0plv3izpmi1sd7nd1ix8nxw7b43hd9bac08f4w62mx";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  request_store = {
+    dependencies = ["rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cx74kispmnw3ljwb239j65a2j14n8jlsygy372hrsa8mxc71hxi";
+      type = "gem";
+    };
+    version = "1.5.0";
+  };
+  rexml = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mkvkcw9fhpaizrhca0pdgjcrbns48rlz4g6lavl5gjjq3rk2sq3";
+      type = "gem";
+    };
+    version = "3.2.4";
+  };
+  rinku = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zcdha17s1wzxyc5814j6319wqg33jbn58pg6wmxpws36476fq4b";
+      type = "gem";
+    };
+    version = "2.0.6";
+  };
+  rotp = {
+    dependencies = ["addressable"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0agqbrjm2w7bk10mxkn21jj20d3n0wc2z1a029vk70xjhhpahvny";
+      type = "gem";
+    };
+    version = "5.1.0";
+  };
+  rqrcode = {
+    dependencies = ["chunky_png" "rqrcode_core"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06lw8b6wfshxd61xw98xyp1a0zsz6av4nls2c9fwb7q59wb05sci";
+      type = "gem";
+    };
+    version = "1.1.2";
+  };
+  rqrcode_core = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jq5hbk7lhc6iwilppbra41jraavgakv763nw2kngvhdpiif9qvp";
+      type = "gem";
+    };
+    version = "0.1.1";
+  };
+  rspec = {
+    dependencies = ["rspec-core" "rspec-expectations" "rspec-mocks"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hzsig4pi9ybr0xl5540m1swiyxa74c8h09225y5sdh2rjkkg84h";
+      type = "gem";
+    };
+    version = "3.9.0";
+  };
+  rspec-core = {
+    dependencies = ["rspec-support"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1qzc1wdjb1qnbimjl8i1q1r1z5hdv2lmcw7ysz7jawj4d1cvpqvd";
+      type = "gem";
+    };
+    version = "3.9.1";
+  };
+  rspec-expectations = {
+    dependencies = ["diff-lcs" "rspec-support"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gjqfb39da6gywdcp4h77738r7khbrn2v4y45589z25bj4z9paf0";
+      type = "gem";
+    };
+    version = "3.9.0";
+  };
+  rspec-html-matchers = {
+    dependencies = ["nokogiri" "rspec"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00k8k0a8a6ccxbmk8xq5xm6m90140rqcjrv33y1ndnc8kmzlfx8l";
+      type = "gem";
+    };
+    version = "0.9.2";
+  };
+  rspec-mocks = {
+    dependencies = ["diff-lcs" "rspec-support"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19vmdqym1v2g1zbdnq37zwmyj87y9yc9ijwc8js55igvbb9hx0mr";
+      type = "gem";
+    };
+    version = "3.9.1";
+  };
+  rspec-rails = {
+    dependencies = ["actionpack" "activesupport" "railties" "rspec-core" "rspec-expectations" "rspec-mocks" "rspec-support"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1a2f8c8v90kbw703b7347jcbad2w25aj2gr0fxr2kk6pmf6ak2ka";
+      type = "gem";
+    };
+    version = "4.0.0.beta2";
+  };
+  rspec-support = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zwpyq1na23pvgacpxs2v9nwfbjbw6x3arca5j3l1xagigqmzhc3";
+      type = "gem";
+    };
+    version = "3.9.2";
+  };
+  rtlit = {
+    groups = ["assets"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0srfh7cl95srjiwbyc9pmn3w739zlvyj89hyj0bm7g92zrsd27qm";
+      type = "gem";
+    };
+    version = "0.0.5";
+  };
+  rubocop = {
+    dependencies = ["jaro_winkler" "parallel" "parser" "rainbow" "rexml" "ruby-progressbar" "unicode-display_width"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0adfpv76whv5dy5wr5brqkki39jfv6r08482saj64h9j4wzwcznb";
+      type = "gem";
+    };
+    version = "0.80.0";
+  };
+  rubocop-discourse = {
+    dependencies = ["rubocop"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cgg660k25w926np4835ad1d5nc3s07ay8y147bqjm5zg690qg17";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
+  ruby-prof = {
+    groups = ["development"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xldkd1sh512sic9xsy9w5ah3gnzbw2vzzvah0wv1l33nnzbhwyw";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+  ruby-progressbar = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k77i0d4wsn23ggdd2msrcwfy0i376cglfqypkk2q77r2l3408zf";
+      type = "gem";
+    };
+    version = "1.10.1";
+  };
+  ruby-readability = {
+    dependencies = ["guess_html_encoding" "nokogiri"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15ivhbry7hf82lww1bzcrwfyjymijfb3rb0wdd32g2z0942wdspa";
+      type = "gem";
+    };
+    version = "0.7.0";
+  };
+  rubyzip = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13b15icwx0c8zzjfzf7bmqq9ynilw0dy8ydgjb199nqzp93p6wqv";
+      type = "gem";
+    };
+    version = "2.2.0";
+  };
+  safe_yaml = {
+    groups = ["default" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0j7qv63p0vqcd838i2iy2f76c3dgwzkiz1d1xkg7n0pbnxj2vb56";
+      type = "gem";
+    };
+    version = "1.0.5";
+  };
+  sanitize = {
+    dependencies = ["crass" "nokogiri" "nokogumbo"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1h9y9fn1dm27a3rgva4rkakp8nhxxz80dh1qncipb07mq041m3qp";
+      type = "gem";
+    };
+    version = "5.1.0";
+  };
+  sassc = {
+    dependencies = ["ffi" "rake"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sr4825rlwsrl7xrsm0sgalcpf5zgp4i56dbi3qxfa9lhs8r6zh4";
+      type = "gem";
+    };
+    version = "2.0.1";
+  };
+  sassc-rails = {
+    dependencies = ["railties" "sassc" "sprockets" "sprockets-rails" "tilt"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d9djmwn36a5m8a83bpycs48g8kh1n2xkyvghn7dr6zwh4wdyksz";
+      type = "gem";
+    };
+    version = "2.1.2";
+  };
+  seed-fu = {
+    dependencies = ["activerecord" "activesupport"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0y7lzcshsq6i20qn1p8zczir4fivr6nbl1km91ns320vvh92v43d";
+      type = "gem";
+    };
+    version = "2.3.9";
+  };
+  shoulda-matchers = {
+    dependencies = ["activesupport"];
+    groups = ["development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09hj7bvksxbfwaw7zi9a208fdjlx946ybssz3mmgcglaghc892z6";
+      type = "gem";
+    };
+    version = "4.3.0";
+  };
+  sidekiq = {
+    dependencies = ["connection_pool" "rack" "rack-protection" "redis"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "14vyjlf8rs0p595ndq3lin4d4pszp6k9frnrxgp9ajznpmm9721c";
+      type = "gem";
+    };
+    version = "6.0.5";
+  };
+  simplecov = {
+    dependencies = ["docile" "simplecov-html"];
+    groups = ["test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0i5vmd7mf38rbpz9r58ssxi65629xaav3496hr6rvgydj7cpqfjg";
+      type = "gem";
+    };
+    version = "0.18.3";
+  };
+  simplecov-html = {
+    groups = ["default" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zvz82l99iq6h3j5l61s653z0dvp11x8qr3pbr3h8ycpj911md69";
+      type = "gem";
+    };
+    version = "0.12.1";
+  };
+  sprockets = {
+    dependencies = ["concurrent-ruby" "rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "182jw5a0fbqah5w9jancvfmjbk88h8bxdbwnl4d3q809rpxdg8ay";
+      type = "gem";
+    };
+    version = "3.7.2";
+  };
+  sprockets-rails = {
+    dependencies = ["actionpack" "activesupport" "sprockets"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ab42pm8p5zxpv3sfraq45b9lj39cz9mrpdirm30vywzrwwkm5p1";
+      type = "gem";
+    };
+    version = "3.2.1";
+  };
+  sshkey = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "03bkn55qsng484iqwz2lmm6rkimj01vsvhwk661s3lnmpkl65lbp";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  stackprof = {
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g2zzasjdr1qnwmpmn28ddv2z9jsnv4w5raiz26y9h1jh03sagqd";
+      type = "gem";
+    };
+    version = "0.2.15";
+  };
+  test-prof = {
+    groups = ["test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1dg670hadjaywps0f2k9srbwvf580j243f710hyqck7wal9z5mgf";
+      type = "gem";
+    };
+    version = "0.11.3";
+  };
+  thor = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xbhkmyhlxwzshaqa7swy2bx6vd64mm0wrr8g3jywvxy7hg0cwkm";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+  thread_safe = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nmhcgq6cgz44srylra07bmaw99f5271l0dpsvl5f75m44l0gmwy";
+      type = "gem";
+    };
+    version = "0.3.6";
+  };
+  tilt = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rn8z8hda4h41a64l0zhkiwz2vxw9b1nb70gl37h1dg2k874yrlv";
+      type = "gem";
+    };
+    version = "2.0.10";
+  };
+  tzinfo = {
+    dependencies = ["thread_safe"];
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04f18jdv6z3zn3va50rqq35nj3izjpb72fnf21ixm7vanq6nc4fp";
+      type = "gem";
+    };
+    version = "1.2.6";
+  };
+  uglifier = {
+    dependencies = ["execjs"];
+    groups = ["assets"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wgh7bzy68vhv9v68061519dd8samcy8sazzz0w3k8kqpy3g4s5f";
+      type = "gem";
+    };
+    version = "4.2.0";
+  };
+  unf = {
+    dependencies = ["unf_ext"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bh2cf73i2ffh4fcpdn9ir4mhq8zi50ik0zqa1braahzadx536a9";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+  unf_ext = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1ll6w64ibh81qwvjx19h8nj7mngxgffg7aigjx11klvf5k2g4nxf";
+      type = "gem";
+    };
+    version = "0.0.7.6";
+  };
+  unicode-display_width = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pppclzq4qb26g321553nm9xqca3zgllvpwb2kqxsdadwj51s09x";
+      type = "gem";
+    };
+    version = "1.6.1";
+  };
+  unicorn = {
+    dependencies = ["kgio" "raindrops"];
+    groups = ["default"];
+    platforms = [{
+      engine = "maglev";
+    } {
+      engine = "ruby";
+    }];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xnr2fp7rdbzxniifymmxaimp5lp2mmnl98kka5cmsjyd69balq1";
+      type = "gem";
+    };
+    version = "5.5.3";
+  };
+  uniform_notifier = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vm4aix8jmv42s1x58m3lj3xwkbxyn9qn6lzhhig0d1j8fv6j30c";
+      type = "gem";
+    };
+    version = "1.13.0";
+  };
+  webmock = {
+    dependencies = ["addressable" "crack" "hashdiff"];
+    groups = ["test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vg6rlw6g72047pcsylycfrrnzhgpwv7dgb0vjmz38dkgs0fi7wl";
+      type = "gem";
+    };
+    version = "3.8.2";
+  };
+  webpush = {
+    dependencies = ["hkdf" "jwt"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0risllxidmi22mjlqrw57cp6cbh5n9kifh76mx5i6n1h3c7gmyx0";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  yaml-lint = {
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1m9n4sg7i0334yac7dcrhnhv5rzvrccgnh687n9x77ba3awk4yx1";
+      type = "gem";
+    };
+    version = "0.0.10";
+  };
+  zeitwerk = {
+    groups = ["default" "development" "test"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jywi63w1m2b2w9fj9rjb9n3imf6p5bfijfmml1xzdnsrdrjz0x1";
+      type = "gem";
+    };
+    version = "2.2.2";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1689,6 +1689,8 @@ in
 
   h = callPackage ../tools/misc/h { };
 
+  discourse = callPackage ../servers/web-apps/discourse { };
+
   discount = callPackage ../tools/text/discount { };
 
   diskscan = callPackage ../tools/misc/diskscan { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1690,6 +1690,7 @@ in
   h = callPackage ../tools/misc/h { };
 
   discourse = callPackage ../servers/web-apps/discourse { };
+  discourse-mail-receiver = callPackage ../servers/web-apps/discourse/mail-receiver.nix { };
 
   discount = callPackage ../tools/text/discount { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Discourse NixOS support.

###### Things done

Packaged two main components - rails application and mail forwarding utility.
Rail application has one major problem - it cannot compile javascript assets - `assets:recompile` fails on `SIGTERM` when trying to use `mini_racer`. Ping @zimbatm according to IRC logs.
Assets compilation is now restricted to `css` only. (Btw asset compilation needs database access which is why it is running in `preStart`).

The application also doesn't quite  like running from other places than its root directory so we "abuse" `tmpfiles` to create `/var/lib/discourse` with all the files. I've tried to do this selectively but hit weird errors with rails loader.

Only basic vhost locations are configured and might need improvements according to https://github.com/discourse/discourse/blob/master/config/nginx.sample.conf#L90

###### Things to do

- [ ] Fix javascript asset compilation (`mini_racer SIGTERM`)
- [ ] Improve `nginx` locations
- [ ] Find co-maintainers
- [ ] Consider adding option to enable performance tweaks for pg/redis

###### Formalities

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
