### PR TITLE
higan: fix darwin build

### DIFF
--- a/pkgs/misc/emulators/higan/default.nix
+++ b/pkgs/misc/emulators/higan/default.nix
@@ -1,8 +1,9 @@
 { stdenv, fetchurl
-, p7zip, pkgconfig
+, p7zip, pkgconfig, libicns
 , libX11, libXv
 , udev
 , libGLU, libGL, SDL
+, Carbon, Cocoa, OpenGL, OpenAL
 , libao, openal, libpulseaudio
 , gtk2, gtksourceview
 , runtimeShell }:
@@ -21,11 +22,24 @@ stdenv.mkDerivation rec {
   };
 
   patches = [ ./0001-change-flags.diff ];
-  postPatch = "sed '1i#include <cmath>' -i higan/fc/ppu/ppu.cpp";
+  postPatch = ''
+    sed '1i#include <cmath>' -i higan/fc/ppu/ppu.cpp
+
+    for file in icarus/GNUmakefile higan/target-tomoko/GNUmakefile; do
+      substituteInPlace "$file" \
+        --replace 'sips -s format icns data/$(name).png --out out/$(name).app/Contents/Resources/$(name).icns' \
+                  'png2icns out/$(name).app/Contents/Resources/$(name).icns data/$(name).png'
+    done
+  '';
+
+  nativeBuildInputs = [ p7zip pkgconfig ]
+    ++ optional stdenv.isDarwin [ libicns ];
 
   buildInputs =
-  [ p7zip pkgconfig libX11 libXv udev libGLU libGL
-    SDL libao openal libpulseaudio gtk2 gtksourceview ];
+    [ SDL libao ]
+    ++ optionals stdenv.isLinux [ openal libpulseaudio udev libX11 libXv libGLU libGL gtk2 gtksourceview ]
+    ++ optionals stdenv.isDarwin [ Carbon Cocoa OpenGL OpenAL ]
+    ;
 
   unpackPhase = ''
     7z x $src
@@ -38,27 +52,36 @@ stdenv.mkDerivation rec {
   '';
 
   # Now the cheats file will be distributed separately
-  installPhase = ''
-    install -dm 755 $out/bin $out/share/applications $out/share/higan $out/share/pixmaps
-    install -m 755 icarus/out/icarus $out/bin/
-    install -m 755 higan/out/higan $out/bin/
-    install -m 644 higan/data/higan.desktop $out/share/applications/
-    install -m 644 higan/data/higan.png $out/share/pixmaps/higan-icon.png
-    install -m 644 higan/resource/logo/higan.png $out/share/pixmaps/higan-logo.png
+  installPhase = (if !stdenv.isDarwin then ''
+    mkdir -p "$out"/bin "$out"/share/applications "$out"/share/pixmaps
+    install -m 755 icarus/out/icarus "$out"/bin/
+    install -m 755 higan/out/higan "$out"/bin/
+    install -m 644 higan/data/higan.desktop "$out"/share/applications/
+    install -m 644 higan/data/higan.png "$out"/share/pixmaps/higan-icon.png
+    install -m 644 higan/resource/logo/higan.png "$out"/share/pixmaps/higan-logo.png
+  '' else ''
+    mkdir "$out"
+    mv higan/out/higan.app "$out"/
+    mv icarus/out/icarus.app "$out"/
+  '') + ''
+    mkdir -p  "$out"/share/higan
     cp --recursive --no-dereference --preserve='links' --no-preserve='ownership' \
-      higan/systems/* $out/share/higan/
+      higan/systems/* "$out"/share/higan/
   '';
 
-  fixupPhase = ''
+  fixupPhase = let
+    dest = if !stdenv.isDarwin then "\\$HOME/.local/share/higan" else "\\$HOME/Library/Application Support/higan";
+  in ''
     # A dirty workaround, suggested by @cpages:
     # we create a first-run script to populate
     # the local $HOME with all the auxiliary
     # stuff needed by higan at runtime
 
+    mkdir -p "$out"/bin
     cat <<EOF > $out/bin/higan-init.sh
     #!${runtimeShell}
 
-    cp --recursive --update $out/share/higan/*.sys \$HOME/.local/share/higan/
+    cp --recursive --update $out/share/higan/*.sys "${dest}"/
 
     EOF
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26305,6 +26305,7 @@ in
 
   higan = callPackage ../misc/emulators/higan {
     inherit (gnome2) gtksourceview;
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa OpenGL OpenAL;
   };
 
   bullet = callPackage ../development/libraries/bullet {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
