### PR TITLE
yadm: install from build directory instead of $src

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -87,6 +87,12 @@
     githubId = 178750;
     name = "Andreas Baldeau";
   };
+  abathur = {
+    email = "travis.a.everett+nixpkgs@gmail.com";
+    github = "abathur";
+    githubId = 2548365;
+    name = "Travis A. Everett";
+  };
   abbe = {
     email = "ashish.is@lostca.se";
     github = "wahjava";

--- a/pkgs/applications/version-management/yadm/default.nix
+++ b/pkgs/applications/version-management/yadm/default.nix
@@ -19,10 +19,10 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    install -Dt $out/bin $src/yadm
-    install -Dt $out/share/man/man1 $src/yadm.1
-    install -D $src/completion/yadm.zsh_completion $out/share/zsh/site-functions/_yadm
-    install -D $src/completion/yadm.bash_completion $out/share/bash-completion/completions/yadm.bash
+    install -Dt $out/bin yadm
+    install -Dt $out/share/man/man1 yadm.1
+    install -D completion/yadm.zsh_completion $out/share/zsh/site-functions/_yadm
+    install -D completion/yadm.bash_completion $out/share/bash-completion/completions/yadm.bash
     runHook postInstall
   '';
 
@@ -36,6 +36,7 @@ stdenv.mkDerivation {
       * Supplies a method of encrypting confidential data so it can safely be stored in your repository.
     '';
     license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ abathur ];
     platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Noticed while trying to use substituteInPlace from prePatch that my changes
weren't applying to the installed copy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

You can see this by adding something silly like:

```
prePatch = ''
  substituteInPlace yadm --replace "Tim Byrne" "Bim Tyrne"
'';
postInstall = "diff -u yadm $out/bin/yadm | head";
```

Which, in the build output, looks like:

```
building
Overwrote '/private/var/folders/8g/qgvf93_s1_b40dd8nhsvqk_m0000gn/T/nix-build-yadm-2.4.0.drv-0/source/yadm'
installing
--- yadm        2020-04-02 00:05:55.973420427 +0000
+++ /nix/store/czxzg7xd8hsnk4r1za7biiyvkb5wh28s-yadm-2.4.0/bin/yadm     2020-04-02 00:05:55.990144968 +0000
@@ -1,6 +1,6 @@
 #!/bin/sh
 # yadm - Yet Another Dotfiles Manager
-# Copyright (C) 2015-2020 Bim Tyrne
+# Copyright (C) 2015-2020 Tim Byrne
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
```