### PR TITLE
haskellPackages: mass unmark non-broken packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2684,7 +2684,6 @@ broken-packages:
   - adaptive-containers
   - adaptive-tuple
   - adb
-  - adblock2privoxy
   - adhoc-network
   - adict
   - adobe-swatch-exchange
@@ -2740,12 +2739,10 @@ broken-packages:
   - aivika-distributed
   - ajhc
   - AlanDeniseEricLauren
-  - alarmclock
   - alerta
   - alex-prelude
   - alfred
   - alga
-  - algebra-checkers
   - algebra-dag
   - algebra-sql
   - algebraic
@@ -2794,7 +2791,6 @@ broken-packages:
   - animate-frames
   - animate-preview
   - animate-sdl2
-  - anki-tools
   - annah
   - Annotations
   - anonymous-sums
@@ -2885,9 +2881,7 @@ broken-packages:
   - artery
   - artifact
   - asap
-  - ascetic
   - ascii
-  - ascii-cows
   - ascii-flatten
   - ascii-string
   - ascii-table
@@ -2985,7 +2979,6 @@ broken-packages:
   - aws-kinesis-client
   - aws-kinesis-reshard
   - aws-lambda
-  - aws-lambda-haskell-runtime
   - aws-mfa-credentials
   - aws-performance-tests
   - aws-route53
@@ -3025,7 +3018,6 @@ broken-packages:
   - bamstats
   - Bang
   - bank-holiday-usa
-  - bank-holidays-england
   - banwords
   - barchart
   - barcodes-code128
@@ -3034,7 +3026,6 @@ broken-packages:
   - barrie
   - barrier
   - barrier-monad
-  - base-compat-migrate
   - base-feature-macros
   - base-generics
   - base-io-access
@@ -3115,7 +3106,6 @@ broken-packages:
   - binary-search
   - binary-streams
   - binary-strict
-  - binary-tagged
   - binary-typed
   - bind-marshal
   - BinderAnn
@@ -3367,7 +3357,6 @@ broken-packages:
   - cabal-dependency-licenses
   - cabal-dev
   - cabal-dir
-  - cabal-file-th
   - cabal-ghc-dynflags
   - cabal-ghci
   - cabal-graphdeps
@@ -3386,7 +3375,6 @@ broken-packages:
   - cabal-sort
   - cabal-src
   - cabal-test
-  - cabal-toolkit
   - cabal-upload
   - cabal2arch
   - cabal2doap
@@ -3432,7 +3420,6 @@ broken-packages:
   - cao
   - cap
   - Capabilities
-  - capability
   - capnp
   - capped-list
   - capri
@@ -3446,7 +3433,6 @@ broken-packages:
   - carte
   - cartel
   - Cartesian
-  - cas-store
   - casa-abbreviations-and-acronyms
   - casadi-bindings
   - casadi-bindings-control
@@ -3512,7 +3498,6 @@ broken-packages:
   - cgrep
   - chalkboard
   - chalkboard-viewer
-  - character-cases
   - charade
   - chart-cli
   - Chart-fltkhs
@@ -3575,8 +3560,6 @@ broken-packages:
   - clarifai
   - CLASE
   - clash
-  - clash-ghc
-  - clash-lib
   - clash-multisignal
   - Clash-Royale-Hack-Cheats
   - clash-systemverilog
@@ -3601,7 +3584,6 @@ broken-packages:
   - clckwrks-theme-clckwrks
   - clckwrks-theme-geo-bootstrap
   - Clean
-  - clean-home
   - clean-unions
   - cless
   - clevercss
@@ -3663,7 +3645,6 @@ broken-packages:
   - codemonitor
   - codepad
   - codeworld-api
-  - codex
   - codo-notation
   - coin
   - coinbase-exchange
@@ -3746,7 +3727,6 @@ broken-packages:
   - concurrent-buffer
   - Concurrent-Cache
   - concurrent-machines
-  - concurrent-resource-map
   - concurrent-state
   - concurrent-utilities
   - Concurrential
