### PR TITLE
yuzu: init at 482

### DIFF
--- a/pkgs/misc/emulators/yuzu/default.nix
+++ b/pkgs/misc/emulators/yuzu/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub
+, cmake, pkgconfig, wrapQtAppsHook
+, boost173, catch2, fmt, lz4, nlohmann_json, rapidjson, zlib, zstd, SDL2
+, udev, libusb1, libzip, qtbase, qtwebengine, qttools, ffmpeg
+, libpulseaudio, libjack2, alsaLib, sndio, ecasound
+, useVulkan ? true, vulkan-loader, vulkan-headers
+}:
+
+stdenv.mkDerivation rec {
+  pname = "yuzu";
+  version = "482";
+
+  src = fetchFromGitHub {
+    owner = "yuzu-emu";
+    repo = "yuzu-mainline"; # They use a separate repo for mainline “branch”
+    rev = "mainline-0-${version}";
+    sha256 = "1bhkdbhj1dv33qv0np26gzsw65p4z88whjmd6bc7mh2b5lvrjwxm";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
+  buildInputs = [ qtbase qtwebengine qttools boost173 catch2 fmt lz4 nlohmann_json rapidjson zlib zstd SDL2 udev libusb1 libpulseaudio alsaLib sndio ecasound libjack2 libzip ffmpeg ]
+    ++ stdenv.lib.optionals useVulkan [ vulkan-loader vulkan-headers ];
+  cmakeFlags = [ "-DENABLE_QT_TRANSLATION=ON" "-DYUZU_USE_QT_WEB_ENGINE=ON" "-DUSE_DISCORD_PRESENCE=ON" ]
+    ++ stdenv.lib.optionals (!useVulkan) [ "-DENABLE_VULKAN=No" ];
+
+  # Trick the configure system. This prevents a check for submodule directories.
+  preConfigure = "rm .gitmodules";
+
+  # Fix vulkan detection
+  postFixup = stdenv.lib.optionals useVulkan ''
+    wrapProgram $out/bin/yuzu --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
+    wrapProgram $out/bin/yuzu-cmd --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://yuzu-emu.org";
+    description = "An experimental Nintendo Switch emulator written in C++";
+    license = with licenses; [
+      gpl2Plus
+      # Icons
+      cc-by-nd-30 cc0
+    ];
+    maintainers = with maintainers; [ ivar joshuafern ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28569,6 +28569,10 @@ in
 
   yaxg = callPackage ../tools/graphics/yaxg {};
 
+  yuzu = libsForQt5.callPackage ../misc/emulators/yuzu {
+    stdenv = gcc10Stdenv;
+  };
+
   zap = callPackage ../tools/networking/zap { };
 
   zigbee2mqtt = callPackage ../servers/zigbee2mqtt { };


### PR DESCRIPTION
###### Motivation for this change
This adds the yuzu-mainline package, a Nintendo Switch emulator.
~~The `DENABLE_VULKAN=No` CMake flag is used due to [this issue](https://github.com/yuzu-emu/yuzu/issues/3375).~~ EDIT: The issue is fixed, this is no longer required.
~~Libressl is included as its required for [this issue](https://github.com/yuzu-emu/yuzu/issues/2957).~~ EDIT: The issue is fixed, this is no longer required.

Closes #58176

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  