### PR TITLE
maintainers: Add Th0rgal

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7336,6 +7336,12 @@
     githubId = 378734;
     name = "TG ⊗ Θ";
   };
+  th0rgal = {
+    email = "thomas.marchand@tuta.io";
+    github = "Th0rgal";
+    githubId = 41830259;
+    name = "Thomas Marchand";
+  };
   thall = {
     email = "niclas.thall@gmail.com";
     github = "thall";


### PR DESCRIPTION
###### Motivation for this change
I wanted to add myself as a maintainer for a few packages like wpsoffice which I update because I use them every day and I saw that I had to add myself to the maintainer's file.

###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
