### PR TITLE
emacs: fix setup-hook

### DIFF
--- a/pkgs/build-support/emacs/setup-hook.sh
+++ b/pkgs/build-support/emacs/setup-hook.sh
@@ -1,15 +1,23 @@
+addToEmacsLoadPath() {
+  local lispDir="$1"
+  if [[ -d $lispDir && ${EMACSLOADPATH-} != *"$lispDir":* ]] ; then
+    # It turns out, that the trailing : is actually required
+    # see https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Search.html
+    export EMACSLOADPATH="$lispDir:${EMACSLOADPATH-}"
+  fi
+}
+
 addEmacsVars () {
+  addToEmacsLoadPath "$1/share/emacs/site-lisp"
+
+  # Add sub paths to the Emacs load path if it is a directory
+  # containing .el files. This is necessary to build some packages,
+  # e.g., using trivialBuild.
   for lispDir in \
-      "$1/share/emacs/site-lisp" \
       "$1/share/emacs/site-lisp/"* \
       "$1/share/emacs/site-lisp/elpa/"*; do
-    # Add the path to the Emacs load path if it is a directory
-    # containing .el files and it has not already been added to the
-    # load path.
-    if [[ -d $lispDir && "$(echo "$lispDir"/*.el)" && ${EMACSLOADPATH-} != *"$lispDir":* ]] ; then
-      # It turns out, that the trailing : is actually required
-      # see https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Search.html
-      export EMACSLOADPATH="$lispDir:${EMACSLOADPATH-}"
+    if [[ -d $lispDir && "$(echo "$lispDir"/*.el)" ]] ; then
+      addToEmacsLoadPath "$lispDir"
     fi
   done
 }


### PR DESCRIPTION
This change fixes byte compilation of, e.g., Helm without breaking builds using, e.g., `trivialBuild`.

See https://github.com/NixOS/nixpkgs/pull/82604#issuecomment-607201755