### PR TITLE
python3.pkgs.wolframclient: init at 1.1.2

### DIFF
--- a/pkgs/development/python-modules/wolframclient/default.nix
+++ b/pkgs/development/python-modules/wolframclient/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyzmq
+, numpy
+, pytz
+, requests
+, aiohttp
+, oauthlib
+}:
+
+buildPythonPackage rec {
+  pname = "wolframclient";
+  version = "1.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vhgmr9i6qa98qv8sn7ph35m2gayjyif6d2q0sjbfdgihsh0ly8f";
+  };
+
+  propagatedBuildInputs = [
+    pyzmq
+    numpy
+    pytz
+    requests
+    aiohttp
+    oauthlib
+  ];
+
+  # see https://github.com/WolframResearch/WolframClientForPython/issues/18
+  doCheck = false;
+  pythonImportsCheck = [
+    "wolframclient"
+    "wolframclient.cli"
+    "wolframclient.evaluation"
+    "wolframclient.language"
+  ];
+
+  meta = with lib; {
+    homepage = "https://reference.wolfram.com/language/WolframClientForPython/index.html";
+    description = "Call Wolfram Language functions from Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1554,6 +1554,8 @@ in {
 
   wordcloud = callPackage ../development/python-modules/wordcloud { };
 
+  wolframclient = disabledIf (!isPy3k) (callPackage ../development/python-modules/wolframclient { });
+
   wrf-python = callPackage ../development/python-modules/wrf-python { };
 
   pyunbound = callPackage ../tools/networking/unbound/python.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Include Wolfram's Mathematica client library -  https://github.com/WolframResearch/WolframClientForPython .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
