### PR TITLE
xdg-desktop-portal-wlr: init at 0.1.0

### DIFF
--- a/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal-wlr";
-  version = "2020-03-13";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = pname;
-    rev = "dfa0ac704064304824b6d4fea7870d33359dcd15";
-    sha256 = "0k73nyd9z25ph4pc4vpa3xsd49b783qfk1dxqk20bgyg1ln54b81";
+    rev = "v${version}";
+    sha256 = "12k92h9dmn1fyn8nzxk69cyv0gnb7g9gj7a66mw5dcl5zqnl07nc";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig wayland-protocols ];

--- a/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkgconfig, wayland-protocols
+, pipewire, wayland, elogind, systemd, libdrm }:
+
+stdenv.mkDerivation rec {
+  pname = "xdg-desktop-portal-wlr";
+  version = "2020-03-13";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = pname;
+    rev = "dfa0ac704064304824b6d4fea7870d33359dcd15";
+    sha256 = "0k73nyd9z25ph4pc4vpa3xsd49b783qfk1dxqk20bgyg1ln54b81";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig wayland-protocols ];
+  buildInputs = [ pipewire wayland elogind systemd libdrm ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/emersion/xdg-desktop-portal-wlr";
+    description = "xdg-desktop-portal backend for wlroots";
+    maintainers = with maintainers; [ minijackson ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22904,6 +22904,8 @@ in
 
   xdg-desktop-portal-gtk = callPackage ../development/libraries/xdg-desktop-portal-gtk { };
 
+  xdg-desktop-portal-wlr = callPackage ../development/libraries/xdg-desktop-portal-wlr { };
+
   xdg-user-dirs = callPackage ../tools/X11/xdg-user-dirs { };
 
   xdg_utils = callPackage ../tools/X11/xdg-utils {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

In this tiring times, more and more people are using conference calls, some of them being in Sway (me included). It was a sad day when I realised a had to change environments to share my screen. This is an attempt to solve the issue.

By enabling the `pipewire` service, enabling `xdg.portal`, and adding this package to the `xdg.portal.extraPortals`, some applications (including Firefox if `gtkUsePortal` is true), should be able to copy the screen.

Notes:
- This package depends on Pipewire 0.3+, hence why I was branching from/to the staging branch (see pull #81626)
- This package depends on wlroots 0.9.0+, also not currently on NixOS 19.09 (#76787)

I didn't want to rebuild my PC config using the staging branch so I tried to build a VM using the following minimal config, but Firefox was so slow I couldn't test anything :-/

```nix
{ config, pkgs, ... }:

{
  fileSystems."/".label = "vmdisk";
  networking.hostName = "vmHost";

  users.extraUsers.vm = {
    password = "vm";
    shell = "${pkgs.bash}/bin/bash";
    group = "wheel";
    packages = with pkgs; [ firefox-wayland ];
    isNormalUser = true;
  };
  security.sudo = {
    enable = true;
    wheelNeedsPassword = false;
  };

  programs.sway.enable = true;

  xdg.portal = {
    enable = true;
    extraPortals = with pkgs; [ xdg-desktop-portal-wlr ];
    gtkUsePortal = true;
  };

  services.pipewire.enable = true;

  documentation = {
    enable = false;
    nixos.enable = false;
  };
}
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
