### PR TITLE
installShellFiles: Enhance installShellCompletion

### DIFF
--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -2070,7 +2070,7 @@ nativeBuildInputs = [ breakpointHook ];
        The <literal>installManPage</literal> function takes one or more paths to manpages to install. The manpages must have a section suffix, and may optionally be compressed (with <literal>.gz</literal> suffix). This function will place them into the correct directory.
       </para>
       <para>
-       The <literal>installShellCompletion</literal> function takes one or more paths to shell completion files. By default it will autodetect the shell type from the completion file extension, but you may also specify it by passing one of <literal>--bash</literal>, <literal>--fish</literal>, or <literal>--zsh</literal>. These flags apply to all paths listed after them (up until another shell flag is given). Each path may also have a custom installation name provided by providing a flag <literal>--name NAME</literal> before the path. If this flag is not provided, zsh completions will be renamed automatically such that <literal>foobar.zsh</literal> becomes <literal>_foobar</literal>.
+       The <literal>installShellCompletion</literal> function takes one or more paths to shell completion files. By default it will autodetect the shell type from the completion file extension, but you may also specify it by passing one of <literal>--bash</literal>, <literal>--fish</literal>, or <literal>--zsh</literal>. These flags apply to all paths listed after them (up until another shell flag is given). Each path may also have a custom installation name provided by providing a flag <literal>--name NAME</literal> before the path. If this flag is not provided, zsh completions will be renamed automatically such that <literal>foobar.zsh</literal> becomes <literal>_foobar</literal>. A root name may be provided for all paths using the flag <literal>--cmd NAME</literal>; this synthesizes the appropriate name depending on the shell (e.g. <literal>--cmd foo</literal> will synthesize the name <literal>foo.bash</literal> for bash and <literal>_foo</literal> for zsh). The path may also be a fifo or named fd (such as produced by <literal>&lt;(cmd)</literal>), in which case the shell and name must be provided.
 <programlisting>
 nativeBuildInputs = [ installShellFiles ];
 postInstall = ''
@@ -2081,6 +2081,11 @@ postInstall = ''
   installShellCompletion --zsh --name _foobar share/completions.zsh
   # implicit behavior
   installShellCompletion share/completions/foobar.{bash,fish,zsh}
+  # using named fd
+  installShellCompletion --cmd foobar \
+    --bash &lt;($out/bin/foobar --bash-completion) \
+    --fish &lt;($out/bin/foobar --fish-completion) \
+    --zsh &lt;($out/bin/foobar --zsh-completion)
 '';
 </programlisting>
       </para>

--- a/pkgs/build-support/install-shell-files/default.nix
+++ b/pkgs/build-support/install-shell-files/default.nix
@@ -1,4 +1,12 @@
-{ makeSetupHook }:
+{ makeSetupHook, tests }:
 
 # See the header comment in ../setup-hooks/install-shell-files.sh for example usage.
-makeSetupHook { name = "install-shell-files"; } ../setup-hooks/install-shell-files.sh
+let
+  setupHook = makeSetupHook { name = "install-shell-files"; } ../setup-hooks/install-shell-files.sh;
+in
+
+setupHook.overrideAttrs (oldAttrs: {
+  passthru = (oldAttrs.passthru or {}) // {
+    tests = tests.install-shell-files;
+  };
+})

--- a/pkgs/build-support/setup-hooks/install-shell-files.sh
+++ b/pkgs/build-support/setup-hooks/install-shell-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+# shellcheck shell=bash
 # Setup hook for the `installShellFiles` package.
 #
 # Example usage in a derivation:
@@ -49,7 +49,7 @@ installManPage() {
     done
 }
 
-# installShellCompletion [--bash|--fish|--zsh] ([--name <name>] <path>)...
+# installShellCompletion [--cmd <name>] ([--bash|--fish|--zsh] [--name <name>] <path>)...
 #
 # Each path is installed into the appropriate directory for shell completions for the given shell.
 # If one of `--bash`, `--fish`, or `--zsh` is given the path is assumed to belong to that shell.
