### PR TITLE
nixos/languagetool-http: added services.languageToolHttp option

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1022,6 +1022,7 @@
   ./services/web-apps/lemmy.nix
   ./services/web-apps/invidious.nix
   ./services/web-apps/invoiceplane.nix
+  ./services/web-apps/languagetool.nix
   ./services/web-apps/limesurvey.nix
   ./services/web-apps/mastodon.nix
   ./services/web-apps/mattermost.nix

--- a/nixos/modules/services/web-apps/languagetool.nix
+++ b/nixos/modules/services/web-apps/languagetool.nix
@@ -63,13 +63,6 @@ in
         PrivateNetwork = !cfg.public;
         RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
       };
-      confinement = {
-        enable = true;
-        # besides the config argument, the config file can refer to other
-        # files in some keys, including arbitrary spellcheck dicrtionaries
-        # with the lang-xx-dictPath (eg: lang-tr-dictPath=/path/to/tr.dic)
-        fullUnit = true;
-      };
     };
     users.users.langtool = {
       isSystemUser = true;

--- a/nixos/modules/services/web-apps/languagetool.nix
+++ b/nixos/modules/services/web-apps/languagetool.nix
@@ -7,7 +7,7 @@ let
 in
 {
   options.services.languageToolHttp = {
-    enable = mkEnableOption "the LanguagTool http server";
+    enable = mkEnableOption "the LanguageTool http server";
     allowBrowserPluginAccess = mkEnableOption "access from the browser plugin";
     public = mkEnableOption ''
       access this server from anywhere, not only localhost.
@@ -16,7 +16,7 @@ in
     '';
     settings = mkOption {
       description = ''
-        Contents of the configuration file. ${confDoc}
+        Content of the configuration file. ${confDoc}
       '';
       inherit (format) type;
       default = { };

--- a/nixos/modules/services/web-apps/languagetool.nix
+++ b/nixos/modules/services/web-apps/languagetool.nix
@@ -50,8 +50,7 @@ in
       after = [ "network.target" ];
       description = "LanguageTool HTTP server";
       serviceConfig = {
-        User = "languagetool";
-        Group = "languagetool";
+        DynamicUser = true;
         Type = "simple";
         ExecStart = "${pkgs.languagetool}/bin/languagetool-http-server ${cli.toGNUCommandLineShell {} cfg.args}";
         PrivateTmp = true;
@@ -64,10 +63,5 @@ in
         RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
       };
     };
-    users.users.languagetool = {
-      isSystemUser = true;
-      group = "languagetool";
-    };
-    users.groups.languagetool = { };
   };
 }

--- a/nixos/modules/services/web-apps/languagetool.nix
+++ b/nixos/modules/services/web-apps/languagetool.nix
@@ -50,8 +50,8 @@ in
       after = [ "network.target" ];
       description = "LanguageTool HTTP server";
       serviceConfig = {
-        User = "langtool";
-        Group = "langtool";
+        User = "languagetool";
+        Group = "languagetool";
         Type = "simple";
         ExecStart = "${pkgs.languagetool}/bin/languagetool-http-server ${cli.toGNUCommandLineShell {} cfg.args}";
         PrivateTmp = true;
@@ -64,10 +64,10 @@ in
         RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
       };
     };
-    users.users.langtool = {
+    users.users.languagetool = {
       isSystemUser = true;
-      group = "langtool";
+      group = "languagetool";
     };
-    users.groups.langtool = { };
+    users.groups.languagetool = { };
   };
 }

--- a/nixos/modules/services/web-apps/languagetool.nix
+++ b/nixos/modules/services/web-apps/languagetool.nix
@@ -1,0 +1,50 @@
+{config, pkgs, lib, ...}:
+with lib;
+{
+  options.services.languageToolHttp = {
+    enable = mkEnableOption "the LanguagTool http server";
+    port = mkOption {
+      description = ''
+        The port which the LanguageTool server listen.
+      '';
+      type = types.port;
+      default = 8081;
+    };
+    address = mkOption{
+      description = ''
+        The address on which the server listen.
+      '';
+      default = "127.0.0.1";
+      type = types.str;
+    };
+    allowBrowserPluginAccess = mkEnableOption "access from the browser plugin";
+    args = mkOption {
+      description = ''
+        Arguments to be passed when starting the server.
+      '';
+      #TODO: GNU commandline type
+      type = with types;attrsOf (oneOf [ int str bool ]);
+      default = { };
+    };
+  };
+  
+  config = 
+    let
+      cfg = config.services.languageToolHttp;
+    in {
+      services.languageToolHttp.args = {
+        allow-origin = 
+        mkIf cfg.allowBrowserPluginAccess (mkDefault "*");
+        port = mkDefault cfg.port;
+      };
+      #TODO:socket activation
+      # systemd.sockets.languagetool-http = {
+      #   socketConfig.ListenStream = with cfg;["${address}:${toString port}"];
+      # };
+      systemd.services.languagetool-http = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig.ExecStart = 
+          "${pkgs.languagetool}/bin/languagetool-http-server ${cli.toGNUCommandLineShell {} cfg.args}";
+      };
+    };
+}

--- a/nixos/tests/langtool.nix
+++ b/nixos/tests/langtool.nix
@@ -1,0 +1,15 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+  {
+    name = "languagetool-http";
+    machine = {
+      services.languageToolHttp.enable = true;
+      environment.systemPackages = [ pkgs.curl ];
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_open_port(8081)
+      machine.succeed('curl -d "language=en-US" -d "text=a simple test" http://localhost:8081/v2/check')
+    '';
+  })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
