### PR TITLE
python: Shapely: 1.6.4.post2 -> 1.7.0

### DIFF
--- a/pkgs/development/python-modules/shapely/default.nix
+++ b/pkgs/development/python-modules/shapely/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "Shapely";
-  version = "1.6.4.post2";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c4b87bb61fc3de59fc1f85e71a79b0c709dc68364d9584473697aad4aa13240f";
+    sha256 = "07lmrihj6pa7f99m97hbf2anqlhhwippcdz03bqkyihnlkhry6p2";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/shapely/library-paths.patch
+++ b/pkgs/development/python-modules/shapely/library-paths.patch
@@ -1,9 +1,9 @@
 diff --git a/shapely/geos.py b/shapely/geos.py
-index 09bf1ab..837aa98 100644
+index d5a67d2..19b7ffc 100644
 --- a/shapely/geos.py
 +++ b/shapely/geos.py
-@@ -55,100 +55,10 @@ def load_dll(libname, fallbacks=None, mode=DEFAULT_MODE):
-             "Could not find lib {0} or load any of its variants {1}.".format(
+@@ -61,123 +61,11 @@ def load_dll(libname, fallbacks=None, mode=DEFAULT_MODE):
+             "Could not find lib {} or load any of its variants {}.".format(
                  libname, fallbacks or []))
  
 -_lgeos = None
@@ -16,15 +16,25 @@ index 09bf1ab..837aa98 100644
 -    if len(geos_whl_so) == 1:
 -        _lgeos = CDLL(geos_whl_so[0])
 -        LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
+-    elif hasattr(sys, 'frozen'):
+-        geos_pyinstaller_so = glob.glob(os.path.join(sys.prefix, 'libgeos_c-*.so.*'))
+-        if len(geos_pyinstaller_so) == 1:
+-            _lgeos = CDLL(geos_pyinstaller_so[0])
+-            LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
+-    elif os.getenv('CONDA_PREFIX', ''):
+-        # conda package.
+-        _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.so'))
 -    else:
 -        alt_paths = [
 -            'libgeos_c.so.1',
 -            'libgeos_c.so',
--            # anaconda
--            os.path.join(sys.prefix, "lib", "libgeos_c.so"),
 -        ]
 -        _lgeos = load_dll('geos_c', fallbacks=alt_paths)
--    free = load_dll('c').free
+-    # Necessary for environments with only libc.musl
+-    c_alt_paths = [
+-        'libc.musl-x86_64.so.1'
+-    ]
+-    free = load_dll('c', fallbacks=c_alt_paths).free
 -    free.argtypes = [c_void_p]
 -    free.restype = None
 -
@@ -32,10 +42,19 @@ index 09bf1ab..837aa98 100644
 -    # Test to see if we have a delocated wheel with a GEOS dylib.
 -    geos_whl_dylib = os.path.abspath(os.path.join(os.path.dirname(
 -        __file__), '.dylibs/libgeos_c.1.dylib'))
--    if os.path.exists(geos_whl_dylib):
--        _lgeos = CDLL(geos_whl_dylib)
--        LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
 -
+-    if os.path.exists(geos_whl_dylib):
+-        handle = CDLL(None)
+-        if hasattr(handle, "initGEOS_r"):
+-            LOG.debug("GEOS already loaded")
+-            _lgeos = handle
+-        else:
+-            _lgeos = CDLL(geos_whl_dylib)
+-            LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
+-
+-    elif os.getenv('CONDA_PREFIX', ''):
+-        # conda package.
+-        _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.dylib'))
 -    else:
 -        if hasattr(sys, 'frozen'):
 -            try:
