### PR TITLE
libfive: 2018-07-01 -> 2020-02-15

### DIFF
--- a/pkgs/development/libraries/libfive/default.nix
+++ b/pkgs/development/libraries/libfive/default.nix
@@ -1,30 +1,41 @@
-{ stdenv, fetchFromGitHub, cmake, ninja, pkgconfig, eigen,
-zlib, libpng, boost, qt5, guile
+{ lib
+, mkDerivation
+, wrapQtAppsHook
+, fetchFromGitHub
+, cmake
+, ninja
+, pkgconfig
+, eigen
+, zlib
+, libpng
+, boost
+, guile
 }:
 
-stdenv.mkDerivation {
-  pname = "libfive";
-  version = "2018-07-01";
+mkDerivation {
+  pname = "libfive-unstable";
+  version = "2020-02-15";
 
   src = fetchFromGitHub {
-    owner  = "libfive";
-    repo   = "libfive";
-    rev    = "0f517dde9521d751310a22f85ee69b2c84690267";
-    sha256 = "0bfxysf5f4ripgcv546il8wnw5p0d4s75kdjlwvj32549537hlz0";
+    owner = "libfive";
+    repo = "libfive";
+    rev = "5b7717a25064478cd6bdb190683566eaf4c7afdd";
+    sha256 = "102zw2n3vzv84i323is4qrwwqqha8v1cniw54ss8f4bq6dmic0bg";
   };
-  nativeBuildInputs = [ cmake ninja pkgconfig ];
-  buildInputs = [ eigen zlib libpng boost qt5.qtimageformats guile ];
+
+  nativeBuildInputs = [ wrapQtAppsHook cmake ninja pkgconfig ];
+  buildInputs = [ eigen zlib libpng boost guile ];
 
   # Link "Studio" binary to "libfive-studio" to be more obvious:
   postFixup = ''
     ln -s "$out/bin/Studio" "$out/bin/libfive-studio"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Infrastructure for solid modeling with F-Reps in C, C++, and Guile";
     homepage = "https://libfive.com/";
-    maintainers = with maintainers; [ hodapp ];
-    license = licenses.lgpl2;
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ hodapp kovirobi ];
+    license = with licenses; [ mpl20 gpl2Plus ];
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12802,7 +12802,7 @@ in
 
   libfabric = callPackage ../os-specific/linux/libfabric {};
 
-  libfive = callPackage ../development/libraries/libfive { };
+  libfive = libsForQt5.callPackage ../development/libraries/libfive { };
 
   libfixposix = callPackage ../development/libraries/libfixposix {};
 


### PR DESCRIPTION
Use proper Qt bindings (#65399). Note, current version didn't work for
me, new version does.

The libfive library is licensed under MPL 2.0, while the libfive-guile
and libfive-studio are under GPL 2+

Superseeds / closes #66128

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
