### PR TITLE
modules/xrdp: refactor

### DIFF
--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -4,39 +4,58 @@ with lib;
 
 let
   cfg = config.services.xrdp;
-  confDir = pkgs.runCommand "xrdp.conf" { preferLocalBuild = true; } ''
-    mkdir $out
+  sessionData = config.services.xserver.displayManager.sessionData;
 
-    cp ${cfg.package}/etc/xrdp/{km-*,xrdp,sesman,xrdp_keyboard}.ini $out
+  toINI = generators.toINI {};
+  mkParams = concatMapStringsSep "\n" (param: "param=${param}");
 
-    cat > $out/startwm.sh <<EOF
-    #!/bin/sh
-    . /etc/profile
-    ${cfg.defaultWindowManager}
-    EOF
-    chmod +x $out/startwm.sh
+  xrdpIni = toINI {
+    Globals = cfg.globals;
+    Logging = cfg.logging;
+    Channels = cfg.channels;
+    Xorg = cfg.sessions.xorg;
+  };
 
-    substituteInPlace $out/xrdp.ini \
-      --replace "#rsakeys_ini=" "rsakeys_ini=/run/xrdp/rsakeys.ini" \
-      --replace "certificate=" "certificate=${cfg.sslCert}" \
-      --replace "key_file=" "key_file=${cfg.sslKey}" \
-      --replace LogFile=xrdp.log LogFile=/dev/null \
-      --replace EnableSyslog=true EnableSyslog=false
-
-    substituteInPlace $out/sesman.ini \
-      --replace LogFile=xrdp-sesman.log LogFile=/dev/null \
-      --replace EnableSyslog=1 EnableSyslog=0
-
-    # Ensure that clipboard works for non-ASCII characters
-    sed -i -e '/.*SessionVariables.*/ a\
-    LANG=${config.i18n.defaultLocale}\
-    LOCALE_ARCHIVE=${config.i18n.glibcLocales}/lib/locale/locale-archive
-    ' $out/sesman.ini
+  sesmanIni = (toINI {
+    Globals = cfg.sesman.globals;
+    Security = cfg.sesman.security;
+    Logging = cfg.sesman.logging;
+    Sessions = cfg.sesman.sessions;
+    Chansrv = cfg.sesman.chansrv;
+    SessionVariables = cfg.sesman.sessionVariables;
+  }) + ''
+    [Xorg]
+    ${mkParams cfg.sesman.xorg.params}
   '';
