### PR TITLE
fwupd: 1.3.9 → 1.4.0

### DIFF
--- a/nixos/tests/installed-tests/default.nix
+++ b/nixos/tests/installed-tests/default.nix
@@ -91,6 +91,7 @@ in
   ibus = callInstalledTest ./ibus.nix {};
   libgdata = callInstalledTest ./libgdata.nix {};
   glib-testing = callInstalledTest ./glib-testing.nix {};
+  libjcat = callInstalledTest ./libjcat.nix {};
   libxmlb = callInstalledTest ./libxmlb.nix {};
   malcontent = callInstalledTest ./malcontent.nix {};
   ostree = callInstalledTest ./ostree.nix {};

--- a/nixos/tests/installed-tests/libjcat.nix
+++ b/nixos/tests/installed-tests/libjcat.nix
@@ -1,0 +1,5 @@
+{ pkgs, makeInstalledTest, ... }:
+
+makeInstalledTest {
+  tested = pkgs.libjcat;
+}

--- a/pkgs/development/libraries/libjcat/default.nix
+++ b/pkgs/development/libraries/libjcat/default.nix
@@ -1,0 +1,91 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, docbook_xml_dtd_43
+, docbook-xsl-nons
+, glib
+, json-glib
+, gnutls
+, gpgme
+, gobject-introspection
+, vala
+, help2man
+, gtk-doc
+, meson
+, ninja
+, pkg-config
+, python3
+, nixosTests
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libjcat";
+  version = "0.1.1";
+
+  outputs = [ "bin" "out" "dev" "devdoc" "man" "installedTests" ];
+
+  src = fetchFromGitHub {
+    owner = "hughsie";
+    repo = "libjcat";
+    rev = version;
+    sha256 = "hWJUzpQvy2V4pS8C/nW7Xrs9U9LQWMsGuTVOnm5UJc0=";
+  };
+
+  patches = [
+    # Installed tests are installed to different output
+    ./installed-tests-path.patch
+
+    # Fix version file generation
+    (fetchpatch {
+      url = "https://github.com/hughsie/libjcat/commit/cf2d9298a5fab7278ee040bc0b4be384a7b5538e.patch";
+      sha256 = "3749qih+wfhU8ECklh5BvReJ7pS+Ao1Q7YueZ1tT0Is=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    docbook_xml_dtd_43
+    docbook-xsl-nons
+    gobject-introspection
+    vala
+    help2man
+    gtk-doc
+    (python3.withPackages (pkgs: with pkgs; [
+      setuptools
+    ]))
+  ];
+
+  buildInputs = [
+    glib
+    json-glib
+    gnutls
+    gpgme
+  ];
+
+  mesonFlags = [
+    "-Dgtkdoc=true"
+    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+  ];
+
+  postPatch = ''
+    patchShebangs contrib/generate-version-script.py
+  '';
+
+  doCheck = true;
+
+  passthru = {
+    tests = {
+      installed-tests = nixosTests.installed-tests.libjcat;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Library for reading and writing Jcat files";
+    homepage = "https://github.com/hughsie/libjcat";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libjcat/installed-tests-path.patch
+++ b/pkgs/development/libraries/libjcat/installed-tests-path.patch
@@ -1,0 +1,24 @@
+diff --git a/meson.build b/meson.build
+index f69968d..d1d6c6e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -114,8 +114,8 @@ else
+   datadir = join_paths(prefix, get_option('datadir'))
+   localstatedir = join_paths(prefix, get_option('localstatedir'))
+   libexecdir = join_paths(prefix, get_option('libexecdir'))
+-  installed_test_bindir = join_paths(libexecdir, 'installed-tests', meson.project_name())
+-  installed_test_datadir = join_paths(datadir, 'installed-tests', meson.project_name())
++  installed_test_bindir = join_paths(get_option('installed_test_prefix'), 'libexec', 'installed-tests', meson.project_name())
++  installed_test_datadir = join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests', meson.project_name())
+ endif
+ mandir = join_paths(prefix, get_option('mandir'))
+ localedir = join_paths(prefix, get_option('localedir'))
+diff --git a/meson_options.txt b/meson_options.txt
+index 4784300..d382fc1 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1,3 +1,4 @@
++option('installed_test_prefix', type: 'string', value: '', description: 'Prefix for installed tests')
+ option('gtkdoc', type : 'boolean', value : false, description : 'enable developer documentation')
+ option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')
+ option('tests', type : 'boolean', value : true, description : 'enable tests')

--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,5 +1,5 @@
 diff --git a/data/meson.build b/data/meson.build
-index 0667bd78..92d6c7b9 100644
+index bb749fd4..b611875b 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -17,7 +17,7 @@ endif
@@ -12,41 +12,38 @@ index 0667bd78..92d6c7b9 100644
  endif
  
 diff --git a/data/pki/meson.build b/data/pki/meson.build
-index eefcc914..dc801fa1 100644
+index 94bb0b6f..1ea6a9ac 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
-@@ -4,14 +4,14 @@ if get_option('gpg')
-       'GPG-KEY-Linux-Foundation-Firmware',
-       'GPG-KEY-Linux-Vendor-Firmware-Service',
-     ],
--    install_dir : join_paths(sysconfdir, 'pki', 'fwupd')
-+    install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd')
-   )
+@@ -3,24 +3,23 @@ install_data([
+     'GPG-KEY-Linux-Foundation-Firmware',
+     'GPG-KEY-Linux-Vendor-Firmware-Service',
+   ],
+-  install_dir : join_paths(sysconfdir, 'pki', 'fwupd')
++  install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd')
+ )
  
-   install_data([
-       'GPG-KEY-Linux-Foundation-Metadata',
-       'GPG-KEY-Linux-Vendor-Firmware-Service',
-     ],
--    install_dir : join_paths(sysconfdir, 'pki', 'fwupd-metadata')
-+    install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
-   )
- endif
+ install_data([
+     'GPG-KEY-Linux-Foundation-Metadata',
+     'GPG-KEY-Linux-Vendor-Firmware-Service',
+   ],
+-  install_dir : join_paths(sysconfdir, 'pki', 'fwupd-metadata')
++  install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
+ )
  
-@@ -19,12 +19,12 @@ if get_option('pkcs7')
-   install_data([
-       'LVFS-CA.pem',
-     ],
--    install_dir : join_paths(sysconfdir, 'pki', 'fwupd')
-+    install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd')
-   )
-   install_data([
-       'LVFS-CA.pem',
-     ],
--    install_dir : join_paths(sysconfdir, 'pki', 'fwupd-metadata')
-+    install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
-   )
- endif
- 
+ install_data([
+     'LVFS-CA.pem',
+   ],
+-  install_dir : join_paths(sysconfdir, 'pki', 'fwupd')
++  install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd')
+ )
+ install_data([
+     'LVFS-CA.pem',
+   ],
+-  install_dir : join_paths(sysconfdir, 'pki', 'fwupd-metadata')
++  install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
+ )
+-
 diff --git a/data/remotes.d/meson.build b/data/remotes.d/meson.build
 index 826a3c1d..b78db663 100644
 --- a/data/remotes.d/meson.build
@@ -76,10 +73,10 @@ index 826a3c1d..b78db663 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index b1a523d2..aacb8e0a 100644
+index 87ea67e5..3a4374db 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -169,6 +169,12 @@ endif
+@@ -175,6 +175,12 @@ endif
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
  
@@ -93,10 +90,10 @@ index b1a523d2..aacb8e0a 100644
  gio = dependency('gio-2.0', version : '>= 2.45.8')
  giounix = dependency('gio-unix-2.0', version : '>= 2.45.8', required: false)
 diff --git a/meson_options.txt b/meson_options.txt
-index be0adfef..73983333 100644
+index 3da9b6c4..6c80275b 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -26,6 +26,7 @@ option('plugin_coreboot', type : 'boolean', value : true, description : 'enable
+@@ -24,6 +24,7 @@ option('plugin_coreboot', type : 'boolean', value : true, description : 'enable
  option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
  option('systemdunitdir', type: 'string', value: '', description: 'Directory for systemd units')
  option('elogind', type : 'boolean', value : false, description : 'enable elogind support')
@@ -104,6 +101,19 @@ index be0adfef..73983333 100644
  option('tests', type : 'boolean', value : true, description : 'enable tests')
  option('udevdir', type: 'string', value: '', description: 'Directory for udev rules')
  option('efi-cc', type : 'string', value : 'gcc', description : 'the compiler to use for EFI modules')
+diff --git a/plugins/ata/meson.build b/plugins/ata/meson.build
+index 8444bb8a..fa4a8ad1 100644
+--- a/plugins/ata/meson.build
++++ b/plugins/ata/meson.build
+@@ -7,7 +7,7 @@ install_data([
+ )
+ 
+ install_data(['ata.conf'],
+-  install_dir:  join_paths(sysconfdir, 'fwupd')
++  install_dir:  join_paths(sysconfdir_install, 'fwupd')
+ )
+ 
+ shared_module('fu_plugin_ata',
 diff --git a/plugins/dell-esrt/meson.build b/plugins/dell-esrt/meson.build
 index ed4eee70..76dbdb1d 100644
 --- a/plugins/dell-esrt/meson.build
@@ -142,10 +152,10 @@ index 06ab34ee..297a9182 100644
  # we use functions from 2.52 in the tests
  if get_option('tests') and umockdev.found() and gio.version().version_compare('>= 2.52')
 diff --git a/plugins/uefi/meson.build b/plugins/uefi/meson.build
-index 7252580d..7188d1c5 100644
+index 5838cecc..9ba3d5cd 100644
 --- a/plugins/uefi/meson.build
 +++ b/plugins/uefi/meson.build
-@@ -104,7 +104,7 @@ if get_option('man')
+@@ -101,7 +101,7 @@ if get_option('man')
  endif
  
  install_data(['uefi.conf'],

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -2,6 +2,7 @@
 
 { stdenv
 , fetchurl
+, fetchpatch
 , substituteAll
 , gtk-doc
 , pkgconfig
@@ -16,7 +17,7 @@
 , glib-networking
 , libsoup
 , help2man
-, gpgme
+, libjcat
 , libxslt
 , elfutils
 , libsmbios
@@ -31,7 +32,6 @@
 , docbook_xsl
 , ninja
 , gcab
-, gnutls
 , python3
 , wrapGAppsHook
 , json-glib
@@ -87,11 +87,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "fwupd";
-  version = "1.3.9";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-    sha256 = "ZuRG+UN8ebXv5Z8fOYWT0eCtHykGXoB8Ysu3wAeqx0A=";
+    sha256 = "V131/l05FKYFavRMXRaiW1bQkTCEn7MTyyD+bqYClU4=";
   };
 
   # libfwupd goes to lib
@@ -130,9 +130,8 @@ stdenv.mkDerivation rec {
     libyaml
     libgudev
     colord
-    gpgme
+    libjcat
     libuuid
-    gnutls
     glib-networking
     json-glib
     umockdev
@@ -151,15 +150,43 @@ stdenv.mkDerivation rec {
     ./fix-paths.patch
     ./add-option-for-installation-sysconfdir.patch
 
-    # install plug-ins and libfwupdplugin to out,
-    # they are not really part of the library
+    # Install plug-ins and libfwupdplugin to out,
+    # they are not really part of the library.
     ./install-fwupdplugin-to-out.patch
 
-    # installed tests are installed to different output
-    # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle
+    # Make it easier to patch installed-tests directory.
+    # https://github.com/fwupd/fwupd/pull/2002
+    (fetchpatch {
+      url = "https://github.com/fwupd/fwupd/commit/2f12e38e61d982dea63778736e2b71d16f0e9925.patch";
+      sha256 = "goTyDj0v50FOQYCS+LhPjo0AEugubr6aBIGfO9ztZOA=";
+    })
+
+    # Install systemd files to our prefix.
+    # https://github.com/fwupd/fwupd/pull/2006
+    (fetchpatch {
+      url = "https://github.com/fwupd/fwupd/commit/463db5162fe4f6fea417973ff95a44ed51ec6402.patch";
+      sha256 = "I0TIfnCca83QpINABUINtl8nIB78dG8OR9MC/hP2hg8=";
+    })
+
+    # Fix installed tests.
+    # https://github.com/fwupd/fwupd/issues/2007
+    (fetchpatch {
+      url = "https://github.com/fwupd/fwupd/commit/c727742df3702fc934e2d9488c883dcbdfa59e9c.patch";
+      sha256 = "b9D2Xblf1VbpS5XZpHtwEJhzuq7+840l7skW5w0NMBU=";
+    })
+
+    # Fix build with bash-completion 2.10
+    # https://github.com/fwupd/fwupd/pull/2014
+    (fetchpatch {
+      url = "https://github.com/fwupd/fwupd/commit/0f035013dfb150c2c3fc7f51090103ba84bd1c06.patch";
+      sha256 = "VXRf5N3inaWThudk6pc4mtp6cMEIyybkdfqKin+9XSw=";
+    })
+
+    # Installed tests are installed to different output
+    # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle.
     (substituteAll {
       src = ./installed-tests-path.patch;
-      # needs a different set of modules than po/make-images
+      # Needs a different set of modules than po/make-images.
       inherit installedTestsPython;
     })
   ];
@@ -172,14 +199,6 @@ stdenv.mkDerivation rec {
       po/make-images \
       po/make-images.sh \
       po/test-deps
-
-    # we cannot use placeholder in substituteAll
-    # https://github.com/NixOS/nix/issues/1846
-    substituteInPlace data/installed-tests/meson.build --subst-var installedTests
-
-    substituteInPlace data/meson.build --replace \
-      "install_dir: systemd.get_pkgconfig_variable('systemdshutdowndir')" \
-      "install_dir: '${placeholder "out"}/lib/systemd/system-shutdown'"
   '';
 
   # /etc/os-release not available in sandbox
@@ -203,7 +222,8 @@ stdenv.mkDerivation rec {
     "-Dgtkdoc=true"
     "-Dplugin_dummy=true"
     "-Dudevdir=lib/udev"
-    "-Dsystemdunitdir=lib/systemd/system"
+    "-Dsystemd_root_prefix=${placeholder "out"}"
+    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
     "-Defi-libdir=${gnu-efi}/lib"
     "-Defi-ldsdir=${gnu-efi}/lib"
     "-Defi-includedir=${gnu-efi}/include/efi"
@@ -225,23 +245,19 @@ stdenv.mkDerivation rec {
     "-Dplugin_flashrom=true"
   ];
 
-  postInstall = ''
-    moveToOutput share/installed-tests "$installedTests"
-    wrapProgram $installedTests/share/installed-tests/fwupd/hardware.py \
-      --prefix GI_TYPELIB_PATH : "$out/lib/girepository-1.0:${libsoup}/lib/girepository-1.0"
-  '';
-
   FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
 
   # error: “PolicyKit files are missing”
   # https://github.com/NixOS/nixpkgs/pull/67625#issuecomment-525788428
   PKG_CONFIG_POLKIT_GOBJECT_1_ACTIONDIR = "/run/current-system/sw/share/polkit-1/actions";
 
-  # cannot install to systemd prefix
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMPRESETDIR = "${placeholder "out"}/lib/systemd/system-preset";
-
   # TODO: wrapGAppsHook wraps efi capsule even though it is not elf
   dontWrapGApps = true;
+
+  preCheck = ''
+    addToSearchPath XDG_DATA_DIRS "${shared-mime-info}/share"
+  '';
+
   # so we need to wrap the executables manually
   postFixup = ''
     find -L "$out/bin" "$out/libexec" -type f -executable -print0 \
@@ -256,6 +272,7 @@ stdenv.mkDerivation rec {
   # /etc/fwupd/uefi.conf is created by the services.hardware.fwupd NixOS module
   passthru = {
     filesInstalledToEtc = [
+      "fwupd/ata.conf"
       # "fwupd/daemon.conf" # already created by the module
       "fwupd/redfish.conf"
       "fwupd/remotes.d/dell-esrt.conf"

--- a/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
@@ -1,5 +1,5 @@
---- a/data/installed-tests/hardware.py
-+++ b/data/installed-tests/hardware.py
+--- a/data/device-tests/hardware.py
++++ b/data/device-tests/hardware.py
 @@ -1,4 +1,4 @@
 -#!/usr/bin/python3
 +#!@installedTestsPython@/bin/python3
@@ -8,18 +8,23 @@
  # Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
 --- a/data/installed-tests/meson.build
 +++ b/data/installed-tests/meson.build
-@@ -1,6 +1,6 @@
- con2 = configuration_data()
- con2.set('installedtestsdir',
--         join_paths(datadir, 'installed-tests', 'fwupd'))
-+         join_paths('@installedTests@', 'share', 'installed-tests', 'fwupd'))
- con2.set('bindir', bindir)
+@@ -1,4 +1,4 @@
+-installed_test_datadir = join_paths(datadir, 'installed-tests', 'fwupd')
++installed_test_datadir = join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests', 'fwupd')
  
- configure_file(
-@@ -52,5 +52,5 @@
+ con2 = configuration_data()
+ con2.set('installedtestsdir', installed_test_datadir)
+@@ -52,5 +52,5 @@ configure_file(
    output : 'fwupd-tests.conf',
    configuration : con2,
    install: true,
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
-+  install_dir: join_paths('@installedTests@', 'etc', 'fwupd', 'remotes.d'),
++  install_dir: join_paths(get_option('installed_test_prefix'), 'etc', 'fwupd', 'remotes.d'),
  )
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1,3 +1,4 @@
++option('installed_test_prefix', type: 'string', value: '', description: 'Prefix for installed tests')
+ option('build', type : 'combo', choices : ['all', 'standalone', 'library'], value : 'all', description : 'build type')
+ option('agent', type : 'boolean', value : true, description : 'enable the fwupd agent')
+ option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12981,6 +12981,8 @@ in
 
   libiptcdata = callPackage ../development/libraries/libiptcdata { };
 
+  libjcat = callPackage ../development/libraries/libjcat { };
+
   libjpeg_original = callPackage ../development/libraries/libjpeg { };
   libjpeg_turbo = callPackage ../development/libraries/libjpeg-turbo { };
   libjpeg_drop = callPackage ../development/libraries/libjpeg-drop { };


### PR DESCRIPTION
###### Motivation for this change
**jcat**
Will be needed by fwupd in the future

https://blogs.gnome.org/hughsie/2020/03/23/initial-release-of-jcat/

~~Installed tests fail at the moment: https://github.com/hughsie/libjcat/issues/19~~

**fwupd**

https://github.com/fwupd/fwupd/releases/tag/1.4.0
https://github.com/fwupd/fwupd/commit/a3d6ee0e29f333587dce1c68e153130a7d4b637f

Installed tests fail: https://github.com/fwupd/fwupd/issues/2007

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
