### PR TITLE
nixos/dokuwiki: add support for multi-site, additional plugins and templates

### DIFF
--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -24,6 +24,7 @@ let
     $conf['savedir'] = '${cfg.stateDir}';
     $conf['superuser'] = '${toString cfg.superUser}';
     $conf['useacl'] = '${toString cfg.aclUse}';
+    $conf['disableactions'] = '${cfg.disableActions}';
     ${toString cfg.extraConfig}
   '';
 
@@ -142,6 +143,17 @@ let
           Create passwordHash easily by using:$ mkpasswd -5 password `pwgen 8 1`
           Example: <link xlink:href="https://github.com/splitbrain/dokuwiki/blob/master/conf/users.auth.php.dist"/>
           '';
+      };
+
+      disableActions = mkOption {
+        type = types.nullOr types.str;
+        default = "";
+        example = "search,register";
+        description = ''
+          Disable individual action modes. Refer to
+          <link xlink:href="https://www.dokuwiki.org/config:action_modes"/>
+          for details on supported values.
+        '';
       };
 
       extraConfig = mkOption {
@@ -358,7 +370,7 @@ in
       "d ${cfg.stateDir}/meta 0750 ${user} ${group} - -"
       "d ${cfg.stateDir}/pages 0750 ${user} ${group} - -"
       "d ${cfg.stateDir}/tmp 0750 ${user} ${group} - -"
-      "f ${cfg.usersFile} 0640 ${user} ${group} - ${pkg hostName cfg}/conf/users.auth.php.dist"
+      "C ${cfg.usersFile} 0640 ${user} ${group} - ${pkg hostName cfg}/share/dokuwiki/conf/users.auth.php.dist"
     ]) eachSite);
   };
 }

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -278,6 +278,10 @@ in
     {
       assertion = cfg.usersFile != null -> cfg.aclUse != false;
       message = "services.dokuwiki.${hostName}.aclUse must be true when usersFile is not null";
+    }
+    {
+      assertion = cfg.aclUse -> cfg.usersFile != null;
+      message = "services.dokuwiki.${hostName}.usersFile must be set if aclUse is true";
     }]) eachSite);
 
     services.phpfpm.pools = mapAttrs' (hostName: cfg: (

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -53,147 +53,146 @@ let
     '';
   };
 
-  siteOpts = {lib, name, ...}:
-  {
-  options = {
-    enable = mkEnableOption "DokuWiki web application.";
+  siteOpts = {lib, name, ...}: {
+    options = {
+      enable = mkEnableOption "DokuWiki web application.";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.dokuwiki;
-      description = "Which dokuwiki package to use.";
-    };
+      package = mkOption {
+        type = types.package;
+        default = pkgs.dokuwiki;
+        description = "Which dokuwiki package to use.";
+      };
 
-    hostName = mkOption {
-      type = types.str;
-      default = "localhost";
-      description = "FQDN for the instance.";
-    };
+      hostName = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "FQDN for the instance.";
+      };
 
-    stateDir = mkOption {
-      type = types.path;
-      default = "/var/lib/dokuwiki/${name}/data";
-      description = "Location of the dokuwiki state directory.";
-    };
+      stateDir = mkOption {
+        type = types.path;
+        default = "/var/lib/dokuwiki/${name}/data";
+        description = "Location of the dokuwiki state directory.";
+      };
 
-    acl = mkOption {
-      type = types.nullOr types.lines;
-      default = null;
-      example = "*               @ALL               8";
-      description = ''
-        Access Control Lists: see <link xlink:href="https://www.dokuwiki.org/acl"/>
-        Mutually exclusive with services.dokuwiki.aclFile
-        Set this to a value other than null to take precedence over aclFile option.
-      '';
-    };
-
-    aclFile = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      description = ''
-        Location of the dokuwiki acl rules. Mutually exclusive with services.dokuwiki.acl
-        Mutually exclusive with services.dokuwiki.acl which is preferred.
-        Consult documentation <link xlink:href="https://www.dokuwiki.org/acl"/> for further instructions.
-        Example: <link xlink:href="https://github.com/splitbrain/dokuwiki/blob/master/conf/acl.auth.php.dist"/>
-      '';
-    };
-
-    aclUse = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Necessary for users to log in into the system.
-        Also limits anonymous users. When disabled,
-        everyone is able to create and edit content.
-      '';
-    };
-
-    pluginsConfig = mkOption {
-      type = types.lines;
-      default = ''
-        $plugins['authad'] = 0;
-        $plugins['authldap'] = 0;
-        $plugins['authmysql'] = 0;
-        $plugins['authpgsql'] = 0;
-      '';
-      description = ''
-        List of the dokuwiki (un)loaded plugins.
-      '';
-    };
-
-    superUser = mkOption {
-      type = types.nullOr types.str;
-      default = "@admin";
-      description = ''
-        You can set either a username, a list of usernames (“admin1,admin2”), 
-        or the name of a group by prepending an @ char to the groupname
-        Consult documentation <link xlink:href="https://www.dokuwiki.org/config:superuser"/> for further instructions.
-      '';
-    };
-
-    usersFile = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      description = ''
-        Location of the dokuwiki users file. List of users. Format:
-        login:passwordhash:Real Name:email:groups,comma,separated 
-        Create passwordHash easily by using:$ mkpasswd -5 password `pwgen 8 1`
-        Example: <link xlink:href="https://github.com/splitbrain/dokuwiki/blob/master/conf/users.auth.php.dist"/>
+      acl = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        example = "*               @ALL               8";
+        description = ''
+          Access Control Lists: see <link xlink:href="https://www.dokuwiki.org/acl"/>
+          Mutually exclusive with services.dokuwiki.aclFile
+          Set this to a value other than null to take precedence over aclFile option.
         '';
