### PR TITLE
haskellPackages.idris: Fix build (new GHC 8.8 & old megaparsec 7)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -716,10 +716,19 @@ self: super: {
     '';
   });
 
-  # The standard libraries are compiled separately
-  idris = generateOptparseApplicativeCompletion "idris" (
-    doJailbreak (dontCheck super.idris)
-  );
+  # The standard libraries are compiled separately.
+  # The megaparsec-7 override is needed because https://github.com/idris-lang/Idris-dev/issues/4826 declares that
+  # idris1 has no plans to migrate to megaparsec-8.
+  # The idris-lang/Idris-dev#4808 patch is for GHC 8.8 compatibility, and can likely be removed with the next release.
+  idris = generateOptparseApplicativeCompletion "idris" (doJailbreak (dontCheck
+    (appendPatches
+      (super.idris.override { megaparsec = self.megaparsec_7_0_5; }) [
+        (pkgs.fetchpatch {
+          url = "https://github.com/idris-lang/Idris-dev/pull/4808.diff";
+          sha256 = "060ib1rczy34ip8xf3bv1pf28655f6s0bvvij19jhh5dpcr0pf71";
+          excludes = [ ".travis.yml" "Makefile" "appveyor.yml" ];
+        })
+      ])));
 
   # https://github.com/bos/math-functions/issues/25
   math-functions = dontCheck super.math-functions;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2387,6 +2387,7 @@ extra-packages:
   - inline-c-cpp < 0.2                  # required on GHC 8.0.x
   - lens-labels == 0.1.*                # required for proto-lens-descriptors
   - mainland-pretty == 0.6.2.*          # required for tensorflow-opgen-0.1.0.0
+  - megaparsec >= 7.0.4 && < 8          # required for idris: https://github.com/idris-lang/Idris-dev/issues/4826
   - mtl < 2.2                           # newer versions require transformers > 0.4.x, which we cannot provide in GHC 7.8.x
   - mtl-prelude < 2                     # required for to build postgrest on mtl 2.1.x platforms
   - network == 2.6.3.1                  # newer versions don't compile with GHC 7.4.x and below
@@ -6391,7 +6392,6 @@ broken-packages:
   - identifiers
   - idiii
   - idna2008
-  - idris
   - IDynamic
   - ieee-utils
   - iexcloud


### PR DESCRIPTION
###### Motivation for this change
Make idris work.

(This is distinct from #53406, a previous time a megaparsec update broke idris.  That was about megaparsec 6→7.  This is about megaparsec 7→8.  Upstream project [has declared that it plans to stay on megaparsec 7 indefinitely](https://github.com/idris-lang/Idris-dev/issues/4826).)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@Infinisil