### PR TITLE
[20.03] mkl: 2019.5.281 -> 2020.0.166 (Linux only)

### DIFF
--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -7,17 +7,18 @@ let
   # Release notes and download URLs are here:
   # https://registrationcenter.intel.com/en/products/
   version = "${year}.${spot}.${rel}";
-  year = "2019";
 
   # Darwin is pinned to 2019.3 because the DMG does not unpack; see here for details:
   # https://github.com/matthewbauer/undmg/issues/4
-  spot = if stdenvNoCC.isDarwin then "3" else "5";
-  rel = if stdenvNoCC.isDarwin then "199" else "281";
+  year = if stdenvNoCC.isDarwin then "2019" else "2020";
+  spot = if stdenvNoCC.isDarwin then "3" else "0";
+  rel = if stdenvNoCC.isDarwin then "199" else "166";
 
   rpm-ver = "${year}.${spot}-${rel}-${year}.${spot}-${rel}";
 
   # Intel openmp uses its own versioning, but shares the spot release patch.
-  openmp-ver = "19.0.${spot}-${rel}-19.0.${spot}-${rel}";
+  openmp = if stdenvNoCC.isDarwin then "19.0" else "19.1";
+  openmp-ver = "${openmp}.${spot}-${rel}-${openmp}.${spot}-${rel}";
 
 in stdenvNoCC.mkDerivation {
   pname = "mkl";
@@ -31,8 +32,8 @@ in stdenvNoCC.mkDerivation {
       })
     else
       (fetchurl {
-        url = "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15816/l_mkl_${version}.tgz";
-        sha256 = "0zkk4rrq7g44acxaxhpd2053r66w169mww6917an0lxhd52fm5cr";
+        url = "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16318/l_mkl_${version}.tgz";
+        sha256 = "1q4ab87qzraksn8mm4117vj7l3sgpdi2qszj7nx122zi7zmjvngn";
       });
 
   nativeBuildInputs = if stdenvNoCC.isDarwin
@@ -136,7 +137,7 @@ in stdenvNoCC.mkDerivation {
       choice of compilers, languages, operating systems, and linking and
       threading models.
     '';
-    homepage = https://software.intel.com/en-us/mkl;
+    homepage = "https://software.intel.com/en-us/mkl";
     license = licenses.issl;
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ bhipple ];


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/83277

This is not technically part of ZHF #80379, since Hydra doesn't build it, but it
nevertheless contains a number of bugfixes and should be backported.

CC @NixOS/nixos-release-managers 

(cherry picked from commit 335e0973523641cb779667aa2609191b4a273737)