### PR TITLE
weechat: v2.7.1 → v2.8

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -27,12 +27,12 @@ let
   in
     assert lib.all (p: p.enabled -> ! (builtins.elem null p.buildInputs)) plugins;
     stdenv.mkDerivation rec {
-      version = "2.7.1";
+      version = "2.8";
       pname = "weechat";
 
       src = fetchurl {
         url = "https://weechat.org/files/src/weechat-${version}.tar.bz2";
-        sha256 = "0acz41jg7lmipni9z2agfqw4dhmx5hf6k9w4pvr4zih1fhkldva2";
+        sha256 = "0xpzl7985j47rpmly4r833jxd448xpy7chqphaxmhlql2c0gc08z";
       };
 
       outputs = [ "out" "man" ] ++ map (p: p.name) enabledPlugins;


### PR DESCRIPTION
New features

    core: add variable "old_full_name" in buffer, set during buffer renaming (issue weechat/weechat#1428)
    core: add debug option "-d" in command /eval (issue weechat/weechat#1434)
    api: add functions crypto_hash and crypto_hash_pbkdf2
    api: add info "auto_connect" (issue weechat/weechat#1453)
    api: add info "weechat_headless" (issue weechat/weechat#1433)
    buflist: add pointer "window" in bar item evaluation
    irc: add support of fake servers (no I/O, for testing purposes)
    relay: accept hash of password in init command of weechat protocol with option "password_hash" (PBKDF2, SHA256, SHA512)
    relay: reject client with weechat protocol if password or totp is received in init command but not set in WeeChat (issue weechat/weechat#1435)

Bug fixes

    core: fix memory leak in completion
    core: flush stdout/stderr before forking in hook_process function (issue weechat/weechat#1441)
    core: fix evaluation of condition with nested "if" (issue weechat/weechat#1434)
    irc: split AUTHENTICATE message in 400-byte chunks (issue weechat/weechat#1459)
    irc: copy temporary server flag in command /server copy
    irc: add nick changes in the hotlist (except self nick change)
    irc: case-insensitive comparison on incoming CTCP command, force upper case on CTCP replies (issue weechat/weechat#1439)
    irc: fix memory leak when the channel topic is changed
    logger: fix crash when logging is disabled on a buffer and the log file was deleted in the meanwhile, when option logger.file.info_lines is on (issue weechat/weechat#1444)
    php: fix crash when loading script with PHP 7.4 (issue weechat/weechat#1452)
    relay: update buffers synchronization when buffers are renamed (issue weechat/weechat#1428)
    script: fix memory leak in read of script repository file if it has invalid content
    script: fix unexpected display of scripts list in buffer with command /script list -i
    xfer: send signal "xfer_ended" after the received file has been renamed (issue weechat/weechat#1438)

Tests

    scripts: fix generation of test scripts with Python 3.8
    unit: add tests on IRC protocol functions and callbacks
    unit: add tests on function secure_derive_key
    unit: add tests on functions util_get_time_diff and util_file_get_content

Build

    core: fix Cygwin build
    guile: add detection of Guile 3.0.0 (issue weechat/weechat#1442)
    irc: fix build with GnuTLS < 3.1.0 (issue weechat/weechat#1431)
    php: add detection of PHP 7.4
    ruby: add detection of Ruby 2.7 (issue weechat/weechat#1455)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New upstream release

https://github.com/weechat/weechat/releases/tag/v2.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@lovek323 @the-kenny @lheckemann @Ma27