### PR TITLE
linux config: enable Creative Soundblaster DSP loading

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -650,6 +650,12 @@
     githubId = 10285250;
     name = "Artur E. Ruuge";
   };
+  asbachb = {
+    email = "asbachb-nixpkgs-5c2a@impl.it";
+    github = "asbachb";
+    githubId = 1482768;
+    name = "Benjamin Asbach";
+  };
   ashalkhakov = {
     email = "artyom.shalkhakov@gmail.com";
     github = "ashalkhakov";
@@ -8333,5 +8339,3 @@
     name = "Xavier Zwirtz";
   };
 }
-
-

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -412,10 +412,15 @@
     githubId = 20530052;
     name = "Andrew Miloradovsky";
   };
-  aminb = {
-    email = "amin@aminb.org";
-    github = "aminb";
+  notbandali = {
     name = "Amin Bandali";
+    email = "bandali@gnu.org";
+    github = "notbandali";
+    githubId = 1254858;
+    keys = [{
+      longkeyid = "rsa4096/0xA21A020248816103";
+      fingerprint = "BE62 7373 8E61 6D6D 1B3A  08E8 A21A 0202 4881 6103";
+    }];
   };
   aminechikhaoui = {
     email = "amine.chikhaoui91@gmail.com";

--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -697,6 +697,66 @@ auth required pam_succeed_if.so uid >= 1000 quiet
      </para>
     </warning>
    </listitem>
+   <listitem>
+    <para>
+     <package>Hydra</package> has gained a massive performance improvement due to
+     <link xlink:href="https://github.com/NixOS/hydra/pull/710">some database schema
+     changes</link> by adding several IDs and better indexing. However, it's necessary
+     to upgrade Hydra in multiple steps:
+     <itemizedlist>
+      <listitem>
+       <para>
+        At first, an older version of Hydra needs to be deployed which adds those
+        (nullable) columns. When having set <link linkend="opt-system.stateVersion">stateVersion
+        </link> to a value older than <literal>20.03</literal>, this package will be selected
+        by default from the module when upgrading. Otherwise, the package can be deployed using
+        the following config:
+<programlisting>{ pkgs, ... }: {
+  <link linkend="opt-services.hydra.package">services.hydra.package</link> = pkgs.hydra-migration;
+}</programlisting>
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Automatically fill the newly added ID columns on the server by running the following
+        command:
+<screen>
+<prompt>$ </prompt>hydra-backfill-ids
+</screen>
+        <warning>
+         <para>Please note that this process can take a while depending on your database-size!</para>
+        </warning>
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Deploy a newer version of Hydra to activate the DB optimizations. You can choose from
+        either <package>hydra-unstable</package> (latest <literal>master</literal> compiled
+        against <package>nixUnstable</package>) and <package>hydra-flakes</package> (latest
+        version with flake-support).
+        <warning>
+         <para>
+          If your <link linkend="opt-system.stateVersion">stateVersion</link> is set to
+          <literal>20.03</literal> or greater, <package>hydra-unstable</package> will be used
+          automatically! This will break your setup if you didn't run the migration.
+         </para>
+        </warning>
+        Please note that Hydra is currently not available with <package>nixStable</package>
+        as this doesn't compile anymore.
+       </para>
+      </listitem>
+     </itemizedlist>
+     <warning>
+      <para>
+       <package>pkgs.hydra</package> has been removed to ensure a graceful database-migration
+       using the dedicated package-attributes. If you still have <package>pkgs.hydra</package>
+       defined in e.g. an overlay, an assertion error will be thrown. To circumvent this,
+       you need to set <xref linkend="opt-services.hydra.package" /> to <package>pkgs.hydra</package>
+       explicitly and make sure you know what you're doing!
+      </para>
+     </warning>
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/networking/connman.nix
+++ b/nixos/modules/services/networking/connman.nix
@@ -96,6 +96,8 @@ in {
       assertion = !config.networking.useDHCP;
       message = "You can not use services.connman with networking.useDHCP";
     }{
+      # TODO: connman seemingly can be used along network manager and
+      # connmanFull supports this - so this should be worked out somehow
       assertion = !config.networking.networkmanager.enable;
       message = "You can not use services.connman with networking.networkmanager";
     }];

--- a/nixos/modules/services/networking/connman.nix
+++ b/nixos/modules/services/networking/connman.nix
@@ -77,6 +77,13 @@ in {
         '';
       };
 
+      package = mkOption {
+        type = types.path;
+        description = "The connman package / build flavor";
+        default = connman;
+        example = literalExample "pkgs.connmanFull";
+      };
+
     };
 
   };
@@ -93,7 +100,7 @@ in {
       message = "You can not use services.connman with networking.networkmanager";
     }];
 
