### PR TITLE
[20.03] pythonPackages.scikit-build: fix python3.8 bug

### DIFF
--- a/pkgs/development/python-modules/scikit-build/default.nix
+++ b/pkgs/development/python-modules/scikit-build/default.nix
@@ -1,7 +1,28 @@
-{ lib, buildPythonPackage, fetchPypi, wheel, setuptools, packaging
-, cmake, ninja, cython, codecov, coverage, six, virtualenv, pathpy
-, pytest, pytestcov, pytest-virtualenv, pytest-mock, pytestrunner
-, requests, flake8 }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, distro
+, packaging
+, setuptools
+, wheel
+# Test Inputs
+, cmake
+, codecov
+, coverage
+, cython
+, flake8
+, ninja
+, pathpy
+, pytest
+, pytestcov
+, pytest-mock
+, pytestrunner
+, pytest-virtualenv
+, requests
+, six
+, virtualenv
+}:
 
 buildPythonPackage rec {
   pname = "scikit-build";
@@ -12,14 +33,40 @@ buildPythonPackage rec {
     sha256 = "7342017cc82dd6178e3b19377389b8a8d1f8b429d9cdb315cfb1094e34a0f526";
   };
 
-  propagatedBuildInputs = [ wheel setuptools packaging ];
-  checkInputs = [ 
-    cmake ninja cython codecov coverage six pathpy
-    pytest pytestcov pytest-mock pytest-virtualenv pytestrunner
-    requests flake8
+  propagatedBuildInputs = [
+    distro
+    packaging
+    setuptools
+    wheel
+  ];
+  checkInputs = [
+    cmake
+    codecov
+    coverage
+    cython
+    flake8
+    ninja
+    pathpy
+    pytest
+    pytestcov
+    pytest-mock
+    pytestrunner
+    pytest-virtualenv
+    requests
+    six
+    virtualenv
   ];
 
   dontUseCmakeConfigure = true;
+
+  # scikit-build PR #458. Remove in version > 0.10.0
+  patches = [
+    (fetchpatch {
+      name = "python38-platform_linux_distribution-fix-458";
+      url = "https://github.com/scikit-build/scikit-build/commit/faa7284e5bc4c72bc8744987acdf3297b5d2e7e4.patch";
+      sha256 = "1hgl3cnkf266zaw534b64c88waxfz9721wha0m6j3hsnxk76ayjv";
+    })
+  ];
 
   disabledTests = lib.concatMapStringsSep " and " (s: "not " + s) ([
     "test_hello_develop" # tries setuptools develop install
@@ -35,9 +82,9 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    homepage = http://scikit-build.org/;
     description = "Improved build system generator for CPython C/C++/Fortran/Cython extensions";
+    homepage = "http://scikit-build.org/";
     license = with licenses; [ mit bsd2 ]; # BSD due to reuses of PyNE code
-    maintainers = [ maintainers.FlorianFranzen ];
+    maintainers = with maintainers; [ FlorianFranzen ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Backports #83509 

ZHF: #80379 

Python3.8 removes ``platform.linux_distribution()`` call,
must use ``pythonPackages.distro`` to get same information.
Closes #83305
Upstream PR: https://www.github.com/scikit-build/scikit-build/pull/458
Also formatting.

(cherry picked from commit c8dd834189492ea1a0b24695f71e3c6e0da31b94)