### PR TITLE
kubelogin: init at 0.0.6

### DIFF
--- a/pkgs/applications/networking/cluster/kubelogin/default.nix
+++ b/pkgs/applications/networking/cluster/kubelogin/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, buildGoModule, go }:
+
+buildGoModule rec {
+  pname = "kubelogin";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "18rkjdl8asr5c1kgdm2iqb5qwkfcrv2sk3nns3hhfqzs2v9mxmha";
+  };
+
+  vendorSha256 = "0al8y65xvnwl34jkpqyf6zwr21xn30zswknlym9nnn1n47fyayxb";
+
+  buildFlagsArray = ''
+    -ldflags=
+        -X main.version=${version}
+        -X main.goVersion=${stdenv.lib.getVersion go}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Kubernetes credential plugin implementing Azure authentication";
+    inherit (src.meta) homepage;
+    license = licenses.mit;
+    maintainers = with maintainers; [ yurrriq ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20590,6 +20590,8 @@ in
 
   kubeless = callPackage ../applications/networking/cluster/kubeless { };
 
+  kubelogin = callPackage ../applications/networking/cluster/kubelogin { };
+
   k9s = callPackage ../applications/networking/cluster/k9s { };
 
   fluxctl = callPackage ../applications/networking/cluster/fluxctl { };


### PR DESCRIPTION
###### Motivation for this change
Add [kubelogin](https://github.com/Azure/kubelogin)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
