### PR TITLE
catcli: init at 0.5.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5741,6 +5741,12 @@
     githubId = 5515707;
     name = "Peter Romfeld";
   };
+  petersjt014 = {
+    email = "petersjt014@gmail.com";
+    github = "petersjt014";
+    githubId = 29493551;
+    name = "Josh Peters";
+  };
   peti = {
     email = "simons@cryp.to";
     github = "peti";

--- a/pkgs/tools/filesystems/catcli/default.nix
+++ b/pkgs/tools/filesystems/catcli/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, buildPythonApplication
+, docopt, anytree
+}:
+
+buildPythonApplication rec {
+
+  pname = "catcli";
+  version = "0.5.13";
+
+  src = fetchFromGitHub {
+    owner = "deadc0de6";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04mrkqmm2c8fhi1h1hddc4yh3dqhcvkmcwzhj0ggn34v7wavgb5i";
+  };
+
+  propagatedBuildInputs = [ docopt anytree ];
+
+  postPatch = '' patchShebangs . '';
+
+  meta = with stdenv.lib; {
+    description = "The command line catalog tool for your offline data";
+    homepage = "https://github.com/deadc0de6/catcli";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ petersjt014 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -830,6 +830,8 @@ in
 
   certigo = callPackage ../tools/admin/certigo { };
 
+  catcli = python3Packages.callPackage ../tools/filesystems/catcli { };
+
   chezmoi = callPackage ../tools/misc/chezmoi { };
 
   chipsec = callPackage ../tools/security/chipsec {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It's a neat tool.

###### Things done

Added the package, included tests found and done automatically by the `buildPythonApplication` function. Works with both x86-64 and i686. Aarch64 does not build with pkgsCross for reasons that I'm not sure of yet, but it does build natively.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).