### PR TITLE
Vim-plugins: add vim-rainbow

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -5151,6 +5151,17 @@ let
     };
   };
 
+    vim-rainbow = buildVimPluginFrom2Nix {
+    pname = "vim-rainbow";
+    version = "2019-01-13";
+    src = fetchFromGitHub {
+      owner = "frazrepo";
+      repo = "vim-rainbow";
+      rev = "a6c7fd5a2b0193b5dbd03f62ad820b521dea3290";
+      sha256 = "1cwgmh7h3gy69ig5s39mwxipgv6p6bvz38acb022h9apsq2bf5nf";
+    };
+  };
+
   vim-repeat = buildVimPluginFrom2Nix {
     pname = "vim-repeat";
     version = "2019-11-13";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -103,6 +103,7 @@ fenetikm/falcon
 fisadev/vim-isort
 flazz/vim-colorschemes
 floobits/floobits-neovim
+frazrepo/vim-rainbow
 freitass/todo.txt-vim
 frigoeu/psc-ide-vim
 fsharp/vim-fsharp


### PR DESCRIPTION
###### Motivation for this change
add widely used plugin

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
