### PR TITLE
Factor out fetcher of Maven dependencies

### DIFF
--- a/pkgs/build-support/fetch-maven-deps.nix
+++ b/pkgs/build-support/fetch-maven-deps.nix
@@ -1,0 +1,32 @@
+# WARNING: this method of fetching dependencies is not deterministic, DO NOT USE IT if you can help it.
+#
+# Perform fake build to make a fixed-output derivation out of the dependencies required for build.
+# Afterwards build with ('maven.repo.local' must be writable so copy it out of nix store):
+#   mvn package --offline -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
+{ stdenv, maven }:
+
+{ src
+, sha256
+, nativeBuildInputs ? [ maven ]
+, mavenFlags ? ""
+, ...
+}@args:
+
+stdenv.mkDerivation ({
+  name = if args ? name then "${args.name}-maven-deps"
+  else if args ? pname && args ? version then "${args.pname}-${args.version}-maven-deps"
+  else "maven-deps";
+
+  inherit src nativeBuildInputs;
+
+  buildPhase = ''
+    while mvn package -Dmaven.repo.local=$out/.m2 ${mavenFlags} -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
+      echo "timeout, restart maven to continue downloading"
+    done
+  '';
+  # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+  installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = sha256;
+} // (removeAttrs args ["name" "pname" "version"]))

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -1,6 +1,5 @@
-{ stdenv, fetchFromGitHub, jdk, maven, makeWrapper, jre_headless, pcsclite }:
+{ stdenv, fetchFromGitHub, fetchMavenDeps, jdk, maven, makeWrapper, jre_headless, pcsclite }:
 
-# TODO: This is quite a bit of duplicated logic with gephi. Factor it out?
 stdenv.mkDerivation rec {
   pname = "global-platform-pro";
   version = "18.09.14";
@@ -13,25 +12,9 @@ stdenv.mkDerivation rec {
     sha256 = "1vws6cbgm3mrwc2xz9j1y262vw21x3hjc9m7rqc4hn3m7gjpwsvg";
   };
 
-  deps = stdenv.mkDerivation {
-    name = "${pname}-${version}-deps";
-    inherit src;
-    nativeBuildInputs = [ jdk maven ];
-    installPhase = ''
-      # Download the dependencies
-      while ! mvn package "-Dmaven.repo.local=$out/.m2" -Dmaven.wagon.rto=5000; do
-        echo "timeout, restart maven to continue downloading"
-      done
-
-      # And keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files
-      # with lastModified timestamps inside
-      find "$out/.m2" -type f \
-        -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' \
-        -delete
-    '';
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-    outputHash = "1qwgvz6l5wia8q5824c9f3iwyapfskljhqf1z09fw6jjj1jy3b15";
+  deps = fetchMavenDeps {
+    inherit pname version src;
+    sha256 = "1qwgvz6l5wia8q5824c9f3iwyapfskljhqf1z09fw6jjj1jy3b15";
   };
 
   nativeBuildInputs = [ jdk maven makeWrapper ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -276,6 +276,8 @@ in
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  fetchMavenDeps = callPackage ../build-support/fetch-maven-deps.nix { };
+
   prefer-remote-fetch = import ../build-support/prefer-remote-fetch;
 
   global-platform-pro = callPackage ../development/tools/global-platform-pro/default.nix { };


### PR DESCRIPTION
Currently there are 4 slowly-diverging copies. Also added limit on number of retries.

Tested gephi, exhibitor & global-platform-pro on my machine, hadoop is still building.

cc @volth @Radvendii @Ekleog @joelthompson
###### Motivation for this change

Was considering using the same approach for building jitsi-videobridge and jicofo, which would increase the number of copies to 6. The retry limit was added after staring at infinitely looping failing build for too long.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
