### PR TITLE
khronos-ocl-icd-loader: 6c03f8b -> 2020.03.13

### DIFF
--- a/pkgs/development/libraries/khronos-ocl-icd-loader/default.nix
+++ b/pkgs/development/libraries/khronos-ocl-icd-loader/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchFromGitHub, opencl-clhpp, cmake, withTracing ? false }:
+{ stdenv, fetchFromGitHub, opencl-headers, cmake, withTracing ? false }:
 
 stdenv.mkDerivation rec {
   name = "khronos-ocl-icd-loader-${version}";
-  version = "6c03f8b";
+  version = "2020.03.13";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCL-ICD-Loader";
-    rev = "6c03f8b58fafd9dd693eaac826749a5cfad515f8";
-    sha256 = "00icrlc00dpc87prbd2j1350igi9pbgkz27hc3rf73s5994yn86a";
+    rev = "v${version}";
+    sha256 = "0zk6fyfrklx8a848613rfcx0y4yn0dsxkxzzl9pgdh9i6qdfjj9k";
   };
 
   patches = stdenv.lib.lists.optional withTracing ./tracing.patch;
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ opencl-clhpp ];
+  buildInputs = [ opencl-headers ];
 
   meta = with stdenv.lib; {
     description = "Offical Khronos OpenCL ICD Loader";
-    homepage = https://github.com/KhronosGroup/OpenCL-ICD-Loader;
+    homepage = "https://github.com/KhronosGroup/OpenCL-ICD-Loader";
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = with maintainers; [ davidtwco ];

--- a/pkgs/development/libraries/khronos-ocl-icd-loader/tracing.patch
+++ b/pkgs/development/libraries/khronos-ocl-icd-loader/tracing.patch
@@ -1,10 +1,10 @@
 diff --git a/loader/icd.h b/loader/icd.h
-index a1b6969..cf4e272 100644
+index 34751e9..01a33fd 100644
 --- a/loader/icd.h
 +++ b/loader/icd.h
-@@ -122,7 +122,7 @@ void khrIcdContextPropertiesGetPlatform(
+@@ -123,7 +123,7 @@ void khrIcdContextPropertiesGetPlatform(
      cl_platform_id *outPlatform);
-
+ 
  // internal tracing macros
 -#if 0
 +#if 1

--- a/pkgs/development/libraries/opencl-headers/default.nix
+++ b/pkgs/development/libraries/opencl-headers/default.nix
@@ -1,25 +1,25 @@
 { stdenv, fetchFromGitHub
-, version # "12" for "1.2", "22" for "2.2" and so on
 }:
 
-stdenv.mkDerivation {
-  name = "opencl-headers-${version}-2017-07-18";
+stdenv.mkDerivation rec {
+  name = "opencl-headers-${version}";
+  version = "2020.03.13";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCL-Headers";
-    rev = "f039db6764d52388658ef15c30b2237bbda49803";
-    sha256 = "0z04i330zr8czak2624q71aajdcq7ly8mb5bgala5m235qjpsrh7";
+    rev = "v${version}";
+    sha256 = "1d9ibiwicaj17757h9yyjc9i2hny8d8npn4spbjscins8972z3hw";
   };
 
   installPhase = ''
     mkdir -p $out/include/CL
-    cp opencl${version}/CL/* $out/include/CL
+    cp CL/* $out/include/CL
   '';
 
   meta = with stdenv.lib; {
     description = "Khronos OpenCL headers version ${version}";
-    homepage = https://www.khronos.org/registry/cl/;
+    homepage = "https://www.khronos.org/registry/cl/";
     license = licenses.mit;
     platforms = platforms.unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13820,10 +13820,7 @@ in
     nvidia_x11 = linuxPackages.nvidia_x11.override { libsOnly = true; };
   };
 
-  ocl-icd-oclhGen = oclh: callPackage ../development/libraries/ocl-icd { opencl-headers = oclh; };
-  ocl-icd-oclh_1_2 = ocl-icd-oclhGen opencl-headers_1_2;
-  ocl-icd-oclh_2_2 = ocl-icd-oclhGen opencl-headers_2_2;
-  ocl-icd = ocl-icd-oclh_2_2;
+  ocl-icd = callPackage ../development/libraries/ocl-icd { };
 
   ode = callPackage ../development/libraries/ode { };
 
@@ -13855,10 +13852,7 @@ in
   opencascade = callPackage ../development/libraries/opencascade { };
   opencascade-occt = callPackage ../development/libraries/opencascade-occt { };
 
-  opencl-headersGen = v: callPackage ../development/libraries/opencl-headers { version = v; };
-  opencl-headers_1_2 = opencl-headersGen "12";
-  opencl-headers_2_2 = opencl-headersGen "22";
-  opencl-headers = opencl-headers_2_2;
+  opencl-headers = callPackage ../development/libraries/opencl-headers { };
 
   opencl-clhpp = callPackage ../development/libraries/opencl-clhpp { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Khronos group starts to use tags for release of those repositories:
- https://github.com/KhronosGroup/OpenCL-ICD-Loader
- https://github.com/KhronosGroup/OpenCL-Headers

Use those instead of a “arbitrary” tag in the repo history.

`nix-review` fails on few packages, but as far as I can tell, they are already failing on master:

```bash
$ nix-review wip
32 package marked as broken and skipped:
clang-sierraHack clfswm digitalbitbox gdata-sharp glibcCross linuxPackages_4_4.evdi linuxPackages_hardkernel_4_14.bcc linuxPackages_hardkernel_4_14.can-isotp linuxPackages_hardkernel_4_14.chipsec linuxPackages_hardkernel_4_14.digimend linuxPackages_hardkernel_4_14.evdi linuxPackages_hardkernel_4_14.mba6x_bl linuxPackages_hardkernel_4_14.prl-tools muslCross newlibCross octave-jit php72Packages-unit.php_excel php72Packages.php_excel php73Packages-unit.php_excel php73Packages.php_excel php74Packages-unit.couchbase php74Packages-unit.pcs php74Packages-unit.php_excel php74Packages.couchbase php74Packages.php_excel python27Packages.flitBuildHook python37Packages.nixpart python37Packages.notify python37Packages.pyblock python38Packages.nixpart python38Packages.notify uuagc

15 package failed to build:
airwave arrayfire computecpp computecpp-unwrapped ethash ethminer fluidasserts forge gscan2pdf luxcorerender mandelbulber opencl-info python37Packages.pymc3 python38Packages.pymc3 sasview

82 package built:
beignet blender ccextractor cgminer cl clblas clfft clinfo clmagma darktable driversi686Linux.beignet fahclient fmbt futhark gImageReader hashcat k2pdfopt khronos-ocl-icd-loader leela-zero lutris lutris-free ocl-icd ocrmypdf opencl-clhpp opencl-headers opensubdiv paperless paperwork pdfsandwich pipelight playonlinux pybitmessage python27Packages.Lasagne python27Packages.Theano python27Packages.TheanoWithCuda python27Packages.libgpuarray python27Packages.loo-py python27Packages.pyopencl python27Packages.pytesseract python27Packages.reikna python27Packages.sasmodels python27Packages.tesserocr python37Packages.Theano python37Packages.TheanoWithCuda python37Packages.libgpuarray python37Packages.loo-py python37Packages.paperwork-backend python37Packages.pyocr python37Packages.pyopencl python37Packages.pytesseract python37Packages.reikna python37Packages.sasmodels python37Packages.tesserocr python38Packages.Theano python38Packages.TheanoWithCuda python38Packages.libgpuarray python38Packages.loo-py python38Packages.paperwork-backend python38Packages.pyocr python38Packages.pyopencl python38Packages.pytesseract python38Packages.reikna python38Packages.sasmodels python38Packages.tesserocr qt-box-editor ripgrep-all scallion sdrangel sycl-info tesseract tesseract4 utsushi vobsub2srt waifu2x-converter-cpp wf-recorder wifite2 wine wineStaging wineWowPackages.full winetricks wings xmr-stak
```
###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
