### PR TITLE
pythonPackages.alarmdecoder: init at v1.13.9

### DIFF
--- a/pkgs/development/python-modules/alarmdecoder/default.nix
+++ b/pkgs/development/python-modules/alarmdecoder/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pyserial, pyftdi, pyusb
+, pyopenssl, nose, isPy3k, pythonOlder, mock }:
+
+buildPythonPackage rec {
+  pname = "alarmdecoder";
+  version = "1.13.9";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "nutechsoftware";
+    repo = "alarmdecoder";
+    rev = version;
+    sha256 = "0plr2h1qn4ryawbaxf29cfna4wailghhaqy1jcm9kxq6q7b9xqqy";
+  };
+
+  propagatedBuildInputs = [ pyserial pyftdi pyusb pyopenssl ];
+
+  doCheck = !isPy3k;
+  checkInputs = [ nose mock ];
+  pythonImportsCheck = [ "alarmdecoder" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/nutechsoftware/alarmdecoder";
+    description =
+      "Python interface for the Alarm Decoder (AD2) family of alarm devices. (AD2USB, AD2SERIAL and AD2PI)";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pyftdi/default.nix
+++ b/pkgs/development/python-modules/pyftdi/default.nix
@@ -1,26 +1,24 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, pythonOlder
-, pyusb
-, pyserial
-}:
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pyusb, pyserial }:
 
 buildPythonPackage rec {
   pname = "pyftdi";
-  version = "0.44.2";
+  version = "0.49.0";
   disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "18k9wnpjxg71v4jm0pwr2bmksq7sckr6ylh1slf0xgpg89b27bxq";
+  src = fetchFromGitHub {
+    owner = "eblot";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "063kwvgw7g4nn09pyqwqy72vnhzw0aajg23bi32vr0k49g8fx27s";
   };
 
   propagatedBuildInputs = [ pyusb pyserial ];
 
+  pythonImportsCheck = [ "pyftdi" ];
+
   meta = {
     description = "User-space driver for modern FTDI devices";
     homepage = "https://github.com/eblot/pyftdi";
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -15,7 +15,7 @@
     "airvisual" = ps: with ps; [ pyairvisual];
     "aladdin_connect" = ps: with ps; [ ]; # missing inputs: aladdin_connect
     "alarm_control_panel" = ps: with ps; [ ];
-    "alarmdecoder" = ps: with ps; [ ]; # missing inputs: alarmdecoder
+    "alarmdecoder" = ps: with ps; [ alarmdecoder];
     "alarmdotcom" = ps: with ps; [ ]; # missing inputs: pyalarmdotcom
     "alert" = ps: with ps; [ ];
     "alexa" = ps: with ps; [ aiohttp-cors];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1632,6 +1632,8 @@ in {
 
   alabaster = callPackage ../development/python-modules/alabaster {};
 
+  alarmdecoder = callPackage ../development/python-modules/alarmdecoder {};
+
   alembic = callPackage ../development/python-modules/alembic {};
 
   allpairspy = callPackage ../development/python-modules/allpairspy { };


### PR DESCRIPTION
###### Motivation for this change

This includes:
* pythonPackages.pyftdi: v0.44.2 -> 0.49.0
* pythonPackages.alarmdecoder: init at v1.13.9
* home-assistant: regenerate component-packages.nix (alarmdecoder)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
