### PR TITLE
[20.03] mongodb: update

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -649,6 +649,13 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     url = http://metadata.ftp-master.debian.org/changelogs/main/d/debianutils/debianutils_4.8.1_copyright;
   };
 
+  sspl = {
+    shortName = "SSPL";
+    fullName = "Server Side Public License";
+    url = https://www.mongodb.com/licensing/server-side-public-license;
+    free = false;
+  };
+
   tcltk = spdx {
     spdxId = "TCL";
     fullName = "TCL/TK License";

--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -1078,6 +1078,15 @@ auth required pam_succeed_if.so uid >= 1000 quiet
   <listitem>
    <para>
     <package>mongodb</package> has been updated to version <literal>3.4.24</literal>.
+    <warning>
+     <para>
+      Please note that <package>mongodb</package> has been relicensed under their own
+      <link xlink:href="https://www.mongodb.com/licensing/server-side-public-license/faq"><literal>
+      sspl</literal></link>-license. Since it's not entirely free and not OSI-approved,
+      it's listed as non-free. This means that Hydra doesn't provide prebuilt
+      <package>mongodb</package>-packages and needs to be built locally.
+     </para>
+    </warning>
    </para>
   </listitem>
   </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -1075,6 +1075,11 @@ auth required pam_succeed_if.so uid >= 1000 quiet
     not <command>systemd-networkd</command>.
    </para>
   </listitem>
+  <listitem>
+   <para>
+    <package>mongodb</package> has been updated to version <literal>3.4.24</literal>.
+   </para>
+  </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -1,42 +1,42 @@
 # This test start mongodb, runs a query using mongo shell
 
-import ./make-test-python.nix ({ pkgs, ...} : let
-  testQuery = pkgs.writeScript "nixtest.js" ''
-    db.greetings.insert({ "greeting": "hello" });
-    print(db.greetings.findOne().greeting);
-  '';
-in {
-  name = "mongodb";
-  meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ bluescreen303 offline cstrahan rvl phile314 ];
-  };
+import ./make-test.nix ({ pkgs, ... }:
+  let
+    testQuery = pkgs.writeScript "nixtest.js" ''
+      db.greetings.insert({ "greeting": "hello" });
+      print(db.greetings.findOne().greeting);
+    '';
 
-  nodes = {
-    one =
-      { ... }:
-        {
-          services = {
-           mongodb.enable = true;
-           mongodb.enableAuth = true;
-           mongodb.initialRootPassword = "root";
-           mongodb.initialScript = pkgs.writeText "mongodb_initial.js" ''
-             db = db.getSiblingDB("nixtest");
-             db.createUser({user:"nixtest",pwd:"nixtest",roles:[{role:"readWrite",db:"nixtest"}]});
-           '';
-           mongodb.extraConfig = ''
-             # Allow starting engine with only a small virtual disk
-             storage.journal.enabled: false
-             storage.mmapv1.smallFiles: true
-           '';
-          };
-        };
+    runMongoDBTest = pkg: ''
+      $node->execute("(rm -rf data || true) && mkdir data");
+      $node->execute("${pkg}/bin/mongod --fork --logpath logs --dbpath data");
+      $node->waitForOpenPort(27017);
+
+      $node->succeed("mongo ${testQuery}") =~ /hello/ or die;
+
+      $node->execute("${pkg}/bin/mongod --shutdown --dbpath data");
+      $node->waitForClosedPort(27017);
+    '';
+
+  in {
+    name = "mongodb";
+    meta = with pkgs.stdenv.lib.maintainers; {
+      maintainers = [ bluescreen303 offline cstrahan rvl phile314 ];
     };
 
-  testScript = ''
-    start_all()
-    one.wait_for_unit("mongodb.service")
-    one.succeed(
-        "mongo -u nixtest -p nixtest nixtest ${testQuery} | grep -q hello"
-    )
-  '';
-})
+    nodes = {
+      node = {...}: {
+        environment.systemPackages = with pkgs; [
+#          mongodb-3_4
+          mongodb-3_6
+          mongodb-4_0
+        ];
+      };
+    };
+
+    testScript = "$node->start;" 
+#      + runMongoDBTest pkgs.mongodb-3_4
+      + runMongoDBTest pkgs.mongodb-3_6 
+      + runMongoDBTest pkgs.mongodb-4_0
+      + "$node->shutdown;";
+  })

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -33,7 +33,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     nodes = {
       node = {...}: {
         environment.systemPackages = with pkgs; [
-#          mongodb-3_4
+          mongodb-3_4
           mongodb-3_6
           mongodb-4_0
         ];
@@ -43,7 +43,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     testScript = ''
       node.start()
     ''
-#      + runMongoDBTest pkgs.mongodb-3_4
+      + runMongoDBTest pkgs.mongodb-3_4
       + runMongoDBTest pkgs.mongodb-3_6 
       + runMongoDBTest pkgs.mongodb-4_0
       + ''

--- a/pkgs/servers/nosql/mongodb/asio-no-experimental-string-view.patch
+++ b/pkgs/servers/nosql/mongodb/asio-no-experimental-string-view.patch
@@ -1,0 +1,20 @@
+diff --git a/src/third_party/asio-master/asio/include/asio/detail/config.hpp b/src/third_party/asio-master/asio/include/asio/detail/config.hpp
+index 7fe6a95a..ff4cc56b 100644
+--- a/src/third_party/asio-master/asio/include/asio/detail/config.hpp
++++ b/src/third_party/asio-master/asio/include/asio/detail/config.hpp
+@@ -786,7 +786,6 @@
+ #   if (__cplusplus >= 201402)
+ #    if __has_include(<experimental/string_view>)
+ #     define ASIO_HAS_STD_STRING_VIEW 1
+-#     define ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
+ #    endif // __has_include(<experimental/string_view>)
+ #   endif // (__cplusplus >= 201402)
+ #  endif // defined(__clang__)
+@@ -794,7 +793,6 @@
+ #   if ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)) || (__GNUC__ > 4)
+ #    if (__cplusplus >= 201402)
+ #     define ASIO_HAS_STD_STRING_VIEW 1
+-#     define ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW 1
+ #    endif // (__cplusplus >= 201402)
+ #   endif // ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4)
+ #  endif // defined(__GNUC__)

--- a/pkgs/servers/nosql/mongodb/forget-build-dependencies-3-4.patch
+++ b/pkgs/servers/nosql/mongodb/forget-build-dependencies-3-4.patch
@@ -1,0 +1,17 @@
+--- a/site_scons/mongo_scons_utils.py
++++ b/site_scons/mongo_scons_utils.py
+@@ -84,14 +84,11 @@
+ def default_buildinfo_environment_data():
+     return (
+         ('distmod', '$MONGO_DISTMOD', True, True,),
+         ('distarch', '$MONGO_DISTARCH', True, True,),
+         ('cc', '$CC_VERSION', True, False,),
+-        ('ccflags', '$CCFLAGS', True, False,),
+         ('cxx', '$CXX_VERSION', True, False,),
+-        ('cxxflags', '$CXXFLAGS', True, False,),
+-        ('linkflags', '$LINKFLAGS', True, False,),
+         ('target_arch', '$TARGET_ARCH', True, True,),
+         ('target_os', '$TARGET_OS', True, False,),
+     )
+ 
+ # If you want buildInfo and --version to be relatively empty, set

--- a/pkgs/servers/nosql/mongodb/forget-build-dependencies.patch
+++ b/pkgs/servers/nosql/mongodb/forget-build-dependencies.patch
@@ -1,8 +1,6 @@
---- a/site_scons/mongo_scons_utils.py
-+++ b/site_scons/mongo_scons_utils.py
-@@ -84,14 +84,11 @@
- def default_buildinfo_environment_data():
-     return (
+--- a/site_scons/mongo/generators.py
++++ b/site_scons/mongo/generators.py
+@@ -18,10 +18,7 @@ def default_buildinfo_environment_data():
          ('distmod', '$MONGO_DISTMOD', True, True,),
          ('distarch', '$MONGO_DISTARCH', True, True,),
          ('cc', '$CC_VERSION', True, False,),
@@ -13,5 +11,3 @@
          ('target_arch', '$TARGET_ARCH', True, True,),
          ('target_os', '$TARGET_OS', True, False,),
      )
- 
- # If you want buildInfo and --version to be relatively empty, set

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -110,7 +110,6 @@ in stdenv.mkDerivation rec {
     description = "A scalable, high-performance, open source NoSQL database";
     homepage = "http://www.mongodb.org";
     license = licenses.sspl;
-    broken = stdenv.hostPlatform.isAarch64; # g++ has internal compiler errors
 
     maintainers = with maintainers; [ bluescreen303 offline cstrahan ];
     platforms = subtractLists systems.doubles.i686 systems.doubles.unix;

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -39,8 +39,7 @@ in stdenv.mkDerivation rec {
     gperftools
     libpcap
     libyamlcpp
-    openssl.dev
-    openssl.out
+    openssl
     pcre-cpp
     python
     sasl

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -58,8 +58,6 @@ in stdenv.mkDerivation rec {
     substituteInPlace SConstruct \
         --replace "env = Environment(" "env = Environment(ENV = os.environ,"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace src/third_party/asio-master/asio/include/asio/detail/config.hpp --replace ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW ASIO_HAS_STD_STRING_VIEW
-
     substituteInPlace src/third_party/mozjs-45/extract/js/src/jsmath.cpp --replace 'defined(HAVE_SINCOS)' 0
 
     substituteInPlace src/third_party/s2/s1angle.cc --replace drem remainder

--- a/pkgs/servers/nosql/mongodb/mozjs-45_fix-3-byte-opcode.patch
+++ b/pkgs/servers/nosql/mongodb/mozjs-45_fix-3-byte-opcode.patch
@@ -1,0 +1,27 @@
+# HG changeset patch
+# User Dan Gohman <sunfish@mozilla.com>
+# Parent  d9b405d82cffb07343a5f2fd941e029298c7f6c4
+# Bug 1390214 - IonMonkey: Don't test for a 3-byte opcode in a 2-byte opcode predicate.
+# https://bug1390214.bmoattachments.org/attachment.cgi?id=8902972
+
+diff --git a/src/third_party/mozjs-45/extract/js/src/jit/x86-shared/Encoding-x86-shared.h b/src/third_party/mozjs-45/extract/js/src/jit/x86-shared/Encoding-x86-shared.h
+--- a/src/third_party/mozjs-45/extract/js/src/jit/x86-shared/Encoding-x86-shared.h
++++ b/src/third_party/mozjs-45/extract/js/src/jit/x86-shared/Encoding-x86-shared.h
+@@ -310,17 +310,16 @@ enum ThreeByteOpcodeID {
+ 
+ // Test whether the given opcode should be printed with its operands reversed.
+ inline bool IsXMMReversedOperands(TwoByteOpcodeID opcode)
+ {
+     switch (opcode) {
+       case OP2_MOVSD_WsdVsd: // also OP2_MOVPS_WpsVps
+       case OP2_MOVAPS_WsdVsd:
+       case OP2_MOVDQ_WdqVdq:
+-      case OP3_PEXTRD_EdVdqIb:
+         return true;
+       default:
+         break;
+     }
+     return false;
+ }
+ 
+ enum ThreeByteEscape {

--- a/pkgs/servers/nosql/mongodb/v3_4.nix
+++ b/pkgs/servers/nosql/mongodb/v3_4.nix
@@ -1,11 +1,11 @@
-{ stdenv, callPackage, lib, sasl, boost, Security }:
+{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
-  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; };
+  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; inherit CoreFoundation; inherit cctools; };
 in
   buildMongoDB {
-    version = "3.4.20";
-    sha256 = "15avrhakbspz0q1w5n7dqzjjfkxi7md64a9axl97gfxi4ln7mhz0";
+    version = "3.4.22";
+    sha256 = "1rizrr69b26y7fb973n52hk387sf3mxzqg8wka4f3zdjdidfyiny";
     patches = [
       ./forget-build-dependencies-3-4.patch
     ];

--- a/pkgs/servers/nosql/mongodb/v3_4.nix
+++ b/pkgs/servers/nosql/mongodb/v3_4.nix
@@ -1,0 +1,12 @@
+{ stdenv, callPackage, lib, sasl, boost, Security }:
+
+let
+  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; };
+in
+  buildMongoDB {
+    version = "3.4.20";
+    sha256 = "15avrhakbspz0q1w5n7dqzjjfkxi7md64a9axl97gfxi4ln7mhz0";
+    patches = [
+      ./forget-build-dependencies-3-4.patch
+    ];
+  }

--- a/pkgs/servers/nosql/mongodb/v3_4.nix
+++ b/pkgs/servers/nosql/mongodb/v3_4.nix
@@ -1,12 +1,15 @@
 { stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
-  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; inherit CoreFoundation; inherit cctools; };
-in
-  buildMongoDB {
-    version = "3.4.22";
-    sha256 = "1rizrr69b26y7fb973n52hk387sf3mxzqg8wka4f3zdjdidfyiny";
-    patches = [
-      ./forget-build-dependencies-3-4.patch
-    ];
-  }
+  buildMongoDB = callPackage ./mongodb.nix {
+    inherit sasl;
+    inherit boost;
+    inherit Security;
+    inherit CoreFoundation;
+    inherit cctools;
+  };
+in buildMongoDB {
+  version = "3.4.22";
+  sha256 = "1rizrr69b26y7fb973n52hk387sf3mxzqg8wka4f3zdjdidfyiny";
+  patches = [ ./forget-build-dependencies-3-4.patch ];
+}

--- a/pkgs/servers/nosql/mongodb/v3_4.nix
+++ b/pkgs/servers/nosql/mongodb/v3_4.nix
@@ -9,7 +9,7 @@ let
     inherit cctools;
   };
 in buildMongoDB {
-  version = "3.4.22";
-  sha256 = "1rizrr69b26y7fb973n52hk387sf3mxzqg8wka4f3zdjdidfyiny";
+  version = "3.4.24";
+  sha256 = "0j6mvgv0jnsnvgkl8505bl88kbxkba66qijlpi1la0dd5pd1imfr";
   patches = [ ./forget-build-dependencies-3-4.patch ];
 }

--- a/pkgs/servers/nosql/mongodb/v3_6.nix
+++ b/pkgs/servers/nosql/mongodb/v3_6.nix
@@ -1,0 +1,12 @@
+{ stdenv, callPackage, lib, sasl, boost, Security }:
+
+let
+  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; };
+in
+  buildMongoDB {
+    version = "3.6.12";
+    sha256 = "1fi1ccid4rnfjg6yn3183qrhjqc8hz7jfgdpwp1dy6piw6z85n3l";
+    patches = [
+      ./forget-build-dependencies.patch
+    ];
+  }

--- a/pkgs/servers/nosql/mongodb/v3_6.nix
+++ b/pkgs/servers/nosql/mongodb/v3_6.nix
@@ -1,12 +1,15 @@
 { stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
-  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; inherit CoreFoundation; inherit cctools; };
-in
-  buildMongoDB {
-    version = "3.6.13";
-    sha256 = "1mbvk4bmabrswjdm01jssxcygjpq5799zqyx901nsi12vlcymwg4";
-    patches = [
-      ./forget-build-dependencies.patch
-    ];
-  }
+  buildMongoDB = callPackage ./mongodb.nix {
+    inherit sasl;
+    inherit boost;
+    inherit Security;
+    inherit CoreFoundation;
+    inherit cctools;
+  };
+in buildMongoDB {
+  version = "3.6.13";
+  sha256 = "1mbvk4bmabrswjdm01jssxcygjpq5799zqyx901nsi12vlcymwg4";
+  patches = [ ./forget-build-dependencies.patch ];
+}

--- a/pkgs/servers/nosql/mongodb/v3_6.nix
+++ b/pkgs/servers/nosql/mongodb/v3_6.nix
@@ -1,11 +1,11 @@
-{ stdenv, callPackage, lib, sasl, boost, Security }:
+{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
-  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; };
+  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; inherit CoreFoundation; inherit cctools; };
 in
   buildMongoDB {
-    version = "3.6.12";
-    sha256 = "1fi1ccid4rnfjg6yn3183qrhjqc8hz7jfgdpwp1dy6piw6z85n3l";
+    version = "3.6.13";
+    sha256 = "1mbvk4bmabrswjdm01jssxcygjpq5799zqyx901nsi12vlcymwg4";
     patches = [
       ./forget-build-dependencies.patch
     ];

--- a/pkgs/servers/nosql/mongodb/v3_6.nix
+++ b/pkgs/servers/nosql/mongodb/v3_6.nix
@@ -11,5 +11,6 @@ let
 in buildMongoDB {
   version = "3.6.13";
   sha256 = "1mbvk4bmabrswjdm01jssxcygjpq5799zqyx901nsi12vlcymwg4";
-  patches = [ ./forget-build-dependencies.patch ];
+  patches = [ ./forget-build-dependencies.patch ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view.patch ];
 }

--- a/pkgs/servers/nosql/mongodb/v4_0.nix
+++ b/pkgs/servers/nosql/mongodb/v4_0.nix
@@ -1,13 +1,16 @@
 { stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
-  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; inherit CoreFoundation; inherit cctools; };
-in
-  buildMongoDB {
-    version = "4.0.11";
-    sha256 = "0kry8kzzpah0l7j8xa333y1ixwvarc28ip3f6lx5590yy11j8ry2";
-    patches = [
-      ./forget-build-dependencies.patch
-      ./mozjs-45_fix-3-byte-opcode.patch
-    ];
-  }
+  buildMongoDB = callPackage ./mongodb.nix {
+    inherit sasl;
+    inherit boost;
+    inherit Security;
+    inherit CoreFoundation;
+    inherit cctools;
+  };
+in buildMongoDB {
+  version = "4.0.11";
+  sha256 = "0kry8kzzpah0l7j8xa333y1ixwvarc28ip3f6lx5590yy11j8ry2";
+  patches =
+    [ ./forget-build-dependencies.patch ./mozjs-45_fix-3-byte-opcode.patch ];
+}

--- a/pkgs/servers/nosql/mongodb/v4_0.nix
+++ b/pkgs/servers/nosql/mongodb/v4_0.nix
@@ -1,0 +1,12 @@
+{ stdenv, callPackage, lib, sasl, boost, Security }:
+
+let
+  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; };
+in
+  buildMongoDB {
+    version = "4.0.9";
+    sha256 = "0klm6dl1pr9wq4ghm2jjn3wzs1zpj1aabqjqjfddanxq2an7scph";
+    patches = [
+      ./forget-build-dependencies.patch
+    ];
+  }

--- a/pkgs/servers/nosql/mongodb/v4_0.nix
+++ b/pkgs/servers/nosql/mongodb/v4_0.nix
@@ -1,12 +1,13 @@
-{ stdenv, callPackage, lib, sasl, boost, Security }:
+{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
-  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; };
+  buildMongoDB = callPackage ./mongodb.nix { inherit sasl; inherit boost; inherit Security; inherit CoreFoundation; inherit cctools; };
 in
   buildMongoDB {
-    version = "4.0.9";
-    sha256 = "0klm6dl1pr9wq4ghm2jjn3wzs1zpj1aabqjqjfddanxq2an7scph";
+    version = "4.0.11";
+    sha256 = "0kry8kzzpah0l7j8xa333y1ixwvarc28ip3f6lx5590yy11j8ry2";
     patches = [
       ./forget-build-dependencies.patch
+      ./mozjs-45_fix-3-byte-opcode.patch
     ];
   }

--- a/pkgs/servers/nosql/mongodb/v4_0.nix
+++ b/pkgs/servers/nosql/mongodb/v4_0.nix
@@ -9,8 +9,9 @@ let
     inherit cctools;
   };
 in buildMongoDB {
-  version = "4.0.11";
-  sha256 = "0kry8kzzpah0l7j8xa333y1ixwvarc28ip3f6lx5590yy11j8ry2";
+  version = "4.0.12";
+  sha256 = "1j8dqa4jr623y87jrdanyib9r7x18srrvdx952q4azcc8zrdwci1";
   patches =
-    [ ./forget-build-dependencies.patch ./mozjs-45_fix-3-byte-opcode.patch ];
+    [ ./forget-build-dependencies.patch ./mozjs-45_fix-3-byte-opcode.patch ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view.patch ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15536,20 +15536,22 @@ in
   mongodb-3_4 = callPackage ../servers/nosql/mongodb/v3_4.nix {
     sasl = cyrus_sasl;
     boost = boost160;
-    inherit (darwin.apple_sdk.frameworks) Security;
+    inherit (darwin) cctools;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
   mongodb-3_6 = callPackage ../servers/nosql/mongodb/v3_6.nix {
     sasl = cyrus_sasl;
     boost = boost160;
-    inherit (darwin.apple_sdk.frameworks) Security;
+    inherit (darwin) cctools;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
   mongodb-4_0 = callPackage ../servers/nosql/mongodb/v4_0.nix {
     sasl = cyrus_sasl;
-    boost = boost160;
-    openssl = openssl_1_0_2;
-    inherit (darwin.apple_sdk.frameworks) Security;
+    boost = boost169;
+    inherit (darwin) cctools;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
   nginx-sso = callPackage ../servers/nginx-sso { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15531,7 +15531,21 @@ in
   };
   mysql = mariadb; # TODO: move to aliases.nix
 
-  mongodb = callPackage ../servers/nosql/mongodb {
+  mongodb = hiPrio mongodb-3_4;
+  
+  mongodb-3_4 = callPackage ../servers/nosql/mongodb/v3_4.nix {
+    sasl = cyrus_sasl;
+    boost = boost160;
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
+  mongodb-3_6 = callPackage ../servers/nosql/mongodb/v3_6.nix {
+    sasl = cyrus_sasl;
+    boost = boost160;
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
+  mongodb-4_0 = callPackage ../servers/nosql/mongodb/v4_0.nix {
     sasl = cyrus_sasl;
     boost = boost160;
     openssl = openssl_1_0_2;


### PR DESCRIPTION

###### Motivation for this change

Backport PR for #40082 and #83617.

(@worldofpeace I may be wrong, but did you mention that you'd prefer to only backport mongodb 3.4.24? In that case I'd remove 3.6/4.0 from this PR. I just added all of it for now as it was rather tight coupled due to the package split :))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
