### PR TITLE
j2cli: fix missing dependency on setuptools

### DIFF
--- a/pkgs/development/python-modules/j2cli/default.nix
+++ b/pkgs/development/python-modules/j2cli/default.nix
@@ -4,6 +4,7 @@
 , nose
 , jinja2
 , pyyaml
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -16,7 +17,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ nose ];
-  propagatedBuildInputs = [ jinja2 pyyaml ];
+  propagatedBuildInputs = [ jinja2 pyyaml setuptools ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/kolypto/j2cli";

--- a/pkgs/development/python-modules/j2cli/default.nix
+++ b/pkgs/development/python-modules/j2cli/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, nose
 , jinja2
 , pyyaml
 , setuptools
@@ -16,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "6f6f643b3fa5c0f72fbe9f07e246f8e138052b9f689e14c7c64d582c59709ae4";
   };
 
-  checkInputs = [ nose ];
+  doCheck = false; # tests aren't installed thus aren't found, so skip
   propagatedBuildInputs = [ jinja2 pyyaml setuptools ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Was getting

```
...
    import pkg_resources
ImportError: No module named pkg_resources
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
