### PR TITLE
lilyterm: 2017-01-06 -> 2019-07-25

### DIFF
--- a/pkgs/applications/misc/lilyterm/default.nix
+++ b/pkgs/applications/misc/lilyterm/default.nix
@@ -2,40 +2,41 @@
 , pkgconfig
 , autoconf, automake, intltool, gettext
 , gtk, vte
-
 , flavour ? "stable"
 }:
 
 assert lib.assertOneOf "flavour" flavour [ "stable"  "git" ];
 
 let
+  pname = "lilyterm";
   stuff =
     if flavour == "stable"
     then rec {
         version = "0.9.9.4";
         src = fetchurl {
-          url = "https://lilyterm.luna.com.tw/file/lilyterm-${version}.tar.gz";
+          url = "https://lilyterm.luna.com.tw/file/${pname}-${version}.tar.gz";
           sha256 = "0x2x59qsxq6d6xg5sd5lxbsbwsdvkwqlk17iw3h4amjg3m1jc9mp";
         };
       }
     else {
-        version = "2017-01-06";
+        version = "2019-07-25";
         src = fetchFromGitHub {
           owner = "Tetralet";
-          repo = "lilyterm";
-          rev = "20cce75d34fd24901c9828469d4881968183c389";
-          sha256 = "0am0y65674rfqy69q4qz8izb8cq0isylr4w5ychi40jxyp68rkv2";
+          repo = pname;
+          rev = "faf1254f46049edfb1fd6e9191e78b1b23b9c51d";
+          sha256 = "054450gk237c62b677365bcwrijr63gd9xm8pv68br371wdzylz7";
         };
       };
 
 in
-stdenv.mkDerivation {
-  pname = "lilyterm";
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  inherit pname;
 
   inherit (stuff) src version;
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf automake intltool gettext gtk vte ];
+  nativeBuildInputs = [ pkgconfig autoconf automake intltool gettext ];
+  buildInputs = [ gtk vte ];
 
   preConfigure = "sh autogen.sh";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
