### PR TITLE
rofi-emoji: init at 2.1.2

### DIFF
--- a/pkgs/applications/misc/rofi-emoji/0001-Patch-plugindir-to-output.patch
+++ b/pkgs/applications/misc/rofi-emoji/0001-Patch-plugindir-to-output.patch
@@ -1,0 +1,25 @@
+From 695e7a441fc28b874e65917fe2c0059b5b8ca749 Mon Sep 17 00:00:00 2001
+From: Cole Helbling <cole.e.helbling@outlook.com>
+Date: Sat, 28 Mar 2020 23:46:03 -0700
+Subject: [PATCH] Patch plugindir to output
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 75e476f..cb1ddf7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -55,7 +55,7 @@ PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0 ])
+ PKG_CHECK_MODULES([cairo],    [cairo])
+ PKG_CHECK_MODULES([rofi],     [rofi])
+ 
+-[rofi_PLUGIN_INSTALL_DIR]="`$PKG_CONFIG --variable=pluginsdir rofi`"
++[rofi_PLUGIN_INSTALL_DIR]="`echo $out/lib/rofi`"
+ AC_SUBST([rofi_PLUGIN_INSTALL_DIR])
+ 
+ LT_INIT([disable-static])
+-- 
+2.25.1
+

--- a/pkgs/applications/misc/rofi-emoji/default.nix
+++ b/pkgs/applications/misc/rofi-emoji/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, substituteAll
+, makeWrapper
+
+, autoreconfHook
+, pkgconfig
+
+, cairo
+, glib
+, libnotify
+, rofi-unwrapped
+, wl-clipboard
+, xclip
+, xsel
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rofi-emoji";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner = "Mange";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0knsvsdff2c7ww94120bq92735qrfriyd28mi0n72ccb2iikyi8b";
+  };
+
+  patches = [
+    # Look for plugin-related files in $out/lib/rofi
+    ./0001-Patch-plugindir-to-output.patch
+  ];
+
+  postPatch = ''
+    patchShebangs clipboard-adapter.sh
+  '';
+
+  postFixup = ''
+    chmod +x $out/share/rofi-emoji/clipboard-adapter.sh
+    wrapProgram $out/share/rofi-emoji/clipboard-adapter.sh \
+      --prefix PATH ":" ${lib.makeBinPath [ libnotify wl-clipboard xclip xsel ]}
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  buildInputs = [
+    cairo
+    glib
+    libnotify
+    makeWrapper
+    rofi-unwrapped
+    wl-clipboard
+    xclip
+    xsel
+  ];
+
+  meta = with lib; {
+    description = "An emoji selector plugin for Rofi";
+    homepage = "https://github.com/Mange/rofi-emoji";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cole-h ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/rofi/wrapper.nix
+++ b/pkgs/applications/misc/rofi/wrapper.nix
@@ -18,6 +18,7 @@ symlinkJoin {
     rm $out/bin/rofi
     makeWrapper ${rofi-unwrapped}/bin/rofi $out/bin/rofi \
       --prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share \
+      ${lib.optionalString (plugins != []) ''--prefix XDG_DATA_DIRS : ${lib.concatStringsSep ":" (lib.forEach plugins (p: "${p.out}/share"))}''} \
       ${lib.optionalString (theme != null) ''--add-flags "-theme ${theme}"''} \
       ${lib.optionalString (plugins != []) ''--add-flags "-plugin-path $out/lib/rofi"''}
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20675,6 +20675,8 @@ in
 
   rofi-calc = callPackage ../applications/science/math/rofi-calc { };
 
+  rofi-emoji = callPackage ../applications/misc/rofi-emoji { };
+
   ympd = callPackage ../applications/audio/ympd { };
 
   nload = callPackage ../applications/networking/nload { };


### PR DESCRIPTION
This plugin is intended to be supplied to the `rofi` wrapper through an
override:

    pkgs.rofi.override { plugins = [ rofi-emoji ]; }

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Takes inspiration from and relies on https://github.com/NixOS/nixpkgs/pull/83136.

This comes with a script that uses binaries like `notify-send`, `wl-copy`, `xclip`, `xsel`:
https://github.com/Mange/rofi-emoji/blob/61d6a795ef3703c4c5babd7dc861041c4f7d7e50/clipboard-adapter.sh.

~~Should I patch these to be absolute store paths with `substituteAll` (and thus relying on X11 binaries on Wayland and vice-versa), or is it fine as-is? Or is there another solution I haven't though of? I currently don't have any problems, but I'm on Arch and have these binaries in my PATH already.~~

I'm still curious whether or not it's "fine" to rely on the xclip/wl-clipboard binaries unconditionally. Maybe I should add `waylandSupport ? true` and `x11Support ? true` and make them optional (but requiring at least one of those to be set)?

---

To test, run the following:

```
nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/tarball/f0fe89357ea79c8a9fb35876a26f70ce7455cfee -p 'rofi.override { plugins = [ rofi-emoji ]; }' --run 'rofi -show emoji -modi emoji'
```

If you see a rofi window pop up with emoji, it works! Now see if you can select an emoji (with enter) and paste it somewhere. ~~If you can, I likely don't need to substitute the binaries in `clipboard-adapter.sh`; otherwise, I probably will have to.~~

EDIT: Updated the above easy-test command to point to new commits.