### PR TITLE
mirage: init at 0.5.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mirage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mirage/default.nix
@@ -1,0 +1,57 @@
+{ lib, mkDerivation, fetchFromGitHub
+, qmake, pkgconfig, olm, wrapQtAppsHook
+, qtbase, qtquickcontrols2, qtkeychain, qtmultimedia, qttools, qtgraphicaleffects
+, python3Packages, pyotherside
+}:
+
+let
+  pypkgs = with python3Packages; [
+    aiofiles filetype matrix-nio appdirs cairosvg
+    pymediainfo setuptools html-sanitizer mistune blist
+    pyotherside
+  ];
+in
+mkDerivation rec {
+  pname = "mirage";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "mirukana";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15kcac92h82vina3rn08m35y71h7h76hkyys42sa95hxbl3gpi21";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig qmake wrapQtAppsHook python3Packages.wrapPython ];
+
+  buildInputs = [
+    qtbase qtmultimedia
+    qtquickcontrols2
+    qtkeychain qtgraphicaleffects
+    olm pyotherside
+  ];
+
+  propagatedBuildInputs = pypkgs;
+
+  pythonPath = pypkgs;
+
+  qmakeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  dontWrapQtApps = true;
+  postInstall = ''
+    buildPythonPath "$out $pythonPath"
+    wrapProgram $out/bin/mirage \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      "''${qtWrapperArgs[@]}"
+    '';
+
+  meta = with lib; {
+    description = "A fancy, customizable, keyboard-operable Qt/QML+Python Matrix chat client for encrypted and decentralized communication.";
+    homepage = "https://github.com/mirukana/mirage";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ colemickens ];
+    inherit (qtbase.meta) platforms;
+    inherit version;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/mirage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mirage/default.nix
@@ -13,13 +13,13 @@ let
 in
 mkDerivation rec {
   pname = "mirage";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "mirukana";
     repo = pname;
     rev = "v${version}";
-    sha256 = "15kcac92h82vina3rn08m35y71h7h76hkyys42sa95hxbl3gpi21";
+    sha256 = "0i891fafdncdz1xg6nji80jb86agsrbdvai9nwf1yy126q7piryv";
     fetchSubmodules = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1302,6 +1302,8 @@ in
 
   quaternion = libsForQt5.callPackage ../applications/networking/instant-messengers/quaternion { };
 
+  mirage-im = libsForQt5.callPackage ../applications/networking/instant-messengers/mirage {};
+
   tensor = libsForQt5.callPackage ../applications/networking/instant-messengers/tensor { };
 
   libtensorflow-bin = callPackage ../development/libraries/science/math/tensorflow/bin.nix {


### PR DESCRIPTION
###### Motivation for this change

Package new application `mirage` as attribute `mirage-im` (there's an existing alias, maybe I could remove it?).

This is a draft since the application doesn't work yet.

This fixes #84147.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
