### PR TITLE
[20.03] nixos/moinmoin: fix maintainer reference

### DIFF
--- a/nixos/modules/services/web-apps/moinmoin.nix
+++ b/nixos/modules/services/web-apps/moinmoin.nix
@@ -299,5 +299,5 @@ in
     ])));
   };
 
-  meta.maintainers = with lib.maintainers; [ b42 ];
+  meta.maintainers = with lib.maintainers; [ mmilata ];
 }


### PR DESCRIPTION
Backport of #84103.

----

Due to a race condition in PR review the moinmoin module refers to my IRC nick which is not what is in maintainers.nix. cc @Infinisil 

##### Motivation for this change
```
02:31 <infinisil> > :p nixos.config.meta.maintainers
02:31 <nix-build> undefined variable 'b42' at /var/lib/nixbot/nixpkgs/master/repo/nixos/modules/services/web-apps/moinmoin.nix:302:46
```