### PR TITLE
kdeApplications: 19.12.1 -> 19.12.3

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/release-service/19.12.1/src )
+WGET_ARGS=( http://download.kde.org/stable/release-service/19.12.3/src )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1731 +4,1731 @@
 
 {
   akonadi = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akonadi-19.12.1.tar.xz";
-      sha256 = "991680be1b57a5335690341ab2a681fc7d8e77a4951673021f0662f3005856a3";
-      name = "akonadi-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akonadi-19.12.3.tar.xz";
+      sha256 = "e41714d81ecbb629aaa0b267e0c32a4b1d83c6a45cf3f37d52232003b4c0f325";
+      name = "akonadi-19.12.3.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akonadi-calendar-19.12.1.tar.xz";
-      sha256 = "4bec3252bd1a32874a22b28dcb82a2aed533b31e1955ca68803ddf076dbbd5be";
-      name = "akonadi-calendar-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akonadi-calendar-19.12.3.tar.xz";
+      sha256 = "c58d18153ef711a79962ba907e44338a0ddd62968e0a6c50486bba09a6e2a446";
+      name = "akonadi-calendar-19.12.3.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akonadi-calendar-tools-19.12.1.tar.xz";
-      sha256 = "0650e12b2155b08cf70cc4620f9ea3868bad66affc4668775cd050539eacbec9";
-      name = "akonadi-calendar-tools-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akonadi-calendar-tools-19.12.3.tar.xz";
+      sha256 = "ad2c23cf188228dc697d39e2120b56ce445bbea3eb46721794cd6344aa7e94ba";
+      name = "akonadi-calendar-tools-19.12.3.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akonadiconsole-19.12.1.tar.xz";
-      sha256 = "e6a755875b9ef9db4f022888b77bd011a5edf2c21667074b971d15818659dd5b";
-      name = "akonadiconsole-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akonadiconsole-19.12.3.tar.xz";
+      sha256 = "0dedcccfcfd7e6ad9a5af0aa61ce05f26cbb625d8bf6b6d210ac6e3c5813487f";
+      name = "akonadiconsole-19.12.3.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akonadi-contacts-19.12.1.tar.xz";
-      sha256 = "0fbca91b3251d57291629e441ecf5cdd9b71a56f74f05f6c55a428402d3b4c91";
-      name = "akonadi-contacts-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akonadi-contacts-19.12.3.tar.xz";
+      sha256 = "b0baed9edb8c05b6d9b8db84239cd83a334d8f1d14d4aa8027dc1139a543eadf";
+      name = "akonadi-contacts-19.12.3.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akonadi-import-wizard-19.12.1.tar.xz";
-      sha256 = "a58d29407eebd9ce895d38b121cb034f92c81b85afd1b8da9c70cc3d7dc29b3d";
-      name = "akonadi-import-wizard-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akonadi-import-wizard-19.12.3.tar.xz";
+      sha256 = "2c1491e4f5994ed0d317a27cc717184a86f7d92c4b44f8bd056e147e80bee8c5";
+      name = "akonadi-import-wizard-19.12.3.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akonadi-mime-19.12.1.tar.xz";
-      sha256 = "9ca3794a36e31a5dd759b741e91420f4910f05b0d726f6e803d365b8ab058f5b";
-      name = "akonadi-mime-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akonadi-mime-19.12.3.tar.xz";
+      sha256 = "13bdf9a233a183d5aeee1be0991617fca6d73ffd35bc14ca0d18714149f04392";
+      name = "akonadi-mime-19.12.3.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akonadi-notes-19.12.1.tar.xz";
-      sha256 = "cf8059cb14eca880c09fc83285576b4d03a8edf0799cebdf42d59084bb6904ca";
-      name = "akonadi-notes-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akonadi-notes-19.12.3.tar.xz";
+      sha256 = "a34c2420190925b985b0629d7d2d19be04443cfeeaf284229666338e039e56e2";
+      name = "akonadi-notes-19.12.3.tar.xz";
     };
   };
   akonadi-search = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akonadi-search-19.12.1.tar.xz";
-      sha256 = "78a0feaa41d4b474a2e90c74230bc5196349e1c4e72ad46fe341a1cb6e51a5b8";
-      name = "akonadi-search-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akonadi-search-19.12.3.tar.xz";
+      sha256 = "60072a36f6c817d009a8476bad2e80c4131b14358e03b4889a03aa42340ed041";
+      name = "akonadi-search-19.12.3.tar.xz";
     };
   };
   akregator = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/akregator-19.12.1.tar.xz";
-      sha256 = "e6f00777059e5b9fe2458a7e4248a59652f08d836518bf0395aaf2ed77ef4d52";
-      name = "akregator-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/akregator-19.12.3.tar.xz";
+      sha256 = "63db0f6c75bffe9235122201445d151f4eaa7061d2a8df4eb924bca1a4600f68";
+      name = "akregator-19.12.3.tar.xz";
     };
   };
   analitza = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/analitza-19.12.1.tar.xz";
-      sha256 = "0c6c4ee1b4546ab84eb9503220ca0aa09f80cdd7cea3b89201db1d5aac2c4ce5";
-      name = "analitza-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/analitza-19.12.3.tar.xz";
+      sha256 = "47ca3acaf2d2f52e91cd2253742ab97d9b07abc3fef0d632bfc36d253dbf161b";
+      name = "analitza-19.12.3.tar.xz";
     };
   };
   ark = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ark-19.12.1.tar.xz";
-      sha256 = "37b9dfc0b6005ebd0f2757ecce940568839e8a5d73b3bcbc1931ce4eccbb9d0c";
-      name = "ark-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ark-19.12.3.tar.xz";
+      sha256 = "78594029729c197fc90321850696f1bd189b40d8d7fbc9faf51ad6b2ab744a07";
+      name = "ark-19.12.3.tar.xz";
     };
   };
   artikulate = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/artikulate-19.12.1.tar.xz";
-      sha256 = "407f72193c7c4ec3f8ac7fa93889803f2ec6523aebb59bdf9a9210e9fac0ee7d";
-      name = "artikulate-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/artikulate-19.12.3.tar.xz";
+      sha256 = "c27a5cb98a8e2975638fe74683a73f92c160ce133b133878844062dd99ffded6";
+      name = "artikulate-19.12.3.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/audiocd-kio-19.12.1.tar.xz";
-      sha256 = "3b4433bbbdd56bbafcf0418eaebb655b8fd4e03a4c29489112394393f3dc3815";
-      name = "audiocd-kio-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/audiocd-kio-19.12.3.tar.xz";
+      sha256 = "b920170ae816f29a61a6f6b25df68c9125a5d4d9fec225feee45e46317d64d42";
+      name = "audiocd-kio-19.12.3.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/baloo-widgets-19.12.1.tar.xz";
-      sha256 = "a9fb3a136267bb0089192f7bc523903bd304e528160d9f653ccd052b4a8c110c";
-      name = "baloo-widgets-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/baloo-widgets-19.12.3.tar.xz";
+      sha256 = "236c0bb0bcb345f4ce5f07d591bded6221383bc7b190b42b96999893390cd8a5";
+      name = "baloo-widgets-19.12.3.tar.xz";
     };
   };
   blinken = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/blinken-19.12.1.tar.xz";
-      sha256 = "4a1f7c782dc236d963bc1de11b7dcbc79012d47e3e6cc5ce692ca91ecb788388";
-      name = "blinken-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/blinken-19.12.3.tar.xz";
+      sha256 = "06ef385ab73d99fa3f1925a6f2ef522f691d04cd594777f5d9fa52a5f2e45a94";
+      name = "blinken-19.12.3.tar.xz";
     };
   };
   bomber = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/bomber-19.12.1.tar.xz";
-      sha256 = "f0007dae42d6586ab6c9da5775c835fb515cbf180698a1453a90efd2ba8f2795";
-      name = "bomber-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/bomber-19.12.3.tar.xz";
+      sha256 = "ea4926fe08c62ac5da28c3bb480a6986e51f7a77e3245d1dc1603c38617da4b0";
+      name = "bomber-19.12.3.tar.xz";
     };
   };
   bovo = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/bovo-19.12.1.tar.xz";
-      sha256 = "54cee2f71e9736057187c8121313b9c73f6cadd0fa463ea2a29cf0e86969d5ae";
-      name = "bovo-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/bovo-19.12.3.tar.xz";
+      sha256 = "ac67aff75c1e8e0d1a1a8142ae94431e4f39565f411287f57c2778f8820316af";
+      name = "bovo-19.12.3.tar.xz";
     };
   };
   calendarsupport = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/calendarsupport-19.12.1.tar.xz";
-      sha256 = "6f5e3282ff385044061320b7ccb4bef80a1848fa890afcbd12e16bd2524a4189";
-      name = "calendarsupport-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/calendarsupport-19.12.3.tar.xz";
+      sha256 = "ecbd194b5aa39284d33f7f2ddca75175f8699efee1bfbd5000ea10076567bae8";
+      name = "calendarsupport-19.12.3.tar.xz";
     };
   };
   cantor = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/cantor-19.12.1.tar.xz";
-      sha256 = "509ebe0bc173124d28e29483effa07985eef24cdd989e5e4e1fc233632cdf568";
-      name = "cantor-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/cantor-19.12.3.tar.xz";
+      sha256 = "8347160f18993f53c857ec0d418dfebbc533878ad9f480047646d121e4e644cb";
+      name = "cantor-19.12.3.tar.xz";
     };
   };
   cervisia = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/cervisia-19.12.1.tar.xz";
-      sha256 = "2a7d32ac0c1460c135397cedec177db8eb99117b53ec2c9652763b0e90184188";
-      name = "cervisia-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/cervisia-19.12.3.tar.xz";
+      sha256 = "733a90f521cd79157f6d02eeb28376bc703239800473e8cf366611dd4f3342a6";
+      name = "cervisia-19.12.3.tar.xz";
     };
   };
   dolphin = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/dolphin-19.12.1.tar.xz";
-      sha256 = "492b4ca71e33373c7000aad5c7daf6e04d7ad537e1fde8a73d2c3db15858e8c8";
-      name = "dolphin-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/dolphin-19.12.3.tar.xz";
+      sha256 = "ba16f4d5be5ccc3c135a913f2e3c7dd3b7a492cfc9ec9ae518f714fcd7c2ab47";
+      name = "dolphin-19.12.3.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/dolphin-plugins-19.12.1.tar.xz";
-      sha256 = "9392571a7004c08aac02dcc6453f58b6d0de4716b7cd61776f78d9b1783c60e0";
-      name = "dolphin-plugins-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/dolphin-plugins-19.12.3.tar.xz";
+      sha256 = "7dbd5c0fe4281c46df789f86f468c4ea32949285055cae4652bab3de59acdfd3";
+      name = "dolphin-plugins-19.12.3.tar.xz";
     };
   };
   dragon = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/dragon-19.12.1.tar.xz";
-      sha256 = "a804ae2089c0e96700e91d90ba2100d9a42a81a128a3fdbb037ed94c31f380cd";
-      name = "dragon-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/dragon-19.12.3.tar.xz";
+      sha256 = "c5b09b2bd37f4e86f8412d3b950331d330257ba53278b1a569f36bf3fbf560ee";
+      name = "dragon-19.12.3.tar.xz";
     };
   };
   elisa = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/elisa-19.12.1.tar.xz";
-      sha256 = "4929da2ebe68a3dc0d22a809a7b2a84493aa6f072e16515bd557ddaac51fd8fa";
-      name = "elisa-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/elisa-19.12.3.tar.xz";
+      sha256 = "28ad795c1d993969d49ab71514129589a71ee6fe8a2de785e22f17f5af7c3d32";
+      name = "elisa-19.12.3.tar.xz";
     };
   };
   eventviews = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/eventviews-19.12.1.tar.xz";
-      sha256 = "5eb73fb2c541a6b073ad231a28abe6affc0cad92f5fd4d36a4b58aba8a46193c";
-      name = "eventviews-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/eventviews-19.12.3.tar.xz";
+      sha256 = "e2ac6a77c6bdee008229a2b03262ac5602e0cabfd325a92df58be63aaa7db662";
+      name = "eventviews-19.12.3.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ffmpegthumbs-19.12.1.tar.xz";
-      sha256 = "5f7853788c07d409bc2dd2fd7c9afab4cd847f3d2dc6db4dc30cfd78e762bdbd";
-      name = "ffmpegthumbs-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ffmpegthumbs-19.12.3.tar.xz";
+      sha256 = "cc4a1c3b4768dc674d210294a9957d622448cbe9cdaf713c1cb40bff3a79260e";
+      name = "ffmpegthumbs-19.12.3.tar.xz";
     };
   };
   filelight = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/filelight-19.12.1.tar.xz";
