### PR TITLE
coqPackages.paramcoq: 1.1.1 → 1.1.2

### DIFF
--- a/pkgs/development/coq-modules/paramcoq/default.nix
+++ b/pkgs/development/coq-modules/paramcoq/default.nix
@@ -3,33 +3,40 @@
 let params =
   {
     "8.7" = {
-      version = "1.1.1+coq8.7";
-      sha256 = "1i7b5pkx46zf9il2xikbp3rhpnh3wdfbhw5yxcf9yk28ky9s0a0l";
+      sha256 = "09n0ky7ldb24by7yf5j3hv410h85x50ksilf7qacl7xglj4gy5hj";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
     };
     "8.8" = {
-      version = "1.1.1";
-      sha256 = "0b07zvgm9cx6j2d9631zmqjs6sf30kiqg6k15xk3km7n80d53wfh";
+      sha256 = "0rc4lshqvnfdsph98gnscvpmlirs9wx91qcvffggg73xw0p1g9s0";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
     };
     "8.9" = {
-      version = "1.1.1+coq8.9";
-      sha256 = "002xabhjlph394vydw3dx8ipv5ry2nq3py4440bk9a18ljx0w6ll";
+      sha256 = "1jjzgpff09xjn9kgp7w69r096jkj0x2ksng3pawrmhmn7clwivbk";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
+    };
+    "8.10" = {
+      sha256 = "1lq1mw15w4yky79qg3rm0mpzqi2ir51b6ak04ismrdr7ixky49y8";
+    };
+    "8.11" = {
+      sha256 = "09c6813988nvq4fpa45s33k70plnhxsblhm7cxxkg0i37mhvigsa";
     };
   };
   param = params.${coq.coq-version};
 in
 
 stdenv.mkDerivation rec {
-  inherit (param) version;
+  version = "1.1.2";
   name = "coq${coq.coq-version}-paramcoq-${version}";
   src = fetchFromGitHub {
     owner = "coq-community";
     repo = "paramcoq";
-    rev = "v${version}";
+    rev = "v${version}+coq${coq.coq-version}";
     inherit (param) sha256;
   };
 
   buildInputs = [ coq ]
-  ++ (with coq.ocamlPackages; [ ocaml findlib camlp5 ])
+  ++ (with coq.ocamlPackages; [ ocaml findlib ])
+  ++ (param.buildInputs or [])
   ;
 
   installFlags = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
