### PR TITLE
session-desktop: init at 1.0.8

### DIFF
--- a/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
@@ -5,11 +5,11 @@
 
 let
   pname = "session-messenger-desktop";
-  version = "1.0.6";
+  version = "1.0.7";
   name="${pname}-${version}.AppImage";
   src = fetchurl {
     url = "https://github.com/loki-project/session-desktop/releases/download/v${version}/session-messenger-desktop-linux-x86_64-${version}.AppImage";
-    sha256 = "43abf0d0aedf200c14a853070965142d3fdbe39b26e4186e1814418612f9f8b5";
+    sha256 = "5d61a66c96dc098458475d4be85c36522866b833ab677cdd060d3bb521852606";
     name="${pname}-${version}.AppImage";
   };
 

--- a/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
@@ -5,11 +5,11 @@
 
 let
   pname = "session-messenger-desktop";
-  version = "1.0.5";
+  version = "1.0.6";
   name="${pname}-${version}.AppImage";
   src = fetchurl {
     url = "https://github.com/loki-project/session-desktop/releases/download/v${version}/session-messenger-desktop-linux-x86_64-${version}.AppImage";
-    sha256 = "55c7dcccafda186e5cae681d3256ead38aba58885896a94a4c26e96a334061c6";
+    sha256 = "43abf0d0aedf200c14a853070965142d3fdbe39b26e4186e1814418612f9f8b5";
     name="${pname}-${version}.AppImage";
   };
 

--- a/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchurl
+, appimageTools
+}:
+
+let
+  pname = "session-messenger-desktop";
+  version = "1.0.5";
+  name="${pname}-${version}.AppImage";
+  src = fetchurl {
+    url = "https://github.com/loki-project/session-desktop/releases/download/v${version}/session-messenger-desktop-linux-x86_64-${version}.AppImage";
+    sha256 = "55c7dcccafda186e5cae681d3256ead38aba58885896a94a4c26e96a334061c6";
+    name="${pname}-${version}.AppImage";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/session.desktop
+    install -m 444 -D ${appimageContents}/${pname}.png $out/share/icons/hicolor/512x512/apps/session.png
+    substituteInPlace $out/share/applications/session.desktop --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with lib; {
+    description = "Desktop client for Session Messenger";
+    homepage = https://getsession.org/;
+    license = licenses.gpl3;
+    #maintainers = with maintainers; [ ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
@@ -5,11 +5,11 @@
 
 let
   pname = "session-messenger-desktop";
-  version = "1.0.7";
+  version = "1.0.8";
   name="${pname}-${version}.AppImage";
   src = fetchurl {
     url = "https://github.com/loki-project/session-desktop/releases/download/v${version}/session-messenger-desktop-linux-x86_64-${version}.AppImage";
-    sha256 = "5d61a66c96dc098458475d4be85c36522866b833ab677cdd060d3bb521852606";
+    sha256 = "923774ad431f9cef689df417a9f48109711b1c8235f34bd335cc4f6244fe9afc";
     name="${pname}-${version}.AppImage";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6450,6 +6450,8 @@ in
 
   seexpr = callPackage ../development/compilers/seexpr { };
 
+  session-desktop = callPackage ../applications/networking/instant-messengers/session-desktop { };
+
   setroot = callPackage  ../tools/X11/setroot { };
 
   setserial = callPackage ../tools/system/setserial { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes #81927

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
