### PR TITLE
plume: init at 0.4.0-alpha-4

### DIFF
--- a/pkgs/servers/plume/default.nix
+++ b/pkgs/servers/plume/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "plume";
-  version = "0.4.0-alpha-4";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "plume-org";
     repo = "plume";
     rev = version;
-    sha256 = "0ccf7ihpjg261r0znwaasrzakw3jwh5kw202px241bd2vqlf9cv5";
+    sha256 = "0bhl7r8ri0wd8q7vblxlfn3lj7v78qcw2cn9nwad78jsa8y3xyl5";
   };
 
-  cargoSha256 = "1xdnmcvga048av7xfvvgd646q958kl1cw2a7i4m85gjvqq2mp96g";
+  cargoSha256 = "1cihgxsgchx8ihlmnzf62jd8wy4sf9vfmvijxz7fgh8wagnx7h6q";
 
   meta = with stdenv.lib; {
     description = "Serverless Information Tracker";

--- a/pkgs/servers/plume/default.nix
+++ b/pkgs/servers/plume/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, cmake
+, libzip
+, gnupg,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "plume";
+  version = "0.4.0-alpha-4";
+
+  src = fetchFromGitHub {
+    owner = "plume-org";
+    repo = "plume";
+    rev = version;
+    sha256 = "0ccf7ihpjg261r0znwaasrzakw3jwh5kw202px241bd2vqlf9cv5";
+  };
+
+  cargoSha256 = "1xdnmcvga048av7xfvvgd646q958kl1cw2a7i4m85gjvqq2mp96g";
+
+  meta = with stdenv.lib; {
+    description = "Serverless Information Tracker";
+    homepage = "https://joinplu.me";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/servers/plume/default.nix
+++ b/pkgs/servers/plume/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "plume";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "plume-org";
     repo = "plume";
     rev = version;
-    sha256 = "0bhl7r8ri0wd8q7vblxlfn3lj7v78qcw2cn9nwad78jsa8y3xyl5";
+    sha256 = "06y87h07q4ck7f5j1l9lybylr1y1vsrq7ffv8scnqgvqadw68qns";
   };
 
-  cargoSha256 = "1cihgxsgchx8ihlmnzf62jd8wy4sf9vfmvijxz7fgh8wagnx7h6q";
+  cargoSha256 = "14x7g93difzwp68phf5p4h5df12xn5cxaspf4j613n3v7s11fb8j";
 
   meta = with stdenv.lib; {
     description = "Serverless Information Tracker";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23972,6 +23972,8 @@ in
 
   plover = recurseIntoAttrs (libsForQt5.callPackage ../applications/misc/plover { });
 
+  plume = callPackage ../servers/plume { };
+
   plugin-torture = callPackage ../applications/audio/plugin-torture { };
 
   polar-bookshelf = callPackage ../applications/misc/polar-bookshelf { };


### PR DESCRIPTION
Part of #57754

Does not build yet, I don't know why.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
