### PR TITLE
matomo: 3.13.3 -> 3.13.4

### DIFF
--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -3,16 +3,16 @@
 let
   versions = {
     matomo = {
-      version = "3.13.3";
-      sha256 = "11mv7q33nhlz9ylsmwrhs315p14imr7sgr70gdbmi9p8jxc7kxrz";
+      version = "3.13.4";
+      sha256 = "0yd24hn3ajj5bhzv8f5xr6wpgh2ma9zilzbm9c1n225q553scgjw";
     };
 
     matomo-beta = {
-      version = "3.13.3";
+      version = "3.13.4";
       # `beta` examples: "b1", "rc1", null
       # TOOD when updating: use null if stable version is >= latest beta or release candidate
       beta = null;
-      sha256 = "11mv7q33nhlz9ylsmwrhs315p14imr7sgr70gdbmi9p8jxc7kxrz";
+      sha256 = "0yd24hn3ajj5bhzv8f5xr6wpgh2ma9zilzbm9c1n225q553scgjw";
     };
   };
   common = pname: { version, sha256, beta ? null }:


### PR DESCRIPTION
Updated both matomo and matomo-beta to the latest version

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
this should, hopefully, be the last release of the 3.* series. after this it's on to the big four point oh.  it contains security updates so recommend backporting. https://matomo.org/changelog/matomo-3-13-4/

###### Things done
Updated, tested install, ran tests, updated my server from my branch

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@aanderse @florianjacob 