### PR TITLE
matterhorn: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1463,6 +1463,18 @@ self: super: {
   # haskell-ci-0.8 needs cabal-install-parsers ==0.1, but we have 0.2.
   haskell-ci = doJailbreak super.haskell-ci;
 
+  # 2020-01-19 - there were conflicting versions of brick, vty, and brick-skylighting;
+  # multiple versions of them were being pulled in by the others which is not allowed.
+  # There are more complicated ways of doing this but I was able to make it fairly simple -- kiwi
+  # 2020-03-31 - "..." it broke again. so here's a more complicated way -- kiwi
+  matterhorn = super.matterhorn.override {
+    brick-skylighting = self.brick-skylighting.override {
+      brick = self.brick_0_52_1.override {
+        vty = self.vty_5_28_2;
+      };
+    };
+  };
+
   persistent-mysql = dontCheck super.persistent-mysql;
 
   # Fix EdisonAPI and EdisonCore for GHC 8.8:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2459,6 +2459,9 @@ package-maintainers:
     - streaming-wai
   kiwi:
     # - glirc
+    - matterhorn
+    - mattermost-api
+    - mattermost-api-qc
     - Unique
   psibi:
     - path-pieces
@@ -7324,9 +7327,6 @@ broken-packages:
   - matrix-as-xyz
   - matrix-market
   - matsuri
-  - matterhorn
-  - mattermost-api
-  - mattermost-api-qc
   - maude
   - maxent
   - maxent-learner-hw


### PR DESCRIPTION
also fixes mattermost-api, mattermost-api-qc,
and adds them to stewardship by kiwi

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
it was broken and now it's not broken

###### Things done
fixed it

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
