### PR TITLE
buildRustCrate: Add "-r" to cp to make it work under Mac OS

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/install-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/install-crate.nix
@@ -14,7 +14,7 @@ if !buildTests then ''
   fi
   if [[ "$(ls -A target/lib)" ]]; then
     mkdir -p $lib/lib
-    cp target/lib/* $lib/lib #*/
+    cp -r target/lib/* $lib/lib #*/
     for library in $lib/lib/*.so $lib/lib/*.dylib; do #*/
       ln -s $library $(echo $library | sed -e "s/-${metadata}//")
     done
@@ -26,7 +26,7 @@ if !buildTests then ''
   if [[ -d target/bin ]]; then
     if [[ "$(ls -A target/bin)" ]]; then
       mkdir -p $out/bin
-      cp -P target/bin/* $out/bin # */
+      cp -rP target/bin/* $out/bin # */
     fi
   fi
   runHook postInstall

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -14,7 +14,6 @@ build_lib() {
     --crate-name $CRATE_NAME \
     $lib_src \
     --out-dir target/lib \
-    --emit=dep-info,link \
     -L dependency=target/deps \
     --cap-lints allow \
     $LIB_RUSTC_OPTS \
@@ -45,7 +44,6 @@ build_bin() {
     --crate-type bin \
     $BIN_RUSTC_OPTS \
     --out-dir target/bin \
-    --emit=dep-info,link \
     -L dependency=target/deps \
     $LINK \
     $EXTRA_LIB \

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -1,13 +1,14 @@
 { lib
-, stdenv
 , buildRustCrate
-, runCommand
-, runCommandCC
-, writeTextFile
-, symlinkJoin
 , callPackage
 , releaseTools
+, runCommand
+, runCommandCC
+, stdenv
+, symlinkJoin
+, writeTextFile
 }:
+
 let
   mkCrate = args: let
     p = {
@@ -102,6 +103,58 @@ let
           ${lib.concatMapStringsSep "\n" (o: "grep '${o}' $out || {  echo 'output \"${o}\" not found in:'; cat $out; exit 23; }") expectedTestOutputs}
         ''
       );
+
+    /* Returns a derivation that asserts that the crate specified by `crateArgs`
+       has the specified files as output.
+
+       `name` is used as part of the derivation name that performs the checking.
+
+       `crateArgs` is passed to `mkCrate` to build the crate with `buildRustCrate`.
+
+       `expectedFiles` contains a list of expected file paths in the output. E.g.
+       `[ "./bin/my_binary" ]`.
+
+       `output` specifies the name of the output to use. By default, the default
+       output is used but e.g. `output = "lib";` will cause the lib output
+       to be checked instead. You do not need to specify any directories.
+     */
+    assertOutputs = { name, crateArgs, expectedFiles, output? null }:
+      assert (builtins.isString name);
+      assert (builtins.isAttrs crateArgs);
+      assert (builtins.isList expectedFiles);
+
+      let
+        crate = mkCrate (builtins.removeAttrs crateArgs ["expectedTestOutput"]);
+        crateOutput = if output == null then crate else crate."${output}";
+        expectedFilesFile = writeTextFile {
+          name = "expected-files-${name}";
+          text =
+            let sorted = builtins.sort (a: b: a<b) expectedFiles;
+                concatenated = builtins.concatStringsSep "\n" sorted;
+            in "${concatenated}\n";
+        };
+      in
+      runCommand "assert-outputs-${name}" {
+      } ''
+      local actualFiles=$(mktemp)
+
+      cd "${crateOutput}"
+      find . -type f | sort >$actualFiles
+      diff -q ${expectedFilesFile} $actualFiles >/dev/null || {
+        echo -e "\033[0;1;31mERROR: Difference in expected output files in ${crateOutput} \033[0m" >&2
+        echo === Got:
+        sed -e 's/^/  /' $actualFiles
+        echo === Expected:
+        sed -e 's/^/  /' ${expectedFilesFile}
+        echo === Diff:
+        diff -u ${expectedFilesFile} $actualFiles |\
+          tail -n +3 |\
+          sed -e 's/^/  /'
+        exit 1
+      }
+      touch $out
+      ''
+      ;
 
   in rec {
 
@@ -361,7 +414,80 @@ let
           };
     };
     brotliCrates = (callPackage ./brotli-crates.nix {});
-  in lib.mapAttrs (key: value: mkTest (value // lib.optionalAttrs (!value?crateName) { crateName = key; })) cases // {
+    tests = lib.mapAttrs (key: value: mkTest (value // lib.optionalAttrs (!value?crateName) { crateName = key; })) cases;
+  in tests // rec {
+
+    crateBinWithPathOutputs = assertOutputs {
+      name="crateBinWithPath";
+      crateArgs = {
+        crateBin = [{ name = "test_binary1"; path = "src/foobar.rs"; }];
+        src = mkBin "src/foobar.rs";
+      };
+      expectedFiles = [
+        "./bin/test_binary1"
+      ];
+    };
+
+    crateBinWithPathOutputsDebug = assertOutputs {
+      name="crateBinWithPath";
+      crateArgs = {
+        release = false;
+        crateBin = [{ name = "test_binary1"; path = "src/foobar.rs"; }];
+        src = mkBin "src/foobar.rs";
+      };
+      expectedFiles = [
+        "./bin/test_binary1"
+      ] ++ lib.optionals stdenv.isDarwin [
+        # On Darwin, the debug symbols are in a seperate directory.
+        "./bin/test_binary1.dSYM/Contents/Info.plist"
+        "./bin/test_binary1.dSYM/Contents/Resources/DWARF/test_binary1"
+      ];
+    };
+
+    crateBinNoPath1Outputs = assertOutputs {
+      name="crateBinNoPath1";
+      crateArgs = {
+        crateBin = [{ name = "my-binary2"; }];
+        src = mkBin "src/my_binary2.rs";
+      };
+      expectedFiles = [
+        "./bin/my-binary2"
+      ];
+    };
+
+    crateLibOutputs = assertOutputs {
+      name="crateLib";
+      output="lib";
+      crateArgs = {
+        libName = "test_lib";
+        type = [ "rlib" ];
+        libPath = "src/lib.rs";
+        src = mkLib "src/lib.rs";
+      };
+      expectedFiles = [
+        "./nix-support/propagated-build-inputs"
+        "./lib/libtest_lib-042a1fdbef.rlib"
+        "./lib/link"
+      ];
+    };
+
+    crateLibOutputsDebug = assertOutputs {
+      name="crateLib";
+      output="lib";
+      crateArgs = {
+        release = false;
+        libName = "test_lib";
+        type = [ "rlib" ];
+        libPath = "src/lib.rs";
+        src = mkLib "src/lib.rs";
+      };
+      expectedFiles = [
+        "./nix-support/propagated-build-inputs"
+        "./lib/libtest_lib-042a1fdbef.rlib"
+        "./lib/link"
+      ];
+    };
+
     brotliTest = let
       pkg = brotliCrates.brotli_2_5_0 {};
     in runCommand "run-brotli-test-cmd" {


### PR DESCRIPTION
###### Motivation for this change

This fixes errors such as these on Mac OS:

```
Building src/lib.rs (hello_world_lib_and_bin)
Running rustc --crate-name hello_world_lib_and_bin src/lib.rs --out-dir target/lib --emit=dep-info,link -L dependency=target/deps --cap-lints allow -C debuginfo=2 -C codegen-units=1 --remap-path-prefix=/private/var/folders/vj/wn31skn95g9fz4l9wdm5l5kh0000gn/T/nix-build-rust_hello_world_lib_and_bin-0.1.0.drv-0=/ --cfg feature="default" --edition 2018 -C metadata=06b67cb1f9 -C extra-filename=-06b67cb1f9 --crate-type lib --color always
unpacking sources
unpacking source archive /nix/store/bfrhy6p2dzb8qnixqzhgp2sa3770a69z-ansi_term-0.11.0.tar.gz
unpacking sources
unpacking source archive /nix/store/s8x3gwl0y2a5j4ihxpnnzzpl1v0c9vvi-bitflags-1.2.1.tar.gz
Running rustc --crate-name cfg_test src/main.rs --crate-type bin -C debuginfo=2 -C codegen-units=1 --remap-path-prefix=/private/var/folders/vj/wn31skn95g9fz4l9wdm5l5kh0000gn/T/nix-build-rust_cfg-test-0.1.0.drv-0=/ --cfg feature="default" --edition 2018 --out-dir target/bin --emit=dep-info,link -L dependency=target/deps --extern cfg_test=target/lib/libcfg_test-5198681f4a.rlib --cap-lints allow --color always
cp: -r not specified; omitting directory 'target/bin/hello_world_bin.dSYM'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Ran crate2nix tests on
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
