### PR TITLE
pythonPackages.effect: fix build by marking py3 only

### DIFF
--- a/pkgs/development/python-modules/effect/default.nix
+++ b/pkgs/development/python-modules/effect/default.nix
@@ -1,33 +1,40 @@
 { buildPythonPackage
 , fetchPypi
 , lib
+, isPy3k
 , six
 , attrs
 , pytest
 , testtools
 }:
+
 buildPythonPackage rec {
   version = "1.1.0";
   pname = "effect";
+  disabled = (!isPy3k);
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "7affb603707c648b07b11781ebb793a4b9aee8acf1ac5764c3ed2112adf0c9ea";
   };
+
   checkInputs = [
     pytest
     testtools
   ];
+
   propagatedBuildInputs = [
     six
     attrs
   ];
+
   checkPhase = ''
     pytest
   '';
+
   meta = with lib; {
     description = "Pure effects for Python";
-    homepage = https://github.com/python-effect/effect;
+    homepage = "https://github.com/python-effect/effect";
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
Upstream only supports python >= 3.6:
https://github.com/python-effect/effect/#effect

CC @NixOS/nixos-release-managers

ZHF: #80379


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).