### PR TITLE
[WIP] PHP: Make the default package more sane [v2]

### DIFF
--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -1,0 +1,71 @@
+# PHP
+
+## User Guide
+
+### Using PHP
+
+#### Overview
+
+Several versions of PHP is available on Nix, as well as a bunch of extensions
+and libraries available for each version of PHP.
+
+The attribute `php` refers to the latest version of PHP that has undergone
+sufficient testing in nixpkgs. This may not be the latest and we tend to upgrade
+to the latest after branch-off for a new NixOS release so we get more testing
+before the next release.
+
+We keep releases as long as they are supported for the entirety of the next
+NixOS release life cycle. See [PHP Supported Versions](https://www.php.net/supported-versions.php).
+
+As for packages we have `phpPackages` that contains a bunch of attributes where
+some are suitable as extensions (notable example: `phpPackages.imagick`). And some
+are more suitable for command line use (notable example: `phpPackages.composer`).
+
+We have a special section within `phpPackages` called `phpPackages.exts` that
+contain certain PHP modules that may not be part of the default PHP derivation
+(example: `phpPackages.exts.opcache`).
+
+The `phpPackages.exts.*` attributes are official extensions that originates from
+the mainline PHP project while other extensions within the `phpPackages.*`
+attribute is a mix of sources (such as `pecl` and other places).
+
+The different versions of PHP that nixpkgs fetch is located under attributes
+named based on major and minor version number (example: `php74` is PHP 7.4).
+
+The same pattern with the versioning applies to the packages attribute set and
+to the base attributes.
+
+The packages attribute set for PHP 7.4 is named `php74Packages`.
+
+#### Installing PHP with packages
+
+There's two different kinds of things you could install:
+ - A command line utility. Simply refer to it via `php*Packages.*`, and it
+   automatically comes with the necessary PHP environment, certain extensions
+   and libraries around it.
+ - A PHP interpreter with certain extensions available.
+   The `php` attribute provides `php.buildEnv` that allows you to wrap
+   the PHP derivation with an additional config file that makes PHP import
+   additional libraries or dependencies.
+
+##### Example setup for `phpfpm`
+
+Example to build a PHP with `imagick` and `opcache` enabled, and configure it for
+the "foo" `phpfpm` pool:
+
+```nix
+let
+  myPhp = php.buildEnv { exts = pp: with pp; [ imagick exts.opcache ]; };
+in {
+  services.phpfpm.pools."foo".phpPackage = myPhp;
+};
+```
+
+##### Example usage with `nix-shell`
+
+This brings up a temporary environment that contains a PHP interpreter with
+`imagick` and `opcache` enabled.
+
+```sh
+nix-shell -p 'php.buildEnv { exts = pp: with pp; [ imagick exts.opcache ]; }'
+```

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -125,6 +125,71 @@
      documentation for instructions.
     </para>
    </listitem>
+   <listitem>
+     <para>
+       Since this release we have an easy way to customize your PHP install to get a much smaller
+       base PHP with only wanted extensions enabled. See following snippet to install a smaller PHP
+       with <literal>imagick</literal>, <literal>opcache</literal> and <literal>pdo_mysql</literal>:
+
+       <programlisting>
+environment.systemPackages = [
+(pkgs.php.buildEnv { exts = pp: with pp; [
+    imagick
+    exts.opcache
+    exts.pdo_mysql
+  ]; })
+];</programlisting>
+
+       The default <literal>php</literal> attribute haven't lost any extensions by default though. It
+       has added the <literal>opcache</literal> extension as an additional extension.
+
+       All native PHP extensions are available under <package><![CDATA[phpPackages.exts.<name?>]]></package>.
+     </para>
+     <para>
+       Since we have a smaller base package that we base the main <literal>php</literal> on a
+       smaller base package we've decided to remove a big bunch of options to make the main
+       PHP derivation much easier to work with.
+
+       <itemizedlist>
+         <title>PHP <literal>config</literal> flags that we don't read anymore:</title>
+         <listitem><para><literal>config.php.argon2</literal></para></listitem>
+         <listitem><para><literal>config.php.bcmath</literal></para></listitem>
+         <listitem><para><literal>config.php.bz2</literal></para></listitem>
+         <listitem><para><literal>config.php.calendar</literal></para></listitem>
+         <listitem><para><literal>config.php.curl</literal></para></listitem>
+         <listitem><para><literal>config.php.exif</literal></para></listitem>
+         <listitem><para><literal>config.php.ftp</literal></para></listitem>
+         <listitem><para><literal>config.php.gd</literal></para></listitem>
+         <listitem><para><literal>config.php.gettext</literal></para></listitem>
+         <listitem><para><literal>config.php.gmp</literal></para></listitem>
+         <listitem><para><literal>config.php.imap</literal></para></listitem>
+         <listitem><para><literal>config.php.intl</literal></para></listitem>
+         <listitem><para><literal>config.php.ldap</literal></para></listitem>
+         <listitem><para><literal>config.php.libxml2</literal></para></listitem>
+         <listitem><para><literal>config.php.libzip</literal></para></listitem>
+         <listitem><para><literal>config.php.mbstring</literal></para></listitem>
+         <listitem><para><literal>config.php.mysqli</literal></para></listitem>
+         <listitem><para><literal>config.php.mysqlnd</literal></para></listitem>
+         <listitem><para><literal>config.php.openssl</literal></para></listitem>
+         <listitem><para><literal>config.php.pcntl</literal></para></listitem>
+         <listitem><para><literal>config.php.pdo_mysql</literal></para></listitem>
+         <listitem><para><literal>config.php.pdo_odbc</literal></para></listitem>
+         <listitem><para><literal>config.php.pdo_pgsql</literal></para></listitem>
+         <listitem><para><literal>config.php.phpdbg</literal></para></listitem>
+         <listitem><para><literal>config.php.postgresql</literal></para></listitem>
+         <listitem><para><literal>config.php.readline</literal></para></listitem>
+         <listitem><para><literal>config.php.soap</literal></para></listitem>
+         <listitem><para><literal>config.php.sockets</literal></para></listitem>
+         <listitem><para><literal>config.php.sodium</literal></para></listitem>
+         <listitem><para><literal>config.php.sqlite</literal></para></listitem>
+         <listitem><para><literal>config.php.tidy</literal></para></listitem>
+         <listitem><para><literal>config.php.xmlrpc</literal></para></listitem>
+         <listitem><para><literal>config.php.xsl</literal></para></listitem>
+         <listitem><para><literal>config.php.zip</literal></para></listitem>
+         <listitem><para><literal>config.php.zlib</literal></para></listitem>
+       </itemizedlist>
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -168,8 +168,7 @@ let
     };
   });
 
