### PR TITLE
pythonPackages.roku: init at v4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ result-*
 .version-suffix
 
 .DS_Store
+.mypy_cache
 
 /pkgs/development/libraries/qt-5/*/tmp/
 /pkgs/desktops/kde-5/*/tmp/

--- a/pkgs/development/python-modules/roku/default.nix
+++ b/pkgs/development/python-modules/roku/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage, requests, pytest, flask, isPy27
+}:
+
+buildPythonPackage rec {
+  version = "4.1";
+  pname = "roku";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "jcarbaugh";
+    repo = "python-roku";
+    rev = "v${version}";
+    sha256 = "09mq59kjll7gj1srw4qc921ncsm7cld95sbz5v3p2bwmgckpqza7";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [ pytest flask ];
+  pythonImportsCheck = [ "roku" ];
+
+  meta = with stdenv.lib; {
+    description = "Screw remotes. Control your Roku with Python.";
+    homepage = "https://github.com/jcarbaugh/python-roku";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -640,7 +640,7 @@
     "ripple" = ps: with ps; [ ]; # missing inputs: python-ripple-api
     "rmvtransport" = ps: with ps; [ ]; # missing inputs: PyRMVtransport
     "rocketchat" = ps: with ps; [ ]; # missing inputs: rocketchat-API
-    "roku" = ps: with ps; [ ]; # missing inputs: roku
+    "roku" = ps: with ps; [ roku];
     "roomba" = ps: with ps; [ ]; # missing inputs: roombapy
     "route53" = ps: with ps; [ boto3]; # missing inputs: ipify
     "rova" = ps: with ps; [ ]; # missing inputs: rova

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3299,6 +3299,8 @@ in {
 
   rethinkdb = callPackage ../development/python-modules/rethinkdb { };
 
+  roku = callPackage ../development/python-modules/roku { };
+
   roman = callPackage ../development/python-modules/roman { };
 
   rotate-backups = callPackage ../tools/backup/rotate-backups { };


### PR DESCRIPTION
###### Motivation for this change

cc: @Mic92 

add `pythonPacakges.roku`, regenerate home-assistant's `component-packages.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
