### PR TITLE
osinfo-db-tools: 1.6.0 -> 1.7.0, osinfo-db: 20200214 -> 20200515, libosinfo: fix test

### DIFF
--- a/pkgs/data/misc/osinfo-db/default.nix
+++ b/pkgs/data/misc/osinfo-db/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "osinfo-db";
-  version = "20200214";
+  version = "20200515";
 
   src = fetchurl {
     url = "https://releases.pagure.org/libosinfo/${pname}-${version}.tar.xz";
-    sha256 = "1fpdb8r8kzwp1k5dc9xyy9jr2jr3haq7n9b6spamm599zvzf8nb6";
+    sha256 = "1m9idmmb1sjf24lp9lgng2m1jj09mn9fa9pnz36fdv5q0lskgscj";
   };
 
   nativeBuildInputs = [ osinfo-db-tools intltool libxml2 ];

--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -68,10 +68,11 @@ stdenv.mkDerivation rec {
     "-Denable-gtk-doc=true"
   ];
 
-  # FIXME: fails two new tests added in 1.7.1:
-  # libosinfo:symbols / check-symfile
-  # 3/24 libosinfo:symbols / check-symsorting
-  doCheck = false;
+  preCheck = ''
+    patchShebangs ../osinfo/check-symfile.pl ../osinfo/check-symsorting.pl
+  '';
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "GObject based library API for managing information about operating systems, hypervisors and the (virtual) hardware devices they can support";

--- a/pkgs/tools/misc/osinfo-db-tools/default.nix
+++ b/pkgs/tools/misc/osinfo-db-tools/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, pkgconfig, gettext, glib, libxml2, perl
+{ stdenv, fetchurl, pkgconfig, meson, ninja, gettext, glib, libxml2, perl, python3
 , libxslt, libarchive, bzip2, lzma, json-glib, libsoup
 }:
 
 stdenv.mkDerivation rec {
   pname = "osinfo-db-tools";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchurl {
-    url = "https://releases.pagure.org/libosinfo/${pname}-${version}.tar.gz";
-    sha256 = "0x155d4hqz7mabgqvgydqjm9d8aabc78vr0v0pnsp9vkdlcv3mfh";
+    url = "https://releases.pagure.org/libosinfo/${pname}-${version}.tar.xz";
+    sha256 = "08x8mrafphyll0d35xdc143rip3ahrz6bmzhc85nwhq7yk2vxpab";
   };
 
-  nativeBuildInputs = [ pkgconfig gettext perl ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext perl python3 ];
   buildInputs = [ glib json-glib libxml2 libxslt libarchive bzip2 lzma libsoup ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Upstream switched archive format `tar.gz` -> `tar.xz`, that's probably why the bot didn't pick this up.

If you are reading this, it's possible you know something about libosinfo. In that case, please take a look at this PR that attempts to add NixOS to osinfo-db: https://gitlab.com/libosinfo/osinfo-db/-/merge_requests/107

cc @bjornfor @jtojnar @jonringer 

###### Motivation for this change

* https://gitlab.com/libosinfo/libosinfo/-/blob/v1.7.1/NEWS#L4-23
* https://gitlab.com/libosinfo/osinfo-db-tools/-/blob/v1.7.0/NEWS#L1-4
* https://gitlab.com/libosinfo/osinfo-db/compare/v20200214...v20200325

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