-      sha256 = "29806a4149b3fb60f81372d56c184d0e2f861816639a0a21b85cd7af314f860b";
-      name = "filelight-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/filelight-19.12.3.tar.xz";
+      sha256 = "9ea78509f932cd2bd553d934e2af75c25d0b65d85d2b0ab4a007ac5929b2d3b5";
+      name = "filelight-19.12.3.tar.xz";
     };
   };
   granatier = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/granatier-19.12.1.tar.xz";
-      sha256 = "98051d292dd5a3ba3f873e8bc2bed6cdae291c9516b9cb21a64703b3135baa7f";
-      name = "granatier-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/granatier-19.12.3.tar.xz";
+      sha256 = "aa2e410e4eeae74f3902028069955017a31a922dff98b81850f20743f7b54c95";
+      name = "granatier-19.12.3.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/grantlee-editor-19.12.1.tar.xz";
-      sha256 = "63a2571369aff6cc648b064bcbc32227eede19475cad8937cfc454984423ea0c";
-      name = "grantlee-editor-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/grantlee-editor-19.12.3.tar.xz";
+      sha256 = "5df3e5ce7933290f9f6423bdbcb0ff5614a1a4b6fda250a37bd3ed57647f8a3c";
+      name = "grantlee-editor-19.12.3.tar.xz";
     };
   };
   grantleetheme = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/grantleetheme-19.12.1.tar.xz";
-      sha256 = "f23aaf86ff8c630a2f3498b3eebcd6533b01ee806dcf4130df7dd55e3b890ddd";
-      name = "grantleetheme-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/grantleetheme-19.12.3.tar.xz";
+      sha256 = "cc0ce448c9d8396dcadea2a43089feca8e1074572df42752f70dd176676f29f9";
+      name = "grantleetheme-19.12.3.tar.xz";
     };
   };
   gwenview = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/gwenview-19.12.1.tar.xz";
-      sha256 = "ed36590a0193fbe22f08c1a026e58f86a3067f516b3a894f29b72aa229967c84";
-      name = "gwenview-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/gwenview-19.12.3.tar.xz";
+      sha256 = "b453cd55b7409bf8e4446a1b714dc66e73a0376d2da65b184b82f786767164e7";
+      name = "gwenview-19.12.3.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/incidenceeditor-19.12.1.tar.xz";
-      sha256 = "1f1345db2e518bfe9405df5fa441ece3af1093cbc75066673d252a0760262484";
-      name = "incidenceeditor-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/incidenceeditor-19.12.3.tar.xz";
+      sha256 = "c608a95f6d09433b378f5df0243eff77be3738fb56f99ab439774f2cad5908a6";
+      name = "incidenceeditor-19.12.3.tar.xz";
     };
   };
   juk = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/juk-19.12.1.tar.xz";
-      sha256 = "de1d9f3581f791ea050700b467dce4b38d9ec2dc20884b495826e479d3245edf";
-      name = "juk-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/juk-19.12.3.tar.xz";
+      sha256 = "4bc4210d223afc23cb6edc9262eceee038ecc6243a550698e676230168943611";
+      name = "juk-19.12.3.tar.xz";
     };
   };
   k3b = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/k3b-19.12.1.tar.xz";
-      sha256 = "59def9d9c9e14de52a14d58a22c15173d98086d9a156a3a463b9607dc7be602d";
-      name = "k3b-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/k3b-19.12.3.tar.xz";
+      sha256 = "832c314d528ed21971d9d9d26c1c4d6c61323c9b3b01787d710541e3651575a5";
+      name = "k3b-19.12.3.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kaccounts-integration-19.12.1.tar.xz";
-      sha256 = "0dda504f51b86207180aceb00d86d42cb16c7ebe81c60ca1ed6bf8fa20699127";
-      name = "kaccounts-integration-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kaccounts-integration-19.12.3.tar.xz";
+      sha256 = "452b95113de5fb0d19a13ef75e229ee07b0e92cc1e7a17e9a2dc7879121d9d33";
+      name = "kaccounts-integration-19.12.3.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kaccounts-providers-19.12.1.tar.xz";
-      sha256 = "abcd1fa9f63248f3ce7f9c98d940b124ff5c70c1a3381a6cfad6ce7012b23c69";
-      name = "kaccounts-providers-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kaccounts-providers-19.12.3.tar.xz";
+      sha256 = "8774e9a8113e4aba593afeff655e38f6259c78e7dbaf1d95ea00235be880f3dd";
+      name = "kaccounts-providers-19.12.3.tar.xz";
     };
   };
   kaddressbook = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kaddressbook-19.12.1.tar.xz";
-      sha256 = "32e19973015151ac32fe7ae1f0a17e82e2834ce69ba052f31e8d197930f0be5c";
-      name = "kaddressbook-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kaddressbook-19.12.3.tar.xz";
+      sha256 = "1dede421e6fef2b1abc7d36dd1855cef43cc82de909a432cd38cff42d4168fba";
+      name = "kaddressbook-19.12.3.tar.xz";
     };
   };
   kajongg = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kajongg-19.12.1.tar.xz";
-      sha256 = "2f0944ea23cefb07187e0c176ae0a12cbba1b591aefeab9be9a59d5cab9e7a59";
-      name = "kajongg-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kajongg-19.12.3.tar.xz";
+      sha256 = "23e2b1be670b48bdd027e4e7a57e86a94b322afe6d37d8492c3d17689decfae5";
+      name = "kajongg-19.12.3.tar.xz";
     };
   };
   kalarm = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kalarm-19.12.1.tar.xz";
-      sha256 = "06a8d9544d1107ac3f2e8c4c2e9604055706dcb6b7f3b0267f0d4cb45f1caf35";
-      name = "kalarm-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kalarm-19.12.3.tar.xz";
+      sha256 = "526ab8884752c15622233db8b72e88d0c22a7a1bd265763d850b6e18e32de417";
+      name = "kalarm-19.12.3.tar.xz";
     };
   };
   kalarmcal = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kalarmcal-19.12.1.tar.xz";
-      sha256 = "18644d5cbc61b414675de66dd25d9a1dd30b0e93851f6223292f052d30a365e6";
-      name = "kalarmcal-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kalarmcal-19.12.3.tar.xz";
+      sha256 = "0ec5188f1164d91de702639ab2f85a713889feef48fc02dfe7385c945d06aa60";
+      name = "kalarmcal-19.12.3.tar.xz";
     };
   };
   kalgebra = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kalgebra-19.12.1.tar.xz";
-      sha256 = "49d623186800eb8f6fbb91eb43fb14dff78e112624c9cda6b331d494d610b16a";
-      name = "kalgebra-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kalgebra-19.12.3.tar.xz";
+      sha256 = "ac865dded31b61c438ddb9db721543b8facba79c9b39365750b4bebfe2645640";
+      name = "kalgebra-19.12.3.tar.xz";
     };
   };
   kalzium = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kalzium-19.12.1.tar.xz";
-      sha256 = "f50cc18d94ce9a1aaedcbee3a5dccc2cc6723ac8ec151a0ae0ff60009a7c6943";
-      name = "kalzium-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kalzium-19.12.3.tar.xz";
+      sha256 = "e44f359d1343c30cf1993a3970a3e610d0d5782f92a6b331b035cf4fef104195";
+      name = "kalzium-19.12.3.tar.xz";
     };
   };
   kamera = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kamera-19.12.1.tar.xz";
-      sha256 = "831d7b3d7ffdc73b03116b564fb1a23c651d468cae97c1c31791f6df1a8890ac";
-      name = "kamera-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kamera-19.12.3.tar.xz";
+      sha256 = "22e19527bf9748cdc298be4c3fa2cb0a3b8b337da3a3a804c9d6066d7f3e1110";
+      name = "kamera-19.12.3.tar.xz";
     };
   };
   kamoso = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kamoso-19.12.1.tar.xz";
-      sha256 = "c1776bf7f8eafd9f4c501aabc0df30035a0f1d40951e525312aa257e67cf74a7";
-      name = "kamoso-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kamoso-19.12.3.tar.xz";
+      sha256 = "9ae14c4c80cdbbf2ce2e92db5e9c814fbd685e81aa5c319aac5477649fc39fe4";
+      name = "kamoso-19.12.3.tar.xz";
     };
   };
   kanagram = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kanagram-19.12.1.tar.xz";
-      sha256 = "2127eada150ee3f023948b637890aa93d602874fd6c037c4bd031886a12a2fdc";
-      name = "kanagram-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kanagram-19.12.3.tar.xz";
+      sha256 = "441cae90d3b70dbef40bebbcf1325fa06e0df174a3f961b4b117a5fa1b40d6e3";
+      name = "kanagram-19.12.3.tar.xz";
     };
   };
   kapman = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kapman-19.12.1.tar.xz";
-      sha256 = "cd5bef40c51bc6ef635adab501acd2a40c2291c989c4ba3ef6e34a1cbebe4c49";
-      name = "kapman-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kapman-19.12.3.tar.xz";
+      sha256 = "3c81e3395ce2b2ea0937b09c0836cb58b8a941c2b7e2a27bd9741b2a9be1c1dd";
+      name = "kapman-19.12.3.tar.xz";
     };
   };
   kapptemplate = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kapptemplate-19.12.1.tar.xz";
-      sha256 = "b2fc583125aae1968c0342063a6cfcea2dbeff21e0ef505a021b689ed3a34085";
-      name = "kapptemplate-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kapptemplate-19.12.3.tar.xz";
+      sha256 = "5bef4e4fb74da3102cba6672584195962514ee3f53fb369b48d492d6ce7255ad";
+      name = "kapptemplate-19.12.3.tar.xz";
     };
   };
   kate = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kate-19.12.1.tar.xz";
-      sha256 = "9d2401907e5b163d5af0af5b4d28383896ef709bcde7f6ee2234e1a3adc28a47";
-      name = "kate-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kate-19.12.3.tar.xz";
+      sha256 = "f60b52e5a6a78920ac703a458f1eaf0ced02ffcd8b5f2d49de9a48674eeb007c";
+      name = "kate-19.12.3.tar.xz";
     };
   };
   katomic = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/katomic-19.12.1.tar.xz";
-      sha256 = "bc51424757434e905b5b611a6fa634147e533e375922c03f896a093fa61e57a3";
-      name = "katomic-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/katomic-19.12.3.tar.xz";
+      sha256 = "d7ed527e2546e94cb091e433a2e61618301152704c48e1f003e1f8e60b4f0cbd";
+      name = "katomic-19.12.3.tar.xz";
     };
   };
   kbackup = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kbackup-19.12.1.tar.xz";
-      sha256 = "1b30c142576d823043d4e78fa37592e8df79b5e13ea7a980d336b25c1093ecf8";
-      name = "kbackup-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kbackup-19.12.3.tar.xz";
+      sha256 = "1761009f9cd854d3fb4f98eb24b5ee7f3c42c4541f7cfb2ff1589786c86bdc99";
+      name = "kbackup-19.12.3.tar.xz";
     };
   };
   kblackbox = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kblackbox-19.12.1.tar.xz";
-      sha256 = "57901d6bf56228691b6c6436ca2f60e62542854e80f9c4fda7a60362a216e1ed";
-      name = "kblackbox-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kblackbox-19.12.3.tar.xz";
+      sha256 = "dffb910a5d429dfc231b7d2185119430856d26af2c027d34c551a6d664ae49c6";
+      name = "kblackbox-19.12.3.tar.xz";
     };
   };
   kblocks = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kblocks-19.12.1.tar.xz";
-      sha256 = "1077477910d1dfff60f1abad7b1cf937daf1f3e3a5e8b18407b7e2809b2fc3d9";
-      name = "kblocks-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kblocks-19.12.3.tar.xz";
+      sha256 = "5bc5cb14b91c9b230563388b4d935211975bae34ed36cb0479cbf25bc3b652fb";
+      name = "kblocks-19.12.3.tar.xz";
     };
   };
   kblog = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kblog-19.12.1.tar.xz";
