### PR TITLE
python27Packages.application: 2.7.0 -> 2.8.0 and fix build; python27Packages.python-otr: mark as broken

### DIFF
--- a/pkgs/development/python-modules/application/default.nix
+++ b/pkgs/development/python-modules/application/default.nix
@@ -1,21 +1,26 @@
-{ lib, buildPythonPackage, fetchdarcs, zope_interface, isPy3k }:
+{ lib, buildPythonPackage, fetchFromGitHub, zope_interface, isPy3k }:
 
 buildPythonPackage rec {
   pname = "python-application";
-  version = "2.7.0";
+  version = "2.8.0";
   disabled = isPy3k;
 
-  src = fetchdarcs {
-    url = "http://devel.ag-projects.com/repositories/${pname}";
+  src = fetchFromGitHub {
+    owner = "AGProjects";
+    repo = pname;
     rev = "release-${version}";
-    sha256 = "1xpyk2v3naxkjhpyris58dxg1lxbraxgjd6f7w1sah5j0sk7psla";
+    sha256 = "1xd2gbpmx2ghap9cnr1h6sxjai9419bdp3y9qp5lh67977m0qg30";
   };
 
   buildInputs = [ zope_interface ];
 
+  # No tests upstream to run
+  doCheck = false;
+
   meta = with lib; {
     description = "Basic building blocks for python applications";
-    homepage = https://github.com/AGProjects/python-application;
+    homepage = "https://github.com/AGProjects/python-application";
+    changelog = "https://github.com/AGProjects/python-application/blob/master/ChangeLog";
     license = licenses.lgpl2Plus;
   };
 }

--- a/pkgs/development/python-modules/python-otr/default.nix
+++ b/pkgs/development/python-modules/python-otr/default.nix
@@ -24,10 +24,13 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A pure python implementation of OTR";
-    homepage = https://github.com/AGProjects/otr;
+    homepage = "https://github.com/AGProjects/python-otr";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ edwtjo ];
+    # The package itself does not support python3, and its transitive
+    # dependencies rely on namespace package support that does not work in
+    # Nix's python2 infra. See #74619 for details.
+    broken = true;
   };
-
 }


### PR DESCRIPTION
The build is currently broken due to failure to build `darcs` to fetch the src
package. The homepage is already their GitHub repo, and it appears to be the
active src of development anyways. See #83718

I came across this while debugging this failure:
https://hydra.nixos.org/build/115510612

Note that the `application` dependency *does* succeed on Hydra, because it's
already on local disk in Hydra's store, but I cannot rebuild locally because it
has prefer local builds.
https://hydra.nixos.org/build/115512559

This package is not reproducible on 20.03 or buildable outside of Hydra, so I
intend to backport the fix.

CC @NixOS/nixos-release-managers

ZHF: #80379


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).