### PR TITLE
xfce.xfce4-hardware-monitor-plugin: fix url (unmaintained)

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
   version = "1.6.0";
 
   src = fetchurl {
-    url = "https://git.xfce.org/panel-plugins/${pname}/snapshot/${pname}-${version}.tar.bz2";
-    sha256 = "0xg5har11fk1wmdymydxlbk1z8aa39j8k0p4gzw2iqslv3n0zf7b";
+    url = "https://git.xfce.org/archive/${pname}/snapshot/${pname}-${version}.tar.gz";
+    sha256 = "11k7m41jxkaqmpp5njkixw60q517xnw923mz34dnm1llx9ilvfk8";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

From https://goodies.xfce.org/projects/panel-plugins/xfce4-hardware-monitor-plugin:

> As of 2019, this plugin is no longer maintained - I (OmegaPhil) have unfortunately moved on to other things. 

The git repository has been moved to `archived`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).