### PR TITLE
rkdeveloptool: 1.3 -> unstable-2019-07-01

### DIFF
--- a/pkgs/misc/rkdeveloptool/default.nix
+++ b/pkgs/misc/rkdeveloptool/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "rkdeveloptool";
-  version = "1.3";
+  version = "unstable-2019-07-01";
 
   src = fetchFromGitHub {
     owner = "rockchip-linux";
     repo = "rkdeveloptool";
-    rev = "081d237ad5bf8f03170c9d60bd94ceefa0352aaf";
-    sha256 = "05hh7j3xgb8l1k1v2lis3nvlc0gp87ihzg6jci7m5lkkm5qgv3ji";
+    rev = "6e92ebcf8b1812da02663494a68972f956e490d3";
+    sha256 = "0zwrkqfxd671iy69v3q0844gfdpm1yk51i9qh2rqc969bd8glxga";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
ZHF: #80379 
https://hydra.nixos.org/build/115533412

Fixed build by bumping to latest upstream https://github.com/rockchip-linux/rkdeveloptool/commit/6e92ebcf8b1812da02663494a68972f956e490d3


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
