### PR TITLE
[20.03] rt: fix build error

### DIFF
--- a/pkgs/servers/rt/default.nix
+++ b/pkgs/servers/rt/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     perl
     (buildEnv {
       name = "rt-perl-deps";
-      paths = (with perlPackages; [
+      paths = with perlPackages; (requiredPerlModules [
         ApacheSession BusinessHours CGIEmulatePSGI CGIPSGI
         CSSMinifierXS CSSSquish ConvertColor CryptEksblowfish
         CryptSSLeay DBDSQLite DBDmysql DBIxSearchBuilder DataGUID


### PR DESCRIPTION
Backport of #80677

###### Motivation for this change

ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