-in {
-  php72 = generic' {
+  php72base = generic' {
     version = "7.2.28";
     sha256 = "18sjvl67z5a2x5s2a36g6ls1r3m4hbrsw52hqr2qsgfvg5dkm5bw";
 
@@ -177,7 +176,7 @@ in {
     extraPatches = lib.optional stdenv.isDarwin ./php72-darwin-isfinite.patch;
   };
 
-  php73 = generic' {
+  php73base = generic' {
     version = "7.3.15";
     sha256 = "0g84hws15s8gh8iq4h6q747dyfazx47vh3da3whz8d80x83ibgld";
 
@@ -185,8 +184,22 @@ in {
     extraPatches = lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;
   };
 
-  php74 = generic' {
+  php74base = generic' {
     version = "7.4.3";
     sha256 = "wVF7pJV4+y3MZMc6Ptx21PxQfEp6xjmYFYTMfTtMbRQ=";
   };
+
+  defaultPhpExtensions = {
+    exts = pp: with pp.exts; ([
+      bcmath calendar curl exif ftp gd gettext gmp intl json ldap mysqli
+      mysqlnd opcache openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql
+      pgsql posix readline session soap sodium sqlite3 zip zlib
+    ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]);
+  };
+in {
+  inherit php72base php73base php74base;
+
+  php74 = php74base.buildEnv defaultPhpExtensions;
+  php73 = php73base.buildEnv defaultPhpExtensions;
+  php72 = php72base.buildEnv defaultPhpExtensions;
 }

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -144,29 +144,56 @@ let
     };
   };
 
