### PR TITLE
pythonPackages.pytest: 5.3.5 -> 5.4.1

### DIFF
--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, isPy3k, isPy35, async_generator }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, pytest, isPy3k, isPy35, async_generator }:
 buildPythonPackage rec {
   pname = "pytest-asyncio";
   version = "0.10.0";
@@ -9,6 +9,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "9fac5100fd716cbecf6ef89233e8590a4ad61d729d1732e0a96b84182df1daaf";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/pytest-dev/pytest-asyncio/commit/6397a2255e3e9ef858439b164018438a8106f454.patch";
+      sha256 = "0dl365idhi2sjd8hbdpr6k0r16vzd942sa5dzl3ykawy80b6rbq8";
+      includes = [ "pytest_asyncio/plugin.py" ];
+    })
+  ];
 
   buildInputs = [ pytest ]
     ++ stdenv.lib.optionals isPy35 [ async_generator ];

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -1,9 +1,10 @@
 { stdenv, buildPythonPackage, pythonOlder, fetchPypi, attrs, hypothesis, py
 , setuptools_scm, setuptools, six, pluggy, funcsigs, isPy3k, more-itertools
-, atomicwrites, mock, writeText, pathlib2, wcwidth, packaging, isPyPy, python
+, atomicwrites, mock, pygments, writeText, pathlib2, wcwidth, packaging, isPyPy
+, python
 }:
 buildPythonPackage rec {
-  version = "5.3.5";
+  version = "5.4.1";
   pname = "pytest";
 
   disabled = !isPy3k;
@@ -15,10 +16,10 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d";
+    sha256 = "0w7r0pl1rkzpvb7k3926zcc9brd071zc8b1r3wymz05qfmqf7pc4";
   };
 
-  checkInputs = [ hypothesis mock ];
+  checkInputs = [ hypothesis mock pygments ];
   nativeBuildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ attrs py setuptools six pluggy more-itertools atomicwrites wcwidth packaging ]
     ++ stdenv.lib.optionals (pythonOlder "3.6") [ pathlib2 ];
@@ -28,7 +29,7 @@ buildPythonPackage rec {
   # Ignored file https://github.com/pytest-dev/pytest/pull/5605#issuecomment-522243929
   checkPhase = ''
     runHook preCheck
-    $out/bin/py.test -x testing/ -k "not test_collect_pyargs_with_testpaths" --ignore=testing/test_junitxml.py
+    $out/bin/py.test -x testing/ --ignore=testing/test_junitxml.py
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchPypi, buildPythonPackage, isPy3k, isPy35
+{ stdenv, lib, fetchPypi, fetchpatch, buildPythonPackage, isPy3k, isPy35
 , mock
 , pysqlite
 , pytestCheckHook
@@ -12,6 +12,13 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "64a7b71846db6423807e96820993fa12a03b89127d278290ca25c0b11ed7b4fb";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/sqlalchemy/sqlalchemy/commit/993e6449e3f5f3532f6f5426b824718435ce6c6d.patch";
+      sha256 = "1qacqdrzqlsiinlc2fsrkbh9799j79y9jqh5rjg80gi7ngfy8mw0";
+    })
+  ];
 
   checkInputs = [
     pytestCheckHook


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Making pytest work in Python 3.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
