### PR TITLE
mame: add darwin support

### DIFF
--- a/pkgs/misc/emulators/mame/default.nix
+++ b/pkgs/misc/emulators/mame/default.nix
@@ -1,6 +1,9 @@
 { stdenv, mkDerivation, fetchFromGitHub, makeDesktopItem, makeWrapper
 , python, pkgconfig, SDL2, SDL2_ttf, alsaLib, which, qtbase, libXinerama
+, libpcap, CoreAudioKit, ForceFeedback
 , installShellFiles }:
+
+with stdenv;
 
 let
   majorVersion = "0";
@@ -8,7 +11,7 @@ let
 
   desktopItem = makeDesktopItem {
     name = "MAME";
-    exec = "mame${stdenv.lib.optionalString stdenv.is64bit "64"}";
+    exec = "mame${lib.optionalString stdenv.is64bit "64"}";
     desktopName = "MAME";
     genericName = "MAME is a multi-purpose emulation framework";
     categories = "System;Emulator;";
@@ -27,13 +30,22 @@ in mkDerivation {
   };
 
   hardeningDisable = [ "fortify" ];
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=maybe-uninitialized" ];
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=maybe-uninitialized" "-Wno-error=missing-braces" ];
 
-  makeFlags = [ "TOOLS=1" ];
+  makeFlags = [
+    "TOOLS=1"
+    "USE_LIBSDL=1"
+  ]
+  ++ lib.optionals stdenv.cc.isClang [ "CC=clang" "CXX=clang++" ]
+  ;
 
   dontWrapQtApps = true;
 
-  buildInputs = [ SDL2 SDL2_ttf alsaLib qtbase libXinerama ];
+  buildInputs =
+    [ SDL2 SDL2_ttf qtbase libXinerama ]
+    ++ lib.optional stdenv.isLinux alsaLib
+    ++ lib.optionals stdenv.isDarwin [ libpcap CoreAudioKit ForceFeedback ]
+    ;
   nativeBuildInputs = [ python pkgconfig which makeWrapper installShellFiles ];
 
   # by default MAME assumes that paths with stock resources
@@ -58,16 +70,18 @@ in mkDerivation {
     installManPage ${dest}/docs/man/*.1 ${dest}/docs/man/*.6
 
     mv artwork plugins samples ${dest}
-
+  '' + lib.optionalString stdenv.isLinux ''
     mkdir -p $out/share
     ln -s ${desktopItem}/share/applications $out/share
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Is a multi-purpose emulation framework";
     homepage = https://www.mamedev.org/;
     license = with licenses; [ bsd3 gpl2Plus ];
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = platforms.unix;
+    # makefile needs fixes for install target
+    badPlatforms = [ "aarch64-linux" ];
     maintainers = with maintainers; [ gnidorah ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25517,7 +25517,9 @@ in
     icu = icu58;
   };
 
-  mame = libsForQt5.callPackage ../misc/emulators/mame { };
+  mame = libsForQt5.callPackage ../misc/emulators/mame {
+    inherit (darwin.apple_sdk.frameworks) CoreAudioKit ForceFeedback;
+  };
 
   martyr = callPackage ../development/libraries/martyr { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