@@ -3773,7 +3753,6 @@ broken-packages:
   - conferer-provider-dhall
   - conferer-provider-yaml
   - conferer-snap
-  - confetti
   - conffmt
   - confide
   - config-parser
@@ -3785,7 +3764,6 @@ broken-packages:
   - configuration
   - configuration-tools
   - configurator-ng
-  - configurator-pg
   - confsolve
   - congruence-relation
   - conjure
@@ -3875,7 +3853,6 @@ broken-packages:
   - cparsing
   - CPBrainfuck
   - cpio-conduit
-  - cpkg
   - CPL
   - cplusplus-th
   - cprng-aes-effect
@@ -4000,7 +3977,6 @@ broken-packages:
   - data-category
   - data-check
   - data-combinator-gen
-  - data-compat
   - data-concurrent-queue
   - data-construction
   - data-cycle
@@ -4023,8 +3999,6 @@ broken-packages:
   - data-lens-ixset
   - data-lens-template
   - data-map-multikey
-  - data-msgpack
-  - data-msgpack-types
   - data-nat
   - data-object
   - data-object-json
@@ -4138,7 +4112,6 @@ broken-packages:
   - dependent-monoidal-map
   - dependent-state
   - dependent-sum-aeson-orphans
-  - dependent-sum-template
   - depends
   - dephd
   - deptrack-core
@@ -4151,13 +4124,11 @@ broken-packages:
   - derive-gadt
   - derive-IG
   - derive-monoid
-  - derive-storable-plugin
   - derive-topdown
   - derive-trie
   - derp-lib
   - describe
   - descript-lang
-  - desert
   - deterministic-game-engine
   - detour-via-uom
   - deunicode
@@ -4192,7 +4163,6 @@ broken-packages:
   - diagrams-wx
   - dialogflow-fulfillment
   - dib
-  - dice
   - dice-entropy-conduit
   - dice2tex
   - dicom
@@ -4235,7 +4205,6 @@ broken-packages:
   - dirtree
   - discogs-haskell
   - discord-gateway
-  - discord-haskell
   - discord-hs
   - discord-rest
   - discord-types
@@ -4420,35 +4389,27 @@ broken-packages:
   - effect-monad
   - effect-stack
   - effin
-  - egison-pattern-src-th-mode
   - egison-quote
   - ehaskell
   - ehs
   - eibd-client-simple
   - eigen
   - Eight-Ball-Pool-Hack-Cheats
-  - either-list-functions
   - either-unwrap
   - EitherT
-  - ekg
   - ekg-bosun
   - ekg-carbon
-  - ekg-cloudwatch
   - ekg-elastic
   - ekg-elasticsearch
-  - ekg-influxdb
-  - ekg-json
   - ekg-log
   - ekg-push
   - ekg-rrd
-  - ekg-statsd
   - ekg-wai
   - elerea-examples
   - elevator
   - elision
   - elm-street
   - elm-websocket
-  - elsa
   - elynx-seq
   - elynx-tools
   - elynx-tree
@@ -4702,14 +4663,12 @@ broken-packages:
   - fibon
   - ficketed
   - fields
-  - fields-json
   - FieldTrip
   - fieldwise
   - fig
   - file-collection
   - file-command-qq
   - file-location
-  - file-modules
   - filediff
   - FileManip
   - FileManipCompat
@@ -4799,7 +4758,6 @@ broken-packages:
   - FModExRaw
   - fmt-for-rio
   - fn-extra
-  - Focus
   - foldl-incremental
   - foldl-statistics
   - foldl-transduce
@@ -5145,7 +5103,6 @@ broken-packages:
   - gli
   - glicko
   - glider-nlp
-  - glirc
   - GLMatrix
   - glob-posix
   - global
@@ -5165,10 +5122,6 @@ broken-packages:
   - gloss-sodium
   - glpk-hs
   - glue
-  - glue-common
-  - glue-core
-  - glue-ekg
-  - glue-example
   - GLUtil
   - gmap
   - gmndl