@@ -52,12 +71,12 @@ index 09bf1ab..837aa98 100644
 -                        os.path.join(sys._MEIPASS, 'libgeos_c.1.dylib'))
 -        else:
 -            alt_paths = [
--                # anaconda
--                os.path.join(sys.prefix, "lib", "libgeos_c.dylib"),
 -                # The Framework build from Kyng Chaos
 -                "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
 -                # macports
 -                '/opt/local/lib/libgeos_c.dylib',
+-                # homebrew
+-                '/usr/local/lib/libgeos_c.dylib',
 -            ]
 -        _lgeos = load_dll('geos_c', fallbacks=alt_paths)
 -
@@ -66,30 +85,34 @@ index 09bf1ab..837aa98 100644
 -    free.restype = None
 -
 -elif sys.platform == 'win32':
--    try:
--        egg_dlls = os.path.abspath(
--            os.path.join(os.path.dirname(__file__), 'DLLs'))
--        if hasattr(sys, "frozen"):
--            wininst_dlls = os.path.normpath(
--                os.path.abspath(sys.executable + '../../DLLS'))
--        else:
--            wininst_dlls = os.path.abspath(os.__file__ + "../../../DLLs")
--        original_path = os.environ['PATH']
--        os.environ['PATH'] = "%s;%s;%s" % \
--            (egg_dlls, wininst_dlls, original_path)
--        _lgeos = load_dll("geos_c.dll", fallbacks=[
--            os.path.join(sys.prefix, "Library", "lib", "geos_c.dll"),
--        ])
--    except (ImportError, WindowsError, OSError):
--        raise
--
--    def free(m):
+-    if os.getenv('CONDA_PREFIX', ''):
+-        # conda package.
+-        _lgeos = CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll'))
+-    else:
 -        try:
--            cdll.msvcrt.free(m)
--        except WindowsError:
--            # XXX: See http://trac.gispython.org/projects/PCL/ticket/149
--            pass
+-            egg_dlls = os.path.abspath(
+-                os.path.join(os.path.dirname(__file__), 'DLLs'))
+-            if hasattr(sys, '_MEIPASS'):
+-                wininst_dlls = sys._MEIPASS
+-            elif hasattr(sys, "frozen"):
+-                wininst_dlls = os.path.normpath(
+-                    os.path.abspath(sys.executable + '../../DLLS'))
+-            else:
+-                wininst_dlls = os.path.abspath(os.__file__ + "../../../DLLs")
+-            original_path = os.environ['PATH']
+-            os.environ['PATH'] = "%s;%s;%s" % \
+-                (egg_dlls, wininst_dlls, original_path)
+-            _lgeos = load_dll("geos_c.dll")
+-        except (ImportError, WindowsError, OSError):
+-            raise
 -
