### PR TITLE
babashka: Init at 0.0.89

### DIFF
--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -1,0 +1,58 @@
+{ stdenv, lib, graalvm8, fetchurl }:
+
+stdenv.mkDerivation rec{
+  pname = "babashka";
+  version = "0.0.78";
+
+  reflectionJson = fetchurl {
+    name = "reflection.json";
+    url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-reflection.json";
+    sha256 = "1m1nwdxjsc6bkdzkbsll316ly0c3qxaimjzyfph1220irjxnm7xf";
+  };
+
+  src = fetchurl {
+    url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
+    sha256 = "01w990zk5qjrbnc846snh6na002kdyrlrfnqwg03ibx20g3mr7if";
+  };
+
+  dontUnpack = true;
+
+  buildInputs = [ graalvm8 ];
+
+  buildPhase = ''
+    native-image  \
+      -jar ${src} \
+      -H:Name=bb \
+      -H:+ReportExceptionStackTraces \
+      -J-Dclojure.spec.skip-macros=true \
+      -J-Dclojure.compiler.direct-linking=true \
+      "-H:IncludeResources=BABASHKA_VERSION" \
+      "-H:IncludeResources=SCI_VERSION" \
+      -H:ReflectionConfigurationFiles=${reflectionJson} \
+      --initialize-at-run-time=java.lang.Math\$RandomNumberGeneratorHolder \
+      --initialize-at-build-time \
+      -H:Log=registerResource: \
+      -H:EnableURLProtocols=http,https \
+      --enable-all-security-services \
+      -H:+JNI \
+      --verbose \
+      --no-fallback \
+      --no-server \
+      --report-unsupported-elements-at-runtime \
+      "-J-Xmx3g"
+  '';
+
+  installPhase = ''
+    ls -alh
+    mkdir -p $out/bin
+    cp bb $out/bin/bb
+  '';
+
+  meta = with lib; {
+    description = "A Clojure babushka for the grey areas of Bash.";
+    homepage = https://github.com/borkdude/babashka;
+    license = licenses.epl10;
+    platforms = graalvm8.meta.platforms;
+    maintainers = with maintainers; [ bandresen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9155,6 +9155,8 @@ in
 
   angelscript_2_22 = callPackage ../development/interpreters/angelscript/2.22.nix {};
 
+  babashka = callPackage ../development/interpreters/clojure/babashka.nix { };
+
   chibi = callPackage ../development/interpreters/chibi { };
 
   ceptre = callPackage ../development/interpreters/ceptre { };


### PR DESCRIPTION
###### Motivation for this change
a very neat and useful (small) clojure interpreter that has very quick start up times.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

