### PR TITLE
openmsx: 2017-11-02 -> 0.15.0

### DIFF
--- a/pkgs/misc/emulators/openmsx/default.nix
+++ b/pkgs/misc/emulators/openmsx/default.nix
@@ -6,16 +6,17 @@
 , freetype, tcl, zlib
 }:
 
-stdenv.mkDerivation {
+with stdenv.lib;
+stdenv.mkDerivation rec {
 
   pname = "openmsx";
-  version = "git-2017-11-02";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "openMSX";
     repo = "openMSX";
-    rev = "eeb74206ae347a3b17e9b99f91f2b4682c5db22c";
-    sha256 = "170amj7k6wjhwx6psbplqljvckvhxxbv3aw72jrdxl1fb8zlnq3s";
+    rev = "RELEASE_0_15_0";
+    sha256 = "1lv5kdw0812mkf7k20z2djzk0pbs792xq2mibbnz9rfjf02whi7l";
     fetchSubmodules = true;
   };
 
@@ -35,13 +36,13 @@ stdenv.mkDerivation {
   # for providing support to Nixpkgs :)
   TCL_CONFIG="${tcl}/lib/";
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "A MSX emulator";
     longDescription = ''
       OpenMSX is an emulator for the MSX home computer system. Its goal is
       to emulate all aspects of the MSX with 100% accuracy.
     '';
-    homepage = https://openmsx.org;
+    homepage = "https://openmsx.org";
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
