### PR TITLE
Revert "mypy: 0.761 -> 0.770"

### DIFF
--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -5,12 +5,12 @@
 
 buildPythonPackage rec {
   pname = "mypy";
-  version = "0.770";
+  version = "0.761";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1bm40nx9g1n4nj1309cijnh0ns4qbhym3agyl537nc4vxw3paqla";
+    sha256 = "1gw7h84d21wmi267kmgqs9whz0l7rp62pzja2f31wq7cfj6spfl5";
   };
 
   propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];


### PR DESCRIPTION
This reverts commit e7c3e277b621e281c44d5835a97215ec2d2f8739.

See https://github.com/NixOS/nixpkgs/issues/83458

This currently blocks the channel.

We'll put the update back once a proper fix is in place for the new regression.