### PR TITLE
python37Packages.marshmallow-polyfield: 5.7 -> 5.9

### DIFF
--- a/pkgs/development/python-modules/marshmallow-polyfield/default.nix
+++ b/pkgs/development/python-modules/marshmallow-polyfield/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "marshmallow-polyfield";
-  version = "5.7";
+  version = "5.9";
 
   src = fetchFromGitHub {
     owner = "Bachmann1234";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     marshmallow
   ];
-  
+
   # setuptools check can run, but won't find tests
   checkInputs = [ pytestCheckHook pytestcov ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bump version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`. **Didn't find dependent ``pythonPackages.qiskit-terra``, but that builds manually.**
- [x] Tested execution of all binary files (usually in `./result/bin/`) **via pytest**
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
