### PR TITLE
kdenlive: set run-time dep paths (fix #83885)

### DIFF
--- a/pkgs/applications/kde/ffmpeg-path.patch
+++ b/pkgs/applications/kde/ffmpeg-path.patch
@@ -1,0 +1,25 @@
+diff --git a/src/kdenlivesettings.kcfg b/src/kdenlivesettings.kcfg
+index 5edad5ae7..d35347a40 100644
+--- a/src/kdenlivesettings.kcfg
++++ b/src/kdenlivesettings.kcfg
+@@ -403,17 +403,17 @@
+ 
+     <entry name="ffmpegpath" type="Path">
+       <label>FFmpeg / Libav binary path.</label>
+-      <default></default>
++      <default>@ffmpeg@/bin/ffmpeg</default>
+     </entry>
+ 
+     <entry name="ffplaypath" type="Path">
+       <label>FFplay / avplay binary path.</label>
+-      <default></default>
++      <default>@ffmpeg@/bin/ffplay</default>
+     </entry>
+ 
+     <entry name="ffprobepath" type="Path">
+       <label>FFprobe / avprobe binary path.</label>
+-      <default></default>
++      <default>@ffmpeg@/bin/ffprobe</default>
+     </entry>
+ 
+     <entry name="mltthreads" type="Int">

--- a/pkgs/applications/kde/kdenlive.nix
+++ b/pkgs/applications/kde/kdenlive.nix
@@ -70,14 +70,24 @@ mkDerivation {
     kpurpose
     kdeclarative
   ];
-  patches = [ ./mlt-path.patch ];
+  # Both MLT and FFMpeg paths must be set or Kdenlive will complain that it
+  # doesn't find them. See:
+  # https://github.com/NixOS/nixpkgs/issues/83885
+  patches = [ ./mlt-path.patch ./ffmpeg-path.patch ];
   inherit mlt;
+  ffmpeg = ffmpeg-full;
   postPatch =
     # Module Qt5::Concurrent must be included in `find_package` before it is used.
     ''
       sed -i CMakeLists.txt -e '/find_package(Qt5 REQUIRED/ s|)| Concurrent)|'
       substituteAllInPlace src/kdenlivesettings.kcfg
     '';
+  # Frei0r path needs to be set too or Kdenlive will complain. See:
+  # https://github.com/NixOS/nixpkgs/issues/83885
+  # https://github.com/NixOS/nixpkgs/issues/29614#issuecomment-488849325
+  qtWrapperArgs = [
+    "--set FREI0R_PATH ${frei0r}/lib/frei0r-1"
+  ];
   meta = {
     license = with lib.licenses; [ gpl2Plus ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

See #83885 and #29614. Without these fixes, at least for me, kdenlive was complaining on the command line that it doesn't find ffmpeg nor frei0r. Not sure if it had any real effect on the program otherwise though, but at least those suspicious warnings.

Fixes #83885. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
