### PR TITLE
tandem: init at 1.5.0 (help needed!)

### DIFF
--- a/pkgs/applications/networking/instant-messengers/tandem/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tandem/default.nix
@@ -1,0 +1,30 @@
+{ appimageTools, fetchurl, writeTextFile, lib }:
+let
+  version = "1.5.0";
+  tandemApp = appimageTools.wrapType2 {
+    name = "tandem";
+    src = fetchurl {
+      url = "https://tandem-app.sfo2.cdn.digitaloceanspaces.com/Tandemx86_64${version}.AppImage";
+      sha256 = "0xg0vzznqvq38zwdq32d9ryliwfpss1qigprx7jd9kpswknx90w8";
+    };
+    extraPkgs = pkgs: [ pkgs.at-spi2-core ];
+  };
+in with lib; addMetaAttrs {
+    description = "A virtual office for remote teams";
+    homepage = https://tandem.chat;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.chpatrick ];
+  }
+  (writeTextFile {
+    name = "tandem-${version}";
+    executable = true;
+    destination = "/bin/tandem";
+    # TODO: Without this, tandem fails with:
+    # The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that .../tandem-extracted/chrome-sandbox is owned by root and has mode 4755.
+    # Ideally this would use the Chromium sandbox somehow.
+    text = ''
+      #!/usr/bin/env bash
+      ${tandemApp}/bin/tandem --no-sandbox "$@"
+    '';
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17796,6 +17796,8 @@ in
 
   slack-term = callPackage ../applications/networking/instant-messengers/slack-term { };
 
+  tandem = callPackage ../applications/networking/instant-messengers/tandem { };
+
   singularity = callPackage ../applications/virtualization/singularity {
     # XXX: the build is finding references to Go when compiled with go v1.12
     go = go_1_11;


### PR DESCRIPTION
Hi, I'm looking for help with two things:

* Tandem refuses to start without the Chromium sandbox (or `--no-sandbox`). Could the Chromium sandbox be used somehow, like for the browser itself?
* When you sign in, it tries to `xdg-open` the login page in your browser. If you click "sign in without browser", Google won't let you (maybe because of the lack of sandboxing?). It has the `xdg-open` binary available in its chroot, but I guess it can't open a window in the outside world.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
