### PR TITLE
firejail: local profile handling fixed

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -36,10 +36,27 @@ stdenv.mkDerivation {
     sed -e "s@/etc/@$out/etc/@g" -e "/chmod u+s/d" -i Makefile
   '';
 
-  # We need to set the directory for the .local override files to
-  # /etc/firejail so we can actually override them
+  # The profile files provided with the firejail distribution include `.local`
+  # profile files using relative paths. The way firejail works when it comes to
+  # handling includes is by looking target files up in `~/.config/firejail`
+  # first, and then trying `SYSCONFDIR`. The latter normally points to
+  # `/etc/filejail`, but in the case of nixos points to the nix store. This
+  # makes it effectively impossible to place any profile files in
+  # `/etc/firejail`.
+  #
+  # The workaround applied below is by creating a set of `.local` files which
+  # only contain respective includes to `/etc/firejail`. This way
+  # `~/.config/firejail` still takes precedence, but `/etc/firejail` will also
+  # be searched in second order. This replicates the behaviour from
+  # non-nixos platforms.
+  #
+  # See https://github.com/netblue30/firejail/blob/e4cb6b42743ad18bd11d07fd32b51e8576239318/src/firejail/profile.c#L68-L83
+  # for the profile file lookup implementation.
   postInstall = ''
-    sed -E -e 's@^include (.*.local)$@include /etc/firejail/\1@g' -i $out/etc/firejail/*.profile
+    for local in $(grep -Eh '^include.*local$' $out/etc/firejail/*.profile | awk '{print $2}' | sort | uniq)
+    do
+      echo "include /etc/firejail/$local" >$out/etc/firejail/$local
+    done
   '';
 
   # At high parallelism, the build sometimes fails with:


### PR DESCRIPTION
made it possible to place local profiles in `~/.config/firejail`, as well as in `/etc/firejail`.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
