### PR TITLE
ghc-8.4.4.nix: Do not use git.haskell.org

### DIFF
--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -96,8 +96,8 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [(fetchpatch {
-    url = "https://git.haskell.org/hsc2hs.git/patch/738f3666c878ee9e79c3d5e819ef8b3460288edf";
-    sha256 = "0plzsbfaq6vb1023lsarrjglwgr9chld4q3m99rcfzx0yx5mibp3";
+    url = "https://github.com/haskell/hsc2hs/commit/738f3666c878ee9e79c3d5e819ef8b3460288edf.patch";
+    sha256 = "1q3rg7lka5czsryzj2nfr3f2iy2zw87kfd54hc4dlxz79z3vwz8p";
     extraPrefix = "utils/hsc2hs/";
     stripLen = 1;
   }) (fetchpatch rec { # https://phabricator.haskell.org/D5123
@@ -112,8 +112,8 @@ stdenv.mkDerivation (rec {
     })
     ++ stdenv.lib.optional stdenv.isDarwin ./backport-dylib-command-size-limit.patch
     ++ stdenv.lib.optional (targetPlatform.isAarch32 || targetPlatform.isAarch64) (fetchpatch {
-      url = "https://git.haskell.org/ghc.git/patch/d8495549ba9d194815c2d0eaee6797fc7c00756a";
-      sha256 = "1yjcma507c609bcim4rnxq0gaj2dg4d001jklmbpbqpzqzxkn5sz";
+      url = "https://github.com/ghc/ghc/commit/d8495549ba9d194815c2d0eaee6797fc7c00756a.patch";
+      sha256 = "0ck3a26bvy6w3jy2x19zgixpfs3ig1ycdnq08xia1dd8gik9hjgf";
     });
 
   postPatch = "patchShebangs .";

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -96,8 +96,8 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [(fetchpatch {
-    url = "https://github.com/haskell/hsc2hs/commit/738f3666c878ee9e79c3d5e819ef8b3460288edf.patch";
-    sha256 = "1q3rg7lka5czsryzj2nfr3f2iy2zw87kfd54hc4dlxz79z3vwz8p";
+    url = "https://github.com/haskell/hsc2hs/commit/738f3666c878ee9e79c3d5e819ef8b3460288edf.diff";
+    sha256 = "0plzsbfaq6vb1023lsarrjglwgr9chld4q3m99rcfzx0yx5mibp3";
     extraPrefix = "utils/hsc2hs/";
     stripLen = 1;
   }) (fetchpatch rec { # https://phabricator.haskell.org/D5123
@@ -112,8 +112,8 @@ stdenv.mkDerivation (rec {
     })
     ++ stdenv.lib.optional stdenv.isDarwin ./backport-dylib-command-size-limit.patch
     ++ stdenv.lib.optional (targetPlatform.isAarch32 || targetPlatform.isAarch64) (fetchpatch {
-      url = "https://github.com/ghc/ghc/commit/d8495549ba9d194815c2d0eaee6797fc7c00756a.patch";
-      sha256 = "0ck3a26bvy6w3jy2x19zgixpfs3ig1ycdnq08xia1dd8gik9hjgf";
+      url = "https://github.com/ghc/ghc/commit/d8495549ba9d194815c2d0eaee6797fc7c00756a.diff";
+      sha256 = "1yjcma507c609bcim4rnxq0gaj2dg4d001jklmbpbqpzqzxkn5sz";
     });
 
   postPatch = "patchShebangs .";


### PR DESCRIPTION
which was deprecated in 2018 and is now gone for good. I guess many
won’t notice because the nix-cache kept the files around?

This fetches the patches from github. Unfortunately it seems that the
sha256 hashes (calculated with `nix-prefetch-url`) have been modified.

Alternatively, if someone has the old patches around they could arguably
be added to `tarballs.nixos.org` (it seems they are not there right
now).