### PR TITLE
jwasm: 2017-11-12 -> 2.13

### DIFF
--- a/pkgs/development/compilers/jwasm/default.nix
+++ b/pkgs/development/compilers/jwasm/default.nix
@@ -2,24 +2,30 @@
 , cmake }:
 
 with stdenv.lib;
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "jwasm";
-  version = "git-2017-11-22";
+  version = "2.13";
 
   src = fetchFromGitHub {
     owner = "JWasm";
     repo  = "JWasm";
-    rev    = "26f97c8b5c9d9341ec45538701116fa3649b7766";
+    rev = version;
     sha256 = "0m972pc8vk8s9yv1pi85fsjgm6hj24gab7nalw2q04l0359nqi7w";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  installPhase = "mkdir -p $out/bin ; cp jwasm $out/bin/";
+  installPhase = ''
+    install -Dpm755 jwasm -t $out/bin/
+    install -Dpm644 $src/History.txt  $src/Readme.txt \
+                    $src/Doc/enh.txt $src/Doc/fixes.txt \
+                    $src/Doc/gencode.txt $src/Doc/overview.txt \
+                    -t $out/share/doc/jwasm/
+  '';
 
   meta = {
     description = "A MASM-compatible x86 assembler";
-    homepage = http://jwasm.github.io/;
+    homepage = "http://jwasm.github.io/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.darwin ++ platforms.linux;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
