### PR TITLE
[20.03] pythonPackages.ntlm-auth: 1.0.3 -> 1.4.0 to fix build

### DIFF
--- a/pkgs/development/python-modules/ntlm-auth/default.nix
+++ b/pkgs/development/python-modules/ntlm-auth/default.nix
@@ -3,22 +3,23 @@
 , fetchFromGitHub
 , mock
 , pytest
+, requests
 , unittest2
 , six
 }:
 
 buildPythonPackage rec {
   pname = "ntlm-auth";
-  version = "1.0.3";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "jborean93";
     repo = "ntlm-auth";
     rev = "v${version}";
-    sha256 = "09f2g4ivfi9lh1kr30hlg0q4n2imnvmd79w83gza11q9nmhhiwpz";
+    sha256 = "168k3ygwbvnfcwn7q1nv3vvy6b9jc4cnpix0xgg5j8av7v1x0grn";
   };
 
-  checkInputs = [ mock pytest unittest2 ];
+  checkInputs = [ mock pytest requests unittest2 ];
   propagatedBuildInputs = [ six ];
 
   # Functional tests require networking
@@ -28,8 +29,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Calculates NTLM Authentication codes";
-    homepage = https://github.com/jborean93/ntlm-auth;
-    license = licenses.lgpl3;
+    homepage = "https://github.com/jborean93/ntlm-auth";
+    license = licenses.mit;
     maintainers = with maintainers; [ elasticdog ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/83560

Fixed failing build:
https://hydra.nixos.org/build/115517329

CC @NixOS/nixos-release-managers
ZHF: #80379

(cherry picked from commit 8cd2c6d579624222c4a52e2034d090720d75f24e)