### PR TITLE
mullvad-vpn: add libappindicator dependency and fix mullvad-problem-report link

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -1,7 +1,7 @@
 { stdenv, makeWrapper, fetchurl, dpkg
 , alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype
 , gdk-pixbuf, glib, gnome2, pango, nspr, nss, gtk3
-, xorg, autoPatchelfHook, systemd, libnotify
+, xorg, autoPatchelfHook, systemd, libnotify, libappindicator
 }:
 
 let deps = [
@@ -18,6 +18,7 @@ let deps = [
     gnome2.GConf
     pango
     gtk3
+    libappindicator
     libnotify
     xorg.libX11
     xorg.libXScrnSaver
@@ -59,7 +60,7 @@ stdenv.mkDerivation rec {
 
   unpackPhase = "dpkg-deb -x $src .";
 
-  runtimeDependencies = [ systemd.lib libnotify ];
+  runtimeDependencies = [ systemd.lib libnotify libappindicator ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
 
     ln -s $out/share/mullvad/mullvad-{gui,vpn} $out/bin/
     ln -s $out/share/mullvad/resources/mullvad-daemon $out/bin/mullvad-daemon
+    ln -sf $out/share/mullvad/resources/mullvad-problem-report $out/bin/mullvad-problem-report
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding libappindicator as a runtime dependency allows the Electron-based gui app
to have an appindicator in desktop environments that support them (eg,
Gnome with the appindicator support extension).

Also, previous versions had a broken link in bin/ (mullvad-problem-report) that I noticed while filling out the PR checklist.  I have added a commit to fix this.

I have tested that this is compatible with #80721 and #70762.  In particular, #80721 really needs to be merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) ~~(mullvad-problem-report does not work before or after this change)~~ (now fixed by second commit)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
