### PR TITLE
lib.licenses: Add Unicode Terms of Use

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -682,6 +682,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     # channel and NixOS images.
   };
 
+  unicode-tou = spdx {
+    spdxId = "Unicode-TOU";
+    fullName = "Unicode Terms of Use";
+  };
+
   unlicense = spdx {
     spdxId = "Unlicense";
     fullName = "The Unlicense";

--- a/pkgs/data/misc/cldr-emoji-annotation/default.nix
+++ b/pkgs/data/misc/cldr-emoji-annotation/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Emoji annotation files in CLDR";
     homepage = "https://www.unicode.org/";
-    license = licenses.free; # https://www.unicode.org/license.html
+    license = licenses.unicode-tou;
     platforms = platforms.all;
   };
 }

--- a/pkgs/data/misc/unicode-character-database/default.nix
+++ b/pkgs/data/misc/unicode-character-database/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Unicode Character Database";
     homepage = "https://www.unicode.org/";
-    license = licenses.free; # https://www.unicode.org/license.html
+    license = licenses.unicode-tou;
     platforms = platforms.all;
   };
 }

--- a/pkgs/data/misc/unicode-emoji/default.nix
+++ b/pkgs/data/misc/unicode-emoji/default.nix
@@ -53,7 +53,7 @@ symlinkJoin rec {
   meta = with stdenv.lib; {
     description = "Unicode Emoji Data Files";
     homepage = "https://home.unicode.org/emoji/";
-    license = licenses.free; # https://www.unicode.org/license.html
+    license = licenses.unicode-tou;
     platforms = platforms.all;
   };
 }

--- a/pkgs/data/misc/unihan-database/default.nix
+++ b/pkgs/data/misc/unihan-database/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Unicode Han Database";
     homepage = "https://www.unicode.org/";
-    license = licenses.free; # https://www.unicode.org/license.html
+    license = licenses.unicode-tou;
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Reducing usage of `free` license.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
