### PR TITLE
[20.03] python27Packages.gym: 0.15.4 -> 0.16.0 to fix build

### DIFF
--- a/pkgs/development/python-modules/gym/default.nix
+++ b/pkgs/development/python-modules/gym/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "gym";
-  version = "0.15.4";
+  version = "0.16.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3b930cbe1c76bbd30455b5e82ba723dea94159a5f988e927f443324bf7cc7ddd";
+    sha256 = "06h5b639nmzhmy4m1j3vigm86iv5pv7k8jy6xpldyd4jdlf37nn5";
   };
 
   postPatch = ''
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A toolkit by OpenAI for developing and comparing your reinforcement learning agents";
-    homepage = https://gym.openai.com/;
+    homepage = "https://gym.openai.com/";
     license = licenses.mit;
     maintainers = with maintainers; [ hyphon81 ];
   };


### PR DESCRIPTION
Fixes broken build by backporting https://github.com/NixOS/nixpkgs/pull/81577
and previous update.

CC @NixOS/nixos-release-managers

ZHF: #80379

(cherry picked from commit 908c6e8214a3933d43f55f5c4ae6df0572c34568)