### PR TITLE
scallion: use openssl 1.0

### DIFF
--- a/pkgs/tools/security/scallion/default.nix
+++ b/pkgs/tools/security/scallion/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, mono, openssl, ocl-icd }:
+{ stdenv, fetchFromGitHub, makeWrapper, mono, openssl_1_0_2, ocl-icd }:
 
 stdenv.mkDerivation rec {
   version = "2.1";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share
     cp scallion/bin/Debug/* $out/share/
     makeWrapper ${mono}/bin/mono $out/bin/scallion \
-      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ openssl ocl-icd ]} \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ openssl_1_0_2 ocl-icd ]} \
       --add-flags $out/share/scallion.exe
   '';
 


### PR DESCRIPTION
it does not work with openssl 1.1 (upstream issue https://github.com/lachesis/scallion/issues/113)
