### PR TITLE
sanoid: fix sanoid.conf generation

### DIFF
--- a/nixos/tests/sanoid.nix
+++ b/nixos/tests/sanoid.nix
@@ -33,7 +33,7 @@ in {
 
           autosnap = true;
         };
-        datasets."pool/sanoid".useTemplate = [ "test" ];
+        datasets."pool/sanoid".use_template = [ "test" ];
         extraArgs = [ "--verbose" ];
       };
 


### PR DESCRIPTION
###### Motivation for this change
`sanoid` currently generates a bogus `sanoid.conf`: defaults of NixOS' options are put into templates and into datasets (making the use of templates useless).

###### Things done
Simplify the generation of `sanoid.conf`.
As in other modules like `services.postfix.config` I'm also renaming options to use original names because they are 1:1 mapping to sanoid's config.

A relevant discussion, on `#nixos-dev`:

> julm : while I'm at writing a fix to nixos/modules/services/backup/sanoid.nix (which generates a bogus configfile) I'm wondering if there is a rationale for using CamelCase for options which are direct mapping to sanoid options which use snake_case? eg. use_template becomes useTemplate in NixOS. I'd personnaly prefer to stick to the original, but what's the policy?
> rnhmjoj : julm: if it's not too late.. i know at least of the matrix-synapse module, which keeps the original snake_case names. there are also the module.settings options from RFC 0042. personally i don't like having different options styles but keeping the original also has value.
> julm : rnhmjoj: thanks!
> julm : I'll try to justify to keep the original names because it makes the code simpler (no mapping to be done before supplying the attrset to toINI)
> rnhmjoj : julm: if you are doing a 1:1 map of options, yes, i would keep the original names

```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
