### PR TITLE
calibre: fix build of desktop items

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -113,6 +113,7 @@ mkDerivation rec {
   disallowedReferences = [ podofo.dev ];
 
   calibreDesktopItem = makeDesktopItem {
+    fileValidation = false; # fails before substitution
     name = "calibre-gui";
     desktopName = "calibre";
     exec = "@out@/bin/calibre --detach %F";
@@ -159,6 +160,7 @@ mkDerivation rec {
   };
 
   ebookEditDesktopItem = makeDesktopItem {
+    fileValidation = false; # fails before substitution
     name = "calibre-edit-book";
     desktopName = "Edit E-book";
     genericName = "E-book Editor";
@@ -171,6 +173,7 @@ mkDerivation rec {
   };
 
   ebookViewerDesktopItem = makeDesktopItem {
+    fileValidation = false; # fails before substitution
     name = "calibre-ebook-viewer";
     desktopName = "E-book Viewer";
     genericName = "E-book Viewer";


### PR DESCRIPTION
#### Motivation for this change

Broken by https://github.com/NixOS/nixpkgs/pull/75729 since the desktop
items are only valid after post-processing. There's probably multiple
better ways to do this, but I'm not a calibre maintainer and I just want
to get this unbroken as quickly as possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
