### PR TITLE
nexus: 3.20.1-01 -> 3.22.0-02

### DIFF
--- a/pkgs/development/tools/repository-managers/nexus/default.nix
+++ b/pkgs/development/tools/repository-managers/nexus/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nexus";
-  version = "3.20.1-01";
+  version = "3.22.0-02";
 
   src = fetchurl {
     url = "https://sonatype-download.global.ssl.fastly.net/nexus/3/nexus-${version}-unix.tar.gz";
-    sha256 = "0l8fwcnpbc35lqadyrsljvr4rr5kp9gkx5dxs9i35mg2f0z9bagv";
+    sha256 = "12433fgva03gsgi37xqgkdnbglgq4b66lmzk5cyxfg22szl4xvwz";
   };
 
   preferLocalBuild = true;


### PR DESCRIPTION
###### Motivation for this change
https://help.sonatype.com/repomanager3/release-notes/2020-release-notes

```
Security Fix

A critical security vulnerability has been found in all versions of NXRM 3 up to and including 3.21.1. For details, please see CVE-2020-10199, CVE-2020-10203, CVE-2020-10204.

Sonatype recommends that administrators upgrade to 3.21.2 or newer immediately.
```

Maybe this pr should be backported to 19.09.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
