### PR TITLE
pythonPackages.pyarrow: remove dead code in preCheck, use pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchpatch, buildPythonPackage, python, isPy3k, arrow-cpp, cmake, cython, futures, hypothesis, numpy, pandas, pytest, pytest-lazy-fixture, pkgconfig, setuptools_scm, six }:
+{ lib, fetchpatch, buildPythonPackage, python, isPy3k, arrow-cpp, cmake, cython, futures, hypothesis, numpy, pandas, pytestCheckHook, pytest-lazy-fixture, pkgconfig, setuptools_scm, six }:
 
 let
   _arrow-cpp = arrow-cpp.override { inherit python; };
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ cmake cython pkgconfig setuptools_scm ];
   propagatedBuildInputs = [ numpy six ] ++ lib.optionals (!isPy3k) [ futures ];
-  checkInputs = [ hypothesis pandas pytest pytest-lazy-fixture ];
+  checkInputs = [ hypothesis pandas pytestCheckHook pytest-lazy-fixture ];
 
   PYARROW_BUILD_TYPE = "release";
   PYARROW_WITH_PARQUET = true;
@@ -34,6 +34,8 @@ buildPythonPackage rec {
     # ourselves
     "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
   ];
+  ARROW_HOME = _arrow-cpp;
+  PARQUET_HOME = _arrow-cpp;
 
   dontUseCmakeConfigure = true;
 
@@ -41,40 +43,12 @@ buildPythonPackage rec {
     export PYARROW_PARALLEL=$NIX_BUILD_CORES
   '';
 
+  dontUseSetuptoolsCheck = true;
   preCheck = ''
-    rm pyarrow/tests/test_jvm.py
-    rm pyarrow/tests/test_hdfs.py
-    rm pyarrow/tests/test_cuda.py
-
-    # fails: "ArrowNotImplementedError: Unsupported numpy type 22"
-    substituteInPlace pyarrow/tests/test_feather.py --replace "test_timedelta_with_nulls" "_disabled"
-
-    # runs out of memory on @grahamcofborg linux box
-    substituteInPlace pyarrow/tests/test_feather.py --replace "test_large_dataframe" "_disabled"
-
-    # probably broken on python2
-    substituteInPlace pyarrow/tests/test_feather.py --replace "test_unicode_filename" "_disabled"
-
-    # fails "error: [Errno 2] No such file or directory: 'test'" because
-    # nix_run_setup invocation somehow manages to import deserialize_buffer.py
-    # when it is not intended to be imported at all
-    rm pyarrow/tests/deserialize_buffer.py
-    substituteInPlace pyarrow/tests/test_feather.py --replace "test_deserialize_buffer_in_different_process" "_disabled"
-
-    # Fails to bind a socket
-    # "PermissionError: [Errno 1] Operation not permitted"
-    substituteInPlace pyarrow/tests/test_ipc.py --replace "test_socket_" "_disabled"
-  '';
-
-  ARROW_HOME = _arrow-cpp;
-  PARQUET_HOME = _arrow-cpp;
-
-  checkPhase = ''
     mv pyarrow/tests tests
     rm -rf pyarrow
     mkdir pyarrow
     mv tests pyarrow/tests
-    pytest -v
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
