### PR TITLE
maestral: 0.6.1 -> 0.6.3

### DIFF
--- a/pkgs/applications/networking/maestral/default.nix
+++ b/pkgs/applications/networking/maestral/default.nix
@@ -8,7 +8,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maestral${lib.optionalString withGui "-gui"}";
-  version = "0.6.1";
+  version = "0.6.3";
 
   disabled = python3.pkgs.pythonOlder "3.6";
 
@@ -16,7 +16,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "SamSchott";
     repo = "maestral-dropbox";
     rev = "v${version}";
-    sha256 = "06i3c7i85x879np158156mba7kxz2cwh75390sc9gwwngc95d9h9";
+    sha256 = "0h1vbx00mps2msdhsab1yz64c8sprwrg38nkqyj86mkb6jkirq92";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -27,6 +27,7 @@ python3.pkgs.buildPythonApplication rec {
     keyring
     keyrings-alt
     lockfile
+    pathspec
     Pyro5
     requests
     u-msgpack-python

--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -1,31 +1,23 @@
-{ lib, buildPythonPackage, fetchPypi, locale, pytest }:
+{ lib, buildPythonPackage, fetchPypi, locale, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "click";
-  version = "7.0";
+  version = "7.1.1";
 
   src = fetchPypi {
-    pname = "Click";
-    inherit version;
-    sha256 = "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7";
+    inherit pname version;
+    sha256 = "1k60i2fvxf8rxazlv04mnsmlsjrj5i5sda3x1ifhr0nqi7mb864a";
   };
 
   postPatch = ''
-    substituteInPlace click/_unicodefun.py \
+    substituteInPlace src/click/_unicodefun.py \
       --replace "'locale'" "'${locale}/bin/locale'"
   '';
 
-  buildInputs = [ pytest ];
-
-  checkPhase = ''
-    py.test tests
-  '';
-
-  # https://github.com/pallets/click/issues/823
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
-    homepage = http://click.pocoo.org/;
+    homepage = "https://click.palletsprojects.com/";
     description = "Create beautiful command line interfaces in Python";
     longDescription = ''
       A Python package for creating beautiful command line interfaces in a


### PR DESCRIPTION
Upstream update.

Works well here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).