### PR TITLE
buildRustCrate: fewer backslashes

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (rec {
     );
 
     crateFeatures = lib.optionalString (crate ? features)
-      (lib.concatMapStringsSep " " (f: "--cfg feature=\\\"${f}\\\"") (crate.features ++ features));
+      (lib.concatMapStringsSep " " (f: ''--cfg feature=\"${f}\"'') (crate.features ++ features));
 
     libName = if crate ? libName then crate.libName else crate.crateName;
     libPath = if crate ? libPath then crate.libPath else "";


### PR DESCRIPTION
This is a slight readability boost, I think.