### PR TITLE
weechatScripts.weechat-matrix: unstable-2020-01-21 -> 0.1.0

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
@@ -22,13 +22,13 @@ let
   ]);
 in buildPythonPackage {
   pname = "weechat-matrix";
-  version = "unstable-2020-01-21";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "poljar";
     repo = "weechat-matrix";
-    rev = "46640df3e0bfb058e97d8abe723bb88fdf4e5177";
-    sha256 = "1j3l43j741csfxsp1nsc74y6wj2wm86c45iraf167g6p0sdzcq8z";
+    rev = "65a5db7291439b6132e35e8cc09ed901614fabf6";
+    sha256 = "0m3k5vrv5ab1aw1mjd0r8d71anwqzvncvv9v5zx9xp1i188sdm8x";
   };
 
   propagatedBuildInputs = [
@@ -53,11 +53,9 @@ in buildPythonPackage {
     mkdir -p $out/share $out/bin
     cp $src/main.py $out/share/matrix.py
 
-    cp \
-      $src/contrib/matrix_upload \
-      $src/contrib/matrix_decrypt \
-      $src/contrib/matrix_sso_helper \
-      $out/bin/
+    cp $src/contrib/matrix_upload.py $out/bin/matrix_upload
+    cp $src/contrib/matrix_decrypt.py $out/bin/matrix_decrypt
+    cp $src/contrib/matrix_sso_helper.py $out/bin/matrix_sso_helper
     substituteInPlace $out/bin/matrix_upload \
       --replace '/usr/bin/env -S python3' '${scriptPython}/bin/python'
     substituteInPlace $out/bin/matrix_sso_helper \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Stable update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
