### PR TITLE
network-interfaces: fix literalExample arguments

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -634,19 +634,23 @@ in
 
     networking.bonds =
       let
-        driverOptionsExample = {
-          miimon = "100";
-          mode = "active-backup";
-        };
+        driverOptionsExample =  ''
+          {
+            miimon = "100";
+            mode = "active-backup";
+          }
+        '';
       in mkOption {
         default = { };
-        example = literalExample {
-          bond0 = {
-            interfaces = [ "eth0" "wlan0" ];
-            driverOptions = driverOptionsExample;
-          };
-          anotherBond.interfaces = [ "enp4s0f0" "enp4s0f1" "enp5s0f0" "enp5s0f1" ];
-        };
+        example = literalExample ''
+          {
+            bond0 = {
+              interfaces = [ "eth0" "wlan0" ];
+              driverOptions = ${driverOptionsExample};
+            };
+            anotherBond.interfaces = [ "enp4s0f0" "enp4s0f1" "enp5s0f0" "enp5s0f1" ];
+          }
+        '';
         description = ''
           This option allows you to define bond devices that aggregate multiple,
           underlying networking interfaces together. The value of this option is
@@ -731,12 +735,14 @@ in
 
     networking.macvlans = mkOption {
       default = { };
-      example = literalExample {
-        wan = {
-          interface = "enp2s0";
-          mode = "vepa";
-        };
-      };
+      example = literalExample ''
+        {
+          wan = {
+            interface = "enp2s0";
+            mode = "vepa";
+          };
+        }
+      '';
       description = ''
         This option allows you to define macvlan interfaces which should
         be automatically created.
@@ -764,18 +770,20 @@ in
 
     networking.sits = mkOption {
       default = { };
-      example = literalExample {
-        hurricane = {
-          remote = "10.0.0.1";
-          local = "10.0.0.22";
-          ttl = 255;
-        };
-        msipv6 = {
-          remote = "192.168.0.1";
-          dev = "enp3s0";
-          ttl = 127;
-        };
-      };
+      example = literalExample ''
+        {
+          hurricane = {
+            remote = "10.0.0.1";
+            local = "10.0.0.22";
+            ttl = 255;
+          };
+          msipv6 = {
+            remote = "192.168.0.1";
+            dev = "enp3s0";
+            ttl = 127;
+          };
+        }
+      '';
       description = ''
         This option allows you to define 6-to-4 interfaces which should be automatically created.
       '';
@@ -826,16 +834,18 @@ in
 
     networking.vlans = mkOption {
       default = { };
-      example = literalExample {
-        vlan0 = {
-          id = 3;
-          interface = "enp3s0";
-        };
-        vlan1 = {
-          id = 1;
-          interface = "wlan0";
-        };
-      };
+      example = literalExample ''
+        {
+          vlan0 = {
+            id = 3;
+            interface = "enp3s0";
+          };
+          vlan1 = {
+            id = 1;
+            interface = "wlan0";
+          };
+        }
+      '';
       description =
         ''
           This option allows you to define vlan devices that tag packets
@@ -868,24 +878,26 @@ in
 
     networking.wlanInterfaces = mkOption {
       default = { };
-      example = literalExample {
-        wlan-station0 = {
-            device = "wlp6s0";
-        };
-        wlan-adhoc0 = {
-            type = "ibss";
-            device = "wlp6s0";
-            mac = "02:00:00:00:00:01";
-        };
-        wlan-p2p0 = {
-            device = "wlp6s0";
-            mac = "02:00:00:00:00:02";
-        };
-        wlan-ap0 = {
-            device = "wlp6s0";
-            mac = "02:00:00:00:00:03";
-        };
-      };
+      example = literalExample ''
+        {
+          wlan-station0 = {
+              device = "wlp6s0";
+          };
+          wlan-adhoc0 = {
+              type = "ibss";
+              device = "wlp6s0";
+              mac = "02:00:00:00:00:01";
+          };
+          wlan-p2p0 = {
+              device = "wlp6s0";
+              mac = "02:00:00:00:00:02";
+          };
+          wlan-ap0 = {
+              device = "wlp6s0";
+              mac = "02:00:00:00:00:03";
+          };
+        }
+      '';
       description =
         ''
           Creating multiple WLAN interfaces on top of one physical WLAN device (NIC).


### PR DESCRIPTION
Fix nixos/nixos-homepage#255

###### Motivation for this change

literalExample is assumed to take a string argument. When this is not the case both nixos-option utility and the nixos option webpage render the example wrong.