@@ -5225,8 +5178,6 @@ broken-packages:
   - gps2htmlReport
   - GPX
   - gpx-conduit
-  - grab
-  - grab-form
   - graceful
   - grafana
   - graflog
@@ -5300,11 +5251,9 @@ broken-packages:
   - gsl-random-fu
   - gstorable
   - gstreamer
-  - gt-tools
   - GTALib
   - gtfs
   - gtfs-realtime
-  - gtk-jsinput
   - gtk-serialized-event
   - gtk-toy
   - gtk2hs-hello
@@ -5404,7 +5353,6 @@ broken-packages:
   - hakyll-R
   - hakyll-series
   - hakyll-shortcode
-  - hakyll-shortcut-links
   - hakyll-typescript
   - hal
   - halberd
@@ -5492,8 +5440,6 @@ broken-packages:
   - harvest-api
   - has
   - has-th
-  - hasbolt
-  - hasbolt-extras
   - HasCacBDD
   - hascar
   - hascas
@@ -5515,7 +5461,6 @@ broken-packages:
   - haskarrow
   - haskbot-core
   - haskdeep
-  - haskdogs
   - haskeem
   - haskeline-class
   - haskelisp
@@ -5561,10 +5506,8 @@ broken-packages:
   - haskell-src-exts-prisms
   - haskell-src-exts-qq
   - haskell-src-exts-sc
-  - haskell-src-exts-simple
   - haskell-src-meta-mwotton
   - haskell-stack-trace-plugin
-  - haskell-to-elm
   - haskell-token-utils
   - haskell-tools-ast
   - haskell-tools-ast-fromghc
@@ -5683,7 +5626,6 @@ broken-packages:
   - haste-lib
   - haste-markup
   - haste-prim
-  - Hastodon
   - Hate
   - hatex-guide
   - HaTeX-meta
@@ -5760,7 +5702,6 @@ broken-packages:
   - HDRUtils
   - headed-megaparsec
   - headergen
-  - headroom
   - heapsort
   - heart-app
   - heart-core
@@ -5785,7 +5726,6 @@ broken-packages:
   - hedis-pile
   - hedis-simple
   - hedis-tags
-  - hedn
   - hedn-functor
   - hedra
   - hein
@@ -5997,7 +5937,6 @@ broken-packages:
   - hmumps
   - hnetcdf
   - hnix
-  - hnix-store-core
   - hnix-store-remote
   - HNM
   - hnormalise
@@ -6046,7 +5985,6 @@ broken-packages:
   - hoodle-types
   - hoogle-index
   - hooks-dir
-  - hookup
   - hoopl
   - hoovie
   - hopencc
@@ -6146,7 +6084,6 @@ broken-packages:
   - hs-re
   - hs-rs-notify
   - hs-scrape
-  - hs-server-starter
   - hs-snowtify
   - hs-twitter
   - hs-twitterarchiver
@@ -6155,7 +6092,6 @@ broken-packages:
   - hs2bf
   - Hs2lib
   - hs2ps
-  - hS3
   - hsaml2
   - hsay
   - hsbackup
@@ -6206,7 +6142,6 @@ broken-packages:
   - hsgnutls
   - hsgnutls-yj
   - hsgsom
-  - HSH
   - HsHaruPDF
   - HSHHelpers
   - HsHTSLib
@@ -6245,13 +6180,11 @@ broken-packages:
   - hspec-expectations-pretty
   - hspec-experimental
   - hspec-hashable
-  - hspec-hedgehog
   - hspec-jenkins
   - hspec-monad-control
   - hspec-pg-transact
   - hspec-setup
   - hspec-shouldbe
-  - hspec-snap
   - hspec-structured-formatter
   - hspec-test-sandbox
   - hspec-webdriver
@@ -6303,7 +6236,6 @@ broken-packages:
   - hsXenCtrl
   - hsyscall
   - hsyslog-tcp
-  - hsyslog-udp
   - hszephyr
   - HTab
   - hTalos
@@ -6347,7 +6279,6 @@ broken-packages:
   - http-response-decoder
   - http-server
   - http-shed
