### PR TITLE
buildPythonPackage: add prefix to pname

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -27,10 +27,9 @@
 , eggInstallHook
 }:
 
-{ name ? "${attrs.pname}-${attrs.version}"
-
+{
 # Build-time dependencies for the package
-, nativeBuildInputs ? []
+  nativeBuildInputs ? []
 
 # Run-time dependencies for the package
 , buildInputs ? []
@@ -94,17 +93,17 @@
 
 # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
 if disabled
-then throw "${name} not supported for interpreter ${python.executable}"
+then throw "${attrs.pname} of version ${attrs.version} not supported for interpreter ${python.executable}"
 else
 
 let
   inherit (python) stdenv;
 
   self = toPythonModule (stdenv.mkDerivation ((builtins.removeAttrs attrs [
-    "disabled" "checkPhase" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "format"
+    "pname" "disabled" "checkPhase" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "format"
   ]) // {
 
-  name = namePrefix + name;
+  pname = namePrefix + attrs.pname;
 
   nativeBuildInputs = [
     python

--- a/pkgs/development/python-modules/cddb/default.nix
+++ b/pkgs/development/python-modules/cddb/default.nix
@@ -5,13 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  name = "CDDB-1.4";
+  pname = "CDDB";
+  version = "1.4";
   disabled = isPy3k;
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.IOKit ];
 
   src = pkgs.fetchurl {
-    url = "http://cddb-py.sourceforge.net/${name}.tar.gz";
+    url = "http://cddb-py.sourceforge.net/${pname}-${version}.tar.gz";
     sha256 = "098xhd575ibvdx7i3dny3lwi851yxhjg2hn5jbbgrwj833rg5l5w";
   };
 

--- a/pkgs/development/python-modules/deskcon/default.nix
+++ b/pkgs/development/python-modules/deskcon/default.nix
@@ -7,7 +7,8 @@
 }:
 
 buildPythonPackage {
-  name = "deskcon-0.3";
+  pname = "deskcon";
+  version = "0.3";
   disabled = isPy3k;
 
   src = pkgs.fetchFromGitHub {

--- a/pkgs/development/python-modules/gateone/default.nix
+++ b/pkgs/development/python-modules/gateone/default.nix
@@ -8,7 +8,8 @@
 }:
 
 buildPythonPackage {
-  name = "gateone-1.2-0d57c3";
+  pname = "gateone";
+  version = "1.2-0d57c3";
   disabled = isPy3k;
 
   src = pkgs.fetchFromGitHub {

--- a/pkgs/development/python-modules/mutag/default.nix
+++ b/pkgs/development/python-modules/mutag/default.nix
@@ -6,7 +6,8 @@
 }:
 
 buildPythonPackage {
-  name = "mutag-0.0.2-2ffa0258ca";
+  pname = "mutag";
+  version = "0.0.2-2ffa0258ca";
   disabled = ! isPy3k;
 
   src = fetchgit {

--- a/pkgs/development/python-modules/notmuch/default.nix
+++ b/pkgs/development/python-modules/notmuch/default.nix
@@ -1,20 +1,18 @@
 { stdenv
 , buildPythonPackage
-, pkgs
+, notmuch
 , python
 }:
 
 buildPythonPackage {
-  name = "python-${pkgs.notmuch.name}";
+  inherit (notmuch) pname version src;
 
-  src = pkgs.notmuch.src;
+  sourceRoot = notmuch.pythonSourceRoot;
 
-  sourceRoot = pkgs.notmuch.pythonSourceRoot;
-
-  buildInputs = [ python pkgs.notmuch ];
+  buildInputs = [ python notmuch ];
 
   postPatch = ''
-    sed -i -e '/CDLL/s@"libnotmuch\.@"${pkgs.notmuch}/lib/libnotmuch.@' \
+    sed -i -e '/CDLL/s@"libnotmuch\.@"${notmuch}/lib/libnotmuch.@' \
       notmuch/globals.py
   '';
 

--- a/pkgs/development/python-modules/slob/default.nix
+++ b/pkgs/development/python-modules/slob/default.nix
@@ -7,8 +7,8 @@
 }:
 
 buildPythonPackage {
-  name = "slob";
-  verison = "unstable-2016-11-03";
+  pname = "slob";
+  version = "unstable-2016-11-03";
   disabled = !isPy3k;
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/tkinter/default.nix
+++ b/pkgs/development/python-modules/tkinter/default.nix
@@ -6,7 +6,8 @@
 }:
 
 buildPythonPackage {
-  name = "tkinter-${python.version}";
+  pname = "tkinter";
+  version = python.version;
   src = py;
   format = "other";
 

--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -4,8 +4,8 @@
 }:
 
 python.pkgs.buildPythonApplication rec {
+  pname = "bcc";
   version = "0.13.0";
-  name = "bcc-${version}";
 
   src = fetchurl {
     url = "https://github.com/iovisor/bcc/releases/download/v${version}/bcc-src-with-submodule.tar.gz";

--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, pythonPackages, nasm, libelf
 , kernel ? null, withDriver ? false }:
 pythonPackages.buildPythonApplication rec {
-  name = "chipsec-${version}";
+  pname = "chipsec";
   version = "1.4.7";
 
   src = fetchFromGitHub {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -90,7 +90,7 @@ let
         # Remove Python prefix from name so we have a "normal" name.
         # While the prefix shows up in the store path, it won't be
         # used by `nix-env`.
-        name = removePythonPrefix oldAttrs.name;
+        pname = removePythonPrefix oldAttrs.pname;
         pythonModule = false;
       };
     });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4590,7 +4590,9 @@ in {
 
   notify2 = callPackage ../development/python-modules/notify2 {};
 
-  notmuch = callPackage ../development/python-modules/notmuch { };
+  notmuch = callPackage ../development/python-modules/notmuch {
+    inherit (pkgs) notmuch;
+  };
 
   emoji = callPackage ../development/python-modules/emoji { };
 


### PR DESCRIPTION
The `pname` passed to `stdenv.mkDerivation` consists of the name prefix
as well as the `pname` passed to `stdenv.mkDerivation`.

This is needed in case we want to test for valid `pname` in
`stdenv.mkDerivation`.
https://github.com/NixOS/nixpkgs/pull/68620#issuecomment-605599680

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
