### PR TITLE
swiftshader: init at 2020-03-31

### DIFF
--- a/pkgs/development/libraries/swiftshader/default.nix
+++ b/pkgs/development/libraries/swiftshader/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchgit, python3, cmake, jq, libX11, libXext }:
+
+stdenv.mkDerivation rec {
+  pname = "swiftshader";
+  version = "2020-06-17";
+
+  src = fetchgit {
+    url = "https://swiftshader.googlesource.com/SwiftShader";
+    rev = "763957e6b4fc1aa360ab19c4109b8b26686783e8";
+    sha256 = "0sdh48swx0qyq2nfkv1nggs14am0qc7z239qrxb69p2ddqm76g1s";
+  };
+
+  nativeBuildInputs = [ cmake python3 jq ];
+  buildInputs = [ libX11 libXext ];
+
+  # Make sure we include the drivers and icd files in the output as the cmake
+  # generated install command only puts in the spirv-tools stuff.
+  installPhase = ''
+    runHook preInstall
+
+    #
+    # Vulkan driver
+    #
+    vk_so_path="$out/lib/libvk_swiftshader.so"
+    mkdir -p "$(dirname "$vk_so_path")"
+    mv Linux/libvk_swiftshader.so "$vk_so_path"
+
+    vk_icd_json="$out/share/vulkan/icd.d/vk_swiftshader_icd.json"
+    mkdir -p "$(dirname "$vk_icd_json")"
+    jq ".ICD.library_path = \"$vk_so_path\"" <Linux/vk_swiftshader_icd.json >"$vk_icd_json"
+
+    #
+    # GL driver
+    #
+    gl_so_path="$out/lib/libEGL.so"
+    mkdir -p "$(dirname "$gl_so_path")"
+    mv Linux/libEGL.so "$gl_so_path"
+
+    gl_icd_json="$out/share/glvnd/egl_vendor.d/swiftshader.json"
+    mkdir -p "$(dirname "$gl_icd_json")"
+    cat >"$gl_icd_json" <<EOF
+    {
+      "file_format_version" : "1.0.0",
+      "ICD" : {
+          "library_path" : "$gl_so_path"
+      }
+    }
+    EOF
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description =
+      "A high-performance CPU-based implementation of the Vulkan, OpenGL ES, and Direct3D 9 graphics APIs";
+    homepage = "https://opensource.google/projects/swiftshader";
+    license = licenses.asl20;
+    # Should be possible to support Darwin by changing the install phase with
+    # 's/Linux/Darwin/' and 's/so/dylib/' or something similar.
+    platforms = [ "i686-linux" "x86_64-linux" "armv7l-linux" "mipsel-linux" ];
+    maintainers = with maintainers; [ expipiplus1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11039,6 +11039,8 @@ in
 
   swiftformat = callPackage ../development/tools/swiftformat { };
 
+  swiftshader = callPackage ../development/libraries/swiftshader { };
+
   systemfd = callPackage ../development/tools/systemfd { };
 
   swig1 = callPackage ../development/tools/misc/swig { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Although swiftshader is used as part of Chromium, it's not available as a
standalone package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (Tested libvulkan.so.1)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).