### PR TITLE
[20.03] buildRustCrate fixes backports

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, echo_build_heading, noisily, mkRustcDepArgs, rust }:
+{ lib, stdenv, mkRustcDepArgs, rust }:
 { crateName,
   dependencies,
   crateFeatures, crateRenames, libName, release, libPath,
@@ -35,16 +35,13 @@
     build_bin = if buildTests then "build_bin_test" else "build_bin";
   in ''
     runHook preBuild
-    ${echo_build_heading colors}
-    ${noisily colors verbose}
-
+ 
     # configure & source common build functions
     LIB_RUSTC_OPTS="${libRustcOpts}"
     BIN_RUSTC_OPTS="${binRustcOpts}"
     LIB_EXT="${stdenv.hostPlatform.extensions.sharedLibrary}"
     LIB_PATH="${libPath}"
     LIB_NAME="${libName}"
-    source ${./lib.sh}
 
     CRATE_NAME='${lib.replaceStrings ["-"] ["_"] libName}'
 

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -11,6 +11,7 @@
     baseRustcOpts =
       [(if release then "-C opt-level=3" else "-C debuginfo=2")]
       ++ ["-C codegen-units=$NIX_BUILD_CORES"]
+      ++ ["--remap-path-prefix=$NIX_BUILD_TOP=/" ]
       ++ [(mkRustcDepArgs dependencies crateRenames)]
       ++ [crateFeatures]
       ++ extraRustcOpts

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -172,7 +172,7 @@ in ''
      set +e
      EXTRA_BUILD=$(sed -n "s/^cargo:rustc-flags=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ' | sort -u)
      EXTRA_FEATURES=$(sed -n "s/^cargo:rustc-cfg=\(.*\)/--cfg \1/p" target/build/${crateName}.opt | tr '\n' ' ')
-     EXTRA_LINK=$(sed -n "s/^cargo:rustc-link-lib=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ' | sort -u)
+     EXTRA_LINK=$(sed -n "s/^cargo:rustc-link-lib=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ')
      EXTRA_LINK_SEARCH=$(sed -n "s/^cargo:rustc-link-search=\(.*\)/\1/p" target/build/${crateName}.opt | tr '\n' ' ' | sort -u)
 
      for env in $(sed -n "s/^cargo:rustc-env=\(.*\)/\1/p" target/build/${crateName}.opt); do

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -102,19 +102,16 @@ in ''
 
   # Remove duplicate linker flags from the build dependencies.
   if [[ -e target/link.build ]]; then
-    sort -u target/link.build > target/link.build.sorted
-    mv target/link.build.sorted target/link.build
+    sort -uo target/link.build target/link.build
   fi
 
   # Remove duplicate linker flags from the dependencies.
-  sort -u target/link > target/link.sorted
-  mv target/link.sorted target/link
+  sort -uo target/link target/link
   tr '\n' ' ' < target/link > target/link_
 
   # Remove duplicate linker flags from the that are written
   # to the derivation's output.
-  sort -u target/link.final > target/link.final.sorted
-  mv target/link.final.sorted target/link.final
+  sort -uo target/link.final target/link.final
 
   EXTRA_BUILD=""
   BUILD_OUT_DIR=""

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -56,32 +56,66 @@ in ''
     i=$1
     ln -s -f $i/lib/*.rlib $2 #*/
     ln -s -f $i/lib/*.so $i/lib/*.dylib $2 #*/
-    if [ -e "$i/lib/link" ]; then
-        cat $i/lib/link >> target/link
-        cat $i/lib/link >> target/link.final
-    fi
     if [ -e $i/env ]; then
         source $i/env
     fi
   }
 
+  # The following steps set up the dependencies of the crate. Two
+  # kinds of dependencies are distinguished: build dependencies
+  # (used by the build script) and crate dependencies. For each
+  # dependency we have to:
+  #
+  # - Make its Rust library available to rustc. This is done by
+  #   symlinking all library dependencies into a directory that
+  #   can be provided to rustc.
+  # - Accumulate linking flags. These flags are largely used for
+  #   linking native libraries.
+  #
+  # The crate link flags are added to the `link` and `link.final`
+  # files. The `link` file is used for linkage in the current
+  # crate. The `link.final` file will be copied to the output and can
+  # be used by downstream crates to get the linker flags of this
+  # crate.
+
   mkdir -p target/{deps,lib,build,buildDeps}
   chmod uga+w target -R
   echo ${extraLinkFlags} > target/link
   echo ${extraLinkFlags} > target/link.final
+
+  # Prepare crate dependencies
   for i in ${completeDepsDir}; do
     symlink_dependency $i target/deps
+    if [ -e "$i/lib/link" ]; then
+      cat $i/lib/link >> target/link
+      cat $i/lib/link >> target/link.final
+    fi
   done
+
+  # Prepare crate build dependencies that are used for the build script.
   for i in ${completeBuildDepsDir}; do
-     symlink_dependency $i target/buildDeps
+    symlink_dependency $i target/buildDeps
+    if [ -e "$i/lib/link" ]; then
+      cat $i/lib/link >> target/link.build
+    fi
   done
-  if [[ -e target/link ]]; then
-    sort -u target/link > target/link.sorted
-    mv target/link.sorted target/link
-    sort -u target/link.final > target/link.final.sorted
-    mv target/link.final.sorted target/link.final
-    tr '\n' ' ' < target/link > target/link_
+
+  # Remove duplicate linker flags from the build dependencies.
+  if [[ -e target/link.build ]]; then
+    sort -u target/link.build > target/link.build.sorted
+    mv target/link.build.sorted target/link.build
   fi
+
+  # Remove duplicate linker flags from the dependencies.
+  sort -u target/link > target/link.sorted
+  mv target/link.sorted target/link
+  tr '\n' ' ' < target/link > target/link_
+
+  # Remove duplicate linker flags from the that are written
+  # to the derivation's output.
+  sort -u target/link.final > target/link.final.sorted
+  mv target/link.final.sorted target/link.final
+
   EXTRA_BUILD=""
   BUILD_OUT_DIR=""
   export CARGO_PKG_NAME=${crateName}
@@ -120,15 +154,14 @@ in ''
   elif [[ -e "build.rs" ]]; then
      BUILD="build.rs"
   fi
+
+  # Compile and run the build script, when available.
   if [[ ! -z "$BUILD" ]] ; then
      echo_build_heading "$BUILD" ${libName}
      mkdir -p target/build/${crateName}
      EXTRA_BUILD_FLAGS=""
-     if [ -e target/link_ ]; then
-       EXTRA_BUILD_FLAGS=$(cat target/link_)
-     fi
      if [ -e target/link.build ]; then
-       EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS $(cat target/link.build)"
+       EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS $(tr '\n' ' ' < target/link.build)"
      fi
      noisily rustc --crate-name build_script_build $BUILD --crate-type bin ${rustcOpts} \
        ${crateFeatures} --out-dir target/build/${crateName} --emit=dep-info,link \

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, echo_build_heading, noisily, mkRustcDepArgs }:
+{ lib, stdenv, echo_colored, noisily, mkRustcDepArgs }:
 { build
 , buildDependencies
 , colors
@@ -32,9 +32,11 @@ let version_ = lib.splitString "-" crateVersion;
     completeBuildDepsDir = lib.concatStringsSep " " completeBuildDeps;
 in ''
   cd ${workspace_member}
-  runHook preConfigure
-  ${echo_build_heading colors}
+  ${echo_colored colors}
   ${noisily colors verbose}
+  source ${./lib.sh}
+
+  runHook preConfigure
   symlink_dependency() {
     # $1 is the nix-store path of a dependency
     # $2 is the target path

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -31,12 +31,25 @@ let version_ = lib.splitString "-" crateVersion;
     completeDepsDir = lib.concatStringsSep " " completeDeps;
     completeBuildDepsDir = lib.concatStringsSep " " completeBuildDeps;
 in ''
-  cd ${workspace_member}
   ${echo_colored colors}
   ${noisily colors verbose}
   source ${./lib.sh}
 
+  ${lib.optionalString (workspace_member != null) ''
+  noisily cd "${workspace_member}"
+''}
+  ${lib.optionalString (workspace_member == null) ''
+  echo_colored "Searching for matching Cargo.toml (${crateName})" 
+  local cargo_toml_dir=$(matching_cargo_toml_dir "${crateName}")
+  if [ -z "$cargo_toml_dir" ]; then
+    echo_error "ERROR configuring ${crateName}: No matching Cargo.toml in $(pwd) found." >&2
+    exit 23
+  fi
+  noisily cd "$cargo_toml_dir"
+''}
+
   runHook preConfigure
+ 
   symlink_dependency() {
     # $1 is the nix-store path of a dependency
     # $2 is the target path

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -62,9 +62,6 @@ let crate = crate_ // (lib.attrByPath [ crate_.crateName ] (attr: {}) crateOverr
     extraRustcOpts_ = extraRustcOpts;
     buildTests_ = buildTests;
 
-    # take a list of crates that we depend on and override them to fit our overrides, rustc, release, …
-    makeDependencies = map (dep: lib.getLib (dep.override { inherit release verbose crateOverrides; }));
-
     # crate2nix has a hack for the old bash based build script that did split
     # entries at `,`. No we have to work around that hack.
     # https://github.com/kolloch/crate2nix/blame/5b19c1b14e1b0e5522c3e44e300d0b332dc939e7/crate2nix/templates/build.nix.tera#L89
@@ -93,8 +90,8 @@ stdenv.mkDerivation (rec {
     name = "rust_${crate.crateName}-${crate.version}${lib.optionalString buildTests_ "-test"}";
     depsBuildBuild = [ rust stdenv.cc ];
     buildInputs = (crate.buildInputs or []) ++ buildInputs_;
-    dependencies = makeDependencies dependencies_;
-    buildDependencies = makeDependencies buildDependencies_;
+    dependencies = map lib.getLib dependencies_;
+    buildDependencies = map lib.getLib buildDependencies_;
 
     completeDeps = lib.unique (dependencies ++ lib.concatMap (dep: dep.completeDeps) dependencies);
     completeBuildDeps = lib.unique (

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -4,7 +4,7 @@
 # This can be useful for deploying packages with NixOps, and to share
 # binary dependencies between projects.
 
-{ lib, stdenv, defaultCrateOverrides, fetchCrate, rustc, rust }:
+{ lib, stdenv, defaultCrateOverrides, fetchCrate, rustc, rust, cargo, jq }:
 
 let
     # This doesn't appear to be officially documented anywhere yet.
@@ -29,14 +29,14 @@ let
            " --extern ${name}=${dep.lib}/lib/lib${extern}-${dep.metadata}${stdenv.hostPlatform.extensions.sharedLibrary}")
       ) dependencies;
 
-   inherit (import ./log.nix { inherit lib; }) noisily echo_build_heading;
+   inherit (import ./log.nix { inherit lib; }) noisily echo_colored;
 
    configureCrate = import ./configure-crate.nix {
-     inherit lib stdenv echo_build_heading noisily mkRustcDepArgs;
+     inherit lib stdenv echo_colored noisily mkRustcDepArgs;
    };
 
    buildCrate = import ./build-crate.nix {
-     inherit lib stdenv echo_build_heading noisily mkRustcDepArgs rust;
+     inherit lib stdenv mkRustcDepArgs rust;
    };
 
    installCrate = import ./install-crate.nix { inherit stdenv; };

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation (rec {
 
     src = crate.src or (fetchCrate { inherit (crate) crateName version sha256; });
     name = "rust_${crate.crateName}-${crate.version}${lib.optionalString buildTests_ "-test"}";
-    depsBuildBuild = [ rust stdenv.cc ];
+    depsBuildBuild = [ rust stdenv.cc cargo jq ];
     buildInputs = (crate.buildInputs or []) ++ buildInputs_;
     dependencies = map lib.getLib dependencies_;
     buildDependencies = map lib.getLib buildDependencies_;
@@ -114,6 +114,8 @@ stdenv.mkDerivation (rec {
       in lib.substring 0 10 hashedMetadata;
 
     build = crate.build or "";
+    # Either set to a concrete sub path to the crate root
+    # or use `null` for auto-detect.
     workspace_member = crate.workspace_member or ".";
     crateVersion = crate.version;
     crateDescription = crate.description or "";

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (rec {
     );
 
     crateFeatures = lib.optionalString (crate ? features)
-      (lib.concatMapStringsSep " " (f: "--cfg feature=\\\"${f}\\\"") (crate.features ++ features));
+      (lib.concatMapStringsSep " " (f: ''--cfg feature=\"${f}\"'') (crate.features ++ features));
 
     libName = if crate ? libName then crate.libName else crate.crateName;
     libPath = if crate ? libPath then crate.libPath else "";

--- a/pkgs/build-support/rust/build-rust-crate/install-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/install-crate.nix
@@ -14,7 +14,7 @@ if !buildTests then ''
   fi
   if [[ "$(ls -A target/lib)" ]]; then
     mkdir -p $lib/lib
-    cp target/lib/* $lib/lib #*/
+    cp -r target/lib/* $lib/lib #*/
     for library in $lib/lib/*.so $lib/lib/*.dylib; do #*/
       ln -s $library $(echo $library | sed -e "s/-${metadata}//")
     done
@@ -26,7 +26,7 @@ if !buildTests then ''
   if [[ -d target/bin ]]; then
     if [[ "$(ls -A target/bin)" ]]; then
       mkdir -p $out/bin
-      cp -P target/bin/* $out/bin # */
+      cp -rP target/bin/* $out/bin # */
     fi
   fi
   runHook postInstall

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -14,7 +14,6 @@ build_lib() {
     --crate-name $CRATE_NAME \
     $lib_src \
     --out-dir target/lib \
-    --emit=dep-info,link \
     -L dependency=target/deps \
     --cap-lints allow \
     $LIB_RUSTC_OPTS \
@@ -45,7 +44,6 @@ build_bin() {
     --crate-type bin \
     $BIN_RUSTC_OPTS \
     --out-dir target/bin \
-    --emit=dep-info,link \
     -L dependency=target/deps \
     $LINK \
     $EXTRA_LIB \

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -79,6 +79,7 @@ build_bin_test_file() {
     build_bin_test "$derived_crate_name" "$file"
 }
 
+# Add additional link options that were provided by the build script.
 setup_link_paths() {
   EXTRA_LIB=""
   if [[ -e target/link_ ]]; then

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -1,3 +1,11 @@
+echo_build_heading() {
+  if (( $# == 1 )); then
+    echo_colored "Building $1"
+  else
+    echo_colored "Building $1 ($2)"
+  fi
+}
+
 build_lib() {
   lib_src=$1
   echo_build_heading $lib_src ${libName}
@@ -132,7 +140,7 @@ search_for_bin_path() {
   done
 
   if [[ -z "$BIN_PATH" ]]; then
-    echo "failed to find file for binary target: $BIN_NAME" >&2
+    echo_error "ERROR: failed to find file for binary target: $BIN_NAME" >&2
     exit 1
   fi
 }

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -105,11 +105,6 @@ setup_link_paths() {
   done
 
   if [[ -e target/link ]]; then
-     sort -u target/link.final > target/link.final.sorted
-     mv target/link.final.sorted target/link.final
-     sort -u target/link > target/link.sorted
-     mv target/link.sorted target/link
-
      tr '\n' ' ' < target/link > target/link_
      LINK=$(cat target/link_)
   fi

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -1,13 +1,14 @@
 { lib
-, stdenv
 , buildRustCrate
-, runCommand
-, runCommandCC
-, writeTextFile
-, symlinkJoin
 , callPackage
 , releaseTools
+, runCommand
+, runCommandCC
+, stdenv
+, symlinkJoin
+, writeTextFile
 }:
+
 let
   mkCrate = args: let
     p = {
@@ -102,6 +103,58 @@ let
           ${lib.concatMapStringsSep "\n" (o: "grep '${o}' $out || {  echo 'output \"${o}\" not found in:'; cat $out; exit 23; }") expectedTestOutputs}
         ''
       );
+
+    /* Returns a derivation that asserts that the crate specified by `crateArgs`
+       has the specified files as output.
+
+       `name` is used as part of the derivation name that performs the checking.
+
+       `crateArgs` is passed to `mkCrate` to build the crate with `buildRustCrate`.
+
+       `expectedFiles` contains a list of expected file paths in the output. E.g.
+       `[ "./bin/my_binary" ]`.
+
+       `output` specifies the name of the output to use. By default, the default
+       output is used but e.g. `output = "lib";` will cause the lib output
+       to be checked instead. You do not need to specify any directories.
+     */
+    assertOutputs = { name, crateArgs, expectedFiles, output? null }:
+      assert (builtins.isString name);
+      assert (builtins.isAttrs crateArgs);
+      assert (builtins.isList expectedFiles);
+
+      let
+        crate = mkCrate (builtins.removeAttrs crateArgs ["expectedTestOutput"]);
+        crateOutput = if output == null then crate else crate."${output}";
+        expectedFilesFile = writeTextFile {
+          name = "expected-files-${name}";
+          text =
+            let sorted = builtins.sort (a: b: a<b) expectedFiles;
+                concatenated = builtins.concatStringsSep "\n" sorted;
+            in "${concatenated}\n";
+        };
+      in
+      runCommand "assert-outputs-${name}" {
+      } ''
+      local actualFiles=$(mktemp)
+
+      cd "${crateOutput}"
+      find . -type f | sort >$actualFiles
+      diff -q ${expectedFilesFile} $actualFiles >/dev/null || {
+        echo -e "\033[0;1;31mERROR: Difference in expected output files in ${crateOutput} \033[0m" >&2
+        echo === Got:
+        sed -e 's/^/  /' $actualFiles
+        echo === Expected:
+        sed -e 's/^/  /' ${expectedFilesFile}
+        echo === Diff:
+        diff -u ${expectedFilesFile} $actualFiles |\
+          tail -n +3 |\
+          sed -e 's/^/  /'
+        exit 1
+      }
+      touch $out
+      ''
+      ;
 
   in rec {
 
@@ -361,7 +414,80 @@ let
           };
     };
     brotliCrates = (callPackage ./brotli-crates.nix {});
-  in lib.mapAttrs (key: value: mkTest (value // lib.optionalAttrs (!value?crateName) { crateName = key; })) cases // {
+    tests = lib.mapAttrs (key: value: mkTest (value // lib.optionalAttrs (!value?crateName) { crateName = key; })) cases;
+  in tests // rec {
+
+    crateBinWithPathOutputs = assertOutputs {
+      name="crateBinWithPath";
+      crateArgs = {
+        crateBin = [{ name = "test_binary1"; path = "src/foobar.rs"; }];
+        src = mkBin "src/foobar.rs";
+      };
+      expectedFiles = [
+        "./bin/test_binary1"
+      ];
+    };
+
+    crateBinWithPathOutputsDebug = assertOutputs {
+      name="crateBinWithPath";
+      crateArgs = {
+        release = false;
+        crateBin = [{ name = "test_binary1"; path = "src/foobar.rs"; }];
+        src = mkBin "src/foobar.rs";
+      };
+      expectedFiles = [
+        "./bin/test_binary1"
+      ] ++ lib.optionals stdenv.isDarwin [
+        # On Darwin, the debug symbols are in a seperate directory.
+        "./bin/test_binary1.dSYM/Contents/Info.plist"
+        "./bin/test_binary1.dSYM/Contents/Resources/DWARF/test_binary1"
+      ];
+    };
+
+    crateBinNoPath1Outputs = assertOutputs {
+      name="crateBinNoPath1";
+      crateArgs = {
+        crateBin = [{ name = "my-binary2"; }];
+        src = mkBin "src/my_binary2.rs";
+      };
+      expectedFiles = [
+        "./bin/my-binary2"
+      ];
+    };
+
+    crateLibOutputs = assertOutputs {
+      name="crateLib";
+      output="lib";
+      crateArgs = {
+        libName = "test_lib";
+        type = [ "rlib" ];
+        libPath = "src/lib.rs";
+        src = mkLib "src/lib.rs";
+      };
+      expectedFiles = [
+        "./nix-support/propagated-build-inputs"
+        "./lib/libtest_lib-042a1fdbef.rlib"
+        "./lib/link"
+      ];
+    };
+
+    crateLibOutputsDebug = assertOutputs {
+      name="crateLib";
+      output="lib";
+      crateArgs = {
+        release = false;
+        libName = "test_lib";
+        type = [ "rlib" ];
+        libPath = "src/lib.rs";
+        src = mkLib "src/lib.rs";
+      };
+      expectedFiles = [
+        "./nix-support/propagated-build-inputs"
+        "./lib/libtest_lib-042a1fdbef.rlib"
+        "./lib/link"
+      ];
+    };
+
     brotliTest = let
       pkg = brotliCrates.brotli_2_5_0 {};
     in runCommand "run-brotli-test-cmd" {


### PR DESCRIPTION
###### Motivation for this change

This PR backports a bunch of changes that have been done to buildRustCrate since the branch-off. They are (mostly) just fixing bugs. Some of which are more annoying then others.

Since none of these break compatibility with older packages or users I do think they are still good to be included.

The PRs that are included in this:
- #79299: buildRustCrate: remap the current build dir to / for (more) reproducible builds (bugfix)
- #79816: buildRustCrate: remove superfluous dependency overrides (~10x eval speedup in some cases; bugfix)
- #82155: buildRustCrate: Search for matching Cargo.toml in sub directories (feature/bugfix) 
- #82404: buildRustCrate: only link build deps into build script (bugfix)
- #83481: buildRustCrate: fewer backslashes (syntax only change) 
- #83379: buildRustCrate: don't sort link flags  (bugfix for an issue introduced in #82404)
- #83616: buildRustCrateTests: Fix link order test on darwin  (bugfix)
- #83488:  buildRustCrate: Add "-r" to cp to make it work under Mac OS (bugfix)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
