### PR TITLE
scala-runners: init at 0c0b369

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3771,6 +3771,12 @@
     githubId = 1436960;
     name = "Christoph Hrdinka";
   };
+  hrhino = {
+    email = "hora.rhino@gmail.com";
+    github = "hrhino";
+    githubId = 28076058;
+    name = "Harrison Houghton";
+  };
   hschaeidt = {
     email = "he.schaeidt@gmail.com";
     github = "hschaeidt";

--- a/pkgs/development/compilers/scala-runners/default.nix
+++ b/pkgs/development/compilers/scala-runners/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, jre, coursier }:
+
+let
+in stdenv.mkDerivation rec {
+  name = "scala-runners";
+
+  src = fetchFromGitHub {
+    repo = name;
+    owner = "dwijnand";
+    rev = "95e03c9f9de0fe0ab61eeb6dea2a364f9d081d31";
+    sha256 = "0mvlc6fxsh5d6gsyak9n3g98g4r061n8pir37jpiqb7z00m9lfrx";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+    sed -ie "s_\Wcs\W_ ${coursier}/bin/coursier _" scala-runner
+    cp scala-runner $out/lib
+    ln -s $out/lib/scala-runner $out/bin/scala
+    ln -s $out/lib/scala-runner $out/bin/scalac
+    ln -s $out/lib/scala-runner $out/bin/scalap
+    ln -s $out/lib/scala-runner $out/bin/scaladoc
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/dwijnand/scala-runners";
+    description = "An alternative implementation of the Scala distribution's runners";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ hrhino ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10851,6 +10851,10 @@ in
   scala_2_13 = callPackage ../development/compilers/scala/2.x.nix { majorVersion = "2.13"; jre = jdk8; };
 
   scala = scala_2_13;
+  scala-runners = callPackage ../development/compilers/scala-runners/default.nix {
+    coursier = callPackage ../development/tools/coursier { jre = jdk8; };
+    jre = jdk8;
+  };
 
   metal = callPackage ../development/libraries/metal { };
   metals = callPackage ../development/tools/metals { };


### PR DESCRIPTION
This is a script to run multiple versions of scala either by version number or build hash.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It's a good script and useful for testing with pre-release and non-current versions of Scala.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS <-- don't have one!
   - [ ] other Linux distributions <-- don't have any but can if you like
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) <-- manually tested this; coursier and jdk are the only upstreams
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) <-- Total closure size is 390.4Mb but almost all of that is openjdk and coursier
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
