### PR TITLE
services.nixosManual fallout

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -757,6 +757,16 @@ auth required pam_succeed_if.so uid >= 1000 quiet
      </warning>
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The option <option>services.nixosManual.showManual</option> has been removed (and the module).
+	 You can use the <command>nixos-help</command> command instead, without security issues with the module's implementation.
+	 This applies in particular to the installation images.
+    </para>
+    <para>
+	 Similar module <option>services.rogue</option> was also removed (probably not used by anyone).
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -75,6 +75,7 @@ in
     (mkRenamedOptionModule [ "programs" "info" "enable" ] [ "documentation" "info" "enable" ])
     (mkRenamedOptionModule [ "programs" "man"  "enable" ] [ "documentation" "man"  "enable" ])
     (mkRenamedOptionModule [ "services" "nixosManual" "enable" ] [ "documentation" "nixos" "enable" ])
+    (mkRemovedOptionModule [ "services" "nixosManual" "showManual" ] "Use nixos-help command instead.")
   ];
 
   options = {

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -48,6 +48,7 @@ with lib;
       systemd-logind API). Instead of using the module you can now
       simply add the brightnessctl package to environment.systemPackages.
     '')
+    (mkRemovedOptionModule [ "services" "rogue" ] "")
 
     # Do NOT add any option renames here, see top of the file
   ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] N/A Tested execution of all binary files (usually in `./result/bin/`)
- [ ] N/A Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