-    };
-
-    extraConfig = mkOption {
-      type = types.nullOr types.lines;
-      default = null;
-      example = ''
-        $conf['title'] = 'My Wiki';
-        $conf['userewrite'] = 1;
-      '';
-      description = ''
-        DokuWiki configuration. Refer to
-        <link xlink:href="https://www.dokuwiki.org/config"/>
-        for details on supported values.
-      '';
-    };
-
-    poolConfig = mkOption {
-      type = with types; attrsOf (oneOf [ str int bool ]);
-      default = {
-        "pm" = "dynamic";
-        "pm.max_children" = 32;
-        "pm.start_servers" = 2;
-        "pm.min_spare_servers" = 2;
-        "pm.max_spare_servers" = 4;
-        "pm.max_requests" = 500;
       };
-      description = ''
-        Options for the dokuwiki PHP pool. See the documentation on <literal>php-fpm.conf</literal>
-        for details on configuration directives.
-      '';
-    };
 
-    nginx = mkOption {
-      type = types.submodule (
-        recursiveUpdate
-          (import ../web-servers/nginx/vhost-options.nix { inherit config lib; })
-          {
-            # Enable encryption by default,
-            options.forceSSL.default = true;
-            options.enableACME.default = true;
-          }
-      );
-      default = {forceSSL = true; enableACME = true;};
-      example = {
-        serverAliases = [
-          "wiki.\${config.networking.domain}"
-        ];
-        enableACME = false;
+      aclFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Location of the dokuwiki acl rules. Mutually exclusive with services.dokuwiki.acl
+          Mutually exclusive with services.dokuwiki.acl which is preferred.
+          Consult documentation <link xlink:href="https://www.dokuwiki.org/acl"/> for further instructions.
+          Example: <link xlink:href="https://github.com/splitbrain/dokuwiki/blob/master/conf/acl.auth.php.dist"/>
+        '';
       };
-      description = ''
-        With this option, you can customize the nginx virtualHost which already has sensible defaults for DokuWiki.
-      '';
+
+      aclUse = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Necessary for users to log in into the system.
+          Also limits anonymous users. When disabled,
+          everyone is able to create and edit content.
+        '';
+      };
+
+      pluginsConfig = mkOption {
+        type = types.lines;
+        default = ''
+          $plugins['authad'] = 0;
+          $plugins['authldap'] = 0;
+          $plugins['authmysql'] = 0;
+          $plugins['authpgsql'] = 0;
+        '';
+        description = ''
+          List of the dokuwiki (un)loaded plugins.
+        '';
+      };
+
+      superUser = mkOption {
+        type = types.nullOr types.str;
+        default = "@admin";
+        description = ''
+          You can set either a username, a list of usernames (“admin1,admin2”),
+          or the name of a group by prepending an @ char to the groupname
+          Consult documentation <link xlink:href="https://www.dokuwiki.org/config:superuser"/> for further instructions.
+        '';
+      };
+
+      usersFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Location of the dokuwiki users file. List of users. Format:
+          login:passwordhash:Real Name:email:groups,comma,separated
+          Create passwordHash easily by using:$ mkpasswd -5 password `pwgen 8 1`
+          Example: <link xlink:href="https://github.com/splitbrain/dokuwiki/blob/master/conf/users.auth.php.dist"/>
+          '';
+      };
+
+      extraConfig = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        example = ''
+          $conf['title'] = 'My Wiki';
+          $conf['userewrite'] = 1;
+        '';
+        description = ''
+          DokuWiki configuration. Refer to
+          <link xlink:href="https://www.dokuwiki.org/config"/>
+          for details on supported values.
+        '';
+      };
+
+      poolConfig = mkOption {
+        type = with types; attrsOf (oneOf [ str int bool ]);
+        default = {
+          "pm" = "dynamic";
+          "pm.max_children" = 32;
+          "pm.start_servers" = 2;
+          "pm.min_spare_servers" = 2;
+          "pm.max_spare_servers" = 4;
+          "pm.max_requests" = 500;
+        };
+        description = ''
+          Options for the dokuwiki PHP pool. See the documentation on <literal>php-fpm.conf</literal>
+          for details on configuration directives.
+        '';
+      };
+
+      nginx = mkOption {
+        type = types.submodule (
+          recursiveUpdate
+            (import ../web-servers/nginx/vhost-options.nix { inherit config lib; })
+            {
+              # Enable encryption by default,
+              options.forceSSL.default = true;
+              options.enableACME.default = true;
+            }
+        );
+        default = {forceSSL = true; enableACME = true;};
+        example = {
+          serverAliases = [
+            "wiki.\${config.networking.domain}"
+          ];
+          enableACME = false;
+        };
+        description = ''
+          With this option, you can customize the nginx virtualHost which already has sensible defaults for DokuWiki.
+        '';
+      };
     };
