### PR TITLE
litecli: 1.1.0 -> 1.3.2

### DIFF
--- a/pkgs/development/tools/database/litecli/default.nix
+++ b/pkgs/development/tools/database/litecli/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "litecli";
-  version = "1.1.0";
+  version = "1.3.2";
 
   # Python 2 won't have prompt_toolkit 2.x.x
   # See: https://github.com/NixOS/nixpkgs/blob/f49e2ad3657dede09dc998a4a98fd5033fb52243/pkgs/top-level/python-packages.nix#L3408
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication rec {
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0cqil2cmnbw0jvb14v6kbr7l9yarfgy253cbb8v9znp0l4qfs7ra";
+    sha256 = "0bfx7fw6jnkqxa82xvd10yx1w2wbmrrqxwbh4anp5x9wnl91a9lp";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -30,7 +30,8 @@ python3Packages.buildPythonApplication rec {
   preCheck = ''
     export XDG_CONFIG_HOME=$TMP
     # add missing file
-    echo "litecli is awesome!" > tests/test.txt
+    mkdir -p tests/data
+    echo -e "t1,11\nt2,22\n" > tests/data/import_data.csv
   '';
 
   meta = with lib; {


### PR DESCRIPTION
ZHF: #80379

https://hydra.nixos.org/build/115529461

Fixed tests: The 1.3.2 release tarball is missing a csv file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
