### PR TITLE
nixos/gerrit: stop setting jvmPackage

### DIFF
--- a/nixos/tests/gerrit.nix
+++ b/nixos/tests/gerrit.nix
@@ -24,7 +24,6 @@ in {
           enable = true;
           serverId = "aa76c84b-50b0-4711-a0a0-1ee30e45bbd0";
           listenAddress = "[::]:80";
-          jvmPackage = pkgs.jdk12_headless;
           jvmHeapLimit = "1g";
 
           plugins = [ lfs ];


### PR DESCRIPTION
jdk12_headless disappeared in d00559ebb84af84b48a207a5a0a0762ce9d577eb,
and just using the default in the VM test should be fine IMHO.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
