### PR TITLE
gnomeExtensions.drop-down-terminal: v24 -> unstable-2020-03-25

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/drop-down-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/drop-down-terminal/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-drop-down-terminal";
-  version = "24";
+  version = "unstable-2020-03-25";
 
   src = fetchFromGitHub {
     owner = "zzrough";
     repo = "gs-extensions-drop-down-terminal";
-    rev = "v${version}";
-    sha256 = "1gda56xzwsa5pgmgpb7lhb3i3gqishvn84282inwvqm86afks73r";
+    rev = "a59669afdb395b3315619f62c1f740f8b2f0690d";
+    sha256 = "0igfxgrjdqq6z6xg4rsawxn261pk25g5dw2pm3bhwz5sqsy4bq3i";
   };
 
   uuid = "drop-down-terminal@gs-extensions.zzrough.org";
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     description = "Configurable drop down terminal shell";
     license = licenses.gpl3;
     maintainers = with maintainers; [ ericdallo ];
-    homepage = https://github.com/zzrough/gs-extensions-drop-down-terminal;
+    homepage = "https://github.com/zzrough/gs-extensions-drop-down-terminal";
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add support to gnome 3.36.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