-  - http-trace
   - http-wget
   - http2-client
   - http2-client-exe
@@ -6460,7 +6391,6 @@ broken-packages:
   - identifiers
   - idiii
   - idna2008
-  - idringen
   - idris
   - IDynamic
   - ieee-utils
@@ -6557,7 +6487,6 @@ broken-packages:
   - InternedData
   - internetmarke
   - intero
-  - interp
   - interpol
   - interpolatedstring-qq
   - interpolatedstring-qq-mwotton
@@ -6642,7 +6571,6 @@ broken-packages:
   - ivy-web
   - ixdopp
   - ixmonad
-  - ixset-typed
   - ixshader
   - iyql
   - j2hs
@@ -6698,7 +6626,6 @@ broken-packages:
   - json-assertions
   - json-ast-json-encoder
   - json-ast-quickcheck
-  - json-autotype
   - json-b
   - json-builder
   - json-bytes-builder
@@ -6901,7 +6828,6 @@ broken-packages:
   - language-csharp
   - language-css
   - language-dart
-  - language-docker
   - language-dockerfile
   - language-ecmascript-analysis
   - language-eiffel
@@ -6942,7 +6868,6 @@ broken-packages:
   - latest-npm-version
   - latex-formulae-hakyll
   - latex-formulae-pandoc
-  - latex-live-snippets
   - LATS
   - launchdarkly-server-sdk
   - launchpad-control
@@ -6974,7 +6899,6 @@ broken-packages:
   - learn
   - learn-physics-examples
   - Learning
-  - learning-hmm
   - leetify
   - legion
   - legion-discovery
@@ -7009,7 +6933,6 @@ broken-packages:
   - lhe
   - lhs2TeX-hl
   - lhslatex
-  - libarchive
   - LibClang
   - libconfig
   - libcspm
@@ -7041,7 +6964,6 @@ broken-packages:
   - libxslt
   - licensor
   - lie
-  - life-sync
   - lifted-base-tf
   - lifted-protolude
   - lifted-stm
@@ -7143,8 +7065,6 @@ broken-packages:
   - lmonad-yesod
   - load-balancing
   - load-font
-  - loc
-  - loc-test
   - local-address
   - local-search
   - localize
@@ -7156,7 +7076,6 @@ broken-packages:
   - log-elasticsearch
   - log-postgres
   - log-utils
-  - log-warper
   - log2json
   - logentries
   - logger
@@ -7230,7 +7149,6 @@ broken-packages:
   - lxd-client
   - lye
   - Lykah
-  - lz4-bytes
   - lz4-conduit
   - lzma-enumerator
   - lzma-streams
@@ -7262,7 +7180,6 @@ broken-packages:
   - mahoro
   - maid
   - mail-pool
-  - mailbox-count
   - mailchimp
   - mailchimp-subscribe
   - MailchimpSimple
@@ -7322,7 +7239,6 @@ broken-packages:
   - math-metric
   - mathblog
   - mathflow
-  - mathista
   - mathlink
   - matrix-as-xyz
   - matrix-market
@@ -7339,7 +7255,6 @@ broken-packages:
   - MazesOfMonad
   - MBot
   - mbox-tools
-  - mbtiles
   - mbug
   - MC-Fold-DP
   - mcl
@@ -7427,7 +7342,6 @@ broken-packages:
   - miku
   - milena
   - mime-directory
-  - min-max-pqueue
   - minecraft-data
   - minesweeper
   - miniforth
@@ -7442,7 +7356,6 @@ broken-packages:
   - minst-idx
   - mios
   - mirror-tweet
-  - misfortune
   - miso-action-logger
   - miso-examples
   - miss
@@ -7495,7 +7408,6 @@ broken-packages:
   - monad-logger-syslog
   - monad-lrs
   - monad-mersenne-random
-  - monad-metrics
   - monad-metrics-extensible
   - monad-mock
   - monad-open
@@ -7557,7 +7469,6 @@ broken-packages:
   - monus
   - monzo
   - moo
