### PR TITLE
pythonPackages.ntlm-auth: 1.0.3 -> 1.4.0 to fix build

### DIFF
--- a/pkgs/development/python-modules/ntlm-auth/default.nix
+++ b/pkgs/development/python-modules/ntlm-auth/default.nix
@@ -3,22 +3,23 @@
 , fetchFromGitHub
 , mock
 , pytest
+, requests
 , unittest2
 , six
 }:
 
 buildPythonPackage rec {
   pname = "ntlm-auth";
-  version = "1.0.3";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "jborean93";
     repo = "ntlm-auth";
     rev = "v${version}";
-    sha256 = "09f2g4ivfi9lh1kr30hlg0q4n2imnvmd79w83gza11q9nmhhiwpz";
+    sha256 = "168k3ygwbvnfcwn7q1nv3vvy6b9jc4cnpix0xgg5j8av7v1x0grn";
   };
 
-  checkInputs = [ mock pytest unittest2 ];
+  checkInputs = [ mock pytest requests unittest2 ];
   propagatedBuildInputs = [ six ];
 
   # Functional tests require networking
@@ -28,8 +29,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Calculates NTLM Authentication codes";
-    homepage = https://github.com/jborean93/ntlm-auth;
-    license = licenses.lgpl3;
+    homepage = "https://github.com/jborean93/ntlm-auth";
+    license = licenses.mit;
     maintainers = with maintainers; [ elasticdog ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
On master and 20.03, this is failing to build on `python 3.8`.

https://hydra.nixos.org/build/115517329
https://hydra.nixos.org/build/114714922

CC @NixOS/nixos-release-managers
ZHF: #80379



<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).