-  generic' = { version, sha256, ... }@args: let php = generic args; in php.overrideAttrs (_: {
-    passthru.buildEnv = { exts ? (_: []), extraConfig ? "" }: let
-      extraInit = writeText "custom-php.ini" ''
-        ${extraConfig}
-        ${lib.concatMapStringsSep "\n" (ext: let
-          extName = lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
-          type = "${lib.optionalString (ext.zendExtension or false) "zend_"}extension";
-        in ''
-          ${type}=${ext}/lib/php/extensions/${extName}.so
-        '') (exts (callPackage ../../../top-level/php-packages.nix { inherit php; }))}
-      '';
-    in symlinkJoin {
-      name = "php-custom-${version}";
-      nativeBuildInputs = [ makeWrapper ];
-      paths = [ php ];
-      postBuild = ''
-        wrapProgram $out/bin/php \
-          --add-flags "-c ${extraInit}"
-        wrapProgram $out/bin/php-fpm \
-          --add-flags "-c ${extraInit}"
-      '';
-    };
-  });
+  generic' = { version, sha256, ... }@args:
+    let
+      php = generic args;
+      buildEnv = { exts ? (_: []), extraConfig ? "" }:
+        let
+          getExtName = ext: lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
+          extList = exts (callPackage ../../../top-level/php-packages.nix { inherit php; });
+
+          # Generate extension load configuration snippets from
+          # exts. This is an attrset suitable for use with
+          # textClosureList, which is used to put the strings in the
+          # right order - if a plugin which is dependent on another
+          # plugin is placed before its dependency, it will fail to
+          # load.
+          extensionTexts =
+            lib.listToAttrs
+              (map (ext:
+                let
+                  extName = getExtName ext;
+                  type = "${lib.optionalString (ext.zendExtension or false) "zend_"}extension";
+                in
+                  lib.nameValuePair extName {
+                    text = "${type}=${ext}/lib/php/extensions/${extName}.so";
+                    deps = lib.optionals (ext ? internalDeps) ext.internalDeps;
+                  })
+                extList);
+
+          extNames = map getExtName extList;
+          extraInit = writeText "custom-php.ini" ''
+            ${extraConfig}
+            ${lib.concatStringsSep "\n"
+              (lib.textClosureList extensionTexts extNames)}
+          '';
+        in
+          symlinkJoin {
+            name = "php-with-extensions-${version}";
+            nativeBuildInputs = [ makeWrapper ];
+            passthru.buildEnv = buildEnv;
+            paths = [ php ];
+            postBuild = ''
+              wrapProgram $out/bin/php \
+                --add-flags "-c ${extraInit}"
+              wrapProgram $out/bin/php-fpm \
+                --add-flags "-c ${extraInit}"
+            '';
+          };
+    in
+      php.overrideAttrs (_: {
+        passthru.buildEnv = buildEnv;
+      });
 
   php72base = generic' {
     version = "7.2.28";

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -184,10 +184,10 @@ let
             passthru.buildEnv = buildEnv;
             paths = [ php ];
             postBuild = ''