-  - moonshine
   - morfette
   - morfeusz
   - morley
@@ -7624,7 +7535,6 @@ broken-packages:
   - multibase
   - multifocal
   - multihash
-  - multihash-cryptonite
   - multihash-serialise
   - multilinear
   - multilinear-io
@@ -7692,7 +7602,6 @@ broken-packages:
   - n-tuple
   - n2o-protocols
   - n2o-web
-  - nagios-perfdata
   - nagios-plugin-ekg
   - nakadi-client
   - named-lock
@@ -7725,7 +7634,6 @@ broken-packages:
   - needle
   - neet
   - nehe-tuts
-  - neil
   - neither
   - neko-lib
   - Neks
@@ -7774,7 +7682,6 @@ broken-packages:
   - network-hans
   - network-house
   - network-interfacerequest
-  - network-messagepack-rpc
   - network-messagepack-rpc-websocket
   - network-minihttp
   - network-msgpack-rpc
@@ -7824,7 +7731,6 @@ broken-packages:
   - nitro
   - nix-delegate
   - nix-deploy
-  - nix-diff
   - nix-eval
   - nix-freeze-tree
   - nix-tools
@@ -7993,7 +7899,6 @@ broken-packages:
   - ordrea
   - organize-imports
   - orgmode
-  - orgstat
   - origami
   - orizentic
   - OrPatterns
@@ -8010,7 +7915,6 @@ broken-packages:
   - OTP
   - otp-authenticator
   - ottparse-pretty
-  - outsort
   - overload
   - overloaded-records
   - overture
@@ -8101,13 +8005,10 @@ broken-packages:
   - parser-helper
   - parser241
   - parsergen
-  - parsers-megaparsec
   - parsestar
   - parsimony
-  - parsix
   - partage
   - partial-lens
-  - partial-order
   - partial-records
   - partial-semigroup
   - partial-semigroup-hedgehog
@@ -8199,7 +8100,6 @@ broken-packages:
   - persistent-redis
   - persistent-relational-record
   - persistent-template-classy
-  - persistent-typed-db
   - persistent-vector
   - persistent-zookeeper
   - persona
@@ -8218,7 +8118,6 @@ broken-packages:
   - phasechange
   - phaser
   - phoityne
-  - phoityne-vscode
   - phone-numbers
   - phone-push
   - phooey
@@ -8260,7 +8159,6 @@ broken-packages:
   - pipes-conduit
   - pipes-core
   - pipes-courier
-  - pipes-csv
   - pipes-errors
   - pipes-extra
   - pipes-files
@@ -8342,7 +8240,6 @@ broken-packages:
   - polysemy-RandomFu
   - polysemy-zoo
   - polyseq
-  - polysoup
   - polytypeable
   - polytypeable-utils
   - pomodoro
@@ -8648,17 +8545,12 @@ broken-packages:
   - random-derive
   - random-eff
   - random-effin
-  - random-extras
-  - random-fu
-  - random-fu-multivariate
   - random-hypergeometric
   - random-stream
   - RandomDotOrg
-  - Randometer
   - Range
   - range-space
   - rangemin
-  - rank-product
   - rank1dynamic
   - Ranka
   - rapid
@@ -8747,8 +8639,6 @@ broken-packages:
   - Referees
   - references
   - refh
-  - refined
-  - refined-http-api-data
   - reflection-extras
   - reflex
   - reflex-animation
@@ -8851,7 +8741,6 @@ broken-packages:
   - req-conduit
   - req-oauth2
   - req-url-extra
-  - reqcatcher
   - request-monad
   - require
   - reserve
@@ -8875,7 +8764,6 @@ broken-packages:
   - rest-types
   - rest-wai
   - restful-snap
-  - restless-git
   - restricted-workers
   - restyle
   - rethinkdb
@@ -8904,7 +8792,6 @@ broken-packages:
   - rib
   - ribbit
   - RichConditional
-  - richreports
   - ridley
   - ridley-extras
   - riemann
