### PR TITLE
slirp4netns: 0.4.4 -> 1.0.0

### DIFF
--- a/pkgs/tools/networking/slirp4netns/default.nix
+++ b/pkgs/tools/networking/slirp4netns/default.nix
@@ -1,19 +1,27 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkg-config, glib, libcap, libseccomp }:
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, glib
+, libcap
+, libseccomp
+, libslirp
+}:
 
 stdenv.mkDerivation rec {
   pname = "slirp4netns";
-  version = "0.4.4";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "rootless-containers";
     repo = "slirp4netns";
     rev = "v${version}";
-    sha256 = "1932q80s6187k4fsvgia5iwc9lqsdkxzqqwpw1ksy0mx8wzmwbih";
+    sha256 = "152wmccz47anvx5w88qcz8higw80l17jl7i24xfj5574adviqnv2";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
-  buildInputs = [ libcap libseccomp glib ];
+  buildInputs = [ glib libcap libseccomp libslirp ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
https://github.com/rootless-containers/slirp4netns/releases/tag/v1.0.0

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @orivej @saschagrunert 