### PR TITLE
syncoid: fix PATH to let it use sudo

### DIFF
--- a/pkgs/tools/backup/sanoid/default.nix
+++ b/pkgs/tools/backup/sanoid/default.nix
@@ -52,12 +52,12 @@ stdenv.mkDerivation rec {
     # incompatibilities with the ZFS kernel module.
     wrapProgram "$out/bin/sanoid" \
       --prefix PERL5LIB : "$PERL5LIB" \
-      --prefix PATH : "${makeBinPath [ procps "/run/booted-system/sw" zfs ]}"
+      --prefix PATH : "${makeBinPath [ procps "/run/wrappers" "/run/booted-system/sw" zfs ]}"
 
     install -m755 syncoid "$out/bin/syncoid"
     wrapProgram "$out/bin/syncoid" \
       --prefix PERL5LIB : "$PERL5LIB" \
-      --prefix PATH : "${makeBinPath [ openssh procps which pv mbuffer lzop gzip pigz "/run/booted-system/sw" zfs ]}"
+      --prefix PATH : "${makeBinPath [ openssh procps which pv mbuffer lzop gzip pigz "/run/wrappers" "/run/booted-system/sw" zfs ]}"
 
     install -m755 findoid "$out/bin/findoid"
     wrapProgram "$out/bin/findoid" \


### PR DESCRIPTION
###### Motivation for this change
ˋsyncoidˋ uses ˋsudoˋ but ˋsudoˋ is in ˋ/run/wrappersˋ not in ˋ/run/booted-system/swˋ.

###### Things done
Add ˋ/run/wrappersˋ to the ˋPATHˋ of ˋsyncoidˋ (and ˋsanoidˋ which has a comment suggesting it may use ˋsudoˋ one day).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
