### PR TITLE
python38Packages.zetup: fix build

### DIFF
--- a/pkgs/development/python-modules/zetup/default.nix
+++ b/pkgs/development/python-modules/zetup/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ lib, buildPythonPackage, fetchPypi
 , setuptools_scm, pathpy, nbconvert
 , pytest }:
 
@@ -11,11 +11,10 @@ buildPythonPackage rec {
     sha256 = "b8a9bdcfa4b705d72b55b218658bc9403c157db7b57a14158253c98d03ab713d";
   };
 
-  # Python 3.7 compatibility
-  # See https://github.com/zimmermanncode/zetup/pull/1
+  # Python 3.8 compatibility
   postPatch = ''
     substituteInPlace zetup/zetup_config.py \
-      --replace "'3.6']" "'3.6', '3.7']"
+      --replace "'3.7']" "'3.7', '3.8']"
   '';
 
   checkPhase = ''
@@ -25,11 +24,9 @@ buildPythonPackage rec {
   checkInputs = [ pytest pathpy nbconvert ];
   propagatedBuildInputs = [ setuptools_scm ];
 
-  meta = with stdenv.lib; {
-    description = ''
-      Zimmermann's Extensible Tools for Unified Project setups
-    '';
-    homepage = https://github.com/zimmermanncode/zetup;
+  meta = with lib; {
+    description = "Zimmermann's Extensible Tools for Unified Project setups";
+    homepage = "https://github.com/zimmermanncode/zetup";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
Currently fails to build on python 3.8 due to an overly restrictive version bound.

ZHF: #80379

CC @NixOS/nixos-release-managers


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).