### PR TITLE
[20.03] rpcs3: 0.0.6-8187-790962425 -> 0.0.8-9300-341fdf7eb

### DIFF
--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, lib, fetchgit, cmake, pkgconfig, git
-, qt5, openal, glew, vulkan-loader, libpng, ffmpeg, libevdev, python27
+{ mkDerivation, lib, fetchgit, cmake, pkgconfig, git
+, qtbase, qtquickcontrols, openal, glew, vulkan-loader, libpng, ffmpeg, libevdev, python3
 , pulseaudioSupport ? true, libpulseaudio
 , waylandSupport ? true, wayland
 , alsaSupport ? true, alsaLib
 }:
 
 let
-  majorVersion = "0.0.6";
-  gitVersion = "8187-790962425"; # echo $(git rev-list HEAD --count)-$(git rev-parse --short HEAD)
+  majorVersion = "0.0.8";
+  gitVersion = "9300-341fdf7eb"; # echo $(git rev-list HEAD --count)-$(git rev-parse --short HEAD)
 in
-stdenv.mkDerivation {
+mkDerivation {
   pname = "rpcs3";
   version = "${majorVersion}-${gitVersion}";
 
   src = fetchgit {
     url = "https://github.com/RPCS3/rpcs3";
-    rev = "790962425cfb893529f72b3ef0dd1424fcc42973";
-    sha256 = "154ys29b9xdws3bp4b7rb3kc0h9hd49g2yf3z9268cdq8aclahaa";
+    rev = "341fdf7eb14763fd06e2eab9a4b2b8f1adf9fdbd";
+    sha256 = "1qx97zkkjl6bmv5rhfyjqynbz0v8h40b2wxqnl59g287wj0yk3y1";
   };
 
   preConfigure = ''
@@ -36,14 +36,14 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake pkgconfig git ];
 
   buildInputs = [
-    qt5.qtbase qt5.qtquickcontrols openal glew vulkan-loader libpng ffmpeg libevdev python27
+    qtbase qtquickcontrols openal glew vulkan-loader libpng ffmpeg libevdev python3
   ] ++ lib.optional pulseaudioSupport libpulseaudio
     ++ lib.optional alsaSupport alsaLib
     ++ lib.optional waylandSupport wayland;
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "PS3 emulator/debugger";
     homepage = "https://rpcs3.net/";
     maintainers = with maintainers; [ abbradar nocent ];


### PR DESCRIPTION
Backports #82998 to fix issues with #65399

CC @NixOS/nixos-release-managers
ZHF: #80379

(cherry picked from commit f028498f634b4924a26d7eaaabd235bdbf827547)


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).