+-        def free(m):
+-            try:
+-                cdll.msvcrt.free(m)
+-            except WindowsError:
+-                # XXX: See http://trac.gispython.org/projects/PCL/ticket/149
+-                pass
+ 
 -elif sys.platform == 'sunos5':
 -    _lgeos = load_dll('geos_c', fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
 -    free = CDLL('libc.so.1').free


### PR DESCRIPTION
##### Motivation for this change

unblock #71607

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `LC_ALL=C.utf8 nix run nixpkgs.nixpkgs-review -c nixpkgs-review wip`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### result of `nixpkgs-review wip`
<details><summary>output of <code>LC_ALL=C.utf8 nix run nixpkgs.nixpkgs-review -c nixpkgs-review wip</code> (click to expand)</summary>

```
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 20, done.
remote: Counting objects: 100% (20/20), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 24 (delta 18), reused 20 (delta 18), pack-reused 4
Entpacke Objekte: 100% (24/24), Fertig.
Von https://github.com/NixOS/nixpkgs
   604b4ddcb29..9344204b92b  master     -> refs/nixpkgs-review/0
$ git worktree add /home/das-g/.cache/nixpkgs-review/rev-74b2eaea0c3c3eda60417bd2887ca4387443c5a7-dirty/nixpkgs 9344204b92bdc0edb4cc6ec73bbce55577dce4df
Bereite Arbeitsverzeichnis vor (losgelöster HEAD 9344204b92b)
Aktualisiere Dateien: 100% (21313/21313), Fertig.
HEAD ist jetzt bei 9344204b92b Merge pull request #83399 from r-ryantm/auto-update/subunit
$ nix-env -f /home/das-g/.cache/nixpkgs-review/rev-74b2eaea0c3c3eda60417bd2887ca4387443c5a7-dirty/nixpkgs -qaP --xml --out-path --show-trace
^Cerror: interrupted by the user
$ git worktree prune

[das-g@nixos:~/dev/nixos/nixpkgs]$ ^C

(failed reverse-i-search)`LANG': QT_QPA_P^CTFORM=wayland qgis

(failed reverse-i-search)`LC_': NIXPKGS_AL^CW_UNFREE=1 nix run -f channel:nixpkgs-unstable amoeba

[das-g@nixos:~/dev/nixos/nixpkgs]$ LC_ALL=C.utf8 nix run nixpkgs.nixpkgs-review -c nixpkgs-review wip
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /home/das-g/.cache/nixpkgs-review/rev-74b2eaea0c3c3eda60417bd2887ca4387443c5a7-dirty-1/nixpkgs 9344204b92bdc0edb4cc6ec73bbce55577dce4df
Preparing worktree (detached HEAD 9344204b92b)
Updating files: 100% (21313/21313), done.
HEAD is now at 9344204b92b Merge pull request #83399 from r-ryantm/auto-update/subunit
$ nix-env -f /home/das-g/.cache/nixpkgs-review/rev-74b2eaea0c3c3eda60417bd2887ca4387443c5a7-dirty-1/nixpkgs -qaP --xml --out-path --show-trace
Applying `nixpkgs` diff...
<stdin>:155: trailing whitespace.
 
warning: 1 line adds whitespace errors.
$ nix-env -f /home/das-g/.cache/nixpkgs-review/rev-74b2eaea0c3c3eda60417bd2887ca4387443c5a7-dirty-1/nixpkgs -qaP --xml --out-path --show-trace --meta
47 package updated:
apache-airflow buku cura cura-lulzbot python2.7-descartes python2.7-flask-admin python2.7-GeoAlchemy2 python2.7-labelbox python2.7-pyosmium python2.7-Shapely (1.6.4.post2 → 1.7.0) python3.7-apache-airflow python3.7-aplpy python3.7-basemap python3.7-cartopy python3.7-descartes python3.7-detox python3.7-flask-admin python3.7-GeoAlchemy2 python3.7-geopandas python3.7-imgaug python3.7-labelbox python3.7-mask-rcnn python3.7-osmnx python3.7-OWSLib python3.7-pyosmium python3.7-pyproj python3.7-Shapely (1.6.4.post2 → 1.7.0) python3.7-uranium python3.8-apache-airflow python3.8-aplpy python3.8-basemap python3.8-cartopy python3.8-descartes python3.8-detox python3.8-flask-admin python3.8-GeoAlchemy2 python3.8-geopandas python3.8-imgaug python3.8-labelbox python3.8-osmnx python3.8-OWSLib python3.8-pyosmium python3.8-pyproj python3.8-Shapely (1.6.4.post2 → 1.7.0) python3.8-uranium qgis qgis-unwrapped

$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/das-g/.cache/nixpkgs-review/rev-74b2eaea0c3c3eda60417bd2887ca4387443c5a7-dirty-1/build.nix
builder for '/nix/store/fksffrcc7q4nhgba87rw9z8f4m92nnd1-python3.8-apache-airflow-1.10.5.drv' failed with exit code 1; last 10 log lines:
  airflow.models.dagbag.DagBag: DEBUG: Importing /build/source/airflow/example_dags/example_python_operator.py
  airflow.models.dagbag.DagBag: DEBUG: Loaded DAG <DAG: example_python_operator>
  airflow.models.dagbag.DagBag: DEBUG: Importing /build/source/airflow/example_dags/subdags/subdag.py
  --------------------- >> end captured logging << ---------------------
  
  ----------------------------------------------------------------------
  Ran 56 tests in 26.869s
  
  FAILED (errors=3, failures=1)
  [2020-03-29 10:05:11,859] {settings.py:238} DEBUG - Disposing DB connection pool (PID 456)
cannot build derivation '/nix/store/f8k8iz6c75i6rzi8p123gq0g5dl314cl-env.drv': 1 dependencies couldn't be built
[44 built (1 failed), 151 copied (1385.9 MiB), 323.1 MiB DL]
error: build of '/nix/store/f8k8iz6c75i6rzi8p123gq0g5dl314cl-env.drv' failed
2 package marked as broken and skipped:
python37Packages.detox python38Packages.detox

1 package failed to build:
python38Packages.apache-airflow

43 package built:
apache-airflow buku cura curaLulzbot python27Packages.descartes python27Packages.flask-admin python27Packages.geoalchemy2 python27Packages.labelbox python27Packages.pyosmium python27Packages.shapely python37Packages.aplpy python37Packages.basemap python37Packages.cartopy python37Packages.descartes python37Packages.flask-admin python37Packages.geoalchemy2 python37Packages.geopandas python37Packages.imgaug python37Packages.labelbox python37Packages.mask-rcnn python37Packages.osmnx python37Packages.owslib python37Packages.pyosmium python37Packages.pyproj python37Packages.shapely python37Packages.uranium python38Packages.aplpy python38Packages.basemap python38Packages.cartopy python38Packages.descartes python38Packages.flask-admin python38Packages.geoalchemy2 python38Packages.geopandas python38Packages.imgaug python38Packages.labelbox python38Packages.osmnx python38Packages.owslib python38Packages.pyosmium python38Packages.pyproj python38Packages.shapely python38Packages.uranium qgis qgis-unwrapped

$ nix-shell /home/das-g/.cache/nixpkgs-review/rev-74b2eaea0c3c3eda60417bd2887ca4387443c5a7-dirty-1/shell.nix

```

</details>

2 package marked as broken and skipped:
* `python37Packages.detox`
* `python38Packages.detox`

1 package failed to build:
* `python38Packages.apache-airflow`

<details><summary>43 package built (click to expand):</summary>

 * `apache-airflow`
 * `buku`
 * `cura`
 * `curaLulzbot`
 * `python27Packages.descartes`
 * `python27Packages.flask-admin`
 * `python27Packages.geoalchemy2`
 * `python27Packages.labelbox`
 * `python27Packages.pyosmium`
 * `python27Packages.shapely`
 * `python37Packages.aplpy`
 * `python37Packages.basemap`
 * `python37Packages.cartopy`
 * `python37Packages.descartes`
 * `python37Packages.flask-admin`
 * `python37Packages.geoalchemy2`
 * `python37Packages.geopandas`
 * `python37Packages.imgaug`
 * `python37Packages.labelbox`
 * `python37Packages.mask-rcnn`
 * `python37Packages.osmnx`
 * `python37Packages.owslib`
 * `python37Packages.pyosmium`
 * `python37Packages.pyproj`
 * `python37Packages.shapely`
 * `python37Packages.uranium`
 * `python38Packages.aplpy`
 * `python38Packages.basemap`
 * `python38Packages.cartopy`
 * `python38Packages.descartes`
 * `python38Packages.flask-admin`
 * `python38Packages.geoalchemy2`
 * `python38Packages.geopandas`
 * `python38Packages.imgaug`
 * `python38Packages.labelbox`
 * `python38Packages.osmnx`
 * `python38Packages.owslib`
 * `python38Packages.pyosmium`
 * `python38Packages.pyproj`
 * `python38Packages.shapely`
 * `python38Packages.uranium`
 * `qgis`
 * `qgis-unwrapped`

</details>