### PR TITLE
ion: 1.0.5 -> unstable-2020-03-22 and fix build

### DIFF
--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -1,29 +1,24 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
-with rustPlatform;
-
-buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "ion";
-  version = "1.0.5";
+  version = "unstable-2020-03-22";
 
   src = fetchFromGitHub {
     owner = "redox-os";
     repo = "ion";
-    rev = version;
-    sha256 = "0i0acl5nw254mw8dbfmb4792rr71is98a5wg32yylfnlrk7zlf8z";
+    rev = "1fbd29a6d539faa6eb0f3186a361e208d0a0bc05";
+    sha256 = "0r5c87cs8jlc9kpb6bi2aypldw1lngf6gzjirf13gi7iy4q08ik7";
   };
 
-  cargoSha256 = "0f266kygvw2id771g49s25qsbqb6a0gr1r0czkcj96n5r0wg8wrn";
+  cargoSha256 = "1ph3r3vspy700mb8pica8478v9arqz07k2nzpbrdkdkqgfcwlgcg";
 
   meta = with stdenv.lib; {
     description = "Modern system shell with simple (and powerful) syntax";
-    homepage = https://github.com/redox-os/ion;
+    homepage = "https://gitlab.redox-os.org/redox-os/ion";
     license = licenses.mit;
     maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
-    # This has not had a release since 2017, and no longer compiles with the
-    # latest Rust compiler.
-    broken = false;
   };
 
   passthru = {


### PR DESCRIPTION
The app is still maintained upstream, but they aren't cutting releases on
crates.io anymore:
https://crates.io/crates/ion-shell

This fixes the build with the latest Rust toolchain by upgrading to the current
commit off the project's `master`.

ZHF: #80379

CC @NixOS/nixos-release-managers


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).