### PR TITLE
[20.03] perlPackages.CryptSSLeay: 0.72 -> 0.73_06

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1195,6 +1195,21 @@ let
     };
   };
 
+  BytesRandomSecure = buildPerlPackage {
+    pname = "Bytes-Random-Secure";
+    version = "0.29";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DA/DAVIDO/Bytes-Random-Secure-0.29.tar.gz";
+      sha256 = "53bbd339e6a11efca07c619a615c7c188a68bb2be849a1cb7efc3dd4d9ae85ae";
+    };
+    propagatedBuildInputs = [ CryptRandomSeed MathRandomISAAC ];
+    meta = {
+      description = "Perl extension to generate cryptographically-secure random bytes";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.sgo ];
+    };
+  };
+
   CacheCache = buildPerlPackage {
     pname = "Cache-Cache";
     version = "1.08";
@@ -3557,6 +3572,22 @@ let
     };
   };
 
+  CryptRandomSeed = buildPerlPackage {
+    pname = "Crypt-Random-Seed";
+    version = "0.03";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DA/DANAJ/Crypt-Random-Seed-0.03.tar.gz";
+      sha256 = "593da54b522c09cc26bbcc0e4e49c1c8e688a6fd33b0726af801d722a5c8d0f1";
+    };
+    propagatedBuildInputs = [ CryptRandomTESHA2 ];
+    meta = {
+      homepage = "https://github.com/danaj/Crypt-Random-Seed";
+      description = "Provide strong randomness for seeding";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.sgo ];
+    };
+  };
+
   CryptRandomSource = buildPerlModule {
     pname = "Crypt-Random-Source";
     version = "0.14";
@@ -3568,6 +3599,20 @@ let
     propagatedBuildInputs = [ CaptureTiny ModuleFind Moo SubExporter TypeTiny namespaceclean ];
     meta = {
       description = "Get weak or strong random data from pluggable sources";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  CryptRandomTESHA2 = buildPerlPackage {
+    pname = "Crypt-Random-TESHA2";
+    version = "0.01";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DA/DANAJ/Crypt-Random-TESHA2-0.01.tar.gz";
+      sha256 = "a0912b42c52be173da528d5527e40d967324bc04ac78d9fc2ddc91ff16fe9633";
+    };
+    meta = {
+      homepage = "https://github.com/danaj/Crypt-Random-TESHA2";
+      description = "Random numbers using timer/schedule entropy, aka userspace voodoo entropy";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3764,14 +3809,15 @@ let
 
   CryptSSLeay = buildPerlPackage {
     pname = "Crypt-SSLeay";
-    version = "0.72";
+    version = "0.73_06";
     src = fetchurl {
-      url = mirror://cpan/authors/id/N/NA/NANIS/Crypt-SSLeay-0.72.tar.gz;
-      sha256 = "1s7zm6ph37kg8jzaxnhi4ff4snxl7mi5h14arxbri0kp6s0lzlzm";
+      url = "mirror://cpan/authors/id/N/NA/NANIS/Crypt-SSLeay-0.73_06.tar.gz";
+      sha256 = "0b159lw3ia5r87qsgff3qhdnz3l09xcz04rbk4ji7fbyr12wmv7q";
     };
+
     makeMakerFlags = "--libpath=${pkgs.openssl.out}/lib --incpath=${pkgs.openssl.dev}/include";
     buildInputs = [ PathClass ];
-    propagatedBuildInputs = [ LWPProtocolHttps ];
+    propagatedBuildInputs = [ LWPProtocolHttps BytesRandomSecure ];
   };
 
   CSSDOM = buildPerlPackage {


### PR DESCRIPTION
Backport of #81438

###### Motivation for this change

ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

----

Result of `nixpkgs-review pr 83565` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>58 package marked as broken and skipped:</summary>

  - clang-sierraHack
  - clang-sierraHack-stdenv
  - digitalbitbox
  - gdata-sharp
  - linuxPackages.sch_cake
  - linuxPackages_4_14.sch_cake
  - linuxPackages_4_4.evdi
  - linuxPackages_4_4.sysdig
  - linuxPackages_hardkernel_4_14.bcc
  - linuxPackages_hardkernel_4_14.bpftrace
  - linuxPackages_hardkernel_4_14.can-isotp
  - linuxPackages_hardkernel_4_14.chipsec
  - linuxPackages_hardkernel_4_14.digimend
  - linuxPackages_hardkernel_4_14.evdi
  - linuxPackages_hardkernel_4_14.mba6x_bl
  - linuxPackages_hardkernel_4_14.nvidia_x11
  - linuxPackages_hardkernel_4_14.nvidiabl
  - linuxPackages_hardkernel_4_14.rtl8814au
  - linuxPackages_hardkernel_4_14.rtl8821au
  - linuxPackages_hardkernel_4_14.rtl8821ce
  - linuxPackages_hardkernel_4_14.rtlwifi_new
  - linuxPackages_hardkernel_4_14.sysdig
  - linuxPackages_hardkernel_4_14.vhba
  - linuxPackages_hardkernel_4_14.virtualbox
  - linuxPackages_hardkernel_4_14.virtualboxGuestAdditions
  - linuxPackages_latest_hardened.sch_cake
  - linuxPackages_latest_xen_dom0.sch_cake
  - linuxPackages_latest_xen_dom0_hardened.sch_cake
  - linuxPackages_testing_hardened.sch_cake
  - linuxPackages_xen_dom0.sch_cake
  - linuxPackages_xen_dom0_hardened.sch_cake
  - muslCross
  - php72Packages-unit.php_excel
  - php72Packages-unit.v8
  - php72Packages-unit.v8js
  - php72Packages.php_excel
  - php72Packages.v8
  - php72Packages.v8js
  - php73Packages-unit.php_excel
  - php73Packages-unit.v8
  - php73Packages.php_excel
  - php73Packages.v8
  - php74Packages-unit.couchbase
  - php74Packages-unit.php_excel
  - php74Packages-unit.v8
  - php74Packages.couchbase
  - php74Packages.pcs
  - php74Packages.php_excel
  - php74Packages.v8
  - python27Packages.flitBuildHook
  - python37Packages.notify
  - python37Packages.pyblock
  - python38Packages.poezio
  - qes
  - telepathy-salut
  - telepathy_salut
  - torchPackages.lua-cjson
  - torchPackages.luaffifb
</details>
<details>
  <summary>1 package failed to build:</summary>

  - rt
</details>
<details>
  <summary>11 package built:</summary>

  - debian-devscripts (debian_devscripts)
  - ikiwiki
  - longview
  - perl528Packages.BytesRandomSecure
  - perl528Packages.CryptRandomSeed
  - perl528Packages.CryptRandomTESHA2
  - perl528Packages.CryptSSLeay
  - perl530Packages.BytesRandomSecure
  - perl530Packages.CryptRandomSeed
  - perl530Packages.CryptRandomTESHA2
  - perl530Packages.CryptSSLeay
</details>

RT is fixed in #83566.