@@ -61,8 +61,19 @@ installManPage() {
 # If the shell completion needs to be renamed before installing the optional `--name <name>` flag
 # may be given. Any name provided with this flag only applies to the next path.
 #
+# If all shell completions need to be renamed before installing the optional `--cmd <name>` flag
+# may be given. This will synthesize a name for each file, unless overridden with an explicit
+# `--name` flag. For example, `--cmd foobar` will synthesize the name `_foobar` for zsh and
+# `foobar.bash` for bash.
+#
 # For zsh completions, if the `--name` flag is not given, the path will be automatically renamed
 # such that `foobar.zsh` becomes `_foobar`.
+#
+# A path may be a named fd, such as produced by the bash construct `<(cmd)`. When using a named fd,
+# the shell type flag must be provided, and either the `--name` or `--cmd` flag must be provided.
+# This might look something like:
+#
+#   installShellCompletion --zsh --name _foobar <($out/bin/foobar --zsh-completion)
 #
 # This command accepts multiple shell flags in conjunction with multiple paths if you wish to
 # install them all in one command:
@@ -76,9 +87,16 @@ installManPage() {
 #   installShellCompletion --fish --name foobar.fish share/completions.fish
 #   installShellCompletion --zsh --name _foobar share/completions.zsh
 #
+# Or to use shell newline escaping to split a single invocation across multiple lines:
+#
+#   installShellCompletion --cmd foobar \
+#     --bash <($out/bin/foobar --bash-completion) \
+#     --fish <($out/bin/foobar --fish-completion) \
+#     --zsh <($out/bin/foobar --zsh-completion)
+#
 # If any argument is `--` the remaining arguments will be treated as paths.
 installShellCompletion() {
-    local shell='' name='' retval=0 parseArgs=1 arg
+    local shell='' name='' cmdname='' retval=0 parseArgs=1 arg
     while { arg=$1; shift; }; do
         # Parse arguments
         if (( parseArgs )); then
@@ -97,6 +115,17 @@ installShellCompletion() {
                 # treat `--name=foo` the same as `--name foo`
                 name=${arg#--name=}
                 continue;;
+            --cmd)
+                cmdname=$1
+                shift || {
+                    echo 'installShellCompletion: error: --cmd flag expected an argument' >&2
+                    return 1
+                }
+                continue;;
+            --cmd=*)
+                # treat `--cmd=foo` the same as `--cmd foo`
+                cmdname=${arg#--cmd=}
+                continue;;
             --?*)
                 echo "installShellCompletion: warning: unknown flag ${arg%%=*}" >&2
                 retval=2
@@ -110,39 +139,67 @@ installShellCompletion() {
         if (( "${NIX_DEBUG:-0}" >= 1 )); then
             echo "installShellCompletion: installing $arg${name:+ as $name}"
         fi
-        # if we get here, this is a path
-        # Identify shell
-        local basename
-        basename=$(stripHash "$arg")
+        # if we get here, this is a path or named pipe
+        # Identify shell and output name
         local curShell=$shell
-        if [[ -z "$curShell" ]]; then
-            # auto-detect the shell
-            case "$basename" in
-            ?*.bash) curShell=bash;;
-            ?*.fish) curShell=fish;;
-            ?*.zsh) curShell=zsh;;
-            *)
-                if [[ "$basename" = _* && "$basename" != *.* ]]; then
-                    # probably zsh
-                    echo "installShellCompletion: warning: assuming path \`$arg' is zsh; please specify with --zsh" >&2
-                    curShell=zsh
-                else
-                    echo "installShellCompletion: warning: unknown shell for path: $arg" >&2
-                    retval=2
-                    continue
-                fi;;
-            esac
+        local outName=''
+        if [[ -z "$arg" ]]; then
+            echo "installShellCompletion: error: empty path is not allowed" >&2
+            return 1
+        elif [[ -p "$arg" ]]; then
+            # this is a named fd or fifo
+            if [[ -z "$curShell" ]]; then
+                echo "installShellCompletion: error: named pipe requires one of --bash, --fish, or --zsh" >&2
+                return 1
+            elif [[ -z "$name" && -z "$cmdname" ]]; then
+                echo "installShellCompletion: error: named pipe requires one of --cmd or --name" >&2
+                return 1
+            fi
+        else
+            # this is a path
+            local argbase
+            argbase=$(stripHash "$arg")
+            if [[ -z "$curShell" ]]; then
+                # auto-detect the shell
+                case "$argbase" in
+                ?*.bash) curShell=bash;;
+                ?*.fish) curShell=fish;;
+                ?*.zsh) curShell=zsh;;
+                *)
+                    if [[ "$argbase" = _* && "$argbase" != *.* ]]; then
+                        # probably zsh
+                        echo "installShellCompletion: warning: assuming path \`$arg' is zsh; please specify with --zsh" >&2
+                        curShell=zsh
+                    else
+                        echo "installShellCompletion: warning: unknown shell for path: $arg" >&2
+                        retval=2
+                        continue
+                    fi;;
+                esac
+            fi
+            outName=$argbase
         fi
         # Identify output path
-        local outName sharePath
-        outName=${name:-$basename}
+        if [[ -n "$name" ]]; then
+            outName=$name
+        elif [[ -n "$cmdname" ]]; then
+            case "$curShell" in
+            bash|fish) outName=$cmdname.$curShell;;
+            zsh) outName=_$cmdname;;
+            *)
+                # Our list of shells is out of sync with the flags we accept or extensions we detect.
+                echo 'installShellCompletion: internal error' >&2
+                return 1;;
+            esac
+        fi
+        local sharePath
         case "$curShell" in
         bash) sharePath=bash-completion/completions;;
         fish) sharePath=fish/vendor_completions.d;;
         zsh)
             sharePath=zsh/site-functions
             # only apply automatic renaming if we didn't have a manual rename
