### PR TITLE
pythonPackages.jupyter_core: fix search path

### DIFF
--- a/pkgs/development/python-modules/jupyter_core/default.nix
+++ b/pkgs/development/python-modules/jupyter_core/default.nix
@@ -21,7 +21,10 @@ buildPythonPackage rec {
   checkInputs = [ pytest mock glibcLocales nose ];
   propagatedBuildInputs = [ ipython traitlets ];
 
-  patches = [ ./tests_respect_pythonpath.patch ];
+  patches = [
+    ./fix-search-path.patch
+    ./tests_respect_pythonpath.patch
+  ];
 
   checkPhase = ''
     HOME=$TMPDIR LC_ALL=en_US.utf8 py.test

--- a/pkgs/development/python-modules/jupyter_core/fix-search-path.patch
+++ b/pkgs/development/python-modules/jupyter_core/fix-search-path.patch
@@ -1,0 +1,13 @@
+diff --git a/jupyter_core/command.py b/jupyter_core/command.py
+index b9c60d2..d30e2fd 100644
+--- a/jupyter_core/command.py
++++ b/jupyter_core/command.py
+@@ -166,7 +166,7 @@ def _path_with_self():
+     else:
+         path_list.append(bindir)
+ 
+-    scripts = [sys.argv[0]]
++    scripts = [sys.argv[0],sys.executable]
+     if os.path.islink(scripts[0]):
+         # include realpath, if `jupyter` is a symlink
+         scripts.append(os.path.realpath(scripts[0]))


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Not sure if this is expected but if one does `python.withPackages (ps: [ ps.jupyter ])`, the `jupyter-*` commands aren't found in environments where `PATH` isn't propagated from the shell environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
