### PR TITLE
nixos/pxe: init (WIP, do not merge)

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -694,6 +694,7 @@
   ./services/networking/prayer.nix
   ./services/networking/privoxy.nix
   ./services/networking/prosody.nix
+  ./services/networking/pxe.nix
   ./services/networking/quagga.nix
   ./services/networking/quassel.nix
   ./services/networking/quorum.nix

--- a/nixos/modules/services/networking/netboot.nix
+++ b/nixos/modules/services/networking/netboot.nix
@@ -1,0 +1,29 @@
+{ config, pkgs, lib }:
+
+let
+  configuration = with lib; {
+    imports = [
+        (pkgs.path + "/nixos/modules/installer/netboot/netboot-minimal.nix")
+    ];
+    ## Some useful options for setting up a new system
+    services.mingetty.autologinUser = mkForce "root";
+    # Enable sshd which gets disabled by netboot-minimal.nix
+    systemd.services.sshd.wantedBy = mkOverride 0 [ "multi-user.target" ];
+    # users.users.root.openssh.authorizedKeys.keys = [ ... ];
+    # i18n.consoleKeyMap = "de";
+  };
+
+  nixos = import (pkgs.path + "/nixos") {
+    inherit configuration;
+    # system = ...;
+  };
+in
+  pkgs.symlinkJoin {
+    name = "netboot";
+    paths = with nixos.config.system.build; [
+      netbootRamdisk
+      kernel
+      netbootIpxeScript
+    ];
+    preferLocalBuild = true;
+  }

--- a/nixos/modules/services/networking/pxe.nix
+++ b/nixos/modules/services/networking/pxe.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.pxe;
+  netboot = pkgs.callPackage ./netboot.nix {};
+in
+{
+  meta.maintainers = with maintainers; [ bbigras ];
+
+  options = {
+    services.pxe = {
+      enable = mkEnableOption "Pxe";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.pixiecore = {
+      enable = true;
+      mode = "boot";
+      kernel = "${netboot}/bzImage";
+      port = 8080;
+      statusPort = 8080;
+    };
+  };
+}


### PR DESCRIPTION
Ignore the first commit. It's from another PR not yet merged.

Can someone tell me why I can call `nix-build -E 'with import <nixpkgs> {}; callPackage ./netboot.nix {}'`fine but if I try to build the module with `nixos-rebuild build` I get:

```
$ sudo nixos-rebuild switch -I nixpkgs=~/nixpkgs
building Nix...
building the system configuration...
error: file '/home/bbigras/nixpkgs/nixos/tests/vde1.ctl/.05386-00000' has an unsupported type
(use '--show-trace' to show detailed location information)
```