-in
-{
+
+  startwm = pkgs.writeScript "startwm.sh" ''
+    #! ${pkgs.bash}/bin/bash
+
+    # get session desktop file
+    session_desktop_file=${sessionData.desktops}/share/xsessions/${cfg.sessionName}.desktop
+
+    # parse Exec from desktop file, so we can start session
+    session_command=$(grep '^Exec' $session_desktop_file | tail -1 | sed 's/^Exec=//' | sed 's/%.//' | sed 's/^"//g' | sed 's/" *$//g')
+
+    ${cfg.sessionCommand}
+  '';
+
+  # keyboard map files
+  kmFiles = filterAttrs (k: _: hasPrefix "km-" k) (builtins.readDir "${cfg.package}/etc/xrdp");
+
+  mkAllOptionDefault = mapAttrs (_: mkOptionDefault);
+
+  stringIntOrBool = with types; nullOr (either (either str int) bool);
+
+in {
 
   ###### interface
+
+  imports = [
+    (mkRenamedOptionModule
+      ["services" "xrdp" "defaultWindowManager"]
+      ["services" "xrdp" "sessionCommand"])
+  ];
 
   options = {
 
@@ -81,23 +100,229 @@ in
         '';
       };
 
-      defaultWindowManager = mkOption {
+      sessionName = mkOption {
         type = types.str;
-        default = "xterm";
-        example = "xfce4-session";
+        default = sessionData.autologinSession;
+        defaultText = "default desktop session";
         description = ''
-          The script to run when user log in, usually a window manager, e.g. "icewm", "xfce4-session"
-          This is per-user overridable, if file ~/startwm.sh exists it will be used instead.
+          Name of the session to be launched.
         '';
       };
 
+      sessionCommand = mkOption {
+        type = types.str;
+        default = ''${sessionData.wrapper} "$session_command"'';
+        defaultText = "sessionWrapper $session_command";
+        example = "xfce4-session";
+        description = ''
+          Command to run to start session.
+        '';
+      };
+
+      globals = mkOption {
+        type = types.attrsOf stringIntOrBool;
+        default = {};
+        description = "Global configuration option.";
+      };
+
+      logging = mkOption {
+        type = types.attrsOf stringIntOrBool;
+        default = {};
+        description = "Logging configuration options.";
+      };
+
+      channels = mkOption {
+        type = types.attrsOf types.bool;
+        default = {};
+        description = "Attribute set of channels to enable.";
+      };
+
+      sessions = {
+        xorg = mkOption {
+          type = types.attrsOf stringIntOrBool;
+          default = {};
+          description = "Attribute set of Xorg session options.";
+        };
+      };
+
+      sesman = {
+        globals = mkOption {
+          type = types.attrsOf stringIntOrBool;
+          default = {};
+          description = "Xrdp sesman global configuration options.";
+        };
+
+        security = mkOption {
+          type = types.attrsOf stringIntOrBool;
+          default = {};
+          description = "Xrdp sesman security configuration options.";
+        };
+
+        logging = mkOption {
+          type = types.attrsOf stringIntOrBool;
+          default = {};
+          description = "Xrdp sesman logging configuration options.";
+        };
+
+        sessions = mkOption {
+          type = types.attrsOf stringIntOrBool;
+          default = {};
+          description = "Attribute set of session options.";
+        };
+
+        chansrv = mkOption {
+          type = types.attrsOf stringIntOrBool;
+          default = {};
+          description = "Attribute set of chansrv options.";
+        };
+
+        xorg = {
+          modules = mkOption {
+            type = types.listOf types.package;
+            default = with pkgs; [ xorgxrdp xorg.xorgserver ];
+            description = ''
+              Packages to be added to the module search path of the X server.
+            '';
+          };
+
+          configFile = mkOption {
+            type = types.path;
+            default = "${pkgs.xorgxrdp}/etc/X11/xrdp/xorg.conf";
+            description = ''
+              Path to xorg configuration.
+            '';
+          };
+
+          params = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = "Lits of additional xorg parameters.";
+          };
+        };
+
+        sessionVariables = mkOption {
+          type = types.attrsOf types.str;
+          description = "Attribute set of session variables to pass to session";
+        };
+      };
     };
   };
