### PR TITLE
obs-v4l2sink: init at unstable-20181012

### DIFF
--- a/pkgs/applications/video/obs-studio/0001-find-ObsPluginHelpers.cmake-in-the-obs-src.patch
+++ b/pkgs/applications/video/obs-studio/0001-find-ObsPluginHelpers.cmake-in-the-obs-src.patch
@@ -1,0 +1,25 @@
+From 5798a2691467604e89fd9fb1cd5289ebd1b1d7b8 Mon Sep 17 00:00:00 2001
+From: Graham Christensen <graham@grahamc.com>
+Date: Fri, 20 Mar 2020 22:32:02 -0400
+Subject: [PATCH] find ObsPluginHelpers.cmake in the obs src
+
+---
+ external/FindLibObs.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/external/FindLibObs.cmake b/external/FindLibObs.cmake
+index ab0a3de..53a46b8 100644
+--- a/external/FindLibObs.cmake
++++ b/external/FindLibObs.cmake
+@@ -95,7 +95,7 @@ if(LIBOBS_FOUND)
+ 
+ 	set(LIBOBS_INCLUDE_DIRS ${LIBOBS_INCLUDE_DIR} ${W32_PTHREADS_INCLUDE_DIR})
+ 	set(LIBOBS_LIBRARIES ${LIBOBS_LIB} ${W32_PTHREADS_LIB})
+-	include(${LIBOBS_INCLUDE_DIR}/../cmake/external/ObsPluginHelpers.cmake)
++	include(${OBS_SRC}/cmake/external/ObsPluginHelpers.cmake)
+ 
+ 	# allows external plugins to easily use/share common dependencies that are often included with libobs (such as FFmpeg)
+ 	if(NOT DEFINED INCLUDED_LIBOBS_CMAKE_MODULES)
+-- 
+2.25.0
+

--- a/pkgs/applications/video/obs-studio/v4l2sink.nix
+++ b/pkgs/applications/video/obs-studio/v4l2sink.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub
+, cmake, pkgconfig, wrapQtAppsHook
+, obs-studio }:
+
+stdenv.mkDerivation {
+  pname = "obs-v4l2sink-unstable";
+  version = "20181012";
+
+  src = fetchFromGitHub {
+    owner = "CatxFish";
+    repo = "obs-v4l2sink";
+    rev = "1ec3c8ada0e1040d867ce567f177be55cd278378";
+    sha256 = "03ah91cm1qz26k90mfx51l0d598i9bcmw39lkikjs1msm4c9dfxx";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
+  buildInputs = [ obs-studio ];
+
+  patches = [
+    ./0001-find-ObsPluginHelpers.cmake-in-the-obs-src.patch
+  ];
+
+  cmakeFlags = [
+    "-DLIBOBS_INCLUDE_DIR=${obs-studio}/include/obs"
+    "-DLIBOBS_LIBRARIES=${obs-studio}/lib"
+    "-DCMAKE_CXX_FLAGS=-I${obs-studio.src}/UI/obs-frontend-api"
+    "-DOBS_SRC=${obs-studio.src}"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/share/obs/obs-plugins/v4l2sink/bin/64bit
+    cp ./v4l2sink.so $out/share/obs/obs-plugins/v4l2sink/bin/64bit/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "obs studio output plugin for Video4Linux2 device";
+    homepage = "https://github.com/CatxFish/obs-v4l2sink";
+    maintainers = with maintainers; [ colemickens ];
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21226,6 +21226,8 @@ in
 
   obs-wlrobs = callPackage ../applications/video/obs-studio/wlrobs.nix { };
 
+  obs-v4l2sink = libsForQt5.callPackage ../applications/video/obs-studio/v4l2sink.nix { };
+
   obs-ndi = callPackage ../applications/video/obs-studio/obs-ndi.nix { };
 
   octoprint = callPackage ../applications/misc/octoprint { };


### PR DESCRIPTION
###### Motivation for this change

If I recall correctly I started this, couldn't get it built, @grahamc got it built, couldn't get it working.

I got it working. YUY2 format, exclusive_caps=1 with v4l2loopback. I flipped the video on hte OBS stage, but I think that Jitsi mirror your local video, so this is probably actually the wrong thing to do.

Here's a screenshot of my Sway desktop being captured in OBS-Studio (specifically, this build: https://github.com/obsproject/obs-studio/pull/2484) and then shown in a Jit.si Meet call.

![output](https://user-images.githubusercontent.com/327028/78315286-68b7ef00-7511-11ea-93cf-c4677034cace.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
