### PR TITLE
notmuch: extract optional dependencies

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -1,12 +1,13 @@
 { fetchurl, stdenv
 , pkgconfig, gnupg
 , xapian, gmime, talloc, zlib
-, doxygen, perl
+, doxygen, perl, texinfo
 , pythonPackages
 , bash-completion
 , emacs
 , ruby
 , which, dtach, openssl, bash, gdb, man
+, withEmacs ? true
 }:
 
 with stdenv.lib;
@@ -25,15 +26,20 @@ stdenv.mkDerivation rec {
     sha256 = "0dfwa38vgnxk9cvvpza66szjgp8lir6iz6yy0cry9593lywh9xym";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    pkgconfig
+    doxygen                   # (optional) api docs
+    pythonPackages.sphinx     # (optional) documentation -> doc/INSTALL
+    texinfo                   # (optional) documentation -> doc/INSTALL
+    bash-completion           # (optional) dependency to install bash completion
+  ] ++ optional withEmacs [ emacs ];
+
   buildInputs = [
-    gnupg # undefined dependencies
+    gnupg                     # undefined dependencies
     xapian gmime talloc zlib  # dependencies described in INSTALL
-    doxygen perl  # (optional) api docs
-    pythonPackages.sphinx pythonPackages.python  # (optional) documentation -> doc/INSTALL
-    bash-completion  # (optional) dependency to install bash completion
-    emacs  # (optional) to byte compile emacs code, also needed for tests
-    ruby  # (optional) ruby bindings
+    perl
+    pythonPackages.python
+    ruby
   ];
 
   postPatch = ''
@@ -42,19 +48,26 @@ stdenv.mkDerivation rec {
 
     substituteInPlace lib/Makefile.local \
       --replace '-install_name $(libdir)' "-install_name $out/lib"
-
+  '' + optionalString withEmacs ''
     substituteInPlace emacs/notmuch-emacs-mua \
       --replace 'EMACS:-emacs' 'EMACS:-${emacs}/bin/emacs' \
       --replace 'EMACSCLIENT:-emacsclient' 'EMACSCLIENT:-${emacs}/bin/emacsclient'
   '';
 
-  configureFlags = [ "--zshcompletiondir=${placeholder "out"}/share/zsh/site-functions" ];
+  configureFlags = [
+    "--zshcompletiondir=${placeholder "out"}/share/zsh/site-functions"
+    "--infodir=${placeholder "info"}"
+  ] ++ optional (!withEmacs) "--without-emacs"
+    ++ optional (isNull ruby) "--without-ruby";
 
   # Notmuch doesn't use autoconf and consequently doesn't tag --bindir and
   # friends
   setOutputFlags = false;
   enableParallelBuilding = true;
   makeFlags = [ "V=1" ];
+
+
+  outputs = [ "out" "man" "info" ];
 
   preCheck = let
     test-database = fetchurl {
@@ -68,10 +81,10 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
   checkInputs = [
     which dtach openssl bash
-    gdb man
+    gdb man emacs
   ];
 
-  installTargets = [ "install" "install-man" ];
+  installTargets = [ "install" "install-man" "install-info" ];
 
   dontGzipMan = true; # already compressed
 


### PR DESCRIPTION
###### Motivation for this change

I realized today that installing `neomutt` installs `notmuch` which installs `emacs` which to me, using `neovim`, seems a bit wasteful :)

I extracted the optional dependencies and put them behind a few package options. Using this as an overlay on my system works, but would be happy to discuss everything, from formatting to defaults of the optional parameters to testing/touching other derivations depending on this one, ...

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
