### PR TITLE
tdesktop: 1.9.21 -> 2.0.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -19,12 +19,12 @@ with lib;
 
 mkDerivation rec {
   pname = "telegram-desktop";
-  version = "2.0.0";
+  version = "2.0.1";
 
   # Telegram-Desktop with submodules
   src = fetchurl {
     url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "1ayyrb1z1hbmglshc4qif2zs2vysfj9c97wxkk00ll9d79w50hqx";
+    sha256 = "0g3jw4can9gmp48s3b8s1w8n9xi54i142y74fszxf9jyq5drzlff";
   };
 
   postPatch = ''

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -19,12 +19,12 @@ with lib;
 
 mkDerivation rec {
   pname = "telegram-desktop";
-  version = "1.9.21";
+  version = "2.0.0";
 
   # Telegram-Desktop with submodules
   src = fetchurl {
     url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "1b7z68q2sb2y203nf4p6lmz72zkpi5gyv9ypqi5h99bm2j6bbyg1";
+    sha256 = "1ayyrb1z1hbmglshc4qif2zs2vysfj9c97wxkk00ll9d79w50hqx";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It was usable without any issues so far, but unfortunately there seem to be a few regressions behind the scene. At least some errors are printed to the console.

X11:
```
error: : cannot open
error: : cannot open
error: : cannot open
```

Wayland (unfortunately it deterministically segfaults after exiting):
```
error: : cannot open
error: : cannot open
error: : cannot open
Using the 'xdg-shell' shell integration
Segmentation fault (core dumped)
```

It's also possible that the first launch on Wayland always results in a frozen telegram-desktop, but at least it works after closing the window and launching it again...

Strace reveals the following:
```
14322 statx(26, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL,  <unfinished ...>
14316 openat(AT_FDCWD, ".hz", O_RDONLY <unfinished ...>
14338 access("/nix/store/kp60cyq5iig35gzp7l2pr0ilxxa4m919-bash-interactive-4.4-p23/lib/qt-5.12.7/plugins/bearer/.", F_OK <unfinished ...>
14321 <... statx resumed>{stx_mask=STATX_ALL, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=4868, ...}) = 0
14316 <... openat resumed>)             = -1 ENOENT (No such file or directory)
14338 <... access resumed>)             = -1 ENOENT (No such file or directory)
14322 <... statx resumed>{stx_mask=STATX_ALL, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=51588, ...}) = 0
14316 write(2, "error: : cannot open\n", 21 <unfinished ...>
14338 access("/nix/store/mwfy3ihfydvrjmsimbd2kkr20n9abqsv-patchelf-0.9/lib/qt-5.12.7/plugins/bearer/.", F_OK <unfinished ...>
14321 lseek(25, 4, SEEK_SET <unfinished ...>
14338 <... access resumed>)             = -1 ENOENT (No such file or directory)
14322 lseek(26, 4, SEEK_SET <unfinished ...>
14316 <... write resumed>)              = 21
14321 <... lseek resumed>)              = 4
14322 <... lseek resumed>)              = 4
14316 openat(AT_FDCWD, "", O_RDONLY <unfinished ...>
14321 read(25,  <unfinished ...>
14316 <... openat resumed>)             = -1 ENOENT (No such file or directory)
14338 access("/nix/store/1wb31gzrjw055xl6d3igzj1gnajzlwbk-gcc-wrapper-9.2.0/lib/qt-5.12.7/plugins/bearer/.", F_OK <unfinished ...>
14316 openat(AT_FDCWD, ".hz", O_RDONLY <unfinished ...>
14321 <... read resumed>"\315r-\202\330\206f&\352\367\215\2\20\307\373\263r\223o\324\225\257GL\311n\35\373,sw\212"..., 16384) = 4864
14316 <... openat resumed>)             = -1 ENOENT (No such file or directory)
14338 <... access resumed>)             = -1 ENOENT (No such file or directory)
14316 write(2, "error: : cannot open\n", 21 <unfinished ...>
14321 read(25,  <unfinished ...>
14316 <... write resumed>)              = 21
14338 access("/nix/store/gh9a48qcwzw588vy4w72w93kad0mhhi8-gcc-9.2.0/lib/qt-5.12.7/plugins/bearer/.", F_OK <unfinished ...>
14321 <... read resumed>"", 11520)      = 0
14338 <... access resumed>)             = -1 ENOENT (No such file or directory)
14321 statx(25, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL,  <unfinished ...>
14338 access("/nix/store/c2lx3lsqp0y5kwvwkqma8iihc7xjj1m8-glibc-2.30-bin/lib/qt-5.12.7/plugins/bearer/.", F_OK <unfinished ...>
14316 openat(AT_FDCWD, "", O_RDONLY <unfinished ...>
14321 <... statx resumed>{stx_mask=STATX_ALL, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=4868, ...}) = 0
14316 <... openat resumed>)             = -1 ENOENT (No such file or directory)
14338 <... access resumed>)             = -1 ENOENT (No such file or directory)
14316 openat(AT_FDCWD, ".hz", O_RDONLY <unfinished ...>
14321 futex(0x357d674, FUTEX_WAKE_PRIVATE, 1 <unfinished ...>
14316 <... openat resumed>)             = -1 ENOENT (No such file or directory)
14338 access("/nix/store/hzvl3dvv8651iqlb5g6gq5hzjzmhjn7m-coreutils-8.31/lib/qt-5.12.7/plugins/bearer/.", F_OK <unfinished ...>
14321 <... futex resumed>)              = 1
14320 <... futex resumed>)              = 0
14316 write(2, "error: : cannot open\n", 21 <unfinished ...>
14338 <... access resumed>)             = -1 ENOENT (No such file or directory)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
