### PR TITLE
line-awesome: init at 1.3.0

### DIFF
--- a/pkgs/data/fonts/line-awesome/default.nix
+++ b/pkgs/data/fonts/line-awesome/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  pname = "line-awesome";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url =
+      "https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/${version}/line-awesome-${version}.zip";
+    hash = "sha256:07qkz8s1wjh5xwqlq1b4lpihr1zah3kh6bnqvfwvncld8l9wjqfk";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = "${version}/fonts";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/fonts/woff
+    mkdir -p $out/share/fonts/woff2
+    cp *.ttf $out/share/fonts/truetype
+    cp *.woff $out/share/fonts/woff
+    cp *.woff2 $out/share/fonts/woff2
+  '';
+
+  meta = with lib; {
+    description = "Replace Font Awesome with modern line icons";
+    longDescription = ''
+      This package includes only the TTF, WOFF and WOFF2 fonts. For full CSS etc. see the project website.
+    '';
+    homepage = "https://icons8.com/line-awesome";
+    license = licenses.mit;
+    maintainers = with maintainers; [ puzzlewolf ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17905,6 +17905,8 @@ in
 
   libre-franklin = callPackage ../data/fonts/libre-franklin { };
 
+  line-awesome = callPackage ../data/fonts/line-awesome { };
+
   lmmath = callPackage ../data/fonts/lmmath {};
 
   lmodern = callPackage ../data/fonts/lmodern { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Line Awesome is a free alternative to Font Awesome, in line icon style. 
https://icons8.com/line-awesome/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
