### PR TITLE
python3Packages.azure-storage: 0.20.3 -> 0.36.0

### DIFF
--- a/pkgs/development/python-modules/azure-storage/default.nix
+++ b/pkgs/development/python-modules/azure-storage/default.nix
@@ -10,20 +10,21 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.20.3";
+  version = "0.36.0";
   pname = "azure-storage";
 
   src = fetchPypi {
     inherit pname version;
-    extension = "zip";
-    sha256 = "06bmw6k2000kln5jwk5r9bgcalqbyvqirmdh9gq4s6nb4fv3c0jb";
+    sha256 = "0pyasfxkin6j8j00qmky7d9cvpxgis4fi9bscgclj6yrpvf14qpv";
   };
 
   propagatedBuildInputs = [ azure-common dateutil requests ]
                             ++ pkgs.lib.optionals (!isPy3k) [ futures ];
 
-  postInstall = ''
-    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+  postPatch = ''
+    rm azure_bdist_wheel.py
+    substituteInPlace setup.cfg \
+      --replace "azure-namespace-package = azure-nspkg" ""
   '';
 
   meta = with pkgs.lib; {


### PR DESCRIPTION
###### Motivation for this change
this package might be able to be dropped, it hasn't seen an update in 3 years, and has been split into the `azure-mgmt-storage*` packages.

However, it was bugging me that it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
