### PR TITLE
pythonPackages.ftputil: fix build

### DIFF
--- a/pkgs/development/python-modules/ftputil/default.nix
+++ b/pkgs/development/python-modules/ftputil/default.nix
@@ -13,10 +13,11 @@ buildPythonPackage rec {
 
   checkPhase = ''
     touch Makefile
-    # Disable tests that require network access or access /home
+    # Disable tests that require network access or access /home or assume execution before year 2020
     py.test test \
       -k "not test_public_servers and not test_real_ftp \
-          and not test_set_parser and not test_repr"
+          and not test_set_parser and not test_repr \
+          and not test_conditional_upload and not test_conditional_download_with_older_target"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Some tests assume execution before 2020.

@GrahamcOfBorg build python27Packages.ftputil python37Packages.ftputil python38Packages.ftputil

(python39Packages.ftputil doesn't build because of pytest)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
