### PR TITLE
krb5: Add patches to fix build with musl on 1.18

### DIFF
--- a/pkgs/development/libraries/kerberos/krb5-Fix-Linux-build-error-with-musl-libc.patch
+++ b/pkgs/development/libraries/kerberos/krb5-Fix-Linux-build-error-with-musl-libc.patch
@@ -1,0 +1,32 @@
+From cbdbc8d00d31344fafe00e0fdf984e04e631f7c4 Mon Sep 17 00:00:00 2001
+From: TBK <tbk@jjtc.eu>
+Date: Wed, 26 Feb 2020 21:12:45 +0100
+Subject: [PATCH] Fix Linux build error with musl libc
+
+Commit bf5953c549a6d279977df69ffe89b2ba51460eaf caused a build failure
+on non-glibc Linux build environments.  Change the conditionalization
+so that __GLIBC_PREREQ will only be used if it is defined.
+
+[ghudson@mit.edu: simplified conditionals; rewrote commit message]
+
+ticket: 8880 (new)
+tags: pullup
+target_version: 1.18-next
+---
+ src/util/support/plugins.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/util/support/plugins.c b/src/util/support/plugins.c
+index 3329db7dc3..1644d16fd0 100644
+--- a/src/util/support/plugins.c
++++ b/src/util/support/plugins.c
+@@ -62,8 +62,7 @@
+  * dlopen() with RTLD_NODELETE, we weren't going to unload the plugin objects
+  * anyway.
+  */
+-#ifdef __linux__
+-#include <features.h>
++#ifdef __GLIBC__PREREQ
+ #if ! __GLIBC_PREREQ(2, 25)
+ #define dlclose(x)
+ #endif

--- a/pkgs/development/libraries/kerberos/krb5-Fix-typo-in-musl-build-fix.patch
+++ b/pkgs/development/libraries/kerberos/krb5-Fix-typo-in-musl-build-fix.patch
@@ -1,0 +1,28 @@
+From b009cca2026b615ef5386faa4c0230bc27c4161d Mon Sep 17 00:00:00 2001
+From: Greg Hudson <ghudson@mit.edu>
+Date: Thu, 12 Mar 2020 00:44:10 -0400
+Subject: [PATCH] Fix typo in musl build fix
+
+Commit cbdbc8d00d31344fafe00e0fdf984e04e631f7c4 checked for
+__GLIBC__PREREQ instead of __GLIBC_PREREQ, thus accidentally reverting
+the workaround introduced in commit
+bf5953c549a6d279977df69ffe89b2ba51460eaf.  Fix the typo.
+
+ticket: 8880
+---
+ src/util/support/plugins.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/util/support/plugins.c b/src/util/support/plugins.c
+index 1644d16fd0..1ff10c354d 100644
+--- a/src/util/support/plugins.c
++++ b/src/util/support/plugins.c
+@@ -62,7 +62,7 @@
+  * dlopen() with RTLD_NODELETE, we weren't going to unload the plugin objects
+  * anyway.
+  */
+-#ifdef __GLIBC__PREREQ
++#ifdef __GLIBC_PREREQ
+ #if ! __GLIBC_PREREQ(2, 25)
+ #define dlclose(x)
+ #endif

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -14,13 +14,22 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "${type}krb5-${version}";
-  majorVersion = "1.18";
+  majorVersion = "1.18"; # remove patches below with next upgrade
   version = majorVersion;
 
   src = fetchurl {
     url = "https://kerberos.org/dist/krb5/${majorVersion}/krb5-${version}.tar.gz";
     sha256 = "121c5xsy3x0i4wdkrpw62yhvji6virbh6n30ypazkp0isws3k4bk";
   };
+
+  patches = optionals stdenv.hostPlatform.isMusl [
+    # TODO: Remove with next release > 1.18
+    # Patches to fix musl build with 1.18.
+    # Not using `fetchpatch` for these for now to avoid infinite recursion
+    # errors in downstream projects (unclear if it's a nixpkgs issue so far).
+    ./krb5-Fix-Linux-build-error-with-musl-libc.patch
+    ./krb5-Fix-typo-in-musl-build-fix.patch
+  ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
###### Motivation for this change

Unbreak musl build, see https://github.com/krb5/krb5/commit/bf5953c549a6d279977df69ffe89b2ba51460eaf#r37504446

These fixes are only in `krb5` `master` so far, a release that includes them has not been made yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
