### PR TITLE
pythonPackages.fcmaes: init at 0.9.5.7

### DIFF
--- a/pkgs/development/python-modules/fcmaes/default.nix
+++ b/pkgs/development/python-modules/fcmaes/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, armadillo
+, buildPythonPackage
+, cmake
+, fetchPypi
+, isPy27
+, mkl
+, pytestCheckHook
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "fcmaes";
+  version = "0.9.5.7";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1za05afp6x98dmdj61brkkdfzkgv0ixyafp8zh94fa001vs2qrvl";
+  };
+  
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  # Fix the configuration of the internal library:
+  #   - unset the C++ compiler (clang++);
+  #   - fix the installation path;
+  #   - install without sudo (unnessary since the library is installed locally).
+  preConfigure = ''
+    sed -i '/clang/d' _fcmaescpp/CMakeLists.txt
+    sed -i 's!../fcmaes!../fcmaes/lib!' _fcmaescpp/CMakeLists.txt
+    sed -i 's/sudo//' _fcmaescpp/install.sh
+  '';
+
+  # Build the internal library, using the install script:
+  #   - run cmake/make in the _fcmaescpp folder;
+  #   - install the built lib to the fcmaes/lib/ folder (as expected by the
+  #     python module).
+  preBuild = ''
+    cd _fcmaescpp
+    sh install.sh
+    cd ..
+  '';
+
+  propagatedBuildInputs = [
+    armadillo
+    mkl
+    scipy
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Fast Python implementation of the CMA-ES optimization algorithm";
+    homepage = "https://github.com/dietmarwo/fast-cma-es";
+    license = licenses.mit;
+    maintainers = with maintainers; [ juliendehos ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2724,6 +2724,8 @@ in {
 
   fb-re2 = callPackage ../development/python-modules/fb-re2 { };
 
+  fcmaes = callPackage ../development/python-modules/fcmaes { };
+
   ffmpeg-python = callPackage ../development/python-modules/ffmpeg-python { };
 
   fenics = callPackage ../development/libraries/science/math/fenics {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds `fcmaes`.
Should also help packaging `nevergrad` https://github.com/NixOS/nixpkgs/pull/80424#issuecomment-605820661

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