-      sha256 = "6385ecfc024cf554a55e2840c3faf6b9e6ee81eb3536d5632899d32aecd54b9f";
-      name = "kblog-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kblog-19.12.3.tar.xz";
+      sha256 = "3fba584c4c217c5b5b3be52752f8f3c371fb877fe3b730a48711028fedc6b3d4";
+      name = "kblog-19.12.3.tar.xz";
     };
   };
   kbounce = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kbounce-19.12.1.tar.xz";
-      sha256 = "e9e1df6f2f57e102d95707b82b0aa582f9f1a6c3e395660b5faa33ef953e7fb3";
-      name = "kbounce-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kbounce-19.12.3.tar.xz";
+      sha256 = "d1b7ac99e54070e1e28a3449e8773691e90625c9f881cf94352ef752700197d0";
+      name = "kbounce-19.12.3.tar.xz";
     };
   };
   kbreakout = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kbreakout-19.12.1.tar.xz";
-      sha256 = "17475a5aa80f494876fb3b91d32df4c447417e79f4dd60d46f594cfab03f489f";
-      name = "kbreakout-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kbreakout-19.12.3.tar.xz";
+      sha256 = "ca662c9f2c6765f5f8b07bd4cc2e2aa0a43b69fec6428c3deda2cfad0ab675fa";
+      name = "kbreakout-19.12.3.tar.xz";
     };
   };
   kbruch = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kbruch-19.12.1.tar.xz";
-      sha256 = "94f9951c0ee3b4aea6d649f971f2d946d462b916a76e4e76ddafa809ce7e5550";
-      name = "kbruch-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kbruch-19.12.3.tar.xz";
+      sha256 = "522ddae0b2ec640e70c717a9fe0d6a95aef1ed3fe2acbca4b93a99a309abd559";
+      name = "kbruch-19.12.3.tar.xz";
     };
   };
   kcachegrind = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kcachegrind-19.12.1.tar.xz";
-      sha256 = "210e04441519c47d103871e52d98351abc41a04b9385c577a7839eec31a2f400";
-      name = "kcachegrind-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kcachegrind-19.12.3.tar.xz";
+      sha256 = "a30b70bac32f2b33c3c90b8c17754cfbf7d293c9eff0d573747eca2b45353b41";
+      name = "kcachegrind-19.12.3.tar.xz";
     };
   };
   kcalc = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kcalc-19.12.1.tar.xz";
-      sha256 = "51630cd5c6d7ebbf35fb91419acfe9b2d2719ebfcdc2fff8358dbfaa2cecda57";
-      name = "kcalc-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kcalc-19.12.3.tar.xz";
+      sha256 = "bbda4fc074e1ea748e95840aa79c51fdf0a1943ebb63ce6c7b68c197831258bd";
+      name = "kcalc-19.12.3.tar.xz";
     };
   };
   kcalutils = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kcalutils-19.12.1.tar.xz";
-      sha256 = "0298e92d84d9f4b612ea1a27abee1368bc624af2bc5bc4b5eb1053a27575ea04";
-      name = "kcalutils-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kcalutils-19.12.3.tar.xz";
+      sha256 = "00da1f331110a63c3d3c2c96394ead3d282f582d73fa925065560a50807fb7ff";
+      name = "kcalutils-19.12.3.tar.xz";
     };
   };
   kcharselect = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kcharselect-19.12.1.tar.xz";
-      sha256 = "5f23458974d6fa66c49d434937e7a7a31cc94e46616db866b35316025bb84b0c";
-      name = "kcharselect-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kcharselect-19.12.3.tar.xz";
+      sha256 = "9be6ac607148b0815bd985075fbb97d44561fdd6a955b60f0afc728f9cbd978b";
+      name = "kcharselect-19.12.3.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kcolorchooser-19.12.1.tar.xz";
-      sha256 = "713d1151f45382d8a889187ebb02f8e73ffbf28ac8abea0e03626888711d2c22";
-      name = "kcolorchooser-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kcolorchooser-19.12.3.tar.xz";
+      sha256 = "cb0395c1b4f953fd51129cfe5088702ec261f84cc045f889e22c13e81793744a";
+      name = "kcolorchooser-19.12.3.tar.xz";
     };
   };
   kcron = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kcron-19.12.1.tar.xz";
-      sha256 = "8c7d5fa24349b9ff7c4927579876ef84895398d8cde6122804d7104a4f4d5963";
-      name = "kcron-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kcron-19.12.3.tar.xz";
+      sha256 = "22d07834e8431d0fcc756a0e7d92d4e8993008766bf336254f8650c9455c9ab0";
+      name = "kcron-19.12.3.tar.xz";
     };
   };
   kdav = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdav-19.12.1.tar.xz";
-      sha256 = "5059a295f3ecd9046da6f5ecadab596b3e47c75c5090650a1d6cd1f86a8b7498";
-      name = "kdav-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdav-19.12.3.tar.xz";
+      sha256 = "7a0ed47378e064536b26dfdfcf7abcdb8dd2ec253a7bbcef7962b701d368872a";
+      name = "kdav-19.12.3.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdebugsettings-19.12.1.tar.xz";
-      sha256 = "2730430123e6198131acbabb5d02800981082f7249f0d9b9001b5313b2d45f35";
-      name = "kdebugsettings-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdebugsettings-19.12.3.tar.xz";
+      sha256 = "ad18d13dd0943a3651ec4729441899b103bd2dc743a4a373ce7bd14fb38dd3e0";
+      name = "kdebugsettings-19.12.3.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kde-dev-scripts-19.12.1.tar.xz";
-      sha256 = "c2965dee649abea0791774ae264230dbe673af07eb0bd85bf3e8c7c6a739cea5";
-      name = "kde-dev-scripts-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kde-dev-scripts-19.12.3.tar.xz";
+      sha256 = "94c0ba9de369dd6af14dcea505616025bf06599618a6c7557861aa9fb89ea628";
+      name = "kde-dev-scripts-19.12.3.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kde-dev-utils-19.12.1.tar.xz";
-      sha256 = "94f983c9b49ed3bc59b20849b23e7c26b64b7b303fbd86147c4bc823f87cda7d";
-      name = "kde-dev-utils-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kde-dev-utils-19.12.3.tar.xz";
+      sha256 = "772ec425865082b8be3650cf0af10ad943f38096036227cab22405b32c4e1fae";
+      name = "kde-dev-utils-19.12.3.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdeedu-data-19.12.1.tar.xz";
-      sha256 = "d140f048e1ca8bd777b4a431904b3313a86446a5fd04e1f9c4e1fb4641a09b15";
-      name = "kdeedu-data-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdeedu-data-19.12.3.tar.xz";
+      sha256 = "76fd5c0efaf339bcfc5ac9f131bac8889cff1df2dd3452ea7dd507b8d9e2645b";
+      name = "kdeedu-data-19.12.3.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdegraphics-mobipocket-19.12.1.tar.xz";
-      sha256 = "546d11af89e97831cc09868051142d4180e9621cc537c2941272b42a85e71c6a";
-      name = "kdegraphics-mobipocket-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdegraphics-mobipocket-19.12.3.tar.xz";
+      sha256 = "c459f9f04cf98cdc88a6763da8880f418e0c33b3cbd1d06b9a7347ebb470d835";
+      name = "kdegraphics-mobipocket-19.12.3.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdegraphics-thumbnailers-19.12.1.tar.xz";
-      sha256 = "a91335c11637a351d3ea8798f5519ac5596d655aec92266e46ed2a1bab46a299";
-      name = "kdegraphics-thumbnailers-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdegraphics-thumbnailers-19.12.3.tar.xz";
+      sha256 = "92a045ac0e9ca57ea27760df3cca0203f29ba435574e9d837d0c1069b8e88f72";
+      name = "kdegraphics-thumbnailers-19.12.3.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdenetwork-filesharing-19.12.1.tar.xz";
-      sha256 = "823e31424998e96084eeb909dfb7ee6a8e8e6d33b5d2a57ada7d583350967684";
-      name = "kdenetwork-filesharing-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdenetwork-filesharing-19.12.3.tar.xz";
+      sha256 = "8cc75f47ef8038cd7ee75974056cd48022816ab42c76cb6bd2c35a3619445180";
+      name = "kdenetwork-filesharing-19.12.3.tar.xz";
     };
   };
   kdenlive = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdenlive-19.12.1.tar.xz";
-      sha256 = "fccf34a4660ce8a78ceefe8a4b9dd93d104f6871976d991ceec769366627dc77";
-      name = "kdenlive-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdenlive-19.12.3.tar.xz";
+      sha256 = "cebcb8f019bc0fc719ef54d00507dc1281758e3c8c69ea2f93f99feda777bc64";
+      name = "kdenlive-19.12.3.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdepim-addons-19.12.1.tar.xz";
-      sha256 = "091e3fd007ad54cd1dcd4e2d51c4ac883a2d9e365ca78592aa91a37835c4dcf5";
-      name = "kdepim-addons-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdepim-addons-19.12.3.tar.xz";
+      sha256 = "f33bc70ac54ab56eea7bd8ca4c0ac98d9612acc4ddc9ce989d06b99f04f62c19";
+      name = "kdepim-addons-19.12.3.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdepim-apps-libs-19.12.1.tar.xz";
-      sha256 = "4ff633c98cd128f2409cb78c193dd72f1078ae29eba8db3e304248a019e17e43";
-      name = "kdepim-apps-libs-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdepim-apps-libs-19.12.3.tar.xz";
+      sha256 = "e133cf76364f6b244338eafd39845a9f392eb9b55c43446541acbcb24a6f4796";
+      name = "kdepim-apps-libs-19.12.3.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdepim-runtime-19.12.1.tar.xz";
-      sha256 = "31b1fe9778723079048d0fe1750028fd3f5f5b467ee10dcfa7fab37202a6ca39";
-      name = "kdepim-runtime-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdepim-runtime-19.12.3.tar.xz";
+      sha256 = "dabf7da1ad35dfaa3531639a8964b61dbd7094ec0a9b3d62f50fa24a22f5db13";
+      name = "kdepim-runtime-19.12.3.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdesdk-kioslaves-19.12.1.tar.xz";
-      sha256 = "e8e8f02e019bad7983cdc5cddbd435ccf676fd804ee7f960653acdda5676abb2";
-      name = "kdesdk-kioslaves-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdesdk-kioslaves-19.12.3.tar.xz";
+      sha256 = "8b075bff545883aba24fee1763d0cdc64bf9444ae865f0623a33fc1ca295d254";
+      name = "kdesdk-kioslaves-19.12.3.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdesdk-thumbnailers-19.12.1.tar.xz";
-      sha256 = "77f64ddb075407f781cf2d658af760840f9427cc171e8ec15805f47105da0e56";
-      name = "kdesdk-thumbnailers-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdesdk-thumbnailers-19.12.3.tar.xz";
+      sha256 = "b304843045f93e91e0aeeeacf968018dc192ea71ed9977be3d9cfc4e149edcde";
+      name = "kdesdk-thumbnailers-19.12.3.tar.xz";
     };
   };
   kdf = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdf-19.12.1.tar.xz";
-      sha256 = "bf5c96e5a78e0465e9b91617ffff0c37f04e896dc059d70962bbdd943c6c1c04";
-      name = "kdf-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdf-19.12.3.tar.xz";
+      sha256 = "257e07e27376f45eaa1bfb1b3055c7f10759ca7ec185aa7572dc60317c8119bd";
+      name = "kdf-19.12.3.tar.xz";
     };
   };
   kdialog = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdialog-19.12.1.tar.xz";
-      sha256 = "2a13d1957089e4a0307681786b9b5467b5df777311afd4598dd1cb69b4e070f6";
-      name = "kdialog-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdialog-19.12.3.tar.xz";
+      sha256 = "e6f9a7a6b7c2f18795070bf9466dd6256568b02683d955ef3253432216594d00";
+      name = "kdialog-19.12.3.tar.xz";
     };
   };
   kdiamond = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kdiamond-19.12.1.tar.xz";
-      sha256 = "4f7770138d16bb7b91920b7f3c7024a89ef35dc330a2ac929a2fa5d4ee12b982";
-      name = "kdiamond-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kdiamond-19.12.3.tar.xz";
+      sha256 = "95dfd2fd3daa59a58d128c35b95b609117438efdb5d60110414ab7aff5fe3e7c";
+      name = "kdiamond-19.12.3.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/keditbookmarks-19.12.1.tar.xz";
-      sha256 = "11a950d53bc6e0b50d62a3ced2b74eaaa85c595b845ca8f2dcfa65e69d407fb0";
-      name = "keditbookmarks-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/keditbookmarks-19.12.3.tar.xz";
+      sha256 = "1c5efb63eb0a714942677eb03f91ae0bbd10731eace5471ea12ae9d3296b6b05";
+      name = "keditbookmarks-19.12.3.tar.xz";
     };
   };
   kfind = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kfind-19.12.1.tar.xz";
