### PR TITLE
bluespec: unstable-2020.02.09 -> unstable-2020.04.03

### DIFF
--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -11,6 +11,10 @@
 , libpoly
 , perl
 , pkgconfig
+, itktcl
+, incrtcl
+, tcl
+, tk
 , verilog
 , xorg
 , zlib
@@ -23,16 +27,16 @@ let
   # Compiling PreludeBSV fails with more recent GHC versions
   # > imperative statement (not BVI context)
   # https://github.com/B-Lang-org/bsc/issues/20#issuecomment-583724030
-  ghcWithPackages = haskell.packages.ghc844.ghc.withPackages (g: (with g; [old-time regex-compat syb]));
+  ghcWithPackages = haskell.packages.ghc844.ghc.withPackages (g: (with g; [old-time regex-compat syb split]));
 in stdenv.mkDerivation rec {
   pname = "bluespec";
-  version = "unstable-2020.02.09";
+  version = "unstable-2020.04.03";
 
   src = fetchFromGitHub {
     owner  = "B-Lang-org";
     repo   = "bsc";
-    rev    = "05c8afb08078e437c635b9c708124b428ac51b3d";
-    sha256 = "06yhpkz7wga1a0p9031cfjqbzw7205bj2jxgdghhfzmllaiphniy";
+    rev    = "4c4509894388cd7a17fbd4fffab2f35572673539";
+    sha256 = "1m51hagbvqv5kglhik1123rkv3fj57ybqispx8i7xm73rmcayinv";
     fetchSubmodules = true;
   };
 
@@ -41,6 +45,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     zlib
     gmpStatic gperf libpoly # yices
+    tcl tk
     libX11 # tcltk
     xorg.libXft
     fontconfig
@@ -57,13 +62,7 @@ in stdenv.mkDerivation rec {
     verilog
   ];
 
-  patches = [
-    # drop stp support https://github.com/B-Lang-org/bsc/pull/31
-    (fetchpatch {
-      url = "https://github.com/flokli/bsc/commit/0bd48ecc2561541dc1368918863c0b2f4915006f.patch";
-      sha256 = "0bam9anld33zfi9d4gs502g94w49zhl5iqmbs2d1p5i19aqpy38l";
-    })
-  ];
+  NIX_LDFLAGS="-L${incrtcl}/lib -L${itktcl}/lib";
 
   preBuild = ''
     patchShebangs \
@@ -80,6 +79,7 @@ in stdenv.mkDerivation rec {
   makeFlags = [
     "NOGIT=1" # https://github.com/B-Lang-org/bsc/issues/12
     "LDCONFIG=ldconfig" # https://github.com/B-Lang-org/bsc/pull/43
+    "STP_STUB=1"
   ];
 
   installPhase = "mv inst $out";

--- a/pkgs/development/libraries/incrtcl/default.nix
+++ b/pkgs/development/libraries/incrtcl/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rmdir $out/bin
     mv $out/lib/itcl${version}/* $out/lib
+    ln -s libitcl${version}${stdenv.hostPlatform.extensions.sharedLibrary} \
+      $out/lib/libitcl${stdenv.lib.versions.major version}${stdenv.hostPlatform.extensions.sharedLibrary}
     rmdir $out/lib/itcl${version}
   '';
 

--- a/pkgs/development/libraries/itktcl/default.nix
+++ b/pkgs/development/libraries/itktcl/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rmdir $out/bin
     mv $out/lib/itk${version}/* $out/lib
+    ln -s libitk${version}${stdenv.hostPlatform.extensions.sharedLibrary} \
+      $out/lib/libitk${stdenv.lib.versions.major version}${stdenv.hostPlatform.extensions.sharedLibrary}
     rmdir $out/lib/itk${version}
   '';
 


### PR DESCRIPTION
This bumps bluespec to the latest version, which now doesn't use the
bundled tcl anymore (so we use the nixpkgs-provided one).

STP can also be easily stubbed away, by setting STP_STUB=1.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