-            if test -z "$name"; then
+            if [[ -z "$name" && -z "$cmdname" ]]; then
                 # convert a name like `foo.zsh` into `_foo`
                 outName=${outName%.zsh}
                 outName=_${outName#_}
@@ -153,8 +210,16 @@ installShellCompletion() {
             return 1;;
         esac
         # Install file
-        install -Dm644 -T "$arg" "${!outputBin:?}/share/$sharePath/$outName" || return
-        # Clear the name, it only applies to one path
+        local outDir="${!outputBin:?}/share/$sharePath"
+        local outPath="$outDir/$outName"
+        if [[ -p "$arg" ]]; then
+            # install handles named pipes on NixOS but not on macOS
+            mkdir -p "$outDir" \
+            && cat "$arg" > "$outPath"
+        else
+            install -Dm644 -T "$arg" "$outPath"
+        fi || return
+        # Clear the per-path flags
         name=
     done
     if [[ -n "$name" ]]; then

--- a/pkgs/build-support/setup-hooks/install-shell-files.sh
+++ b/pkgs/build-support/setup-hooks/install-shell-files.sh
@@ -19,8 +19,8 @@
 # installManPage <path> [...<path>]
 #
 # Each argument is checked for its man section suffix and installed into the appropriate
-# share/man<n>/ directory. The function returns an error if any paths don't have the man section
-# suffix (with optional .gz compression).
+# share/man/man<n>/ directory. The function returns an error if any paths don't have the man
+# section suffix (with optional .gz compression).
 installManPage() {
     local path
     for path in "$@"; do

--- a/pkgs/development/compilers/purescript/psc-package/default.nix
+++ b/pkgs/development/compilers/purescript/psc-package/default.nix
@@ -44,12 +44,10 @@ stdenv.mkDerivation rec {
   '' + ''
     chmod u-w $PSC_PACKAGE
 
-    $PSC_PACKAGE --bash-completion-script $PSC_PACKAGE > psc-package.bash
-    $PSC_PACKAGE --fish-completion-script $PSC_PACKAGE > psc-package.fish
-    $PSC_PACKAGE --zsh-completion-script $PSC_PACKAGE > _psc-package
-    installShellCompletion \
-      psc-package.{bash,fish} \
-      --zsh _psc-package
+    installShellCompletion --cmd psc-package \
+      --bash <($PSC_PACKAGE --bash-completion-script $PSC_PACKAGE) \
+      --fish <($PSC_PACKAGE --fish-completion-script $PSC_PACKAGE) \
+      --zsh <($PSC_PACKAGE --zsh-completion-script $PSC_PACKAGE)
   '';
 
   meta = with lib; {

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -27,6 +27,8 @@ with pkgs;
   cc-multilib-gcc = callPackage ./cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };
   cc-multilib-clang = callPackage ./cc-wrapper/multilib.nix { stdenv = clangMultiStdenv; };
 
+  install-shell-files = callPackage ./install-shell-files {};
+
   kernel-config = callPackage ./kernel.nix {};
 
   ld-library-path = callPackage ./ld-library-path {};

--- a/pkgs/test/install-shell-files/default.nix
+++ b/pkgs/test/install-shell-files/default.nix
@@ -1,0 +1,125 @@
+{ stdenv, runCommandLocal, recurseIntoAttrs, installShellFiles }:
+
+let
+  runTest = name: env: buildCommand:
+    runCommandLocal "install-shell-files--${name}" ({
+      nativeBuildInputs = [ installShellFiles ];
+      meta.platforms = stdenv.lib.platforms.all;
+    } // env) buildCommand;
+in
+
+recurseIntoAttrs {
+  # installManPage
+
+  install-manpage = runTest "install-manpage" {} ''
+    mkdir -p doc
+    echo foo > doc/foo.1
+    echo bar > doc/bar.2.gz
+    echo baz > doc/baz.3
+
+    installManPage doc/*
+
+    cmp doc/foo.1 $out/share/man/man1/foo.1
+    cmp doc/bar.2.gz $out/share/man/man2/bar.2.gz
+    cmp doc/baz.3 $out/share/man/man3/baz.3
+  '';
+  install-manpage-outputs = runTest "install-manpage-outputs" {
+    outputs = [ "out" "man" "devman" ];
+  } ''
+    mkdir -p doc
+    echo foo > doc/foo.1
+    echo bar > doc/bar.3
+
+    installManPage doc/*
+
+    # assert they didn't go into $out
+    [[ ! -f $out/share/man/man1/foo.1 && ! -f $out/share/man/man3/bar.3 ]]
+
+    # foo.1 alone went into man
+    cmp doc/foo.1 ''${!outputMan:?}/share/man/man1/foo.1
+    [[ ! -f ''${!outputMan:?}/share/man/man3/bar.3 ]]
+
+    # bar.3 alone went into devman
+    cmp doc/bar.3 ''${!outputDevman:?}/share/man/man3/bar.3
+    [[ ! -f ''${!outputDevman:?}/share/man/man1/foo.1 ]]
+
+    touch $out
+  '';
+
+  # installShellCompletion
+
+  install-completion = runTest "install-completion" {} ''
+    echo foo > foo
+    echo bar > bar
+    echo baz > baz
+    echo qux > qux.zsh
+    echo quux > quux
+
+    installShellCompletion --bash foo bar --zsh baz qux.zsh --fish quux
+
+    cmp foo $out/share/bash-completion/completions/foo
+    cmp bar $out/share/bash-completion/completions/bar
+    cmp baz $out/share/zsh/site-functions/_baz
+    cmp qux.zsh $out/share/zsh/site-functions/_qux
+    cmp quux $out/share/fish/vendor_completions.d/quux
+  '';
+  install-completion-output = runTest "install-completion-output" {
+    outputs = [ "out" "bin" ];
+  } ''
+    echo foo > foo
+
+    installShellCompletion --bash foo
+
+    # assert it didn't go into $out
+    [[ ! -f $out/share/bash-completion/completions/foo ]]
+
+    cmp foo ''${!outputBin:?}/share/bash-completion/completions/foo
+
+    touch $out
+  '';
+  install-completion-name = runTest "install-completion-name" {} ''
+    echo foo > foo
+    echo bar > bar
+    echo baz > baz
+
+    installShellCompletion --bash --name foobar.bash foo --zsh --name _foobar bar --fish baz
+
+    cmp foo $out/share/bash-completion/completions/foobar.bash
+    cmp bar $out/share/zsh/site-functions/_foobar
+    cmp baz $out/share/fish/vendor_completions.d/baz
+  '';
+  install-completion-inference = runTest "install-completion-inference" {} ''
+    echo foo > foo.bash
+    echo bar > bar.zsh
+    echo baz > baz.fish
+
+    installShellCompletion foo.bash bar.zsh baz.fish
+
+    cmp foo.bash $out/share/bash-completion/completions/foo.bash
+    cmp bar.zsh $out/share/zsh/site-functions/_bar
+    cmp baz.fish $out/share/fish/vendor_completions.d/baz.fish
+  '';
+  install-completion-cmd = runTest "install-completion-cmd" {} ''
+    echo foo > foo.bash
+    echo bar > bar.zsh
+    echo baz > baz.fish
+    echo qux > qux.fish
+
+    installShellCompletion --cmd foobar --bash foo.bash --zsh bar.zsh --fish baz.fish --name qux qux.fish
+
+    cmp foo.bash $out/share/bash-completion/completions/foobar.bash
+    cmp bar.zsh $out/share/zsh/site-functions/_foobar
+    cmp baz.fish $out/share/fish/vendor_completions.d/foobar.fish
+    cmp qux.fish $out/share/fish/vendor_completions.d/qux
+  '';
+  install-completion-fifo = runTest "install-completion-fifo" {} ''
+    installShellCompletion \
+      --bash --name foo.bash <(echo foo) \
+      --zsh --name _foo <(echo bar) \
+      --fish --name foo.fish <(echo baz)
+
+    [[ $(<$out/share/bash-completion/completions/foo.bash) == foo ]] || { echo "foo.bash comparison failed"; exit 1; }
+    [[ $(<$out/share/zsh/site-functions/_foo) == bar ]] || { echo "_foo comparison failed"; exit 1; }
+    [[ $(<$out/share/fish/vendor_completions.d/foo.fish) == baz ]] || { echo "foo.fish comparison failed"; exit 1; }
+  '';
+}


### PR DESCRIPTION
###### Motivation for this change
Some packages don't bundle shell completions as files in their source tree but instead synthesize them by invoking the built tool with specific flags. This enhances the `installShellCompletion` command such that it can install these completions without having to pipe them to a file first. To do this, it now supports a named pipe as a path, such as produced by `<(cmd)`. It also now has a convenience flag to synthesize the name for all files based on the shell.

Examples:

```sh
installShellCompletion --cmd foobar \
  --bash <($out/bin/foobar --bash-completion) \
  --fish <($out/bin/foobar --fish-completion) \
  --zsh <($out/bin/foobar --zsh-completion)
```

Fixes #83284

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested one package that uses `installShellCompletion` (`ffsend`) and it produced the same output. I also manually tested all of the new functionality, including error cases.