-      sha256 = "e9f5defa7796bbb54208b28af1fa76333a38e743d7febb8dd14739cf00d376eb";
-      name = "kfind-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kfind-19.12.3.tar.xz";
+      sha256 = "b3738d6e3f26fffbfcc204d946e165ae0727d9f460cb2065ceb221b4872019b1";
+      name = "kfind-19.12.3.tar.xz";
     };
   };
   kfloppy = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kfloppy-19.12.1.tar.xz";
-      sha256 = "77581323d16f8666fefca3372c91567dfe5233c0f92c79ead11b2253aee64e2c";
-      name = "kfloppy-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kfloppy-19.12.3.tar.xz";
+      sha256 = "7f384f9197d5066a5db978a9551665ae9a90b1f3afd1937f800ab61e376d3723";
+      name = "kfloppy-19.12.3.tar.xz";
     };
   };
   kfourinline = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kfourinline-19.12.1.tar.xz";
-      sha256 = "76e31b59f1b31ddb755def377324d5fa5b5a4835f1f537a30632a028bf671a3e";
-      name = "kfourinline-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kfourinline-19.12.3.tar.xz";
+      sha256 = "1d2f4fdbf427e2ce86a0519ee61a70df0675f039cebd658cd75bd27af4fe69f6";
+      name = "kfourinline-19.12.3.tar.xz";
     };
   };
   kgeography = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kgeography-19.12.1.tar.xz";
-      sha256 = "47f809fdb6da503c0b00f5d2052f9def3af0964ace45325e683227a1971c3a1b";
-      name = "kgeography-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kgeography-19.12.3.tar.xz";
+      sha256 = "3947ca1f50910d77f85c630b49128a085fed4230c7919e09281bc1765529a533";
+      name = "kgeography-19.12.3.tar.xz";
     };
   };
   kget = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kget-19.12.1.tar.xz";
-      sha256 = "33b043857b3d1c55d877d1c3af2bcc46feefe15019b7af40a9951c16e288658c";
-      name = "kget-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kget-19.12.3.tar.xz";
+      sha256 = "a4b1d8fb94617c80a557c27ae58a14131bda4476340c136262e5bf8f51d918d9";
+      name = "kget-19.12.3.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kgoldrunner-19.12.1.tar.xz";
-      sha256 = "1f2044656732ab7a72117139576201ca1701666d525c93b726473d4cd9aed29c";
-      name = "kgoldrunner-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kgoldrunner-19.12.3.tar.xz";
+      sha256 = "5808d797fb9df178526b3ea462bc902ca36b5926ef7c51233816ba3da6bc0bdd";
+      name = "kgoldrunner-19.12.3.tar.xz";
     };
   };
   kgpg = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kgpg-19.12.1.tar.xz";
-      sha256 = "e64dc85f303e45b8a7ef635525f6834c4fd2db36c5131fdb231fa11f7237fdb5";
-      name = "kgpg-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kgpg-19.12.3.tar.xz";
+      sha256 = "53e5726a1ccf34a70090ac0bbf2effb6f1f9f9b3d0164a5beead982a24c97e38";
+      name = "kgpg-19.12.3.tar.xz";
     };
   };
   khangman = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/khangman-19.12.1.tar.xz";
-      sha256 = "42fa9d9a9a72fe4b14127b12d5b662d66c00c1899eeefba6102be95136333def";
-      name = "khangman-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/khangman-19.12.3.tar.xz";
+      sha256 = "55286b318ec2c2d8b7e63f4063fc0e39a8ff81c0a9d3f06c9879f141c94762a8";
+      name = "khangman-19.12.3.tar.xz";
     };
   };
   khelpcenter = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/khelpcenter-19.12.1.tar.xz";
-      sha256 = "cd38f6b719f4f6228e3a7f94fc63f16020e86382ca402179ae767f2f0b846466";
-      name = "khelpcenter-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/khelpcenter-19.12.3.tar.xz";
+      sha256 = "526c89e46cace9e8afb4e748f9bbf0d105472a4cc4a6d8bb821e8b9b88ab0f73";
+      name = "khelpcenter-19.12.3.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kidentitymanagement-19.12.1.tar.xz";
-      sha256 = "7df38592610e0ed74c55baf6670331d07b2df0c98484d5f8cf8f135b6d229702";
-      name = "kidentitymanagement-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kidentitymanagement-19.12.3.tar.xz";
+      sha256 = "254bfc3a60df7bc1960fa1e6d5b7733f6aa5ed7772c1097d9a8cfcdda2704516";
+      name = "kidentitymanagement-19.12.3.tar.xz";
     };
   };
   kig = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kig-19.12.1.tar.xz";
-      sha256 = "507d89cddc0e128ab398ce0f551af22af0ba1583a4419574296cfefb96d944ee";
-      name = "kig-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kig-19.12.3.tar.xz";
+      sha256 = "1ae2c3024cdd14e476ff15b730f4ebe9b279477b67cc4cc89606755c7d3beef3";
+      name = "kig-19.12.3.tar.xz";
     };
   };
   kigo = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kigo-19.12.1.tar.xz";
-      sha256 = "235df9bca39b02dac6648b408d71f7b0978604f8389ea7ef5aa8e0be87fbcf9d";
-      name = "kigo-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kigo-19.12.3.tar.xz";
+      sha256 = "ee18b8563c49e3e01924ea76cd8c6ec376482c2100e0fac7cdfd14b5899592d5";
+      name = "kigo-19.12.3.tar.xz";
     };
   };
   killbots = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/killbots-19.12.1.tar.xz";
-      sha256 = "3d524028e7df412e4306daf4e7b1aca803d26b65985fa429c98db10cffff010f";
-      name = "killbots-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/killbots-19.12.3.tar.xz";
+      sha256 = "3c5dc7e1f27036d2584f6ee58bf3bbffd9e56a467f30a8e2eab9e1bda1e7d4a3";
+      name = "killbots-19.12.3.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kimagemapeditor-19.12.1.tar.xz";
-      sha256 = "9869f3a060dc44f2fad0646fa9c0f1c2924d68c3cc3de5147170456f27a39e77";
-      name = "kimagemapeditor-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kimagemapeditor-19.12.3.tar.xz";
+      sha256 = "1aee6521974bde5151744d92823f6b405ee4a8bd2dfe3c538324a209e18c6b35";
+      name = "kimagemapeditor-19.12.3.tar.xz";
     };
   };
   kimap = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kimap-19.12.1.tar.xz";
-      sha256 = "898e1f3b233b3631ffc74859d54bf402d36f0c5bae7f792e97d3fa5116d8bd0e";
-      name = "kimap-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kimap-19.12.3.tar.xz";
+      sha256 = "5c3b3cdf928754f9919030d865a2cdad0ad342c82c436afef660d018f85de4d2";
+      name = "kimap-19.12.3.tar.xz";
     };
   };
   kio-extras = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kio-extras-19.12.1.tar.xz";
-      sha256 = "79b3735510c3c8da9b3e019ee5a54b115f85bb8d89f1c04dbbf16dde3007e7b6";
-      name = "kio-extras-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kio-extras-19.12.3.tar.xz";
+      sha256 = "413cb21479fedf1421a6e2585b4df813c3a3fadaa77c248a9f810021f58cea4b";
+      name = "kio-extras-19.12.3.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kipi-plugins-19.12.1.tar.xz";
-      sha256 = "bcd27ab29b491f13116a156e403126d04ffbaa352b581eca7fb0904e13c5dabe";
-      name = "kipi-plugins-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kipi-plugins-19.12.3.tar.xz";
+      sha256 = "16997bd6fbb59c194c2997732c870e33bbacd3d7346546af9a255db3330ec5ac";
+      name = "kipi-plugins-19.12.3.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kirigami-gallery-19.12.1.tar.xz";
-      sha256 = "de7f9d739feeac481223c7992179cb3cfaa2aabca1097b0d3597c5c9d737cb19";
-      name = "kirigami-gallery-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kirigami-gallery-19.12.3.tar.xz";
+      sha256 = "17febaeb77e0dfc6f591dd285fd7f538466572f2f2e3253461c41f92d6cb05fe";
+      name = "kirigami-gallery-19.12.3.tar.xz";
     };
   };
   kiriki = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kiriki-19.12.1.tar.xz";
-      sha256 = "f3079b53ed45ec46def7a95b336d441dba18151cc77c88ef8ce2d02fcf1d6375";
-      name = "kiriki-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kiriki-19.12.3.tar.xz";
+      sha256 = "abbaa49f9b47286f9afbe7c968eb6fbfeecb4be84ed4b2ce7514a3ed1e92b2d5";
+      name = "kiriki-19.12.3.tar.xz";
     };
   };
   kiten = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kiten-19.12.1.tar.xz";
-      sha256 = "abee050c05b54fae25562237b91a14156dabcb26ea142c714b5ec9e1907f54f3";
-      name = "kiten-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kiten-19.12.3.tar.xz";
+      sha256 = "663739a8b252cb95a38294c6f7d675c833daaa81f2654f5cabd8e512fd353560";
+      name = "kiten-19.12.3.tar.xz";
     };
   };
   kitinerary = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kitinerary-19.12.1.tar.xz";
-      sha256 = "6497469e9966c9c21c2810a1f21c2633b89e54dafb74d5689aa24382e3824926";
-      name = "kitinerary-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kitinerary-19.12.3.tar.xz";
+      sha256 = "4188efe8672091cbdaa4f757f5d8b94a30b1373dceafc076b01330602d5086e2";
+      name = "kitinerary-19.12.3.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kjumpingcube-19.12.1.tar.xz";
-      sha256 = "3e4abd57d14dccc9b39669eebdab578fc865464b8a4309c3ab8103002edc2ff0";
-      name = "kjumpingcube-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kjumpingcube-19.12.3.tar.xz";
+      sha256 = "b969111cb884efc9ad8ef585066ca33d7168bb045c93a3f18668173a11d29ea2";
+      name = "kjumpingcube-19.12.3.tar.xz";
     };
   };
   kldap = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kldap-19.12.1.tar.xz";
-      sha256 = "5595f840c2b97e96f265ffd91fb007f4beb198aaf67a0dbfd941108acbcb9aa3";
-      name = "kldap-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kldap-19.12.3.tar.xz";
+      sha256 = "49f1ad32ae10b7f997c77f3a8db0776b972b93f9e18873b77baabf0db05cd5d4";
+      name = "kldap-19.12.3.tar.xz";
     };
   };
   kleopatra = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kleopatra-19.12.1.tar.xz";
-      sha256 = "94ee94031696dd5d79d7a0ca00a2e51b4569466689e8a76c129deae645af08f4";
-      name = "kleopatra-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kleopatra-19.12.3.tar.xz";
+      sha256 = "04edf29e42088b2bccdfe36b9b7170c38acd7816657673da5393244b73773098";
+      name = "kleopatra-19.12.3.tar.xz";
     };
   };
   klettres = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/klettres-19.12.1.tar.xz";
-      sha256 = "4f103d85918d40e0a3ffc451bf3862c45b37b8bd2453e6ee7d21d4c738967c36";
-      name = "klettres-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/klettres-19.12.3.tar.xz";
+      sha256 = "f2a1bbb002954a80045780de24f494154214b8add53a5c01a8783cbeb26d26c7";
+      name = "klettres-19.12.3.tar.xz";
     };
   };
   klickety = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/klickety-19.12.1.tar.xz";
-      sha256 = "66cba17839023b6fe563a461da8f52a3c8a2bd4949195da2d63d780547f2e159";
-      name = "klickety-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/klickety-19.12.3.tar.xz";
+      sha256 = "351e421ecca5fc80955ed614453c81d8b790200185db16f56be1e0ca9325ad39";
+      name = "klickety-19.12.3.tar.xz";
     };
   };
   klines = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/klines-19.12.1.tar.xz";
-      sha256 = "111c4e607c4ba434a8ff593e45ba669c78e6c1fbf9e4d77d0fc5d611e733604e";
-      name = "klines-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/klines-19.12.3.tar.xz";
+      sha256 = "8d11894d0a02de20090e52ef697a5a3c00e902213c018a82c94ca0985e92350a";
+      name = "klines-19.12.3.tar.xz";
     };
   };
   kmag = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmag-19.12.1.tar.xz";