-
 
   ###### implementation
 
   config = mkIf cfg.enable {
+
+    services.xrdp = {
+      globals = mkAllOptionDefault {
+        ini_version = 1;
+        fork = true;
+        port = cfg.port;
+        use_vsock = false;
+        tcp_nodelay = true;
+        tcp_keepalive = true;
+
+        security_layer = "negotiate";
+        crypt_level = "none";
+        certificate = cfg.sslCert;
+        key_file = cfg.sslKey;
+
+        allow_channels = true;
+        allow_multimon = true;
+        bitmap_cache = true;
+        bitmap_compression = true;
+        bulk_compression = true;
+        max_bpp = 32;
+        new_cursor = true;
+        use_fastpath = "both";
+      };
+
+      channels = mkAllOptionDefault {
+        rdpdr = true;
+        rdpsnd = true;
+        drdynvc = true;
+        cliprdr = true;
+        rail = true;
+        xrdpvr = true;
+        tcutils = true;
+      };
+
+      logging = mkAllOptionDefault {
+        LogFile = "/dev/null";
+        LogLevel = "DEBUG";
+        EnableSyslog = true;
+        SyslogLevel = "DEBUG";
+      };
+
+      sessions = {
+        xorg = mkAllOptionDefault {
+          name = "Xorg";
+          lib = "libxup.so";
+          username = "ask";
+          password = "ask";
+          ip = "127.0.0.1";
+          sesmanport = 3350;
+          code = 20;
+        };
+      };
+
+      sesman = {
+        globals = mkAllOptionDefault {
+          ListenAddress = "127.0.0.1";
+          ListenPort = 3350;
+          EnableUserWindowManager = true;
+          UserWindowManager = "startwm.sh";
+          DefaultWindowManager = "startwm.sh";
+        };
+
+        security = mkAllOptionDefault {
+          AllowRootLogin = true;
+          MaxLoginRetry = 4;
+          TerminalServerUsers = "tsusers";
+          TerminalServerAdmins = "tsadmins";
+          AlwaysGroupCheck = false;
+        };
+
+        sessions = mkAllOptionDefault {
+          X11DisplayOffset = 10;
+          MaxSessions = 50;
+          KillDisconnected = true;
+          DisconnectedTimeLimit = 0;
+          IdleTimeLimit = 0;
+          Policy = "Default";
+        };
+
+        logging = mkAllOptionDefault {
+          LogFile = "/dev/null";
+          LogLevel = "DEBUG";
+          EnableSyslog = true;
+          SyslogLevel = "DEBUG";
+        };
+
+        chansrv = mkAllOptionDefault {
+          FuseMountName = "thinclient_drives";
+          FileUmask = 077;
+        };
+
+        sessionVariables = {
+          PULSE_SCRIPT = mkOptionDefault "/etc/xrdp/pulse/default.pa";
+        };
+
+        xorg = {
+          params = [
+            "${pkgs.xorg.xorgserver}/bin/Xorg"
+            "-modulepath"
+            "${concatMapStringsSep "," (x: "${x}/lib/xorg/modules") cfg.sesman.xorg.modules}"
+            "-config"
+            cfg.sesman.xorg.configFile
+            "-noreset"
+            "-nolisten"
+            "tcp"
+            "-logfile"
+            ".xorgxrdp.%s.log"
+          ];
+        };
+      };
+    };
 
     # xrdp can run X11 program even if "services.xserver.enable = false"
     xdg = {
@@ -109,13 +334,28 @@ in
 
     fonts.enableDefaultFonts = mkDefault true;
 
+    environment.etc = {
+      "xrdp/xrdp.ini".text = xrdpIni;
+      "xrdp/sesman.ini".text = sesmanIni;
+      "xrdp/startwm.sh".source = startwm;
+
+      "xrdp/xrdp_keyboard.ini".source = "${cfg.package}/etc/xrdp/xrdp_keyboard.ini";
+      "xrdp/pulse/default.pa".source = "${cfg.package}/etc/xrdp/pulse/default.pa";
+    } // (mapAttrs (k: _: {
+      target = "xrdp/${k}";
+      source = "${pkgs.xrdp}/etc/xrdp/${k}";
+    }) kmFiles);
+
     systemd = {
       services.xrdp = {
         wantedBy = [ "multi-user.target" ];
-        after = [ "network.target" ];
+        after = [ "network.target" "xrdp-sesman.service" ];
         description = "xrdp daemon";
-        requires = [ "xrdp-sesman.service" ];
         preStart = ''
+          # create run directory
+          mkdir -p /run/xrdp
+          chown xrdp:xrdp /run/xrdp
+
           # prepare directory for unix sockets (the sockets will be owned by loggedinuser:xrdp)
           mkdir -p /tmp/.xrdp || true
           chown xrdp:xrdp /tmp/.xrdp
@@ -132,27 +372,40 @@ in
             chown root:xrdp ${cfg.sslKey} ${cfg.sslCert}
             chmod 440 ${cfg.sslKey} ${cfg.sslCert}
           fi
+
+          # generate rsa keys
           if [ ! -s /run/xrdp/rsakeys.ini ]; then
             mkdir -p /run/xrdp
             ${cfg.package}/bin/xrdp-keygen xrdp /run/xrdp/rsakeys.ini
           fi
         '';
         serviceConfig = {
+          Type = "forking";
+          PIDFile = "/run/xrdp/xrdp.pid";
+          ExecStart = "${cfg.package}/bin/xrdp";
+          ExecStop = "${cfg.package}/bin/xrdp --kill";
           User = "xrdp";
           Group = "xrdp";
           PermissionsStartOnly = true;
-          ExecStart = "${cfg.package}/bin/xrdp --nodaemon --port ${toString cfg.port} --config ${confDir}/xrdp.ini";
         };
       };
 
       services.xrdp-sesman = {
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
+        bindsTo = [ "xrdp.service" ];
         description = "xrdp session manager";
         restartIfChanged = false; # do not restart on "nixos-rebuild switch". like "display-manager", it can have many interactive programs as children
+        preStart = ''
+          # create run directory
+          mkdir -p /run/xrdp
+          chown xrdp:xrdp /run/xrdp
+        '';
         serviceConfig = {
-          ExecStart = "${cfg.package}/bin/xrdp-sesman --nodaemon --config ${confDir}/sesman.ini";
-          ExecStop  = "${pkgs.coreutils}/bin/kill -INT $MAINPID";
+          Type = "forking";
+          PIDFile = "/run/xrdp/xrdp-sesman.pid";
+          ExecStart = "${cfg.package}/bin/xrdp-sesman";
+          ExecStop  = "${cfg.package}/bin/xrdp-sesman --kill";
         };
       };
 

--- a/nixos/tests/xrdp.nix
+++ b/nixos/tests/xrdp.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     server = { pkgs, ... }: {
       imports = [ ./common/user-account.nix ];
       services.xrdp.enable = true;
-      services.xrdp.defaultWindowManager = "${pkgs.xterm}/bin/xterm";
+      services.xserver.desktopManager.xterm.enable = true;
       networking.firewall.allowedTCPPorts = [ 3389 ];
     };
 
@@ -17,7 +17,6 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       test-support.displayManager.auto.user = "alice";
       environment.systemPackages = [ pkgs.freerdp ];
       services.xrdp.enable = true;
-      services.xrdp.defaultWindowManager = "${pkgs.icewm}/bin/icewm";
     };
   };
 