@@ -8990,7 +8877,6 @@ broken-packages:
   - rungekutta
   - runmany
   - runtime-arbitrary
-  - rvar
   - rws
   - RxHaskell
   - s-expression
@@ -9001,10 +8887,8 @@ broken-packages:
   - safe-failure-cme
   - safe-freeze
   - safe-globals
-  - safe-json
   - safe-lazy-io
   - safe-length
-  - safe-money-xmlbf
   - safe-plugins
   - safe-printf
   - safecopy-migrate
@@ -9170,7 +9054,6 @@ broken-packages:
   - servant-db-postgresql
   - servant-dhall
   - servant-ede
-  - servant-ekg
   - servant-errors
   - servant-examples
   - servant-exceptions
@@ -9204,15 +9087,12 @@ broken-packages:
   - servant-scotty
   - servant-server-namedargs
   - servant-smsc-ru
-  - servant-snap
   - servant-streaming
   - servant-streaming-client
   - servant-streaming-docs
   - servant-streaming-server
   - servant-swagger-tags
-  - servant-to-elm
   - servant-waargonaut
-  - servant-xml
   - servant-zeppelin
   - servant-zeppelin-client
   - servant-zeppelin-server
@@ -9221,7 +9101,6 @@ broken-packages:
   - serversession-backend-acid-state
   - serversession-backend-persistent
   - serversession-backend-redis
-  - serversession-frontend-snap
   - serversession-frontend-yesod
   - services
   - ses-html-snaplet
@@ -9232,7 +9111,6 @@ broken-packages:
   - set-of
   - set-with
   - setdown
-  - setgame
   - setoid
   - setters
   - sexp
@@ -9357,7 +9235,6 @@ broken-packages:
   - siphon
   - siren-json
   - sirkel
-  - sitepipe
   - sixfiguregroup
   - sized-grid
   - sized-types
@@ -9369,7 +9246,6 @@ broken-packages:
   - skeletons
   - skell
   - skemmtun
-  - skews
   - skulk
   - skylark-client
   - skylighting-lucid
@@ -9378,7 +9254,6 @@ broken-packages:
   - slack-notify-haskell
   - slack-web
   - slave-thread
-  - slice-cpp-gen
   - sliceofpy
   - slidemews
   - Slides
@@ -9441,7 +9316,6 @@ broken-packages:
   - snaplet-customauth
   - snaplet-environments
   - snaplet-fay
-  - snaplet-ghcjs
   - snaplet-hasql
   - snaplet-haxl
   - snaplet-hdbc
@@ -9486,7 +9360,6 @@ broken-packages:
   - snowflake-server
   - snowtify
   - Snusmumrik
-  - soap-openssl
   - SoccerFun
   - SoccerFunGL
   - socket-activation
@@ -9550,7 +9423,6 @@ broken-packages:
   - spiros
   - splay
   - splaytree
-  - spline3
   - splines
   - split-morphism
   - splitter
@@ -9609,7 +9481,6 @@ broken-packages:
   - stack-prism
   - stack-run
   - stack-run-auto
-  - stack-tag
   - stack-type
   - stack-wrapper
   - stack2cabal
@@ -9640,10 +9511,8 @@ broken-packages:
   - stateWriter
   - static-canvas
   - static-closure
-  - static-resources
   - static-tensor
   - static-text
-  - staticanalysis
   - statistics-dirichlet
   - statistics-fusion
   - statistics-hypergeometric-genvar
@@ -9851,7 +9720,6 @@ broken-packages:
   - tagsoup-parsec
   - tagsoup-selection
   - tagstream-conduit
-  - tai
   - tai64
   - takahashi
   - Takusen
@@ -9908,7 +9776,6 @@ broken-packages:
   - template-yj
   - templateify
   - templatepg
-  - tempo
   - tempodb
   - temporal-csound
   - tempus
@@ -9958,7 +9825,6 @@ broken-packages:
   - text-containers
   - text-format
   - text-format-heavy
-  - text-format-simple
   - text-generic-pretty
   - text-icu-normalized
   - text-lens
