### PR TITLE
atari800: 4.0.0 -> 4.2.0

### DIFF
--- a/pkgs/misc/emulators/atari800/default.nix
+++ b/pkgs/misc/emulators/atari800/default.nix
@@ -1,15 +1,19 @@
-{ stdenv, fetchurl
+{ stdenv, fetchFromGitHub, autoreconfHook
 , unzip, zlib, SDL, readline, libGLU, libGL, libX11 }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec{
   pname = "atari800";
-  version = "4.0.0";
+  version = "4.2.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/atari800/atari800/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1dcynsf8i52y7zyg62bkbhl3rdd22ss95zs2s9jm4y5jvn4vks88";
+  src = fetchFromGitHub {
+    owner = "atari800";
+    repo = "atari800";
+    rev = "ATARI800_4_2_0";
+    sha256 = "15l08clqqayi9izrgsz9achan6gl4x57wqsc8mad3yn0xayzz3qy";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ unzip zlib SDL readline libGLU libGL libX11 ];
 
@@ -23,10 +27,8 @@ stdenv.mkDerivation rec{
     "--enable-riodevice"
   ];
 
-  preConfigure = "cd src";
-
   meta = {
-    homepage = http://atari800.sourceforge.net/;
+    homepage = "http://atari800.github.io/";
     description = "An Atari 8-bit emulator";
     longDescription = ''
       Atari800 is the emulator of Atari 8-bit computer systems and

--- a/pkgs/misc/emulators/atari800/default.nix
+++ b/pkgs/misc/emulators/atari800/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec{
   ];
 
   meta = {
-    homepage = "http://atari800.github.io/";
+    homepage = "https://atari800.github.io/";
     description = "An Atari 8-bit emulator";
     longDescription = ''
       Atari800 is the emulator of Atari 8-bit computer systems and

--- a/pkgs/misc/emulators/atari800/default.nix
+++ b/pkgs/misc/emulators/atari800/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec{
   src = fetchFromGitHub {
     owner = "atari800";
     repo = "atari800";
-    rev = "ATARI800_4_2_0";
+    rev = "ATARI800_${replaceChars ["."] ["_"] version}";
     sha256 = "15l08clqqayi9izrgsz9achan6gl4x57wqsc8mad3yn0xayzz3qy";
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
