### PR TITLE
python37Packages.picos: 1.2.0 -> 2.0

### DIFF
--- a/pkgs/development/python-modules/picos/default.nix
+++ b/pkgs/development/python-modules/picos/default.nix
@@ -4,19 +4,25 @@
 , numpy
 , cvxopt
 , python
+, networkx
 }:
 
 buildPythonPackage rec {
   pname = "picos";
-  version = "1.2.0";
+  version = "2.0";
 
   src = fetchFromGitLab {
     owner = "picos-api";
     repo = "picos";
     rev = "v${version}";
-    sha256 = "018xhc7cb2crkk27lhl63c7h77w5wa37fg41i7nqr4xclr43cs9z";
+    sha256 = "1k65iq791k5r08gh2kc6iz0xw1wyzqik19j6iam8ip732r7jm607";
   };
 
+  # Needed only for the tests
+  checkInputs = [
+    networkx
+  ];
+  
   propagatedBuildInputs = [
     numpy
     cvxopt
@@ -28,9 +34,8 @@ buildPythonPackage rec {
   
   meta = with lib; {
     description = "A Python interface to conic optimization solvers";
-    homepage = https://gitlab.com/picos-api/picos;
+    homepage = "https://gitlab.com/picos-api/picos";
     license = licenses.gpl3;
     maintainers = with maintainers; [ tobiasBora ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

Update of picos, the automatic [PR 81971](https://github.com/NixOS/nixpkgs/pull/81971) was failing due to a missing dependency for the tests. 

closes #81971 

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
