### PR TITLE
Fix kernel configuration merge

### DIFF
--- a/lib/kernel.nix
+++ b/lib/kernel.nix
@@ -8,10 +8,10 @@ with lib;
   option = x:
       x // { optional = true; };
 
-  yes      = { tristate    = "y"; };
-  no       = { tristate    = "n"; };
-  module   = { tristate    = "m"; };
-  freeform = x: { freeform = x; };
+  yes      = { tristate    = "y"; optional = false; };
+  no       = { tristate    = "n"; optional = false; };
+  module   = { tristate    = "m"; optional = false; };
+  freeform = x: { freeform = x; optional = false; };
 
   /*
     Common patterns/legacy used in common-config/hardened-config.nix

--- a/nixos/modules/system/boot/kernel_config.nix
+++ b/nixos/modules/system/boot/kernel_config.nix
@@ -22,7 +22,7 @@ let
 
   mergeFalseByDefault = locs: defs:
     if defs == [] then abort "This case should never happen."
-    else if any (x: x == false) defs then false
+    else if any (x: x == false) (getValues defs) then false
     else true;
 
   kernelItem = types.submodule {
@@ -55,6 +55,7 @@ let
         default = false;
         description = ''
           Wether option should generate a failure when unused.
+          Upon merging values, mandatory wins over optional.
         '';
       };
     };
@@ -121,7 +122,7 @@ in
       type = types.attrsOf kernelItem;
       example = literalExample '' with lib.kernel; {
         "9P_NET" = yes;
-        USB = optional yes;
+        USB = option yes;
         MMC_BLOCK_MINORS = freeform "32";
       }'';
       description = ''

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -179,7 +179,6 @@ let
 
       # needed for ss
       INET_DIAG         = yes;
-      INET_TCP_DIAG     = option module;
       INET_UDP_DIAG     = module;
       INET_RAW_DIAG     = whenAtLeast "4.14" module;
       INET_DIAG_DESTROY = whenAtLeast "4.9" yes;

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -42,7 +42,7 @@ let
       TIMER_STATS               = whenOlder "4.11" yes;
       DEBUG_NX_TEST             = whenOlder "4.11" no;
       DEBUG_STACK_USAGE         = no;
-      DEBUG_STACKOVERFLOW       = mkIf (!features.grsecurity) no;
+      DEBUG_STACKOVERFLOW       = mkIf (!features.grsecurity) (option no);
       RCU_TORTURE_TEST          = no;
       SCHEDSTATS                = no;
       DETECT_HUNG_TASK          = yes;
@@ -179,7 +179,7 @@ let
 
       # needed for ss
       INET_DIAG         = yes;
-      INET_TCP_DIAG     = module;
+      INET_TCP_DIAG     = option module;
       INET_UDP_DIAG     = module;
       INET_RAW_DIAG     = whenAtLeast "4.14" module;
       INET_DIAG_DESTROY = whenAtLeast "4.9" yes;
@@ -337,7 +337,7 @@ let
       CIFS_STATS        = whenOlder "4.19" yes;
       CIFS_WEAK_PW_HASH = yes;
       CIFS_UPCALL       = yes;
-      CIFS_ACL          = yes;
+      CIFS_ACL          = option yes;
       CIFS_DFS_UPCALL   = yes;
       CIFS_SMB2         = whenOlder "4.13" yes;
 
@@ -368,7 +368,7 @@ let
       DEBUG_SET_MODULE_RONX            = { optional = true; tristate = whenOlder "4.11" "y"; };
       RANDOMIZE_BASE                   = option yes;
       STRICT_DEVMEM                    = option yes; # Filter access to /dev/mem
-      SECURITY_SELINUX_BOOTPARAM_VALUE = freeform "0"; # Disable SELinux by default
+      SECURITY_SELINUX_BOOTPARAM_VALUE = option (freeform "0"); # Disable SELinux by default
       # Prevent processes from ptracing non-children processes
       SECURITY_YAMA                    = option yes;
       DEVKMEM                          = mkIf (!features.grsecurity) no; # Disable /dev/kmem
@@ -676,7 +676,7 @@ let
       KEXEC_JUMP      = option yes;
 
       # Windows Logical Disk Manager (Dynamic Disk) support
-      LDM_PARTITION         = yes;
+      LDM_PARTITION         = option yes;
       LOGIRUMBLEPAD2_FF     = yes; # Logitech Rumblepad 2 force feedback
       LOGO                  = no; # not needed
       MEDIA_ATTACH          = yes;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -158,11 +158,8 @@ let
         ;
       }).config;
 
-      #
       structuredConfig = moduleStructuredConfig.settings;
     };
-
-
   }; # end of configfile derivation
 
   kernel = (callPackage ./manual-config.nix {}) {


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Fix https://github.com/NixOS/nixpkgs/issues/71803

Was a bit tougher than expected because I misunderstood how mkMerge worked. I thought using submodule would create the missing fields in attribute sets but it doesn't. 
The fix made apparent that some configuration entries in common-config.nix are unused.
As it may depend on kernel version, I marked the entries optional. It felt less likely to break builds than plainly removing them (but removing them could be the correct thing to do). 

I improved the tests and made them more readable.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