-      sha256 = "59e5a59407894976574acf78e7248fd0609ce6ee222c60388a99e5576ac2061f";
-      name = "kmag-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmag-19.12.3.tar.xz";
+      sha256 = "d1e8bbc8006cd2cfcb345e30aac73350562bff98b69b0333ad49726cdce81e7e";
+      name = "kmag-19.12.3.tar.xz";
     };
   };
   kmahjongg = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmahjongg-19.12.1.tar.xz";
-      sha256 = "e157f2e603c03128fb99ac4d0b4bc3ab2002a60960c780a3907e35bb8aee9bd3";
-      name = "kmahjongg-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmahjongg-19.12.3.tar.xz";
+      sha256 = "41a07f74cc4e3bf05f6a57a380d4e093b0303528cb703369981b262a0b1787c8";
+      name = "kmahjongg-19.12.3.tar.xz";
     };
   };
   kmail = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmail-19.12.1.tar.xz";
-      sha256 = "a8fa4a604f8f88b91beebf0f3f9bb0ac7c040671bd75ab4478d8087a21cde40c";
-      name = "kmail-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmail-19.12.3.tar.xz";
+      sha256 = "7f70e5270960e474b15631a36110e13fdf7238d6fd9f1b3fdb6d8c145b6529ba";
+      name = "kmail-19.12.3.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmail-account-wizard-19.12.1.tar.xz";
-      sha256 = "e7cbda3946b19d01f5c3a722d2c104b7be072ab411f80437a25b8200d73e7cfa";
-      name = "kmail-account-wizard-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmail-account-wizard-19.12.3.tar.xz";
+      sha256 = "4199e8c73456bf31b829596919ca481c3a95e59dee7c9bfb2e680311d0354ff0";
+      name = "kmail-account-wizard-19.12.3.tar.xz";
     };
   };
   kmailtransport = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmailtransport-19.12.1.tar.xz";
-      sha256 = "1a46563c441a7d09e6cc2bf98a628b724944193e0df88607d5d867f4fa65c1a4";
-      name = "kmailtransport-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmailtransport-19.12.3.tar.xz";
+      sha256 = "077b3dba7c02dde9693c003ab7039f3b2a530e3b1aecfcf187313db5226e8953";
+      name = "kmailtransport-19.12.3.tar.xz";
     };
   };
   kmbox = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmbox-19.12.1.tar.xz";
-      sha256 = "7442fd3a421a917a3f27e47259a7da7e08ff6191290a0e9e67c67005c82c606a";
-      name = "kmbox-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmbox-19.12.3.tar.xz";
+      sha256 = "de69683abb42c5c24ccb4f034e067f50c94d5a10c53f359b0e6ad4b75a70b376";
+      name = "kmbox-19.12.3.tar.xz";
     };
   };
   kmime = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmime-19.12.1.tar.xz";
-      sha256 = "4d6db5d59b239b884bf8811f3ea616520ab1f69224a809cef3f79023b2563085";
-      name = "kmime-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmime-19.12.3.tar.xz";
+      sha256 = "5ed20ad77000c60ba5723aaa22149fca3a3956f930d63e70984f0a17b9339300";
+      name = "kmime-19.12.3.tar.xz";
     };
   };
   kmines = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmines-19.12.1.tar.xz";
-      sha256 = "8f921aa4bda7397c0fa6265ba07a6ce68190174864d0ee16ee575be806b49539";
-      name = "kmines-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmines-19.12.3.tar.xz";
+      sha256 = "05d8004f2e560bf2c9e32a3ca1988b3848b99bfb9cc96307c1ac2b703c202dad";
+      name = "kmines-19.12.3.tar.xz";
     };
   };
   kmix = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmix-19.12.1.tar.xz";
-      sha256 = "97fff89e4a102351d01265a9659c5664b030b9b4f27fa021b997fe7ab8801ad6";
-      name = "kmix-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmix-19.12.3.tar.xz";
+      sha256 = "a4c637383e988ffa21b9c48c72ef6d8855fe207c852d0679011337a331ccfc5c";
+      name = "kmix-19.12.3.tar.xz";
     };
   };
   kmousetool = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmousetool-19.12.1.tar.xz";
-      sha256 = "d056fd05ffb900f65670e3a77dc8a0c08fbc02d86f4fba1b34dd8f6b5f60c3e5";
-      name = "kmousetool-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmousetool-19.12.3.tar.xz";
+      sha256 = "3741aff20c778bb704c76df7ff005da36ef6c41b07fca35f257ba440741b8413";
+      name = "kmousetool-19.12.3.tar.xz";
     };
   };
   kmouth = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmouth-19.12.1.tar.xz";
-      sha256 = "da46e472a05920225c3ae0caba21279dc817b7c8e77ae981b1ad6cf2083a49ad";
-      name = "kmouth-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmouth-19.12.3.tar.xz";
+      sha256 = "424dd4cf81cd43e47630ada0f2a9e47be8106b31ebf2e5c8c1077e55e3a8113f";
+      name = "kmouth-19.12.3.tar.xz";
     };
   };
   kmplot = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kmplot-19.12.1.tar.xz";
-      sha256 = "b82d9f9d4f3d3447e9125b42918819fe8effd5658d9a385da79e81e12f7466cf";
-      name = "kmplot-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kmplot-19.12.3.tar.xz";
+      sha256 = "2743e3a472ccf40281f5afd9c6110dde6fb9bc437e8e291beba484d405d8152e";
+      name = "kmplot-19.12.3.tar.xz";
     };
   };
   knavalbattle = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/knavalbattle-19.12.1.tar.xz";
-      sha256 = "1cc2c7fec2e2edc634cb1f83cf7e433522b0bc7d76c04cbcde66bb486a832856";
-      name = "knavalbattle-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/knavalbattle-19.12.3.tar.xz";
+      sha256 = "59875e10b0f2b06c2d3165f2f2457113f04550215947c8296ce1dcaf385ee37f";
+      name = "knavalbattle-19.12.3.tar.xz";
     };
   };
   knetwalk = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/knetwalk-19.12.1.tar.xz";
-      sha256 = "95725a45c56956a2b8e8e2db36b6baedfc0271af0d6e3541d6143342e6f41ca5";
-      name = "knetwalk-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/knetwalk-19.12.3.tar.xz";
+      sha256 = "24cb7cfa4143b2ab1bcaf38a6698cd01252201238c6561bc711e0673366642ae";
+      name = "knetwalk-19.12.3.tar.xz";
     };
   };
   knights = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/knights-19.12.1.tar.xz";
-      sha256 = "60ce0d76eb13c95ba81b0f2dfe5bd3e80ed2226319e4ef97150c3240f428d355";
-      name = "knights-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/knights-19.12.3.tar.xz";
+      sha256 = "4796654dcaff355b4f1097260748cfe04812ff926acc7ca0f037711875dd1512";
+      name = "knights-19.12.3.tar.xz";
     };
   };
   knotes = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/knotes-19.12.1.tar.xz";
-      sha256 = "e89f22ee1a918553be5241e167bd038797391502cb98c5f260c96b25017dd235";
-      name = "knotes-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/knotes-19.12.3.tar.xz";
+      sha256 = "b27846609dfac1ffcb3ac5e7165b7557231b096f6a84206da956c37233aed7b0";
+      name = "knotes-19.12.3.tar.xz";
     };
   };
   kolf = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kolf-19.12.1.tar.xz";
-      sha256 = "78c5e74d61f8c19b31d4d08781d12a87bc6101d0105081e0c15f4506e36ef6f5";
-      name = "kolf-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kolf-19.12.3.tar.xz";
+      sha256 = "2ba1f781d7d98ca0b10231e4f963b27d043c726f44da662b6c77105da4f9cffc";
+      name = "kolf-19.12.3.tar.xz";
     };
   };
   kollision = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kollision-19.12.1.tar.xz";
-      sha256 = "a48515f63c0dbcc890aa9c01e344ea5bcb123e587459879796acc39a16243c09";
-      name = "kollision-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kollision-19.12.3.tar.xz";
+      sha256 = "ce0bb077e8db8a959f965d463bb25bac02c91585b422af6c9249ad8a8f25eaab";
+      name = "kollision-19.12.3.tar.xz";
     };
   };
   kolourpaint = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kolourpaint-19.12.1.tar.xz";
-      sha256 = "a2db2312ddf79024358309da8b70cb2b9979d208372ce5f0960f662b8aab2518";
-      name = "kolourpaint-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kolourpaint-19.12.3.tar.xz";
+      sha256 = "7c134da2feb75a87bfda6b4265ef705868a9be03d70a828111a2869ca0b517b1";
+      name = "kolourpaint-19.12.3.tar.xz";
     };
   };
   kompare = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kompare-19.12.1.tar.xz";
-      sha256 = "c2eede65a85d59067caf6161606c3de4f18ec6b5e824cb1da9e6b3a8f1b7a92d";
-      name = "kompare-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kompare-19.12.3.tar.xz";
+      sha256 = "b89b266b6f648500627d2e70df29b73248c7b7d7d5e7c1bbcaddaedf072f6f1a";
+      name = "kompare-19.12.3.tar.xz";
     };
   };
   konqueror = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/konqueror-19.12.1.tar.xz";
-      sha256 = "20da57d7dd141e2c45345457ca90be26af28c2078224eb461dff9f9589889a09";
-      name = "konqueror-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/konqueror-19.12.3.tar.xz";
+      sha256 = "0f2b31a1dae1740839232bd646bf22d7cb57e34995584b9a96271ebcb0da7f0e";
+      name = "konqueror-19.12.3.tar.xz";
     };
   };
   konquest = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/konquest-19.12.1.tar.xz";
-      sha256 = "178e42f76115f8e8b47494ea7732fb76a692debe714590c06d84f7071930b65a";
-      name = "konquest-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/konquest-19.12.3.tar.xz";
+      sha256 = "e23732a7d78382c73fca0d31afb3ed85614ee4b4bfe2f07647a13582fa0811a5";
+      name = "konquest-19.12.3.tar.xz";
     };
   };
   konsole = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/konsole-19.12.1.tar.xz";
-      sha256 = "39797ed81c5ace12fd90f4a6e65c25d33db8e4385ab2baad2bd6a3b2db0ef075";
-      name = "konsole-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/konsole-19.12.3.tar.xz";
+      sha256 = "0bde8eb6365c53e96489d0ceb05baa0bb0385ee865492622033164a4c4bfccdc";
+      name = "konsole-19.12.3.tar.xz";
     };
   };
   kontact = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kontact-19.12.1.tar.xz";
-      sha256 = "e9f7911154953d58be962bd392baf7d9c310e9e665adb0c875ed5a50dcfe5e01";
-      name = "kontact-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kontact-19.12.3.tar.xz";
+      sha256 = "8dbd01f73c181f7b44df5dfffac1cf33c36b36149294fd854403bada9ef33052";
+      name = "kontact-19.12.3.tar.xz";
     };
   };
   kontactinterface = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kontactinterface-19.12.1.tar.xz";
-      sha256 = "a88b782b495d662920fd5f51c287c472c107c577af92431b4470787a78866b2c";
-      name = "kontactinterface-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kontactinterface-19.12.3.tar.xz";
+      sha256 = "1a0392cbeb6833f4834c86f202ff06e5b6069d12100bffe37de6427f0531af89";
+      name = "kontactinterface-19.12.3.tar.xz";
     };
   };
   kopete = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kopete-19.12.1.tar.xz";
-      sha256 = "eca3610cc9607c27620c7c23f9bb54bdd80d2fb295adaf6636506597fc0b848d";
-      name = "kopete-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kopete-19.12.3.tar.xz";
+      sha256 = "8d58fb0c9dd8b651bfc996e6928f7ccdad8e21cba39ffd0e54d46f7145fa7b27";
+      name = "kopete-19.12.3.tar.xz";
     };
   };
   korganizer = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/korganizer-19.12.1.tar.xz";
-      sha256 = "8bd84dfdca4f4738152c19d336b8c516f0c79fd888f0361005bc5d6359eeb117";
-      name = "korganizer-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/korganizer-19.12.3.tar.xz";
+      sha256 = "ea0a970aa510d5cdbbf80e974049fa3e7591e02c9ec2c4206137c49266df1acb";
+      name = "korganizer-19.12.3.tar.xz";
     };
   };
   kpat = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kpat-19.12.1.tar.xz";
