### PR TITLE
marktext: 0.16.0-rc.2 -> 0.16.1

### DIFF
--- a/pkgs/applications/misc/marktext/default.nix
+++ b/pkgs/applications/misc/marktext/default.nix
@@ -2,14 +2,14 @@
 
 let
   pname = "marktext";
-  version = "v0.16.1";
+  version = "v0.16.2";
 in
 appimageTools.wrapType2 rec {
   name = "${pname}-${version}-binary";
 
   src = fetchurl {
     url = "https://github.com/marktext/marktext/releases/download/${version}/marktext-x86_64.AppImage";
-    sha256 = "1v2kjvccxfqj76c2krlmfnhrhs03y5n1pjcljgxaj2kc5vi80c1p";
+    sha256 = "0ivf9lvv2jk7dvxmqprzcsxgya3617xmx5bppjvik44z14b5x8r7";
   };
 
   profile = ''

--- a/pkgs/applications/misc/marktext/default.nix
+++ b/pkgs/applications/misc/marktext/default.nix
@@ -1,19 +1,25 @@
-{ appimageTools, fetchurl, lib }:
+{ appimageTools, fetchurl, lib, gsettings-desktop-schemas, gtk3 }:
 
 let
   pname = "marktext";
-  version = "v0.16.0-rc.2";
+  version = "v0.16.1";
 in
 appimageTools.wrapType2 rec {
   name = "${pname}-${version}-binary";
 
   src = fetchurl {
     url = "https://github.com/marktext/marktext/releases/download/${version}/marktext-x86_64.AppImage";
-    sha256 = "1w1mxa1j94zr36xhvlhzq8d77pi359vdxqb2j8mnz2bib9khxk9k";
+    sha256 = "1v2kjvccxfqj76c2krlmfnhrhs03y5n1pjcljgxaj2kc5vi80c1p";
   };
 
   profile = ''
     export LC_ALL=C.UTF-8
+  ''
+  # Fixes file open dialog error
+  #     GLib-GIO-ERROR **: 20:36:48.243: No GSettings schemas are installed on the system
+  # See https://github.com/NixOS/nixpkgs/pull/83701#issuecomment-608034097
+  + ''
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
   '';
 
   multiPkgs = null; # no 32bit needed


### PR DESCRIPTION
##### Motivation for this change

Changelog: https://github.com/marktext/marktext/blob/v0.16.1/.github/CHANGELOG.md#0161

Follow-up to #77694.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
