### PR TITLE
python3Packages.pdfminer: 20191020 -> 20200402

### DIFF
--- a/pkgs/development/python-modules/pdfminer_six/default.nix
+++ b/pkgs/development/python-modules/pdfminer_six/default.nix
@@ -1,19 +1,29 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, isPy3k, six, pycryptodome, chardet, nose, sortedcontainers }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy3k, pycryptodome, chardet, nose, sortedcontainers, fetchpatch }:
 
 buildPythonPackage rec {
   pname = "pdfminer_six";
-  version = "20191020";
+  version = "20200402";
+
+  disabled = !isPy3k;
 
   # No tests in PyPi Tarball
   src = fetchFromGitHub {
     owner = "pdfminer";
     repo = "pdfminer.six";
     rev = version;
-    sha256 = "1fqn4ilcscvw6ws9a1yqiprha9d3rgw3d0280clkbk6s4l26wm9h";
+    sha256 = "1wl64r3ifpwi7mm5pcxc0ji7w380nxcq3zrv66n95lglm4zqkf26";
   };
 
-  propagatedBuildInputs = [ six pycryptodome sortedcontainers ]
-    ++ stdenv.lib.optionals isPy3k [ chardet ];
+  patches = [
+    # Add shebang line to scripts. See: https://github.com/pdfminer/pdfminer.six/pull/408
+    (fetchpatch {
+      url = "https://github.com/pdfminer/pdfminer.six/commit/0c2f44b6de064d9a3cea99bde5b8e9c6a525a69c.patch";
+      sha256 = "1vml66grnvg4g26mya24kiyxsz809d4mr7wz8qmawjbn4ss65y21";
+      excludes = [ "CHANGELOG.md" ];
+    })
+  ];
+
+  propagatedBuildInputs = [ chardet pycryptodome sortedcontainers ];
 
   checkInputs = [ nose ];
   checkPhase = ''
@@ -21,8 +31,8 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "fork of PDFMiner using six for Python 2+3 compatibility";
-    homepage = https://github.com/pdfminer/pdfminer.six;
+    description = "PDF parser and analyzer";
+    homepage = "https://github.com/pdfminer/pdfminer.six";
     license = licenses.mit;
     maintainers = with maintainers; [ psyanticy marsam ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
