### PR TITLE
nixos/local: deprecate provider

### DIFF
--- a/nixos/modules/config/locale.nix
+++ b/nixos/modules/config/locale.nix
@@ -64,6 +64,8 @@ in
         type = types.enum [ "manual" "geoclue2" ];
         default = "manual";
         description = ''
+          DEPRECATED: please set `services.geoclue2.enable = true;`
+
           The location provider to use for determining your location. If set to
           <literal>manual</literal> you must also provide latitude/longitude.
         '';
@@ -76,7 +78,11 @@ in
 
     environment.sessionVariables.TZDIR = "/etc/zoneinfo";
 
-    services.geoclue2.enable = mkIf (lcfg.provider == "geoclue2") true;
+    services.geoclue2.enable = mkIf (lcfg.provider == "geoclue2") (
+      lib.warn ''
+        Setting 'location.provider = "geoclue2";' is deprecated.
+        Please use 'services.geoclue2.enable = true;'
+      '' true);
 
     # This way services are restarted when tzdata changes.
     systemd.globalEnvironment.TZDIR = tzdir;


### PR DESCRIPTION
###### Motivation for this change
related: #83929 #83933

Instead of ensuring that two pieces of state are in sync (and causes infinite recursion). Just deprecate one of them.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
