### PR TITLE
acme: fix darwin build

### DIFF
--- a/pkgs/development/compilers/acme/default.nix
+++ b/pkgs/development/compilers/acme/default.nix
@@ -14,6 +14,11 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "BINDIR=$(out)/bin" ];
 
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "= gcc" "?= gcc"
+  '';
+
   meta = with stdenv.lib; {
     description = "A multi-platform cross assembler for 6502/6510/65816 CPUs.";
     homepage = "https://sourceforge.net/projects/acme-crossass/";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken on hydra

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
