### PR TITLE
diffr: 0.1.2 -> 0.1.4

### DIFF
--- a/pkgs/tools/text/diffr/default.nix
+++ b/pkgs/tools/text/diffr/default.nix
@@ -2,22 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "diffr";
-  version = "v0.1.2";
-
-  # diffr's tests expect the diffr binary to be at `$CARGO_MANIFEST_DIR/target/debug/diffr`.
-  doCheck = false;
+  version = "v0.1.4";
 
   src = fetchFromGitHub {
     owner = "mookid";
     repo = pname;
     rev = version;
-    sha256 = "1fpcyl4kc4djfl6a2jlj56xqra42334vygz8n7614zgjpyxz3zx2";
+    sha256 = "18ks5g4bx6iz9hdjxmi6a41ncxpb1hnsscdlddp2gr40k3vgd0pa";
   };
 
-  cargoSha256 = "17xgjk8li29b8q8p2bi56klqg0v2q0j6ich438c4p06jrszccx1f";
+  cargoSha256 = "09yn02985yv40n9y0ipz0jmj7iqhz7l8hd3ry9ib3fyw9pyklnfa";
 
-  nativeBuildInputs = [];
   buildInputs = (stdenv.lib.optional stdenv.isDarwin Security);
+
+  preCheck = ''
+    export DIFFR_TESTS_BINARY_PATH=$releaseDir/diffr
+  '';
 
   meta = with stdenv.lib; {
     description = "Yet another diff highlighting tool";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update to most recent release of diffr.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