-      sha256 = "cb72a256a2a6a34bd8ee05e09b28f0eedee6643f24f793c5f67a9465040c30c3";
-      name = "kpat-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kpat-19.12.3.tar.xz";
+      sha256 = "00b823b1b204b68e0c8671e5ddfe5f96abe8c9fcfb1efa9b7f70191cfa5384e1";
+      name = "kpat-19.12.3.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kpimtextedit-19.12.1.tar.xz";
-      sha256 = "253ded44f3ccb7de1a0a8879e45cc361c14dda2924619aeb04f4286c917f5475";
-      name = "kpimtextedit-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kpimtextedit-19.12.3.tar.xz";
+      sha256 = "64be03d7a8d4b9ece40c0065a23113023c2b3320dc57068fe00f6c4bc72537d5";
+      name = "kpimtextedit-19.12.3.tar.xz";
     };
   };
   kpkpass = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kpkpass-19.12.1.tar.xz";
-      sha256 = "b5a079dc1c102c52e29c1d0da3e5a1e51bf9e0a666bb82d6b783f1b55eaa7ada";
-      name = "kpkpass-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kpkpass-19.12.3.tar.xz";
+      sha256 = "45723989170e86c6739c8a377c54b3ba7456a8dc3ed6cf52eef884074c2df189";
+      name = "kpkpass-19.12.3.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kqtquickcharts-19.12.1.tar.xz";
-      sha256 = "641f5c993e627dd6d0778066016d20196b7502e34ab793fcf17dd6b226d08ae8";
-      name = "kqtquickcharts-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kqtquickcharts-19.12.3.tar.xz";
+      sha256 = "94669a7add0cef9a1c0969a92ece8e60a67fbb0ff32826cc49ce87bd890c976c";
+      name = "kqtquickcharts-19.12.3.tar.xz";
     };
   };
   krdc = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/krdc-19.12.1.tar.xz";
-      sha256 = "b3d9b9c43bfe5801d807be08172ca4c773ff6fc2d846cf5b2456c3360ca21824";
-      name = "krdc-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/krdc-19.12.3.tar.xz";
+      sha256 = "12602912abbc22e061067b6b5048d37a7cbdaaf99d203829d3f52fdf7319acce";
+      name = "krdc-19.12.3.tar.xz";
     };
   };
   kreversi = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kreversi-19.12.1.tar.xz";
-      sha256 = "b81e6544ba23b0869329d734618b3bc4408b585d550985338e6d90bf2d3a17f3";
-      name = "kreversi-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kreversi-19.12.3.tar.xz";
+      sha256 = "6bfe3a2faa7c0d08fb689b75341bfd5881d66bc865445573b2f4dbb316a751e8";
+      name = "kreversi-19.12.3.tar.xz";
     };
   };
   krfb = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/krfb-19.12.1.tar.xz";
-      sha256 = "7f25790480ac3a8db8a8bd847d80937a0ab763f6c5c12fa2ce704c4b24810287";
-      name = "krfb-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/krfb-19.12.3.tar.xz";
+      sha256 = "cb88997dc7b15b992d1de5c5cabaeccb37122e20823501ac29140875259782ee";
+      name = "krfb-19.12.3.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kross-interpreters-19.12.1.tar.xz";
-      sha256 = "c5ec40971befd1d214d80c8c2ced3e30aaadfd2d4000ea782751f769783f8130";
-      name = "kross-interpreters-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kross-interpreters-19.12.3.tar.xz";
+      sha256 = "2b4060494901a68ca1d07e0c345cc0814e11fb84e9f48014a7231021e4377487";
+      name = "kross-interpreters-19.12.3.tar.xz";
     };
   };
   kruler = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kruler-19.12.1.tar.xz";
-      sha256 = "0ecbc70561c0d973866c4bd27333a5ddc904b748fb3a64f66b6b06040b30d34a";
-      name = "kruler-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kruler-19.12.3.tar.xz";
+      sha256 = "803a0d31bbb5bfbfa057b13a7f6bbf7630dcc1816a0d41ea13cc4592bdacaa47";
+      name = "kruler-19.12.3.tar.xz";
     };
   };
   kshisen = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kshisen-19.12.1.tar.xz";
-      sha256 = "a361dfc41595640287dd5b800921859ff17a45f7360e5e2fc6f520cc0e421afa";
-      name = "kshisen-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kshisen-19.12.3.tar.xz";
+      sha256 = "f6ce353725d71ce65269b1b7b3d118cb8555cd065db0d3b17fe4696d87c10601";
+      name = "kshisen-19.12.3.tar.xz";
     };
   };
   ksirk = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ksirk-19.12.1.tar.xz";
-      sha256 = "4f71e4ef3b4d2041edd48537f4b475cb505fc54e45b39b81a08c82d4eec7cc8e";
-      name = "ksirk-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ksirk-19.12.3.tar.xz";
+      sha256 = "6387d7a6320e644157f10b94474ca715e7ad7fd15cdf7156a8e7d94bff019dcb";
+      name = "ksirk-19.12.3.tar.xz";
     };
   };
   ksmtp = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ksmtp-19.12.1.tar.xz";
-      sha256 = "6c7d6ce91d65d7430cb31fb4a1fd44a600a5a459b3956807ee3180b5822dbac0";
-      name = "ksmtp-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ksmtp-19.12.3.tar.xz";
+      sha256 = "1fd69f494afee91c11667ddbba43bc6cc316b51acf5894fe4c3a2631f53fae27";
+      name = "ksmtp-19.12.3.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ksnakeduel-19.12.1.tar.xz";
-      sha256 = "73e9c55cce88a6e5d00683c73382ee82db64bfe788c14c3a4eda8decf382188f";
-      name = "ksnakeduel-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ksnakeduel-19.12.3.tar.xz";
+      sha256 = "8db1dece78571f3e6933f8edcd693c3ceb1035acff780547a72c98b9f7decb87";
+      name = "ksnakeduel-19.12.3.tar.xz";
     };
   };
   kspaceduel = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kspaceduel-19.12.1.tar.xz";
-      sha256 = "0bc1f1c12bcfc9e5c778918fb9fa644f5c7ec5c3e687c015d45a7c5c31a27834";
-      name = "kspaceduel-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kspaceduel-19.12.3.tar.xz";
+      sha256 = "a9b5dc498b3695b59ae8925cc572cfc521ccadc8532756fa95ac876a7423c444";
+      name = "kspaceduel-19.12.3.tar.xz";
     };
   };
   ksquares = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ksquares-19.12.1.tar.xz";
-      sha256 = "955225b9fadbda464bdaf1b59c95c3d12310f84484a296968737e9fb87b37b46";
-      name = "ksquares-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ksquares-19.12.3.tar.xz";
+      sha256 = "45a922e4d85835cc655de560b6fd9be87d8cabc74eadbdecda3f17ba53ac92af";
+      name = "ksquares-19.12.3.tar.xz";
     };
   };
   ksudoku = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ksudoku-19.12.1.tar.xz";
-      sha256 = "4dd72a5b0bb0c951508bbe2c60ce280efcd0414899e025a2ca4d92336576ec2a";
-      name = "ksudoku-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ksudoku-19.12.3.tar.xz";
+      sha256 = "1cf36e762f31464b0640a88c739dfbb39b10129cace7fb5b74093ec607dea06c";
+      name = "ksudoku-19.12.3.tar.xz";
     };
   };
   ksystemlog = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ksystemlog-19.12.1.tar.xz";
-      sha256 = "497496ca7451cd34f193ba11fe3100479515a89a34f0437ca2f508a48e68e895";
-      name = "ksystemlog-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ksystemlog-19.12.3.tar.xz";
+      sha256 = "8225b1308ace76ebbf9bb805a2b6fae9bf8a425d0b09518645234c1b2df522dc";
+      name = "ksystemlog-19.12.3.tar.xz";
     };
   };
   kteatime = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kteatime-19.12.1.tar.xz";
-      sha256 = "49a0531b64e93ceb29548a7f75da755e75afda001fce2e6ba906372456b5dc17";
-      name = "kteatime-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kteatime-19.12.3.tar.xz";
+      sha256 = "0ab5fb6e33583e6d627b8f9dfaba5ce59e2b363e8045dfc66a4f65236d56542f";
+      name = "kteatime-19.12.3.tar.xz";
     };
   };
   ktimer = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktimer-19.12.1.tar.xz";
-      sha256 = "0c5fac1baddfa3144b8930f3d42b78a3eb8681d642a3c3339c903ad2cb30a2ba";
-      name = "ktimer-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktimer-19.12.3.tar.xz";
+      sha256 = "921af876a176a4731a74b5e9e76d751853043ec4f4857301b39a5c680246557c";
+      name = "ktimer-19.12.3.tar.xz";
     };
   };
   ktnef = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktnef-19.12.1.tar.xz";
-      sha256 = "2fce576e517e6ae9001ade6f07a51fcfa899a6569bc4b8c3948827adfc0af20c";
-      name = "ktnef-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktnef-19.12.3.tar.xz";
+      sha256 = "3537515b432e5da00d401046e94e0098fa54c071246cb0e357e3d8f47296ed3c";
+      name = "ktnef-19.12.3.tar.xz";
     };
   };
   ktouch = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktouch-19.12.1.tar.xz";
-      sha256 = "64b8a025f82b951c69c3be7aa7d3c23f14ccef9ed5e900776eb01462cff9a99f";
-      name = "ktouch-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktouch-19.12.3.tar.xz";
+      sha256 = "522fb081da5877717d577493fdaeeecbfe3d8d773e5d7fc83ecced008744ef0e";
+      name = "ktouch-19.12.3.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-accounts-kcm-19.12.1.tar.xz";
-      sha256 = "1ae81e4b7bae97d9d18c1fdc9e7083cc810b39d58dff5755dc9d78bd62551577";
-      name = "ktp-accounts-kcm-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-accounts-kcm-19.12.3.tar.xz";
+      sha256 = "ae5ae5004ecbf34596711a56e069d480c952de5ea784f5e90c391750439aff51";
+      name = "ktp-accounts-kcm-19.12.3.tar.xz";
     };
   };
   ktp-approver = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-approver-19.12.1.tar.xz";
