### PR TITLE
buildFHSChrootEnv: link gsettings-schemas to FHS location

### DIFF
--- a/doc/builders/special/fhs-environments.xml
+++ b/doc/builders/special/fhs-environments.xml
@@ -119,4 +119,8 @@
  <para>
   Running <literal>nix-shell</literal> would then drop you into a shell with these libraries and binaries available. You can use this to run closed-source applications which expect FHS structure without hassles: simply change <literal>runScript</literal> to the application path, e.g. <filename>./bin/start.sh</filename> -- relative paths are supported.
  </para>
+
+ <para>
+  Additonally, the FHS builder links all relocated gsettings-schemas (the glib setup-hook moves them to share/gsettings-schemas/${name}/glib-2.0/schemas) to their standard FHS location. This means you don't need to wrap binaries with <literal>wrapGAppsHook</literal>.
+ </para>
 </section>

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -124,6 +124,24 @@ let
     paths = [ etcPkg ] ++ basePkgs ++ targetPaths;
     extraOutputsToInstall = [ "out" "lib" "bin" ] ++ extraOutputsToInstall;
     ignoreCollisions = true;
+    postBuild = ''
+      if [ -d  $out/share/gsettings-schemas/ ]; then
+          # Create the standard schemas directory
+          rm -rf $out/share/glib-2.0
+          mkdir -p $out/share/glib-2.0/schemas
+
+          # symlink any schema files to the standard schema directory
+          for d in $out/share/gsettings-schemas/*; do
+              # Force symlink, in case there are duplicates
+              ln -fs $d/glib-2.0/schemas/*.xml $out/share/glib-2.0/schemas
+          done
+
+          # and compile them
+          if [ -w $out/share/glib-2.0/schemas ]; then
+              ${pkgs.glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+          fi
+      fi
+    '';
   };
 
   staticUsrProfileMulti = buildEnv {

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -125,21 +125,22 @@ let
     extraOutputsToInstall = [ "out" "lib" "bin" ] ++ extraOutputsToInstall;
     ignoreCollisions = true;
     postBuild = ''
-      if [ -d  $out/share/gsettings-schemas/ ]; then
-          # Create the standard schemas directory
-          rm -rf $out/share/glib-2.0
-          mkdir -p $out/share/glib-2.0/schemas
+      if [[ -d  $out/share/gsettings-schemas/ ]]; then
+          # Create the standard schemas directory if needed
+          if [[ -L $out/share/glib-2.0 ]]; then
+              rm -rf $out/share/glib-2.0
+              mkdir -p $out/share/glib-2.0/schemas
+          fi
 
-          # symlink any schema files to the standard schema directory
+          # symlink any schema files or overrides to the standard schema directory
           for d in $out/share/gsettings-schemas/*; do
               # Force symlink, in case there are duplicates
               ln -fs $d/glib-2.0/schemas/*.xml $out/share/glib-2.0/schemas
+              ln -fs $d/glib-2.0/schemas/*.gschema.override $out/share/glib-2.0/schemas
           done
 
           # and compile them
-          if [ -w $out/share/glib-2.0/schemas ]; then
-              ${pkgs.glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
-          fi
+          ${pkgs.glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
       fi
     '';
   };


### PR DESCRIPTION
We shouldn't need to use wrapGAppsHook in expressions
that use this builder. The code to do this is from https://github.com/NixOS/nixpkgs/pull/54083.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/83410 ssb-patchwork should now work without any wrapping. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
