### PR TITLE
python3Packages.dcmstack: init at 0.8

### DIFF
--- a/pkgs/development/python-modules/dcmstack/default.nix
+++ b/pkgs/development/python-modules/dcmstack/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pythonAtLeast
+, nose
+, nibabel
+, pydicom
+}:
+
+buildPythonPackage rec {
+  pname = "dcmstack";
+  version = "0.8";
+
+  disabled = pythonAtLeast "3.8";
+  # https://github.com/moloney/dcmstack/issues/67
+
+  src = fetchFromGitHub {
+    owner = "moloney";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1n24pp3rqz7ss1z6276fxynnppraxadbl3b9p8ijrcqnpzbzih7p";
+  };
+
+  propagatedBuildInputs = [ nibabel pydicom ];
+
+  checkInputs = [ nose ];
+  checkPhase = ''
+    runHook preCheck
+    nosetests
+    runHook postCheck
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/moloney/dcmstack";
+    description = "DICOM to Nifti conversion preserving metadata";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -637,6 +637,8 @@ in {
 
   exchangelib = callPackage ../development/python-modules/exchangelib { };
 
+  dcmstack = callPackage ../development/python-modules/dcmstack { };
+
   dbus-python = callPackage ../development/python-modules/dbus {
     inherit (pkgs) dbus pkgconfig;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [NA] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
