### PR TITLE
hcxdumptool: init at 6.0.5

### DIFF
--- a/pkgs/tools/security/hcxdumptool/default.nix
+++ b/pkgs/tools/security/hcxdumptool/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "hxcdumptool";
+  version = "6.0.5";
+
+  src = fetchFromGitHub {
+    owner = "ZerBea";
+    repo = "hcxdumptool";
+    rev = version;
+    sha256 = "0rh19lblz8wp8q2x123nlwvxq1pjq9zw12w18z83v2l2knjbc524";
+  };
+
+  buildInputs = [ openssl ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ZerBea/hcxdumptool";
+    description = "Small tool to capture packets from wlan devices";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ danielfullmer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4029,6 +4029,8 @@ in
 
   hcxtools = callPackage ../tools/security/hcxtools { };
 
+  hcxdumptool = callPackage ../tools/security/hcxdumptool { };
+
   hdapsd = callPackage ../os-specific/linux/hdapsd { };
 
   hdaps-gl = callPackage ../tools/misc/hdaps-gl { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This package is used by `wifite2`. I intend to update the `wifite2` package after this and `pyrit` are included in nixpkgs.

CC @dywedir  @Lassulus 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
