### PR TITLE
xow: init at 0.4

### DIFF
--- a/nixos/modules/hardware/uinput.nix
+++ b/nixos/modules/hardware/uinput.nix
@@ -1,0 +1,19 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.hardware.uinput;
+in {
+  options.hardware.uinput = {
+    enable = lib.mkEnableOption "Whether to enable uinput support";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelModules = [ "uinput" ];
+
+    users.groups.uinput = {};
+
+    services.udev.extraRules = ''
+      SUBSYSTEM=="misc", KERNEL=="uinput", MODE="0660", GROUP="uinput", OPTIONS+="static_node=uinput"
+    '';
+  };
+}

--- a/nixos/modules/hardware/uinput.nix
+++ b/nixos/modules/hardware/uinput.nix
@@ -4,7 +4,7 @@ let
   cfg = config.hardware.uinput;
 in {
   options.hardware.uinput = {
-    enable = lib.mkEnableOption "Whether to enable uinput support";
+    enable = lib.mkEnableOption "uinput support";
   };
 
   config = lib.mkIf cfg.enable {

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -65,6 +65,7 @@
   ./hardware/usb-wwan.nix
   ./hardware/onlykey.nix
   ./hardware/wooting.nix
+  ./hardware/uinput.nix
   ./hardware/video/amdgpu.nix
   ./hardware/video/amdgpu-pro.nix
   ./hardware/video/ati.nix
@@ -368,6 +369,7 @@
   ./services/hardware/thermald.nix
   ./services/hardware/undervolt.nix
   ./services/hardware/vdr.nix
+  ./services/hardware/xow.nix
   ./services/logging/SystemdJournal2Gelf.nix
   ./services/logging/awstats.nix
   ./services/logging/fluentd.nix

--- a/nixos/modules/services/hardware/xow.nix
+++ b/nixos/modules/services/hardware/xow.nix
@@ -1,0 +1,30 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.services.hardware.xow;
+in {
+  options.services.hardware.xow = {
+    enable = lib.mkEnableOption "Whether to enable xow or not.";
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.uinput.enable = true;
+
+    users.users.xow = {
+      group = "uinput";
+      isSystemUser = true;
+    };
+
+    systemd.services.xow = {
+      wantedBy = [ "multi-user.target" ];
+      description = "Xbox One Wireless Dongle Driver";
+      after = [ "systemd-udev-settle.service" ];
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.xow}/bin/xow
+        '';
+        User = "xow";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/hardware/xow.nix
+++ b/nixos/modules/services/hardware/xow.nix
@@ -4,27 +4,14 @@ let
   cfg = config.services.hardware.xow;
 in {
   options.services.hardware.xow = {
-    enable = lib.mkEnableOption "Whether to enable xow or not.";
+    enable = lib.mkEnableOption "xow as a systemd service";
   };
 
   config = lib.mkIf cfg.enable {
     hardware.uinput.enable = true;
 
-    users.users.xow = {
-      group = "uinput";
-      isSystemUser = true;
-    };
+    systemd.packages = [ pkgs.xow ];
 
-    systemd.services.xow = {
-      wantedBy = [ "multi-user.target" ];
-      description = "Xbox One Wireless Dongle Driver";
-      after = [ "systemd-udev-settle.service" ];
-      serviceConfig = {
-        ExecStart = ''
-          ${pkgs.xow}/bin/xow
-        '';
-        User = "xow";
-      };
-    };
+    services.udev.packages = [ pkgs.xow ];
   };
 }

--- a/pkgs/misc/drivers/xow/default.nix
+++ b/pkgs/misc/drivers/xow/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, libusb, gitMinimal }:
+
+stdenv.mkDerivation rec {
+  pname = "xow";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "medusalix";
+    repo = "xow";
+    rev = "v${version}";
+    sha256 = "03ajal91xi52svzy621aa4jcdf0vj4pqd52kljam0wryrlmcpbr3";
+  };
+
+  makeFlags = [ "BUILD=RELEASE" "VERSION=${version}" ];
+  enableParallelBuilding = true;
+  buildInputs = [ libusb ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp xow $out/bin
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/medusalix/xow";
+    description = "Linux driver for the Xbox One wireless dongle";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.pmiddend ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/misc/drivers/xow/default.nix
+++ b/pkgs/misc/drivers/xow/default.nix
@@ -1,32 +1,33 @@
-{ stdenv, fetchFromGitHub, libusb, gitMinimal }:
+{ stdenv, fetchFromGitHub, libusb }:
 
 stdenv.mkDerivation rec {
   pname = "xow";
-  version = "0.2";
+  version = "0.4";
 
   src = fetchFromGitHub {
     owner = "medusalix";
     repo = "xow";
     rev = "v${version}";
-    sha256 = "03ajal91xi52svzy621aa4jcdf0vj4pqd52kljam0wryrlmcpbr3";
+    sha256 = "1xkwcx2gqip9v2h3zjmrn7sgcck3midl5alhsmr3zivgdipamynv";
   };
 
-  makeFlags = [ "BUILD=RELEASE" "VERSION=${version}" ];
+  makeFlags = [
+    "BUILD=RELEASE"
+    "VERSION=${version}"
+    "BINDIR=${placeholder ''out''}/bin"
+    "UDEVDIR=${placeholder ''out''}/lib/udev/rules.d"
+    "MODLDIR=${placeholder ''out''}/lib/modules-load.d"
+    "MODPDIR=${placeholder ''out''}/lib/modprobe.d"
+    "SYSDDIR=${placeholder ''out''}/lib/systemd/system"
+  ];
   enableParallelBuilding = true;
   buildInputs = [ libusb ];
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    cp xow $out/bin
-    runHook postInstall
-  '';
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/medusalix/xow";
     description = "Linux driver for the Xbox One wireless dongle";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.pmiddend ];
+    maintainers = [ maintainers.jansol ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26011,6 +26011,8 @@ in
 
   xboxdrv = callPackage ../misc/drivers/xboxdrv { };
 
+  xow = callPackage ../misc/drivers/xow { };
+
   xbps = callPackage ../tools/package-management/xbps { };
 
   xcftools = callPackage ../tools/graphics/xcftools { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Taking over from #76185 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