-              wrapProgram $out/bin/php \
-                --add-flags "-c ${extraInit}"
-              wrapProgram $out/bin/php-fpm \
-                --add-flags "-c ${extraInit}"
+              cp ${extraInit} $out/lib/custom-php.ini
+
+              wrapProgram $out/bin/php     --set PHP_INI_SCAN_DIR $out/lib
+              wrapProgram $out/bin/php-fpm --set PHP_INI_SCAN_DIR $out/lib
             '';
           };
     in

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,13 +1,7 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
-{ config, lib, stdenv, fetchurl
-, autoconf, automake, bison, file, flex, libtool, pkgconfig, re2c
-, libxml2, readline, zlib, curl, postgresql, gettext
-, openssl, pcre, pcre2, sqlite
-, libxslt, bzip2, icu, openldap, cyrus_sasl, unixODBC
-, uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium, html-tidy, libargon2
-, gd, freetype, libXpm, libjpeg, libpng, libwebp
-, libzip, valgrind, oniguruma, symlinkJoin, writeText
-, makeWrapper, callPackage
+{ callPackage, config, fetchurl, lib, makeWrapper, stdenv, symlinkJoin
+, writeText , autoconf, automake, bison, flex, libtool, pkgconfig, re2c
+, apacheHttpd, libargon2, libxml2, pcre, pcre2 , systemd, valgrind
 }:
 
 let
@@ -15,182 +9,83 @@ let
   { version
   , sha256
   , extraPatches ? []
-  , withSystemd ? config.php.systemd or stdenv.isLinux
-  , imapSupport ? config.php.imap or (!stdenv.isDarwin)
-  , ldapSupport ? config.php.ldap or true
-  , mysqlndSupport ? config.php.mysqlnd or true
-  , mysqliSupport ? (config.php.mysqli or true) && (mysqlndSupport)
-  , pdo_mysqlSupport ? (config.php.pdo_mysql or true) && (mysqlndSupport)
-  , libxml2Support ? config.php.libxml2 or true
-  , apxs2Support ? config.php.apxs2 or (!stdenv.isDarwin)
-  , embedSupport ? config.php.embed or false
-  , bcmathSupport ? config.php.bcmath or true
-  , socketsSupport ? config.php.sockets or true
-  , curlSupport ? config.php.curl or true
-  , gettextSupport ? config.php.gettext or true
-  , pcntlSupport ? config.php.pcntl or true
-  , pdo_odbcSupport ? config.php.pdo_odbc or true
-  , postgresqlSupport ? config.php.postgresql or true
-  , pdo_pgsqlSupport ? config.php.pdo_pgsql or true
-  , readlineSupport ? config.php.readline or true
-  , sqliteSupport ? config.php.sqlite or true
-  , soapSupport ? (config.php.soap or true) && (libxml2Support)
-  , zlibSupport ? config.php.zlib or true
-  , opensslSupport ? config.php.openssl or true
-  , mbstringSupport ? config.php.mbstring or true
-  , gdSupport ? config.php.gd or true
-  , intlSupport ? config.php.intl or true
-  , exifSupport ? config.php.exif or true
-  , xslSupport ? config.php.xsl or false
-  , bz2Support ? config.php.bz2 or false
-  , zipSupport ? config.php.zip or true
-  , ftpSupport ? config.php.ftp or true
-  , fpmSupport ? config.php.fpm or true
-  , gmpSupport ? config.php.gmp or true
-  , ztsSupport ? (config.php.zts or false) || (apxs2Support)
-  , calendarSupport ? config.php.calendar or true
-  , sodiumSupport ? (config.php.sodium or true) && (lib.versionAtLeast version "7.2")
-  , tidySupport ? (config.php.tidy or false)
-  , argon2Support ? (config.php.argon2 or true) && (lib.versionAtLeast version "7.2")
-  , libzipSupport ? (config.php.libzip or true) && (lib.versionAtLeast version "7.2")
-  , phpdbgSupport ? config.php.phpdbg or true
+
+  # Sapi flags
   , cgiSupport ? config.php.cgi or true
   , cliSupport ? config.php.cli or true
+  , fpmSupport ? config.php.fpm or true
+  , pearSupport ? config.php.pear or true
   , pharSupport ? config.php.phar or true
-  , xmlrpcSupport ? (config.php.xmlrpc or false) && (libxml2Support)
+  , phpdbgSupport ? config.php.phpdbg or true
+
+
+  # Misc flags
+  , apxs2Support ? config.php.apxs2 or (!stdenv.isDarwin)
+  , argon2Support ? config.php.argon2 or true
   , cgotoSupport ? config.php.cgoto or false
-  , valgrindSupport ? (config.php.valgrind or true) && (lib.versionAtLeast version "7.2")
+  , embedSupport ? config.php.embed or false
   , ipv6Support ? config.php.ipv6 or true
-  , pearSupport ? (config.php.pear or true) && (libxml2Support)
-  }: stdenv.mkDerivation {
+  , systemdSupport ? config.php.systemd or stdenv.isLinux
+  , valgrindSupport ? config.php.valgrind or true
+  , ztsSupport ? (config.php.zts or false) || (apxs2Support)
+  }: let
+    pcre' = if (lib.versionAtLeast version "7.3") then pcre2 else pcre;
+  in stdenv.mkDerivation {
     pname = "php";
 
     inherit version;
 
     enableParallelBuilding = true;
 
-    nativeBuildInputs = [ autoconf automake bison file flex libtool pkgconfig re2c ];
+    nativeBuildInputs = [ autoconf automake bison flex libtool pkgconfig re2c ];
 
-    buildInputs = [ ]
-      ++ lib.optional (lib.versionOlder version "7.3") pcre
-      ++ lib.optional (lib.versionAtLeast version "7.3") pcre2
-      ++ lib.optional (lib.versionAtLeast version "7.4") oniguruma
-      ++ lib.optional withSystemd systemd
-      ++ lib.optionals imapSupport [ uwimap openssl pam ]
-      ++ lib.optionals curlSupport [ curl openssl ]
-      ++ lib.optionals ldapSupport [ openldap openssl ]
-      ++ lib.optionals gdSupport [ gd freetype libXpm libjpeg libpng libwebp ]
-      ++ lib.optionals opensslSupport [ openssl openssl.dev ]
+    buildInputs =
+      # PCRE extension
+      [ pcre' ]
+
+      # Enable sapis
+      ++ lib.optional pearSupport [ libxml2.dev ]
+
+      # Misc deps
       ++ lib.optional apxs2Support apacheHttpd
-      ++ lib.optional (ldapSupport && stdenv.isLinux) cyrus_sasl
-      ++ lib.optional zlibSupport zlib
-      ++ lib.optional libxml2Support libxml2
-      ++ lib.optional readlineSupport readline
-      ++ lib.optional sqliteSupport sqlite
-      ++ lib.optional postgresqlSupport postgresql
-      ++ lib.optional pdo_odbcSupport unixODBC
-      ++ lib.optional pdo_pgsqlSupport postgresql
-      ++ lib.optional gmpSupport gmp
-      ++ lib.optional gettextSupport gettext
-      ++ lib.optional intlSupport icu
-      ++ lib.optional xslSupport libxslt
-      ++ lib.optional bz2Support bzip2
-      ++ lib.optional sodiumSupport libsodium
-      ++ lib.optional tidySupport html-tidy
       ++ lib.optional argon2Support libargon2
-      ++ lib.optional libzipSupport libzip
-      ++ lib.optional valgrindSupport valgrind;
+      ++ lib.optional systemdSupport systemd
+      ++ lib.optional valgrindSupport valgrind
+    ;
 
     CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
 
-    configureFlags = [ "--with-config-file-scan-dir=/etc/php.d" ]
-      ++ lib.optionals (lib.versionOlder version "7.3") [ "--with-pcre-regex=${pcre.dev}" "PCRE_LIBDIR=${pcre}" ]
-      ++ lib.optionals (lib.versions.majorMinor version == "7.3") [ "--with-pcre-regex=${pcre2.dev}" "PCRE_LIBDIR=${pcre2}" ]
-      ++ lib.optionals (lib.versionAtLeast version "7.4") [ "--with-external-pcre=${pcre2.dev}" "PCRE_LIBDIR=${pcre2}" ]
-      ++ lib.optional stdenv.isDarwin "--with-iconv=${libiconv}"
-      ++ lib.optional withSystemd "--with-fpm-systemd"
-      ++ lib.optionals imapSupport [
-        "--with-imap=${uwimap}"
-        "--with-imap-ssl"
-      ]
-      ++ lib.optionals ldapSupport [
-        "--with-ldap=/invalid/path"
-        "LDAP_DIR=${openldap.dev}"
-        "LDAP_INCDIR=${openldap.dev}/include"
-        "LDAP_LIBDIR=${openldap.out}/lib"
-      ]
-      ++ lib.optional (ldapSupport && stdenv.isLinux) "--with-ldap-sasl=${cyrus_sasl.dev}"
-      ++ lib.optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
-      ++ lib.optional embedSupport "--enable-embed"
-      ++ lib.optional curlSupport "--with-curl=${curl.dev}"
-      ++ lib.optional zlibSupport "--with-zlib=${zlib.dev}"
-      ++ lib.optional (libxml2Support && (lib.versionOlder version "7.4")) "--with-libxml-dir=${libxml2.dev}"
-      ++ lib.optional (!libxml2Support) [
-        "--disable-dom"
-        (if (lib.versionOlder version "7.4") then "--disable-libxml" else "--without-libxml")
-        "--disable-simplexml"
-        "--disable-xml"
-        "--disable-xmlreader"
-        "--disable-xmlwriter"
-        "--without-pear"
-      ]
-      ++ lib.optional pcntlSupport "--enable-pcntl"
-      ++ lib.optional readlineSupport "--with-readline=${readline.dev}"
-      ++ lib.optional sqliteSupport "--with-pdo-sqlite=${sqlite.dev}"
-      ++ lib.optional postgresqlSupport "--with-pgsql=${postgresql}"
-      ++ lib.optional pdo_odbcSupport "--with-pdo-odbc=unixODBC,${unixODBC}"
-      ++ lib.optional pdo_pgsqlSupport "--with-pdo-pgsql=${postgresql}"
-      ++ lib.optional (pdo_mysqlSupport && mysqlndSupport) "--with-pdo-mysql=mysqlnd"
-      ++ lib.optional (mysqliSupport && mysqlndSupport) "--with-mysqli=mysqlnd"
-      ++ lib.optional (pdo_mysqlSupport || mysqliSupport) "--with-mysql-sock=/run/mysqld/mysqld.sock"
-      ++ lib.optional bcmathSupport "--enable-bcmath"
-      ++ lib.optionals (gdSupport && lib.versionAtLeast version "7.4") [
-        "--enable-gd"
-        "--with-external-gd=${gd.dev}"
-        "--with-webp=${libwebp}"
-        "--with-jpeg=${libjpeg.dev}"
-        "--with-xpm=${libXpm.dev}"
-        "--with-freetype=${freetype.dev}"
-        "--enable-gd-jis-conv"
-      ] ++ lib.optionals (gdSupport && lib.versionOlder version "7.4") [
-        "--with-gd=${gd.dev}"
-        "--with-webp-dir=${libwebp}"
-        "--with-jpeg-dir=${libjpeg.dev}"
-        "--with-png-dir=${libpng.dev}"
-        "--with-freetype-dir=${freetype.dev}"
-        "--with-xpm-dir=${libXpm.dev}"
-        "--enable-gd-jis-conv"
-      ]
-      ++ lib.optional gmpSupport "--with-gmp=${gmp.dev}"
-      ++ lib.optional soapSupport "--enable-soap"
-      ++ lib.optional socketsSupport "--enable-sockets"
-      ++ lib.optional opensslSupport "--with-openssl"
-      ++ lib.optional mbstringSupport "--enable-mbstring"
-      ++ lib.optional gettextSupport "--with-gettext=${gettext}"
-      ++ lib.optional intlSupport "--enable-intl"
-      ++ lib.optional exifSupport "--enable-exif"
-      ++ lib.optional xslSupport "--with-xsl=${libxslt.dev}"
-      ++ lib.optional bz2Support "--with-bz2=${bzip2.dev}"
-      ++ lib.optional (zipSupport && (lib.versionOlder version "7.4")) "--enable-zip"
-      ++ lib.optional (zipSupport && (lib.versionAtLeast version "7.4")) "--with-zip"
-      ++ lib.optional ftpSupport "--enable-ftp"
-      ++ lib.optional fpmSupport "--enable-fpm"
-      ++ lib.optional ztsSupport "--enable-maintainer-zts"
-      ++ lib.optional calendarSupport "--enable-calendar"
-      ++ lib.optional sodiumSupport "--with-sodium=${libsodium.dev}"
-      ++ lib.optional tidySupport "--with-tidy=${html-tidy}"
-      ++ lib.optional argon2Support "--with-password-argon2=${libargon2}"
-      ++ lib.optional (libzipSupport && (lib.versionOlder version "7.4")) "--with-libzip=${libzip.dev}"
-      ++ lib.optional phpdbgSupport "--enable-phpdbg"
-      ++ lib.optional (!phpdbgSupport) "--disable-phpdbg"
+    configureFlags =
+      # Disable all extensions
+      [ "--disable-all" ]
+
+      # PCRE
+      ++ lib.optionals (lib.versionAtLeast version "7.4") [ "--with-external-pcre=${pcre'.dev}" ]
+      ++ lib.optionals (lib.versions.majorMinor version == "7.3") [ "--with-pcre-regex=${pcre'.dev}" ]
+      ++ lib.optionals (lib.versionOlder version "7.3") [ "--with-pcre-regex=${pcre'.dev}" ]
+      ++ [ "PCRE_LIBDIR=${pcre'}" ]
+
+
+      # Enable sapis
       ++ lib.optional (!cgiSupport) "--disable-cgi"
       ++ lib.optional (!cliSupport) "--disable-cli"
-      ++ lib.optional (!pharSupport) "--disable-phar"
-      ++ lib.optional xmlrpcSupport "--with-xmlrpc"
+      ++ lib.optional fpmSupport    "--enable-fpm"
+      ++ lib.optional pearSupport [ "--with-pear=$(out)/lib/php/pear" "--enable-xml" "--with-libxml" ]
+      ++ lib.optional (pearSupport && (lib.versionOlder version "7.4")) "--enable-libxml"
+      ++ lib.optional pharSupport   "--enable-phar"
+      ++ lib.optional phpdbgSupport "--enable-phpdbg"
+
+
+      # Misc flags
+      ++ lib.optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
+      ++ lib.optional argon2Support "--with-password-argon2=${libargon2}"
       ++ lib.optional cgotoSupport "--enable-re2c-cgoto"
-      ++ lib.optional valgrindSupport "--with-valgrind=${valgrind.dev}"
+      ++ lib.optional embedSupport "--enable-embed"
       ++ lib.optional (!ipv6Support) "--disable-ipv6"
-      ++ lib.optional (pearSupport && libxml2Support) "--with-pear=$(out)/lib/php/pear";
+      ++ lib.optional systemdSupport "--with-fpm-systemd"
+      ++ lib.optional valgrindSupport "--with-valgrind=${valgrind.dev}"
+      ++ lib.optional ztsSupport "--enable-maintainer-zts"
+    ;
 
     hardeningDisable = [ "bindnow" ];
 
@@ -203,8 +98,6 @@ let
           --replace '@CONFIGURE_OPTIONS@' "" \
           --replace '@PHP_LDFLAGS@' ""
       done
-
-      substituteInPlace ./build/libtool.m4 --replace /usr/bin/file ${file}/bin/file
 
       export EXTENSION_DIR=$out/lib/php/extensions
 
@@ -235,6 +128,12 @@ let
       inherit sha256;
     };
 
+    patches = [ ./fix-paths-php7.patch ] ++ extraPatches;
+
+    separateDebugInfo = true;
+
+    outputs = [ "out" "dev" ];
+
     meta = with stdenv.lib; {
       description = "An HTML-embedded scripting language";
       homepage = "https://www.php.net/";
@@ -243,12 +142,6 @@ let
       platforms = platforms.all;
       outputsToInstall = [ "out" "dev" ];
     };
-
-    patches = [ ./fix-paths-php7.patch ] ++ extraPatches;
-
-    stripDebugList = "bin sbin lib modules";
-
-    outputs = [ "out" "dev" ];
   };
 
   generic' = { version, sha256, ... }@args: let php = generic args; in php.overrideAttrs (_: {

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, which
 , withPython2 ? false, python2
 , withPython3 ? true, python3, ncurses
-, withPHP72 ? false, php72
-, withPHP73 ? true, php73
+, withPHP72 ? false, php72base
+, withPHP73 ? true, php73base
 , withPerl528 ? false, perl528
 , withPerl530 ? true, perl530
 , withPerldevel ? false, perldevel
@@ -16,7 +16,19 @@
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
+let
+  phpConfig = {
+    config.php.embed = true;
+    config.php.apxs2 = false;
+    config.php.systemd = false;
+    config.php.phpdbg = false;
+    config.php.cgi = false;
+    config.php.fpm = false;
+  };
+
+  php72 = php72base.override phpConfig;
+  php73 = php73base.override phpConfig;
+in stdenv.mkDerivation rec {
   version = "1.16.0";
   pname = "unit";
 

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -4,10 +4,15 @@
 , pam, withPAM ? stdenv.isLinux
 , systemd, withSystemd ? stdenv.isLinux
 , python2, python3, ncurses
-, ruby, php-embed, libmysqlclient
+, ruby, php, libmysqlclient
 }:
 
-let pythonPlugin = pkg : lib.nameValuePair "python${if pkg.isPy2 then "2" else "3"}" {
+let php-embed = php.override {
+      config.php.embed = true;
+      config.php.apxs2 = false;
+    };
+
+    pythonPlugin = pkg : lib.nameValuePair "python${if pkg.isPy2 then "2" else "3"}" {
                            interpreter = pkg.interpreter;
                            path = "plugins/python";
                            inputs = [ pkg ncurses ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9375,20 +9375,6 @@ in
     php = php74base;
   });
 
-  phpPackages-unit = php74Packages-unit;
-
-  php72Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php72-unit;
-  });
-
-  php73Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php73-unit;
-  });
-
-  php74Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php74-unit;
-  });
-
   inherit (callPackages ../development/interpreters/php {
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   }) php74 php73 php72 php74base php73base php72base;
@@ -9408,35 +9394,6 @@ in
   php74-embed = php74.override {
     config.php.embed = true;
     config.php.apxs2 = false;
-  };
-
-  php-unit = php74-unit;
-
-  php72-unit = php72.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-    config.php.systemd = false;
-    config.php.phpdbg = false;
-    config.php.cgi = false;
-    config.php.fpm = false;
-  };
-
-  php73-unit = php73.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-    config.php.systemd = false;
-    config.php.phpdbg = false;
-    config.php.cgi = false;
-    config.php.fpm = false;
-  };
-
-  php74-unit = php74.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-    config.php.systemd = false;
-    config.php.phpdbg = false;
-    config.php.cgi = false;
-    config.php.fpm = false;
   };
 
   picoc = callPackage ../development/interpreters/picoc {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9379,22 +9379,6 @@ in
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   }) php74 php73 php72 php74base php73base php72base;
 
