### PR TITLE
nix-script: 2015-09-22 -> 2020-03-23

### DIFF
--- a/pkgs/tools/nix/nix-script/default.nix
+++ b/pkgs/tools/nix/nix-script/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "nix-script";
-  version = "2015-09-22";
+  version = "2020-03-23";
 
   src  = fetchFromGitHub {
     owner  = "bennofs";
     repo   = "nix-script";
-    rev    = "83064dc557b642f6748d4f2372b2c88b2a82c4e7";
-    sha256 = "0iwclyd2zz8lv012yghfr4696kdnsq6xvc91wv00jpwk2c09xl7a";
+    rev    = "7706b45429ff22c35bab575734feb2926bf8840b";
+    sha256 = "0yiqljamcj9x8z801bwj7r30sskrwv4rm6sdf39j83jqql1fyq7y";
   };
 
   buildInputs  = [


### PR DESCRIPTION
###### Motivation for this change
A long-waited update

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox))
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).