### PR TITLE
wp-cli: 2.2.0 -> 2.4.0

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -1,10 +1,9 @@
 { stdenv, lib, fetchurl, writeText, php, makeWrapper }:
-
 let
-  version = "2.2.0";
+  version = "2.4.0";
 
   completion = fetchurl {
-    url    = "https://raw.githubusercontent.com/wp-cli/wp-cli/v${version}/utils/wp-completion.bash";
+    url = "https://raw.githubusercontent.com/wp-cli/wp-cli/v${version}/utils/wp-completion.bash";
     sha256 = "15d330x6d3fizrm6ckzmdknqg6wjlx5fr87bmkbd5s6a1ihs0g24";
   };
 
@@ -15,14 +14,14 @@ let
     [Phar]
     phar.readonly = Off
   '';
-
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "wp-cli";
   inherit version;
 
   src = fetchurl {
-    url    = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${pname}-${version}.phar";
-    sha256 = "0s03jbsjwvkcbyss6rvpgw867hiwvk5p4n1qznkghyzi94j8mvki";
+    url = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${pname}-${version}.phar";
+    sha256 = "0h5mjxrw4z3648v4wb4pvapz2a1mlmbszgggg4b7bvrrxn3cr78k";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -45,9 +44,9 @@ in stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A command line interface for WordPress";
-    homepage    = https://wp-cli.org;
-    license     = licenses.mit;
+    homepage = "https://wp-cli.org";
+    license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
-    platforms   = platforms.all;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

I have unfortunately had to try it out - it works.

Oh corona, come take me if it means I don't ever have to touch a single line of PHP in my life again....

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).