### PR TITLE
gwyddion: support darwin

### DIFF
--- a/pkgs/applications/science/chemistry/gwyddion/default.nix
+++ b/pkgs/applications/science/chemistry/gwyddion/default.nix
@@ -12,7 +12,7 @@
   zlibSupport ? true, zlib ? null,
   libuniqueSupport ? true, libunique ? null,
   libpngSupport ? true, libpng ? null,
-  openglSupport ? true
+  openglSupport ? !stdenv.isDarwin
 }:
 
 assert openexrSupport -> openexr != null;
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   
   buildInputs = with stdenv.lib;
     [ gtk2 fftw ] ++
-    optionals openglSupport [gnome2.gtkglext] ++
+    optional openglSupport gnome2.gtkglext ++
     optional openexrSupport openexr ++
     optional libXmuSupport xorg.libXmu ++
     optional fitsSupport cfitsio ++
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
       spectrophotometry.
     '';
     license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     maintainers = [ stdenv.lib.maintainers.cge ];
   };
 }

--- a/pkgs/development/libraries/libunique/default.nix
+++ b/pkgs/development/libraries/libunique/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.gnome.org/Attic/LibUnique";
     description = "A library for writing single instance applications";
     license = stdenv.lib.licenses.lgpl21;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Gwyddion will build on Darwin, but gnome2.gtkglext is broken there,
and so I am disabling it as an optional dependency here when building
on Darwin.

###### Things done

Note that I personally have only tested that this will continue to build and work on NixOS.  Someone else tested that the previous Gwyddion derivation builds, all binaries work, and the Python 2.7 module loads, so long as gnome2.gtkglext is not used (it fails to build on OS X); that is what this change is meant to ensure.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
