### PR TITLE
wshowkeys: init at 2020-03-29

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -172,6 +172,7 @@
   ./programs/wavemon.nix
   ./programs/waybar.nix
   ./programs/wireshark.nix
+  ./programs/wshowkeys.nix
   ./programs/x2goserver.nix
   ./programs/xfs_quota.nix
   ./programs/xonsh.nix

--- a/nixos/modules/programs/wshowkeys.nix
+++ b/nixos/modules/programs/wshowkeys.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.wshowkeys;
+in {
+  meta.maintainers = with maintainers; [ primeos ];
+
+  options = {
+    programs.wshowkeys = {
+      enable = mkEnableOption ''
+        wshowkeys (displays keypresses on screen on supported Wayland
+        compositors). It requires root permissions to read input events, but
+        these permissions are dropped after startup'';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    security.wrappers.wshowkeys.source = "${pkgs.wshowkeys}/bin/wshowkeys";
+  };
+}

--- a/pkgs/tools/wayland/wshowkeys/default.nix
+++ b/pkgs/tools/wayland/wshowkeys/default.nix
@@ -4,15 +4,15 @@
 }:
 
 let
-  version = "2019-09-26";
-  commit = "a9bf6bca0361b57c67e4627bf53363a7048457fd";
+  version = "2020-03-29";
+  commit = "6388a49e0f431d6d5fcbd152b8ae4fa8e87884ee";
 in stdenv.mkDerivation rec {
   pname = "wshowkeys-unstable";
   inherit version;
 
   src = fetchurl {
     url = "https://git.sr.ht/~sircmpwn/wshowkeys/archive/${commit}.tar.gz";
-    sha256 = "0b21z3csd3v4lw5b8a6lpx5gfsdk0gjmm8906sa72hyfd1p39b7g";
+    sha256 = "0iplmw13jmc8d3m307kc047zq8yqwm42kw9fpm270562i3p0qk4d";
   };
 
   nativeBuildInputs = [ meson pkg-config wayland ninja ];
@@ -30,6 +30,6 @@ in stdenv.mkDerivation rec {
     homepage = "https://git.sr.ht/~sircmpwn/wshowkeys";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ primeos berbiche ];
   };
 }

--- a/pkgs/tools/wayland/wshowkeys/default.nix
+++ b/pkgs/tools/wayland/wshowkeys/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl
+, meson, pkg-config, wayland, ninja
+, cairo, libinput, pango, wayland-protocols, libxkbcommon
+}:
+
+let
+  version = "2019-09-26";
+  commit = "a9bf6bca0361b57c67e4627bf53363a7048457fd";
+in stdenv.mkDerivation rec {
+  pname = "wshowkeys-unstable";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://git.sr.ht/~sircmpwn/wshowkeys/archive/${commit}.tar.gz";
+    sha256 = "0b21z3csd3v4lw5b8a6lpx5gfsdk0gjmm8906sa72hyfd1p39b7g";
+  };
+
+  nativeBuildInputs = [ meson pkg-config wayland ninja ];
+  buildInputs = [ cairo libinput pango wayland-protocols libxkbcommon ];
+
+  meta = with stdenv.lib; {
+    description = "Displays keys being pressed on a Wayland session";
+    longDescription = ''
+      Displays keypresses on screen on supported Wayland compositors (requires
+      wlr_layer_shell_v1 support).
+      Note: This tool requires root permissions to read input events, but these
+      permissions are dropped after startup. The NixOS module provides such a
+      setuid binary (use "programs.wshowkeys.enable = true;").
+    '';
+    homepage = "https://git.sr.ht/~sircmpwn/wshowkeys";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3431,6 +3431,8 @@ in
 
   wrangler = callPackage ../development/tools/wrangler { };
 
+  wshowkeys = callPackage ../tools/wayland/wshowkeys { };
+
   xkcdpass = with pythonPackages; toPythonApplication xkcdpass;
 
   xob = callPackage ../tools/X11/xob { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Only a draft for discoverability (not sure if that makes sense, but there where a few requests already and maybe someone would like to use it already).

I've tested it and it works but the software itself seems still alpha/beta quality and I don't think it's ready for Nixpkgs yet (it doesn't crash, but there are some rendering issues, the overlay doesn't disappear automatically after a few secondes, etc. and we should wait for a tagged (pre-)release anyway).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
