### PR TITLE
fcgi: 2.4.0 -> 2.4.2

### DIFF
--- a/pkgs/development/libraries/fcgi/default.nix
+++ b/pkgs/development/libraries/fcgi/default.nix
@@ -1,24 +1,17 @@
-{ stdenv, fetchurl, fetchpatch }:
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "fcgi";
-  version = "2.4.0";
+  version = "2.4.2";
 
-  src = fetchurl {
-    url = "https://launchpad.net/debian/+archive/primary/+files/libfcgi_${version}.orig.tar.gz";
-    #    url = "http://www.fastcgi.com/dist/${name}.tar.gz";
-    sha256 = "1f857wnl1d6jfrgfgfpz3zdaj8fch3vr13mnpcpvy8bang34bz36";
+  src = fetchFromGitHub {
+    owner = "FastCGI-Archives";
+    repo = "fcgi2";
+    rev = version;
+    sha256 = "1jhz6jfwv5kawa8kajvg18nfwc1b30f38zc0lggszd1vcmrwqkz1";
   };
 
-  patches = [
-    ./gcc-4.4.diff
-    (fetchpatch {
-      # Fix a stack-smashing bug:
-      # xhttps://bugs.debian.org/cgi-bin/bugreport.cgi?bug=681591
-      url = "https://bugs.launchpad.net/ubuntu/+source/libfcgi/+bug/933417/+attachment/2745025/+files/poll.patch";
-      sha256 = "0v3gw0smjvrxh1bv3zx9xp633gbv5dd5bcn3ipj6ckqjyv4i6i7m";
-    })
-  ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   postInstall = "ln -s . $out/include/fastcgi";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
