### PR TITLE
wolf-spectrum: init at 1.0.0

### DIFF
--- a/pkgs/applications/audio/wolf-spectrum/default.nix
+++ b/pkgs/applications/audio/wolf-spectrum/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, libjack2
+, lv2
+, xorg
+, liblo
+, libGL
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wolf-spectrum";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "pdesaulniers";
+    repo = "wolf-spectrum";
+    rev = "v${version}";
+    sha256 = "17db1jlj7vb1xyvkdhhrsvdbwb7jqw6i4168cdvlj3yvn2ra8gpm";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libjack2 lv2 xorg.libX11 liblo libGL xorg.libXcursor ];
+
+  makeFlags = [
+    "BUILD_LV2=true"
+    "BUILD_DSSI=false"
+    "BUILD_VST2=true"
+    "BUILD_JACK=true"
+  ];
+
+  patchPhase = ''
+    patchShebangs ./dpf/utils/generate-ttl.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2
+    #mkdir -p $out/lib/dssi
+    mkdir -p $out/lib/vst
+    mkdir -p $out/bin/
+    cp -r bin/wolf-spectrum.lv2    $out/lib/lv2/
+    #cp -r bin/wolf-spectrum-dssi*  $out/lib/dssi/
+    cp -r bin/wolf-spectrum-vst.so $out/lib/vst/
+    cp -r bin/wolf-spectrum        $out/bin/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/pdesaulniers/wolf-spectrum";
+    description = "Real-time 2D spectrogram plugin (LV2, VST and Jack)";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/audio/wolf-spectrum/default.nix
+++ b/pkgs/applications/audio/wolf-spectrum/default.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib/vst
     mkdir -p $out/bin/
     cp -r bin/wolf-spectrum.lv2    $out/lib/lv2/
-    #cp -r bin/wolf-spectrum-dssi*  $out/lib/dssi/
     cp -r bin/wolf-spectrum-vst.so $out/lib/vst/
     cp -r bin/wolf-spectrum        $out/bin/
   '';
@@ -51,6 +50,6 @@ stdenv.mkDerivation rec {
     description = "Real-time 2D spectrogram plugin (LV2, VST and Jack)";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.matthiasbeyer ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3818,6 +3818,8 @@ in
 
   wob = callPackage ../tools/misc/wob { };
 
+  wolf-spectrum = callPackage ../applications/audio/wolf-spectrum { };
+
   wtype = callPackage ../tools/wayland/wtype { };
 
   wrangler = callPackage ../development/tools/wrangler { };


### PR DESCRIPTION
Thanks for @mrVanDalo as this is only copy-paste from here: https://git.ingolf-wagner.de/palo/nixos-config/src/master/pkgs/wolf-spectrum/default.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
