### PR TITLE
ruby: 2.5.7 -> 2.5.8, 2.6.5 -> 2.6.6, 2.7.0 -> 2.7.1

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -224,10 +224,10 @@ let
 
 in {
   ruby_2_5 = generic {
-    version = rubyVersion "2" "5" "7" "";
+    version = rubyVersion "2" "5" "8" "";
     sha256 = {
-      src = "1m6nmnj9shifp8g3yh7aimac01vl035bzcc19x2spdji6ig0sb8b";
-      git = "0wppf82c9ccdbnvj30mppr5a3mc7sxm05diahjdw7hhk29n43knp";
+      src = "16md4jspjwixjlbhx3pnd5iwpca07p23ghkxkqd82sbchw3xy2vc";
+      git = "19gkk3q9l33cwkfsp5k8f8fipq7gkyqkqirm9farbvy425519rv2";
     };
   };
 

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -240,10 +240,10 @@ in {
   };
 
   ruby_2_7 = generic {
-    version = rubyVersion "2" "7" "0" "";
+    version = rubyVersion "2" "7" "1" "";
     sha256 = {
-      src = "1glc3zpnih6h8mrgfcak0aa7cgmi4zyvxfyi6y2brwg2nn9sm6cc";
-      git = "11iz64k95czs273mb10195d1j75mmbcgddfdx1vay5876ffw81dq";
+      src = "0674x98f542y02r7n2yv2qhmh97blqhi2mvh2dn5f000vlxlh66l";
+      git = "0qk729kr5wm67xmwpljpdprwhp5wvn5y4ikqy00p1zcgwlwdcs33";
     };
   };
 }

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -232,10 +232,10 @@ in {
   };
 
   ruby_2_6 = generic {
-    version = rubyVersion "2" "6" "5" "";
+    version = rubyVersion "2" "6" "6" "";
     sha256 = {
-      src = "0zgdrgylq6avbblf78kpaf0k2xnkpc3jng3wkd7x67ycdrqnp5v6";
-      git = "0pay6ic22ag3bnvxffhgwp7z6clkd0p93944a1l4lvc5hxc8v77j";
+      src = "1492x795qzgp3zhpl580kd1sdp50n5hfsmpbfhdsq2rnxwyi8jrn";
+      git = "1jr9v99a7awssqmw7531afbx4a8i9x5yfqyffha545g7r4s7kj50";
     };
   };
 

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -16,6 +16,9 @@
     "${patchSet}/patches/ruby/2.6/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.6/head/railsexpress/03-more-detailed-stacktrace.patch"
   ];
-  "2.7.0" = ops useRailsExpress [ # no patches yet (2019-12-25)
+  "2.7.1" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch"
   ];
 }

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,11 +1,6 @@
 { patchSet, useRailsExpress, ops, patchLevel, fetchpatch }:
 
 {
-  "2.4.9" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.4/head/railsexpress/01-skip-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.4/head/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.4/head/railsexpress/03-display-more-detailed-stack-trace.patch"
-  ];
   "2.5.8" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.5/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
     "${patchSet}/patches/ruby/2.5/head/railsexpress/02-improve-gc-stats.patch"

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -11,7 +11,7 @@
     "${patchSet}/patches/ruby/2.5/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.5/head/railsexpress/03-more-detailed-stacktrace.patch"
   ];
-  "2.6.5" = ops useRailsExpress [
+  "2.6.6" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.6/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
     "${patchSet}/patches/ruby/2.6/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.6/head/railsexpress/03-more-detailed-stacktrace.patch"

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -6,7 +6,7 @@
     "${patchSet}/patches/ruby/2.4/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.4/head/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
-  "2.5.7" = ops useRailsExpress [
+  "2.5.8" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.5/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
     "${patchSet}/patches/ruby/2.5/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.5/head/railsexpress/03-more-detailed-stacktrace.patch"

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner  = "skaes";
   repo   = "rvm-patchsets";
-  rev    = "58f72dccc8bb4dc9b1035f6af903d21f2465367a";
-  sha256 = "00gbrhvnf05g6zmfim472ld0l1lp100dy4pi3lixm6ry9iw9m4ag";
+  rev    = "6d8888d34a321198f7fd9253343b78c209efb046";
+  sha256 = "0xczl0nng1649km3bcbjn6zrr591l6m2kkwgnknh1fnwmmrdaya7";
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://www.ruby-lang.org/en/news/2020/03/31/heap-exposure-in-socket-cve-2020-10933/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
