### PR TITLE
cpython: Use optimizations, for a 25% speedup.

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -85,6 +85,9 @@ let
       # backported in debian since 2013.
       # https://bugs.python.org/issue13146
       ./atomic_pyc.patch
+
+      # Backport from CPython 3.8 of a good list of tests to run for PGO.
+      ./profile-task.patch
     ] ++ optionals (x11Support && stdenv.isDarwin) [
       ./use-correct-tcl-tk-on-darwin.patch
     ] ++ optionals stdenv.isLinux [
@@ -135,6 +138,7 @@ let
     '';
 
   configureFlags = [
+    "--enable-optimizations"
     "--enable-shared"
     "--with-threads"
     "--enable-unicode=ucs${toString ucsEncoding}"

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -100,6 +100,13 @@ let
       # libuuid, slowing down program startup a lot).
       ./no-ldconfig.patch
 
+      # Optimize symbol tables for the sake of dynamic linking.
+      # Significant for Python because of extension modules.
+      (fetchpatch {
+        url = "https://salsa.debian.org/cpython-team/python3/-/raw/27103a32e/debian/patches/link-opt.diff";
+        sha256 = "0vp36276ndbrwr7882vg7vjd61c8mv7bqgal6bbh2fimp6zlkdhv";
+      })
+
     ] ++ optionals stdenv.hostPlatform.isCygwin [
       ./2.5.2-ctypes-util-find_library.patch
       ./2.5.2-tkinter-x11.patch

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -12,6 +12,7 @@
 , zlib
 , self
 , configd, coreutils
+, autoreconfHook
 , python-setup-hook
 # Some proprietary libs assume UCS2 unicode, especially on darwin :(
 , ucsEncoding ? 4
@@ -186,8 +187,9 @@ let
     ++ optionals x11Support [ tcl tk xlibsWrapper libX11 ]
     ++ optional (stdenv.isDarwin && configd != null) configd;
   nativeBuildInputs =
-    optionals (stdenv.hostPlatform != stdenv.buildPlatform)
-    [ buildPackages.stdenv.cc buildPackages.python ];
+    [ autoreconfHook ]
+    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform)
+      [ buildPackages.stdenv.cc buildPackages.python ];
 
   mkPaths = paths: {
     C_INCLUDE_PATH = makeSearchPathOutput "dev" "include" paths;

--- a/pkgs/development/interpreters/python/cpython/2.7/profile-task.patch
+++ b/pkgs/development/interpreters/python/cpython/2.7/profile-task.patch
@@ -1,0 +1,21 @@
+Backport from CPython 3.8 of a good list of tests to run for PGO.
+
+Upstream commit:
+  https://github.com/python/cpython/commit/4e16a4a31
+
+Upstream discussion:
+  https://bugs.python.org/issue36044
+
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index 00fdd21ce..713dc1e53 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -259,7 +259,7 @@ TCLTK_LIBS=
+ # The task to run while instrumented when building the profile-opt target.
+ # We exclude unittests with -x that take a rediculious amount of time to
+ # run in the instrumented training build or do not provide much value.
+-PROFILE_TASK=-m test.regrtest --pgo -x test_asyncore test_gdb test_multiprocessing test_subprocess
++PROFILE_TASK=-m test.regrtest --pgo test_array test_base64 test_binascii test_binop test_bisect test_bytes test_bz2 test_cmath test_codecs test_collections test_complex test_dataclasses test_datetime test_decimal test_difflib test_embed test_float test_fstring test_functools test_generators test_hashlib test_heapq test_int test_itertools test_json test_long test_lzma test_math test_memoryview test_operator test_ordered_dict test_pickle test_pprint test_re test_set test_sqlite test_statistics test_struct test_tabnanny test_time test_unicode test_xml_etree test_xml_etree_c
+ 
+ # report files for gcov / lcov coverage report
+ COVERAGE_INFO= $(abs_builddir)/coverage.info

--- a/pkgs/development/interpreters/python/cpython/3.5/profile-task.patch
+++ b/pkgs/development/interpreters/python/cpython/3.5/profile-task.patch
@@ -1,0 +1,21 @@
+Backport from CPython 3.8 of a good list of tests to run for PGO.
+
+Upstream commit:
+  https://github.com/python/cpython/commit/4e16a4a31
+
+Upstream discussion:
+  https://bugs.python.org/issue36044
+
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index 00fdd21ce..713dc1e53 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -259,7 +259,7 @@ TCLTK_LIBS=
+ # The task to run while instrumented when building the profile-opt target.
+ # We exclude unittests with -x that take a rediculious amount of time to
+ # run in the instrumented training build or do not provide much value.
+-PROFILE_TASK=-m test.regrtest --pgo -x test_asyncore test_gdb test_multiprocessing_fork test_multiprocessing_forkserver test_multiprocessing_main_handling test_multiprocessing_spawn test_subprocess
++PROFILE_TASK=-m test.regrtest --pgo test_array test_base64 test_binascii test_binop test_bisect test_bytes test_bz2 test_cmath test_codecs test_collections test_complex test_dataclasses test_datetime test_decimal test_difflib test_embed test_float test_fstring test_functools test_generators test_hashlib test_heapq test_int test_itertools test_json test_long test_lzma test_math test_memoryview test_operator test_ordered_dict test_pickle test_pprint test_re test_set test_sqlite test_statistics test_struct test_tabnanny test_time test_unicode test_xml_etree test_xml_etree_c
+ 
+ # report files for gcov / lcov coverage report
+ COVERAGE_INFO= $(abs_builddir)/coverage.info

--- a/pkgs/development/interpreters/python/cpython/3.6/profile-task.patch
+++ b/pkgs/development/interpreters/python/cpython/3.6/profile-task.patch
@@ -1,0 +1,21 @@
+Backport from CPython 3.8 of a good list of tests to run for PGO.
+
+Upstream commit:
+  https://github.com/python/cpython/commit/4e16a4a31
+
+Upstream discussion:
+  https://bugs.python.org/issue36044
+
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index 00fdd21ce..713dc1e53 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -259,7 +259,7 @@ TCLTK_LIBS=
+ # The task to run while instrumented when building the profile-opt target.
+ # We exclude unittests with -x that take a rediculious amount of time to
+ # run in the instrumented training build or do not provide much value.
+-PROFILE_TASK=-m test.regrtest --pgo
++PROFILE_TASK=-m test.regrtest --pgo test_array test_base64 test_binascii test_binop test_bisect test_bytes test_bz2 test_cmath test_codecs test_collections test_complex test_dataclasses test_datetime test_decimal test_difflib test_embed test_float test_fstring test_functools test_generators test_hashlib test_heapq test_int test_itertools test_json test_long test_lzma test_math test_memoryview test_operator test_ordered_dict test_pickle test_pprint test_re test_set test_sqlite test_statistics test_struct test_tabnanny test_time test_unicode test_xml_etree test_xml_etree_c
+ 
+ # report files for gcov / lcov coverage report
+ COVERAGE_INFO= $(abs_builddir)/coverage.info

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -136,10 +136,12 @@ in with passthru; stdenv.mkDerivation {
 
   configureFlags = [
     "--enable-shared"
-    "--with-threads"
     "--without-ensurepip"
     "--with-system-expat"
     "--with-system-ffi"
+  ] ++ optionals (pythonOlder "3.7") [
+    # This is unconditionally true starting in CPython 3.7.
+    "--with-threads"
   ] ++ optionals (sqlite != null && isPy3k) [
     "--enable-loadable-sqlite-extensions"
   ] ++ optionals (openssl != null) [

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -97,6 +97,31 @@ in with passthru; stdenv.mkDerivation {
     # (since it will do a futile invocation of gcc (!) to find
     # libuuid, slowing down program startup a lot).
     (./. + "/${sourceVersion.major}.${sourceVersion.minor}/no-ldconfig.patch")
+  ] ++ optionals stdenv.isLinux [
+    # Optimize symbol tables for the sake of dynamic linking.
+    # Significant for Python because of extension modules.
+    (
+      if pythonAtLeast "3.8" then
+        fetchpatch {
+          url = "https://salsa.debian.org/cpython-team/python3/-/raw/3.8.3rc1-1/debian/patches/link-opt.diff";
+          sha256 = "0va85318nahnqgydwjs7723h8gx41inbdawdy6v4hiykzgc8s7vs";
+        }
+      else if isPy37 then
+        fetchurl {
+          url = "https://salsa.debian.org/cpython-team/python3/-/raw/3.7.6-1/debian/patches/link-opt.diff";
+          sha256 = "1aqvsc0p3sxnfsi8jz7537wl6v95v26ba4nflwvmn5lxlc3y3g13";
+        }
+      else if isPy36 then
+        fetchpatch {
+          url = "https://salsa.debian.org/cpython-team/python3/-/raw/3.6.8-1/debian/patches/link-opt.diff";
+          sha256 = "1nhdrgla75ily9gk7xx0crxa7ynqzks0djxk36sa3lgg5w8vjvyr";
+        }
+      else
+        fetchpatch {
+          url = "https://salsa.debian.org/cpython-team/python3/-/raw/27103a32e/debian/patches/link-opt.diff";
+          sha256 = "0vp36276ndbrwr7882vg7vjd61c8mv7bqgal6bbh2fimp6zlkdhv";
+        }
+    )
   ] ++ optionals (isPy35 || isPy36) [
     # Determinism: Write null timestamps when compiling python files.
     ./3.5/force_bytecode_determinism.patch

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -104,6 +104,14 @@ in with passthru; stdenv.mkDerivation {
   ] ++ optionals (isPy37 || isPy38) [
     # Fix darwin build https://bugs.python.org/issue34027
     ./3.7/darwin-libutil.patch
+  ] ++ optionals (pythonOlder "3.8") [
+    # Backport from CPython 3.8 of a good list of tests to run for PGO.
+    (
+      if isPy36 || isPy37 then
+        ./3.6/profile-task.patch
+      else
+        ./3.5/profile-task.patch
+    )
   ] ++ optionals (isPy3k && hasDistutilsCxxPatch) [
     # Fix for http://bugs.python.org/issue1222585
     # Upstream distutils is calling C compiler to compile C++ code, which
@@ -135,6 +143,7 @@ in with passthru; stdenv.mkDerivation {
   PYTHONHASHSEED=0;
 
   configureFlags = [
+    "--enable-optimizations"
     "--enable-shared"
     "--without-ensurepip"
     "--with-system-expat"

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -12,6 +12,7 @@
 , zlib
 , self
 , configd
+, autoreconfHook
 , python-setup-hook
 , nukeReferences
 # For the Python package set
@@ -51,6 +52,7 @@ let
   version = with sourceVersion; "${major}.${minor}.${patch}${suffix}";
 
   nativeBuildInputs = [
+    autoreconfHook
     nukeReferences
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     buildPackages.stdenv.cc


### PR DESCRIPTION
###### Motivation for this change

This PR adds two different kinds of flags to enable different optimizations in building the CPython interpreter.  One makes the resulting interpreter run about 16% faster, and the other makes it about 6% faster; the combined speedup is 25%.

---

One of the flags is `./configure --enable-optimizations`.  Upstream recommends this by having ./configure print a warning if omitted:

    If you want a release build with all stable optimizations active
    (PGO, etc), please run ./configure --enable-optimizations

We're doing a build to distribute to people for day-to-day use, doing things other than developing the Python interpreter.  So that's certainly a release build -- this means us.

And it turns out they aren't kidding!  Running upstream's own preferred benchmarking suite, [pyperformance](https://pyperformance.readthedocs.io/), before and after adding this flag finds a 16% speedup, as the median across the 60 benchmarks in the suite.

This one makes the Python build take somewhat longer, because PGO means first building an instrumented version, running that through some task to get a profile, then building again using the profile.

Fortunately in 2019 a good, short profile task was developed: it takes about 2min to run, and produces good results.  That appears upstream in 3.8, but it takes just a line to backport the same task (it's just a list of files in the test suite) to each older version, so we do that.  That keeps the effect on build time moderate, and well worthwhile for a 16% speedup to users' Python applications.

---

The two other flags are `-Wl,-O1 -Wl,-Bsymbolic-functions`, passed to the compiler at each linking step.  These cause the linker to get the flags `-O1 -Bsymbolic-functions`, and those turn on certain optimizations.  (Details in commit message.)

I learned about these flags from a close look at how Debian builds the Python interpreter.  Both have been used in every Debian and Ubuntu release since 2008; `-Wl,-O1` has been there even longer.  Adding them on top of `--enable-optimizations` gives an additional 6% median speedup.

---

Benchmark results for the combined changes: out of the 60 benchmarks in the suite, the median speedup is 25% (meaning 1.25x faster, taking 20% less time.)  The middle half range from 18% to 32% faster.  All get at least a little faster; two of them by less than 10%, and two of them by over 50%.

Those results are all for Python 3.7, as that's the default `python3`.  Python 3.9, 3.8, and 3.6 see similar, slightly smaller results, with median speedups of 22%, 22%, and 23% respectively.  All results are on my Linux desktop, with an Intel Core i7-8700K (Coffee Lake) CPU.

For numbers on each individual benchmark in the suite, see:
  https://gist.github.com/gnprice/e218f23d97e19a9dd1a15fe27bc61b5f


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
     - [x] python39
     - [x] python38
     - [x] python37
     - [x] python36
     - [x] python35
     - [x] python27
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
