### PR TITLE
cantata: make qtmultimedia and vlc optional

### DIFF
--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig, vlc
-, qtbase, qtmultimedia, qtsvg, qttools
+{ mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig
+, qtbase, qtsvg, qttools
 
 # Cantata doesn't build with cdparanoia enabled so we disable that
 # default for now until I (or someone else) figure it out.
@@ -9,12 +9,14 @@
 , withMusicbrainz ? false, libmusicbrainz5
 
 , withTaglib ? true, taglib, taglib_extras
+, withHttpStream ? true, qtmultimedia
 , withReplaygain ? true, ffmpeg, speex, mpg123
 , withMtp ? true, libmtp
 , withOnlineServices ? true
 , withDevices ? true, udisks2
 , withDynamic ? true
 , withHttpServer ? true
+, withLibVlc ? false, vlc
 , withStreams ? true
 }:
 
@@ -26,6 +28,7 @@ assert withMtp -> withTaglib;
 assert withMusicbrainz -> withCdda && withTaglib;
 assert withOnlineServices -> withTaglib;
 assert withReplaygain -> withTaglib;
+assert withLibVlc -> withHttpStream;
 
 let
   version = "2.4.1";
@@ -45,15 +48,17 @@ in mkDerivation {
     sha256 = "0ix7xp352bziwz31mw79y7wxxmdn6060p8ry2px243ni1lz1qx1c";
   };
 
-  buildInputs = [ vlc qtbase qtmultimedia qtsvg ]
+  buildInputs = [ qtbase qtsvg ]
     ++ lib.optionals withTaglib [ taglib taglib_extras ]
     ++ lib.optionals withReplaygain [ ffmpeg speex mpg123 ]
+    ++ lib.optional  withHttpStream qtmultimedia
     ++ lib.optional  withCdda cdparanoia
     ++ lib.optional  withCddb libcddb
     ++ lib.optional  withLame lame
     ++ lib.optional  withMtp libmtp
     ++ lib.optional  withMusicbrainz libmusicbrainz5
-    ++ lib.optional  withUdisks udisks2;
+    ++ lib.optional  withUdisks udisks2
+    ++ lib.optional  withLibVlc vlc;
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];
 
@@ -62,6 +67,7 @@ in mkDerivation {
   cmakeFlags = lib.flatten [
     (fstats withTaglib        [ "TAGLIB" "TAGLIB_EXTRAS" ])
     (fstats withReplaygain    [ "FFMPEG" "MPG123" "SPEEXDSP" ])
+    (fstat withHttpStream     "HTTP_STREAM_PLAYBACK")
     (fstat withCdda           "CDPARANOIA")
     (fstat withCddb           "CDDB")
     (fstat withLame           "LAME")
@@ -71,6 +77,7 @@ in mkDerivation {
     (fstat withDynamic        "DYNAMIC")
     (fstat withDevices        "DEVICES_SUPPORT")
     (fstat withHttpServer     "HTTP_SERVER")
+    (fstat withLibVlc         "LIBVLC")
     (fstat withStreams        "STREAMS")
     (fstat withUdisks         "UDISKS2")
     "-DENABLE_HTTPS_SUPPORT=ON"


### PR DESCRIPTION
Upstream defaults vlc to off. Its only purpose is as an alternative to
QtMultimedia for "MPD HTTP stream playback" [1]. Similarly, provide a
toggle for qtmultimedia, in case somebody wants to disable HTTP stream
playback.

[1] https://github.com/CDrummond/cantata/blob/efa907c8e03d052718f14834eb968da86d1c34d8/CMakeLists.txt#L51

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`vlc` was declared as a dependency, but was never actually linked to cantata. Now, if the user so chooses, it can be used for HTTP stream playback.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Would be nice to get somebody on NixOS to test the binary and make sure I didn't muck anything up. Inspecting the binary with `ldd` shows it linked to `QtMultimedia` by default, not linked to it when `withHttpStream = false`, as well as not linked to `vlc` by default, and linked when `withLibVlc = true`.