### PR TITLE
Python remove setuptools check with pytest

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -46,4 +46,16 @@ function pytestCheckPhase() {
 if [ -z "${dontUsePytestCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
     echo "Using pytestCheckPhase"
     preDistPhases+=" pytestCheckPhase"
+
+    # It's almost always the case that setuptoolsCheckPhase should not be ran
+    # when the pytestCheckHook is being ran
+    if [ -z "${useSetuptoolsCheck-}" ]; then
+        dontUseSetuptoolsCheck=1
+
+        # Remove command if already injected into preDistPhases
+        if [[ "$preDistPhases" =~ "setuptoolsCheckPhase" ]]; then
+            echo "Removing setuptoolsCheckPhase"
+            preDistPhases=${preDistPhases/setuptoolsCheckPhase/}
+        fi
+    fi
 fi


### PR DESCRIPTION
###### Motivation for this change
Almost all uses of pytestCheckHook also has a `dontUseSetuptoolsCheckPhase`. 

This is to remove some boilerplate.

<details> <summary> python3Packages.azu;e-core test phase without changes </summary>

```
Executing pythonImportsCheckPhase
setuptoolsCheckPhase
Executing setuptoolsCheckPhase
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing azure_core.egg-info/PKG-INFO
writing dependency_links to azure_core.egg-info/dependency_links.txt
writing requirements to azure_core.egg-info/requires.txt
writing top-level names to azure_core.egg-info/top_level.txt
reading manifest file 'azure_core.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'azure_core.egg-info/SOURCES.txt'
running build_ext

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
Finished executing setuptoolsCheckPhase
pytestcachePhase
pytestCheckPhase
Executing pytestCheckPhase
============================= test session starts ==============================
platform linux -- Python 3.7.6, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /build/azure-core-1.3.0
collected 278 items / 128 deselected / 150 selected

tests/test_authentication.py .....                                       [  3%]
tests/test_basic_transport.py .....                                      [  6%]
tests/test_exceptions.py ...                                             [  8%]
tests/test_paging.py .....                                               [ 12%]
tests/test_pipeline.py ...........                                       [ 19%]
tests/test_polling.py ....                                               [ 22%]
tests/test_retry_policy.py .........                                     [ 28%]
tests/test_settings.py ................................................. [ 60%]
.......                                                                  [ 65%]
tests/test_tracing_decorator.py .......                                  [ 70%]
tests/test_tracing_policy.py .....                                       [ 73%]
tests/test_universal_pipeline.py ....                                    [ 76%]
tests/test_user_agent_policy.py ..                                       [ 77%]
tests/azure_core_asynctests/test_authentication.py ssss                  [ 80%]
tests/azure_core_asynctests/test_basic_transport.py sssss                [ 83%]
tests/azure_core_asynctests/test_paging.py sss                           [ 85%]
tests/azure_core_asynctests/test_pipeline.py ssss.                       [ 88%]
tests/azure_core_asynctests/test_retry_policy.py ......sss               [ 94%]
tests/azure_core_asynctests/test_tracing_decorator_async.py ssssss       [ 98%]
tests/azure_core_asynctests/test_universal_http.py ss                    [100%]

=============================== warnings summary ===============================
/nix/store/76grg8gcfk2mgb8dpxja2z76h9jzgxpq-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/mark/structures.py:327
  /nix/store/76grg8gcfk2mgb8dpxja2z76h9jzgxpq-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/mark/structures.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/nix/store/76grg8gcfk2mgb8dpxja2z76h9jzgxpq-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/mark/structures.py:327
  /nix/store/76grg8gcfk2mgb8dpxja2z76h9jzgxpq-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/mark/structures.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.trio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

tests/azure_core_asynctests/test_authentication.py::test_bearer_policy_adds_header
tests/azure_core_asynctests/test_authentication.py::test_bearer_policy_send
tests/azure_core_asynctests/test_authentication.py::test_bearer_policy_token_caching
tests/azure_core_asynctests/test_authentication.py::test_bearer_policy_enforces_tls
tests/azure_core_asynctests/test_basic_transport.py::test_basic_options_aiohttp
tests/azure_core_asynctests/test_basic_transport.py::test_multipart_send
tests/azure_core_asynctests/test_basic_transport.py::test_multipart_receive
tests/azure_core_asynctests/test_basic_transport.py::test_multipart_receive_with_bom
tests/azure_core_asynctests/test_basic_transport.py::test_recursive_multipart_receive
tests/azure_core_asynctests/test_paging.py::TestPaging::test_basic_paging
tests/azure_core_asynctests/test_paging.py::TestPaging::test_advance_paging
tests/azure_core_asynctests/test_paging.py::TestPaging::test_none_value
tests/azure_core_asynctests/test_pipeline.py::test_sans_io_exception
tests/azure_core_asynctests/test_pipeline.py::test_basic_aiohttp
tests/azure_core_asynctests/test_pipeline.py::test_basic_aiohttp_separate_session
tests/azure_core_asynctests/test_pipeline.py::test_async_transport_sleep
tests/azure_core_asynctests/test_retry_policy.py::test_retry_on_429
tests/azure_core_asynctests/test_retry_policy.py::test_retry_seekable_stream
tests/azure_core_asynctests/test_retry_policy.py::test_retry_seekable_file
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_decorator_tracing_attr
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_decorator_has_different_name
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_used
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_span_merge_span
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_span_complicated
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_span_with_exception
tests/azure_core_asynctests/test_universal_http.py::test_basic_aiohttp
tests/azure_core_asynctests/test_universal_http.py::test_aiohttp_auto_headers
  /nix/store/76grg8gcfk2mgb8dpxja2z76h9jzgxpq-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/python.py:157: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - pytest-asyncio
    - pytest-trio
    - pytest-tornasync
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(pyfuncitem.nodeid)))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========= 123 passed, 27 skipped, 128 deselected, 29 warnings in 2.95s =========
Finished executing pytestCheckPhase
```
</details>


<details> <summary> python3Packages.azure-core test phase with changes </summary>

```
Finished executing pythonRemoveTestsDir
running install tests
no Makefile or custom buildPhase, doing nothing
pythonCatchConflictsPhase
pythonRemoveBinBytecodePhase
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
pytestcachePhase
pytestCheckPhase
Executing pytestCheckPhase
============================= test session starts ==============================
platform linux -- Python 3.7.7, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /build/azure-core-1.3.0
collected 278 items / 128 deselected / 150 selected

tests/test_authentication.py .....                                       [  3%]
tests/test_basic_transport.py .....                                      [  6%]
tests/test_exceptions.py ...                                             [  8%]
tests/test_paging.py .....                                               [ 12%]
tests/test_pipeline.py ...........                                       [ 19%]
tests/test_polling.py ....                                               [ 22%]
tests/test_retry_policy.py .........                                     [ 28%]
tests/test_settings.py ................................................. [ 60%]
.......                                                                  [ 65%]
tests/test_tracing_decorator.py .......                                  [ 70%]
tests/test_tracing_policy.py .....                                       [ 73%]
tests/test_universal_pipeline.py ....                                    [ 76%]
tests/test_user_agent_policy.py ..                                       [ 77%]
tests/azure_core_asynctests/test_authentication.py ssss                  [ 80%]
tests/azure_core_asynctests/test_basic_transport.py sssss                [ 83%]
tests/azure_core_asynctests/test_paging.py sss                           [ 85%]
tests/azure_core_asynctests/test_pipeline.py ssss.                       [ 88%]
tests/azure_core_asynctests/test_retry_policy.py ......sss               [ 94%]
tests/azure_core_asynctests/test_tracing_decorator_async.py ssssss       [ 98%]
tests/azure_core_asynctests/test_universal_http.py ss                    [100%]

=============================== warnings summary ===============================
/nix/store/d8m79w1jgpg5mzll6a6513kpjp4rm6mv-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/mark/structures.py:327
  /nix/store/d8m79w1jgpg5mzll6a6513kpjp4rm6mv-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/mark/structures.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/nix/store/d8m79w1jgpg5mzll6a6513kpjp4rm6mv-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/mark/structures.py:327
  /nix/store/d8m79w1jgpg5mzll6a6513kpjp4rm6mv-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/mark/structures.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.trio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

tests/azure_core_asynctests/test_authentication.py::test_bearer_policy_adds_header
tests/azure_core_asynctests/test_authentication.py::test_bearer_policy_send
tests/azure_core_asynctests/test_authentication.py::test_bearer_policy_token_caching
tests/azure_core_asynctests/test_authentication.py::test_bearer_policy_enforces_tls
tests/azure_core_asynctests/test_basic_transport.py::test_basic_options_aiohttp
tests/azure_core_asynctests/test_basic_transport.py::test_multipart_send
tests/azure_core_asynctests/test_basic_transport.py::test_multipart_receive
tests/azure_core_asynctests/test_basic_transport.py::test_multipart_receive_with_bom
tests/azure_core_asynctests/test_basic_transport.py::test_recursive_multipart_receive
tests/azure_core_asynctests/test_paging.py::TestPaging::test_basic_paging
tests/azure_core_asynctests/test_paging.py::TestPaging::test_advance_paging
tests/azure_core_asynctests/test_paging.py::TestPaging::test_none_value
tests/azure_core_asynctests/test_pipeline.py::test_sans_io_exception
tests/azure_core_asynctests/test_pipeline.py::test_basic_aiohttp
tests/azure_core_asynctests/test_pipeline.py::test_basic_aiohttp_separate_session
tests/azure_core_asynctests/test_pipeline.py::test_async_transport_sleep
tests/azure_core_asynctests/test_retry_policy.py::test_retry_on_429
tests/azure_core_asynctests/test_retry_policy.py::test_retry_seekable_stream
tests/azure_core_asynctests/test_retry_policy.py::test_retry_seekable_file
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_decorator_tracing_attr
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_decorator_has_different_name
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_used
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_span_merge_span
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_span_complicated
tests/azure_core_asynctests/test_tracing_decorator_async.py::TestAsyncDecorator::test_span_with_exception
tests/azure_core_asynctests/test_universal_http.py::test_basic_aiohttp
tests/azure_core_asynctests/test_universal_http.py::test_aiohttp_auto_headers
  /nix/store/d8m79w1jgpg5mzll6a6513kpjp4rm6mv-python3.7-pytest-5.3.5/lib/python3.7/site-packages/_pytest/python.py:157: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - pytest-asyncio
    - pytest-trio
    - pytest-tornasync
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(pyfuncitem.nodeid)))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========= 123 passed, 27 skipped, 128 deselected, 29 warnings in 2.98s =========
Finished executing pytestCheckPhase
/nix/store/pbnjbp7i78zzbdwsfd4az78xjcrp86w4-python3.7-azure-core-1.3.0
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
