### PR TITLE
[20.03] pythonPackages.effect: fix build by marking py3 only

### DIFF
--- a/pkgs/development/python-modules/effect/default.nix
+++ b/pkgs/development/python-modules/effect/default.nix
@@ -1,33 +1,40 @@
 { buildPythonPackage
 , fetchPypi
 , lib
+, isPy3k
 , six
 , attrs
 , pytest
 , testtools
 }:
+
 buildPythonPackage rec {
   version = "1.1.0";
   pname = "effect";
+  disabled = (!isPy3k);
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "7affb603707c648b07b11781ebb793a4b9aee8acf1ac5764c3ed2112adf0c9ea";
   };
+
   checkInputs = [
     pytest
     testtools
   ];
+
   propagatedBuildInputs = [
     six
     attrs
   ];
+
   checkPhase = ''
     pytest
   '';
+
   meta = with lib; {
     description = "Pure effects for Python";
-    homepage = https://github.com/python-effect/effect;
+    homepage = "https://github.com/python-effect/effect";
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/83573

Upstream only supports python >= 3.6:
https://github.com/python-effect/effect/#effect

CC @NixOS/nixos-release-managers

ZHF: #80379

(cherry picked from commit 3b7b98ce1e653db0123b7529a5a78961fa424fb3)