### PR TITLE
python3Packages.qiskit-aqua: init at 0.6.5

### DIFF
--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -95,5 +95,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/QISKit/qiskit-aer";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
+    # Doesn't build on aarch64 (libmuparserx issue).
+    # Can fix by building muparserx from source (https://github.com/beltoforion/muparserx)
+    # or in future updates (e.g. Raspberry Pi enabled via https://github.com/Qiskit/qiskit-aer/pull/651 & https://github.com/Qiskit/qiskit-aer/pull/660)
+    platforms = platforms.x86_64;
   };
 }

--- a/pkgs/development/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/development/python-modules/qiskit-aqua/default.nix
@@ -1,0 +1,117 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+, cvxopt
+, dlx
+, docplex
+, fastdtw
+, h5py
+, networkx
+, numpy
+, psutil
+, qiskit-ignis
+, qiskit-terra
+, quandl
+, scikitlearn
+  # Check Inputs
+, parameterized
+, pytestCheckHook
+, qiskit-aer
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-aqua";
+  version = "0.6.5";
+
+  disabled = pythonOlder "3.5";
+
+  # Pypi's tarball doesn't contain tests
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = "qiskit-aqua";
+    rev = version;
+    sha256 = "03c0gl2qxyngf3cccjghjb0bhp0w78sdbvhim08cimf3cd577ldz";
+  };
+
+  # Optional packages: pyscf (see below NOTE) & pytorch. Can install via pip/nix if needed.
+  propagatedBuildInputs = [
+    cvxopt
+    docplex
+    dlx # Python Dancing Links package
+    fastdtw
+    h5py
+    networkx
+    numpy
+    psutil
+    qiskit-terra
+    qiskit-ignis
+    quandl
+    scikitlearn
+  ];
+
+  # *** NOTE ***
+  # We make pyscf optional in this package, due to difficulties packaging it in Nix (test failures, complicated flags, etc).
+  # See nixpkgs#78772, nixpkgs#83447. You are welcome to try to package it yourself,
+  # or use the Nix User Repository version (https://github.com/drewrisinger/nur-packages).
+  # It can also be installed at runtime from the pip wheel.
+  # We disable appropriate tests below to allow building without pyscf installed
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pyscf; sys_platform == 'linux' or (python_version < '3.8' and sys_platform != 'win32')" ""
+
+    # Add ImportWarning when running qiskit.chemistry (pyscf is a chemistry package) that pyscf is not included
+    echo -e "\nimport warnings\ntry: import pyscf;\nexcept:\n    " \
+      "warnings.warn('pyscf is not supported on Nixpkgs so some qiskit features will fail." \
+        "You must install it yourself via pip or add it to your environment from the Nix User Repository." \
+        "See https://github.com/NixOS/nixpkgs/pull/83447 for details', ImportWarning)\n" \
+      >> qiskit/chemistry/__init__.py
+  '';
+
+  checkInputs = [ parameterized qiskit-aer pytestCheckHook ];
+  dontUseSetuptoolsCheck = true;
+  pythonImportsCheck = [
+    "qiskit.aqua"
+    "qiskit.aqua.algorithms"
+    "qiskit.chemistry"
+    "qiskit.finance"
+    "qiskit.ml"
+    "qiskit.optimization"
+  ];
+  pytestFlagsArray = [
+    # Disabled b/c missing pyscf
+    "--ignore=test/chemistry/test_qeom_ee.py"
+    "--ignore=test/chemistry/test_qeom_vqe.py"
+    "--ignore=test/chemistry/test_vqe_uccsd_adapt.py"
+
+    # following tend to be slow tests, all pass
+    "--ignore-glob=*vqc.py"
+    "--ignore-glob=*hhl.py"
+    "--ignore-glob=*qgan.py"
+  ];
+  disabledTests = [
+    # Disabled due to missing pyscf
+    "test_validate" # test/chemistry/test_inputparser.py
+
+    # Disabling slow tests > 1 min
+    "test_qsvm_multiclass_error_correcting_code"
+    "test_vqe_qasm"
+    "test_qgan_training"
+    "test_qgan_training_run_algo_numpy"
+    "test_shor_factoring_0"
+    "test_lookup_rotation_4"
+    "test_lookup_rotation_neg_4"
+    "test_mcrz_11"
+    "test_evolve_1_suzuki"
+    "test_mct_with_dirty_ancillae_15"
+    "test_vqc_with_raw_feature_vector_on_wine"
+  ];
+
+  meta = with lib; {
+    description = "An extensible library of quantum computing algorithms";
+    homepage = "https://github.com/QISKit/qiskit-aqua";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7113,6 +7113,8 @@ in {
 
   qiskit-aer = callPackage ../development/python-modules/qiskit-aer { };
 
+  qiskit-aqua = callPackage ../development/python-modules/qiskit-aqua { };
+
   qiskit-ibmq-provider = callPackage ../development/python-modules/qiskit-ibmq-provider { };
 
   qiskit-ignis = callPackage ../development/python-modules/qiskit-ignis { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Qiskit Aqua: An extensible library of quantum computing algorithms.

This commit follows the new Qiskit scheme of breaking one large package
into smaller packages (terra, aer, etc), and then having a single
meta-package "qiskit" that comprises them.

Broken out of #78772.
Waiting on #83306 #80662 #83372 to pass, builds cleanly when they're cherry-picked.
``python38Packages.qiskit-aqua`` will be broken due to upstream broken ``python38Packages.scikit-build`` (#83305 )

I disabled a lot of tests here, but there's still some 900 that run. So it's pretty well-tested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