-  php-embed = php74-embed;
-
-  php72-embed = php72.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-  };
-
-  php73-embed = php73.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-  };
-
-  php74-embed = php74.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-  };
 
   picoc = callPackage ../development/interpreters/picoc {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9364,15 +9364,15 @@ in
   phpPackages = php74Packages;
 
   php72Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php72;
+    php = php72base;
   });
 
   php73Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php73;
+    php = php73base;
   });
 
   php74Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php74;
+    php = php74base;
   });
 
   phpPackages-unit = php74Packages-unit;
@@ -9391,10 +9391,7 @@ in
 
   inherit (callPackages ../development/interpreters/php {
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
-  })
-    php74
-    php73
-    php72;
+  }) php74 php73 php72 php74base php73base php72base;
 
   php-embed = php74-embed;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15597,10 +15597,7 @@ in
 
   neard = callPackage ../servers/neard { };
 
-  unit = callPackage ../servers/http/unit {
-    php72 = php72-unit;
-    php73 = php73-unit;
-  };
+  unit = callPackage ../servers/http/unit { };
 
   nginx = nginxStable;
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -870,6 +870,25 @@ let
       # odbc (7.4, 7.3, 7.2)
       { name = "opcache";
         buildInputs = [ pcre' ];
+        # HAVE_OPCACHE_FILE_CACHE is defined in config.h, which is
+        # included from ZendAccelerator.h, but ZendAccelerator.h is
+        # included after the ifdef...
+        patches = lib.optional (lib.versionOlder php.version "7.4") [
+          (pkgs.writeText "zend_file_cache_config.patch" ''
+            --- a/zend_file_cache.c
+            +++ b/zend_file_cache.c
+            @@ -27,9 +27,9 @@
+             #include "ext/standard/md5.h"
+             #endif
+
+            +#include "ZendAccelerator.h"
+             #ifdef HAVE_OPCACHE_FILE_CACHE
+
+            -#include "ZendAccelerator.h"
+             #include "zend_file_cache.h"
+             #include "zend_shared_alloc.h"
+             #include "zend_accelerator_util_funcs.h"
+          '') ];
         zendExtension = true;
         doCheck = !(lib.versionOlder php.version "7.4"); }
       { name = "openssl";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -747,7 +747,7 @@ let
 
       installPhase = ''
         mkdir -p $out/lib/php/extensions
-        cp modules/${name}.so $out/lib/php/extensions/ext-${name}.so
+        cp modules/${name}.so $out/lib/php/extensions/${name}.so
       '';
     });
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, pkgs, fetchgit, php, autoconf, pkgconfig, re2c
-, bzip2, curl, libxml2, openssl, gmp5, icu, oniguruma, libsodium, html-tidy
+, bzip2, curl, libxml2, openssl, gmp, icu, oniguruma, libsodium, html-tidy
 , libzip, zlib, pcre, pcre2, libxslt, aspell, openldap, cyrus_sasl, uwimap
 , pam, libiconv, enchant1, libXpm, gd, libwebp, libjpeg, libpng, freetype
 , libffi, freetds, postgresql, sqlite, net-snmp, unixODBC, libedit, readline
