### PR TITLE
unbound: don't implicitly enable local resolver in resolvconf

### DIFF
--- a/nixos/modules/services/networking/unbound.nix
+++ b/nixos/modules/services/networking/unbound.nix
@@ -108,8 +108,6 @@ in
       isSystemUser = true;
     };
 
-    networking.resolvconf.useLocalResolver = mkDefault true;
-
     systemd.services.unbound = {
       description = "Unbound recursive Domain Name Server";
       after = [ "network.target" ];


### PR DESCRIPTION
###### Motivation for this change

Don't implicitly enable local resolving (resulting in `nameserver 127.0.0.1` in */etc/resolv.conf*) when enabling unbound. Unbound may have been configured to not even listen on the loopback device, or the system may have otherwise been configured in a way which make local resolving undesired.

The user can instead explicitly enable local resolving using one of the two following methods:

    networking.nameservers = [ "127.0.0.1" "::1" ];

    networking.resolvconf.useLocalResolver = true;

The implicit functionality was introduced in 01b90dc and was applied to other DNS resolvers as well.

---

For example: in a case where you are setting up a DNS server for a subnet you are part of, configuring `interfaces` to **not** include `127.0.0.1`, there is nothing listening on `127.0.0.1:53`, but `resolvconf` is still setting it as the system wide resolver.

It makes more sense to let the user set this option explicitly if it is your desired behavior. E.g. by setting `networking.nameservers` to `127.0.0.1` which I would expect I'd have to do anyway.

There may be other resolvers affected by this same implicit setting which came in with 01b90dce78ee3906def0fc8d800217a3f9f40aa7, however none of which I have experience with.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