@@ -9970,7 +9836,6 @@ broken-packages:
   - text-plus
   - text-position
   - text-register-machine
-  - text-replace
   - text-time
   - text-trie
   - text-utf8
@@ -9990,7 +9855,6 @@ broken-packages:
   - th-dict-discovery
   - th-fold
   - th-format
-  - th-instance-reification
   - th-instances
   - th-kinds
   - th-kinds-fork
@@ -10011,7 +9875,6 @@ broken-packages:
   - Thingie
   - thorn
   - threadmanager
-  - threadscope
   - threepenny-editors
   - threepenny-gui-contextmenu
   - threepenny-gui-flexbox
@@ -10057,7 +9920,6 @@ broken-packages:
   - timeseries
   - timespan
   - timeutils
-  - timezone-olson-th
   - timezone-unix
   - tintin
   - tiny-scheduler
@@ -10159,17 +10021,6 @@ broken-packages:
   - treap
   - tree-monad
   - tree-render-text
-  - tree-sitter
-  - tree-sitter-go
-  - tree-sitter-haskell
-  - tree-sitter-java
-  - tree-sitter-json
-  - tree-sitter-php
-  - tree-sitter-python
-  - tree-sitter-ql
-  - tree-sitter-ruby
-  - tree-sitter-tsx
-  - tree-sitter-typescript
   - tree-traversals
   - TreeCounter
   - treemap-html
@@ -10268,7 +10119,6 @@ broken-packages:
   - type-tree
   - typeable-th
   - TypeClass
-  - typed-spreadsheet
   - typed-streams
   - typed-wire
   - typedflow
@@ -10329,7 +10179,6 @@ broken-packages:
   - uniquely-represented-sets
   - units-attoparsec
   - unittyped
-  - unity-testresult-parser
   - unitym-yesod
   - universal-binary
   - universe-th
@@ -10387,7 +10236,6 @@ broken-packages:
   - usb-id-database
   - usb-iteratee
   - usb-safe
-  - useragents
   - users-mysql-haskell
   - users-persistent
   - utc
@@ -10424,7 +10272,6 @@ broken-packages:
   - validate-input
   - validated-types
   - Validation
-  - validation-selective
   - validations
   - validationt
   - value-supply
@@ -10474,7 +10321,6 @@ broken-packages:
   - verifiable-expressions
   - verify
   - verilog
-  - verismith
   - versioning
   - versioning-servant
   - vflow-types
@@ -10550,7 +10396,6 @@ broken-packages:
   - wai-middleware-etag
   - wai-middleware-headers
   - wai-middleware-hmac-client
-  - wai-middleware-metrics
   - wai-middleware-preprocessor
   - wai-middleware-rollbar
   - wai-middleware-route
@@ -10592,7 +10437,6 @@ broken-packages:
   - weather-api
   - web-css
   - web-encodings
-  - web-fpco
   - web-inv-route
   - web-mongrel2
   - web-output
@@ -10641,7 +10485,6 @@ broken-packages:
   - whiskers
   - whitespace
   - whois
-  - wholepixels
   - why3
   - WikimediaParser
   - wikipedia4epub
@@ -10672,7 +10515,6 @@ broken-packages:
   - word2vec-model
   - WordAlignment
   - wordify
-  - wordlist
   - WordNet
   - WordNet-ghc74
   - wordpass
@@ -10699,7 +10541,6 @@ broken-packages:
   - wsdl
   - wsedit
   - wshterm
-  - wss-client
   - wtk
   - wtk-gtk
   - wu-wei
@@ -10766,9 +10607,6 @@ broken-packages:
   - xml-tydom-core
   - xml2json
   - xml2x
-  - xmlbf
-  - xmlbf-xeno
-  - xmlbf-xmlhtml
   - XmlHtmlWriter
   - xmltv
   - XMMS


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I checked through haskellPackages looking for packages that were
marked as broken, but successfully built.

I identified these 162 packages that were marked as broken in spite of
building successfully for me with NIXPKGS_ALLOW_BROKEN.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