--- a/pkgs/applications/networking/remote/xrdp/default.nix
+++ b/pkgs/applications/networking/remote/xrdp/default.nix
@@ -1,105 +1,95 @@
-{ stdenv, fetchFromGitHub, pkgconfig, which, perl, autoconf, automake, libtool, openssl, systemd, pam, fuse, libjpeg, libopus, nasm, xorg }:
+{ stdenv, fetchFromGitHub, fetchpatch
+, pkgconfig, which, autoconf, automake, libtool, nasm, perl
+, openssl, systemd, pam, fuse, libjpeg, libopus, pixman, xorg, xorgxrdp }:
 
-let
-  xorgxrdp = stdenv.mkDerivation rec {
-    pname = "xorgxrdp";
-    version = "0.2.9";
+stdenv.mkDerivation rec {
+  version = "0.9.12";
+  pname = "xrdp";
 
-    src = fetchFromGitHub {
-      owner = "neutrinolabs";
-      repo = "xorgxrdp";
-      rev = "v${version}";
-      sha256 = "1bhp5x47hajhinvglmc4vxxnpjvfjm6369njb3ghqfr7c5xypvzr";
-    };
-
-    nativeBuildInputs = [ pkgconfig autoconf automake which libtool nasm ];
-
-    buildInputs = [ xorg.xorgserver ];
-
-    postPatch = ''
-      # patch from Debian, allows to run xrdp daemon under unprivileged user
-      substituteInPlace module/rdpClientCon.c \
-        --replace 'g_sck_listen(dev->listen_sck);' 'g_sck_listen(dev->listen_sck); g_chmod_hex(dev->uds_data, 0x0660);'
-
-      substituteInPlace configure.ac \
-        --replace 'moduledir=`pkg-config xorg-server --variable=moduledir`' "moduledir=$out/lib/xorg/modules" \
-        --replace 'sysconfdir="/etc"' "sysconfdir=$out/etc"
-    '';
-
-    preConfigure = "./bootstrap";
-
-    configureFlags = [ "XRDP_CFLAGS=-I${xrdp.src}/common"  ];
-
-    enableParallelBuilding = true;
+  src = fetchFromGitHub {
+    owner = "neutrinolabs";
+    repo = "xrdp";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "155yixhhq64gyacjhd5llvhxc1ys4smkhlk5573vc9n1h4f49nix";
   };
 
-  xrdp = stdenv.mkDerivation rec {
-    version = "0.9.9";
-    pname = "xrdp";
+  patches = [
+    # patch to allow to specify runtime config
+    (fetchpatch {
+      url = "https://github.com/xtruder/xrdp/commit/fd437b3500d763bb1a9958aefa9506fa363530ea.patch";
+      sha256 = "1xijqpvp7mzzwcja2mz0nmb5n344zgmx3knnigkfd96y60xf4rj4";
+    })
+  ];
 
-    src = fetchFromGitHub {
-      owner = "volth";
-      repo = "xrdp";
-      rev = "refs/tags/runtime-cfg-path-${version}";  # Fixes https://github.com/neutrinolabs/xrdp/issues/609; not a patch on top of the official repo because "xorgxrdp.configureFlags" above includes "xrdp.src" which must be patched already
-      fetchSubmodules = true;
-      sha256 = "0ynj6pml4f38y8571ryhifza57wfqg4frdrjcwzw3fmryiznfm1z";
-    };
+  nativeBuildInputs = [ pkgconfig autoconf automake which libtool nasm perl ];
 
-    nativeBuildInputs = [ pkgconfig autoconf automake which libtool nasm ];
+  buildInputs = with xorg; [
+    openssl systemd pam fuse
+    libjpeg libopus
+    libX11 libXfixes libXrandr pixman
+  ];
 
-    buildInputs = [ openssl systemd pam fuse libjpeg libopus xorg.libX11 xorg.libXfixes xorg.libXrandr ];
+  postPatch = ''
+    substituteInPlace sesman/xauth.c --replace "xauth -q" "${xorg.xauth}/bin/xauth -q"
+  '';
 
-    postPatch = ''
-      substituteInPlace sesman/xauth.c --replace "xauth -q" "${xorg.xauth}/bin/xauth -q"
-    '';
+  preConfigure = ''
+    (cd librfxcodec && ./bootstrap && ./configure --prefix=$out --enable-static --disable-shared)
+    ./bootstrap
+  '';
+  dontDisableStatic = true;
+  configureFlags = [
+    "--with-systemdsystemunitdir=/var/empty"
+    "--enable-ipv6"
+    "--enable-jpeg"
+    "--enable-fuse"
+    "--enable-rfxcodec"
+    "--enable-pixman"
+    "--enable-painter"
+    "--enable-vsock"
+    "--enable-opus"
+  ];
 
-    preConfigure = ''
-      (cd librfxcodec && ./bootstrap && ./configure --prefix=$out --enable-static --disable-shared)
-      ./bootstrap
-    '';
-    dontDisableStatic = true;
-    configureFlags = [ "--with-systemdsystemunitdir=/var/empty" "--enable-ipv6" "--enable-jpeg" "--enable-fuse" "--enable-rfxcodec" "--enable-opus" ];
+  installFlags = [ "DESTDIR=$(out)" "prefix=" ];
 
-    installFlags = [ "DESTDIR=$(out)" "prefix=" ];
+  postInstall = ''
+    # remove generated keys (as non-determenistic) and upstart script
+    rm $out/etc/xrdp/{rsakeys.ini,key.pem,cert.pem}
 
-    postInstall = ''
-      # remove generated keys (as non-determenistic) and upstart script
-      rm $out/etc/xrdp/{rsakeys.ini,key.pem,cert.pem,xrdp.sh}
+    cp $src/keygen/openssl.conf $out/share/xrdp/openssl.conf
 
-      cp $src/keygen/openssl.conf $out/share/xrdp/openssl.conf
+    substituteInPlace $out/etc/xrdp/sesman.ini --replace /etc/xrdp/pulse $out/etc/xrdp/pulse
 
-      substituteInPlace $out/etc/xrdp/sesman.ini --replace /etc/xrdp/pulse $out/etc/xrdp/pulse
+    # remove all session types except Xorg (they are not supported by this setup)
+    ${perl}/bin/perl -i -ne 'print unless /\[(X11rdp|Xvnc|console|vnc-any|sesman-any|rdp-any|neutrinordp-any)\]/ .. /^$/' $out/etc/xrdp/xrdp.ini
 
-      # remove all session types except Xorg (they are not supported by this setup)
-      ${perl}/bin/perl -i -ne 'print unless /\[(X11rdp|Xvnc|console|vnc-any|sesman-any|rdp-any|neutrinordp-any)\]/ .. /^$/' $out/etc/xrdp/xrdp.ini
+    # remove all session types and then add Xorg
+    ${perl}/bin/perl -i -ne 'print unless /\[(X11rdp|Xvnc|Xorg)\]/ .. /^$/' $out/etc/xrdp/sesman.ini
 
-      # remove all session types and then add Xorg
-      ${perl}/bin/perl -i -ne 'print unless /\[(X11rdp|Xvnc|Xorg)\]/ .. /^$/' $out/etc/xrdp/sesman.ini
+    cat >> $out/etc/xrdp/sesman.ini <<EOF
 
-      cat >> $out/etc/xrdp/sesman.ini <<EOF
+    [Xorg]
+    param=${xorg.xorgserver}/bin/Xorg
+    param=-modulepath
+    param=${xorgxrdp}/lib/xorg/modules,${xorg.xorgserver}/lib/xorg/modules
+    param=-config
+    param=${xorgxrdp}/etc/X11/xrdp/xorg.conf
+    param=-noreset
+    param=-nolisten
+    param=tcp
+    param=-logfile
+    param=.xorgxrdp.%s.log
+    EOF
+  '';
 
-      [Xorg]
-      param=${xorg.xorgserver}/bin/Xorg
-      param=-modulepath
-      param=${xorgxrdp}/lib/xorg/modules,${xorg.xorgserver}/lib/xorg/modules
-      param=-config
-      param=${xorgxrdp}/etc/X11/xrdp/xorg.conf
-      param=-noreset
-      param=-nolisten
-      param=tcp
-      param=-logfile
-      param=.xorgxrdp.%s.log
-      EOF
-    '';
+  enableParallelBuilding = true;
 
-    enableParallelBuilding = true;
-
-    meta = with stdenv.lib; {
-      description = "An open source RDP server";
-      homepage = https://github.com/neutrinolabs/xrdp;
-      license = licenses.asl20;
-      maintainers = [ maintainers.volth ];
-      platforms = platforms.linux;
-    };
+  meta = with stdenv.lib; {
+    description = "An open source RDP server";
+    homepage = https://github.com/neutrinolabs/xrdp;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ volth offline ];
+    platforms = platforms.linux;
   };
-in xrdp
+}

--- a/pkgs/applications/networking/remote/xrdp/xorgxrdp.nix
+++ b/pkgs/applications/networking/remote/xrdp/xorgxrdp.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoconf, automake, which, libtool, nasm
+, xorg, xrdp }:
+
+stdenv.mkDerivation rec {
+  pname = "xorgxrdp";
+  version = "0.2.12";
+
+  src = fetchFromGitHub {
+    owner = "neutrinolabs";
+    repo = "xorgxrdp";
+    rev = "v${version}";
+    sha256 = "0fi9bhvykdkwirgcgm5fgkvdzfn983rk077cwyn95pij4xp4g7qb";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoconf automake which libtool nasm ];
+  buildInputs = [ xorg.xorgserver ];
+
+  postPatch = ''
+    # patch from Debian, allows to run xrdp daemon under unprivileged user
+    substituteInPlace module/rdpClientCon.c \
+      --replace 'g_sck_listen(dev->listen_sck);' 'g_sck_listen(dev->listen_sck); g_chmod_hex(dev->uds_data, 0x0660);'
+
+    substituteInPlace configure.ac \
+      --replace 'moduledir=`pkg-config xorg-server --variable=moduledir`' "moduledir=$out/lib/xorg/modules" \
+      --replace 'sysconfdir="/etc"' "sysconfdir=$out/etc"
+  '';
+
+  preConfigure = "./bootstrap";
+  configureFlags = [ "XRDP_CFLAGS=-I${xrdp.src}/common"  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Xorg drivers for xrdp";
+    homepage = https://github.com/neutrinolabs/xorgxrdp;
+    license = licenses.mit;
+    maintainers = with maintainers; [ volth offline ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19706,6 +19706,8 @@ in
 
   xrdp = callPackage ../applications/networking/remote/xrdp { };
 
+  xorgxrdp = callPackage ../applications/networking/remote/xrdp/xorgxrdp.nix { };
+
   freerdp = callPackage ../applications/networking/remote/freerdp {
     inherit libpulseaudio;
     inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Improve xrdp nixos module

###### Things done

- make configuration more explicit
- simplify xrdp package
- put configuration to /etc and use `environment.etc`
- integrate with nixos xserver sessions
- run xrdp and xrdp-sesman as forking daemons
- use syslog for logging

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
