### PR TITLE
nixos/postgresql: add statements option to replace the ensureDatabases and ensureUsers options

### DIFF
--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -335,13 +335,10 @@ in
 
     services.postgresql = optionalAttrs (usePostgresql && cfg.database.createDatabase) {
       enable = mkDefault true;
-
-      ensureDatabases = [ cfg.database.name ];
-      ensureUsers = [
-        { name = cfg.database.user;
-          ensurePermissions = { "DATABASE ${cfg.database.name}" = "ALL PRIVILEGES"; };
-        }
-      ];
+      statements = ''
+        select 'create role ${cfg.database.user}' where not exists (select from pg_roles where rolname = '${cfg.database.user}')\gexec
+        select 'create database ${cfg.database.name} owner ${cfg.database.user}' where not exists (select from pg_database where datname = '${cfg.database.name}')\gexec
+      '';
     };
 
     services.mysql = optionalAttrs (useMysql && cfg.database.createDatabase) {

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -616,28 +616,13 @@ in {
     # We use postgres as the main data store.
     services.postgresql = optionalAttrs databaseActuallyCreateLocally {
       enable = true;
-      ensureUsers = singleton { name = cfg.databaseUsername; };
+      statements = ''
+        select 'create user "${cfg.databaseUsername}"' where not exists (select from pg_roles where rolname = '${cfg.databaseUsername}')\gexec
+        select 'create database "${cfg.databaseName}" owner "${cfg.databaseUsername}"' where not exists (select from pg_database where datname = '${cfg.databaseName}')\gexec
+        \c '${cfg.databaseName}'
+        create extension if not exists pg_trgm
+      '';
     };
-    # The postgresql module doesn't currently support concepts like
-    # objects owners and extensions; for now we tack on what's needed
-    # here.
-    systemd.services.postgresql.postStart = mkAfter (optionalString databaseActuallyCreateLocally ''
-      set -eu
-
-      $PSQL -tAc "SELECT 1 FROM pg_database WHERE datname = '${cfg.databaseName}'" | grep -q 1 || $PSQL -tAc 'CREATE DATABASE "${cfg.databaseName}" OWNER "${cfg.databaseUsername}"'
-      current_owner=$($PSQL -tAc "SELECT pg_catalog.pg_get_userbyid(datdba) FROM pg_catalog.pg_database WHERE datname = '${cfg.databaseName}'")
-      if [[ "$current_owner" != "${cfg.databaseUsername}" ]]; then
-          $PSQL -tAc 'ALTER DATABASE "${cfg.databaseName}" OWNER TO "${cfg.databaseUsername}"'
-          if [[ -e "${config.services.postgresql.dataDir}/.reassigning_${cfg.databaseName}" ]]; then
-              echo "Reassigning ownership of database ${cfg.databaseName} to user ${cfg.databaseUsername} failed on last boot. Failing..."
-              exit 1
-          fi
-          touch "${config.services.postgresql.dataDir}/.reassigning_${cfg.databaseName}"
-          $PSQL "${cfg.databaseName}" -tAc "REASSIGN OWNED BY \"$current_owner\" TO \"${cfg.databaseUsername}\""
-          rm "${config.services.postgresql.dataDir}/.reassigning_${cfg.databaseName}"
-      fi
-      $PSQL '${cfg.databaseName}' -tAc "CREATE EXTENSION IF NOT EXISTS pg_trgm"
-    '');
 
     # Use postfix to send out mails.
     services.postfix.enable = mkDefault true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I have been ~~brainwashed~~ convinced in a reasonably fashion by @grahamc that the `ensure*` options aren't a good fit for NixOS. I'm seeking to remove these options from both the `mysql` and `postgresql` modules, but still leave other module authors who wish to provision databases with a reasonable way to do so. My plan for `postgresql` and `mysql` was as follows:
- remove the `ensureDatabases` and `ensureUsers` options
- add a `statements` (this is a horrible name, please someone come up with a better one) option which module authors (and NixOS users) can use to write idempotent sql statements which will be executed as the `mysql`/`postgresql` super admin user to do things like provision local accounts, databases, etc... (ie. replace the `ensureDatabases` and `ensureUsers` options with a new option that provides the same functionality, but with even more flexibility)
- replace all usage of `ensureDatabases` and `ensureUsers` in NixOS with the new `statements` option
- **strongly** caution NixOS users against carelessly using the `statements` option, very explicitly explaining how it leads to systems which aren't reproducible and why that is bad
- separate the execution of the sql in the `statements` option from the `postgresql`/`mysql` `systemd` service so a full restart of `postgresql`/`mysql` is not required every time someone alters `statements` (this step would be done in a separate PR immediately following the acceptance and merging of this PR)

I wrote some code for the `mysql` module to prove this idea works, and I was relatively happy with the results. Not being a `postgresql` guy myself, I decided I needed to prove this idea translated adequately into `postgresql`. I was surprised to learn `postgresql` doesn't provide a very convenient way to write idempotent statements for database and user creation like `mysql` does :scream: You can't write `create database if not exists`! I searched around and found what appears to be the "best" solution and adopted that method for this PR. For example, creating a database: `select 'create database nextcloud owner nextcloud' where not exists (select from pg_database where datname = 'nextcloud')\gexec`

You might ask **why should we get rid of the `ensure*` options?**
Aside from promoting systems which aren't reproducible, the `ensure*` options have a few other major problems with `postgresql`, mainly dealing with encoding and extensions (which @Ma27 ended up being the victim of, see the recent `matrix-synapse` fiasco for details on that :disappointed:). Currently all attempts to extend the `ensureDatabase` options have led to scenarios where a users `configuration.nix` could very easily not match the reality of what the database actually looks like. After investigating what it would take to make the `ensure*` options truly reproducible and actually enforce what they describe I came to the conclusion this is simply a bad idea because any database changes we might make can lead to data corruption and require a backup before making them - something we don't want to do every time the user does a rebuild.

I am very interested in feedback from `postgresql` users to see how they feel about this PR. I'm guessing that some of you will argue that users can simply add sql statements to the `.postStart` of the `postgresql` `systmed` unit - while I'm not completely opposed to that idea, I do see it as somewhat hacky, provides no documentation, and causes `postgresql` restarts with no easy and user-facing-api friendly way correct that.

**If you have the capacity to please take a few moments to consider this proposal and comment with your thoughts.** I'm very interested in improving the database ecosystem we have here, but will need to rely on the `postgresql` experts because I live in a `mysql` (`mariadb`) world.

Also note that this is a **draft** PR and the code is very sloppy proof of concept. I'll get around to cleaning it up after I get some feedback to see if I'm heading in the right direction here.

Thanks :tada:
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @flokli 