### PR TITLE
qmapshack: add gdal/routino tools to PATH

### DIFF
--- a/pkgs/applications/misc/qmapshack/default.nix
+++ b/pkgs/applications/misc/qmapshack/default.nix
@@ -29,6 +29,10 @@ mkDerivation rec {
     "${src}/FindQuaZip5.patch"
   ];
 
+  qtWrapperArgs = [
+    "--suffix PATH : ${lib.makeBinPath [ gdal routino ]}"
+  ];
+
   meta = with lib; {
     homepage = "https://github.com/Maproom/qmapshack";
     description = "Consumer grade GIS software";


### PR DESCRIPTION
###### Motivation for this change
Fixes runtime errors:
* `Unable to find Routino's planetslitter. Searched for "planetsplitter" and "routino-planetsplitter".`
* `No "gdal_translate" found. Please check setup!`

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
