### PR TITLE
[20.03] ion: 1.0.5 -> unstable-2020-03-22

### DIFF
--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -1,29 +1,24 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
-with rustPlatform;
-
-buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "ion";
-  version = "1.0.5";
+  version = "unstable-2020-03-22";
 
   src = fetchFromGitHub {
     owner = "redox-os";
     repo = "ion";
-    rev = version;
-    sha256 = "0i0acl5nw254mw8dbfmb4792rr71is98a5wg32yylfnlrk7zlf8z";
+    rev = "1fbd29a6d539faa6eb0f3186a361e208d0a0bc05";
+    sha256 = "0r5c87cs8jlc9kpb6bi2aypldw1lngf6gzjirf13gi7iy4q08ik7";
   };
 
-  cargoSha256 = "1hs01b1rhbpafxlhw661k907rznqhcgyng85njkb99bg4lxwxaap";
+  cargoSha256 = "0rpq2zy7563z00i1ms0pyyyaplr3hlfagj8c4syc0dw0vbkqhzzw";
 
   meta = with stdenv.lib; {
     description = "Modern system shell with simple (and powerful) syntax";
-    homepage = https://github.com/redox-os/ion;
+    homepage = "https://gitlab.redox-os.org/redox-os/ion";
     license = licenses.mit;
     maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
-    # This has not had a release since 2017, and no longer compiles with the
-    # latest Rust compiler.
-    broken = false;
   };
 
   passthru = {


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/83542

ZHF: #80379

(cherry picked from commit 16cdff0711dc2871b49a1194efc3073aee6c7f04)