### PR TITLE
openssl: remove build-time dependency to host perl

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -102,11 +102,7 @@ let
     '' +
     ''
       mkdir -p $bin
-    '' + stdenv.lib.optionalString (!stdenv.hostPlatform.isWindows)
-    ''
-      substituteInPlace $out/bin/c_rehash --replace ${buildPackages.perl} ${perl}
-    '' +
-    ''
+
       mv $out/bin $bin/
 
       mkdir $dev


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The related code is introduced in #50926 (issue: #50921).
But now the perl script `c_rehash` produced by `openssl.bin` has shebang `#!/usr/bin/env perl`, which means we don't need to substitute it anymore.

Removing the occurrence of `${perl}` in build script also strip the **build-time** dependency to **host-platform** perl, which is actually unused in runtime. This is helpful when cross-compiling openssl, since we don't need to build cross- perl anymore.

Note that this PR produce identical outputs (except hashes) to the current ones.

May fix #19965.

Check build dependencies when cross-compiling:
```shell
> nix-store -q --references ${$(nix-instantiate . -A pkgsCross.armv7l-hf-multiplatform.openssl)%%\!*}
```

Before the PR: (contains `perl-5.30.1-armv7l-unknown-linux-gnueabihf`)
```
/nix/store/9krlzvny65gdc8s7kpb6lkx8cd02c25b-default-builder.sh
/nix/store/31qsz0rjknaycs3rrg7kpps9pvxrwg51-bash-4.4-p23.drv
/nix/store/162gc3835iscp0zlmczcj8rchax7132z-openssl-1.1.1d.tar.gz.drv
/nix/store/3xk9ps0qz073k641b88swpa4fgx3hzwg-nix-ssl-cert-file.patch
/nix/store/nh6rsfggyqkaax1xlp57vf2gq09knd1f-perl-5.30.1.drv
/nix/store/s8d2d9lp6ayywfrrxj9rwmzhivz1k9fg-stdenv-linux.drv
/nix/store/j4rai10q3bm89s8bpnf1lwq2200is792-coreutils-8.31-armv7l-unknown-linux-gnueabihf.drv
/nix/store/6vs0w351nnh4la9ica8z50cxjzn7i5c4-perl-5.30.1-armv7l-unknown-linux-gnueabihf.drv
/nix/store/ciwp1yj92pvlyzx0zygv0nr653658pw6-separate-debug-info.sh
/nix/store/lzmcfv2m4ripknpvbsv8wcg1ik1kif4h-use-etc-ssl-certs.patch
```

After the PR: (perl-arm is gone)
```
/nix/store/9krlzvny65gdc8s7kpb6lkx8cd02c25b-default-builder.sh
/nix/store/31qsz0rjknaycs3rrg7kpps9pvxrwg51-bash-4.4-p23.drv
/nix/store/11jrn0xjyjs1bf88czk70b5rdjalacgp-openssl-1.1.1d.tar.gz.drv
/nix/store/2apmdnpx75brrrrg3i220x0ff2n8lbj0-stdenv-linux.drv
/nix/store/3xk9ps0qz073k641b88swpa4fgx3hzwg-nix-ssl-cert-file.patch
/nix/store/bqmqj4hj6hs3b73v4z6pi3lnc8gcar3a-perl-5.30.1.drv
/nix/store/ciwp1yj92pvlyzx0zygv0nr653658pw6-separate-debug-info.sh
/nix/store/lzmcfv2m4ripknpvbsv8wcg1ik1kif4h-use-etc-ssl-certs.patch
/nix/store/pli8pmqpj3dwfa70zk69gbnpasgpbm9r-coreutils-8.31-armv7l-unknown-linux-gnueabihf.drv
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
     - [x] `openssl`
     - [x] `pkgsCross.armv7l-hf-multiplatform.openssl`
     - [x]
        ```nix
        with import ./. {
          crossSystem = {
             config = "mips-unknown-linux-musl";
             platform.gcc = { abi = "32"; arch = "mips32r2"; };
          };
        }; openssl
        ```
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Identical outputs (except hashes).
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