-  };
   };
 in
 {
@@ -244,52 +243,51 @@ in
 
     services.nginx = {
       enable = true;
-      
-       virtualHosts = mapAttrs (hostName: cfg:  mkMerge [ cfg.nginx {
-          root = mkForce "${pkg hostName cfg}/share/dokuwiki/";
-          extraConfig = "fastcgi_param HTTPS on;";
+      virtualHosts = mapAttrs (hostName: cfg:  mkMerge [ cfg.nginx {
+        root = mkForce "${pkg hostName cfg}/share/dokuwiki/";
+        extraConfig = "fastcgi_param HTTPS on;";
 
-          locations."~ /(conf/|bin/|inc/|install.php)" = {
-            extraConfig = "deny all;";
-          };
+        locations."~ /(conf/|bin/|inc/|install.php)" = {
+          extraConfig = "deny all;";
+        };
 
-          locations."~ ^/data/" = {
-            root = "${cfg.stateDir}";
-            extraConfig = "internal;";
-          };
+        locations."~ ^/data/" = {
+          root = "${cfg.stateDir}";
+          extraConfig = "internal;";
+        };
 
-          locations."~ ^/lib.*\.(js|css|gif|png|ico|jpg|jpeg)$" = {
-            extraConfig = "expires 365d;";
-          };
+        locations."~ ^/lib.*\.(js|css|gif|png|ico|jpg|jpeg)$" = {
+          extraConfig = "expires 365d;";
+        };
 
-          locations."/" = {
-            priority = 1;
-            index = "doku.php";
-            extraConfig = ''try_files $uri $uri/ @dokuwiki;'';
-          };
+        locations."/" = {
+          priority = 1;
+          index = "doku.php";
+          extraConfig = ''try_files $uri $uri/ @dokuwiki;'';
+        };
 
-          locations."@dokuwiki" = {
-            extraConfig = ''
+        locations."@dokuwiki" = {
+          extraConfig = ''
               # rewrites "doku.php/" out of the URLs if you set the userwrite setting to .htaccess in dokuwiki config page
               rewrite ^/_media/(.*) /lib/exe/fetch.php?media=$1 last;
               rewrite ^/_detail/(.*) /lib/exe/detail.php?media=$1 last;
               rewrite ^/_export/([^/]+)/(.*) /doku.php?do=export_$1&id=$2 last;
               rewrite ^/(.*) /doku.php?id=$1&$args last;
-            '';
-          };
+          '';
+        };
 
-          locations."~ \.php$" = {
-            extraConfig = ''
+        locations."~ \.php$" = {
+          extraConfig = ''
               try_files $uri $uri/ /doku.php;
               include ${pkgs.nginx}/conf/fastcgi_params;
               fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
               fastcgi_param REDIRECT_STATUS 200;
               fastcgi_pass unix:${config.services.phpfpm.pools."dokuwiki-${hostName}".socket};
               fastcgi_param HTTPS on;
-            '';
-          };
-        }]) eachSite;
-      };
+          '';
+        };
+      }]) eachSite;
+    };
 
     systemd.tmpfiles.rules = flatten (mapAttrsToList (hostName: cfg: [
       "d ${stateDir cfg}/attic 0750 ${user} ${group} - -"
@@ -303,6 +301,5 @@ in
       "d ${stateDir cfg}/pages 0750 ${user} ${group} - -"
       "d ${stateDir cfg}/tmp 0750 ${user} ${group} - -"
     ]) eachSite);