-      sha256 = "502a63f13db44fc8a28f64e37c43839b8da22086bf858dc9c492476d9ba14b50";
-      name = "ktp-approver-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-approver-19.12.3.tar.xz";
+      sha256 = "af4f6d247b6332745f6b6dfacef74eb2ea0f7bbea9398080fc7b57e5953fdfbd";
+      name = "ktp-approver-19.12.3.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-auth-handler-19.12.1.tar.xz";
-      sha256 = "109583d4800d293fe11eeaa553d72643f2a3709c0d078a6e842f2e4b228d93e0";
-      name = "ktp-auth-handler-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-auth-handler-19.12.3.tar.xz";
+      sha256 = "40822e78879d97c3cc1d16f44f7d3b581980c4e249a273d7471b291adf3b9225";
+      name = "ktp-auth-handler-19.12.3.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-call-ui-19.12.1.tar.xz";
-      sha256 = "adb3025f8f878fd4a56ce125bd51c155f26b02661b9365b6321fb456153b0c55";
-      name = "ktp-call-ui-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-call-ui-19.12.3.tar.xz";
+      sha256 = "96b1dd64b0f87228d76f12b6cad3677afeb4c44d6f18645c3001555506573fb1";
+      name = "ktp-call-ui-19.12.3.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-common-internals-19.12.1.tar.xz";
-      sha256 = "4a1f189c1393164fba710e63b0e8f1aae6f22a5faacea0d86544e3e4a471603a";
-      name = "ktp-common-internals-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-common-internals-19.12.3.tar.xz";
+      sha256 = "48cde7fc4f2f0d39999f70699867044e0f85e06769a0824aac49c572fb1af5a4";
+      name = "ktp-common-internals-19.12.3.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-contact-list-19.12.1.tar.xz";
-      sha256 = "c293fa90899d496c4e29b9c9986a3864e06ef22dabbd4583123abbc232f4fe25";
-      name = "ktp-contact-list-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-contact-list-19.12.3.tar.xz";
+      sha256 = "093544e84ca12169966837be5f01d339ddc59e5f031d78e68ddf7be4dd890efd";
+      name = "ktp-contact-list-19.12.3.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-contact-runner-19.12.1.tar.xz";
-      sha256 = "a86d8a67f3d8f3d741c6c4548a58cbdff384e8bd5ed5cd1d82db65456240ac0f";
-      name = "ktp-contact-runner-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-contact-runner-19.12.3.tar.xz";
+      sha256 = "50646e8670449d6f6a9b107e36f18174b5ec37052a7b4f471617f4f53fecc96b";
+      name = "ktp-contact-runner-19.12.3.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-desktop-applets-19.12.1.tar.xz";
-      sha256 = "63f1a0df6a392f41a54fda8c4896754c2687ba34968cf5bbc0ac84a37c1a1741";
-      name = "ktp-desktop-applets-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-desktop-applets-19.12.3.tar.xz";
+      sha256 = "4ab8f04537345db8e41ed9f8ff7a6a2f3135e3539382cef97d1a7e9f0eddb54e";
+      name = "ktp-desktop-applets-19.12.3.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-filetransfer-handler-19.12.1.tar.xz";
-      sha256 = "208aab8c78f4b7f38e331802a63fa10d00a65c115900c72c7a710b799ea56034";
-      name = "ktp-filetransfer-handler-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-filetransfer-handler-19.12.3.tar.xz";
+      sha256 = "b2e81fec33b51628d9d88707b6bd844c69eb2c9bfb00cb0b45759a4fd9769b03";
+      name = "ktp-filetransfer-handler-19.12.3.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-kded-module-19.12.1.tar.xz";
-      sha256 = "274f97c6874eeb2af14b937ed20430d2ac2e1a769890a70da8d477ac33ed6082";
-      name = "ktp-kded-module-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-kded-module-19.12.3.tar.xz";
+      sha256 = "6bb0c05683812738e254c88d39936565966096a7156111565d8a64a59c55ef0d";
+      name = "ktp-kded-module-19.12.3.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-send-file-19.12.1.tar.xz";
-      sha256 = "5652e40e02ac191ad6e8df276a5faf8805000760261d495f3f4424416da3b977";
-      name = "ktp-send-file-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-send-file-19.12.3.tar.xz";
+      sha256 = "566d9dccc0c2fa7c23c95051c25543d3aabe76065ddff7dff9d8a37683d2022b";
+      name = "ktp-send-file-19.12.3.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktp-text-ui-19.12.1.tar.xz";
-      sha256 = "226efc09343bb9218c461858747a1bc084ad8291fbbcc9f49eb888acfe2039c6";
-      name = "ktp-text-ui-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktp-text-ui-19.12.3.tar.xz";
+      sha256 = "b8ad9a224ae300c0412874d0877fdc8e050869d3a8f60a4051a0919a8749c50f";
+      name = "ktp-text-ui-19.12.3.tar.xz";
     };
   };
   ktuberling = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/ktuberling-19.12.1.tar.xz";
-      sha256 = "4c0d594ef72bd2dda5d42daf0f8b430319cbea6d28ba5c9725895b1221cdaace";
-      name = "ktuberling-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/ktuberling-19.12.3.tar.xz";
+      sha256 = "c4d74d18173d5761f7e6f8adf6178713a726c671aaa2eda4e6c77115484e9e55";
+      name = "ktuberling-19.12.3.tar.xz";
     };
   };
   kturtle = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kturtle-19.12.1.tar.xz";
-      sha256 = "de10ea1ee142aea6fba8dee0d27d2e431aa806c6d7be4f5b5727cba8984e8d51";
-      name = "kturtle-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kturtle-19.12.3.tar.xz";
+      sha256 = "6958a88c484261919cd89cb1f0d163b0c5d5f1e28b10b3b4e3b6b9e82e379ef1";
+      name = "kturtle-19.12.3.tar.xz";
     };
   };
   kubrick = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kubrick-19.12.1.tar.xz";
-      sha256 = "485e7e4a30b01cb2661c640214bdc71a3e0a8b61a9071c64ffbbe75e2270af3c";
-      name = "kubrick-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kubrick-19.12.3.tar.xz";
+      sha256 = "8fc0a0e68d255481c6efb3f4ff894c5e376367b29958c4738bd72d3f4b1ff557";
+      name = "kubrick-19.12.3.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kwalletmanager-19.12.1.tar.xz";
-      sha256 = "b2370fbf559a3b8e8551daedada9c97d07041388dc74f8bd1286c64ab18b936b";
-      name = "kwalletmanager-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kwalletmanager-19.12.3.tar.xz";
+      sha256 = "247c7f80a54babd21a13e6b9386370b72ec12bdf928c08a7e8a647ccca53e393";
+      name = "kwalletmanager-19.12.3.tar.xz";
     };
   };
   kwave = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kwave-19.12.1.tar.xz";
-      sha256 = "e6c336644c00a457b37820fc87668dd9b8a448d8abf84cda267b6e5cd01e0645";
-      name = "kwave-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kwave-19.12.3.tar.xz";
+      sha256 = "3c90115d4702dbe46767e2404c952d84533137fa558b787b87ff95ed61f6930d";
+      name = "kwave-19.12.3.tar.xz";
     };
   };
   kwordquiz = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/kwordquiz-19.12.1.tar.xz";
-      sha256 = "8ee204de56fe2bf33e11d19b9c0c21d7e3dcf26bf550f9dffa79b22a3082659f";
-      name = "kwordquiz-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/kwordquiz-19.12.3.tar.xz";
+      sha256 = "6965a3b3c171c3f62aeecf4ccdddde14d23062ab914b1860822546a5770b80fc";
+      name = "kwordquiz-19.12.3.tar.xz";
     };
   };
   libgravatar = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libgravatar-19.12.1.tar.xz";
-      sha256 = "84525db5f24c04cfa2bb44376a3bd64368e9d9478a160cf862c695052f3fc254";
-      name = "libgravatar-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libgravatar-19.12.3.tar.xz";
+      sha256 = "70ea306f48aede9f8f327eaa74ea5ce5761e5dfe67f2da50d3242c0f312edc86";
+      name = "libgravatar-19.12.3.tar.xz";
     };
   };
   libkcddb = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkcddb-19.12.1.tar.xz";
-      sha256 = "50c139aaa14a5f27b3818cec7ec6ede4b764d461b6547651b61e4edd295afe6f";
-      name = "libkcddb-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkcddb-19.12.3.tar.xz";
+      sha256 = "69cbaf03adba24c0cabf957ee4149c4fa86d403eb6b8a07f7f80eb17be49e892";
+      name = "libkcddb-19.12.3.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkcompactdisc-19.12.1.tar.xz";
-      sha256 = "95b14098b24a86094b01b357e36ae135fb6c85c838e8735c843d27b101cc2bd9";
-      name = "libkcompactdisc-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkcompactdisc-19.12.3.tar.xz";
+      sha256 = "74aac7dcac84c60a7962f23e7bcc6eb693048fd96ca21015441a87487baa9d1c";
+      name = "libkcompactdisc-19.12.3.tar.xz";
     };
   };
   libkdcraw = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkdcraw-19.12.1.tar.xz";
-      sha256 = "bbdd5b1b9b40780b5f2be567d9ba0ab163fe7dcc7121070b788106e0fe966c1e";
-      name = "libkdcraw-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkdcraw-19.12.3.tar.xz";
+      sha256 = "9454aed707ee311dbfb921f8d45fba11710ffc01f48d65f64585d12c2580116f";
+      name = "libkdcraw-19.12.3.tar.xz";
     };
   };
   libkdegames = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkdegames-19.12.1.tar.xz";
-      sha256 = "317513544e08d03b2381bdb4c0bcd24c844dd8af7ccc4896569dd05933061d9c";
-      name = "libkdegames-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkdegames-19.12.3.tar.xz";
+      sha256 = "39cf5039b7fe11688028df026252c9cd4424546817b5bb635af2558f71ba6b20";
+      name = "libkdegames-19.12.3.tar.xz";
     };
   };
   libkdepim = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkdepim-19.12.1.tar.xz";
-      sha256 = "1d626a959a0f9fcb24c4e01c553126d40314c789db9bc80d6b52f2bb75e233cd";
-      name = "libkdepim-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkdepim-19.12.3.tar.xz";
+      sha256 = "911e7d174240d4c056472549dbd1f3da4467a57c765f3cb34fbac32943f38dbb";
+      name = "libkdepim-19.12.3.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkeduvocdocument-19.12.1.tar.xz";
-      sha256 = "a0e3921dab9d892d5efcddfbca548f230b508fc81ab4d7735c7610a710791816";
-      name = "libkeduvocdocument-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkeduvocdocument-19.12.3.tar.xz";
+      sha256 = "31594d30e03890507b25d676981164fd64258e69c6b264b85939118377eda964";
+      name = "libkeduvocdocument-19.12.3.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkexiv2-19.12.1.tar.xz";
-      sha256 = "53b9a4ecda0f76df1a5b9f7b8184b85e847838cf97e4ad3036a6c5bb719993e5";
-      name = "libkexiv2-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkexiv2-19.12.3.tar.xz";
+      sha256 = "f5d0947f6b1ca0583d569990dc6f68bb01d8f7756a38bcc40b1e54f7814e4d4d";
+      name = "libkexiv2-19.12.3.tar.xz";
     };
   };
   libkgapi = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkgapi-19.12.1.tar.xz";
-      sha256 = "8bfa16ab76b0042e2a0b827cf251b1155c0e693db39ffcb2805613d3393389cf";
-      name = "libkgapi-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkgapi-19.12.3.tar.xz";
+      sha256 = "f52923c382272b47782348fbadb32902fbcd4652f4100875a745ba57033cf48a";
+      name = "libkgapi-19.12.3.tar.xz";
     };
   };
   libkgeomap = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkgeomap-19.12.1.tar.xz";
-      sha256 = "68c9c5b91e77a4b4a07ca646d58e8e890975825f8f851d850c95dacb7a1d90d2";
-      name = "libkgeomap-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkgeomap-19.12.3.tar.xz";
+      sha256 = "eb604deffe78cdcd4a8c7d888416246d0a17f2e3b7d80d6959e1412f03ab2755";
+      name = "libkgeomap-19.12.3.tar.xz";
     };
   };
   libkipi = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkipi-19.12.1.tar.xz";
-      sha256 = "79f0a994b348467353425aea60dc4f4234c9a259cffcb55ac60d8c195bd0122c";
-      name = "libkipi-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkipi-19.12.3.tar.xz";
+      sha256 = "3a57d07cd4fe8e118558d807242bf483fa2aac1bcf3dcdc29139636c2b280786";
+      name = "libkipi-19.12.3.tar.xz";
     };
   };
   libkleo = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkleo-19.12.1.tar.xz";
-      sha256 = "8e9b78fbeb861370ab81f98150ff9ea8afc960293ae8324fedd0b877302994a7";
-      name = "libkleo-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkleo-19.12.3.tar.xz";
+      sha256 = "1e715442a0c52ca561316abdce9662082f52ad9f3101ea01435a90984989a057";
+      name = "libkleo-19.12.3.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkmahjongg-19.12.1.tar.xz";
-      sha256 = "e6a107a32c01c654a2372fda984724b4acd59dbc2902f3f9c7a7d9e14587639c";
-      name = "libkmahjongg-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkmahjongg-19.12.3.tar.xz";
+      sha256 = "f8ea23952a576e6081052d10e9c967bebe5db017ad62775183f91236158cc19f";
+      name = "libkmahjongg-19.12.3.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libkomparediff2-19.12.1.tar.xz";
-      sha256 = "319d61742f7603a60d781151cd717291c5cb976ff0f2895df9d167526cfb0b4a";
-      name = "libkomparediff2-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libkomparediff2-19.12.3.tar.xz";
+      sha256 = "aadc6e420e24bdebe203d4dfc76f5c23c8529be70ac057d89b516ab57b165094";
+      name = "libkomparediff2-19.12.3.tar.xz";
     };
   };
   libksane = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libksane-19.12.1.tar.xz";
-      sha256 = "5a5998996848e83c80589c8ed0b1a6c1fa48bb61686288d199d831ac810e1603";
-      name = "libksane-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libksane-19.12.3.tar.xz";
+      sha256 = "0aab855b8414041c37ddfbb9f0732272206af1c0844376f1370b9d2a907af71d";
+      name = "libksane-19.12.3.tar.xz";
     };
   };
   libksieve = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/libksieve-19.12.1.tar.xz";