@@ -811,10 +811,8 @@ let
         postPhpize = ''substituteInPlace configure --replace 'as_fn_error $? "Cannot locate header file libintl.h" "$LINENO" 5' ':' '';
         configureFlags = "--with-gettext=${gettext}"; }
       { name = "gmp";
-        buildInputs = [ gmp5 ];
-        configureFlags = [ "--with-gmp=${gmp5.dev}" ];
-        # gmp5 doesn't build on darwin.
-        enable = (!stdenv.isDarwin); }
+        buildInputs = [ gmp ];
+        configureFlags = [ "--with-gmp=${gmp.dev}" ]; }
       { name = "hash"; enable = lib.versionOlder php.version "7.4"; }
       { name = "iconv";
         configureFlags = if stdenv.isDarwin then

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -712,8 +712,8 @@ let
       , buildInputs ? []
       , zendExtension ? false
       , ...
-    }: stdenv.mkDerivation {
-      pname = "php-ext-${name}";
+    }@args: stdenv.mkDerivation (args // {
+      pname = "php-${name}";
 
       inherit (php) version src;
       sourceRoot = "php-${php.version}/ext/${name}";
@@ -728,7 +728,7 @@ let
         mkdir -p $out/lib/php/extensions
         cp modules/${name}.so $out/lib/php/extensions/ext-${name}.so
       '';
-    };
+    });
 
     # This list contains build instructions for different modules that one may
     # want to build.


### PR DESCRIPTION
###### Motivation for this change
Our old PHP derivation was crazy big with a crazy amount of enabled extensions that also had a crazy amount of defaults that we pulled in, yet excluded some extensions that would have been nice to have by default.

This is a follow up on: #82348 to utilize #79377 more. And also a follow-up on all of the work done by me and @talyz in #82794. 

##### The current PHP
The current closure size is:
```
/nix/store/4ga497cqvz04vcyw9lf7s74ymrc6r28g-php-7.4.3      245697960
```
And this contains things (among others) like:
```
/nix/store/2zsgfrkp0hn878rnrp0azpmy76ljm2b0-linux-pam-1.3.1       56161288
/nix/store/y5166rf2lkxkf3991qm390vn92czgfgh-openldap-2.4.49       56167840
```
##### The new smaller PHP
Here we have a smaller closure size:
```
/nix/store/94ny228zal94jm1q7ffryi5d1w18mbbr-php-with-extensions-7.4.3	 189682368
```
But we can also get a smaller base package
```
/nix/store/v5v6wn207ibpp6n90z05f11k7svq94wd-php-7.4.3	  89608568
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
