### PR TITLE
ocamlPackages.cppo: 1.6.5 → 1.6.6

### DIFF
--- a/pkgs/development/tools/ocaml/cppo/default.nix
+++ b/pkgs/development/tools/ocaml/cppo/default.nix
@@ -6,9 +6,14 @@ in
 assert stdenv.lib.versionAtLeast ocaml.version "3.12";
 
 let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
+  if stdenv.lib.versionAtLeast ocaml.version "4.02" then
+   (if stdenv.lib.versionAtLeast ocaml.version "4.03" then {
+    version = "1.6.6";
+    sha256 = "1smcc0l6fh2n0y6bp96c69j5nw755jja99w0b206wx3yb2m4w2hs";
+   } else {
     version = "1.6.5";
     sha256 = "03c0amszy28shinvz61hm340jz446zz5763a1pdqlza36kwcj0p0";
+   }) // {
     buildInputs = [ dune ];
     extra = {
       inherit (dune) installPhase;


### PR DESCRIPTION
###### Motivation for this change

Update.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
