### PR TITLE
ursadb: init at v1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5186,6 +5186,12 @@
     githubId = 133448;
     name = "Mikołaj Siedlarek";
   };
+  msm = {
+    email = "msm@tailcall.net";
+    github = "msm-code";
+    githubId = 7026881;
+    name = "Jarosław Jedynak";
+  };
   mstarzyk = {
     email = "mstarzyk@gmail.com";
     github = "mstarzyk";

--- a/pkgs/servers/ursadb/default.nix
+++ b/pkgs/servers/ursadb/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, cmake, zeromq, cppzmq }:
+
+stdenv.mkDerivation {
+  name = "ursadb";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/CERT-Polska/ursadb/archive/v1.2.0.tar.gz";
+    sha256 = "10dax3mswq0x4cfrpi31b7ii7bxl536wz1j11b7f5c0zw9pjxzym";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ursadb $out/bin/
+    cp ursadb_new $out/bin/
+    cp ursadb_trim $out/bin/
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    zeromq
+    cppzmq
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/CERT-Polska/ursadb";
+    description = "Trigram database written in C++, suited for malware indexing";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ msm ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7156,6 +7156,8 @@ in
 
   urlview = callPackage ../applications/misc/urlview {};
 
+  ursadb = callPackage ../servers/ursadb {};
+
   usbmuxd = callPackage ../tools/misc/usbmuxd {};
 
   usync = callPackage ../applications/misc/usync { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux) (AFAIU it's the default on nixos)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (n/a - no packages are dependent on this yet. Tried it, "No diff detected, stopping review..."?)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
