### PR TITLE
google-compute-engine-oslogin: fix bash reference

### DIFF
--- a/pkgs/tools/virtualization/google-compute-engine-oslogin/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine-oslogin/default.nix
@@ -3,6 +3,7 @@
 , curl
 , json_c
 , pam
+, bashInteractive
 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +23,7 @@ stdenv.mkDerivation rec {
     # change sudoers dir from /var/google-sudoers.d to /run/google-sudoers.d (managed through systemd-tmpfiles)
     substituteInPlace pam_module/pam_oslogin_admin.cc --replace /var/google-sudoers.d /run/google-sudoers.d
     # fix "User foo not allowed because shell /bin/bash does not exist"
-    substituteInPlace compat.h --replace /bin/bash ${stdenv.shell}
+    substituteInPlace compat.h --replace /bin/bash ${bashInteractive}/bin/bash
   '';
 
   buildInputs = [ curl.dev pam ];


### PR DESCRIPTION
###### Motivation for this change

Fix the login experience when using OSLogin. The user was running the non-interactive version of bash which leads to a broken prompt and no tab completion or readline support in general.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
