### PR TITLE
python3Packages.subunit: fix build and add tests

### DIFF
--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -1,22 +1,33 @@
 { buildPythonPackage
-, pkgs
-, testtools
+# pkgs dependencies
+, check
+, cppunit
+, pkg-config
+, subunit
+
+# python dependencies
+, fixtures
+, hypothesis
+, pytest
 , testscenarios
+, testtools
 }:
 
 buildPythonPackage {
-  name = pkgs.subunit.name;
-  src = pkgs.subunit.src;
+  inherit (subunit) name src meta;
 
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ check cppunit ];
   propagatedBuildInputs = [ testtools ];
-  checkInputs = [ testscenarios ];
-  nativeBuildInputs = [ pkgs.pkgconfig ];
-  buildInputs = [ pkgs.check pkgs.cppunit ];
 
-  patchPhase = ''
-    sed -i 's/version=VERSION/version="${pkgs.subunit.version}"/' setup.py
+  checkInputs = [ testscenarios hypothesis fixtures pytest ];
+  # ignore tests which call shell code, or call methods which haven't been implemented
+  checkPhase = ''
+    pytest python/subunit \
+      --ignore=python/subunit/tests/test_{output_filter,test_protocol{,2}}.py
   '';
 
-  meta = pkgs.subunit.meta;
-
+  patchPhase = ''
+    sed -i 's/version=VERSION/version="${subunit.version}"/' setup.py
+  '';
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6158,7 +6158,9 @@ in {
 
   subdownloader = callPackage ../development/python-modules/subdownloader { };
 
-  subunit = callPackage ../development/python-modules/subunit { };
+  subunit = callPackage ../development/python-modules/subunit {
+    inherit (pkgs) subunit pkg-config cppunit check;
+  };
 
   sure = callPackage ../development/python-modules/sure { };
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken

did a fair amount of clean up as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
