### PR TITLE
python3Packages.ibis: 1.2.0 -> 1.3.0, fix tests

### DIFF
--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -1,29 +1,26 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
+{ lib, buildPythonPackage, fetchPypi, isPy27, pythonAtLeast
+, graphviz
 , multipledispatch
 , numpy
 , pandas
+, pyarrow
+, pytest
 , pytz
 , regex
-, toolz
-, isPy27
-, pytest
-, sqlalchemy
 , requests
+, sqlalchemy
 , tables
-, pyarrow
-, graphviz
+, toolz
 }:
 
 buildPythonPackage rec {
   pname = "ibis-framework";
-  version = "1.2.0";
-  disabled = isPy27;
+  version = "1.3.0";
+  disabled = isPy27 || pythonAtLeast "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3a0b79dae6924be0a79669c881a9a1d4817997ad2f81a0f3b1cd03d70aebb071";
+    sha256 = "1my94a11jzg1hv6ln8wxklbqrg6z5l2l77vr89aq0829yyxacmv7";
   };
 
   propagatedBuildInputs = [
@@ -44,13 +41,16 @@ buildPythonPackage rec {
     pytest
   ];
 
+  # ignore tests which require test dataset, or frameworks not available
   checkPhase = ''
-    pytest ibis
+    pytest ibis \
+      --ignore=ibis/tests/all \
+      --ignore=ibis/{sql,spark}
   '';
 
   meta = with lib; {
     description = "Productivity-centric Python Big Data Framework";
-    homepage = https://github.com/ibis-project/ibis;
+    homepage = "https://github.com/ibis-project/ibis";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken and causing a lot of issues when reviewing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/83827
32 package marked as broken and skipped:
digitalbitbox gdata-sharp glibcCross linuxPackages_4_4.evdi linuxPackages_hardkernel_4_14.bcc linuxPackages_hardkernel_4_14.can-isotp linuxPackages_hardkernel_4_14.chipsec linuxPackages_hardkernel_4_14.digimend linuxPackages_hardkernel_4_14.evdi linuxPackages_hardkernel_4_14.mba6x_bl linuxPackages_hardkernel_4_14.prl-tools nix-linter php72Packages-unit.php_excel php72Packages-unit.v8 php72Packages-unit.v8js php72Packages.php_excel php72Packages.v8 php72Packages.v8js php73Packages-unit.php_excel php73Packages-unit.v8 php73Packages.php_excel php73Packages.v8 php74Packages-unit.couchbase php74Packages-unit.pcs php74Packages-unit.php_excel php74Packages-unit.v8 php74Packages.couchbase php74Packages.pcs php74Packages.php_excel php74Packages.v8 python27Packages.flitBuildHook python37Packages.pyblock

1 package built:
python37Packages.ibis-framework
```