### PR TITLE
Update Haskell package set to LTS 15.6 (plus other fixes)

### DIFF
--- a/pkgs/data/misc/hackage/default.nix
+++ b/pkgs/data/misc/hackage/default.nix
@@ -1,6 +1,6 @@
 { fetchurl }:
 
 fetchurl {
-  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/e0bc864e0b6edb5e5ce1ec4bfa763a442b343bf5.tar.gz";
-  sha256 = "1lmjxam58srrv9cjqajqz4bishx8hy99db3cx83i95qb3qiiiz6m";
+  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/90b24a91103dca4f0df6cb28cecb205a7d7ab650.tar.gz";
+  sha256 = "1zfj8c6s9icqg83ycfvd150s4jd07ccbjg2w2mn10rx5ng76mn53";
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -37,9 +37,6 @@ self: super: {
   # compiled on Linux. We provide the name to avoid evaluation errors.
   unbuildable = throw "package depends on meta package 'unbuildable'";
 
-  # The test suite depends on old versions of tasty and QuickCheck.
-  hackage-security = dontCheck super.hackage-security;
-
   # enable using a local hoogle with extra packagages in the database
   # nix-shell -p "haskellPackages.hoogleLocal { packages = with haskellPackages; [ mtl lens ]; }"
   # $ hoogle server

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -326,6 +326,7 @@ self: super: {
   hs2048 = dontCheck super.hs2048;
   hsbencher = dontCheck super.hsbencher;
   hsexif = dontCheck super.hsexif;
+  hspec-core = if pkgs.stdenv.isi686 then dontCheck super.hspec-core else super.hspec-core; # tests rely on `Int` being 64-bit; https://github.com/hspec/hspec/issues/431
   hspec-server = dontCheck super.hspec-server;
   HTF = dontCheck super.HTF;
   htsn = dontCheck super.htsn;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1463,6 +1463,18 @@ self: super: {
   # haskell-ci-0.8 needs cabal-install-parsers ==0.1, but we have 0.2.
   haskell-ci = doJailbreak super.haskell-ci;
 
+  # 2020-01-19 - there were conflicting versions of brick, vty, and brick-skylighting;
+  # multiple versions of them were being pulled in by the others which is not allowed.
+  # There are more complicated ways of doing this but I was able to make it fairly simple -- kiwi
+  # 2020-03-31 - "..." it broke again. so here's a more complicated way -- kiwi
+  matterhorn = super.matterhorn.override {
+    brick-skylighting = self.brick-skylighting.override {
+      brick = self.brick_0_52_1.override {
+        vty = self.vty_5_28_2;
+      };
+    };
+  };
+
   persistent-mysql = dontCheck super.persistent-mysql;
 
   # Fix EdisonAPI and EdisonCore for GHC 8.8:

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -83,7 +83,7 @@ self: super: {
       name = "git-annex-${super.git-annex.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + super.git-annex.version;
-      sha256 = "0y2qcjahi705c6nnypqpa5w3bzyzk4kqvbwfnpiaxzk5vna589gg";
+      sha256 = "1jjw6ar8ddcncwzksyx2xky50sm2jg1zjr7iiqk0vn8qq0fn2gwy";
     };
   }).override {
     dbus = if pkgs.stdenv.isLinux then self.dbus else null;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -360,7 +360,6 @@ self: super: {
   optional = dontCheck super.optional;
   orgmode-parse = dontCheck super.orgmode-parse;
   os-release = dontCheck super.os-release;
-  pandoc-crossref = dontCheck super.pandoc-crossref;  # (most likely change when no longer 0.3.2.1) https://github.com/lierdakil/pandoc-crossref/issues/199
   persistent-redis = dontCheck super.persistent-redis;
   pipes-extra = dontCheck super.pipes-extra;
   pipes-websockets = dontCheck super.pipes-websockets;
@@ -1197,6 +1196,14 @@ self: super: {
   superbuffer = overrideCabal super.superbuffer (drv: {
     postPatch = ''
       sed -i 's#QuickCheck < 2.10#QuickCheck < 2.13#' superbuffer.cabal
+    '';
+  });
+
+  # Remove unecessary constraint:
+  # https://github.com/haskell-infra/hackage-trustees/issues/258
+  data-accessor-template = overrideCabal super.data-accessor-template (drv: {
+    postPatch = ''
+      sed -i 's#template-haskell >=2.11 && <2.15#template-haskell#' data-accessor-template.cabal
     '';
   });
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1344,7 +1344,7 @@ self: super: {
   });
 
   # cabal-fmt requires Cabal3
-  cabal-fmt = super.cabal-fmt.override { Cabal = self.Cabal_3_0_0_0; };
+  cabal-fmt = super.cabal-fmt.override { Cabal = self.Cabal_3_2_0_0; };
 
   # Several gtk2hs-provided packages at v0.13.8.0 fail to build on Darwin
   # until we pick up https://github.com/gtk2hs/gtk2hs/pull/293 so apply that

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1463,17 +1463,10 @@ self: super: {
   # haskell-ci-0.8 needs cabal-install-parsers ==0.1, but we have 0.2.
   haskell-ci = doJailbreak super.haskell-ci;
 
-  # 2020-01-19 - there were conflicting versions of brick, vty, and brick-skylighting;
-  # multiple versions of them were being pulled in by the others which is not allowed.
-  # There are more complicated ways of doing this but I was able to make it fairly simple -- kiwi
-  # 2020-03-31 - "..." it broke again. so here's a more complicated way -- kiwi
-  matterhorn = super.matterhorn.override {
-    brick-skylighting = self.brick-skylighting.override {
-      brick = self.brick_0_52_1.override {
-        vty = self.vty_5_28_2;
-      };
-    };
-  };
+  # Needs the latest version of vty.
+  matterhorn = super.matterhorn.overrideScope (self: super: {
+    vty = self.vty_5_28_2;
+  });
 
   persistent-mysql = dontCheck super.persistent-mysql;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1489,4 +1489,12 @@ self: super: {
   # Needs a version that's newer than LTS-15.x provides.
   weeder = super.weeder.override { generic-lens = self.generic-lens_2_0_0_0;  };
 
+  polysemy-plugin = super.polysemy-plugin.override {
+    # polysemy-plugin 0.2.5.0 has constraint ghc-tcplugins-extra (==0.3.*)
+    # This upstream issue is relevant:
+    # https://github.com/polysemy-research/polysemy/issues/322
+    ghc-tcplugins-extra = self.ghc-tcplugins-extra_0_3_2;
+    # version of Polysemy the plugin goes with
+    polysemy = self.polysemy_1_3_0_0;
+  };
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1498,4 +1498,8 @@ self: super: {
     # version of Polysemy the plugin goes with
     polysemy = self.polysemy_1_3_0_0;
   };
+
+  # Fixed at head, but hasn't cut a release in awhile.
+  darcs = doJailbreak super.darcs;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1192,14 +1192,6 @@ self: super: {
   });
 
   # Remove unecessary constraint:
-  # https://github.com/agrafix/superbuffer/pull/2
-  superbuffer = overrideCabal super.superbuffer (drv: {
-    postPatch = ''
-      sed -i 's#QuickCheck < 2.10#QuickCheck < 2.13#' superbuffer.cabal
-    '';
-  });
-
-  # Remove unecessary constraint:
   # https://github.com/haskell-infra/hackage-trustees/issues/258
   data-accessor-template = overrideCabal super.data-accessor-template (drv: {
     postPatch = ''

--- a/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
@@ -44,7 +44,7 @@ self: super: {
   text = self.text_1_2_4_0;
 
   # Needs Cabal 3.0.x.
-  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_0_0_0; };
+  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_2_0_0; };
 
   # https://github.com/bmillwood/applicative-quoters/issues/6
   applicative-quoters = appendPatch super.applicative-quoters (pkgs.fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -40,9 +40,9 @@ self: super: {
   unix = null;
   xhtml = null;
 
-  # Needs Cabal 3.0.x.
-  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_0_0_0; });
-  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_0_0_0; };
+  # Needs Cabal 3.2.x.
+  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
+  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_2_0_0; };
 
   # Restricts aeson to <1.4
   # https://github.com/purescript/purescript/pull/3537

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -42,8 +42,8 @@ self: super: {
   xhtml = null;
 
   # Needs Cabal 3.0.x.
-  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_0_0_0; });
-  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_0_0_0; };
+  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
+  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_2_0_0; };
 
   # https://github.com/tibbe/unordered-containers/issues/214
   unordered-containers = dontCheck super.unordered-containers;
@@ -76,12 +76,10 @@ self: super: {
 
   # cabal2nix needs the latest version of Cabal, and the one
   # hackage-db uses must match, so take the latest
-  cabal2nix = super.cabal2nix.overrideScope (self: super: {
-    Cabal = self.Cabal_3_0_0_0;
-  });
+  cabal2nix = super.cabal2nix.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
 
   # cabal2spec needs a recent version of Cabal
-  cabal2spec = super.cabal2spec.overrideScope (self: super: { Cabal = self.Cabal_3_0_0_0; });
+  cabal2spec = super.cabal2spec.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
 
   # Builds only with ghc-8.8.x and beyond.
   policeman = markBroken super.policeman;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -43,7 +43,7 @@ self: super: {
 
   # These builds need Cabal 3.2.x.
   cabal2spec = super.cabal2spec.override { Cabal = self.Cabal_3_2_0_0; };
-  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; hackage-security = self.hackage-security_0_6_0_0; });
+  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
 
   # Ignore overly restrictive upper version bounds.
   aeson-diff = doJailbreak super.aeson-diff;
@@ -75,12 +75,6 @@ self: super: {
   time-compat = doJailbreak super.time-compat;
   http-media = doJailbreak super.http-media;
   servant-server = doJailbreak super.servant-server;
-
-  # These packages don't work and need patching and/or an update.
-  hackage-security = appendPatch (doJailbreak super.hackage-security) (pkgs.fetchpatch {
-    url = "https://raw.githubusercontent.com/hvr/head.hackage/master/patches/hackage-security-0.5.3.0.patch";
-    sha256 = "0l8x0pbsn18fj5ak5q0g5rva4xw1s9yc4d86a1pfyaz467b9i5a4";
-  });
   foundation = dontCheck super.foundation;
   vault = dontHaddock super.vault;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -41,10 +41,13 @@ self: super: {
   unix = null;
   xhtml = null;
 
+  # These builds need Cabal 3.2.x.
+  cabal2spec = super.cabal2spec.override { Cabal = self.Cabal_3_2_0_0; };
+  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; hackage-security = self.hackage-security_0_6_0_0; });
+
   # Ignore overly restrictive upper version bounds.
   aeson-diff = doJailbreak super.aeson-diff;
   async = doJailbreak super.async;
-  cabal-install = doJailbreak super.cabal-install;
   ChasingBottoms = doJailbreak super.ChasingBottoms;
   chell = doJailbreak super.chell;
   cryptohash-sha256 = doJailbreak super.cryptohash-sha256;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -69,8 +69,6 @@ core-packages:
 default-package-overrides:
   # This was only intended for ghc-7.0.4, and has very old deps, one hidden behind a flag
   - MissingH ==1.4.2.0
-  # for cabal-install-3.0.0.0
-  - hackage-security >=0.5.2.2 && <0.6
   # pandoc-2.9 does not accept the 0.3 version yet
   - doclayout < 0.3
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2476,6 +2476,8 @@ package-maintainers:
     - termonad
   rkrzr:
     - icepeak
+  terlar:
+    - nix-diff
 
 unsupported-platforms:
   alsa-mixer:                                   [ x86_64-darwin ]

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3994,7 +3994,6 @@ broken-packages:
   - dash-haskell
   - data-accessor-monads-fd
   - data-accessor-monads-tf
-  - data-accessor-template
   - data-aviary
   - data-base
   - data-basic
@@ -8042,7 +8041,6 @@ broken-packages:
   - pam
   - pan-os-syslog
   - panda
-  - pandoc-crossref
   - pandoc-emphasize-code
   - pandoc-filter-graphviz
   - pandoc-include

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -76,7 +76,7 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  # LTS Haskell 15.5
+  # LTS Haskell 15.6
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -88,7 +88,7 @@ default-package-overrides:
   - adjunctions ==4.4
   - adler32 ==0.1.2.0
   - advent-of-code-api ==0.2.7.0
-  - aeson ==1.4.7.0
+  - aeson ==1.4.7.1
   - aeson-attoparsec ==0.0.0
   - aeson-better-errors ==0.9.1.0
   - aeson-casing ==0.2.0.0
@@ -238,7 +238,7 @@ default-package-overrides:
   - asif ==6.0.4
   - asn1-encoding ==0.9.6
   - asn1-parse ==0.9.5
-  - asn1-types ==0.3.3
+  - asn1-types ==0.3.4
   - assert-failure ==0.1.2.2
   - assoc ==1.0.1
   - astro ==0.4.2.1
@@ -250,7 +250,7 @@ default-package-overrides:
   - atom-basic ==0.2.5
   - atomic-primops ==0.8.3
   - atomic-write ==0.2.0.7
-  - attoparsec ==0.13.2.3
+  - attoparsec ==0.13.2.4
   - attoparsec-base64 ==0.0.0
   - attoparsec-binary ==0.2
   - attoparsec-expr ==0.1.1.2
@@ -314,7 +314,7 @@ default-package-overrides:
   - bits ==0.5.2
   - bitset-word8 ==0.1.1.1
   - bits-extra ==0.0.1.5
-  - bitvec ==1.0.2.0
+  - bitvec ==1.0.3.0
   - blake2 ==0.3.0
   - blanks ==0.3.0
   - blas-carray ==0.1.0.1
@@ -323,7 +323,7 @@ default-package-overrides:
   - blaze-bootstrap ==0.1.0.1
   - blaze-builder ==0.4.1.0
   - blaze-html ==0.9.1.2
-  - blaze-markup ==0.8.2.3
+  - blaze-markup ==0.8.2.4
   - blaze-svg ==0.3.6.1
   - blaze-textual ==0.2.1.0
   - bmp ==1.2.6.3
@@ -342,10 +342,10 @@ default-package-overrides:
   - boundingboxes ==0.2.3
   - bower-json ==1.0.0.1
   - boxes ==0.1.5
-  - brick ==0.52
+  - brick ==0.52.1
   - brittany ==0.12.1.1
   - bsb-http-chunked ==0.0.0.4
-  - bson ==0.4.0.0
+  - bson ==0.4.0.1
   - btrfs ==0.2.0.0
   - buffer-builder ==0.2.4.7
   - buffer-pipe ==0.0
@@ -406,10 +406,10 @@ default-package-overrides:
   - Chart ==1.9.3
   - Chart-diagrams ==1.9.3
   - chaselev-deque ==0.5.0.5
-  - ChasingBottoms ==1.3.1.7
+  - ChasingBottoms ==1.3.1.8
   - checkers ==0.5.5
   - checksum ==0.0
-  - chimera ==0.3.0.0
+  - chimera ==0.3.1.0
   - choice ==0.2.2
   - chronologique ==0.3.1.1
   - chronos ==1.1
@@ -578,7 +578,7 @@ default-package-overrides:
   - data-tree-print ==0.1.0.2
   - dataurl ==0.1.0.0
   - DAV ==1.3.4
-  - dbus ==1.2.12
+  - dbus ==1.2.13
   - debian-build ==0.10.2.0
   - debug-trace-var ==0.2.0
   - dec ==0.0.3
@@ -626,7 +626,7 @@ default-package-overrides:
   - dockerfile ==0.2.0
   - doclayout ==0.2.0.1
   - doctemplates ==0.8
-  - doctest ==0.16.2
+  - doctest ==0.16.3
   - doctest-discover ==0.2.0.0
   - doctest-driver-gen ==0.3.0.2
   - doldol ==0.4.1.2
@@ -681,12 +681,12 @@ default-package-overrides:
   - epub-metadata ==4.5
   - eq ==4.2
   - equal-files ==0.0.5.3
-  - equational-reasoning ==0.6.0.1
+  - equational-reasoning ==0.6.0.2
   - erf ==2.0.0.0
   - errors ==2.3.0
   - errors-ext ==0.4.2
   - ersatz ==0.4.8
-  - esqueleto ==3.3.1.1
+  - esqueleto ==3.3.3.0
   - etc ==0.4.1.0
   - eventful-core ==0.2.0
   - eventful-test-helpers ==0.2.0
@@ -704,8 +704,8 @@ default-package-overrides:
   - expiring-cache-map ==0.0.6.1
   - explicit-exception ==0.1.10
   - exp-pairs ==0.2.0.0
-  - express ==0.1.2
-  - extended-reals ==0.2.3.0
+  - express ==0.1.3
+  - extended-reals ==0.2.4.0
   - extensible-effects ==5.0.0.1
   - extensible-exceptions ==0.1.1.4
   - extra ==1.6.21
@@ -722,7 +722,7 @@ default-package-overrides:
   - feature-flags ==0.1.0.1
   - fedora-dists ==1.1.2
   - fedora-haskell-tools ==0.9
-  - feed ==1.3.0.0
+  - feed ==1.3.0.1
   - FenwickTree ==0.1.2.1
   - fft ==0.1.8.6
   - fgl ==5.7.0.2
@@ -740,9 +740,9 @@ default-package-overrides:
   - finite-typelits ==0.1.4.2
   - first-class-families ==0.7.0.0
   - first-class-patterns ==0.3.2.5
-  - fitspec ==0.4.7
+  - fitspec ==0.4.8
   - fixed ==0.3
-  - fixed-length ==0.2.1
+  - fixed-length ==0.2.2
   - fixed-vector ==1.2.0.0
   - fixed-vector-hetero ==0.5.0.0
   - flac ==0.2.0
@@ -804,9 +804,9 @@ default-package-overrides:
   - generic-lens ==1.2.0.1
   - generic-monoid ==0.1.0.0
   - GenericPretty ==1.2.2
-  - generic-random ==1.3.0.0
-  - generics-sop ==0.5.0.0
-  - generics-sop-lens ==0.2
+  - generic-random ==1.3.0.1
+  - generics-sop ==0.5.1.0
+  - generics-sop-lens ==0.2.0.1
   - genvalidity ==0.10.0.2
   - genvalidity-aeson ==0.3.0.0
   - genvalidity-bytestring ==0.5.0.1
@@ -893,7 +893,7 @@ default-package-overrides:
   - graph-wrapper ==0.2.6.0
   - gravatar ==0.8.0
   - greskell ==1.0.0.1
-  - greskell-core ==0.1.3.1
+  - greskell-core ==0.1.3.2
   - greskell-websocket ==0.1.2.1
   - groom ==0.1.2.1
   - group-by-date ==0.1.0.3
@@ -919,7 +919,7 @@ default-package-overrides:
   - haskell-lexer ==1.1
   - haskell-lsp ==0.20.0.1
   - haskell-lsp-types ==0.20.0.0
-  - haskell-names ==0.9.7
+  - haskell-names ==0.9.8
   - haskell-src ==1.0.3.1
   - haskell-src-exts ==1.22.0
   - haskell-src-exts-util ==0.2.5
@@ -927,7 +927,7 @@ default-package-overrides:
   - haskey-btree ==0.3.0.1
   - haskoin-core ==0.10.1
   - haskoin-node ==0.9.16
-  - hasql ==1.4.1
+  - hasql ==1.4.2
   - hasql-optparse-applicative ==0.3.0.5
   - hasql-pool ==0.5.1
   - hasql-transaction ==1.0.0.1
@@ -935,7 +935,7 @@ default-package-overrides:
   - HaXml ==1.25.5
   - haxr ==3000.11.4
   - hdaemonize ==0.5.6
-  - headroom ==0.1.2.0
+  - headroom ==0.1.3.0
   - heap ==1.0.4
   - heaps ==0.3.6.1
   - heart-core ==0.1.1
@@ -944,7 +944,7 @@ default-package-overrides:
   - hedgehog-corpus ==0.2.0
   - hedgehog-fn ==1.0
   - hedgehog-quickcheck ==0.1.1
-  - hedis ==0.12.11
+  - hedis ==0.12.13
   - here ==1.2.13
   - heredoc ==0.2.0.0
   - heterocephalus ==1.0.5.3
@@ -986,7 +986,7 @@ default-package-overrides:
   - hreader-lens ==0.1.3.0
   - hruby ==0.3.8
   - hs-bibutils ==6.8.0.0
-  - hsc2hs ==0.68.6
+  - hsc2hs ==0.68.7
   - hscolour ==1.24.4
   - hsdns ==1.8
   - hsebaysdk ==0.4.0.0
@@ -1015,7 +1015,7 @@ default-package-overrides:
   - hspec-expectations-pretty-diff ==0.7.2.5
   - hspec-golden ==0.1.0.1
   - hspec-golden-aeson ==0.7.0.0
-  - hspec-leancheck ==0.0.3
+  - hspec-leancheck ==0.0.4
   - hspec-megaparsec ==2.1.0
   - hspec-meta ==2.6.0
   - hspec-need-env ==0.1.0.4
@@ -1207,7 +1207,7 @@ default-package-overrides:
   - language-c-quote ==0.12.2.1
   - language-haskell-extract ==0.2.4
   - language-java ==0.2.9
-  - language-javascript ==0.7.0.0
+  - language-javascript ==0.7.1.0
   - language-protobuf ==1.0.1
   - language-puppet ==1.4.6.2
   - lapack-carray ==0.0.3
@@ -1221,7 +1221,7 @@ default-package-overrides:
   - lazy-csv ==0.5.1
   - lazyio ==0.1.0.4
   - lca ==0.3.1
-  - leancheck ==0.9.1
+  - leancheck ==0.9.3
   - leancheck-instances ==0.0.3
   - leapseconds-announced ==2017.1.0.1
   - learn-physics ==0.6.5
@@ -1273,7 +1273,7 @@ default-package-overrides:
   - loopbreaker ==0.1.1.1
   - lrucache ==1.2.0.1
   - lrucaching ==0.3.3
-  - lsp-test ==0.10.1.0
+  - lsp-test ==0.10.2.0
   - lucid ==2.9.12
   - lucid-extras ==0.2.2
   - lzma ==0.0.0.3
@@ -1470,7 +1470,7 @@ default-package-overrides:
   - once ==0.4
   - one-liner ==1.0
   - one-liner-instances ==0.1.2.1
-  - OneTuple ==0.2.2
+  - OneTuple ==0.2.2.1
   - Only ==0.1
   - oo-prototypes ==0.1.0.0
   - opaleye ==0.6.7004.1
@@ -1655,7 +1655,7 @@ default-package-overrides:
   - purescript-bridge ==0.13.0.0
   - pushbullet-types ==0.4.1.0
   - pusher-http-haskell ==1.5.1.11
-  - PyF ==0.9.0.0
+  - PyF ==0.9.0.1
   - qchas ==1.1.0.1
   - qm-interpolated-string ==0.3.0.0
   - qrcode-core ==0.9.2
@@ -1731,13 +1731,13 @@ default-package-overrides:
   - relational-schemas ==0.1.8.0
   - relude ==0.6.0.0
   - renderable ==0.2.0.1
-  - replace-attoparsec ==1.2.0.0
+  - replace-attoparsec ==1.2.1.0
   - replace-megaparsec ==1.2.1.0
   - repline ==0.2.2.0
   - req ==3.1.0
   - req-conduit ==1.0.0
   - rerebase ==1.4.1
-  - resolv ==0.1.1.3
+  - resolv ==0.1.2.0
   - resource-pool ==0.2.3.2
   - resourcet ==1.2.3
   - result ==0.2.6.0
@@ -1849,7 +1849,7 @@ default-package-overrides:
   - serversession ==1.0.1
   - serversession-frontend-wai ==1.0
   - ses-html ==0.4.0.0
-  - set-cover ==0.1
+  - set-cover ==0.1.1
   - setenv ==0.1.1.3
   - setlocale ==1.0.0.9
   - SHA ==1.6.4.4
@@ -1869,7 +1869,7 @@ default-package-overrides:
   - simple-affine-space ==0.1
   - simple-cabal ==0.1.1
   - simple-cmd ==0.2.1
-  - simple-cmd-args ==0.1.5
+  - simple-cmd-args ==0.1.6
   - simple-log ==0.9.12
   - simple-reflect ==0.3.3
   - simple-sendfile ==0.2.30
@@ -1879,7 +1879,7 @@ default-package-overrides:
   - simplistic-generics ==0.1.0.0
   - since ==0.0.0
   - singleton-bool ==0.1.5
-  - singleton-nats ==0.4.3
+  - singleton-nats ==0.4.4
   - singletons ==2.6
   - singletons-presburger ==0.3.0.0
   - siphash ==1.0.3
@@ -1902,7 +1902,7 @@ default-package-overrides:
   - soap-tls ==0.1.1.4
   - socks ==0.6.1
   - some ==1.0.1
-  - sop-core ==0.5.0.0
+  - sop-core ==0.5.0.1
   - sort ==1.0.0.0
   - sorted-list ==0.2.1.0
   - sourcemap ==0.1.6
@@ -1940,7 +1940,7 @@ default-package-overrides:
   - stm-split ==0.0.2.1
   - stopwatch ==0.1.0.6
   - storable-complex ==0.2.3.0
-  - storable-record ==0.0.4.1
+  - storable-record ==0.0.5
   - storable-tuple ==0.0.3.3
   - storablevector ==0.2.13
   - stratosphere ==0.49.0
@@ -2094,7 +2094,7 @@ default-package-overrides:
   - timezone-series ==0.1.9
   - tinylog ==0.15.0
   - titlecase ==1.0.1
-  - tldr ==0.6.2
+  - tldr ==0.6.4
   - tls ==1.5.4
   - tls-debug ==0.4.8
   - tls-session-manager ==0.0.4
@@ -2103,7 +2103,7 @@ default-package-overrides:
   - tmp-postgres ==1.34.1.0
   - tomland ==1.2.1.0
   - tonalude ==0.1.1.0
-  - topograph ==1
+  - topograph ==1.0.0.1
   - torsor ==0.1
   - tostring ==0.2.1.1
   - tracing ==0.0.4.0
@@ -2126,7 +2126,7 @@ default-package-overrides:
   - tuples-homogenous-h98 ==0.1.1.0
   - tuple-sop ==0.3.1.0
   - tuple-th ==0.2.5
-  - turtle ==1.5.17
+  - turtle ==1.5.18
   - TypeCompose ==0.9.14
   - typed-process ==0.2.6.0
   - typed-uuid ==0.0.0.2
@@ -2195,7 +2195,7 @@ default-package-overrides:
   - utf8-light ==0.4.2
   - utf8-string ==1.0.1.1
   - util ==0.1.17.1
-  - utility-ht ==0.0.14
+  - utility-ht ==0.0.15
   - uuid ==1.3.13
   - uuid-types ==1.0.3
   - validation ==1.1
@@ -2262,7 +2262,7 @@ default-package-overrides:
   - websockets ==0.12.7.0
   - websockets-snap ==0.10.3.1
   - weigh ==0.0.16
-  - wide-word ==0.1.1.0
+  - wide-word ==0.1.1.1
   - wikicfp-scraper ==0.1.0.11
   - wild-bind ==0.1.2.5
   - wild-bind-x11 ==0.2.0.9
@@ -2321,7 +2321,7 @@ default-package-overrides:
   - xxhash-ffi ==0.2.0.0
   - yaml ==0.11.3.0
   - yesod ==1.6.0.1
-  - yesod-auth ==1.6.9
+  - yesod-auth ==1.6.10
   - yesod-auth-hashdb ==1.7.1.2
   - yesod-bin ==1.6.0.4
   - yesod-core ==1.6.17.3

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3953,7 +3953,6 @@ broken-packages:
   - Dao
   - dao
   - dapi
-  - darcs
   - darcs-benchmark
   - darcs-beta
   - darcs-buildpackage

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2459,6 +2459,9 @@ package-maintainers:
     - streaming-wai
   kiwi:
     # - glirc
+    - matterhorn
+    - mattermost-api
+    - mattermost-api-qc
     - Unique
   psibi:
     - path-pieces
@@ -7329,9 +7332,6 @@ broken-packages:
   - matrix-as-xyz
   - matrix-market
   - matsuri
-  - matterhorn
-  - mattermost-api
-  - mattermost-api-qc
   - maude
   - maxent
   - maxent-learner-hw

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3517,6 +3517,7 @@ broken-packages:
   - Chart-fltkhs
   - chart-histogram
   - Chart-simple
+  - chart-svg
   - chart-unit
   - chatter
   - chatty-text
@@ -5055,6 +5056,7 @@ broken-packages:
   - ghc-srcspan-plugin
   - ghc-syb
   - ghc-syb-utils
+  - ghc-tags-core
   - ghc-tags-plugin
   - ghc-time-alloc-prof
   - ghc-usage
@@ -6282,6 +6284,7 @@ broken-packages:
   - hssqlppp
   - hssqlppp-th
   - HsSVN
+  - hstar
   - hstatistics
   - hstats
   - hstatsd

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2686,7 +2686,6 @@ broken-packages:
   - adaptive-containers
   - adaptive-tuple
   - adb
-  - adblock2privoxy
   - adhoc-network
   - adict
   - adobe-swatch-exchange
@@ -2742,12 +2741,10 @@ broken-packages:
   - aivika-distributed
   - ajhc
   - AlanDeniseEricLauren
-  - alarmclock
   - alerta
   - alex-prelude
   - alfred
   - alga
-  - algebra-checkers
   - algebra-dag
   - algebra-sql
   - algebraic
@@ -2796,7 +2793,6 @@ broken-packages:
   - animate-frames
   - animate-preview
   - animate-sdl2
-  - anki-tools
   - annah
   - Annotations
   - anonymous-sums
@@ -2887,9 +2883,7 @@ broken-packages:
   - artery
   - artifact
   - asap
-  - ascetic
   - ascii
-  - ascii-cows
   - ascii-flatten
   - ascii-string
   - ascii-table
@@ -2987,7 +2981,6 @@ broken-packages:
   - aws-kinesis-client
   - aws-kinesis-reshard
   - aws-lambda
-  - aws-lambda-haskell-runtime
   - aws-mfa-credentials
   - aws-performance-tests
   - aws-route53
@@ -3027,7 +3020,6 @@ broken-packages:
   - bamstats
   - Bang
   - bank-holiday-usa
-  - bank-holidays-england
   - banwords
   - barchart
   - barcodes-code128
@@ -3036,7 +3028,6 @@ broken-packages:
   - barrie
   - barrier
   - barrier-monad
-  - base-compat-migrate
   - base-feature-macros
   - base-generics
   - base-io-access
@@ -3117,7 +3108,6 @@ broken-packages:
   - binary-search
   - binary-streams
   - binary-strict
-  - binary-tagged
   - binary-typed
   - bind-marshal
   - BinderAnn
@@ -3369,7 +3359,6 @@ broken-packages:
   - cabal-dependency-licenses
   - cabal-dev
   - cabal-dir
-  - cabal-file-th
   - cabal-ghc-dynflags
   - cabal-ghci
   - cabal-graphdeps
@@ -3388,7 +3377,6 @@ broken-packages:
   - cabal-sort
   - cabal-src
   - cabal-test
-  - cabal-toolkit
   - cabal-upload
   - cabal2arch
   - cabal2doap
@@ -3434,7 +3422,6 @@ broken-packages:
   - cao
   - cap
   - Capabilities
-  - capability
   - capnp
   - capped-list
   - capri
@@ -3448,7 +3435,6 @@ broken-packages:
   - carte
   - cartel
   - Cartesian
-  - cas-store
   - casa-abbreviations-and-acronyms
   - casadi-bindings
   - casadi-bindings-control
@@ -3514,7 +3500,6 @@ broken-packages:
   - cgrep
   - chalkboard
   - chalkboard-viewer
-  - character-cases
   - charade
   - chart-cli
   - Chart-fltkhs
@@ -3578,8 +3563,6 @@ broken-packages:
   - clarifai
   - CLASE
   - clash
-  - clash-ghc
-  - clash-lib
   - clash-multisignal
   - Clash-Royale-Hack-Cheats
   - clash-systemverilog
@@ -3604,7 +3587,6 @@ broken-packages:
   - clckwrks-theme-clckwrks
   - clckwrks-theme-geo-bootstrap
   - Clean
-  - clean-home
   - clean-unions
   - cless
   - clevercss
@@ -3666,7 +3648,6 @@ broken-packages:
   - codemonitor
   - codepad
   - codeworld-api
-  - codex
   - codo-notation
   - coin
   - coinbase-exchange
@@ -3749,7 +3730,6 @@ broken-packages:
   - concurrent-buffer
   - Concurrent-Cache
   - concurrent-machines
-  - concurrent-resource-map
   - concurrent-state
   - concurrent-utilities
   - Concurrential
@@ -3776,7 +3756,6 @@ broken-packages:
   - conferer-provider-dhall
   - conferer-provider-yaml
   - conferer-snap
-  - confetti
   - conffmt
   - confide
   - config-parser
@@ -3788,7 +3767,6 @@ broken-packages:
   - configuration
   - configuration-tools
   - configurator-ng
-  - configurator-pg
   - confsolve
   - congruence-relation
   - conjure
@@ -3878,7 +3856,6 @@ broken-packages:
   - cparsing
   - CPBrainfuck
   - cpio-conduit
-  - cpkg
   - CPL
   - cplusplus-th
   - cprng-aes-effect
@@ -4003,7 +3980,6 @@ broken-packages:
   - data-category
   - data-check
   - data-combinator-gen
-  - data-compat
   - data-concurrent-queue
   - data-construction
   - data-cycle
@@ -4026,8 +4002,6 @@ broken-packages:
   - data-lens-ixset
   - data-lens-template
   - data-map-multikey
-  - data-msgpack
-  - data-msgpack-types
   - data-nat
   - data-object
   - data-object-json
@@ -4141,7 +4115,6 @@ broken-packages:
   - dependent-monoidal-map
   - dependent-state
   - dependent-sum-aeson-orphans
-  - dependent-sum-template
   - depends
   - dephd
   - deptrack-core
@@ -4154,13 +4127,11 @@ broken-packages:
   - derive-gadt
   - derive-IG
   - derive-monoid
-  - derive-storable-plugin
   - derive-topdown
   - derive-trie
   - derp-lib
   - describe
   - descript-lang
-  - desert
   - deterministic-game-engine
   - detour-via-uom
   - deunicode
@@ -4195,7 +4166,6 @@ broken-packages:
   - diagrams-wx
   - dialogflow-fulfillment
   - dib
-  - dice
   - dice-entropy-conduit
   - dice2tex
   - dicom
@@ -4238,7 +4208,6 @@ broken-packages:
   - dirtree
   - discogs-haskell
   - discord-gateway
-  - discord-haskell
   - discord-hs
   - discord-rest
   - discord-types
@@ -4423,35 +4392,27 @@ broken-packages:
   - effect-monad
   - effect-stack
   - effin
-  - egison-pattern-src-th-mode
   - egison-quote
   - ehaskell
   - ehs
   - eibd-client-simple
   - eigen
   - Eight-Ball-Pool-Hack-Cheats
-  - either-list-functions
   - either-unwrap
   - EitherT
-  - ekg
   - ekg-bosun
   - ekg-carbon
-  - ekg-cloudwatch
   - ekg-elastic
   - ekg-elasticsearch
-  - ekg-influxdb
-  - ekg-json
   - ekg-log
   - ekg-push
   - ekg-rrd
-  - ekg-statsd
   - ekg-wai
   - elerea-examples
   - elevator
   - elision
   - elm-street
   - elm-websocket
-  - elsa
   - elynx-seq
   - elynx-tools
   - elynx-tree
@@ -4705,14 +4666,12 @@ broken-packages:
   - fibon
   - ficketed
   - fields
-  - fields-json
   - FieldTrip
   - fieldwise
   - fig
   - file-collection
   - file-command-qq
   - file-location
-  - file-modules
   - filediff
   - FileManip
   - FileManipCompat
@@ -4802,7 +4761,6 @@ broken-packages:
   - FModExRaw
   - fmt-for-rio
   - fn-extra
-  - Focus
   - foldl-incremental
   - foldl-statistics
   - foldl-transduce
@@ -5149,7 +5107,6 @@ broken-packages:
   - gli
   - glicko
   - glider-nlp
-  - glirc
   - GLMatrix
   - glob-posix
   - global
@@ -5169,10 +5126,6 @@ broken-packages:
   - gloss-sodium
   - glpk-hs
   - glue
-  - glue-common
-  - glue-core
-  - glue-ekg
-  - glue-example
   - GLUtil
   - gmap
   - gmndl
@@ -5229,8 +5182,6 @@ broken-packages:
   - gps2htmlReport
   - GPX
   - gpx-conduit
-  - grab
-  - grab-form
   - graceful
   - grafana
   - graflog
@@ -5304,11 +5255,9 @@ broken-packages:
   - gsl-random-fu
   - gstorable
   - gstreamer
-  - gt-tools
   - GTALib
   - gtfs
   - gtfs-realtime
-  - gtk-jsinput
   - gtk-serialized-event
   - gtk-toy
   - gtk2hs-hello
@@ -5408,7 +5357,6 @@ broken-packages:
   - hakyll-R
   - hakyll-series
   - hakyll-shortcode
-  - hakyll-shortcut-links
   - hakyll-typescript
   - hal
   - halberd
@@ -5496,8 +5444,6 @@ broken-packages:
   - harvest-api
   - has
   - has-th
-  - hasbolt
-  - hasbolt-extras
   - HasCacBDD
   - hascar
   - hascas
@@ -5519,7 +5465,6 @@ broken-packages:
   - haskarrow
   - haskbot-core
   - haskdeep
-  - haskdogs
   - haskeem
   - haskeline-class
   - haskelisp
@@ -5565,10 +5510,8 @@ broken-packages:
   - haskell-src-exts-prisms
   - haskell-src-exts-qq
   - haskell-src-exts-sc
-  - haskell-src-exts-simple
   - haskell-src-meta-mwotton
   - haskell-stack-trace-plugin
-  - haskell-to-elm
   - haskell-token-utils
   - haskell-tools-ast
   - haskell-tools-ast-fromghc
@@ -5687,7 +5630,6 @@ broken-packages:
   - haste-lib
   - haste-markup
   - haste-prim
-  - Hastodon
   - Hate
   - hatex-guide
   - HaTeX-meta
@@ -5764,7 +5706,6 @@ broken-packages:
   - HDRUtils
   - headed-megaparsec
   - headergen
-  - headroom
   - heapsort
   - heart-app
   - heart-core
@@ -5789,7 +5730,6 @@ broken-packages:
   - hedis-pile
   - hedis-simple
   - hedis-tags
-  - hedn
   - hedn-functor
   - hedra
   - hein
@@ -6001,7 +5941,6 @@ broken-packages:
   - hmumps
   - hnetcdf
   - hnix
-  - hnix-store-core
   - hnix-store-remote
   - HNM
   - hnormalise
@@ -6050,7 +5989,6 @@ broken-packages:
   - hoodle-types
   - hoogle-index
   - hooks-dir
-  - hookup
   - hoopl
   - hoovie
   - hopencc
@@ -6150,7 +6088,6 @@ broken-packages:
   - hs-re
   - hs-rs-notify
   - hs-scrape
-  - hs-server-starter
   - hs-snowtify
   - hs-twitter
   - hs-twitterarchiver
@@ -6159,7 +6096,6 @@ broken-packages:
   - hs2bf
   - Hs2lib
   - hs2ps
-  - hS3
   - hsaml2
   - hsay
   - hsbackup
@@ -6210,7 +6146,6 @@ broken-packages:
   - hsgnutls
   - hsgnutls-yj
   - hsgsom
-  - HSH
   - HsHaruPDF
   - HSHHelpers
   - HsHTSLib
@@ -6249,13 +6184,11 @@ broken-packages:
   - hspec-expectations-pretty
   - hspec-experimental
   - hspec-hashable
-  - hspec-hedgehog
   - hspec-jenkins
   - hspec-monad-control
   - hspec-pg-transact
   - hspec-setup
   - hspec-shouldbe
-  - hspec-snap
   - hspec-structured-formatter
   - hspec-test-sandbox
   - hspec-webdriver
@@ -6308,7 +6241,6 @@ broken-packages:
   - hsXenCtrl
   - hsyscall
   - hsyslog-tcp
-  - hsyslog-udp
   - hszephyr
   - HTab
   - hTalos
@@ -6352,7 +6284,6 @@ broken-packages:
   - http-response-decoder
   - http-server
   - http-shed
-  - http-trace
   - http-wget
   - http2-client
   - http2-client-exe
@@ -6465,7 +6396,6 @@ broken-packages:
   - identifiers
   - idiii
   - idna2008
-  - idringen
   - idris
   - IDynamic
   - ieee-utils
@@ -6562,7 +6492,6 @@ broken-packages:
   - InternedData
   - internetmarke
   - intero
-  - interp
   - interpol
   - interpolatedstring-qq
   - interpolatedstring-qq-mwotton
@@ -6647,7 +6576,6 @@ broken-packages:
   - ivy-web
   - ixdopp
   - ixmonad
-  - ixset-typed
   - ixshader
   - iyql
   - j2hs
@@ -6703,7 +6631,6 @@ broken-packages:
   - json-assertions
   - json-ast-json-encoder
   - json-ast-quickcheck
-  - json-autotype
   - json-b
   - json-builder
   - json-bytes-builder
@@ -6906,7 +6833,6 @@ broken-packages:
   - language-csharp
   - language-css
   - language-dart
-  - language-docker
   - language-dockerfile
   - language-ecmascript-analysis
   - language-eiffel
@@ -6947,7 +6873,6 @@ broken-packages:
   - latest-npm-version
   - latex-formulae-hakyll
   - latex-formulae-pandoc
-  - latex-live-snippets
   - LATS
   - launchdarkly-server-sdk
   - launchpad-control
@@ -6979,7 +6904,6 @@ broken-packages:
   - learn
   - learn-physics-examples
   - Learning
-  - learning-hmm
   - leetify
   - legion
   - legion-discovery
@@ -7014,7 +6938,6 @@ broken-packages:
   - lhe
   - lhs2TeX-hl
   - lhslatex
-  - libarchive
   - LibClang
   - libconfig
   - libcspm
@@ -7046,7 +6969,6 @@ broken-packages:
   - libxslt
   - licensor
   - lie
-  - life-sync
   - lifted-base-tf
   - lifted-protolude
   - lifted-stm
@@ -7148,8 +7070,6 @@ broken-packages:
   - lmonad-yesod
   - load-balancing
   - load-font
-  - loc
-  - loc-test
   - local-address
   - local-search
   - localize
@@ -7161,7 +7081,6 @@ broken-packages:
   - log-elasticsearch
   - log-postgres
   - log-utils
-  - log-warper
   - log2json
   - logentries
   - logger
@@ -7235,7 +7154,6 @@ broken-packages:
   - lxd-client
   - lye
   - Lykah
-  - lz4-bytes
   - lz4-conduit
   - lzma-enumerator
   - lzma-streams
@@ -7267,7 +7185,6 @@ broken-packages:
   - mahoro
   - maid
   - mail-pool
-  - mailbox-count
   - mailchimp
   - mailchimp-subscribe
   - MailchimpSimple
@@ -7327,7 +7244,6 @@ broken-packages:
   - math-metric
   - mathblog
   - mathflow
-  - mathista
   - mathlink
   - matrix-as-xyz
   - matrix-market
@@ -7344,7 +7260,6 @@ broken-packages:
   - MazesOfMonad
   - MBot
   - mbox-tools
-  - mbtiles
   - mbug
   - MC-Fold-DP
   - mcl
@@ -7432,7 +7347,6 @@ broken-packages:
   - miku
   - milena
   - mime-directory
-  - min-max-pqueue
   - minecraft-data
   - minesweeper
   - miniforth
@@ -7447,7 +7361,6 @@ broken-packages:
   - minst-idx
   - mios
   - mirror-tweet
-  - misfortune
   - miso-action-logger
   - miso-examples
   - miss
@@ -7500,7 +7413,6 @@ broken-packages:
   - monad-logger-syslog
   - monad-lrs
   - monad-mersenne-random
-  - monad-metrics
   - monad-metrics-extensible
   - monad-mock
   - monad-open
@@ -7562,7 +7474,6 @@ broken-packages:
   - monus
   - monzo
   - moo
-  - moonshine
   - morfette
   - morfeusz
   - morley
@@ -7629,7 +7540,6 @@ broken-packages:
   - multibase
   - multifocal
   - multihash
-  - multihash-cryptonite
   - multihash-serialise
   - multilinear
   - multilinear-io
@@ -7697,7 +7607,6 @@ broken-packages:
   - n-tuple
   - n2o-protocols
   - n2o-web
-  - nagios-perfdata
   - nagios-plugin-ekg
   - nakadi-client
   - named-lock
@@ -7730,7 +7639,6 @@ broken-packages:
   - needle
   - neet
   - nehe-tuts
-  - neil
   - neither
   - neko-lib
   - Neks
@@ -7779,7 +7687,6 @@ broken-packages:
   - network-hans
   - network-house
   - network-interfacerequest
-  - network-messagepack-rpc
   - network-messagepack-rpc-websocket
   - network-minihttp
   - network-msgpack-rpc
@@ -7829,7 +7736,6 @@ broken-packages:
   - nitro
   - nix-delegate
   - nix-deploy
-  - nix-diff
   - nix-eval
   - nix-freeze-tree
   - nix-tools
@@ -7998,7 +7904,6 @@ broken-packages:
   - ordrea
   - organize-imports
   - orgmode
-  - orgstat
   - origami
   - orizentic
   - OrPatterns
@@ -8015,7 +7920,6 @@ broken-packages:
   - OTP
   - otp-authenticator
   - ottparse-pretty
-  - outsort
   - overload
   - overloaded-records
   - overture
@@ -8106,13 +8010,10 @@ broken-packages:
   - parser-helper
   - parser241
   - parsergen
-  - parsers-megaparsec
   - parsestar
   - parsimony
-  - parsix
   - partage
   - partial-lens
-  - partial-order
   - partial-records
   - partial-semigroup
   - partial-semigroup-hedgehog
@@ -8204,7 +8105,6 @@ broken-packages:
   - persistent-redis
   - persistent-relational-record
   - persistent-template-classy
-  - persistent-typed-db
   - persistent-vector
   - persistent-zookeeper
   - persona
@@ -8223,7 +8123,6 @@ broken-packages:
   - phasechange
   - phaser
   - phoityne
-  - phoityne-vscode
   - phone-numbers
   - phone-push
   - phooey
@@ -8265,7 +8164,6 @@ broken-packages:
   - pipes-conduit
   - pipes-core
   - pipes-courier
-  - pipes-csv
   - pipes-errors
   - pipes-extra
   - pipes-files
@@ -8347,7 +8245,6 @@ broken-packages:
   - polysemy-RandomFu
   - polysemy-zoo
   - polyseq
-  - polysoup
   - polytypeable
   - polytypeable-utils
   - pomodoro
@@ -8653,17 +8550,12 @@ broken-packages:
   - random-derive
   - random-eff
   - random-effin
-  - random-extras
-  - random-fu
-  - random-fu-multivariate
   - random-hypergeometric
   - random-stream
   - RandomDotOrg
-  - Randometer
   - Range
   - range-space
   - rangemin
-  - rank-product
   - rank1dynamic
   - Ranka
   - rapid
@@ -8752,8 +8644,6 @@ broken-packages:
   - Referees
   - references
   - refh
-  - refined
-  - refined-http-api-data
   - reflection-extras
   - reflex
   - reflex-animation
@@ -8856,7 +8746,6 @@ broken-packages:
   - req-conduit
   - req-oauth2
   - req-url-extra
-  - reqcatcher
   - request-monad
   - require
   - reserve
@@ -8880,7 +8769,6 @@ broken-packages:
   - rest-types
   - rest-wai
   - restful-snap
-  - restless-git
   - restricted-workers
   - restyle
   - rethinkdb
@@ -8909,7 +8797,6 @@ broken-packages:
   - rib
   - ribbit
   - RichConditional
-  - richreports
   - ridley
   - ridley-extras
   - riemann
@@ -8995,7 +8882,6 @@ broken-packages:
   - rungekutta
   - runmany
   - runtime-arbitrary
-  - rvar
   - rws
   - RxHaskell
   - s-expression
@@ -9006,10 +8892,8 @@ broken-packages:
   - safe-failure-cme
   - safe-freeze
   - safe-globals
-  - safe-json
   - safe-lazy-io
   - safe-length
-  - safe-money-xmlbf
   - safe-plugins
   - safe-printf
   - safecopy-migrate
@@ -9175,7 +9059,6 @@ broken-packages:
   - servant-db-postgresql
   - servant-dhall
   - servant-ede
-  - servant-ekg
   - servant-errors
   - servant-examples
   - servant-exceptions
@@ -9209,15 +9092,12 @@ broken-packages:
   - servant-scotty
   - servant-server-namedargs
   - servant-smsc-ru
-  - servant-snap
   - servant-streaming
   - servant-streaming-client
   - servant-streaming-docs
   - servant-streaming-server
   - servant-swagger-tags
-  - servant-to-elm
   - servant-waargonaut
-  - servant-xml
   - servant-zeppelin
   - servant-zeppelin-client
   - servant-zeppelin-server
@@ -9226,7 +9106,6 @@ broken-packages:
   - serversession-backend-acid-state
   - serversession-backend-persistent
   - serversession-backend-redis
-  - serversession-frontend-snap
   - serversession-frontend-yesod
   - services
   - ses-html-snaplet
@@ -9237,7 +9116,6 @@ broken-packages:
   - set-of
   - set-with
   - setdown
-  - setgame
   - setoid
   - setters
   - sexp
@@ -9362,7 +9240,6 @@ broken-packages:
   - siphon
   - siren-json
   - sirkel
-  - sitepipe
   - sixfiguregroup
   - sized-grid
   - sized-types
@@ -9374,7 +9251,6 @@ broken-packages:
   - skeletons
   - skell
   - skemmtun
-  - skews
   - skulk
   - skylark-client
   - skylighting-lucid
@@ -9383,7 +9259,6 @@ broken-packages:
   - slack-notify-haskell
   - slack-web
   - slave-thread
-  - slice-cpp-gen
   - sliceofpy
   - slidemews
   - Slides
@@ -9446,7 +9321,6 @@ broken-packages:
   - snaplet-customauth
   - snaplet-environments
   - snaplet-fay
-  - snaplet-ghcjs
   - snaplet-hasql
   - snaplet-haxl
   - snaplet-hdbc
@@ -9491,7 +9365,6 @@ broken-packages:
   - snowflake-server
   - snowtify
   - Snusmumrik
-  - soap-openssl
   - SoccerFun
   - SoccerFunGL
   - socket-activation
@@ -9555,7 +9428,6 @@ broken-packages:
   - spiros
   - splay
   - splaytree
-  - spline3
   - splines
   - split-morphism
   - splitter
@@ -9614,7 +9486,6 @@ broken-packages:
   - stack-prism
   - stack-run
   - stack-run-auto
-  - stack-tag
   - stack-type
   - stack-wrapper
   - stack2cabal
@@ -9645,10 +9516,8 @@ broken-packages:
   - stateWriter
   - static-canvas
   - static-closure
-  - static-resources
   - static-tensor
   - static-text
-  - staticanalysis
   - statistics-dirichlet
   - statistics-fusion
   - statistics-hypergeometric-genvar
@@ -9856,7 +9725,6 @@ broken-packages:
   - tagsoup-parsec
   - tagsoup-selection
   - tagstream-conduit
-  - tai
   - tai64
   - takahashi
   - Takusen
@@ -9913,7 +9781,6 @@ broken-packages:
   - template-yj
   - templateify
   - templatepg
-  - tempo
   - tempodb
   - temporal-csound
   - tempus
@@ -9963,7 +9830,6 @@ broken-packages:
   - text-containers
   - text-format
   - text-format-heavy
-  - text-format-simple
   - text-generic-pretty
   - text-icu-normalized
   - text-lens
@@ -9975,7 +9841,6 @@ broken-packages:
   - text-plus
   - text-position
   - text-register-machine
-  - text-replace
   - text-time
   - text-trie
   - text-utf8
@@ -9995,7 +9860,6 @@ broken-packages:
   - th-dict-discovery
   - th-fold
   - th-format
-  - th-instance-reification
   - th-instances
   - th-kinds
   - th-kinds-fork
@@ -10016,7 +9880,6 @@ broken-packages:
   - Thingie
   - thorn
   - threadmanager
-  - threadscope
   - threepenny-editors
   - threepenny-gui-contextmenu
   - threepenny-gui-flexbox
@@ -10062,7 +9925,6 @@ broken-packages:
   - timeseries
   - timespan
   - timeutils
-  - timezone-olson-th
   - timezone-unix
   - tintin
   - tiny-scheduler
@@ -10164,17 +10026,6 @@ broken-packages:
   - treap
   - tree-monad
   - tree-render-text
-  - tree-sitter
-  - tree-sitter-go
-  - tree-sitter-haskell
-  - tree-sitter-java
-  - tree-sitter-json
-  - tree-sitter-php
-  - tree-sitter-python
-  - tree-sitter-ql
-  - tree-sitter-ruby
-  - tree-sitter-tsx
-  - tree-sitter-typescript
   - tree-traversals
   - TreeCounter
   - treemap-html
@@ -10273,7 +10124,6 @@ broken-packages:
   - type-tree
   - typeable-th
   - TypeClass
-  - typed-spreadsheet
   - typed-streams
   - typed-wire
   - typedflow
@@ -10334,7 +10184,6 @@ broken-packages:
   - uniquely-represented-sets
   - units-attoparsec
   - unittyped
-  - unity-testresult-parser
   - unitym-yesod
   - universal-binary
   - universe-th
@@ -10392,7 +10241,6 @@ broken-packages:
   - usb-id-database
   - usb-iteratee
   - usb-safe
-  - useragents
   - users-mysql-haskell
   - users-persistent
   - utc
@@ -10429,7 +10277,6 @@ broken-packages:
   - validate-input
   - validated-types
   - Validation
-  - validation-selective
   - validations
   - validationt
   - value-supply
@@ -10479,7 +10326,6 @@ broken-packages:
   - verifiable-expressions
   - verify
   - verilog
-  - verismith
   - versioning
   - versioning-servant
   - vflow-types
@@ -10555,7 +10401,6 @@ broken-packages:
   - wai-middleware-etag
   - wai-middleware-headers
   - wai-middleware-hmac-client
-  - wai-middleware-metrics
   - wai-middleware-preprocessor
   - wai-middleware-rollbar
   - wai-middleware-route
@@ -10597,7 +10442,6 @@ broken-packages:
   - weather-api
   - web-css
   - web-encodings
-  - web-fpco
   - web-inv-route
   - web-mongrel2
   - web-output
@@ -10646,7 +10490,6 @@ broken-packages:
   - whiskers
   - whitespace
   - whois
-  - wholepixels
   - why3
   - WikimediaParser
   - wikipedia4epub
@@ -10677,7 +10520,6 @@ broken-packages:
   - word2vec-model
   - WordAlignment
   - wordify
-  - wordlist
   - WordNet
   - WordNet-ghc74
   - wordpass
@@ -10704,7 +10546,6 @@ broken-packages:
   - wsdl
   - wsedit
   - wshterm
-  - wss-client
   - wtk
   - wtk-gtk
   - wu-wei
@@ -10771,9 +10612,6 @@ broken-packages:
   - xml-tydom-core
   - xml2json
   - xml2x
-  - xmlbf
-  - xmlbf-xeno
-  - xmlbf-xmlhtml
   - XmlHtmlWriter
   - xmltv
   - XMMS

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -69,8 +69,6 @@ core-packages:
 default-package-overrides:
   # This was only intended for ghc-7.0.4, and has very old deps, one hidden behind a flag
   - MissingH ==1.4.2.0
-  # pandoc-2.9 does not accept the 0.3 version yet
-  - doclayout < 0.3
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2458,7 +2458,7 @@ package-maintainers:
     # - pipes-mongodb
     - streaming-wai
   kiwi:
-    # - glirc
+    - glirc
     - matterhorn
     - mattermost-api
     - mattermost-api-qc

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8346,7 +8346,6 @@ broken-packages:
   - polydata
   - polydata-core
   - polynomial
-  - polysemy-plugin
   - polysemy-RandomFu
   - polysemy-zoo
   - polyseq

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18883,7 +18883,7 @@ in
 
   dablin = callPackage ../applications/radio/dablin { };
 
-  darcs = haskell.lib.overrideCabal (haskell.lib.justStaticExecutables haskellPackages.darcs) (drv: {
+  darcs = haskell.lib.overrideCabal (haskell.lib.justStaticExecutables haskell.packages.ghc865.darcs) (drv: {
     configureFlags = (stdenv.lib.remove "-flibrary" drv.configureFlags or []) ++ ["-f-library"];
   });
 


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-04-03 [20:00 CET](http://www.thetimezoneconverter.com/?t=20:00&tz=Berlin). You can watch this live on Twitch at https://www.twitch.tv/peti343.

## TODO

- [ ] Split-out a minimal `nix` docker image: https://github.com/NixOS/docker/pull/13
- [ ] Run `krank` on our override files and collect a TODO list of possibly outdated items.
- [x] Update `all-cabal-hashes` reference.
- [ ] Merge r-updates, too, if there's time: https://github.com/NixOS/nixpkgs/pull/81307