### PR TITLE
treewide: quoted urls for RFC45, only the rebuilds

### DIFF
--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://kakoune.org/;
+    homepage = "http://kakoune.org/";
     description = "A vim inspired text editor";
     license = licenses.publicDomain;
     maintainers = with maintainers; [ vrthra ];

--- a/pkgs/applications/networking/ipfs-migrator/default.nix
+++ b/pkgs/applications/networking/ipfs-migrator/default.nix
@@ -19,7 +19,7 @@ buildGoPackage {
 
   meta = with stdenv.lib; {
     description = "Migration tool for ipfs repositories";
-    homepage = https://ipfs.io/;
+    homepage = "https://ipfs.io/";
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ elitak ];

--- a/pkgs/applications/networking/ipfs-migrator/deps.nix
+++ b/pkgs/applications/networking/ipfs-migrator/deps.nix
@@ -3,7 +3,7 @@
     goPackagePath = "github.com/jbenet/goprocess";
     fetch = {
       type = "git";
-      url = https://github.com/jbenet/goprocess;
+      url = "https://github.com/jbenet/goprocess";
       rev = "b497e2f366b8624394fb2e89c10ab607bebdde0b";
       sha256 = "1lnvkzki7vnqn5c4m6bigk0k85haicmg27w903kwg30rdvblm82s";
     };
@@ -12,7 +12,7 @@
     goPackagePath = "github.com/jbenet/go-random";
     fetch = {
       type = "git";
-      url = https://github.com/jbenet/go-random;
+      url = "https://github.com/jbenet/go-random";
       rev = "384f606e91f542a98e779e652eed88051618f0f7";
       sha256 = "0gcshzl9n3apzc0jaxqrjsc038yfrzfyhpdqgbpcnajin83l2msa";
     };
@@ -21,7 +21,7 @@
     goPackagePath = "github.com/jbenet/go-random-files";
     fetch = {
       type = "git";
-      url = https://github.com/jbenet/go-random-files;
+      url = "https://github.com/jbenet/go-random-files";
       rev = "737479700b40b4b50e914e963ce8d9d44603e3c8";
       sha256 = "1klpdc4qkrfy31r7qh00fcz42blswzabmcnry9byd5adhszxj9bw";
     };
@@ -30,7 +30,7 @@
     goPackagePath = "github.com/hashicorp/golang-lru";
     fetch = {
       type = "git";
-      url = https://github.com/hashicorp/golang-lru;
+      url = "https://github.com/hashicorp/golang-lru";
       rev = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768";
       sha256 = "12k2cp2k615fjvfa5hyb9k2alian77wivds8s65diwshwv41939f";
     };

--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -137,7 +137,7 @@ mkDerivation {
   updateScript = import ./update.nix { inherit writeScript runtimeShell; };
 
   meta = with stdenv.lib; {
-    homepage = https://www.mendeley.com;
+    homepage = "https://www.mendeley.com";
     description = "A reference manager and academic social network";
     license = licenses.unfree;
     platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/data/fonts/iosevka/bin.nix
+++ b/pkgs/data/fonts/iosevka/bin.nix
@@ -15,7 +15,7 @@ in fetchzip {
   sha256 = "1dfm1888rii5kfmkxp5hnx8ycji57cbs5gazpgkxg1mnmn7i35wl";
 
   meta = with stdenv.lib; {
-    homepage = https://be5invis.github.io/Iosevka/;
+    homepage = "https://be5invis.github.io/Iosevka/";
     downloadPage = "https://github.com/be5invis/Iosevka/releases";
     description = ''
       Slender monospace sans-serif and slab-serif typeface inspired by Pragmata

--- a/pkgs/development/interpreters/clojurescript/lumo/default.nix
+++ b/pkgs/development/interpreters/clojurescript/lumo/default.nix
@@ -279,7 +279,7 @@ stdenv.mkDerivation {
       Thanks to V8's custom startup snapshots, Lumo starts up instantaneously,
       making it the fastest Clojure REPL in existence.
     '';
-    homepage = https://github.com/anmonteiro/lumo;
+    homepage = "https://github.com/anmonteiro/lumo";
     license = stdenv.lib.licenses.epl10;
     maintainers = [ stdenv.lib.maintainers.hlolli ];
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;

--- a/pkgs/development/tools/haskell/ihaskell/wrapper.nix
+++ b/pkgs/development/tools/haskell/ihaskell/wrapper.nix
@@ -9,7 +9,7 @@ let
   ihaskellSh = writeScriptBin "ihaskell-notebook" ''
     #! ${stdenv.shell}
     export GHC_PACKAGE_PATH="$(echo ${ihaskellEnv}/lib/*/package.conf.d| tr ' ' ':'):$GHC_PACKAGE_PATH"
-    export PATH="${stdenv.lib.makeBinPath ([ ihaskellEnv jupyter ])}\${PATH:+':'}$PATH"
+    export PATH="${stdenv.lib.makeBinPath ([ ihaskellEnv jupyter ])}''${PATH:+':'}$PATH
     ${ihaskellEnv}/bin/ihaskell install -l $(${ihaskellEnv}/bin/ghc --print-libdir) && ${jupyter}/bin/jupyter notebook
   '';
 in

--- a/pkgs/misc/documentation-highlighter/default.nix
+++ b/pkgs/misc/documentation-highlighter/default.nix
@@ -2,7 +2,7 @@
 runCommand "documentation-highlighter" {
   meta = {
     description = "Highlight.js sources for the Nix Ecosystem's documentation.";
-    homepage = https://highlightjs.org;
+    homepage = "https://highlightjs.org";
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.grahamc ];


### PR DESCRIPTION
###### Motivation for this change

This is part 2 of the RFC45 cleanup.  There is something peculiar about these particular packages that makes ofborg want to rebuild them after only adding some quotes.  So they were separated from the [main PR](https://github.com/NixOS/nixpkgs/pull/83909).