### PR TITLE
python3Packages.matplotlib: remove propagated nose dep

### DIFF
--- a/pkgs/development/python-modules/bayespy/default.nix
+++ b/pkgs/development/python-modules/bayespy/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi, pythonOlder
-, pytest, glibcLocales
+, pytest, nose, glibcLocales
 , numpy, scipy, matplotlib, h5py }:
 
 buildPythonPackage rec {
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "24e1327ce241a0113abf217fbaf41ac25e04f5a01f9ed606610f2f1f2d82d34f";
   };
 
-  checkInputs = [ pytest glibcLocales ];
+  checkInputs = [ pytest nose glibcLocales ];
   propagatedBuildInputs = [ numpy scipy matplotlib h5py ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/cufflinks/default.nix
+++ b/pkgs/development/python-modules/cufflinks/default.nix
@@ -4,6 +4,7 @@
 , ipython
 , ipywidgets
 , pytest
+, nose
 , numpy
 , pandas
 , six
@@ -30,7 +31,7 @@ buildPythonPackage rec {
     statsmodels
   ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest nose ];
 
   # ignore tests which are incompatible with pandas>=1.0
   # https://github.com/santosjorge/cufflinks/issues/236

--- a/pkgs/development/python-modules/deap/default.nix
+++ b/pkgs/development/python-modules/deap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, python, numpy, matplotlib }:
+{ stdenv, buildPythonPackage, fetchPypi, python, numpy, matplotlib, nose }:
 
 buildPythonPackage rec {
   pname = "deap";
@@ -11,6 +11,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ numpy matplotlib ];
 
+  checkInputs = [ nose ];
   checkPhase = ''
     ${python.interpreter} setup.py nosetests --verbosity=3
   '';

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     ++ stdenv.lib.optional stdenv.isDarwin [ Cocoa ];
 
   propagatedBuildInputs =
-    [ cycler dateutil nose numpy pyparsing tornado freetype kiwisolver
+    [ cycler dateutil numpy pyparsing tornado freetype kiwisolver
       libpng mock pytz ]
     ++ stdenv.lib.optional (pythonOlder "3.3") backports_functools_lru_cache
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobject-introspection pygobject3 ]

--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest
+{ stdenv, buildPythonPackage, fetchPypi, pytest, nose
 , nibabel, numpy, pandas, scikitlearn, scipy, matplotlib, joblib }:
 
 buildPythonPackage rec {
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     pytest nilearn/tests -k 'not test_cache_mixin_with_expand_user'  # accesses ~/
   '';
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest nose ];
 
   propagatedBuildInputs = [
     joblib


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`Matplotlib` doesn't even use `nose` anymore, so there is no reason for `nose` to be in the `matplotlib` closure, much less `propagatedBuildInputs`.

Restored `matplotlib` to `checkInputs` for some packages which failed to build as a result.  It's possible that other currently non-building packages also require this modification.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
