### PR TITLE
texlive.combine: set TEXMFCNF in binary wrapper

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -153,7 +153,8 @@ in buildEnv {
       rm "$link"
       makeWrapper "$target" "$link" \
         --prefix PATH : "$out/bin:${perl}/bin" \
-        --prefix PERL5LIB : "$PERL5LIB"
+        --prefix PERL5LIB : "$PERL5LIB" \
+        --set-default TEXMFCNF "$TEXMFCNF"
 
       # avoid using non-nix shebang in $target by calling interpreter
       if [[ "$(head -c 2 "$target")" = "#!" ]]; then


### PR DESCRIPTION
This helps kpathsea to find texmf.cnf in some cases. For example,
dvipng was trying to look for it in
/nix/store/\<hash\>-texlive-dvipng.bin-2019/ instead of
/nix/store/\<hash\>-texlive-combined-full-2019/.

cc @jethrokuan

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes: #82923

###### Things done

```nix
{ setHome }:
  
with import ./. {};

stdenvNoCC.mkDerivation {
  name = "dvipng-benchmark";

  buildInputs = [
    file
    hyperfine
    imagemagick
    texlive.combined.scheme-full
  ];

  buildCommand = (lib.optionalString setHome ''
    export HOME=$(mktemp -d)
  '') + ''
    cat >test.tex <<EOF
\documentclass[12pt]{article}
\begin{document}
Hello world!
\$Hello world!\$ %math mode
\end{document}
EOF
    latex test.tex 1>/dev/null 2>/dev/null

    mkdir -p $out

    hyperfine -s basic \
      "dvipng -T tight -o $out/dvipng.png test.dvi" \
      "convert -trim -antialias -density 100 test.dvi -quality 100 $out/convert.png" \
      --warmup 50

    file "$out"/*
  '';
}
```

before (need to set HOME to allow mktexpk to write its output):
```
% nix-build bench.nix --arg setHome true 
these derivations will be built:
  /nix/store/4bmv4c20y78cdz4ywrm25fgkf97gln0m-dvipng-benchmark.drv
building '/nix/store/4bmv4c20y78cdz4ywrm25fgkf97gln0m-dvipng-benchmark.drv'...
Benchmark #1: dvipng -T tight -o /nix/store/i0h1axkicn5v8pjn12zd1hlvngic3bnx-dvipng-benchmark/dvipng.png test.dvi
  Time (mean ± σ):      2.094 s ±  0.085 s    [User: 1.807 s, System: 0.292 s]
  Range (min … max):    2.023 s …  2.257 s    10 runs

Benchmark #2: convert -trim -antialias -density 100 test.dvi -quality 100 /nix/store/i0h1axkicn5v8pjn12zd1hlvngic3bnx-dvipng-benchmark/convert.png
  Time (mean ± σ):     257.5 ms ±   2.8 ms    [User: 215.1 ms, System: 52.5 ms]
  Range (min … max):   253.7 ms … 262.8 ms    11 runs

Summary
  'convert -trim -antialias -density 100 test.dvi -quality 100 /nix/store/i0h1axkicn5v8pjn12zd1hlvngic3bnx-dvipng-benchmark/convert.png' ran
    8.13 ± 0.34 times faster than 'dvipng -T tight -o /nix/store/i0h1axkicn5v8pjn12zd1hlvngic3bnx-dvipng-benchmark/dvipng.png test.dvi'
/nix/store/i0h1axkicn5v8pjn12zd1hlvngic3bnx-dvipng-benchmark/convert.png: PNG image data, 249 x 796, 8-bit gray+alpha, non-interlaced
/nix/store/i0h1axkicn5v8pjn12zd1hlvngic3bnx-dvipng-benchmark/dvipng.png:  PNG image data, 249 x 796, 8-bit colormap, non-interlaced
```

after:
```
% nix-build bench.nix --arg setHome false
these derivations will be built:
  /nix/store/58mil3wmkl1dvpxqkdmwykwkvn2j0k0j-dvipng-benchmark.drv
building '/nix/store/58mil3wmkl1dvpxqkdmwykwkvn2j0k0j-dvipng-benchmark.drv'...
Benchmark #1: dvipng -T tight -o /nix/store/amzhv8rrqasfdfr2zmlk94f2kj5ms8bl-dvipng-benchmark/dvipng.png test.dvi
  Time (mean ± σ):      70.1 ms ±   3.1 ms    [User: 59.4 ms, System: 10.5 ms]
  Range (min … max):    65.7 ms …  77.3 ms    42 runs

Benchmark #2: convert -trim -antialias -density 100 test.dvi -quality 100 /nix/store/amzhv8rrqasfdfr2zmlk94f2kj5ms8bl-dvipng-benchmark/convert.png
  Time (mean ± σ):     274.2 ms ±  11.4 ms    [User: 237.8 ms, System: 47.2 ms]
  Range (min … max):   257.2 ms … 295.8 ms    11 runs

Summary
  'dvipng -T tight -o /nix/store/amzhv8rrqasfdfr2zmlk94f2kj5ms8bl-dvipng-benchmark/dvipng.png test.dvi' ran
    3.91 ± 0.24 times faster than 'convert -trim -antialias -density 100 test.dvi -quality 100 /nix/store/amzhv8rrqasfdfr2zmlk94f2kj5ms8bl-dvipng-benchmark/convert.png'
/nix/store/amzhv8rrqasfdfr2zmlk94f2kj5ms8bl-dvipng-benchmark/convert.png: PNG image data, 249 x 796, 8-bit gray+alpha, non-interlaced
/nix/store/amzhv8rrqasfdfr2zmlk94f2kj5ms8bl-dvipng-benchmark/dvipng.png:  PNG image data, 249 x 796, 4-bit colormap, non-interlaced
```