-      sha256 = "6c3d49e2ce4d8e6b7c1b4328aa6065a01c7711223dd4f3b9db3a542f9fc0a84c";
-      name = "libksieve-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/libksieve-19.12.3.tar.xz";
+      sha256 = "990e6a15e7e88120bf6c744fe6f1ac78184d6470318005f24634a70219f45002";
+      name = "libksieve-19.12.3.tar.xz";
     };
   };
   lokalize = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/lokalize-19.12.1.tar.xz";
-      sha256 = "ee29cff9a513d68cde72e6ace0f893de77be5cb3fe56b4b6e0d1fa5b808b424c";
-      name = "lokalize-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/lokalize-19.12.3.tar.xz";
+      sha256 = "8015c994e974fd51c1c7f5903a005bbbc25f094656bdd44cd5e8675cd69cea92";
+      name = "lokalize-19.12.3.tar.xz";
     };
   };
   lskat = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/lskat-19.12.1.tar.xz";
-      sha256 = "0aa36c4cc554b708f7334b32362831537ea52db81b8480b80ffac5c27a041e8f";
-      name = "lskat-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/lskat-19.12.3.tar.xz";
+      sha256 = "5f13417ba9f6831a5f48c220a5c67a8d73787715b8b4aa433e6e356b7ac58776";
+      name = "lskat-19.12.3.tar.xz";
     };
   };
   mailcommon = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/mailcommon-19.12.1.tar.xz";
-      sha256 = "160135049bc2e4984f14022af793a9ac05bf488faa6f9eb7bd86a094de1c9bfe";
-      name = "mailcommon-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/mailcommon-19.12.3.tar.xz";
+      sha256 = "d3999d290505b20aecbb4b14bec5af4d6a7db72d1f26f7a40b4aff231588c7e5";
+      name = "mailcommon-19.12.3.tar.xz";
     };
   };
   mailimporter = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/mailimporter-19.12.1.tar.xz";
-      sha256 = "c1a042560438d6f6195a1f64355515489b74a44c1d2f5f547ced6785439215f1";
-      name = "mailimporter-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/mailimporter-19.12.3.tar.xz";
+      sha256 = "b81e8a5794aee24aa611c1a1912f93a308ce56c429ad4a72afe308e6b554c4a7";
+      name = "mailimporter-19.12.3.tar.xz";
     };
   };
   marble = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/marble-19.12.1.tar.xz";
-      sha256 = "46ec0dcab4773ccfb843ae52881ae833b038a00b7690977a2e721099264dc8dd";
-      name = "marble-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/marble-19.12.3.tar.xz";
+      sha256 = "73a2c5234f8a1728e2a97499166e7bbf8dfb2f48d10fe8cff96380631d064627";
+      name = "marble-19.12.3.tar.xz";
     };
   };
   mbox-importer = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/mbox-importer-19.12.1.tar.xz";
-      sha256 = "04dd6220192095d0f7befb368b9d96a321acac7af43b3575faf25ae89d17b5f4";
-      name = "mbox-importer-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/mbox-importer-19.12.3.tar.xz";
+      sha256 = "62fb1490517e0a49bf823946c8b747062cb970dbe00281d459adda73596f0046";
+      name = "mbox-importer-19.12.3.tar.xz";
     };
   };
   messagelib = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/messagelib-19.12.1.tar.xz";
-      sha256 = "d2514ac31f78235340353701f735a15f69d99374a55566ec7702a3a5ddd23d05";
-      name = "messagelib-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/messagelib-19.12.3.tar.xz";
+      sha256 = "5e776d5ea7b0cbb246b03cf2bfc84a65a959e7433a7f80b77a5f67cfa7c23ccb";
+      name = "messagelib-19.12.3.tar.xz";
     };
   };
   minuet = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/minuet-19.12.1.tar.xz";
-      sha256 = "735b340f9f0d6ee09c2c6aa76061282da6bd921f8b77683c53311731a77edff1";
-      name = "minuet-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/minuet-19.12.3.tar.xz";
+      sha256 = "740a3704004336f08c0fde148257c1562254b4e706704ec7eb2149fb3d7b6b9b";
+      name = "minuet-19.12.3.tar.xz";
     };
   };
   okular = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/okular-19.12.1.tar.xz";
-      sha256 = "485044127c6bbe0d4c71f1518da15050957c06b8fe36633462367d15d684d4bd";
-      name = "okular-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/okular-19.12.3.tar.xz";
+      sha256 = "c5de22cc4292e3b7adae3f6ef6566dcba33a1dd5995fb0b968ea3e705a4c04e0";
+      name = "okular-19.12.3.tar.xz";
     };
   };
   palapeli = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/palapeli-19.12.1.tar.xz";
-      sha256 = "ea4d9dd576066a610444680f3e8686f242bc8be9222020423acab52ec98a185f";
-      name = "palapeli-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/palapeli-19.12.3.tar.xz";
+      sha256 = "6989bbc94ed955f6990d40bccbc0c38768898bf2ccb8163c45119517340b723d";
+      name = "palapeli-19.12.3.tar.xz";
     };
   };
   parley = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/parley-19.12.1.tar.xz";
-      sha256 = "54b91178a9bd1ff9c1817bd0df69a3a4bb9e4f3488f052034dd45e729f1325b6";
-      name = "parley-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/parley-19.12.3.tar.xz";
+      sha256 = "ebf9fdec981abca988d83d8a77e921e7ce871eb010b6cf4ea9065ee6d45f5089";
+      name = "parley-19.12.3.tar.xz";
     };
   };
   picmi = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/picmi-19.12.1.tar.xz";
-      sha256 = "5428ef9add8dd9479f319b8c08fbfefca9ee34fbf503bee1c55b04ecf82ae9f9";
-      name = "picmi-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/picmi-19.12.3.tar.xz";
+      sha256 = "04a69125fc76b1fcd58d873452e4a4e642ee9ee672cdb7656214d8cd854fc178";
+      name = "picmi-19.12.3.tar.xz";
     };
   };
   pimcommon = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/pimcommon-19.12.1.tar.xz";
-      sha256 = "d3058407ec578a32df82eb83eb7631d2904e75d6d345ed61dac0f3744840ebf5";
-      name = "pimcommon-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/pimcommon-19.12.3.tar.xz";
+      sha256 = "443e2915eb42a4f56f1ddf47785ceeceb4ca1e0384ff48bc93fc4a7756392766";
+      name = "pimcommon-19.12.3.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/pim-data-exporter-19.12.1.tar.xz";
-      sha256 = "3f650c1c221826079d7c739e4070e295a7a1b1156f75e8e3100b06f878efed12";
-      name = "pim-data-exporter-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/pim-data-exporter-19.12.3.tar.xz";
+      sha256 = "8e9961fcc4f1ed0305d589e3a417f8924657d89d798a77c53956d73f6bf19938";
+      name = "pim-data-exporter-19.12.3.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/pim-sieve-editor-19.12.1.tar.xz";
-      sha256 = "3fdca7147c581dce4a014dc2d30bd7e6616c0559654cf9fee68e9292fd6ef037";
-      name = "pim-sieve-editor-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/pim-sieve-editor-19.12.3.tar.xz";
+      sha256 = "641ea56304df079a80e098fb253c173b63266990856f8795af093c144c3883ae";
+      name = "pim-sieve-editor-19.12.3.tar.xz";
     };
   };
   poxml = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/poxml-19.12.1.tar.xz";
-      sha256 = "f02aa4d1f7de8fb38921fe73076b3e905185979d9b75ff6345efaca8aad0ebb9";
-      name = "poxml-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/poxml-19.12.3.tar.xz";
+      sha256 = "190178290ce18fe3a684c22d650843f3008a6e31ebbab8fff25491c58b21e276";
+      name = "poxml-19.12.3.tar.xz";
     };
   };
   print-manager = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/print-manager-19.12.1.tar.xz";
-      sha256 = "76336be7da80a7494e2e5d5c9ab431047672a98630c7d61f916aa4b9edc35776";
-      name = "print-manager-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/print-manager-19.12.3.tar.xz";
+      sha256 = "74c13802a65136539b4542fec10fb248149a3324e8060e947a8f305ce665269a";
+      name = "print-manager-19.12.3.tar.xz";
     };
   };
   rocs = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/rocs-19.12.1.tar.xz";
-      sha256 = "cc9ff080b05bd6c48ee438c968917d8eb6f6eccb45ca70b45c5e53dce396bb45";
-      name = "rocs-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/rocs-19.12.3.tar.xz";
+      sha256 = "f834e69e676913e364162906b79da5a75a6043f4a5c8506954d1630abda45e3c";
+      name = "rocs-19.12.3.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/signon-kwallet-extension-19.12.1.tar.xz";
-      sha256 = "a98397cc15733b9c1010f022a8d6bcf7727c4065ba6ae662273ba97864836bbe";
-      name = "signon-kwallet-extension-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/signon-kwallet-extension-19.12.3.tar.xz";
+      sha256 = "46199be023bad630b769b14c2c0a63feff2949da944c76780b1ebd9a50ee3daa";
+      name = "signon-kwallet-extension-19.12.3.tar.xz";
     };
   };
   spectacle = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/spectacle-19.12.1.tar.xz";
-      sha256 = "140f388c531043eeefff8d639eb468d1ed33397925021c6809c0c8a799bb25c9";
-      name = "spectacle-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/spectacle-19.12.3.tar.xz";
+      sha256 = "443f114dab1fb50e7e12a046fdf06c0456bf99a3abdf09dce05605fdf7d3de81";
+      name = "spectacle-19.12.3.tar.xz";
     };
   };
   step = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/step-19.12.1.tar.xz";
-      sha256 = "f171c58b567bb29ed50109b341e53dc00116e814c90f51aa7a6e405326982907";
-      name = "step-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/step-19.12.3.tar.xz";
+      sha256 = "0eb62c87553769e009daa02406b1d95742c946bdffe0d22327776ec558e7584b";
+      name = "step-19.12.3.tar.xz";
     };
   };
   svgpart = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/svgpart-19.12.1.tar.xz";
-      sha256 = "6083457999121ead13b6c267211a78ea04c925d6f9f7447b31677c0b49f6898b";
-      name = "svgpart-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/svgpart-19.12.3.tar.xz";
+      sha256 = "942d877a516d8407ef2782d7c6869ab688274fee6cde9b23ab1061bcbddf2cc9";
+      name = "svgpart-19.12.3.tar.xz";
     };
   };
   sweeper = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/sweeper-19.12.1.tar.xz";
-      sha256 = "50b1464c08b738f4af4c78b4edc291ce93877a52831b810cd12c8ca6a4df0cf9";
-      name = "sweeper-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/sweeper-19.12.3.tar.xz";
+      sha256 = "cf89cfba61c9eeda9b4e7921c21a23e7d9a110b134ab6fbd127c37d036bd0517";
+      name = "sweeper-19.12.3.tar.xz";
     };
   };
   umbrello = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/umbrello-19.12.1.tar.xz";
-      sha256 = "077a1b5a3dfe15d37f03ee97ca5b40a1b8e7e0f2305df2f16a966861cc79e0d6";
-      name = "umbrello-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/umbrello-19.12.3.tar.xz";
+      sha256 = "b2f769c7bd1cc259170b62c68d2dca05b4a143dd1048dbb507cf2bbb3020a193";
+      name = "umbrello-19.12.3.tar.xz";
     };
   };
   yakuake = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/yakuake-19.12.1.tar.xz";
-      sha256 = "abff4f358f41f544b2e12c340a74d92482241b1b95906b14add7810384602e42";
-      name = "yakuake-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/yakuake-19.12.3.tar.xz";
+      sha256 = "0e4f16eaf155750b0c35f1f8f1a625909f386f3359b9f23bf4e7c2f9045384e3";
+      name = "yakuake-19.12.3.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "19.12.1";
+    version = "19.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/19.12.1/src/zeroconf-ioslave-19.12.1.tar.xz";
-      sha256 = "39641a186de9d0704a58063a8a37cfb3a405ff6bd9957c7d09efec3bec4dfc60";
-      name = "zeroconf-ioslave-19.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/19.12.3/src/zeroconf-ioslave-19.12.3.tar.xz";
+      sha256 = "c9b2146030a9845b8164f5784d1c6fcc198b6cfe0e23f6a91edf78d093e4368f";
+      name = "zeroconf-ioslave-19.12.3.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update KDE applications from 19.12.1 to 19.12.3.

Tested on the 20.03 branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