-    environment.systemPackages = [ connman ];
+    environment.systemPackages = [ cfg.package ];
 
     systemd.services.connman = {
       description = "Connection service";
@@ -105,7 +112,7 @@ in {
         BusName = "net.connman";
         Restart = "on-failure";
         ExecStart = toString ([
-          "${pkgs.connman}/sbin/connmand"
+          "${cfg.package}/sbin/connmand"
           "--config=${configFile}"
           "--nodaemon"
         ] ++ optional enableIwd "--wifi=iwd_agent"
@@ -122,7 +129,7 @@ in {
       serviceConfig = {
         Type = "dbus";
         BusName = "net.connman.vpn";
-        ExecStart = "${pkgs.connman}/sbin/connman-vpnd -n";
+        ExecStart = "${cfg.package}/sbin/connman-vpnd -n";
         StandardOutput = "null";
       };
     };
@@ -132,7 +139,7 @@ in {
       serviceConfig = {
         Name = "net.connman.vpn";
         before = [ "connman" ];
-        ExecStart = "${pkgs.connman}/sbin/connman-vpnd -n";
+        ExecStart = "${cfg.package}/sbin/connman-vpnd -n";
         User = "root";
         SystemdService = "connman-vpn.service";
       };

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -176,7 +176,7 @@ let
 
     ${optionalString (cfg.httpConfig != "") ''
     http {
-      ${common.httpConfig}
+      ${commonHttpConfig}
       ${cfg.httpConfig}
     }''}
 

--- a/nixos/modules/services/web-servers/phpfpm/default.nix
+++ b/nixos/modules/services/web-servers/phpfpm/default.nix
@@ -47,6 +47,7 @@ let
             Path to the unix socket file on which to accept FastCGI requests.
             <note><para>This option is read-only and managed by NixOS.</para></note>
           '';
+          example = "${runtimeDir}/<name>.sock";
         };
 
         listen = mkOption {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -130,6 +130,7 @@ in
   home-assistant = handleTest ./home-assistant.nix {};
   hound = handleTest ./hound.nix {};
   hydra = handleTest ./hydra {};
+  hydra-db-migration = handleTest ./hydra/db-migration.nix {};
   i3wm = handleTest ./i3wm.nix {};
   icingaweb2 = handleTest ./icingaweb2.nix {};
   iftop = handleTest ./iftop.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -121,7 +121,10 @@ in
   handbrake = handleTestOn ["x86_64-linux"] ./handbrake.nix {};
   haproxy = handleTest ./haproxy.nix {};
   hardened = handleTest ./hardened.nix {};
-  hibernate = handleTest ./hibernate.nix {};
+  # 9pnet_virtio used to mount /nix partition doesn't support
+  # hibernation. This test happens to work on x86_64-linux but
+  # not on other platforms.
+  hibernate = handleTestOn ["x86_64-linux"] ./hibernate.nix {};
   hitch = handleTest ./hitch {};
   hocker-fetchdocker = handleTest ./hocker-fetchdocker {};
   home-assistant = handleTest ./home-assistant.nix {};

--- a/nixos/tests/hydra/common.nix
+++ b/nixos/tests/hydra/common.nix
@@ -1,0 +1,47 @@
+{ system, ... }:
+{
+  baseConfig = { pkgs, ... }: let
+    trivialJob = pkgs.writeTextDir "trivial.nix" ''
+     { trivial = builtins.derivation {
+         name = "trivial";
+         system = "${system}";
+         builder = "/bin/sh";
+         allowSubstitutes = false;
+         preferLocalBuild = true;
+         args = ["-c" "echo success > $out; exit 0"];
+       };
+     }
+    '';
+
+    createTrivialProject = pkgs.stdenv.mkDerivation {
+      name = "create-trivial-project";
+      dontUnpack = true;
+      buildInputs = [ pkgs.makeWrapper ];
+      installPhase = "install -m755 -D ${./create-trivial-project.sh} $out/bin/create-trivial-project.sh";
+      postFixup = ''
+        wrapProgram "$out/bin/create-trivial-project.sh" --prefix PATH ":" ${pkgs.stdenv.lib.makeBinPath [ pkgs.curl ]} --set EXPR_PATH ${trivialJob}
+      '';
+    };
+  in {
+    virtualisation.memorySize = 2048;
+    time.timeZone = "UTC";
+    environment.systemPackages = [ createTrivialProject pkgs.jq ];
+    services.hydra = {
+      enable = true;
+      # Hydra needs those settings to start up, so we add something not harmfull.
+      hydraURL = "example.com";
+      notificationSender = "example@example.com";
+      extraConfig = ''
+        email_notification = 1
+      '';
+    };
+    services.postfix.enable = true;
+    nix = {
+      buildMachines = [{
+        hostName = "localhost";
+        systems = [ system ];
+      }];
+      binaryCaches = [];
+    };
+  };
+}

--- a/nixos/tests/hydra/db-migration.nix
+++ b/nixos/tests/hydra/db-migration.nix
@@ -1,0 +1,86 @@
+{ system ? builtins.currentSystem, ... }:
+
+let inherit (import ./common.nix { inherit system; }) baseConfig; in
+
+{ mig = import ../make-test-python.nix ({ pkgs, lib, ... }: {
+    name = "hydra-db-migration";
+    meta = with pkgs.stdenv.lib.maintainers; {
+      maintainers = [ ma27 ];
+    };
+
+    nodes = {
+      original = { pkgs, lib, ... }: {
+        imports = [ baseConfig ];
+
+        # An older version of Hydra before the db change
+        # for testing purposes.
+        services.hydra.package = pkgs.hydra-migration.overrideAttrs (old: {
+          inherit (old) pname;
+          version = "2020-02-06";
+          src = pkgs.fetchFromGitHub {
+            owner = "NixOS";
+            repo = "hydra";
+            rev = "2b4f14963b16b21ebfcd6b6bfa7832842e9b2afc";
+            sha256 = "16q0cffcsfx5pqd91n9k19850c1nbh4vvbd9h8yi64ihn7v8bick";
+          };
+        });
+      };
+
+      migration_phase1 = { pkgs, lib, ... }: {
+        imports = [ baseConfig ];
+        services.hydra.package = pkgs.hydra-migration;
+      };
+
+      finished = { pkgs, lib, ... }: {
+        imports = [ baseConfig ];
+        services.hydra.package = pkgs.hydra-unstable;
+      };
+    };
+
+    testScript = { nodes, ... }: let
+      next = nodes.migration_phase1.config.system.build.toplevel;
+      finished = nodes.finished.config.system.build.toplevel;
+    in ''
+      original.start()
+      original.wait_for_unit("multi-user.target")
+      original.wait_for_unit("postgresql.service")
+      original.wait_for_unit("hydra-init.service")
+      original.require_unit_state("hydra-queue-runner.service")
+      original.require_unit_state("hydra-evaluator.service")
+      original.require_unit_state("hydra-notify.service")
+      original.succeed("hydra-create-user admin --role admin --password admin")
+      original.wait_for_open_port(3000)
+      original.succeed("create-trivial-project.sh")
+      original.wait_until_succeeds(
+          'curl -L -s http://localhost:3000/build/1 -H "Accept: application/json" |  jq .buildstatus | xargs test 0 -eq'
+      )
+
+      out = original.succeed("su -l postgres -c 'psql -d hydra <<< \"\\d+ jobs\" -A'")
+      assert "jobset_id" not in out
+
+      original.succeed(
+          "${next}/bin/switch-to-configuration test >&2"
+      )
+      original.wait_for_unit("hydra-init.service")
+
+      out = original.succeed("su -l postgres -c 'psql -d hydra <<< \"\\d+ jobs\" -A'")
+      assert "jobset_id|integer|||" in out
+
+      original.succeed("hydra-backfill-ids")
+
+      original.succeed(
+          "${finished}/bin/switch-to-configuration test >&2"
+      )
+      original.wait_for_unit("hydra-init.service")
+
+      out = original.succeed("su -l postgres -c 'psql -d hydra <<< \"\\d+ jobs\" -A'")
+      assert "jobset_id|integer||not null|" in out
+
+      original.wait_until_succeeds(
+          'curl -L -s http://localhost:3000/build/1 -H "Accept: application/json" |  jq .buildstatus | xargs test 0 -eq'
+      )
+
+      original.shutdown()
+    '';
+  });
+}

--- a/nixos/tests/hydra/default.nix
+++ b/nixos/tests/hydra/default.nix
@@ -3,102 +3,57 @@
 , pkgs ? import ../../.. { inherit system config; }
 }:
 
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+with pkgs.lib;
+
 let
 
-  trivialJob = pkgs.writeTextDir "trivial.nix" ''
-   { trivial = builtins.derivation {
-       name = "trivial";
-       system = "${system}";
-       builder = "/bin/sh";
-       allowSubstitutes = false;
-       preferLocalBuild = true;
-       args = ["-c" "echo success > $out; exit 0"];
-     };
-   }
-  '';
+  inherit (import ./common.nix { inherit system; }) baseConfig;
 
-  createTrivialProject = pkgs.stdenv.mkDerivation {
-    name = "create-trivial-project";
-    dontUnpack = true;
-    buildInputs = [ pkgs.makeWrapper ];
-    installPhase = "install -m755 -D ${./create-trivial-project.sh} $out/bin/create-trivial-project.sh";
-    postFixup = ''
-      wrapProgram "$out/bin/create-trivial-project.sh" --prefix PATH ":" ${pkgs.stdenv.lib.makeBinPath [ pkgs.curl ]} --set EXPR_PATH ${trivialJob}
+  hydraPkgs = {
+    inherit (pkgs) hydra-migration hydra-unstable hydra-flakes;
+  };
+
+  makeHydraTest = with pkgs.lib; name: package: makeTest {
+    name = "hydra-${name}";
+    meta = with pkgs.stdenv.lib.maintainers; {
+      maintainers = [ pstn lewo ma27 ];
+    };
+
+    machine = { pkgs, lib, ... }: {
+      imports = [ baseConfig ];
+      services.hydra = { inherit package; };
+    };
+
+    testScript = ''
+      # let the system boot up
+      machine.wait_for_unit("multi-user.target")
+      # test whether the database is running
+      machine.wait_for_unit("postgresql.service")
+      # test whether the actual hydra daemons are running
+      machine.wait_for_unit("hydra-init.service")
+      machine.require_unit_state("hydra-queue-runner.service")
+      machine.require_unit_state("hydra-evaluator.service")
+      machine.require_unit_state("hydra-notify.service")
+
+      machine.succeed("hydra-create-user admin --role admin --password admin")
+
+      # create a project with a trivial job
+      machine.wait_for_open_port(3000)
+
+      # make sure the build as been successfully built
+      machine.succeed("create-trivial-project.sh")
+
+      machine.wait_until_succeeds(
+          'curl -L -s http://localhost:3000/build/1 -H "Accept: application/json" |  jq .buildstatus | xargs test 0 -eq'
+      )
+
+      machine.wait_until_succeeds(
+          'journalctl -eu hydra-notify.service -o cat | grep -q "sending mail notification to hydra@localhost"'
+      )
     '';
   };
 
-  callTest = f: f { inherit system pkgs; };
-
-  hydraPkgs = {
-    inherit (pkgs) nixStable nixUnstable nixFlakes;
-  };
-
-  tests = pkgs.lib.flip pkgs.lib.mapAttrs hydraPkgs (name: nix:
-    callTest (import ../make-test-python.nix ({ pkgs, lib, ... }:
-      {
-        name = "hydra-with-${name}";
-        meta = with pkgs.stdenv.lib.maintainers; {
-          maintainers = [ pstn lewo ma27 ];
-        };
-
-        machine = { pkgs, ... }:
-          {
-            virtualisation.memorySize = 1024;
-            time.timeZone = "UTC";
-
-            environment.systemPackages = [ createTrivialProject pkgs.jq ];
-            services.hydra = {
-              enable = true;
-
-              #Hydra needs those settings to start up, so we add something not harmfull.
-              hydraURL = "example.com";
-              notificationSender = "example@example.com";
-
-              package = pkgs.hydra.override { inherit nix; };
-
-              extraConfig = ''
-                email_notification = 1
-              '';
-            };
-            services.postfix.enable = true;
-            nix = {
-              buildMachines = [{
-                hostName = "localhost";
-                systems = [ system ];
-              }];
-
-              binaryCaches = [];
-            };
-          };
-
-        testScript = ''
-          # let the system boot up
-          machine.wait_for_unit("multi-user.target")
-          # test whether the database is running
-          machine.wait_for_unit("postgresql.service")
-          # test whether the actual hydra daemons are running
-          machine.wait_for_unit("hydra-init.service")
-          machine.require_unit_state("hydra-queue-runner.service")
-          machine.require_unit_state("hydra-evaluator.service")
-          machine.require_unit_state("hydra-notify.service")
-
-          machine.succeed("hydra-create-user admin --role admin --password admin")
-
-          # create a project with a trivial job
-          machine.wait_for_open_port(3000)
-
-          # make sure the build as been successfully built
-          machine.succeed("create-trivial-project.sh")
-
-          machine.wait_until_succeeds(
-              'curl -L -s http://localhost:3000/build/1 -H "Accept: application/json" |  jq .buildstatus | xargs test 0 -eq'
-          )
-
-          machine.wait_until_succeeds(
-              'journalctl -eu hydra-notify.service -o cat | grep -q "sending mail notification to hydra@localhost"'
-          )
-        '';
-      })));
-
 in
-  tests
+
+mapAttrs makeHydraTest hydraPkgs

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -33,7 +33,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     nodes = {
       node = {...}: {
         environment.systemPackages = with pkgs; [
-#          mongodb-3_4
+          mongodb-3_4
           mongodb-3_6
           mongodb-4_0
         ];
@@ -43,7 +43,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     testScript = ''
       node.start()
     ''
-#      + runMongoDBTest pkgs.mongodb-3_4
+      + runMongoDBTest pkgs.mongodb-3_4
       + runMongoDBTest pkgs.mongodb-3_6 
       + runMongoDBTest pkgs.mongodb-4_0
       + ''

--- a/pkgs/applications/backup/vorta/default.nix
+++ b/pkgs/applications/backup/vorta/default.nix
@@ -1,0 +1,42 @@
+{ buildPythonApplication, fetchFromGitHub, lib, paramiko, peewee, pyqt5
+, python-dateutil, APScheduler, psutil, qdarkstyle, secretstorage
+, appdirs, setuptools, qt5
+}:
+
+buildPythonApplication rec {
+  pname = "vorta";
+  version = "0.6.24";
+
+  src = fetchFromGitHub {
+    owner = "borgbase";
+    repo = "vorta";
+    rev = "v${version}";
+    sha256 = "1xc4cng4npc7g739qd909a8wim6s6sn8h8bb1wpxzg4gcnfyin8z";
+  };
+
+  postPatch = ''
+    sed -i -e '/setuptools_git/d' -e '/pytest-runner/d' setup.cfg
+  '';
+
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+
+  propagatedBuildInputs = [
+    paramiko peewee pyqt5 python-dateutil APScheduler psutil qdarkstyle
+    secretstorage appdirs setuptools
+  ];
+
+  # QT setup in tests broken.
+  doCheck = false;
+
+  postFixup = ''
+    wrapQtApp $out/bin/vorta
+  '';
+
+  meta = with lib; {
+    license = licenses.gpl3;
+    homepage = "https://vorta.borgbase.com/";
+    maintainers = with maintainers; [ ma27 ];
+    description = "Desktop Backup Client for Borg";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "11.2";
+  version = "11.3";
   desktopItem = makeDesktopItem {
     name = "netbeans";
     exec = "netbeans";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = "mirror://apache/netbeans/netbeans/${version}/netbeans-${version}-bin.zip";
-    sha512 = "d589481808832c4f0391ee1ecb8e18202cebeee8bd844cb4bdbf6125113b41f9138a34c4c2ef1fdf228294ef8c24b242ffec9ba5fdc4f1d288db4a3f19ba1509";
+    sha512 = "ae828836138b5a4156d58df24dd4053be58018cb6b5beb179cb0f4cd8b5db72d2a7356a434d01157aacb78d228732950cf4e3a0b6c725da8e053b6ccd91075d6";
   };
 
   buildCommand = ''

--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
     description = "An integrated development environment for Java, C, C++ and PHP";
     homepage = "https://netbeans.apache.org/";
     license = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib.maintainers; [ sander rszibele ];
+    maintainers = with stdenv.lib.maintainers; [ sander rszibele asbachb ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "drawio";
-  version = "12.6.5";
+  version = "12.9.3";
 
   src = fetchurl {
     url = "https://github.com/jgraph/drawio-desktop/releases/download/v${version}/draw.io-x86_64-${version}.rpm";
-    sha256 = "14x4h680q3w9wsdmivy2k1bggb09vdm3a3wrpfwd79dbaagjk4lc";
+    sha256 = "1jhw3p5r9dgn7320ca9n6hzyv2x557a8m9mh80vgrccd6i2mgm5i";
   };
 
   nativeBuildInputs = [
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A desktop application for creating diagrams";
-    homepage = https://about.draw.io/;
+    homepage = "https://about.draw.io/";
     license = licenses.asl20;
     maintainers = with maintainers; [ danieldk ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/misc/wofi/default.nix
+++ b/pkgs/applications/misc/wofi/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://paste.sr.ht/blob/1cbddafac3806afb203940c029e78ce8390d8f49";
-      sha256 = "18960y9ajilrwwl6mjnrh6wj0sm4ivczmacck36p2dj9xd0n8vkh";
+      sha256 = "1n4jpmh66p7asjhj0z2s94ny91lmaq4hhh2356nj406vlqr15vbb";
     })
   ];
 

--- a/pkgs/applications/misc/wofi/default.nix
+++ b/pkgs/applications/misc/wofi/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "A launcher/menu program for wlroots based wayland compositors such as sway";
     homepage = "https://hg.sr.ht/~scoopta/wofi";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ erictapen ];
+    maintainers = with maintainers; [ elyhaka ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -90,19 +90,19 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "9.0.6";
+  version = "9.0.7";
 
   lang = "en-US";
 
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz";
-      sha256 = "1vk1pww8zmpjd5snyfz0if9v17g140ymlp6navxp28snzlffahss";
+      sha256 = "11pgafa2lgj35s6kacy1b7pnzjg3ckqjxg0pf0aywxvc2qr3syv1";
     };
 
     i686-linux = fetchurl {
       url = "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz";
-      sha256 = "0bhikdilfz31iilgb48mayy9f4lilycq24pqsrq7w3dqdjg4v55v";
+      sha256 = "1mjz41n53gxpaxx7jdxk226f085v23kwr31m20vv4ar4vxfa42d8";
     };
   };
 in

--- a/pkgs/applications/networking/instant-messengers/matrix-dl/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-dl/default.nix
@@ -1,0 +1,25 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "matrix-dl-unstable";
+  version = "2019-09-22";
+
+  src = fetchFromGitHub {
+    owner = "rubo77";
+    repo = "matrix-dl";
+    rev = "e91610f45b7b3b0aca34923309fc83ba377f8a69";
+    sha256 = "036xfdd21pcfjlilknc67z5jqpk0vz07853wwcsiac32iypc6f2q";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    matrix-client
+  ];
+
+  meta = with lib; {
+    description = "Download backlogs from Matrix as raw text";
+    homepage = src.meta.homepage;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ aw ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
@@ -70,7 +70,7 @@ in mkYarnPackage rec {
     comment = meta.description;
     categories = "Network;InstantMessaging;Chat;";
     extraEntries = ''
-      StartupWMClass="riot"
+      StartupWMClass=riot
     '';
   };
 

--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -27,11 +27,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "mutt";
-  version = "1.13.4";
+  version = "1.13.5";
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/${pname}-${version}.tar.gz";
-    sha256 = "016dzx2c0kr9xgnw4nfzpkn4nvpk56rdlcqhrwa820fq8083yzdm";
+    sha256 = "0lx65a44b03rbvcrz0y9syrik67fx3hvblxyyvz5l9bb7rdipmvc";
   };
 
   patches = optional smimeSupport (fetchpatch {

--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -10,13 +10,13 @@ with lib;
 
 mkDerivation rec {
   pname = "qbittorrent";
-  version = "4.2.1";
+  version = "4.2.2";
 
   src = fetchFromGitHub {
     owner = "qbittorrent";
     repo = "qbittorrent";
     rev = "release-${version}";
-    sha256 = "0bz4l7awkx4qf3gh9c8gj8fab989439zj8qy4x9r36wxdjg5cxil";
+    sha256 = "1iqgwhgwa2kx85zj1rwfnnclr1433a7m2gbs3j7w6rx39vxnzhcc";
   };
 
   # NOTE: 2018-05-31: CMake is working but it is not officially supported

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, openssl, libsamplerate, alsaLib }:
+{ stdenv, fetchFromGitHub, openssl, libsamplerate, alsaLib }:
 
 stdenv.mkDerivation rec {
   pname = "pjsip";
-  version = "2.9";
+  version = "2.10";
 
-  src = fetchurl {
-    url = "https://www.pjsip.org/release/${version}/pjproject-${version}.tar.bz2";
-    sha256 = "0dm6l8fypkimmzvld35zyykbg957cm5zb4ny3lchgv68amwfz1fi";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "pjproject";
+    rev = version;
+    sha256 = "1aklicpgwc88578k03i5d5cm5h8mfm7hmx8vfprchbmaa2p8f4z0";
   };
 
   patches = [ ./fix-aarch64.patch ];

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -30,9 +30,7 @@ let
 
   diff-so-fancy = callPackage ./diff-so-fancy { };
 
-  gh = callPackage ./gh {
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
+  gh = callPackage ./gh { };
 
   ghq = callPackage ./ghq { };
 

--- a/pkgs/applications/version-management/git-and-tools/gh/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildGoModule, installShellFiles, Security }:
+{ lib, fetchFromGitHub, buildGoModule, installShellFiles }:
 
 buildGoModule rec {
   pname = "gh";
@@ -20,7 +20,6 @@ buildGoModule rec {
   subPackages = [ "cmd/gh" ];
 
   nativeBuildInputs = [ installShellFiles ];
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
   postInstall = ''
     for shell in bash fish zsh; do
       $out/bin/gh completion -s $shell > gh.$shell
@@ -28,7 +27,7 @@ buildGoModule rec {
     done
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "GitHub CLI tool";
     homepage = "https://cli.github.com/";
     license = licenses.mit;

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -31,6 +31,7 @@
 , vdpauSupport ? true, libvdpau ? null
 , useWayland ? false, wayland ? null, wayland-protocols ? null
 , waylandpp ?  null, libxkbcommon ? null
+, useGbm ? false, mesa ? null, libinput ? null
 }:
 
 assert dbusSupport  -> dbus != null;
@@ -185,6 +186,11 @@ in stdenv.mkDerivation {
       wayland waylandpp
       # Not sure why ".dev" is needed here, but CMake doesn't find libxkbcommon otherwise
       libxkbcommon.dev
+    ]
+    ++ lib.optional useGbm [
+      libxkbcommon.dev
+      mesa.dev
+      libinput.dev
     ];
 
     nativeBuildInputs = [
@@ -207,6 +213,9 @@ in stdenv.mkDerivation {
     ] ++ lib.optional useWayland [
       "-DCORE_PLATFORM_NAME=wayland"
       "-DWAYLAND_RENDER_SYSTEM=gl"
+    ] ++ lib.optional useGbm [
+      "-DCORE_PLATFORM_NAME=gbm"
+      "-DGBM_RENDER_SYSTEM=gles"
     ];
 
     enableParallelBuilding = true;

--- a/pkgs/applications/video/plex-mpv-shim/default.nix
+++ b/pkgs/applications/video/plex-mpv-shim/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonApplication rec {
   pname = "plex-mpv-shim";
-  version = "1.7.12";
+  version = "1.7.14";
 
   src = fetchFromGitHub {
     owner = "iwalton3";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0l13g4vkvcd1q4lkdkbgv4hgkx5pql6ym2fap35581z7rzy9jhkq";
+    sha256 = "1rjifqvs59w2aacfird02myqfd34qadhacj9zpy5xjz25x410zza";
   };
 
   propagatedBuildInputs = [ mpv requests python-mpv-jsonipc ];

--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -20,7 +20,7 @@ let
   buildTags = "apparmor seccomp selinux containers_image_ostree_stub";
 in buildGoPackage rec {
   project = "cri-o";
-  version = "1.17.0";
+  version = "1.17.1";
   name = "${project}-${version}${flavor}";
 
   goPackagePath = "github.com/${project}/${project}";
@@ -29,7 +29,7 @@ in buildGoPackage rec {
     owner = "cri-o";
     repo = "cri-o";
     rev = "v${version}";
-    sha256 = "0xjmylf0ww23qqcg7kw008px6608r4qq6q57pfqis0661kp6f24j";
+    sha256 = "0zipigjcnhcnn0w69dkd8312qb6z98l65ir175wp3jfvj4cx3g28";
   };
 
   outputs = [ "bin" "out" ];

--- a/pkgs/data/themes/jade1/default.nix
+++ b/pkgs/data/themes/jade1/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "theme-jade1";
-  version = "1.6";
+  version = "1.7";
 
   src = fetchFromGitHub {
     owner = "madmaxms";
     repo = "theme-jade-1";
     rev = "v${version}";
-    sha256 = "1lnajrsikw6dljf6dvgmj8aqwywmgdp34h3xsc0xiyq07arhp606";
+    sha256 = "19vg95bf0ylmfhg0frs2k0k7c0wfn933h06wrklb9p5qy84hfig3";
   };
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Fork of the original Linux Mint theme with dark menus, more intensive green and some other modifications";
+    description = "Based on Linux Mint theme with dark menus and more intensive green";
     homepage = "https://github.com/madmaxms/theme-jade-1";
     license = with licenses; [ gpl3 ];
     platforms = platforms.linux;

--- a/pkgs/development/coq-modules/coqhammer/default.nix
+++ b/pkgs/development/coq-modules/coqhammer/default.nix
@@ -3,17 +3,25 @@
 let
   params = {
     "8.8" = {
+      version = "1.1";
       sha256 = "0ms086wp4jmrzyglb8wymchzyflflk01nsfsk4r6qv8rrx81nx9h";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
     };
     "8.9" = {
-      sha256 = "0hmqwsry8ldg4g4hhwg4b84dgzibpdrg1wwsajhlyqfx3fb3n3b5";
+      version = "1.1.1";
+      sha256 = "1knjmz4hr8vlp103j8n4fyb2lfxysnm512gh3m2kp85n6as6fvb9";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
+    };
+    "8.10" = {
+      version = "1.1.1";
+      sha256 = "0b6r7bsygl1axbqybkhkr7zlwcd51ski5ql52994klrrxvjd58df";
     };
   };
   param = params.${coq.coq-version};
 in
 
 stdenv.mkDerivation rec {
-  version = "1.1";
+  inherit (param) version;
   name = "coq${coq.coq-version}-coqhammer-${version}";
 
   src = fetchFromGitHub {
@@ -31,8 +39,8 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ coq ] ++ (with coq.ocamlPackages; [
-    ocaml findlib camlp5
-  ]);
+    ocaml findlib
+  ]) ++ (param.buildInputs or []);
 
   preInstall = ''
     mkdir -p $out/bin

--- a/pkgs/development/coq-modules/paramcoq/default.nix
+++ b/pkgs/development/coq-modules/paramcoq/default.nix
@@ -3,33 +3,40 @@
 let params =
   {
     "8.7" = {
-      version = "1.1.1+coq8.7";
-      sha256 = "1i7b5pkx46zf9il2xikbp3rhpnh3wdfbhw5yxcf9yk28ky9s0a0l";
+      sha256 = "09n0ky7ldb24by7yf5j3hv410h85x50ksilf7qacl7xglj4gy5hj";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
     };
     "8.8" = {
-      version = "1.1.1";
-      sha256 = "0b07zvgm9cx6j2d9631zmqjs6sf30kiqg6k15xk3km7n80d53wfh";
+      sha256 = "0rc4lshqvnfdsph98gnscvpmlirs9wx91qcvffggg73xw0p1g9s0";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
     };
     "8.9" = {
-      version = "1.1.1+coq8.9";
-      sha256 = "002xabhjlph394vydw3dx8ipv5ry2nq3py4440bk9a18ljx0w6ll";
+      sha256 = "1jjzgpff09xjn9kgp7w69r096jkj0x2ksng3pawrmhmn7clwivbk";
+      buildInputs = [ coq.ocamlPackages.camlp5 ];
+    };
+    "8.10" = {
+      sha256 = "1lq1mw15w4yky79qg3rm0mpzqi2ir51b6ak04ismrdr7ixky49y8";
+    };
+    "8.11" = {
+      sha256 = "09c6813988nvq4fpa45s33k70plnhxsblhm7cxxkg0i37mhvigsa";
     };
   };
   param = params.${coq.coq-version};
 in
 
 stdenv.mkDerivation rec {
-  inherit (param) version;
+  version = "1.1.2";
   name = "coq${coq.coq-version}-paramcoq-${version}";
   src = fetchFromGitHub {
     owner = "coq-community";
     repo = "paramcoq";
-    rev = "v${version}";
+    rev = "v${version}+coq${coq.coq-version}";
     inherit (param) sha256;
   };
 
   buildInputs = [ coq ]
-  ++ (with coq.ocamlPackages; [ ocaml findlib camlp5 ])
+  ++ (with coq.ocamlPackages; [ ocaml findlib ])
+  ++ (param.buildInputs or [])
   ;
 
   installFlags = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];

--- a/pkgs/development/interpreters/erlang/R22.nix
+++ b/pkgs/development/interpreters/erlang/R22.nix
@@ -3,8 +3,8 @@
 # How to obtain `sha256`:
 # nix-prefetch-url --unpack https://github.com/erlang/otp/archive/OTP-${version}.tar.gz
 mkDerivation {
-  version = "22.1.7";
-  sha256 = "18aqy2s8nqd82v4lzzxknrwjva8mv1y2hvai9cakz5nkyd3vwq62";
+  version = "22.3";
+  sha256 = "0srbyncgnr1kp0rrviq14ia3h795b3gk0iws5ishv6rphcq1rs27";
 
   prePatch = ''
     substituteInPlace make/configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"

--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # CVE-2019-20421
     # included in next release
     (fetchpatch {
+      name = "cve-2019-20421.patch";
       url = "https://github.com/Exiv2/exiv2/commit/a82098f4f90cd86297131b5663c3dec6a34470e8.patch";
       sha256 = "16r19qb9l5j43ixm5jqid9sdv5brlkk1wq0w79rm5agxq4kblfyc";
       excludes = [ "tests/bugfixes/github/test_issue_1011.py" "test/data/Jp2Image_readMetadata_loop.poc" ];

--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , zlib
 , expat
 , cmake
@@ -22,6 +23,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0n8il52yzbmvbkryrl8waz7hd9a2fdkw8zsrmhyh63jlvmmc31gf";
   };
+
+  patches = [
+    # CVE-2019-20421
+    # included in next release
+    (fetchpatch {
+      url = "https://github.com/Exiv2/exiv2/commit/a82098f4f90cd86297131b5663c3dec6a34470e8.patch";
+      sha256 = "16r19qb9l5j43ixm5jqid9sdv5brlkk1wq0w79rm5agxq4kblfyc";
+      excludes = [ "tests/bugfixes/github/test_issue_1011.py" "test/data/Jp2Image_readMetadata_loop.poc" ];
+    })
+  ];
 
   cmakeFlags = [
     "-DEXIV2_BUILD_PO=ON"

--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "1.1.11";
+  version = "1.2.5";
   formattedVersion = lib.replaceChars ["."] ["_"] version;
 
   # Make sure we override python, so the correct version is chosen
@@ -17,13 +17,14 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "arvidn";
     repo = "libtorrent";
-    rev = "libtorrent_${formattedVersion}";
+    rev = "libtorrent-${formattedVersion}";
     sha256 = "0nwdsv6d2gkdsh7l5a46g6cqx27xwh3msify5paf02l1qzjy4s5l";
   };
 
   enableParallelBuilding = true;
   nativeBuildInputs = [ automake autoconf libtool pkgconfig ];
   buildInputs = [ boostPython openssl zlib python libiconv geoip ncurses ];
+
   preConfigure = "./autotool.sh";
 
   postInstall = ''

--- a/pkgs/development/python-modules/globus-sdk/default.nix
+++ b/pkgs/development/python-modules/globus-sdk/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "globus-sdk";
-  version = "1.8.0";
+  version = "1.9.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ggxa3av4rwva9h5idg1vfdybr7wkajw7g0sn42k04sxxa0cigwz";
+    sha256 = "1fm0iqfbzd13m1lkd4h3ss4y9isp5cadd2w2k0qr3yqwfmrqqba2";
   };
 
   checkPhase = ''

--- a/pkgs/development/python-modules/mayavi/default.nix
+++ b/pkgs/development/python-modules/mayavi/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "mayavi";
-  version = "4.7.0";
+  version = "4.7.1";
 
   src = fetchPypi {
     inherit pname version;
     extension = "tar.bz2";
-    sha256 = "02rg4j1vkny2piqn3f728kg34m54kgx396g6h5y7ykz2lk3f3h44";
+    sha256 = "095p7mds6kqqrp7xqv24iygr3mw85rm7x41wb5y4yc3gi1pznldy";
   };
 
   # Discovery of 'vtk' in setuptools is not working properly, due to a missing
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "3D visualization of scientific data in Python";
-    homepage = https://github.com/enthought/mayavi;
+    homepage = "https://github.com/enthought/mayavi";
     maintainers = with stdenv.lib.maintainers; [ knedlsepp ];
     license = licenses.bsdOriginal;
   };

--- a/pkgs/development/python-modules/ntlm-auth/default.nix
+++ b/pkgs/development/python-modules/ntlm-auth/default.nix
@@ -3,22 +3,23 @@
 , fetchFromGitHub
 , mock
 , pytest
+, requests
 , unittest2
 , six
 }:
 
 buildPythonPackage rec {
   pname = "ntlm-auth";
-  version = "1.0.3";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "jborean93";
     repo = "ntlm-auth";
     rev = "v${version}";
-    sha256 = "09f2g4ivfi9lh1kr30hlg0q4n2imnvmd79w83gza11q9nmhhiwpz";
+    sha256 = "168k3ygwbvnfcwn7q1nv3vvy6b9jc4cnpix0xgg5j8av7v1x0grn";
   };
 
-  checkInputs = [ mock pytest unittest2 ];
+  checkInputs = [ mock pytest requests unittest2 ];
   propagatedBuildInputs = [ six ];
 
   # Functional tests require networking
@@ -28,8 +29,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Calculates NTLM Authentication codes";
-    homepage = https://github.com/jborean93/ntlm-auth;
-    license = licenses.lgpl3;
+    homepage = "https://github.com/jborean93/ntlm-auth";
+    license = licenses.mit;
     maintainers = with maintainers; [ elasticdog ];
     platforms = platforms.all;
   };

--- a/pkgs/development/python-modules/qdarkstyle/default.nix
+++ b/pkgs/development/python-modules/qdarkstyle/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "qdarkstyle";
-  version = "2.8";
+  version = "2.8.1";
 
   src = fetchPypi {
     inherit version;
     pname = "QDarkStyle";
-    sha256 = "6a967c4b664446f8bed9df12d1032cf68cb54f186bfc9cbfdbbc756bf9a5d475";
+    sha256 = "0883vzg35fzpyl1aiijzpfcdfvpq5vi325w0m7xkx7nxplh02fym";
   };
 
   # No tests available
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A dark stylesheet for Python and Qt applications";
-    homepage = https://github.com/ColinDuquesnoy/QDarkStyleSheet;
+    homepage = "https://github.com/ColinDuquesnoy/QDarkStyleSheet";
     license = licenses.mit;
     maintainers = with maintainers; [ nyanloutre ];
   };

--- a/pkgs/development/python-modules/xml2rfc/default.nix
+++ b/pkgs/development/python-modules/xml2rfc/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "xml2rfc";
-  version = "2.37.3";
+  version = "2.41.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4ae4e99a4b482caac89d8ffd93d16a4510db36907475b1879713a1dc885646ad";
+    sha256 = "0xmhgn62a8a7282yd003zz63mrgyajb6sg29bfyllx3mxmdlb0iz";
   };
 
   propagatedBuildInputs = [
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Tool generating IETF RFCs and drafts from XML sources";
-    homepage = https://tools.ietf.org/tools/xml2rfc/trac/;
+    homepage = "https://tools.ietf.org/tools/xml2rfc/trac/";
     # Well, parts might be considered unfree, if being strict; see:
     # http://metadata.ftp-master.debian.org/changelogs/non-free/x/xml2rfc/xml2rfc_2.9.6-1_copyright
     license = licenses.bsd3;

--- a/pkgs/development/tools/alloy/default.nix
+++ b/pkgs/development/tools/alloy/default.nix
@@ -45,7 +45,7 @@ let generic = { major, version, src }:
       downloadPage = http://alloytools.org/download.html;
       license = licenses.mit;
       platforms = platforms.linux;
-      maintainers = with maintainers; [ aminb ];
+      maintainers = with maintainers; [ notbandali ];
     };
   };
 

--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -28,7 +28,7 @@ let
         CatalystPluginSessionStateCookie
         CatalystPluginSessionStoreFastMmap
         CatalystPluginStackTrace
-        CatalystPluginUnicodeEncoding
+        CatalystRuntime
         CatalystTraitForRequestProxyBase
         CatalystViewDownload
         CatalystViewJSON
@@ -61,7 +61,6 @@ let
         Starman
         SysHostnameLong
         TermSizeAny
-        TestMore
         TextDiff
         TextTable
         XMLSimple

--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -1,0 +1,135 @@
+{ stdenv, nix, perlPackages, buildEnv, fetchFromGitHub
+, makeWrapper, autoconf, automake, libtool, unzip, pkgconfig, sqlite, libpqxx
+, gitAndTools, mercurial, darcs, subversion, bazaar, openssl, bzip2, libxslt
+, guile, perl, postgresql, nukeReferences, git, boehmgc, nlohmann_json
+, docbook_xsl, openssh, gnused, coreutils, findutils, gzip, lzma, gnutar
+, rpm, dpkg, cdrkit, pixz, lib, boost, autoreconfHook, src ? null, version ? null
+, migration ? false
+}:
+
+with stdenv;
+
+if lib.versions.major nix.version == "1"
+  then throw "This Hydra version doesn't support Nix 1.x"
+else
+
+let
+  perlDeps = buildEnv {
+    name = "hydra-perl-deps";
+    paths = with perlPackages; lib.closePropagation
+      [ ModulePluggable
+        CatalystActionREST
+        CatalystAuthenticationStoreDBIxClass
+        CatalystDevel
+        CatalystDispatchTypeRegex
+        CatalystPluginAccessLog
+        CatalystPluginAuthorizationRoles
+        CatalystPluginCaptcha
+        CatalystPluginSessionStateCookie
+        CatalystPluginSessionStoreFastMmap
+        CatalystPluginStackTrace
+        CatalystPluginUnicodeEncoding
+        CatalystTraitForRequestProxyBase
+        CatalystViewDownload
+        CatalystViewJSON
+        CatalystViewTT
+        CatalystXScriptServerStarman
+        CatalystXRoleApplicator
+        CryptRandPasswd
+        DBDPg
+        DBDSQLite
+        DataDump
+        DateTime
+        DigestSHA1
+        EmailMIME
+        EmailSender
+        FileSlurp
+        IOCompress
+        IPCRun
+        JSON
+        JSONAny
+        JSONXS
+        LWP
+        LWPProtocolHttps
+        NetAmazonS3
+        NetPrometheus
+        NetStatsd
+        PadWalker
+        Readonly
+        SQLSplitStatement
+        SetScalar
+        Starman
+        SysHostnameLong
+        TermSizeAny
+        TestMore
+        TextDiff
+        TextTable
+        XMLSimple
+        nix
+        nix.perl-bindings
+        git
+        boehmgc
+      ];
+  };
+in stdenv.mkDerivation rec {
+  pname = "hydra";
+
+  inherit stdenv src version;
+
+  buildInputs =
+    [ makeWrapper autoconf automake libtool unzip nukeReferences sqlite libpqxx
+      gitAndTools.top-git mercurial /*darcs*/ subversion bazaar openssl bzip2 libxslt
+      perlDeps perl nix
+      postgresql # for running the tests
+      nlohmann_json
+      boost
+    ];
+
+  hydraPath = lib.makeBinPath (
+    [ sqlite subversion openssh nix coreutils findutils pixz
+      gzip bzip2 lzma gnutar unzip git gitAndTools.top-git mercurial /*darcs*/ gnused bazaar
+    ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
+
+  NIX_CFLAGS_COMPILE = "-pthread";
+
+  shellHook = ''
+    PATH=$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$(pwd)/src/hydra-evaluator:$PATH
+    PERL5LIB=$(pwd)/src/lib:$PERL5LIB;
+  '';
+
+  enableParallelBuilding = true;
+
+  preCheck = ''
+    patchShebangs .
+    export LOGNAME=''${LOGNAME:-foo}
+  '';
+
+  postInstall = ''
+    mkdir -p $out/nix-support
+    for i in $out/bin/*; do
+        read -n 4 chars < $i
+        if [[ $chars =~ ELF ]]; then continue; fi
+        wrapProgram $i \
+            --prefix PERL5LIB ':' $out/libexec/hydra/lib:$PERL5LIB \
+            --prefix PATH ':' $out/bin:$hydraPath \
+            --set HYDRA_RELEASE ${version} \
+            --set HYDRA_HOME $out/libexec/hydra \
+            --set NIX_RELEASE ${nix.name or "unknown"}
+    done
+  ''; # */
+
+  dontStrip = true;
+
+  passthru = { inherit perlDeps migration; };
+
+  meta = with stdenv.lib; {
+    description = "Nix-based continuous build system";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -1,143 +1,42 @@
-{ stdenv, nix, perlPackages, buildEnv, fetchFromGitHub
-, makeWrapper, autoconf, automake, libtool, unzip, pkgconfig, sqlite, libpqxx
-, gitAndTools, mercurial, darcs, subversion, bazaar, openssl, bzip2, libxslt
-, guile, perl, postgresql, nukeReferences, git, boehmgc, nlohmann_json
-, docbook_xsl, openssh, gnused, coreutils, findutils, gzip, lzma, gnutar
-, rpm, dpkg, cdrkit, pixz, lib, boost, autoreconfHook
-}:
+{ fetchFromGitHub, nixStable, nixUnstable, callPackage, nixFlakes }:
 
-with stdenv;
-
-if lib.versions.major nix.version == "1"
-  then throw "This Hydra version doesn't support Nix 1.x"
-else
-
-let
-  perlDeps = buildEnv {
-    name = "hydra-perl-deps";
-    paths = with perlPackages; lib.closePropagation
-      [ ModulePluggable
-        CatalystActionREST
-        CatalystAuthenticationStoreDBIxClass
-        CatalystDevel
-        CatalystDispatchTypeRegex
-        CatalystPluginAccessLog
-        CatalystPluginAuthorizationRoles
-        CatalystPluginCaptcha
-        CatalystPluginSessionStateCookie
-        CatalystPluginSessionStoreFastMmap
-        CatalystPluginStackTrace
-        CatalystPluginUnicodeEncoding
-        CatalystTraitForRequestProxyBase
-        CatalystViewDownload
-        CatalystViewJSON
-        CatalystViewTT
-        CatalystXScriptServerStarman
-        CatalystXRoleApplicator
-        CryptRandPasswd
-        DBDPg
-        DBDSQLite
-        DataDump
-        DateTime
-        DigestSHA1
-        EmailMIME
-        EmailSender
-        FileSlurp
-        IOCompress
-        IPCRun
-        JSON
-        JSONAny
-        JSONXS
-        LWP
-        LWPProtocolHttps
-        NetAmazonS3
-        NetPrometheus
-        NetStatsd
-        PadWalker
-        Readonly
-        SQLSplitStatement
-        SetScalar
-        Starman
-        SysHostnameLong
-        TermSizeAny
-        TestMore
-        TextDiff
-        TextTable
-        XMLSimple
-        nix
-        nix.perl-bindings
-        git
-        boehmgc
-      ];
-  };
-in stdenv.mkDerivation rec {
-  pname = "hydra";
-  version = "2020-02-06";
-
-  inherit stdenv;
-
-  src = fetchFromGitHub {
-    owner = "NixOS";
-    repo = pname;
-    rev = "2b4f14963b16b21ebfcd6b6bfa7832842e9b2afc";
-    sha256 = "16q0cffcsfx5pqd91n9k19850c1nbh4vvbd9h8yi64ihn7v8bick";
+{
+  # Package for phase-1 of the db migration for Hydra.
+  # https://github.com/NixOS/hydra/pull/711
+  hydra-migration = callPackage ./common.nix {
+    version = "2020-02-10";
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "hydra";
+      rev = "add4f610ce6f206fb44702b5a894d877b3a30e3a";
+      sha256 = "1d8hdgjx2ys0zmixi2ydmimdq7ml20h1ji4amwawcyw59kssh6l3";
+    };
+    nix = nixStable;
+    migration = true;
   };
 
-  buildInputs =
-    [ makeWrapper autoconf automake libtool unzip nukeReferences sqlite libpqxx
-      gitAndTools.top-git mercurial darcs subversion bazaar openssl bzip2 libxslt
-      guile # optional, for Guile + Guix support
-      perlDeps perl nix
-      postgresql # for running the tests
-      nlohmann_json
-      boost
-    ];
+  # Hydra from latest master (or flakes) branch. Contains breaking changes,
+  # so when having an older version, `pkgs.hydra-migration` should be deployed first.
 
-  hydraPath = lib.makeBinPath (
-    [ sqlite subversion openssh nix coreutils findutils pixz
-      gzip bzip2 lzma gnutar unzip git gitAndTools.top-git mercurial darcs gnused bazaar
-    ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
+  hydra-unstable = callPackage ./common.nix {
+    version = "2020-03-24";
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "hydra";
+      rev = "12cc46cdb36321acd4c982429a86eb0f8f3cc969";
+      sha256 = "10ipxzdxr47c8w5jg69mbax2ykc7lb5fs9bbdd3iai9wzyfz17ln";
+    };
+    nix = nixUnstable;
+  };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-
-  configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
-
-  NIX_CFLAGS_COMPILE = "-pthread";
-
-  shellHook = ''
-    PATH=$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$(pwd)/src/hydra-evaluator:$PATH
-    PERL5LIB=$(pwd)/src/lib:$PERL5LIB;
-  '';
-
-  enableParallelBuilding = true;
-
-  preCheck = ''
-    patchShebangs .
-    export LOGNAME=''${LOGNAME:-foo}
-  '';
-
-  postInstall = ''
-    mkdir -p $out/nix-support
-    for i in $out/bin/*; do
-        read -n 4 chars < $i
-        if [[ $chars =~ ELF ]]; then continue; fi
-        wrapProgram $i \
-            --prefix PERL5LIB ':' $out/libexec/hydra/lib:$PERL5LIB \
-            --prefix PATH ':' $out/bin:$hydraPath \
-            --set HYDRA_RELEASE ${version} \
-            --set HYDRA_HOME $out/libexec/hydra \
-            --set NIX_RELEASE ${nix.name or "unknown"}
-    done
-  ''; # */
-
-  dontStrip = true;
-
-  passthru.perlDeps = perlDeps;
-
-  meta = with stdenv.lib; {
-    description = "Nix-based continuous build system";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ ma27 ];
+  hydra-flakes = callPackage ./common.nix {
+    version = "2020-03-27";
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "hydra";
+      rev = "a7540b141d085a7e78c21fda8e8c05907c659b34";
+      sha256 = "08fs7593w5zs8vh4c66gvrxk6s840pp6hj8nwf51wsa27kg5a943";
+    };
+    nix = nixFlakes;
   };
 }

--- a/pkgs/misc/emulators/higan/default.nix
+++ b/pkgs/misc/emulators/higan/default.nix
@@ -1,8 +1,9 @@
 { stdenv, fetchurl
-, p7zip, pkgconfig
+, p7zip, pkgconfig, libicns
 , libX11, libXv
 , udev
 , libGLU, libGL, SDL
+, Carbon, Cocoa, OpenGL, OpenAL
 , libao, openal, libpulseaudio
 , gtk2, gtksourceview
 , runtimeShell }:
@@ -21,11 +22,24 @@ stdenv.mkDerivation rec {
   };
 
   patches = [ ./0001-change-flags.diff ];
-  postPatch = "sed '1i#include <cmath>' -i higan/fc/ppu/ppu.cpp";
+  postPatch = ''
+    sed '1i#include <cmath>' -i higan/fc/ppu/ppu.cpp
+
+    for file in icarus/GNUmakefile higan/target-tomoko/GNUmakefile; do
+      substituteInPlace "$file" \
+        --replace 'sips -s format icns data/$(name).png --out out/$(name).app/Contents/Resources/$(name).icns' \
+                  'png2icns out/$(name).app/Contents/Resources/$(name).icns data/$(name).png'
+    done
+  '';
+
+  nativeBuildInputs = [ p7zip pkgconfig ]
+    ++ optional stdenv.isDarwin [ libicns ];
 
   buildInputs =
-  [ p7zip pkgconfig libX11 libXv udev libGLU libGL
-    SDL libao openal libpulseaudio gtk2 gtksourceview ];
+    [ SDL libao ]
+    ++ optionals stdenv.isLinux [ openal libpulseaudio udev libX11 libXv libGLU libGL gtk2 gtksourceview ]
+    ++ optionals stdenv.isDarwin [ Carbon Cocoa OpenGL OpenAL ]
+    ;
 
   unpackPhase = ''
     7z x $src
@@ -38,27 +52,36 @@ stdenv.mkDerivation rec {
   '';
 
   # Now the cheats file will be distributed separately
-  installPhase = ''
-    install -dm 755 $out/bin $out/share/applications $out/share/higan $out/share/pixmaps
-    install -m 755 icarus/out/icarus $out/bin/
-    install -m 755 higan/out/higan $out/bin/
-    install -m 644 higan/data/higan.desktop $out/share/applications/
-    install -m 644 higan/data/higan.png $out/share/pixmaps/higan-icon.png
-    install -m 644 higan/resource/logo/higan.png $out/share/pixmaps/higan-logo.png
+  installPhase = (if !stdenv.isDarwin then ''
+    mkdir -p "$out"/bin "$out"/share/applications "$out"/share/pixmaps
+    install -m 755 icarus/out/icarus "$out"/bin/
+    install -m 755 higan/out/higan "$out"/bin/
+    install -m 644 higan/data/higan.desktop "$out"/share/applications/
+    install -m 644 higan/data/higan.png "$out"/share/pixmaps/higan-icon.png
+    install -m 644 higan/resource/logo/higan.png "$out"/share/pixmaps/higan-logo.png
+  '' else ''
+    mkdir "$out"
+    mv higan/out/higan.app "$out"/
+    mv icarus/out/icarus.app "$out"/
+  '') + ''
+    mkdir -p  "$out"/share/higan
     cp --recursive --no-dereference --preserve='links' --no-preserve='ownership' \
-      higan/systems/* $out/share/higan/
+      higan/systems/* "$out"/share/higan/
   '';
 
-  fixupPhase = ''
+  fixupPhase = let
+    dest = if !stdenv.isDarwin then "\\$HOME/.local/share/higan" else "\\$HOME/Library/Application Support/higan";
+  in ''
     # A dirty workaround, suggested by @cpages:
     # we create a first-run script to populate
     # the local $HOME with all the auxiliary
     # stuff needed by higan at runtime
 
+    mkdir -p "$out"/bin
     cat <<EOF > $out/bin/higan-init.sh
     #!${runtimeShell}
 
-    cp --recursive --update $out/share/higan/*.sys \$HOME/.local/share/higan/
+    cp --recursive --update $out/share/higan/*.sys "${dest}"/
 
     EOF
 

--- a/pkgs/misc/emulators/mame/default.nix
+++ b/pkgs/misc/emulators/mame/default.nix
@@ -1,6 +1,9 @@
 { stdenv, mkDerivation, fetchFromGitHub, makeDesktopItem, makeWrapper
 , python, pkgconfig, SDL2, SDL2_ttf, alsaLib, which, qtbase, libXinerama
+, libpcap, CoreAudioKit, ForceFeedback
 , installShellFiles }:
+
+with stdenv;
 
 let
   majorVersion = "0";
@@ -8,7 +11,7 @@ let
 
   desktopItem = makeDesktopItem {
     name = "MAME";
-    exec = "mame${stdenv.lib.optionalString stdenv.is64bit "64"}";
+    exec = "mame${lib.optionalString stdenv.is64bit "64"}";
     desktopName = "MAME";
     genericName = "MAME is a multi-purpose emulation framework";
     categories = "System;Emulator;";
@@ -27,13 +30,22 @@ in mkDerivation {
   };
 
   hardeningDisable = [ "fortify" ];
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=maybe-uninitialized" ];
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=maybe-uninitialized" "-Wno-error=missing-braces" ];
 
-  makeFlags = [ "TOOLS=1" ];
+  makeFlags = [
+    "TOOLS=1"
+    "USE_LIBSDL=1"
+  ]
+  ++ lib.optionals stdenv.cc.isClang [ "CC=clang" "CXX=clang++" ]
+  ;
 
   dontWrapQtApps = true;
 
-  buildInputs = [ SDL2 SDL2_ttf alsaLib qtbase libXinerama ];
+  buildInputs =
+    [ SDL2 SDL2_ttf qtbase libXinerama ]
+    ++ lib.optional stdenv.isLinux alsaLib
+    ++ lib.optionals stdenv.isDarwin [ libpcap CoreAudioKit ForceFeedback ]
+    ;
   nativeBuildInputs = [ python pkgconfig which makeWrapper installShellFiles ];
 
   # by default MAME assumes that paths with stock resources
@@ -58,16 +70,18 @@ in mkDerivation {
     installManPage ${dest}/docs/man/*.1 ${dest}/docs/man/*.6
 
     mv artwork plugins samples ${dest}
-
+  '' + lib.optionalString stdenv.isLinux ''
     mkdir -p $out/share
     ln -s ${desktopItem}/share/applications $out/share
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Is a multi-purpose emulation framework";
     homepage = https://www.mamedev.org/;
     license = with licenses; [ bsd3 gpl2Plus ];
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = platforms.unix;
+    # makefile needs fixes for install target
+    badPlatforms = [ "aarch64-linux" ];
     maintainers = with maintainers; [ gnidorah ];
   };
 }

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -244,6 +244,7 @@ let
       SND_HDA_RECONFIG    = yes; # Support reconfiguration of jack functions
       # Support configuring jack functions via fw mechanism at boot
       SND_HDA_PATCH_LOADER = yes;
+      SND_HDA_CODEC_CA0132_DSP = yes; # Enable DSP firmware loading on Creative Soundblaster Z/Zx/ZxR/Recon
       SND_OSSEMUL         = yes;
       SND_USB_CAIAQ_INPUT = yes;
       # Enable PSS mixer (Beethoven ADSP-16 and other compatible)

--- a/pkgs/servers/search/solr/default.nix
+++ b/pkgs/servers/search/solr/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "solr";
-  version = "8.4.1";
+  version = "8.5.0";
 
   src = fetchurl {
     url = "mirror://apache/lucene/${pname}/${version}/${pname}-${version}.tgz";
-    sha256 = "00a35a6ppd4ngp80dxak3bqrp8vmx0wixr4x2h2p9qxj4khf2fgc";
+    sha256 = "1pb1vja9spybkp2qw150kymy47njy06b5pic7mrfjq5as0d72m4y";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/networking/connman/connman.nix
+++ b/pkgs/tools/networking/connman/connman.nix
@@ -73,9 +73,6 @@ stdenv.mkDerivation rec {
     pkgconfig
     file
   ]
-    ++ optionals (enableOpenvpn) [ openvpn ]
-    ++ optionals (enableOpenconnect) [ openconnect ]
-    ++ optionals (enableVpnc) [ vpnc ]
     ++ optionals (enablePolkit) [ polkit ]
     ++ optionals (enablePptp) [ pptp ppp ]
     ++ optionals (firewallType == "iptables") [ iptables ]

--- a/pkgs/tools/networking/connman/connman.nix
+++ b/pkgs/tools/networking/connman/connman.nix
@@ -42,7 +42,6 @@
 , enableDatafiles ? true
 # optional features which are turned *off* by default
 , enableNetworkManager ? false
-, networkmanager ? null
 , enableHh2serialGps ? false
 , enableL2tp ? false
 , enableIospm ? false

--- a/pkgs/tools/networking/connman/connman.nix
+++ b/pkgs/tools/networking/connman/connman.nix
@@ -84,10 +84,8 @@ stdenv.mkDerivation rec {
   ;
 
   # fix invalid path to 'file'
-  patchPhase = ''
-    runHook prePatch
+  postPatch = ''
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
-    runHook postPatch
   '';
 
   configureFlags = [

--- a/pkgs/tools/networking/connman/connman.nix
+++ b/pkgs/tools/networking/connman/connman.nix
@@ -1,0 +1,177 @@
+{ stdenv
+, fetchurl
+, pkgconfig
+, file
+, glib
+# always required runtime dependencies
+, dbus
+, libmnl
+, gnutls
+, readline
+# configureable options
+, firewallType ? "iptables" # or "nftables"
+, iptables ? null
+, libnftnl ? null # for nftables
+, dnsType ? "internal" # or "systemd-resolved"
+# optional features which are turned *on* by default
+, enableOpenconnect ? true
+, openconnect ? null
+, enableOpenvpn ? true
+, openvpn ? null
+, enableVpnc ? true
+, vpnc ? true
+, enablePolkit ? true
+, polkit ? null
+, enablePptp ? true
+, pptp ? null
+, ppp ? null
+, enableLoopback ? true
+, enableEthernet ? true
+, enableWireguard ? true
+, enableGadget ? true
+, enableWifi ? true
+, enableBluetooth ? true
+, enableOfono ? true
+, enableDundee ? true
+, enablePacrunner ? true
+, enableNeard ? true
+, enableWispr ? true
+, enableTools ? true
+, enableStats ? true
+, enableClient ? true
+, enableDatafiles ? true
+# optional features which are turned *off* by default
+, enableNetworkManager ? false
+, networkmanager ? null
+, enableHh2serialGps ? false
+, enableL2tp ? false
+, enableIospm ? false
+, enableTist ? false
+}:
+
+assert stdenv.lib.asserts.assertOneOf "firewallType" firewallType [ "iptables" "nftables" ];
+assert stdenv.lib.asserts.assertOneOf "dnsType" dnsType [ "internal" "systemd-resolved" ];
+
+let inherit (stdenv.lib) optionals; in
+
+stdenv.mkDerivation rec {
+  pname = "connman";
+  version = "1.38";
+  src = fetchurl {
+    url = "mirror://kernel/linux/network/connman/${pname}-${version}.tar.xz";
+    sha256 = "0awkqigvhwwxiapw0x6yd4whl465ka8a4al0v2pcqy9ggjlsqc6b";
+  };
+
+  buildInputs = [
+    glib
+    dbus
+    libmnl
+    gnutls
+    readline
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    file
+  ]
+    ++ optionals (enableOpenvpn) [ openvpn ]
+    ++ optionals (enableOpenconnect) [ openconnect ]
+    ++ optionals (enableVpnc) [ vpnc ]
+    ++ optionals (enablePolkit) [ polkit ]
+    ++ optionals (enablePptp) [ pptp ppp ]
+    ++ optionals (firewallType == "iptables") [ iptables ]
+    ++ optionals (firewallType == "nftables") [ libnftnl ]
+  ;
+
+  # fix invalid path to 'file'
+  patchPhase = ''
+    runHook prePatch
+    sed -i "s/\/usr\/bin\/file/file/g" ./configure
+    runHook postPatch
+  '';
+
+  configureFlags = [
+    # directories flags
+    "--sysconfdir=${placeholder "out"}/etc"
+    "--localstatedir=/var"
+    "--with-dbusconfdir=${placeholder "out"}/share"
+    "--with-dbusdatadir=${placeholder "out"}/share"
+    "--with-tmpfilesdir=${placeholder "out"}/lib/tmpfiles.d"
+    "--with-systemdunitdir=${placeholder "out"}/lib/systemd/system"
+    "--with-dns-backend=${dnsType}"
+    "--with-firewall=${firewallType}"
+    # production build flags
+    "--disable-maintainer-mode"
+    "--enable-session-policy-local=builtin"
+    # for building and running tests
+    # "--enable-tests" # installs the tests, we don't want that
+    "--enable-tools"
+  ]
+    ++ optionals (!enableLoopback) [ "--disable-loopback" ]
+    ++ optionals (!enableEthernet) [ "--disable-ethernet" ]
+    ++ optionals (!enableWireguard) [ "--disable-wireguard" ]
+    ++ optionals (!enableGadget) [ "--disable-gadget" ]
+    ++ optionals (!enableWifi) [ "--disable-wifi" ]
+    # enable IWD support for wifi as it doesn't require any new dependencies
+    # and it's easier for the NixOS module to use only one connman package when
+    # IWD is requested
+    ++ optionals (enableWifi) [ "--enable-iwd" ]
+    ++ optionals (!enableBluetooth) [ "--disable-bluetooth" ]
+    ++ optionals (!enableOfono) [ "--disable-ofono" ]
+    ++ optionals (!enableDundee) [ "--disable-dundee" ]
+    ++ optionals (!enablePacrunner) [ "--disable-pacrunner" ]
+    ++ optionals (!enableNeard) [ "--disable-neard" ]
+    ++ optionals (!enableWispr) [ "--disable-wispr" ]
+    ++ optionals (!enableTools) [ "--disable-tools" ]
+    ++ optionals (!enableStats) [ "--disable-stats" ]
+    ++ optionals (!enableClient) [ "--disable-client" ]
+    ++ optionals (!enableDatafiles) [ "--disable-datafiles" ]
+    ++ optionals (enableOpenconnect) [
+      "--enable-openconnect=builtin"
+      "--with-openconnect=${openconnect}/sbin/openconnect"
+    ]
+    ++ optionals (enableOpenvpn) [
+      "--enable-openvpn=builtin"
+      "--with-openvpn=${openvpn}/sbin/openvpn"
+    ]
+    ++ optionals (enableVpnc) [
+      "--enable-vpnc=builtin"
+      "--with-vpnc=${vpnc}/sbin/vpnc"
+    ]
+    ++ optionals (enablePolkit) [
+      "--enable-polkit"
+    ]
+    ++ optionals (enablePptp) [
+      "--enable-pptp"
+      "--with-pptp=${pptp}/sbin/pptp"
+    ]
+    ++ optionals (!enableWireguard) [
+      "--disable-wireguard"
+    ]
+    ++ optionals (enableNetworkManager) [
+      "--enable-nmcompat"
+    ]
+    ++ optionals (enableHh2serialGps) [
+      "--enable-hh2serial-gps"
+    ]
+    ++ optionals (enableL2tp) [
+      "--enable-l2tp"
+    ]
+    ++ optionals (enableIospm) [
+      "--enable-iospm"
+    ]
+    ++ optionals (enableTist) [
+      "--enable-tist"
+    ]
+  ;
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "A daemon for managing internet connections";
+    homepage = "https://01.org/connman";
+    maintainers = [ maintainers.matejc ];
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -84,8 +84,10 @@ stdenv.mkDerivation rec {
   ;
 
   # fix invalid path to 'file'
-  preConfigure = ''
+  patchPhase = ''
+    runHook prePatch
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
+    runHook postPatch
   '';
 
   configureFlags = [

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -3,7 +3,6 @@
 , pkgconfig
 , openconnect
 , file
-, gawk,
   openvpn
 , vpnc
 , glib
@@ -11,7 +10,6 @@
 , iptables
 , gnutls
 , polkit,
-  wpa_supplicant
 , readline6
 , pptp
 , ppp
@@ -34,7 +32,6 @@ stdenv.mkDerivation rec {
     dbus
     iptables
     gnutls
-    wpa_supplicant
     readline6
     pptp
     ppp
@@ -43,13 +40,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig
     file
-    gawk
   ];
 
   preConfigure = ''
-    export WPASUPPLICANT=${wpa_supplicant}/sbin/wpa_supplicant
     export PPPD=${ppp}/sbin/pppd
-    export AWK=${gawk}/bin/gawk
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
   '';
 

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--sysconfdir=\${out}/etc"
+    "--sysconfdir=${placeholder "out"}/etc"
     "--localstatedir=/var"
     "--with-dbusconfdir=${placeholder "out"}/share"
     "--with-dbusdatadir=${placeholder "out"}/share"

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -19,10 +19,10 @@
 
 stdenv.mkDerivation rec {
   pname = "connman";
-  version = "1.37";
+  version = "1.38";
   src = fetchurl {
     url = "mirror://kernel/linux/network/connman/${pname}-${version}.tar.xz";
-    sha256 = "05kfjiqhqfmbbwc4snnyvi5hc4zxanac62f6gcwaf5mvn0z9pqkc";
+    sha256 = "0awkqigvhwwxiapw0x6yd4whl465ka8a4al0v2pcqy9ggjlsqc6b";
   };
 
   buildInputs = [

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A daemon for managing internet connections";
-    homepage = https://01.org/connman;
+    homepage = "https://01.org/connman";
     maintainers = [ maintainers.matejc ];
     platforms = platforms.linux;
     license = licenses.gpl2;

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -52,6 +52,8 @@
 assert stdenv.lib.asserts.assertOneOf "firewallType" firewallType [ "iptables" "nftables" ];
 assert stdenv.lib.asserts.assertOneOf "dnsType" dnsType [ "internal" "systemd-resolved" ];
 
+let inherit (stdenv.lib) optionals; 
+
 stdenv.mkDerivation rec {
   pname = "connman";
   version = "1.38";
@@ -72,13 +74,13 @@ stdenv.mkDerivation rec {
     pkgconfig
     file
   ]
-    ++ stdenv.lib.optionals (enableOpenvpn) [ openvpn ]
-    ++ stdenv.lib.optionals (enableOpenconnect) [ openconnect ]
-    ++ stdenv.lib.optionals (enableVpnc) [ vpnc ]
-    ++ stdenv.lib.optionals (enablePolkit) [ polkit ]
-    ++ stdenv.lib.optionals (enablePptp) [ pptp ppp ]
-    ++ stdenv.lib.optionals (firewallType == "iptables") [ iptables ]
-    ++ stdenv.lib.optionals (firewallType == "nftables") [ libnftnl ]
+    ++ optionals (enableOpenvpn) [ openvpn ]
+    ++ optionals (enableOpenconnect) [ openconnect ]
+    ++ optionals (enableVpnc) [ vpnc ]
+    ++ optionals (enablePolkit) [ polkit ]
+    ++ optionals (enablePptp) [ pptp ppp ]
+    ++ optionals (firewallType == "iptables") [ iptables ]
+    ++ optionals (firewallType == "nftables") [ libnftnl ]
   ;
 
   # fix invalid path to 'file'
@@ -103,60 +105,60 @@ stdenv.mkDerivation rec {
     # --enable-tests # installs the tests, we don't want that
     "--enable-tools"
   ]
-    ++ stdenv.lib.optionals (!enableLoopback) [ "--disable-loopback" ]
-    ++ stdenv.lib.optionals (!enableEthernet) [ "--disable-ethernet" ]
-    ++ stdenv.lib.optionals (!enableWireguard) [ "--disable-wireguard" ]
-    ++ stdenv.lib.optionals (!enableGadget) [ "--disable-gadget" ]
-    ++ stdenv.lib.optionals (!enableWifi) [ "--disable-wifi" ]
+    ++ optionals (!enableLoopback) [ "--disable-loopback" ]
+    ++ optionals (!enableEthernet) [ "--disable-ethernet" ]
+    ++ optionals (!enableWireguard) [ "--disable-wireguard" ]
+    ++ optionals (!enableGadget) [ "--disable-gadget" ]
+    ++ optionals (!enableWifi) [ "--disable-wifi" ]
     # enable IWD support for wifi as it doesn't require any new dependencies
     # and it's easier for the NixOS module to use only one connman package when
     # IWD is requested
-    ++ stdenv.lib.optionals (enableWifi) [ "--enable-iwd" ]
-    ++ stdenv.lib.optionals (!enableBluetooth) [ "--disable-bluetooth" ]
-    ++ stdenv.lib.optionals (!enableOfono) [ "--disable-ofono" ]
-    ++ stdenv.lib.optionals (!enableDundee) [ "--disable-dundee" ]
-    ++ stdenv.lib.optionals (!enablePacrunner) [ "--disable-pacrunner" ]
-    ++ stdenv.lib.optionals (!enableNeard) [ "--disable-neard" ]
-    ++ stdenv.lib.optionals (!enableWispr) [ "--disable-wispr" ]
-    ++ stdenv.lib.optionals (!enableTools) [ "--disable-tools" ]
-    ++ stdenv.lib.optionals (!enableStats) [ "--disable-stats" ]
-    ++ stdenv.lib.optionals (!enableClient) [ "--disable-client" ]
-    ++ stdenv.lib.optionals (!enableDatafiles) [ "--disable-datafiles" ]
-    ++ stdenv.lib.optionals (enableOpenconnect) [
+    ++ optionals (enableWifi) [ "--enable-iwd" ]
+    ++ optionals (!enableBluetooth) [ "--disable-bluetooth" ]
+    ++ optionals (!enableOfono) [ "--disable-ofono" ]
+    ++ optionals (!enableDundee) [ "--disable-dundee" ]
+    ++ optionals (!enablePacrunner) [ "--disable-pacrunner" ]
+    ++ optionals (!enableNeard) [ "--disable-neard" ]
+    ++ optionals (!enableWispr) [ "--disable-wispr" ]
+    ++ optionals (!enableTools) [ "--disable-tools" ]
+    ++ optionals (!enableStats) [ "--disable-stats" ]
+    ++ optionals (!enableClient) [ "--disable-client" ]
+    ++ optionals (!enableDatafiles) [ "--disable-datafiles" ]
+    ++ optionals (enableOpenconnect) [
       "--enable-openconnect=builtin"
       "--with-openconnect=${openconnect}/sbin/openconnect"
     ]
-    ++ stdenv.lib.optionals (enableOpenvpn) [
+    ++ optionals (enableOpenvpn) [
       "--enable-openvpn=builtin"
       "--with-openvpn=${openvpn}/sbin/openvpn"
     ]
-    ++ stdenv.lib.optionals (enableVpnc) [
+    ++ optionals (enableVpnc) [
       "--enable-vpnc=builtin"
       "--with-vpnc=${vpnc}/sbin/vpnc"
     ]
-    ++ stdenv.lib.optionals (enablePolkit) [
+    ++ optionals (enablePolkit) [
       "--enable-polkit"
     ]
-    ++ stdenv.lib.optionals (enablePptp) [
+    ++ optionals (enablePptp) [
       "--enable-pptp"
       "--with-pptp=${pptp}/sbin/pptp"
     ]
-    ++ stdenv.lib.optionals (!enableWireguard) [
+    ++ optionals (!enableWireguard) [
       "--disable-wireguard"
     ]
-    ++ stdenv.lib.optionals (enableNetworkManager) [
+    ++ optionals (enableNetworkManager) [
       "--enable-nmcompat"
     ]
-    ++ stdenv.lib.optionals (enableHh2serialGps) [
+    ++ optionals (enableHh2serialGps) [
       "--enable-hh2serial-gps"
     ]
-    ++ stdenv.lib.optionals (enableL2tp) [
+    ++ optionals (enableL2tp) [
       "--enable-l2tp"
     ]
-    ++ stdenv.lib.optionals (enableIospm) [
+    ++ optionals (enableIospm) [
       "--enable-iospm"
     ]
-    ++ stdenv.lib.optionals (enableTist) [
+    ++ optionals (enableTist) [
       "--enable-tist"
     ]
   ;

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     vpnc
     glib
     dbus
+    libmnl
     iptables
     gnutls
     readline
@@ -69,6 +70,9 @@ stdenv.mkDerivation rec {
     "--with-pptp=${pptp}/sbin/pptp"
     "--enable-iwd"
   ];
+  doCheck = true;
+
+  outputs = [ "out" "dev" ];
 
   meta = with stdenv.lib; {
     description = "A daemon for managing internet connections";

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    export PPPD=${ppp}/sbin/pppd
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
   '';
 
@@ -70,10 +69,6 @@ stdenv.mkDerivation rec {
     "--with-pptp=${pptp}/sbin/pptp"
     "--enable-iwd"
   ];
-
-  postInstall = ''
-    cp ./client/connmanctl $out/sbin/connmanctl
-  '';
 
   meta = with stdenv.lib; {
     description = "A daemon for managing internet connections";

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,6 +1,9 @@
 { callPackage }:
 
 {
+  # All the defaults
+  connman = callPackage ./connman.nix { };
+
   connmanFull = callPackage ./connman.nix {
     enableNetworkManager = true;
     enableHh2serialGps = true;
@@ -32,7 +35,4 @@
     enableClient = false;
     # enableDatafiles = false; # If disabled, configuration and data files are not installed
   };
-
-  # All the defaults
-  connman = callPackage ./connman.nix { };
 }

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,177 +1,38 @@
-{ stdenv
-, fetchurl
-, pkgconfig
-, file
-, glib
-# always required runtime dependencies
-, dbus
-, libmnl
-, gnutls
-, readline
-# configureable options
-, firewallType ? "iptables" # or "nftables"
-, iptables ? null
-, libnftnl ? null # for nftables
-, dnsType ? "internal" # or "systemd-resolved"
-# optional features which are turned *on* by default
-, enableOpenconnect ? true
-, openconnect ? null
-, enableOpenvpn ? true
-, openvpn ? null
-, enableVpnc ? true
-, vpnc ? true
-, enablePolkit ? true
-, polkit ? null
-, enablePptp ? true
-, pptp ? null
-, ppp ? null
-, enableLoopback ? true
-, enableEthernet ? true
-, enableWireguard ? true
-, enableGadget ? true
-, enableWifi ? true
-, enableBluetooth ? true
-, enableOfono ? true
-, enableDundee ? true
-, enablePacrunner ? true
-, enableNeard ? true
-, enableWispr ? true
-, enableTools ? true
-, enableStats ? true
-, enableClient ? true
-, enableDatafiles ? true
-# optional features which are turned *off* by default
-, enableNetworkManager ? false
-, networkmanager ? null
-, enableHh2serialGps ? false
-, enableL2tp ? false
-, enableIospm ? false
-, enableTist ? false
-}:
+{ callPackage, lowPrio }:
 
-assert stdenv.lib.asserts.assertOneOf "firewallType" firewallType [ "iptables" "nftables" ];
-assert stdenv.lib.asserts.assertOneOf "dnsType" dnsType [ "internal" "systemd-resolved" ];
-
-let inherit (stdenv.lib) optionals; 
-
-stdenv.mkDerivation rec {
-  pname = "connman";
-  version = "1.38";
-  src = fetchurl {
-    url = "mirror://kernel/linux/network/connman/${pname}-${version}.tar.xz";
-    sha256 = "0awkqigvhwwxiapw0x6yd4whl465ka8a4al0v2pcqy9ggjlsqc6b";
+{
+  connmanFull = callPackage ./connman.nix {
+    enableNetworkManager = true;
+    enableHh2serialGps = true;
+    enableL2tp = true;
+    enableIospm = true;
+    enableTist = true;
   };
 
-  buildInputs = [
-    glib
-    dbus
-    libmnl
-    gnutls
-    readline
-  ];
+  connmanMinimal = lowPrio (callPackage ./connman.nix {
+    enableOpenconnect = false;
+    enableOpenvpn = false;
+    enableVpnc = false;
+    vpnc = false;
+    enablePolkit = false;
+    enablePptp = false;
+    enableLoopback = false;
+    # enableEthernet = false; # If disabled no ethernet connection can be performed
+    enableWireguard = false;
+    enableGadget = false;
+    # enableWifi = false; # If disabled no WiFi connection can be performed
+    enableBluetooth = false;
+    enableOfono = false;
+    enableDundee = false;
+    enablePacrunner = false;
+    enableNeard = false;
+    enableWispr = false;
+    enableTools = false;
+    enableStats = false;
+    enableClient = false;
+    # enableDatafiles = false; # If disabled, configuration and data files are not installed
+  });
 
-  nativeBuildInputs = [
-    pkgconfig
-    file
-  ]
-    ++ optionals (enableOpenvpn) [ openvpn ]
-    ++ optionals (enableOpenconnect) [ openconnect ]
-    ++ optionals (enableVpnc) [ vpnc ]
-    ++ optionals (enablePolkit) [ polkit ]
-    ++ optionals (enablePptp) [ pptp ppp ]
-    ++ optionals (firewallType == "iptables") [ iptables ]
-    ++ optionals (firewallType == "nftables") [ libnftnl ]
-  ;
-
-  # fix invalid path to 'file'
-  patchPhase = ''
-    runHook prePatch
-    sed -i "s/\/usr\/bin\/file/file/g" ./configure
-    runHook postPatch
-  '';
-
-  configureFlags = [
-    # directories flags
-    "--sysconfdir=${placeholder "out"}/etc"
-    "--localstatedir=/var"
-    "--with-dbusconfdir=${placeholder "out"}/share"
-    "--with-dbusdatadir=${placeholder "out"}/share"
-    "--with-tmpfilesdir=${placeholder "out"}/lib/tmpfiles.d"
-    "--with-systemdunitdir=${placeholder "out"}/lib/systemd/system"
-    "--with-dns-backend=${dnsType}"
-    "--with-firewall=${firewallType}"
-    # production build flags
-    "--disable-maintainer-mode"
-    "--enable-session-policy-local=builtin"
-    # for building and running tests
-    # --enable-tests # installs the tests, we don't want that
-    "--enable-tools"
-  ]
-    ++ optionals (!enableLoopback) [ "--disable-loopback" ]
-    ++ optionals (!enableEthernet) [ "--disable-ethernet" ]
-    ++ optionals (!enableWireguard) [ "--disable-wireguard" ]
-    ++ optionals (!enableGadget) [ "--disable-gadget" ]
-    ++ optionals (!enableWifi) [ "--disable-wifi" ]
-    # enable IWD support for wifi as it doesn't require any new dependencies
-    # and it's easier for the NixOS module to use only one connman package when
-    # IWD is requested
-    ++ optionals (enableWifi) [ "--enable-iwd" ]
-    ++ optionals (!enableBluetooth) [ "--disable-bluetooth" ]
-    ++ optionals (!enableOfono) [ "--disable-ofono" ]
-    ++ optionals (!enableDundee) [ "--disable-dundee" ]
-    ++ optionals (!enablePacrunner) [ "--disable-pacrunner" ]
-    ++ optionals (!enableNeard) [ "--disable-neard" ]
-    ++ optionals (!enableWispr) [ "--disable-wispr" ]
-    ++ optionals (!enableTools) [ "--disable-tools" ]
-    ++ optionals (!enableStats) [ "--disable-stats" ]
-    ++ optionals (!enableClient) [ "--disable-client" ]
-    ++ optionals (!enableDatafiles) [ "--disable-datafiles" ]
-    ++ optionals (enableOpenconnect) [
-      "--enable-openconnect=builtin"
-      "--with-openconnect=${openconnect}/sbin/openconnect"
-    ]
-    ++ optionals (enableOpenvpn) [
-      "--enable-openvpn=builtin"
-      "--with-openvpn=${openvpn}/sbin/openvpn"
-    ]
-    ++ optionals (enableVpnc) [
-      "--enable-vpnc=builtin"
-      "--with-vpnc=${vpnc}/sbin/vpnc"
-    ]
-    ++ optionals (enablePolkit) [
-      "--enable-polkit"
-    ]
-    ++ optionals (enablePptp) [
-      "--enable-pptp"
-      "--with-pptp=${pptp}/sbin/pptp"
-    ]
-    ++ optionals (!enableWireguard) [
-      "--disable-wireguard"
-    ]
-    ++ optionals (enableNetworkManager) [
-      "--enable-nmcompat"
-    ]
-    ++ optionals (enableHh2serialGps) [
-      "--enable-hh2serial-gps"
-    ]
-    ++ optionals (enableL2tp) [
-      "--enable-l2tp"
-    ]
-    ++ optionals (enableIospm) [
-      "--enable-iospm"
-    ]
-    ++ optionals (enableTist) [
-      "--enable-tist"
-    ]
-  ;
-
-  doCheck = true;
-
-  meta = with stdenv.lib; {
-    description = "A daemon for managing internet connections";
-    homepage = "https://01.org/connman";
-    maintainers = [ maintainers.matejc ];
-    platforms = platforms.linux;
-    license = licenses.gpl2;
-  };
+  # All the defaults
+  connman = callPackage ./connman.nix { };
 }

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -5,6 +5,8 @@
   connman = callPackage ./connman.nix { };
 
   connmanFull = callPackage ./connman.nix {
+    # TODO: Why is this in `connmanFull` and not the default build? See TODO in
+    # nixos/modules/services/networking/connman.nix (near the assertions)
     enableNetworkManager = true;
     enableHh2serialGps = true;
     enableL2tp = true;

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, lowPrio }:
+{ callPackage }:
 
 {
   connmanFull = callPackage ./connman.nix {
@@ -9,7 +9,7 @@
     enableTist = true;
   };
 
-  connmanMinimal = lowPrio (callPackage ./connman.nix {
+  connmanMinimal = callPackage ./connman.nix {
     enableOpenconnect = false;
     enableOpenvpn = false;
     enableVpnc = false;
@@ -31,7 +31,7 @@
     enableStats = false;
     enableClient = false;
     # enableDatafiles = false; # If disabled, configuration and data files are not installed
-  });
+  };
 
   # All the defaults
   connman = callPackage ./connman.nix { };

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -8,7 +8,7 @@
 , libmnl
 , gnutls
 , readline
-# Choices one has to decide
+# configureable options
 , firewallType ? "iptables" # or "nftables"
 , iptables ? null
 , libnftnl ? null # for nftables
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals (firewallType == "nftables") [ libnftnl ]
   ;
 
-  # Fix file program not found
+  # fix invalid path to 'file'
   preConfigure = ''
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
   '';
@@ -99,8 +99,8 @@ stdenv.mkDerivation rec {
     # production build flags
     "--disable-maintainer-mode"
     "--enable-session-policy-local=builtin"
-    # This is for building and running tests (probably enabled by default),
-    # --enable-tests installs the tests as well
+    # for building and running tests
+    # --enable-tests # installs the tests, we don't want that
     "--enable-tools"
   ]
     ++ stdenv.lib.optionals (!enableLoopback) [ "--disable-loopback" ]
@@ -108,8 +108,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals (!enableWireguard) [ "--disable-wireguard" ]
     ++ stdenv.lib.optionals (!enableGadget) [ "--disable-gadget" ]
     ++ stdenv.lib.optionals (!enableWifi) [ "--disable-wifi" ]
-    # We (almost) always turn on IWD support as it doesn't require any new dependencies
-    # and it's easier for the NixOS module to use only 1 connmand package when
+    # enable IWD support for wifi as it doesn't require any new dependencies
+    # and it's easier for the NixOS module to use only one connman package when
     # IWD is requested
     ++ stdenv.lib.optionals (enableWifi) [ "--enable-iwd" ]
     ++ stdenv.lib.optionals (!enableBluetooth) [ "--disable-bluetooth" ]

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -10,7 +10,7 @@
 , iptables
 , gnutls
 , polkit,
-, readline6
+, readline
 , pptp
 , ppp
 }:
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     dbus
     iptables
     gnutls
-    readline6
+    readline
     pptp
     ppp
   ];

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,19 +1,56 @@
 { stdenv
 , fetchurl
 , pkgconfig
-, openconnect
 , file
-  openvpn
-, vpnc
 , glib
+# always required runtime dependencies
 , dbus
-, iptables
+, libmnl
 , gnutls
-, polkit,
 , readline
-, pptp
-, ppp
+# Choices one has to decide
+, firewallType ? "iptables" # or "nftables"
+, iptables ? null
+, libnftnl ? null # for nftables
+, dnsType ? "internal" # or "systemd-resolved"
+# optional features which are turned *on* by default
+, enableOpenconnect ? true
+, openconnect ? null
+, enableOpenvpn ? true
+, openvpn ? null
+, enableVpnc ? true
+, vpnc ? true
+, enablePolkit ? true
+, polkit ? null
+, enablePptp ? true
+, pptp ? null
+, ppp ? null
+, enableLoopback ? true
+, enableEthernet ? true
+, enableWireguard ? true
+, enableGadget ? true
+, enableWifi ? true
+, enableBluetooth ? true
+, enableOfono ? true
+, enableDundee ? true
+, enablePacrunner ? true
+, enableNeard ? true
+, enableWispr ? true
+, enableTools ? true
+, enableStats ? true
+, enableClient ? true
+, enableDatafiles ? true
+# optional features which are turned *off* by default
+, enableNetworkManager ? false
+, networkmanager ? null
+, enableHh2serialGps ? false
+, enableL2tp ? false
+, enableIospm ? false
+, enableTist ? false
 }:
+
+assert stdenv.lib.asserts.assertOneOf "firewallType" firewallType [ "iptables" "nftables" ];
+assert stdenv.lib.asserts.assertOneOf "dnsType" dnsType [ "internal" "systemd-resolved" ];
 
 stdenv.mkDerivation rec {
   pname = "connman";
@@ -24,55 +61,107 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    openconnect
-    polkit
-    openvpn
-    vpnc
     glib
     dbus
     libmnl
-    iptables
     gnutls
     readline
-    pptp
-    ppp
   ];
 
   nativeBuildInputs = [
     pkgconfig
     file
-  ];
+  ]
+    ++ stdenv.lib.optionals (enableOpenvpn) [ openvpn ]
+    ++ stdenv.lib.optionals (enableOpenconnect) [ openconnect ]
+    ++ stdenv.lib.optionals (enableVpnc) [ vpnc ]
+    ++ stdenv.lib.optionals (enablePolkit) [ polkit ]
+    ++ stdenv.lib.optionals (enablePptp) [ pptp ppp ]
+    ++ stdenv.lib.optionals (firewallType == "iptables") [ iptables ]
+    ++ stdenv.lib.optionals (firewallType == "nftables") [ libnftnl ]
+  ;
 
+  # Fix file program not found
   preConfigure = ''
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
   '';
 
   configureFlags = [
+    # directories flags
     "--sysconfdir=${placeholder "out"}/etc"
     "--localstatedir=/var"
     "--with-dbusconfdir=${placeholder "out"}/share"
     "--with-dbusdatadir=${placeholder "out"}/share"
+    "--with-tmpfilesdir=${placeholder "out"}/lib/tmpfiles.d"
+    "--with-systemdunitdir=${placeholder "out"}/lib/systemd/system"
+    "--with-dns-backend=${dnsType}"
+    "--with-firewall=${firewallType}"
+    # production build flags
     "--disable-maintainer-mode"
-    "--enable-openconnect=builtin"
-    "--with-openconnect=${openconnect}/sbin/openconnect"
-    "--enable-openvpn=builtin"
-    "--with-openvpn=${openvpn}/sbin/openvpn"
-    "--enable-vpnc=builtin"
-    "--with-vpnc=${vpnc}/sbin/vpnc"
     "--enable-session-policy-local=builtin"
-    "--enable-client"
-    "--enable-bluetooth"
-    "--enable-wifi"
-    "--enable-polkit"
+    # This is for building and running tests (probably enabled by default),
+    # --enable-tests installs the tests as well
     "--enable-tools"
-    "--enable-datafiles"
-    "--enable-pptp"
-    "--with-pptp=${pptp}/sbin/pptp"
-    "--enable-iwd"
-  ];
-  doCheck = true;
+  ]
+    ++ stdenv.lib.optionals (!enableLoopback) [ "--disable-loopback" ]
+    ++ stdenv.lib.optionals (!enableEthernet) [ "--disable-ethernet" ]
+    ++ stdenv.lib.optionals (!enableWireguard) [ "--disable-wireguard" ]
+    ++ stdenv.lib.optionals (!enableGadget) [ "--disable-gadget" ]
+    ++ stdenv.lib.optionals (!enableWifi) [ "--disable-wifi" ]
+    # We (almost) always turn on IWD support as it doesn't require any new dependencies
+    # and it's easier for the NixOS module to use only 1 connmand package when
+    # IWD is requested
+    ++ stdenv.lib.optionals (enableWifi) [ "--enable-iwd" ]
+    ++ stdenv.lib.optionals (!enableBluetooth) [ "--disable-bluetooth" ]
+    ++ stdenv.lib.optionals (!enableOfono) [ "--disable-ofono" ]
+    ++ stdenv.lib.optionals (!enableDundee) [ "--disable-dundee" ]
+    ++ stdenv.lib.optionals (!enablePacrunner) [ "--disable-pacrunner" ]
+    ++ stdenv.lib.optionals (!enableNeard) [ "--disable-neard" ]
+    ++ stdenv.lib.optionals (!enableWispr) [ "--disable-wispr" ]
+    ++ stdenv.lib.optionals (!enableTools) [ "--disable-tools" ]
+    ++ stdenv.lib.optionals (!enableStats) [ "--disable-stats" ]
+    ++ stdenv.lib.optionals (!enableClient) [ "--disable-client" ]
+    ++ stdenv.lib.optionals (!enableDatafiles) [ "--disable-datafiles" ]
+    ++ stdenv.lib.optionals (enableOpenconnect) [
+      "--enable-openconnect=builtin"
+      "--with-openconnect=${openconnect}/sbin/openconnect"
+    ]
+    ++ stdenv.lib.optionals (enableOpenvpn) [
+      "--enable-openvpn=builtin"
+      "--with-openvpn=${openvpn}/sbin/openvpn"
+    ]
+    ++ stdenv.lib.optionals (enableVpnc) [
+      "--enable-vpnc=builtin"
+      "--with-vpnc=${vpnc}/sbin/vpnc"
+    ]
+    ++ stdenv.lib.optionals (enablePolkit) [
+      "--enable-polkit"
+    ]
+    ++ stdenv.lib.optionals (enablePptp) [
+      "--enable-pptp"
+      "--with-pptp=${pptp}/sbin/pptp"
+    ]
+    ++ stdenv.lib.optionals (!enableWireguard) [
+      "--disable-wireguard"
+    ]
+    ++ stdenv.lib.optionals (enableNetworkManager) [
+      "--enable-nmcompat"
+    ]
+    ++ stdenv.lib.optionals (enableHh2serialGps) [
+      "--enable-hh2serial-gps"
+    ]
+    ++ stdenv.lib.optionals (enableL2tp) [
+      "--enable-l2tp"
+    ]
+    ++ stdenv.lib.optionals (enableIospm) [
+      "--enable-iospm"
+    ]
+    ++ stdenv.lib.optionals (enableTist) [
+      "--enable-tist"
+    ]
+  ;
 
-  outputs = [ "out" "dev" ];
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "A daemon for managing internet connections";

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,6 +1,21 @@
-{ stdenv, fetchurl, pkgconfig, openconnect, file, gawk,
-  openvpn, vpnc, glib, dbus, iptables, gnutls, polkit,
-  wpa_supplicant, readline6, pptp, ppp }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, openconnect
+, file
+, gawk,
+  openvpn
+, vpnc
+, glib
+, dbus
+, iptables
+, gnutls
+, polkit,
+  wpa_supplicant
+, readline6
+, pptp
+, ppp
+}:
 
 stdenv.mkDerivation rec {
   pname = "connman";
@@ -10,11 +25,26 @@ stdenv.mkDerivation rec {
     sha256 = "05kfjiqhqfmbbwc4snnyvi5hc4zxanac62f6gcwaf5mvn0z9pqkc";
   };
 
-  buildInputs = [ openconnect polkit
-                  openvpn vpnc glib dbus iptables gnutls
-                  wpa_supplicant readline6 pptp ppp ];
+  buildInputs = [
+    openconnect
+    polkit
+    openvpn
+    vpnc
+    glib
+    dbus
+    iptables
+    gnutls
+    wpa_supplicant
+    readline6
+    pptp
+    ppp
+  ];
 
-  nativeBuildInputs = [ pkgconfig file gawk ];
+  nativeBuildInputs = [
+    pkgconfig
+    file
+    gawk
+  ];
 
   preConfigure = ''
     export WPASUPPLICANT=${wpa_supplicant}/sbin/wpa_supplicant

--- a/pkgs/tools/networking/findomain/default.nix
+++ b/pkgs/tools/networking/findomain/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "findomain";
-  version = "1.4.2";
+  version = "1.4.5";
 
   src = fetchFromGitHub {
     owner = "Edu4rdSHL";
     repo = pname;
     rev = version;
-    sha256 = "0c6jjr1343lqwggvpxdhbjyi1far4f7f3yzq1y0nj1j952j7a36x";
+    sha256 = "1p4ddyqg1v27hf19n1ksmfvj5s6z2c8i13syb0anhlyzqy576hwb";
   };
 
-  cargoSha256 = "1cyfxfhbc2xhavnkhva1xdcw8vy9i5pqhfbiwn6idpfy6hm1w0bx";
+  cargoSha256 = "0mdcj4almwziq1ph3imfdx41a96xq19sbjm7wsm9lxlzhvv256br";
 
   nativeBuildInputs = [ installShellFiles perl ];
   buildInputs = lib.optional stdenv.isDarwin Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22675,6 +22675,8 @@ in
 
   kodiPlainWayland = callPackage ../applications/video/kodi { useWayland = true; };
 
+  kodiGBM = callPackage ../applications/video/kodi { useGbm = true; };
+
   kodiPlugins = recurseIntoAttrs (callPackage ../applications/video/kodi/plugins.nix {});
 
   kodi = wrapKodi {
@@ -22683,6 +22685,10 @@ in
 
   kodi-wayland = wrapKodi {
     kodi = kodiPlainWayland;
+  };
+
+  kodi-gbm = wrapKodi {
+    kodi = kodiGBM;
   };
 
   kodi-cli = callPackage ../tools/misc/kodi-cli { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2500,9 +2500,9 @@ in
   conspy = callPackage ../os-specific/linux/conspy {};
 
   inherit (callPackage ../tools/networking/connman {})
+    connman
     connmanFull
     connmanMinimal
-    connman
   ;
 
   connman-gtk = callPackage ../tools/networking/connman/connman-gtk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20472,6 +20472,8 @@ in
       canonicaljson;
   };
 
+  matrix-dl = callPackage ../applications/networking/instant-messengers/matrix-dl { };
+
   matrix-recorder = callPackage ../applications/networking/instant-messengers/matrix-recorder {};
 
   mblaze = callPackage ../applications/networking/mailreaders/mblaze { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26091,6 +26091,7 @@ in
 
   higan = callPackage ../misc/emulators/higan {
     inherit (gnome2) gtksourceview;
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa OpenGL OpenAL;
   };
 
   bullet = callPackage ../development/libraries/bullet {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25309,7 +25309,9 @@ in
     icu = icu58;
   };
 
-  mame = libsForQt5.callPackage ../misc/emulators/mame { };
+  mame = libsForQt5.callPackage ../misc/emulators/mame {
+    inherit (darwin.apple_sdk.frameworks) CoreAudioKit ForceFeedback;
+  };
 
   martyr = callPackage ../development/libraries/martyr { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12121,7 +12121,8 @@ in
 
   hwloc = callPackage ../development/libraries/hwloc {};
 
-  hydra = callPackage ../development/tools/misc/hydra { };
+  inherit (callPackage ../development/tools/misc/hydra { })
+    hydra-migration hydra-unstable hydra-flakes;
 
   hydra-cli = callPackage ../development/tools/misc/hydra-cli { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3080,6 +3080,8 @@ in
 
   volctl = callPackage ../tools/audio/volctl { };
 
+  vorta = python3Packages.callPackage ../applications/backup/vorta { };
+
   wallutils = callPackage ../tools/graphics/wallutils { };
 
   wev = callPackage ../tools/misc/wev { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2499,37 +2499,11 @@ in
 
   conspy = callPackage ../os-specific/linux/conspy {};
 
-  connman = callPackage ../tools/networking/connman { };
-  connmanThin = callPackage ../tools/networking/connman {
-    enableOpenconnect = false;
-    enableOpenvpn = false;
-    enableVpnc = false;
-    vpnc = false;
-    enablePolkit = false;
-    enablePptp = false;
-    enableLoopback = false;
-    # enableEthernet = false; # If disabled no ethernet connection can be performed
-    enableWireguard = false;
-    enableGadget = false;
-    # enableWifi = false; # If disabled no WiFi connection can be performed
-    enableBluetooth = false;
-    enableOfono = false;
-    enableDundee = false;
-    enablePacrunner = false;
-    enableNeard = false;
-    enableWispr = false;
-    enableTools = false;
-    enableStats = false;
-    enableClient = false;
-    # enableDatafiles = false; # If disabled, configuration and data files are not installed
-  };
-  connmanFull = callPackage ../tools/networking/connman {
-    enableNetworkManager = true;
-    enableHh2serialGps = true;
-    enableL2tp = true;
-    enableIospm = true;
-    enableTist = true;
-  };
+  inherit (callPackage ../tools/networking/connman {})
+    connmanFull
+    connmanMinimal
+    connman
+  ;
 
   connman-gtk = callPackage ../tools/networking/connman/connman-gtk { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2508,10 +2508,10 @@ in
     enablePolkit = false;
     enablePptp = false;
     enableLoopback = false;
-    # enableEthernet = false;
+    # enableEthernet = false; # If disabled no ethernet connection can be performed
     enableWireguard = false;
     enableGadget = false;
-    # enableWifi = false;
+    # enableWifi = false; # If disabled no WiFi connection can be performed
     enableBluetooth = false;
     enableOfono = false;
     enableDundee = false;
@@ -2521,7 +2521,7 @@ in
     enableTools = false;
     enableStats = false;
     enableClient = false;
-    # enableDatafiles = false;
+    # enableDatafiles = false; # If disabled, configuration and data files are not installed
   };
   connmanFull = callPackage ../tools/networking/connman {
     enableNetworkManager = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2500,6 +2500,36 @@ in
   conspy = callPackage ../os-specific/linux/conspy {};
 
   connman = callPackage ../tools/networking/connman { };
+  connmanThin = callPackage ../tools/networking/connman {
+    enableOpenconnect = false;
+    enableOpenvpn = false;
+    enableVpnc = false;
+    vpnc = false;
+    enablePolkit = false;
+    enablePptp = false;
+    enableLoopback = false;
+    # enableEthernet = false;
+    enableWireguard = false;
+    enableGadget = false;
+    # enableWifi = false;
+    enableBluetooth = false;
+    enableOfono = false;
+    enableDundee = false;
+    enablePacrunner = false;
+    enableNeard = false;
+    enableWispr = false;
+    enableTools = false;
+    enableStats = false;
+    enableClient = false;
+    # enableDatafiles = false;
+  };
+  connmanFull = callPackage ../tools/networking/connman {
+    enableNetworkManager = true;
+    enableHh2serialGps = true;
+    enableL2tp = true;
+    enableIospm = true;
+    enableTist = true;
+  };
 
   connman-gtk = callPackage ../tools/networking/connman/connman-gtk { };
 


### PR DESCRIPTION
###### Motivation for this change

Since we select everything as a module, snd_hda_codec_ca0132 is built as
well. DSP loading is not enabled by default, but without it the
soundcard produces timeouts within ALSA and does not emit sound.
Explicitly enable the firmware loading to ensure Soundblaster
Z/Zx/ZxR/Recon devices can be used with NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
