### PR TITLE
vimPlugins.vim-pico8-syntax: init at 2016-10-30

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -4953,6 +4953,17 @@ let
     };
   };
 
+  vim-pico8-syntax = buildVimPluginFrom2Nix {
+    pname = "vim-pico8-syntax";
+    version = "2016-10-30";
+    src = fetchFromGitHub {
+      owner = "justinj";
+      repo = "vim-pico8-syntax";
+      rev = "dbdd92fad0533eeaeaea844815d4de11e9507ce7";
+      sha256 = "0say0bb74rdbabgsf7rrbm8x841pmgh80fwr6kn94fgphr3vhm0s";
+    };
+  };
+
   vim-plug = buildVimPluginFrom2Nix {
     pname = "vim-plug";
     version = "2020-01-27";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -376,6 +376,7 @@ Raimondi/delimitMate
 rakr/vim-one
 rbgrouleff/bclose.vim
 reedes/vim-pencil
+justinj/vim-pico8-syntax
 reedes/vim-wordy
 rhysd/committia.vim
 rhysd/vim-grammarous


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Ubuntu 18.04
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
