### PR TITLE
zulip: 4.0.0 -> 5.0.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zulip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zulip/default.nix
@@ -5,12 +5,12 @@
 
 let
   pname = "zulip";
-  version = "4.0.0";
+  version = "5.0.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/zulip/zulip-desktop/releases/download/v${version}/Zulip-${version}-x86_64.AppImage";
-    sha256 = "1pni02mb5bvwx3k45vd6ga269ghdl633gjklyslai24rrhp16h9z";
+    sha256 = "0qwlhkzb3lbzk3piyfx8nn827kcafrl3j1nxrn18f8px9gwasinz";
     name="${pname}-${version}.AppImage";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Zulip 5.0 fixes multiple security issues <https://blog.zulip.org/2020/04/01/zulip-desktop-5-0-0-security-release/>

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
