### PR TITLE
glxinfo: add eglinfo binary

### DIFF
--- a/pkgs/tools/graphics/glxinfo/default.nix
+++ b/pkgs/tools/graphics/glxinfo/default.nix
@@ -18,10 +18,11 @@ stdenv.mkDerivation rec {
     $CC src/xdemos/glxgears.c -o glxgears -lGL -lX11 -lm
     $CC src/egl/opengles2/es2_info.c -o es2_info -lEGL -lGLESv2 -lX11
     $CC src/egl/opengles2/es2gears.c src/egl/eglut/{eglut.c,eglut_x11.c} -o es2gears -Isrc/egl/eglut -lEGL -lGLESv2 -lX11 -lm
+    $CC src/egl/opengl/eglinfo.c -o eglinfo -lEGL -lGLESv2 -lX11
   ";
 
   installPhase = "
-    install -Dm 555 -t $out/bin glx{info,gears} es2{_info,gears}
+    install -Dm 555 -t $out/bin glx{info,gears} es2{_info,gears} eglinfo
   ";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
XWayland master did not work correctly for OpenGL, during the bug
discussion upstream asked for the output of eglinfo. Add eglinfo to the
glxinfo package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
