### PR TITLE
abseil-cpp: 20191119 -> 20200225.1

### DIFF
--- a/pkgs/development/libraries/abseil-cpp/default.nix
+++ b/pkgs/development/libraries/abseil-cpp/default.nix
@@ -2,23 +2,22 @@
 
 stdenv.mkDerivation rec {
   pname = "abseil-cpp";
-  date = "20191119";
-  rev = "8ba96a8244bbe334d09542e92d566673a65c1f78";
-  version = "${date}-${rev}";
+  version = "20200225.1";
 
   src = fetchFromGitHub {
     owner = "abseil";
     repo = "abseil-cpp";
-    rev = rev;
-    sha256 = "089bvlspgdgi40fham20qy1m97gr1jh5k5czz49dincpd18j6inb";
+    rev = version;
+    sha256 = "035bffayslawc19q2gmlkr6n6r7k7mvriaq7352rv6gyzaplr98w";
   };
 
   nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     description = "An open-source collection of C++ code designed to augment the C++ standard library";
-    homepage = https://abseil.io/;
+    homepage = "https://abseil.io/";
     license = licenses.asl20;
+    platforms = platforms.all;
     maintainers = [ maintainers.andersk ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
