### PR TITLE
squashfs-tools-ng: 0.8 -> 0.9

### DIFF
--- a/pkgs/tools/filesystems/squashfs-tools-ng/default.nix
+++ b/pkgs/tools/filesystems/squashfs-tools-ng/default.nix
@@ -1,18 +1,18 @@
 { stdenv, lib, fetchurl, doxygen, graphviz, perl, pkgconfig
-, lz4, xz, zlib, zstd
+, lz4, lzo, xz, zlib, zstd
 }:
 
 stdenv.mkDerivation rec {
   pname = "squashfs-tools-ng";
-  version = "0.8";
+  version = "0.9";
 
   src = fetchurl {
     url = "https://infraroot.at/pub/squashfs/squashfs-tools-ng-${version}.tar.xz";
-    sha256 = "1km18qm9kgmm39aj9yq2aaq99708nmj9cpa9lqf5bp1y617bhh7y";
+    sha256 = "1jx6bga0k07cckpv0yk77kwql7rjiicf9wkbadc8yqhp463xn90q";
   };
 
   nativeBuildInputs = [ doxygen graphviz pkgconfig perl ];
-  buildInputs = [ zlib xz lz4 zstd ];
+  buildInputs = [ zlib xz lz4 lzo zstd ];
 
   meta = with lib; {
     homepage = https://github.com/AgentD/squashfs-tools-ng;


### PR DESCRIPTION
Like all supported formats (I think), LZO is optional.  I don't see
any reason to bother with options for now, so I've just enabled it.  Plus,
there's a bug in this release that makes compilation fail if LZO is
disabled due to a missing include.  I've sent a fix[1] for that
upstream.

[1]: https://github.com/AgentD/squashfs-tools-ng/pull/41

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
