### PR TITLE
change howoldis link to status page link

### DIFF
--- a/doc/preface.chapter.md
+++ b/doc/preface.chapter.md
@@ -37,7 +37,7 @@ security updates. More up to date packages and modules are available via the
 
 Both `nixos-unstable` and `nixpkgs` follow the `master` branch of the Nixpkgs
 repository, although both do lag the `master` branch by generally
-[a couple of days](https://howoldis.herokuapp.com/). Updates to a channel are
+[a couple of days](https://status.nixos.org/). Updates to a channel are
 distributed as soon as all tests for that channel pass, e.g.
 [this table](https://hydra.nixos.org/job/nixpkgs/trunk/unstable#tabs-constituents)
 shows the status of tests for the `nixpkgs` channel.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Howoldis has been [shut down](https://github.com/madjar/howoldis/issues/40), with the author recommending status.nixos.org.