### PR TITLE
Revert "nixos: default `environment.homeBinInPath` to false"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -227,13 +227,6 @@ services.xserver.displayManager.defaultSession = "xfce+icewm";
    </listitem>
    <listitem>
     <para>
-      Going forward, <literal>~/bin</literal> in the users home directory will no longer be in <literal>PATH</literal> by default.
-      If you depend on this you should set the option <literal>environment.homeBinInPath</literal> to <literal>true</literal>.
-      The aforementioned option was added this release.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
       The <literal>buildRustCrate</literal> infrastructure now produces <literal>lib</literal> outputs in addition to the <literal>out</literal> output.
       This has led to drastically reduced closure sizes for some rust crates since development dependencies are now in the <literal>lib</literal> output.
     </para>

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -122,7 +122,7 @@ in
       description = ''
         Include ~/bin/ in $PATH.
       '';
-      default = false;
+      default = true;
       type = types.bool;
     };
 


### PR DESCRIPTION
This reverts commit a06529b7adbfe39e06c10d0c539418d130f2fecc. Having `~/bin` in `$PATH` has been the case in NixOS since forever or so, so I don't see a strong reason for changing this. People who don't want this can set `environment.homeBinInPath` to false now.
