### PR TITLE
nghttp2: add python bindings as pythonPackages.nghttp2

### DIFF
--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -9,14 +9,16 @@
 , enableGetAssets ? false, libxml2 ? null
 , enableJemalloc ? false, jemalloc ? null
 , enableApp ? !stdenv.hostPlatform.isWindows
+, enablePython ? false, python ? null, cython ? null, ncurses ? null, setuptools ? null
 }:
 
 assert enableHpack -> jansson != null;
 assert enableAsioLib -> boost != null;
 assert enableGetAssets -> libxml2 != null;
 assert enableJemalloc -> jemalloc != null;
+assert enablePython -> python != null && cython != null && ncurses != null && setuptools != null;
 
-let inherit (stdenv.lib) optional; in
+let inherit (stdenv.lib) optional optionals optionalString; in
 
 stdenv.mkDerivation rec {
   pname = "nghttp2";
@@ -27,7 +29,8 @@ stdenv.mkDerivation rec {
     sha256 = "0kyrgd4s2pq51ps5z385kw1hn62m8qp7c4h6im0g4ibrf89qwxc2";
   };
 
-  outputs = [ "bin" "out" "dev" "lib" ];
+  outputs = [ "bin" "out" "dev" "lib" ]
+    ++ optional enablePython "python";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ]
@@ -37,16 +40,31 @@ stdenv.mkDerivation rec {
     ++ optional enableHpack jansson
     ++ optional enableAsioLib boost
     ++ optional enableGetAssets libxml2
-    ++ optional enableJemalloc jemalloc;
+    ++ optional enableJemalloc jemalloc
+    ++ optionals enablePython [ python ncurses setuptools ];
 
   enableParallelBuilding = true;
 
   configureFlags = [
     "--with-spdylay=no"
     "--disable-examples"
-    "--disable-python-bindings"
     (stdenv.lib.enableFeature enableApp "app")
-  ] ++ optional enableAsioLib "--enable-asio-lib --with-boost-libdir=${boost}/lib";
+  ] ++ optional enableAsioLib "--enable-asio-lib --with-boost-libdir=${boost}/lib"
+    ++ (if enablePython then [
+    "--with-cython=${cython}/bin/cython"
+  ] else [
+    "--disable-python-bindings"
+  ]);
+
+  preInstall = optionalString enablePython ''
+    mkdir -p $out/${python.sitePackages}
+    # convince installer it's ok to install here
+    export PYTHONPATH="$PYTHONPATH:$out/${python.sitePackages}"
+  '';
+  postInstall = optionalString enablePython ''
+    mkdir -p $python/${python.sitePackages}
+    mv $out/${python.sitePackages}/* $python/${python.sitePackages}
+  '';
 
   #doCheck = true;  # requires CUnit ; currently failing at test_util_localtime_date in util_test.cc
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4533,6 +4533,12 @@ in {
 
   nevow = callPackage ../development/python-modules/nevow { };
 
+  nghttp2 = (toPythonModule (pkgs.nghttp2.override {
+    inherit (self) python cython setuptools;
+    inherit (pkgs) ncurses;
+    enablePython = true;
+  })).python;
+
   nibabel = callPackage ../development/python-modules/nibabel {};
 
   nidaqmx = callPackage ../development/python-modules/nidaqmx { };


### PR DESCRIPTION
###### Motivation for this change
Make `nghttp2`'s python bindings available. A side effect of some other work I'm doing.

It's tricky to enable in `nghttp2`'s default build, however, because it needs to be usable by `curl`, and we get cyclical dependencies if we add python to its requirements. Having it available as a separate build is better than nothing, though.

Of course, there's a massive rebuild because of `curl`, hence this is targeted at `staging` and I haven't done a full rebuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
