### PR TITLE
tensorflow-estimator-1.x: Put back comment

### DIFF
--- a/pkgs/development/python-modules/tensorflow-estimator/1/default.nix
+++ b/pkgs/development/python-modules/tensorflow-estimator/1/default.nix
@@ -6,6 +6,9 @@
 
 buildPythonPackage rec {
   pname = "tensorflow-estimator";
+  # This is effectively 1.15.0. Upstream tagged 1.15.0 by mistake before
+  # actually updating the version in setup.py, which is why this tag is called
+  # 1.15.1.
   version = "1.15.1";
   format = "wheel";
 


### PR DESCRIPTION
###### Motivation for this change

This was removed in a version bump, and no added back when I made the old version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
