### PR TITLE
PHP: Make the default package more sane [v3]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -178,6 +178,7 @@
 /nixos/tests/prometheus-exporters.nix                        @WilliButz
 
 # PHP
-/pkgs/development/interpreters/php  @etu
-/pkgs/top-level/php-packages.nix    @etu
-/pkgs/build-support/build-pecl.nix  @etu
+/doc/languages-frameworks/php.section.md @etu
+/pkgs/development/interpreters/php       @etu
+/pkgs/top-level/php-packages.nix         @etu
+/pkgs/build-support/build-pecl.nix       @etu

--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -21,20 +21,12 @@ of a given NixOS release will be included in that release of
 NixOS. See [PHP Supported
 Versions](https://www.php.net/supported-versions.php).
 
-As for packages we have `php.packages` that contains a bunch of
-attributes where some are suitable as extensions (notable example:
-`php.packages.imagick`). And some are more suitable for command
-line use (notable example: `php.packages.composer`).
+For packages we have `php.packages` that contains packages related
+for human interaction, notable example is `php.packages.composer`.
 
-We have a special section within `php.packages` called
-`php.packages.exts` that contain certain PHP modules that may not
-be part of the default PHP derivation (example:
-`php.packages.exts.opcache`).
-
-The `php.packages.exts.*` attributes are official extensions which
-originate from the mainline PHP project, while other extensions within
-the `php.packages.*` attribute are of mixed origin (such as `pecl`
-and other places).
+For extensions we have `php.extensions` that contains most upstream
+extensions as separate attributes as well some additional extensions
+that tend to be popular, notable example is: `php.extensions.imagick`.
 
 The different versions of PHP that nixpkgs fetch is located under
 attributes named based on major and minor version number; e.g.,
@@ -43,23 +35,20 @@ attributes named based on major and minor version number; e.g.,
 
 #### Installing PHP with packages
 
-There's two different kinds of things you could install:
- - A command line utility. Simply refer to it via
-   `php*.packages.*`, and it automatically comes with the necessary
-   PHP environment, certain extensions and libraries around it.
- - A PHP interpreter with certain extensions available.  The `php`
-   attribute provides `php.buildEnv` that allows you to wrap the PHP
-   derivation with an additional config file that makes PHP import
-   additional libraries or dependencies.
+There's two majorly different parts of the PHP ecosystem in NixOS:
+ - Command line utilities for human interaction. These comes from the
+   `php.packages.*` attributes.
+ - PHP environments with different extensions enabled. These are
+   composed with `php.buildEnv` using an additional configuration file.
 
 ##### Example setup for `phpfpm`
 
-Example to build a PHP with `imagick` and `opcache` enabled, and
-configure it for the "foo" `phpfpm` pool:
+Example to build a PHP with the extensions `imagick` and `opcache`
+enabled. Then to configure it for the "foo" `phpfpm` pool:
 
 ```nix
 let
-  myPhp = php.buildEnv { exts = pp: with pp; [ imagick exts.opcache ]; };
+  myPhp = php.buildEnv { exts = pp: with pp; [ imagick opcache ]; };
 in {
   services.phpfpm.pools."foo".phpPackage = myPhp;
 };
@@ -68,8 +57,8 @@ in {
 ##### Example usage with `nix-shell`
 
 This brings up a temporary environment that contains a PHP interpreter
-with `imagick` and `opcache` enabled.
+with the extensions `imagick` and `opcache` enabled.
 
 ```sh
-nix-shell -p 'php.buildEnv { exts = pp: with pp; [ imagick exts.opcache ]; }'
+nix-shell -p 'php.buildEnv { exts = pp: with pp; [ imagick opcache ]; }'
 ```

--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -48,6 +48,21 @@ enabled:
 php.withExtensions (e: with e; [ imagick opcache ])
 ```
 
+Note that this will give you a package with _only_ opcache and
+ImageMagick, none of the other extensions which are enabled by default
+in the `php` package will be available.
+
+To enable building on a previous PHP package, the currently enabled
+extensions are made available in its `enabledExtensions`
+attribute. For example, to generate a package with all default
+extensions enabled, except opcache, but with ImageMagick:
+
+```nix
+php.withExtensions (e:
+  (lib.filter (e: e != php.extensions.opcache) php.enabledExtensions)
+  ++ [ e.imagick ])
+```
+
 If you want a PHP build with extra configuration in the `php.ini`
 file, you can use `php.buildEnv`. This function takes two named and
 optional parameters: `extensions` and `extraConfig`. `extensions`

--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -1,0 +1,75 @@
+# PHP
+
+## User Guide
+
+### Using PHP
+
+#### Overview
+
+Several versions of PHP are available on Nix, each of which having a
+wide variety of extensions and libraries available.
+
+The attribute `php` refers to the version of PHP considered most
+stable and thoroughly tested in nixpkgs for any given release of
+NixOS. Note that while this version of PHP may not be the latest major
+release from upstream, any version of PHP supported in nixpkgs may be
+utilized by specifying the desired attribute by version, such as
+`php74`.
+
+Only versions of PHP that are supported by upstream for the entirety
+of a given NixOS release will be included in that release of
+NixOS. See [PHP Supported
+Versions](https://www.php.net/supported-versions.php).
+
+As for packages we have `php.packages` that contains a bunch of
+attributes where some are suitable as extensions (notable example:
+`php.packages.imagick`). And some are more suitable for command
+line use (notable example: `php.packages.composer`).
+
+We have a special section within `php.packages` called
+`php.packages.exts` that contain certain PHP modules that may not
+be part of the default PHP derivation (example:
+`php.packages.exts.opcache`).
+
+The `php.packages.exts.*` attributes are official extensions which
+originate from the mainline PHP project, while other extensions within
+the `php.packages.*` attribute are of mixed origin (such as `pecl`
+and other places).
+
+The different versions of PHP that nixpkgs fetch is located under
+attributes named based on major and minor version number; e.g.,
+`php74` is PHP 7.4 with commonly used extensions installed,
+`php74base` is the same PHP runtime without extensions.
+
+#### Installing PHP with packages
+
+There's two different kinds of things you could install:
+ - A command line utility. Simply refer to it via
+   `php*.packages.*`, and it automatically comes with the necessary
+   PHP environment, certain extensions and libraries around it.
+ - A PHP interpreter with certain extensions available.  The `php`
+   attribute provides `php.buildEnv` that allows you to wrap the PHP
+   derivation with an additional config file that makes PHP import
+   additional libraries or dependencies.
+
+##### Example setup for `phpfpm`
+
+Example to build a PHP with `imagick` and `opcache` enabled, and
+configure it for the "foo" `phpfpm` pool:
+
+```nix
+let
+  myPhp = php.buildEnv { exts = pp: with pp; [ imagick exts.opcache ]; };
+in {
+  services.phpfpm.pools."foo".phpPackage = myPhp;
+};
+```
+
+##### Example usage with `nix-shell`
+
+This brings up a temporary environment that contains a PHP interpreter
+with `imagick` and `opcache` enabled.
+
+```sh
+nix-shell -p 'php.buildEnv { exts = pp: with pp; [ imagick exts.opcache ]; }'
+```

--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -21,34 +21,67 @@ of a given NixOS release will be included in that release of
 NixOS. See [PHP Supported
 Versions](https://www.php.net/supported-versions.php).
 
-For packages we have `php.packages` that contains packages related
-for human interaction, notable example is `php.packages.composer`.
+Interactive tools built on PHP are put in `php.packages`; composer is
+for example available at `php.packages.composer`.
 
-For extensions we have `php.extensions` that contains most upstream
-extensions as separate attributes as well some additional extensions
-that tend to be popular, notable example is: `php.extensions.imagick`.
+Most extensions that come with PHP, as well as some popular
+third-party ones, are available in `php.extensions`; for example, the
+opcache extension shipped with PHP is available at
+`php.extensions.opcache` and the third-party ImageMagick extension at
+`php.extensions.imagick`.
 
-The different versions of PHP that nixpkgs fetch is located under
+The different versions of PHP that nixpkgs provides is located under
 attributes named based on major and minor version number; e.g.,
 `php74` is PHP 7.4 with commonly used extensions installed,
 `php74base` is the same PHP runtime without extensions.
 
 #### Installing PHP with packages
 
-There's two majorly different parts of the PHP ecosystem in NixOS:
- - Command line utilities for human interaction. These comes from the
-   `php.packages.*` attributes.
- - PHP environments with different extensions enabled. These are
-   composed with `php.buildEnv` using an additional configuration file.
+A PHP package with specific extensions enabled can be built using
+`php.withExtensions`. This is a function which accepts an anonymous
+function as its only argument; the function should take one argument,
+the set of all extensions, and return a list of wanted extensions. For
+example, a PHP package with the opcache and ImageMagick extensions
+enabled:
+
+```nix
+php.withExtensions (e: with e; [ imagick opcache ])
+```
+
+If you want a PHP build with extra configuration in the `php.ini`
+file, you can use `php.buildEnv`. This function takes two named and
+optional parameters: `extensions` and `extraConfig`. `extensions`
+takes an extension specification equivalent to that of
+`php.withExtensions`, `extraConfig` a string of additional `php.ini`
+configuration parameters. For example, a PHP package with the opcache
+and ImageMagick extensions enabled, and `memory_limit` set to `256M`:
+
+```nix
+php.buildEnv {
+  extensions = e: with e; [ imagick opcache ];
+  extraConfig = "memory_limit=256M";
+}
+```
 
 ##### Example setup for `phpfpm`
 
-Example to build a PHP with the extensions `imagick` and `opcache`
-enabled. Then to configure it for the "foo" `phpfpm` pool:
+You can use the previous examples in a `phpfpm` pool called `foo` as
+follows:
 
 ```nix
 let
-  myPhp = php.buildEnv { exts = pp: with pp; [ imagick opcache ]; };
+  myPhp = php.withExtensions (e: with e; [ imagick opcache ]);
+in {
+  services.phpfpm.pools."foo".phpPackage = myPhp;
+};
+```
+
+```nix
+let
+  myPhp = php.buildEnv {
+    extensions = e: with e; [ imagick opcache ];
+    extraConfig = "memory_limit=256M";
+  };
 in {
   services.phpfpm.pools."foo".phpPackage = myPhp;
 };
@@ -60,5 +93,5 @@ This brings up a temporary environment that contains a PHP interpreter
 with the extensions `imagick` and `opcache` enabled.
 
 ```sh
-nix-shell -p 'php.buildEnv { exts = pp: with pp; [ imagick opcache ]; }'
+nix-shell -p 'php.buildEnv { extensions = e: with e; [ imagick opcache ]; }'
 ```

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -127,25 +127,30 @@
    </listitem>
    <listitem>
      <para>
-       Since this release we have an easy way to customize your PHP install to get a much smaller
-       base PHP with only wanted extensions enabled. See following snippet to install a smaller PHP
-       with <literal>imagick</literal>, <literal>opcache</literal> and <literal>pdo_mysql</literal>:
+       Since this release there's an easy way to customize your PHP install to get a much smaller
+       base PHP with only wanted extensions enabled. See the following snippet installing a smaller PHP
+       with the extensions <literal>imagick</literal>, <literal>opcache</literal> and
+       <literal>pdo_mysql</literal> loaded:
 
        <programlisting>
 environment.systemPackages = [
-(pkgs.phpbase.buildEnv { exts = pp: with pp; [
-    imagick
-    exts.opcache
-    exts.pdo_mysql
+(pkgs.php.buildEnv { exts = pp: with pp.exts; [
+    pp.imagick
+    opcache
+    pdo_mysql
   ]; })
 ];</programlisting>
 
-       All native PHP extensions are available under <package><![CDATA[phpPackages.exts.<name?>]]></package>.
+       The default <literal>php</literal> attribute hasn't lost any extensions -
+       the <literal>opcache</literal> extension was added there.
+
+       All upstream PHP extensions are available under <package><![CDATA[php.packages.exts.<name?>]]></package>.
      </para>
      <para>
-       Since we have a smaller base package that we base the main <literal>php</literal> on a
-       smaller base package we've decided to remove a big bunch of options to make the main
-       PHP derivation much easier to work with.
+       The updated <literal>php</literal> attribute is now easily customizable to your liking
+       by using extensions instead of writing config files or changing configure flags.
+
+       Therefore we have removed the following configure flags:
 
        <itemizedlist>
          <title>PHP <literal>config</literal> flags that we don't read anymore:</title>

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -125,6 +125,68 @@
      documentation for instructions.
     </para>
    </listitem>
+   <listitem>
+     <para>
+       Since this release we have an easy way to customize your PHP install to get a much smaller
+       base PHP with only wanted extensions enabled. See following snippet to install a smaller PHP
+       with <literal>imagick</literal>, <literal>opcache</literal> and <literal>pdo_mysql</literal>:
+
+       <programlisting>
+environment.systemPackages = [
+(pkgs.phpbase.buildEnv { exts = pp: with pp; [
+    imagick
+    exts.opcache
+    exts.pdo_mysql
+  ]; })
+];</programlisting>
+
+       All native PHP extensions are available under <package><![CDATA[phpPackages.exts.<name?>]]></package>.
+     </para>
+     <para>
+       Since we have a smaller base package that we base the main <literal>php</literal> on a
+       smaller base package we've decided to remove a big bunch of options to make the main
+       PHP derivation much easier to work with.
+
+       <itemizedlist>
+         <title>PHP <literal>config</literal> flags that we don't read anymore:</title>
+         <listitem><para><literal>config.php.argon2</literal></para></listitem>
+         <listitem><para><literal>config.php.bcmath</literal></para></listitem>
+         <listitem><para><literal>config.php.bz2</literal></para></listitem>
+         <listitem><para><literal>config.php.calendar</literal></para></listitem>
+         <listitem><para><literal>config.php.curl</literal></para></listitem>
+         <listitem><para><literal>config.php.exif</literal></para></listitem>
+         <listitem><para><literal>config.php.ftp</literal></para></listitem>
+         <listitem><para><literal>config.php.gd</literal></para></listitem>
+         <listitem><para><literal>config.php.gettext</literal></para></listitem>
+         <listitem><para><literal>config.php.gmp</literal></para></listitem>
+         <listitem><para><literal>config.php.imap</literal></para></listitem>
+         <listitem><para><literal>config.php.intl</literal></para></listitem>
+         <listitem><para><literal>config.php.ldap</literal></para></listitem>
+         <listitem><para><literal>config.php.libxml2</literal></para></listitem>
+         <listitem><para><literal>config.php.libzip</literal></para></listitem>
+         <listitem><para><literal>config.php.mbstring</literal></para></listitem>
+         <listitem><para><literal>config.php.mysqli</literal></para></listitem>
+         <listitem><para><literal>config.php.mysqlnd</literal></para></listitem>
+         <listitem><para><literal>config.php.openssl</literal></para></listitem>
+         <listitem><para><literal>config.php.pcntl</literal></para></listitem>
+         <listitem><para><literal>config.php.pdo_mysql</literal></para></listitem>
+         <listitem><para><literal>config.php.pdo_odbc</literal></para></listitem>
+         <listitem><para><literal>config.php.pdo_pgsql</literal></para></listitem>
+         <listitem><para><literal>config.php.phpdbg</literal></para></listitem>
+         <listitem><para><literal>config.php.postgresql</literal></para></listitem>
+         <listitem><para><literal>config.php.readline</literal></para></listitem>
+         <listitem><para><literal>config.php.soap</literal></para></listitem>
+         <listitem><para><literal>config.php.sockets</literal></para></listitem>
+         <listitem><para><literal>config.php.sodium</literal></para></listitem>
+         <listitem><para><literal>config.php.sqlite</literal></para></listitem>
+         <listitem><para><literal>config.php.tidy</literal></para></listitem>
+         <listitem><para><literal>config.php.xmlrpc</literal></para></listitem>
+         <listitem><para><literal>config.php.xsl</literal></para></listitem>
+         <listitem><para><literal>config.php.zip</literal></para></listitem>
+         <listitem><para><literal>config.php.zlib</literal></para></listitem>
+       </itemizedlist>
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -134,7 +134,7 @@
 
        <programlisting>
 environment.systemPackages = [
-(pkgs.php.buildEnv { exts = pp: with pp; [
+(pkgs.php.buildEnv { extensions = pp: with pp; [
     imagick
     opcache
     pdo_mysql

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -134,8 +134,8 @@
 
        <programlisting>
 environment.systemPackages = [
-(pkgs.php.buildEnv { exts = pp: with pp.exts; [
-    pp.imagick
+(pkgs.php.buildEnv { exts = pp: with pp; [
+    imagick
     opcache
     pdo_mysql
   ]; })
@@ -144,7 +144,7 @@ environment.systemPackages = [
        The default <literal>php</literal> attribute hasn't lost any extensions -
        the <literal>opcache</literal> extension was added there.
 
-       All upstream PHP extensions are available under <package><![CDATA[php.packages.exts.<name?>]]></package>.
+       All upstream PHP extensions are available under <package><![CDATA[php.extensions.<name?>]]></package>.
      </para>
      <para>
        The updated <literal>php</literal> attribute is now easily customizable to your liking

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -7,7 +7,7 @@ let
   fpm = config.services.phpfpm.pools.nextcloud;
 
   phpPackage = pkgs.php74.buildEnv {
-    exts = pp: with pp; [
+    extensions = e: with e; [
       bcmath calendar curl exif ftp filter gd gettext gmp intl json ldap
       mysqlnd opcache openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql
       pdo_sqlite pgsql readline session soap sodium sqlite3 zip zlib mbstring

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -6,12 +6,12 @@ let
   cfg = config.services.nextcloud;
   fpm = config.services.phpfpm.pools.nextcloud;
 
-  phpPackage = pkgs.php73.buildEnv {
+  phpPackage = pkgs.php74.buildEnv {
     exts = pp: with pp.exts; [
       bcmath calendar curl exif ftp filter gd gettext gmp intl json ldap
       mysqlnd opcache openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql
       pdo_sqlite pgsql readline session soap sodium sqlite3 zip zlib mbstring
-      posix hash ctype dom simplexml xmlreader xmlwriter pp.apcu
+      posix ctype dom simplexml xmlreader xmlwriter pp.apcu
       pp.redis pp.memcached pp.imagick
     ];
     extraConfig = phpOptionsStr;

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -6,16 +6,17 @@ let
   cfg = config.services.nextcloud;
   fpm = config.services.phpfpm.pools.nextcloud;
 
-  phpPackage = pkgs.php74.buildEnv {
-    extensions = e: with e; [
-      bcmath calendar curl exif ftp filter gd gettext gmp intl json ldap
-      mysqlnd opcache openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql
-      pdo_sqlite pgsql readline session soap sodium sqlite3 zip zlib mbstring
-      posix ctype dom simplexml xmlreader xmlwriter
-      apcu redis memcached imagick
-    ];
-    extraConfig = phpOptionsStr;
-  };
+  phpPackage =
+    let
+      base = pkgs.php74;
+    in
+      base.buildEnv {
+        extensions = e: with e;
+          base.enabledExtensions ++ [
+            apcu redis memcached imagick
+          ];
+        extraConfig = phpOptionsStr;
+      };
 
   toKeyValue = generators.toKeyValue {
     mkKeyValue = generators.mkKeyValueDefault {} " = ";

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -7,12 +7,12 @@ let
   fpm = config.services.phpfpm.pools.nextcloud;
 
   phpPackage = pkgs.php74.buildEnv {
-    exts = pp: with pp.exts; [
+    exts = pp: with pp; [
       bcmath calendar curl exif ftp filter gd gettext gmp intl json ldap
       mysqlnd opcache openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql
       pdo_sqlite pgsql readline session soap sodium sqlite3 zip zlib mbstring
-      posix ctype dom simplexml xmlreader xmlwriter pp.apcu
-      pp.redis pp.memcached pp.imagick
+      posix ctype dom simplexml xmlreader xmlwriter
+      apcu redis memcached imagick
     ];
     extraConfig = phpOptionsStr;
   };

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -112,7 +112,7 @@ in rec {
       "nixos.tests.nfs4.simple.x86_64-linux"
       "nixos.tests.openssh.x86_64-linux"
       "nixos.tests.pantheon.x86_64-linux"
-      "nixos.tests.php-pcre.x86_64-linux"
+      "nixos.tests.php.x86_64-linux"
       "nixos.tests.plasma5.x86_64-linux"
       "nixos.tests.predictable-interface-names.predictableNetworkd.x86_64-linux"
       "nixos.tests.predictable-interface-names.predictable.x86_64-linux"

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -40,7 +40,7 @@ in rec {
         nat
         nfs3
         openssh
-        php-pcre
+        php
         predictable-interface-names
         proxy
         simple;
@@ -108,7 +108,7 @@ in rec {
         "nixos.tests.nat.standalone.x86_64-linux"
         "nixos.tests.nfs3.simple.x86_64-linux"
         "nixos.tests.openssh.x86_64-linux"
-        "nixos.tests.php-pcre.x86_64-linux"
+        "nixos.tests.php.x86_64-linux"
         "nixos.tests.predictable-interface-names.predictable.x86_64-linux"
         "nixos.tests.predictable-interface-names.predictableNetworkd.x86_64-linux"
         "nixos.tests.predictable-interface-names.unpredictable.x86_64-linux"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -240,6 +240,7 @@ in
   peerflix = handleTest ./peerflix.nix {};
   pgjwt = handleTest ./pgjwt.nix {};
   pgmanage = handleTest ./pgmanage.nix {};
+  php = handleTest ./php {};
   php-pcre = handleTest ./php-pcre.nix {};
   plasma5 = handleTest ./plasma5.nix {};
   plotinus = handleTest ./plotinus.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -241,7 +241,6 @@ in
   pgjwt = handleTest ./pgjwt.nix {};
   pgmanage = handleTest ./pgmanage.nix {};
   php = handleTest ./php {};
-  php-pcre = handleTest ./php-pcre.nix {};
   plasma5 = handleTest ./plasma5.nix {};
   plotinus = handleTest ./plotinus.nix {};
   postgis = handleTest ./postgis.nix {};

--- a/nixos/tests/php/default.nix
+++ b/nixos/tests/php/default.nix
@@ -3,4 +3,5 @@
   pkgs ? import ../../.. { inherit system config; }
 }: {
   fpm = import ./fpm.nix { inherit system pkgs; };
+  pcre = import ./pcre.nix { inherit system pkgs; };
 }

--- a/nixos/tests/php/default.nix
+++ b/nixos/tests/php/default.nix
@@ -1,0 +1,6 @@
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../../.. { inherit system config; }
+}: {
+  fpm = import ./fpm.nix { inherit system pkgs; };
+}

--- a/nixos/tests/php/fpm.nix
+++ b/nixos/tests/php/fpm.nix
@@ -1,0 +1,55 @@
+import ../make-test-python.nix ({pkgs, ...}: {
+  name = "php-fpm-nginx-test";
+  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ etu ];
+
+  machine = { config, lib, pkgs, ... }: {
+    services.nginx = {
+      enable = true;
+
+      virtualHosts."phpfpm" = let
+        testdir = pkgs.writeTextDir "web/index.php" "<?php phpinfo();";
+      in {
+        root = "${testdir}/web";
+        locations."~ \.php$".extraConfig = ''
+          fastcgi_pass unix:${config.services.phpfpm.pools.foobar.socket};
+          fastcgi_index index.php;
+          include ${pkgs.nginx}/conf/fastcgi_params;
+          include ${pkgs.nginx}/conf/fastcgi.conf;
+        '';
+        locations."/" = {
+          tryFiles = "$uri $uri/ index.php";
+          index = "index.php index.html index.htm";
+        };
+      };
+    };
+
+    services.phpfpm.pools."foobar" = {
+      user = "nginx";
+      settings = {
+        "listen.group" = "nginx";
+        "listen.mode" = "0600";
+        "listen.owner" = "nginx";
+        "pm" = "dynamic";
+        "pm.max_children" = 5;
+        "pm.max_requests" = 500;
+        "pm.max_spare_servers" = 3;
+        "pm.min_spare_servers" = 1;
+        "pm.start_servers" = 2;
+      };
+    };
+  };
+  testScript = { ... }: ''
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_unit("phpfpm-foobar.service")
+
+    # Check so we get an evaluated PHP back
+    assert "PHP Version ${pkgs.php.version}" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+
+    # Check so we have database and some other extensions loaded
+    assert "json" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+    assert "opcache" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+    assert "pdo_mysql" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+    assert "pdo_pgsql" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+    assert "pdo_sqlite" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+  '';
+})

--- a/nixos/tests/php/pcre.nix
+++ b/nixos/tests/php/pcre.nix
@@ -1,7 +1,6 @@
-
-let testString = "can-use-subgroups"; in
-
-import ./make-test-python.nix ({ ...}: {
+let
+  testString = "can-use-subgroups";
+in import ../make-test-python.nix ({ ...}: {
   name = "php-httpd-pcre-jit-test";
   machine = { lib, pkgs, ... }: {
     time.timeZone = "UTC";
@@ -10,15 +9,13 @@ import ./make-test-python.nix ({ ...}: {
       adminAddr = "please@dont.contact";
       enablePHP = true;
       phpOptions = "pcre.jit = true";
-      extraConfig =
-      let
+      extraConfig = let
         testRoot = pkgs.writeText "index.php"
-        ''
-          <?php
+          ''
+            <?php
             preg_match('/(${testString})/', '${testString}', $result);
             var_dump($result);
-          ?>
-        '';
+          '';
       in
         ''
           Alias / ${testRoot}/
@@ -30,11 +27,11 @@ import ./make-test-python.nix ({ ...}: {
     };
   };
   testScript = { ... }:
-  ''
-    machine.wait_for_unit("httpd.service")
-    # Ensure php evaluation by matching on the var_dump syntax
-    assert 'string(${toString (builtins.stringLength testString)}) "${testString}"' in machine.succeed(
-        "curl -vvv -s http://127.0.0.1:80/index.php"
-    )
-  '';
+    ''
+      machine.wait_for_unit("httpd.service")
+      # Ensure php evaluation by matching on the var_dump syntax
+      assert 'string(${toString (builtins.stringLength testString)}) "${testString}"' in machine.succeed(
+          "curl -vvv -s http://127.0.0.1:80/index.php"
+      )
+    '';
 })

--- a/pkgs/build-support/build-pecl.nix
+++ b/pkgs/build-support/build-pecl.nix
@@ -1,9 +1,11 @@
-{ stdenv, php, autoreconfHook, fetchurl, re2c }:
+{ stdenv, lib, php, autoreconfHook, fetchurl, re2c }:
 
 { pname
 , version
+, internalDeps ? []
 , buildInputs ? []
 , nativeBuildInputs ? []
+, postPhpize ? ""
 , makeFlags ? []
 , src ? fetchurl {
     url = "http://pecl.php.net/get/${pname}-${version}.tgz";
@@ -22,5 +24,11 @@ stdenv.mkDerivation (args // {
 
   makeFlags = [ "EXTENSION_DIR=$(out)/lib/php/extensions" ] ++ makeFlags;
 
-  autoreconfPhase = "phpize";
+  autoreconfPhase = ''
+    phpize
+    ${postPhpize}
+    ${lib.concatMapStringsSep "\n"
+      (dep: "mkdir -p ext; ln -s ${dep.dev}/include ext/${dep.extensionName}")
+      internalDeps}
+  '';
 })

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,4 +1,6 @@
-# pcre functionality is tested in nixos/tests/php-pcre.nix
+# We have tests for PCRE and PHP-FPM in nixos/tests/php/ or
+# both in the same attribute named nixosTests.php
+
 { callPackage, config, fetchurl, lib, makeWrapper, stdenv, symlinkJoin
 , writeText , autoconf, automake, bison, flex, libtool, pkgconfig, re2c
 , apacheHttpd, libargon2, libxml2, pcre, pcre2 , systemd, valgrind

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -178,9 +178,9 @@ let
 
           extNames = map getExtName extList;
           extraInit = writeText "custom-php.ini" ''
-            ${extraConfig}
             ${lib.concatStringsSep "\n"
               (lib.textClosureList extensionTexts extNames)}
+            ${extraConfig}
           '';
         in
           symlinkJoin {

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -252,9 +252,12 @@ let
     tokenizer xmlreader xmlwriter zip zlib
   ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]);
 
+  defaultPhpExtensionsWithHash = extensions:
+    (defaultPhpExtensions extensions) ++ [ extensions.hash ];
+
   php74 = php74base.withExtensions defaultPhpExtensions;
-  php73 = php73base.withExtensions defaultPhpExtensions;
-  php72 = php72base.withExtensions defaultPhpExtensions;
+  php73 = php73base.withExtensions defaultPhpExtensionsWithHash;
+  php72 = php72base.withExtensions defaultPhpExtensionsWithHash;
 
 in {
   inherit php72base php73base php74base php72 php73 php74;

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -171,7 +171,8 @@ let
                 in
                   lib.nameValuePair extName {
                     text = "${type}=${ext}/lib/php/extensions/${extName}.so";
-                    deps = lib.optionals (ext ? internalDeps) ext.internalDeps;
+                    deps = lib.optionals (ext ? internalDeps)
+                      (map getExtName ext.internalDeps);
                   })
                 extList);
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -192,10 +192,13 @@ let
             };
             paths = [ php ];
             postBuild = ''
-              wrapProgram $out/bin/php \
-                --add-flags "-c ${extraInit}"
-              wrapProgram $out/bin/php-fpm \
-                --add-flags "-c ${extraInit}"
+              cp ${extraInit} $out/lib/custom-php.ini
+
+              wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
+
+              if test -e $out/bin/php-fpm; then
+                 wrapProgram $out/bin/php-fpm --set PHP_INI_SCAN_DIR $out/lib
+              fi
             '';
           };
     in

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -188,8 +188,7 @@ let
     };
   });
 
-in {
-  php72 = generic' {
+  php72base = generic' {
     version = "7.2.28";
     sha256 = "18sjvl67z5a2x5s2a36g6ls1r3m4hbrsw52hqr2qsgfvg5dkm5bw";
 
@@ -197,7 +196,7 @@ in {
     extraPatches = lib.optional stdenv.isDarwin ./php72-darwin-isfinite.patch;
   };
 
-  php73 = generic' {
+  php73base = generic' {
     version = "7.3.15";
     sha256 = "0g84hws15s8gh8iq4h6q747dyfazx47vh3da3whz8d80x83ibgld";
 
@@ -205,8 +204,24 @@ in {
     extraPatches = lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;
   };
 
-  php74 = generic' {
+  php74base = generic' {
     version = "7.4.3";
     sha256 = "wVF7pJV4+y3MZMc6Ptx21PxQfEp6xjmYFYTMfTtMbRQ=";
   };
+
+  defaultPhpExtensions = {
+    exts = pp: with pp.exts; ([
+      bcmath calendar curl ctype dom exif fileinfo filter ftp gd
+      gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
+      openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
+      posix readline session simplexml sockets soap sodium sqlite3
+      tokenizer xmlreader xmlwriter zip zlib
+    ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]);
+  };
+in {
+  inherit php72base php73base php74base;
+
+  php74 = php74base.buildEnv defaultPhpExtensions;
+  php73 = php73base.buildEnv defaultPhpExtensions;
+  php72 = php72base.buildEnv defaultPhpExtensions;
 }

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -193,7 +193,7 @@ let
             inherit (php) dev;
             nativeBuildInputs = [ makeWrapper ];
             passthru = {
-              inherit buildEnv;
+              inherit buildEnv withExtensions;
               inherit (php-packages) packages extensions;
             };
             paths = [ php ];
@@ -207,10 +207,12 @@ let
               fi
             '';
           };
+
+      withExtensions = extensions: buildEnv { inherit extensions; };
     in
       php.overrideAttrs (_: {
         passthru = {
-          inherit buildEnv;
+          inherit buildEnv withExtensions;
           inherit (php-packages) packages extensions;
         };
       });
@@ -242,19 +244,17 @@ let
     selfWithExtensions = php74;
   };
 
-  defaultPhpExtensions = {
-    extensions = extensions: with extensions; ([
-      bcmath calendar curl ctype dom exif fileinfo filter ftp gd
-      gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
-      openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
-      posix readline session simplexml sockets soap sodium sqlite3
-      tokenizer xmlreader xmlwriter zip zlib
-    ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]);
-  };
+  defaultPhpExtensions = extensions: with extensions; ([
+    bcmath calendar curl ctype dom exif fileinfo filter ftp gd
+    gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
+    openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
+    posix readline session simplexml sockets soap sodium sqlite3
+    tokenizer xmlreader xmlwriter zip zlib
+  ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]);
 
-  php74 = php74base.buildEnv defaultPhpExtensions;
-  php73 = php73base.buildEnv defaultPhpExtensions;
-  php72 = php72base.buildEnv defaultPhpExtensions;
+  php74 = php74base.withExtensions defaultPhpExtensions;
+  php73 = php73base.withExtensions defaultPhpExtensions;
+  php72 = php72base.withExtensions defaultPhpExtensions;
 
 in {
   inherit php72base php73base php74base php72 php73 php74;

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -195,6 +195,7 @@ let
           symlinkJoin {
             name = "php-with-extensions-${version}";
             inherit version;
+            inherit (php) dev;
             nativeBuildInputs = [ makeWrapper ];
             passthru = {
               inherit buildEnv packages extensions;

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, which
 , withPython2 ? false, python2
 , withPython3 ? true, python3, ncurses
-, withPHP72 ? false, php72base
-, withPHP73 ? true, php73base
+, withPHP72 ? false, php72
+, withPHP73 ? true, php73
 , withPerl528 ? false, perl528
 , withPerl530 ? true, perl530
 , withPerldevel ? false, perldevel
@@ -26,8 +26,8 @@ let
     config.php.fpm = false;
   };
 
-  php72-unit = php72base.override phpConfig;
-  php73-unit = php73base.override phpConfig;
+  php72-unit = php72.override phpConfig;
+  php73-unit = php73.override phpConfig;
 in stdenv.mkDerivation rec {
   version = "1.16.0";
   pname = "unit";
@@ -49,8 +49,8 @@ in stdenv.mkDerivation rec {
   buildInputs = [ ]
     ++ optional withPython2 python2
     ++ optionals withPython3 [ python3 ncurses ]
-    ++ optional withPHP72 php72
-    ++ optional withPHP73 php73
+    ++ optional withPHP72 php72-unit
+    ++ optional withPHP73 php73-unit
     ++ optional withPerl528 perl528
     ++ optional withPerl530 perl530
     ++ optional withPerldevel perldevel
@@ -71,8 +71,8 @@ in stdenv.mkDerivation rec {
   postConfigure = ''
     ${optionalString withPython2    "./configure python --module=python2  --config=${python2}/bin/python2-config  --lib-path=${python2}/lib"}
     ${optionalString withPython3    "./configure python --module=python3  --config=${python3}/bin/python3-config  --lib-path=${python3}/lib"}
-    ${optionalString withPHP72      "./configure php    --module=php72    --config=${php72.dev}/bin/php-config    --lib-path=${php72}/lib"}
-    ${optionalString withPHP73      "./configure php    --module=php73    --config=${php73.dev}/bin/php-config    --lib-path=${php73}/lib"}
+    ${optionalString withPHP72      "./configure php    --module=php72    --config=${php72-unit.dev}/bin/php-config    --lib-path=${php72-unit}/lib"}
+    ${optionalString withPHP73      "./configure php    --module=php73    --config=${php73-unit.dev}/bin/php-config    --lib-path=${php73-unit}/lib"}
     ${optionalString withPerl528    "./configure perl   --module=perl528  --perl=${perl528}/bin/perl"}
     ${optionalString withPerl530    "./configure perl   --module=perl530  --perl=${perl530}/bin/perl"}
     ${optionalString withPerldevel  "./configure perl   --module=perldev  --perl=${perldevel}/bin/perl"}

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, which
 , withPython2 ? false, python2
 , withPython3 ? true, python3, ncurses
-, withPHP72 ? false, php72
-, withPHP73 ? true, php73
+, withPHP72 ? false, php72base
+, withPHP73 ? true, php73base
 , withPerl528 ? false, perl528
 , withPerl530 ? true, perl530
 , withPerldevel ? false, perldevel
@@ -16,7 +16,19 @@
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
+let
+  phpConfig = {
+    config.php.embed = true;
+    config.php.apxs2 = false;
+    config.php.systemd = false;
+    config.php.phpdbg = false;
+    config.php.cgi = false;
+    config.php.fpm = false;
+  };
+
+  php72-unit = php72base.override phpConfig;
+  php73-unit = php73base.override phpConfig;
+in stdenv.mkDerivation rec {
   version = "1.16.0";
   pname = "unit";
 

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -4,10 +4,15 @@
 , pam, withPAM ? stdenv.isLinux
 , systemd, withSystemd ? stdenv.isLinux
 , python2, python3, ncurses
-, ruby, php-embed, libmysqlclient
+, ruby, php, libmysqlclient
 }:
 
-let pythonPlugin = pkg : lib.nameValuePair "python${if pkg.isPy2 then "2" else "3"}" {
+let php-embed = php.override {
+      config.php.embed = true;
+      config.php.apxs2 = false;
+    };
+
+    pythonPlugin = pkg : lib.nameValuePair "python${if pkg.isPy2 then "2" else "3"}" {
                            interpreter = pkg.interpreter;
                            path = "plugins/python";
                            inputs = [ pkg ncurses ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -320,6 +320,25 @@ mapAliases ({
   perlArchiveCpio = perlPackages.ArchiveCpio; # added 2018-10-12
   pgp-tools = signing-party; # added 2017-03-26
   pg_tmp = ephemeralpg; # added 2018-01-16
+
+  php-embed = throw ''
+    php*-embed has been dropped, you can build the same package by using
+     something similar with this following snippet:
+    (php74.override { config.php.embed = true; config.php.apxs2 = false; })
+  ''; # added 2020-04-01
+  php72-embed = php-embed; # added 2020-04-01
+  php73-embed = php-embed; # added 2020-04-01
+  php74-embed = php-embed; # added 2020-04-01
+
+  phpPackages-embed = throw ''
+    php*Packages-embed has been dropped, you can build the same package by using
+     something similar with this following snippet:
+    (php74.override { config.php.embed = true; config.php.apxs2 = false; }).packages
+  ''; # added 2020-04-01
+  php74Packages-embed = phpPackages-embed;
+  php73Packages-embed = phpPackages-embed;
+  php72Packages-embed = phpPackages-embed;
+
   pidgin-with-plugins = pidgin; # added 2016-06
   pidginlatex = pidgin-latex; # added 2018-01-08
   pidginlatexSF = pidgin-latex; # added 2014-11-02

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -339,6 +339,36 @@ mapAliases ({
   php73Packages-embed = phpPackages-embed;
   php72Packages-embed = phpPackages-embed;
 
+  php-unit = throw ''
+    php*-unit has been dropped, you can build the same package by using
+     something similar with this following snippet:
+    (php74.override {
+      config.php.embed = true;
+      config.php.apxs2 = false;
+      config.php.systemd = false;
+      config.php.phpdbg = false;
+      config.php.cgi = false;
+      config.php.fpm = false; })
+  ''; # added 2020-04-01
+  php72-unit = php-unit; # added 2020-04-01
+  php73-unit = php-unit; # added 2020-04-01
+  php74-unit = php-unit; # added 2020-04-01
+
+  phpPackages-unit = throw ''
+    php*Packages-unit has been dropped, you can build the same package by using
+     something similar with this following snippet:
+    (php74.override {
+      config.php.embed = true;
+      config.php.apxs2 = false;
+      config.php.systemd = false;
+      config.php.phpdbg = false;
+      config.php.cgi = false;
+      config.php.fpm = false; }).packages
+  ''; # added 2020-04-01
+  php74Packages-unit = phpPackages-unit;
+  php73Packages-unit = phpPackages-unit;
+  php72Packages-unit = phpPackages-unit;
+
   pidgin-with-plugins = pidgin; # added 2016-06
   pidginlatex = pidgin-latex; # added 2018-01-08
   pidginlatexSF = pidgin-latex; # added 2014-11-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9371,19 +9371,11 @@ in
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };
 
   php = php74;
+
   phpPackages = php74Packages;
-
-  php72Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php72base;
-  });
-
-  php73Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php73base;
-  });
-
-  php74Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php74base;
-  });
+  php72Packages = recurseIntoAttrs php72.packages;
+  php73Packages = recurseIntoAttrs php73.packages;
+  php74Packages = recurseIntoAttrs php74.packages;
 
   inherit (callPackages ../development/interpreters/php {
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9374,15 +9374,15 @@ in
   phpPackages = php74Packages;
 
   php72Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php72;
+    php = php72base;
   });
 
   php73Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php73;
+    php = php73base;
   });
 
   php74Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php74;
+    php = php74base;
   });
 
   phpPackages-unit = php74Packages-unit;
@@ -9401,10 +9401,7 @@ in
 
   inherit (callPackages ../development/interpreters/php {
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
-  })
-    php74
-    php73
-    php72;
+  }) php74 php73 php72 php74base php73base php72base;
 
   php-embed = php74-embed;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9377,6 +9377,11 @@ in
   php73Packages = recurseIntoAttrs php73.packages;
   php74Packages = recurseIntoAttrs php74.packages;
 
+  phpExtensions = php74Extensions;
+  php72Extensions = recurseIntoAttrs php72.extensions;
+  php73Extensions = recurseIntoAttrs php73.extensions;
+  php74Extensions = recurseIntoAttrs php74.extensions;
+
   inherit (callPackages ../development/interpreters/php {
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   }) php74 php73 php72 php74base php73base php72base;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9385,52 +9385,9 @@ in
     php = php74base;
   });
 
-  phpPackages-unit = php74Packages-unit;
-
-  php72Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php72-unit;
-  });
-
-  php73Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php73-unit;
-  });
-
-  php74Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
-    php = php74-unit;
-  });
-
   inherit (callPackages ../development/interpreters/php {
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   }) php74 php73 php72 php74base php73base php72base;
-
-  php-unit = php74-unit;
-
-  php72-unit = php72.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-    config.php.systemd = false;
-    config.php.phpdbg = false;
-    config.php.cgi = false;
-    config.php.fpm = false;
-  };
-
-  php73-unit = php73.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-    config.php.systemd = false;
-    config.php.phpdbg = false;
-    config.php.cgi = false;
-    config.php.fpm = false;
-  };
-
-  php74-unit = php74.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-    config.php.systemd = false;
-    config.php.phpdbg = false;
-    config.php.cgi = false;
-    config.php.fpm = false;
-  };
 
   picoc = callPackage ../development/interpreters/picoc {};
 
@@ -15591,10 +15548,7 @@ in
 
   neard = callPackage ../servers/neard { };
 
-  unit = callPackage ../servers/http/unit {
-    php72 = php72-unit;
-    php73 = php73-unit;
-  };
+  unit = callPackage ../servers/http/unit { };
 
   nginx = nginxStable;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9403,23 +9403,6 @@ in
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   }) php74 php73 php72 php74base php73base php72base;
 
-  php-embed = php74-embed;
-
-  php72-embed = php72.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-  };
-
-  php73-embed = php73.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-  };
-
-  php74-embed = php74.override {
-    config.php.embed = true;
-    config.php.apxs2 = false;
-  };
-
   php-unit = php74-unit;
 
   php72-unit = php72.override {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -621,6 +621,27 @@ in
       };
     };
 
+    pthreads = let
+      version = "3.2.0";
+      src = pkgs.fetchFromGitHub ({
+        owner = "krakjoe";
+        repo = "pthreads";
+      } // (if (isPhp73) then {
+        rev = "4d1c2483ceb459ea4284db4eb06646d5715e7154";
+        sha256 = "07kdxypy0bgggrfav2h1ccbv67lllbvpa3s3zsaqci0gq4fyi830";
+      } else {
+        rev = "v3.2.0";
+        sha256 = "17hypm75d4w7lvz96jb7s0s87018yzmmap0l125d5fd7abnhzfvv";
+      }));
+    in buildPecl {
+      pname = "pthreads";
+      inherit version src;
+
+      buildInputs = [ pcre'.dev ];
+
+      meta.broken = isPhp74;
+    };
+
     redis = buildPecl {
       version = "5.1.1";
       pname = "redis";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -779,10 +779,6 @@ let
           "--enable-gd-jis-conv"
         ];
         enable = lib.versionOlder php.version "7.4"; }
-      ## gettext (7.2, 7.3, 7.4) -- configure: error: Cannot locate header file libintl.h
-      #{ name = "gettext";
-      #  buildInputs = [ gettext ];
-      #  configureFlags = "--with-gettext=${gettext}"; }
       { name = "gmp";
         buildInputs = [ gmp5 ];
         configureFlags = [ "--with-gmp=${gmp5.dev}" ];
@@ -827,13 +823,8 @@ let
       { name = "pdo_pgsql"; configureFlags = [ "--with-pdo-pgsql=${postgresql}" ]; }
       { name = "pdo_sqlite"; buildInputs = [ sqlite ]; configureFlags = [ "--with-pdo-sqlite=${sqlite.dev}" ]; }
       { name = "pgsql"; buildInputs = [ pcre' ]; configureFlags = [ "--with-pgsql=${postgresql}" ]; }
-      { name = "phar"; buildInputs = [ pcre' openssl ]; }
       { name = "posix"; }
       { name = "pspell"; configureFlags = [ "--with-pspell=${aspell}" ]; }
-      ## readline (7.4, 7.3, 7.2) -- configure: error: Please reinstall libedit - I cannot find readline.h
-      #{ name = "readline";
-      #  buildInputs = [ libedit readline ];
-      #  configureFlags = [ "--with-readline=${readline.dev}" ]; }
       { name = "recode";
         configureFlags = [ "--with-recode=${recode}" ];
         # Removed in php 7.4.

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -26,8 +26,7 @@ in
 {
   inherit buildPecl;
 
-  # Packages are an attribute set meant for for human interaction and not
-  # extensions for the language itself.
+  # This is a set of interactive tools based on PHP.
   packages = {
     box = mkDerivation rec {
       version = "2.7.5";
@@ -293,8 +292,9 @@ in
 
 
 
-  # Extensions are an attribute set meant for for PHP extensions that extend the
-  # language rather than human interaction.
+  # This is a set of PHP extensions meant to be used in php.buildEnv
+  # or php.withExtensions to extend the functionality of the PHP
+  # interpreter.
   extensions = {
     apcu = buildPecl {
       version = "5.1.18";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, pkgs, fetchgit, php, autoconf, pkgconfig, re2c
-, bzip2, curl, libxml2, openssl, gmp5, icu, oniguruma, libsodium, html-tidy
+, bzip2, curl, libxml2, openssl, gmp, icu, oniguruma, libsodium, html-tidy
 , libzip, zlib, pcre, pcre2, libxslt, aspell, openldap, cyrus_sasl, uwimap
 , pam, libiconv, enchant1, libXpm, gd, libwebp, libjpeg, libpng, freetype
 , libffi, freetds, postgresql, sqlite, recode, net-snmp, unixODBC }:
@@ -780,10 +780,8 @@ let
         ];
         enable = lib.versionOlder php.version "7.4"; }
       { name = "gmp";
-        buildInputs = [ gmp5 ];
-        configureFlags = [ "--with-gmp=${gmp5.dev}" ];
-        # gmp5 doesn't build on darwin.
-        enable = (!stdenv.isDarwin); }
+        buildInputs = [ gmp ];
+        configureFlags = [ "--with-gmp=${gmp.dev}" ]; }
       { name = "hash"; enable = lib.versionOlder php.version "7.4"; }
       { name = "iconv"; configureFlags = if stdenv.isDarwin then
                            [ "--with-iconv=${libiconv}" ]

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -1,8 +1,9 @@
-{ stdenv, lib, pkgs, fetchgit, php, autoconf, pkgconfig, re2c
+{ stdenv, lib, pkgs, fetchgit, php, autoconf, pkgconfig, re2c, gettext
 , bzip2, curl, libxml2, openssl, gmp, icu, oniguruma, libsodium, html-tidy
 , libzip, zlib, pcre, pcre2, libxslt, aspell, openldap, cyrus_sasl, uwimap
 , pam, libiconv, enchant1, libXpm, gd, libwebp, libjpeg, libpng, freetype
-, libffi, freetds, postgresql, sqlite, recode, net-snmp, unixODBC }:
+, libffi, freetds, postgresql, sqlite, net-snmp, unixODBC, libedit, readline
+}:
 
 let
   self = with self; {
@@ -709,6 +710,8 @@ let
     mkExtension = {
       name
       , configureFlags ? [ "--enable-${name}" ]
+      , internalDeps ? []
+      , postPhpize ? ""
       , buildInputs ? []
       , zendExtension ? false
       , ...
@@ -720,10 +723,24 @@ let
 
       enableParallelBuilding = true;
       nativeBuildInputs = [ php autoconf pkgconfig re2c ];
-      inherit configureFlags buildInputs zendExtension;
+      inherit configureFlags internalDeps buildInputs zendExtension;
 
-      preConfigure = "phpize";
+      preConfigure = ''
+        nullglobRestore=$(shopt -p nullglob)
+        shopt -u nullglob   # To make ?-globbing work
 
+        # Some extensions have a config0.m4 or config9.m4
+        if [ -f config?.m4 ]; then
+          mv config?.m4 config.m4
+        fi
+
+        $nullglobRestore
+        phpize
+        ${postPhpize}
+        ${lib.concatMapStringsSep "\n"
+          (dep: "mkdir -p ext; ln -s ../../${dep} ext/")
+          internalDeps}
+      '';
       installPhase = ''
         mkdir -p $out/lib/php/extensions
         cp modules/${name}.so $out/lib/php/extensions/ext-${name}.so
@@ -779,6 +796,10 @@ let
           "--enable-gd-jis-conv"
         ];
         enable = lib.versionOlder php.version "7.4"; }
+      { name = "gettext";
+        buildInputs = [ gettext ];
+        postPhpize = ''substituteInPlace configure --replace 'as_fn_error $? "Cannot locate header file libintl.h" "$LINENO" 5' ':' '';
+        configureFlags = "--with-gettext=${gettext}"; }
       { name = "gmp";
         buildInputs = [ gmp ];
         configureFlags = [ "--with-gmp=${gmp.dev}" ]; }
@@ -804,29 +825,96 @@ let
           "LDAP_LIBDIR=${openldap.out}/lib"
         ] ++ lib.optional stdenv.isLinux "--with-ldap-sasl=${cyrus_sasl.dev}"; }
       { name = "mbstring"; buildInputs = [ oniguruma ]; }
-      { name = "mysqli"; configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ]; }
+      { name = "mysqli";
+        internalDeps = [ "mysqlnd" ];
+        configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ]; }
+      { name = "mysqlnd";
+        buildInputs = [ zlib openssl ];
+        # The configure script doesn't correctly add library link
+        # flags, so we add them to the variable used by the Makefile
+        # when linking.
+        MYSQLND_SHARED_LIBADD = "-lssl -lcrypto -lz";
+        # The configure script builds a config.h which is never
+        # included. Let's include it in the main header file
+        # included by all .c-files.
+        patches = [
+          (pkgs.writeText "mysqlnd_config.patch" ''
+            --- a/mysqlnd.h
+            +++ b/mysqlnd.h
+            @@ -1,3 +1,6 @@
+            +#ifdef HAVE_CONFIG_H
+            +#include "config.h"
+            +#endif
+             /*
+               +----------------------------------------------------------------------+
+               | Copyright (c) The PHP Group                                          |
+          '')
+        ];
+        postPhpize = lib.optionalString (lib.versionOlder php.version "7.4") ''
+          substituteInPlace configure --replace '$OPENSSL_LIBDIR' '${openssl}/lib' \
+                                      --replace '$OPENSSL_INCDIR' '${openssl.dev}/include'
+        ''; }
       # oci8 (7.4, 7.3, 7.2)
       # odbc (7.4, 7.3, 7.2)
-      { name = "opcache"; buildInputs = [ pcre' ]; zendExtension = true; }
+      { name = "opcache";
+        buildInputs = [ pcre' ];
+        # HAVE_OPCACHE_FILE_CACHE is defined in config.h, which is
+        # included from ZendAccelerator.h, but ZendAccelerator.h is
+        # included after the ifdef...
+        patches = lib.optional (lib.versionOlder php.version "7.4") [
+          (pkgs.writeText "zend_file_cache_config.patch" ''
+            --- a/zend_file_cache.c
+            +++ b/zend_file_cache.c
+            @@ -27,9 +27,9 @@
+             #include "ext/standard/md5.h"
+             #endif
+
+            +#include "ZendAccelerator.h"
+             #ifdef HAVE_OPCACHE_FILE_CACHE
+
+            -#include "ZendAccelerator.h"
+             #include "zend_file_cache.h"
+             #include "zend_shared_alloc.h"
+             #include "zend_accelerator_util_funcs.h"
+          '') ];
+        zendExtension = true; }
+      { name = "openssl";
+        buildInputs = [ openssl ];
+        configureFlags = [ "--with-openssl" ]; }
       { name = "pcntl"; }
       { name = "pdo"; }
       { name = "pdo_dblib";
+        internalDeps = [ "pdo" ];
         configureFlags = [ "--with-pdo-dblib=${freetds}" ];
         # Doesn't seem to work on darwin.
         enable = (!stdenv.isDarwin); }
       # pdo_firebird (7.4, 7.3, 7.2)
-      { name = "pdo_mysql"; configureFlags = [ "--with-pdo-mysql=mysqlnd" ]; }
+      { name = "pdo_mysql";
+        internalDeps = [ "mysqlnd" "pdo" ];
+        configureFlags = [ "--with-pdo-mysql=mysqlnd" ]; }
       # pdo_oci (7.4, 7.3, 7.2)
-      { name = "pdo_odbc"; configureFlags = [ "--with-pdo-odbc=unixODBC,${unixODBC}" ]; }
-      { name = "pdo_pgsql"; configureFlags = [ "--with-pdo-pgsql=${postgresql}" ]; }
-      { name = "pdo_sqlite"; buildInputs = [ sqlite ]; configureFlags = [ "--with-pdo-sqlite=${sqlite.dev}" ]; }
-      { name = "pgsql"; buildInputs = [ pcre' ]; configureFlags = [ "--with-pgsql=${postgresql}" ]; }
+      { name = "pdo_odbc";
+        internalDeps = [ "pdo" ];
+        configureFlags = [ "--with-pdo-odbc=unixODBC,${unixODBC}" ]; }
+      { name = "pdo_pgsql";
+        internalDeps = [ "pdo" ];
+        configureFlags = [ "--with-pdo-pgsql=${postgresql}" ]; }
+      { name = "pdo_sqlite";
+        internalDeps = [ "pdo" ];
+        buildInputs = [ sqlite ];
+        configureFlags = [ "--with-pdo-sqlite=${sqlite.dev}" ]; }
+      { name = "pgsql";
+        buildInputs = [ pcre' ];
+        configureFlags = [ "--with-pgsql=${postgresql}" ]; }
       { name = "posix"; }
       { name = "pspell"; configureFlags = [ "--with-pspell=${aspell}" ]; }
-      { name = "recode";
-        configureFlags = [ "--with-recode=${recode}" ];
-        # Removed in php 7.4.
-        enable = lib.versionOlder php.version "7.4"; }
+      { name = "readline";
+        buildInputs = [ libedit readline ];
+        configureFlags = [ "--with-readline=${readline.dev}" ];
+        postPhpize = lib.optionalString (lib.versionOlder php.version "7.4") ''
+          substituteInPlace configure --replace 'as_fn_error $? "Please reinstall libedit - I cannot find readline.h" "$LINENO" 5' ':'
+        ''; }
+      # recode (7.3, 7.2)
       { name = "session"; }
       { name = "shmop"; }
       { name = "simplexml";
@@ -846,6 +934,7 @@ let
           ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
       { name = "sockets"; }
       { name = "sodium"; buildInputs = [ libsodium ]; }
+      { name = "sqlite3"; buildInputs = [ sqlite ]; }
       { name = "sysvmsg"; }
       { name = "sysvsem"; }
       { name = "sysvshm"; }
@@ -853,6 +942,7 @@ let
       { name = "tokenizer"; }
       { name = "wddx";
         buildInputs = [ libxml2 ];
+        internalDeps = [ "session" ];
         configureFlags = [ "--enable-wddx" "--with-libxml-dir=${libxml2.dev}" ];
         # Removed in php 7.4.
         enable = lib.versionOlder php.version "7.4"; }
@@ -882,6 +972,10 @@ let
         configureFlags = [ "--with-zip" ]
           ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]
           ++ lib.optional (lib.versionOlder php.version "7.3") [ "--with-libzip" ]; }
+      { name = "zlib";
+        buildInputs = [ zlib ];
+        configureFlags = [ "--with-zlib" ]
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]; }
     ];
 
     # Convert the list of attrs:

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -716,7 +716,7 @@ let
       , zendExtension ? false
       , doCheck ? true
       , ...
-    }: stdenv.mkDerivation {
+    }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
       pname = "php-${name}";
 
       inherit (php) version src;
@@ -748,7 +748,7 @@ let
         mkdir -p $out/lib/php/extensions
         cp modules/${name}.so $out/lib/php/extensions/${name}.so
       '';
-    };
+    });
 
     # This list contains build instructions for different modules that one may
     # want to build.

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -717,7 +717,7 @@ let
       , doCheck ? true
       , ...
     }: stdenv.mkDerivation {
-      pname = "php-ext-${name}";
+      pname = "php-${name}";
 
       inherit (php) version src;
       sourceRoot = "php-${php.version}/ext/${name}";
@@ -746,7 +746,7 @@ let
       checkPhase = "echo n | make test";
       installPhase = ''
         mkdir -p $out/lib/php/extensions
-        cp modules/${name}.so $out/lib/php/extensions/ext-${name}.so
+        cp modules/${name}.so $out/lib/php/extensions/${name}.so
       '';
     };
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -578,6 +578,32 @@ in
       configureFlags = [ "--with-excel" "--with-libxl-incdir=${pkgs.libxl}/include_c" "--with-libxl-libdir=${pkgs.libxl}/lib" ];
     };
 
+    pinba = let
+      version = if isPhp73 then "1.1.2-dev" else "1.1.1";
+      src = pkgs.fetchFromGitHub ({
+        owner = "tony2001";
+        repo = "pinba_extension";
+      } // (if (isPhp73) then {
+        rev = "edbc313f1b4fb8407bf7d5acf63fbb0359c7fb2e";
+        sha256 = "02sljqm6griw8ccqavl23f7w1hp2zflcv24lpf00k6pyrn9cwx80";
+      } else {
+        rev = "RELEASE_1_1_1";
+        sha256 = "1kdp7vav0y315695vhm3xifgsh6h6y6pny70xw3iai461n58khj5";
+      }));
+    in buildPecl {
+      pname = "pinba";
+      inherit version src;
+
+      meta = with pkgs.lib; {
+        description = "PHP extension for Pinba";
+        longDescription = ''
+          Pinba is a MySQL storage engine that acts as a realtime monitoring and
+          statistics server for PHP using MySQL as a read-only interface.
+        '';
+        homepage = "http://pinba.org/";
+      };
+    };
+
     protobuf = buildPecl {
       version = "3.11.2";
       pname = "protobuf";


### PR DESCRIPTION
###### Motivation for this change
Our old PHP derivation was crazy big with a crazy amount of enabled extensions that also had a crazy amount of defaults that we pulled in, yet excluded some extensions that would have been nice to have by default.

This is a follow up on: #82348 to utilize #79377 more. And also a follow-up on all of the work done by me and @talyz in #82794 and #83514

But this grew a bit more, and was more complex than I imagined when I started this. But it became a collaboration project with @talyz to finish everything up.

We have also written the initial documentation for PHP in NixOS.

#### The current PHP
The current closure size is:
```
/nix/store/4ga497cqvz04vcyw9lf7s74ymrc6r28g-php-7.4.3	234.3M
````

And this contains things (among others) like:
```
/nix/store/y5166rf2lkxkf3991qm390vn92czgfgh-openldap-2.4.49          	 53.6M
/nix/store/2zsgfrkp0hn878rnrp0azpmy76ljm2b0-linux-pam-1.3.1          	 53.6M
```

#### The new smaller PHP
Here we have a smaller closure size:
```
/nix/store/10867i6grp8w8p6p6k1w8rxiwza5nyyy-php-with-extensions-7.4.3	189.4M
```

And we have a smaller base package:
```
/nix/store/v5v6wn207ibpp6n90z05f11k7svq94wd-php-7.4.3	 85.5M
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
