### PR TITLE
pyrit: init at 2019-12-13

### DIFF
--- a/pkgs/tools/security/pyrit/default.nix
+++ b/pkgs/tools/security/pyrit/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchFromGitHub, python2Packages, openssl, zlib, libpcap, opencl-headers, ocl-icd }:
+
+let
+  version = "2019-12-13";
+  src = fetchFromGitHub {
+    owner = "JPaulMora";
+    repo = "Pyrit";
+    rev = "f0f1913c645b445dd391fb047b812b5ba511782c";
+    sha256 = "1npkvngc4g3g6mpjip2wwhvcd4a75jy3dbddxhxhzrrz4p7259gr";
+  };
+
+  cpyrit_opencl = python2Packages.buildPythonPackage {
+    pname = "cpyrit-opencl";
+    inherit version;
+
+    src = "${src}/modules/cpyrit_opencl";
+
+    buildInputs = [ opencl-headers ocl-icd openssl zlib ];
+
+    postInstall = let
+      python = python2Packages.python;
+    in ''
+      # pyrit uses "import _cpyrit_cuda" so put the output in the root site-packages
+      mv $out/lib/${python.libPrefix}/site-packages/cpyrit/_cpyrit_opencl.so $out/lib/${python.libPrefix}/site-packages/
+    '';
+  };
+in
+python2Packages.buildPythonApplication rec {
+  pname = "pyrit";
+  inherit version src;
+
+  buildInputs = [ openssl zlib libpcap ];
+  propagatedBuildInputs = [ cpyrit_opencl ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/JPaulMora/Pyrit";
+    description = "GPGPU-driven WPA/WPA2-PSK key cracker";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ danielfullmer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2099,6 +2099,8 @@ in
 
   pyCA = python3Packages.callPackage ../applications/video/pyca {};
 
+  pyrit = callPackage ../tools/security/pyrit {};
+
   pyznap = python3Packages.callPackage ../tools/backup/pyznap {};
 
   procs = callPackage ../tools/admin/procs {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This package is used by `wifite2`. I intend to update the `wifite2` package after this and `hcxdumptool` are included in nixpkgs.

I've tested the opencl support works with nvidia by running `pyrit benchmark`, after setting `use_OpenCL = true` in `~/.pyrit/config`.

CC @Lassulus 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
