### PR TITLE
uberwriter: renamed to apostrophe

### DIFF
--- a/pkgs/applications/editors/apostrophe/default.nix
+++ b/pkgs/applications/editors/apostrophe/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, cmake
+{ stdenv, fetchFromGitLab, meson, ninja, cmake
 , wrapGAppsHook, pkgconfig, desktop-file-utils
 , appstream-glib, pythonPackages, glib, gobject-introspection
 , gtk3, webkitgtk, glib-networking, gnome3, gspell, texlive
@@ -10,14 +10,15 @@ let
   texliveDist = texlive.combined.scheme-medium;
 
 in stdenv.mkDerivation rec {
-  pname = "uberwriter";
-  version = "unstable-2020-01-24";
+  pname = "apostrophe";
+  version = "unstable-2020-03-29";
 
-  src = fetchFromGitHub {
-    owner  = pname;
+  src = fetchFromGitLab {
+    owner  = "somas";
     repo   = pname;
-    rev    = "0647b413407eb8789a25c353602c4ac979dc342a";
-    sha256 = "19z52fpbf0p7dzx7q0r5pk3nn0c8z69g1hv6db0cqp61cqv5z95q";
+    domain = "gitlab.gnome.org";
+    rev    = "219fa8976e3b8a6f0cea15cfefe4e336423f2bdb";
+    sha256 = "192n5qs3x6rx62mqxd6wajwm453pns8kjyz5v3xc891an6bm1kqx";
   };
 
   nativeBuildInputs = [ meson ninja cmake pkgconfig desktop-file-utils
@@ -30,10 +31,10 @@ in stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs --build build-aux/meson_post_install.py
 
-    substituteInPlace uberwriter/config.py --replace "/usr/share/uberwriter" "$out/share/uberwriter"
+    substituteInPlace ${pname}/config.py --replace "/usr/share/${pname}" "$out/share/${pname}"
 
     # get rid of unused distributed dependencies
-    rm -r uberwriter/{pylocales,pressagio}
+    rm -r ${pname}/pylocales
   '';
 
   preFixup = ''
@@ -46,7 +47,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://uberwriter.github.io/uberwriter/;
+    homepage = "https://gitlab.gnome.org/somas/apostrophe";
     description = "A distraction free Markdown editor for GNU/Linux";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7175,10 +7175,6 @@ in
 
   ua = callPackage ../tools/networking/ua { };
 
-  uberwriter = callPackage ../applications/editors/uberwriter {
-    pythonPackages = python3Packages;
-  };
-
   ubridge = callPackage ../tools/networking/ubridge { };
 
   ucl = callPackage ../development/libraries/ucl { };
@@ -18581,6 +18577,10 @@ in
   apngasm_2 = callPackage ../applications/graphics/apngasm/2.nix {};
 
   appeditor = callPackage ../applications/misc/appeditor { };
+
+  apostrophe = callPackage ../applications/editors/apostrophe {
+    pythonPackages = python3Packages;
+  };
 
   aqemu = libsForQt5.callPackage ../applications/virtualization/aqemu { };
 


### PR DESCRIPTION
###### Motivation for this change

UberWriter was renamed to Apostrophe and the upstream repository moved to GNOME's Gitlab.

Is there by now a process for package renaming? I quickly checked, but it didn't find anything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
