### PR TITLE
ghc-8.4.4.nix: Do not use git.haskell.org

### DIFF
--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [(fetchpatch {
-    url = "https://git.haskell.org/hsc2hs.git/patch/738f3666c878ee9e79c3d5e819ef8b3460288edf";
+    url = "https://github.com/haskell/hsc2hs/commit/738f3666c878ee9e79c3d5e819ef8b3460288edf.diff";
     sha256 = "0plzsbfaq6vb1023lsarrjglwgr9chld4q3m99rcfzx0yx5mibp3";
     extraPrefix = "utils/hsc2hs/";
     stripLen = 1;
@@ -110,7 +110,7 @@ stdenv.mkDerivation (rec {
     })
     ++ stdenv.lib.optional stdenv.isDarwin ./backport-dylib-command-size-limit.patch
     ++ stdenv.lib.optional (targetPlatform.isAarch32 || targetPlatform.isAarch64) (fetchpatch {
-      url = "https://git.haskell.org/ghc.git/patch/d8495549ba9d194815c2d0eaee6797fc7c00756a";
+      url = "https://github.com/ghc/ghc/commit/d8495549ba9d194815c2d0eaee6797fc7c00756a.diff";
       sha256 = "1yjcma507c609bcim4rnxq0gaj2dg4d001jklmbpbqpzqzxkn5sz";
     });
 


### PR DESCRIPTION
which was deprecated in 2018 and is now gone for good. I guess many
won’t notice because the nix-cache kept the files around?

(cherry picked from commits
b872b8a2009d68636fce8e4078dc9e65a70547fe and 29ca177c684cb42f0ea57171be5653b9b5060ba7)