### PR TITLE
picard: add optional qtmultimedia dependency

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -1,7 +1,15 @@
-{ stdenv, python3Packages, fetchFromGitHub, gettext, chromaprint, qt5 }:
+{ stdenv, python3Packages, fetchFromGitHub, gettext, chromaprint, qt5
+, enablePlayback ? true
+, gst_all_1
+}:
 
 let
   pythonPackages = python3Packages;
+  pyqt5 = if enablePlayback then
+    pythonPackages.pyqt5_with_qtmultimedia
+  else
+    pythonPackages.pyqt5
+  ;
 in pythonPackages.buildPythonApplication rec {
   pname = "picard";
   version = "2.3.1";
@@ -13,7 +21,16 @@ in pythonPackages.buildPythonApplication rec {
     sha256 = "0xalg4dvaqb396h4s6gzxnplgv1lcvsczmmrlhyrj0kfj10amhsj";
   };
 
-  nativeBuildInputs = [ gettext qt5.wrapQtAppsHook qt5.qtbase ];
+  nativeBuildInputs = [ gettext qt5.wrapQtAppsHook qt5.qtbase ]
+    ++ stdenv.lib.optionals (pyqt5.multimediaEnabled) [
+      qt5.qtmultimedia.bin
+      gst_all_1.gstreamer
+      gst_all_1.gst-vaapi
+      gst_all_1.gst-libav
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+    ]
+  ;
 
   propagatedBuildInputs = with pythonPackages; [
     pyqt5
@@ -31,6 +48,9 @@ in pythonPackages.buildPythonApplication rec {
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   ''
+    + stdenv.lib.optionalString (pyqt5.multimediaEnabled) ''
+      makeWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+    ''
   ;
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -27,10 +27,11 @@ in pythonPackages.buildPythonApplication rec {
     substituteInPlace setup.cfg --replace "‘" "'"
   '';
 
-  installPhase = ''
-    python setup.py install --prefix="$out"
-    wrapQtApp $out/bin/picard
-  '';
+  # In order to spare double wrapping, we use:
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  ''
+  ;
 
   meta = with stdenv.lib; {
     homepage = "https://picard.musicbrainz.org/";

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -80,6 +80,9 @@ in buildPythonPackage rec {
 
   passthru = {
     inherit sip;
+    multimediaEnabled = withMultimedia;
+    webKitEnabled = withWebKit;
+    WebSocketsEnabled = withWebSockets;
   };
 
   configurePhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

~~Enable to~~ Fix this harmless error on startup:

```
W: 11:34:59,057 /nix/store/nhrp6qwqgvk34dvdrm7icalwqdi2h9a2-picard-2.3.1/lib/python3.7/site-packages/picard/ui/playertoolbar.__init__:106: Internal player: unavailable, cannot import name 'QtMultimedia' from 'PyQt5' (/nix/store/y5q9hfgg7pk9khgd0q45bms7gmk9nvnx-python3.7-PyQt5.sip-4.19.18/lib/python3.7/site-packages/PyQt5/__init__.py)
```

And make the integrated media player work.

###### Things done

- [x] Added new `enablePlayback` flag set by default to `false` which adds `qt5.qtmultimedia` to `nativeBuildInputs` and "chooses" the right pyqt5 build flavor.
- [x] Added a `passthru` for `pyqt5` that should be useful to easily indicate packages including it that it has (e.g) `multimediaEnabled`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