-
   };
 }

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -7,7 +7,7 @@ let
 
   eachSite = config.services.dokuwiki;
 
-  user = config.services.nginx.user;
+  user = "dokuwiki";
   group = config.services.nginx.group;
 
   dokuwikiAclAuthConfig = cfg: pkgs.writeText "acl.auth.php" ''
@@ -372,5 +372,10 @@ in
       "d ${cfg.stateDir}/tmp 0750 ${user} ${group} - -"
       "C ${cfg.usersFile} 0640 ${user} ${group} - ${pkg hostName cfg}/share/dokuwiki/conf/users.auth.php.dist"
     ]) eachSite);
+
+    users.users.${user} = {
+      group = group;
+      isSystemUser = true;
+    };
   };
 }

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -57,7 +57,7 @@ let
     '';
   };
 
-  siteOpts = {lib, name, ...}: {
+  siteOpts = { config, lib, name, ...}: {
     options = {
       enable = mkEnableOption "DokuWiki web application.";
 
@@ -95,7 +95,7 @@ let
 
       aclFile = mkOption {
         type = with types; nullOr str;
-        default = null;
+        default = if (config.aclUse && config.acl == null) then "/var/lib/dokuwiki/${name}/users.auth.php" else null;
         description = ''
           Location of the dokuwiki acl rules. Mutually exclusive with services.dokuwiki.acl
           Mutually exclusive with services.dokuwiki.acl which is preferred.
@@ -140,7 +140,7 @@ let
 
       usersFile = mkOption {
         type = with types; nullOr str;
-        default = null;
+        default = if config.aclUse then "/var/lib/dokuwiki/${name}/users.auth.php" else null;
         description = ''
           Location of the dokuwiki users file. List of users. Format:
           login:passwordhash:Real Name:email:groups,comma,separated

--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -1,29 +1,42 @@
-import ./make-test-python.nix ({ lib, ... }:
-
-with lib;
+import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "dokuwiki";
-  meta.maintainers = with maintainers; [ maintainers."1000101" ];
+  meta.maintainers = with pkgs.lib.maintainers; [ "1000101" ];
 
-  nodes.machine =
-    { pkgs, ... }:
-    { services.dokuwiki = {
-        enable = true;
-        acl = " ";
-        superUser = null;
-        nginx = {
-          forceSSL = false;
-          enableACME = false;
-        };
-      }; 
+  machine = { ... }: {
+    services.dokuwiki."site1.local" = {
+      acl = " ";
+      superUser = null;
+      nginx = {
+        forceSSL = false;
+        enableACME = false;
+      };
     };
+    services.dokuwiki."site2.local" = {
+      acl = " ";
+      superUser = null;
+      nginx = {
+        forceSSL = false;
+        enableACME = false;
+      };
+    };
+    networking.hosts."127.0.0.1" = [ "site1.local" "site2.local" ];
+  };
 
   testScript = ''
-    machine.start()
-    machine.wait_for_unit("phpfpm-dokuwiki.service")
+    site_names = ["site1.local", "site2.local"]
+
+    start_all()
+
+    machine.wait_for_unit("phpfpm-dokuwiki-site1.local.service")
+    machine.wait_for_unit("phpfpm-dokuwiki-site2.local.service")
+
     machine.wait_for_unit("nginx.service")
+
     machine.wait_for_open_port(80)
-    machine.succeed("curl -sSfL http://localhost/ | grep 'DokuWiki'")
+
+    machine.succeed("curl -sSfL http://site1.local/ | grep 'DokuWiki'")
+    machine.succeed("curl -sSfL http://site2.local/ | grep 'DokuWiki'")
   '';
 })

--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -36,7 +36,7 @@ in {
 
   machine = { ... }: {
     services.dokuwiki."site1.local" = {
-      acl = " ";
+      aclUse = false;
       superUser = "admin";
       nginx = {
         forceSSL = false;
@@ -44,7 +44,7 @@ in {
       };
     };
     services.dokuwiki."site2.local" = {
-      acl = " ";
+      aclUse = true;
       superUser = "admin";
       nginx = {
         forceSSL = false;

--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -1,13 +1,43 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 
-{
+let
+  template-bootstrap3 = pkgs.stdenv.mkDerivation {
+    name = "bootstrap3";
+    # Download the theme from the dokuwiki site
+    src = pkgs.fetchurl {
+      url = https://github.com/giterlizzi/dokuwiki-template-bootstrap3/archive/v2019-05-22.zip;
+      sha256 = "4de5ff31d54dd61bbccaf092c9e74c1af3a4c53e07aa59f60457a8f00cfb23a6";
+    };
+    # We need unzip to build this package
+    buildInputs = [ pkgs.unzip ];
+    # Installing simply means copying all files to the output directory
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+
+  # Let's package the icalevents plugin
+  plugin-icalevents = pkgs.stdenv.mkDerivation {
+    name = "icalevents";
+    # Download the plugin from the dokuwiki site
+    src = pkgs.fetchurl {
+      url = https://github.com/real-or-random/dokuwiki-plugin-icalevents/releases/download/2017-06-16/dokuwiki-plugin-icalevents-2017-06-16.zip;
+      sha256 = "e40ed7dd6bbe7fe3363bbbecb4de481d5e42385b5a0f62f6a6ce6bf3a1f9dfa8";
+    };
+    # We need unzip to build this package
+    buildInputs = [ pkgs.unzip ];
+    sourceRoot = ".";
+    # Installing simply means copying all files to the output directory
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+in {
   name = "dokuwiki";
   meta.maintainers = with pkgs.lib.maintainers; [ "1000101" ];
 
   machine = { ... }: {
     services.dokuwiki."site1.local" = {
       acl = " ";
-      superUser = null;
+      superUser = "admin";
       nginx = {
         forceSSL = false;
         enableACME = false;
@@ -15,11 +45,13 @@ import ./make-test-python.nix ({ pkgs, ... }:
     };
     services.dokuwiki."site2.local" = {
       acl = " ";
-      superUser = null;
+      superUser = "admin";
       nginx = {
         forceSSL = false;
         enableACME = false;
       };
+      templates = [ template-bootstrap3 ];
+      plugins = [ plugin-icalevents ];
     };
     networking.hosts."127.0.0.1" = [ "site1.local" "site2.local" ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This MR introduces multi-site dokuwiki configurations (e.g. multiple nginx servers) using the <name?> option syntax. It also enables the use of additional plugins and templates similarly to how wordpress.nix does it.

So far everything seems to work fine, but marking as WIP since I'd like to do some manual testing first. I can split this up into two MRs if requested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
