### PR TITLE
iso-image: normalize volumeID

### DIFF
--- a/nixos/lib/make-iso9660-image.sh
+++ b/nixos/lib/make-iso9660-image.sh
@@ -107,6 +107,7 @@ xorriso="xorriso
  -publisher nixos
  -graft-points
  -full-iso9660-filenames
+ -joliet
  ${isoBootFlags}
  ${usbBootFlags}
  ${efiBootFlags}

--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -18,8 +18,6 @@ with lib;
   # ISO naming.
   isoImage.isoName = "${config.isoImage.isoBaseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.iso";
 
-  isoImage.volumeID = substring 0 11 "NIXOS_ISO";
-
   # EFI booting
   isoImage.makeEfiBootable = true;
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -7,6 +7,8 @@ with lib;
 {
   imports = [ ./installation-cd-graphical-base.nix ];
 
+  isoImage.edition = "gnome";
+
   services.xserver.desktopManager.gnome3.enable = true;
 
   # Wayland can be problematic for some hardware like Nvidia graphics cards.

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix
@@ -8,6 +8,8 @@ with lib;
 {
   imports = [ ./installation-cd-graphical-base.nix ];
 
+  isoImage.edition = "plasma5";
+
   services.xserver = {
     desktopManager.plasma5 = {
       enable = true;

--- a/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
@@ -8,5 +8,7 @@
     [ ./installation-cd-base.nix
     ];
 
+  isoImage.edition = "minimal";
+
   fonts.fontconfig.enable = false;
 }

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -524,6 +524,19 @@ in
   };
 
   config = {
+    assertions = [
+      {
+        assertion = !(stringLength config.isoImage.volumeID > 32);
+        # https://wiki.osdev.org/ISO_9660#The_Primary_Volume_Descriptor
+        # Volume Identifier can only be 32 bytes
+        message = let
+          length = stringLength config.isoImage.volumeID;
+          howmany = toString length;
+          toomany = toString (length - 32);
+        in
+        "isoImage.volumeID ${config.isoImage.volumeID} is ${howmany} characters. That is ${toomany} characters longer than the limit of 32.";
+      }
+    ];
 
     boot.loader.grub.version = 2;
 

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -417,8 +417,17 @@ in
       '';
     };
 
+    isoImage.edition = mkOption {
+      default = "";
+      description = ''
+        Specifies which edition string to use in the volume ID of the generated
+        ISO image.
+      '';
+    };
+
     isoImage.volumeID = mkOption {
-      default = "NIXOS_BOOT_CD";
+      # nixos-$EDITION-$RELEASE-$ARCH
+      default = "nixos${optionalString (config.isoImage.edition != "") "-${config.isoImage.edition}"}-${config.system.nixos.release}-${pkgs.stdenv.hostPlatform.system}";
       description = ''
         Specifies the label or volume ID of the generated ISO image.
         Note that the label is used by stage 1 of the boot process to


### PR DESCRIPTION
###### Motivation for this change
The volumeID of nixos images will now be in the format of:
```
nixos-$EDITION-$RELEASE-$ARCH
nixos-minimal-20.09-x86-64-linux
```

We're trying to get nixos into osinfo-db, see https://gitlab.com/libosinfo/osinfo-db/-/merge_requests/107 and https://gitlab.com/libosinfo/osinfo-db/-/merge_requests/107#note_313094852 as motivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
