### PR TITLE
plymouth: attempt to make flicker-free

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -24,6 +24,7 @@ let
   configFile = writeText "plymouthd.conf" ''
     [Daemon]
     ShowDelay=0
+    DeviceTimeout=8
     Theme=${cfg.theme}
     ${cfg.extraConfig}
   '';

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -47,6 +47,14 @@ in
         '';
       };
 
+      font = mkOption {
+        default = "${pkgs.dejavu_fonts.minimal}/share/fonts/truetype/DejaVuSans.ttf";
+        type = types.path;
+        description = ''
+          Splash font label
+        '';
+      };
+
       theme = mkOption {
         default = "breeze";
         type = types.str;
@@ -113,8 +121,12 @@ in
 
       mkdir -p $out/lib/plymouth/renderers
       # module might come from a theme
-      cp ${themesEnv}/lib/plymouth/{text,details,$moduleName}.so $out/lib/plymouth
+      cp ${themesEnv}/lib/plymouth/{text,details,label-ft,$moduleName}.so $out/lib/plymouth
       cp ${plymouth}/lib/plymouth/renderers/{drm,frame-buffer}.so $out/lib/plymouth/renderers
+
+      # copy font
+      mkdir -p $out/share/plymouth
+      cp ${cfg.font} $out/share/plymouth/label.ttf
 
       mkdir -p $out/share/plymouth/themes
       cp ${plymouth}/share/plymouth/plymouthd.defaults $out/share/plymouth
@@ -154,6 +166,7 @@ in
       ln -s $extraUtils/share/plymouth/logo.png /etc/plymouth/logo.png
       ln -s $extraUtils/share/plymouth/themes /etc/plymouth/themes
       ln -s $extraUtils/lib/plymouth /etc/plymouth/plugins
+      ln -s $extraUtils/share/plymouth/label.ttf /etc/plymouth/label.ttf
 
       plymouthd --mode=boot --pid-file=/run/plymouth/pid --attach-to-session
       plymouth show-splash
@@ -161,6 +174,9 @@ in
 
     boot.initrd.postMountCommands = ''
       plymouth update-root-fs --new-root-dir="$targetRoot"
+
+      # not needed anymore
+      rm /etc/plymouth/label.ttf
     '';
 
     # `mkBefore` to ensure that any custom prompts would be visible.

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -9,18 +9,20 @@ let
   commonFunctions = ''
     prompt() {
         local name="$1"
-        printf "enter passphrase for $name: "
+        # printf "enter passphrase for $name: "
+        _prompt --text "enter passphrase for $name"
     }
     tryUnlock() {
         local name="$1"
         local path="$2"
         if bcachefs unlock -c $path > /dev/null 2> /dev/null; then    # test for encryption
             prompt $name
-            until bcachefs unlock $path 2> /dev/null; do              # repeat until sucessfully unlocked
-                printf "unlocking failed!\n"
+            until _read | bcachefs unlock $path 2> /dev/null; do              # repeat until sucessfully unlocked
+                # printf "unlocking failed!\n"
                 prompt $name
             done
-            printf "unlocking successful.\n"
+            # printf "unlocking successful.\n"
+            _prompt --text "unlocked $name successfully"
         fi
     }
   '';

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -418,7 +418,11 @@ in
             fi
             ${if isBool cfgZfs.requestEncryptionCredentials
               then optionalString cfgZfs.requestEncryptionCredentials ''
-                zfs load-key -a
+                while true; do
+                  _prompt --text "enter passphrase for '${pool}'"
+                  _read | zfs load-key "${pool}" && break
+                done
+                _prompt --text "unlocked '${pool}' successfully"
               ''
               else concatMapStrings (fs: ''
                 zfs load-key ${fs}

--- a/pkgs/os-specific/linux/plymouth/default.nix
+++ b/pkgs/os-specific/linux/plymouth/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, libxslt, docbook_xsl
-, gtk3, udev, systemd, lib
+{ lib, stdenv, fetchurl, autoreconfHook, pkgconfig, libxslt, docbook_xsl
+, gtk3, udev, systemd
 }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    autoreconfHook pkgconfig libxslt docbook_xsl
+    pkgconfig autoreconfHook
+    libxslt docbook_xsl
   ];
 
   buildInputs = [
@@ -28,35 +29,39 @@ stdenv.mkDerivation rec {
       configure.ac
   '';
 
+  configurePlatforms = [ "host" ];
+
   configureFlags = [
     "--sysconfdir=/etc"
-    "--with-systemdunitdir=${placeholder "out"}/etc/systemd/system"
     "--localstatedir=/var"
+    "--with-systemdunitdir=${placeholder "out"}/etc/systemd/system"
+
     "--with-logo=/etc/plymouth/logo.png"
+    "--with-release-file=/etc/os-release"
+
     "--with-background-color=0x000000"
     "--with-background-start-color-stop=0x000000"
     "--with-background-end-color-stop=0x000000"
-    "--with-release-file=/etc/os-release"
-    "--without-system-root-install"
+
     "--without-rhgb-compat-link"
-    "--enable-tracing"
-    "--enable-systemd-integration"
-    "--enable-pango"
-    "--enable-gdm-transition"
+    "--without-system-root-install"
+
     "--enable-gtk"
+    "--enable-pango"
+    "--enable-tracing"
+    "--enable-gdm-transition"
+    "--enable-systemd-integration"
     "ac_cv_path_SYSTEMD_ASK_PASSWORD_AGENT=${lib.getBin systemd}/bin/systemd-tty-ask-password-agent"
   ];
 
-  configurePlatforms = [ "host" ];
-
   installFlags = [
-    "plymouthd_defaultsdir=$(out)/share/plymouth"
     "plymouthd_confdir=$(out)/etc/plymouth"
+    "plymouthd_defaultsdir=$(out)/share/plymouth"
   ];
 
-  meta = with stdenv.lib; {
-    homepage = "http://www.freedesktop.org/wiki/Software/Plymouth";
-    description = "A graphical boot animation";
+  meta = with lib; {
+    homepage = "https://www.freedesktop.org/wiki/Software/Plymouth/";
+    description = "Boot splash and boot logger";
     license = licenses.gpl2;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/plymouth/v3-0001-ply-label-Don-t-crash-if-label-plugin-fails.patch
+++ b/pkgs/os-specific/linux/plymouth/v3-0001-ply-label-Don-t-crash-if-label-plugin-fails.patch
@@ -1,0 +1,35 @@
+From d0c6281f0a9ecf31931f6eb3e663ee9f7bca35da Mon Sep 17 00:00:00 2001
+From: Fabian Vogt <fvogt@suse.com>
+Date: Thu, 21 Jan 2016 10:39:21 +0100
+Subject: [PATCH v3 1/4] ply-label: Don't crash if label plugin fails
+
+The label plugin's create_control function can return NULL if allocation
+failed, for example, but ply-label.c ignores that and uses the NULL control,
+causing various SEGVs.
+---
+ src/libply-splash-graphics/ply-label.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/libply-splash-graphics/ply-label.c b/src/libply-splash-graphics/ply-label.c
+index cfc8098..836059c 100644
+--- a/src/libply-splash-graphics/ply-label.c
++++ b/src/libply-splash-graphics/ply-label.c
+@@ -125,6 +125,15 @@ ply_label_load_plugin (ply_label_t *label)
+ 
+         label->control = label->plugin_interface->create_control ();
+ 
++        if (label->control == NULL) {
++                ply_save_errno ();
++                label->plugin_interface = NULL;
++                ply_close_module (label->module_handle);
++                label->module_handle = NULL;
++                ply_restore_errno ();
++                return false;
++        }
++
+         if (label->text != NULL)
+                 label->plugin_interface->set_text_for_control (label->control,
+                                                                label->text);
+-- 
+2.11.0
+

--- a/pkgs/os-specific/linux/plymouth/v3-0002-Add-label-ft-plugin.patch
+++ b/pkgs/os-specific/linux/plymouth/v3-0002-Add-label-ft-plugin.patch
@@ -1,0 +1,607 @@
+From 278461754b7f0ae240e748415158d1ff2f3dd296 Mon Sep 17 00:00:00 2001
+From: Fabian Vogt <fvogt@suse.com>
+Date: Mon, 25 Jan 2016 08:58:03 +0100
+Subject: [PATCH v3 2/4] Add label-ft plugin
+
+This adds a FreeType-based label plugin with minimal dependencies.
+Is is a replacement for the label plugin, except that it lacks support for
+Unicode and different fonts families.
+It's purpose is to be included in the initrd, which isn't easily possible
+with the label plugin due to it's massive dependency list.
+---
+ configure.ac                              |  10 +
+ src/libply-splash-graphics/ply-label.c    |   5 +
+ src/plugins/controls/Makefile.am          |   6 +-
+ src/plugins/controls/label-ft/Makefile.am |  22 ++
+ src/plugins/controls/label-ft/plugin.c    | 490 ++++++++++++++++++++++++++++++
+ 5 files changed, 532 insertions(+), 1 deletion(-)
+ create mode 100644 src/plugins/controls/label-ft/Makefile.am
+ create mode 100644 src/plugins/controls/label-ft/plugin.c
+
+diff --git a/configure.ac b/configure.ac
+index d145c69..c67f376 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -69,6 +69,15 @@ if test x$enable_pango = xyes; then
+   AC_SUBST(PANGO_LIBS)
+ fi
+ 
++AC_ARG_ENABLE(freetype, AS_HELP_STRING([--enable-freetype],[enable building the FreeType-based label plugin]),enable_freetype=$enableval,enable_freetype=yes)
++AM_CONDITIONAL(ENABLE_FREETYPE,  [test "$enable_freetype" = yes])
++
++if test x$enable_freetype = xyes; then
++  PKG_CHECK_MODULES(FREETYPE, [freetype2])
++  AC_SUBST(FREETYPE_CFLAGS)
++  AC_SUBST(FREETYPE_LIBS)
++fi
++
+ AC_ARG_ENABLE(gtk, AS_HELP_STRING([--enable-gtk],[enable building with gtk, disabled there is no x11 renderer]),enable_gtk=$enableval,enable_gtk=yes)
+ AM_CONDITIONAL(ENABLE_GTK,  [test "$enable_gtk" = yes])
+ 
+@@ -304,6 +313,7 @@ AC_CONFIG_FILES([Makefile
+            src/plugins/splash/script/Makefile
+            src/plugins/controls/Makefile
+            src/plugins/controls/label/Makefile
++           src/plugins/controls/label-ft/Makefile
+            src/Makefile
+            src/client/ply-boot-client.pc
+            src/client/Makefile
+diff --git a/src/libply-splash-graphics/ply-label.c b/src/libply-splash-graphics/ply-label.c
+index 836059c..9de5916 100644
+--- a/src/libply-splash-graphics/ply-label.c
++++ b/src/libply-splash-graphics/ply-label.c
+@@ -96,8 +96,13 @@ ply_label_load_plugin (ply_label_t *label)
+ 
+         get_plugin_interface_function_t get_label_plugin_interface;
+ 
++        /* Try the pango/cairo based label plugin first... */
+         label->module_handle = ply_open_module (PLYMOUTH_PLUGIN_PATH "label.so");
+ 
++        /* ...and the FreeType based one after that, it is not a complete substitute (yet). */
++        if (label->module_handle == NULL)
++            label->module_handle = ply_open_module (PLYMOUTH_PLUGIN_PATH "label-ft.so");
++
+         if (label->module_handle == NULL)
+                 return false;
+ 
+diff --git a/src/plugins/controls/Makefile.am b/src/plugins/controls/Makefile.am
+index f1621f9..284b206 100644
+--- a/src/plugins/controls/Makefile.am
++++ b/src/plugins/controls/Makefile.am
+@@ -1,4 +1,8 @@
++SUBDIRS =
+ if ENABLE_PANGO
+-SUBDIRS = label
++SUBDIRS += label
++endif
++if ENABLE_FREETYPE
++SUBDIRS += label-ft
+ endif
+ MAINTAINERCLEANFILES = Makefile.in
+diff --git a/src/plugins/controls/label-ft/Makefile.am b/src/plugins/controls/label-ft/Makefile.am
+new file mode 100644
+index 0000000..2ff864d
+--- /dev/null
++++ b/src/plugins/controls/label-ft/Makefile.am
+@@ -0,0 +1,22 @@
++AM_CPPFLAGS = -I$(top_srcdir)                                                 \
++           -I$(srcdir)/../../../libply                                        \
++           -I$(srcdir)/../../../libply-splash-core                            \
++           -I$(srcdir)/../../../libply-splash-graphics                        \
++           -I$(srcdir)/../../..                                               \
++           -I$(srcdir)/../..                                                  \
++           -I$(srcdir)/..                                                     \
++           -I$(srcdir)
++
++plugindir = $(libdir)/plymouth
++plugin_LTLIBRARIES = label-ft.la
++
++label_ft_la_CFLAGS = $(PLYMOUTH_CFLAGS) $(FREETYPE_CFLAGS)
++
++label_ft_la_LDFLAGS = -module -avoid-version -export-dynamic
++label_ft_la_LIBADD = $(PLYMOUTH_LIBS) $(FREETYPE_LIBS)                           \
++                  ../../../libply/libply.la                                \
++                  ../../../libply-splash-core/libply-splash-core.la        \
++                  ../../../libply-splash-graphics/libply-splash-graphics.la
++label_ft_la_SOURCES = $(srcdir)/plugin.c
++
++MAINTAINERCLEANFILES = Makefile.in
+diff --git a/src/plugins/controls/label-ft/plugin.c b/src/plugins/controls/label-ft/plugin.c
+new file mode 100644
+index 0000000..7872d8b
+--- /dev/null
++++ b/src/plugins/controls/label-ft/plugin.c
+@@ -0,0 +1,490 @@
++/* label-ft.c - FreeType based label control
++ *
++ * Copyright (C) 2008 Red Hat, Inc.
++ * Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2, or (at your option)
++ * any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
++ * 02111-1307, USA.
++ *
++ * Written by: Ray Strode <rstrode@redhat.com>
++ * Written by: Fabian Vogt <fvogt@suse.com>
++ */
++#include "config.h"
++
++#include <stdio.h>
++#include <stdint.h>
++#include <string.h>
++#include <limits.h>
++
++#include <ft2build.h>
++#include FT_FREETYPE_H
++
++#include "ply-pixel-buffer.h"
++#include "ply-pixel-display.h"
++#include "ply-utils.h"
++
++#include "ply-label-plugin.h"
++
++/* This is used if fontconfig (fc-match) is not available, like in the initrd.
++ * Used in plymouth-populate-initrd.  */
++#define FONT_FALLBACK "/usr/share/plymouth/label.ttf"
++
++/* FreeType works with 26.6 grid units (1/64th of a pixel) */
++#define FT_GRID_TO_PX(x) ((x) >> 6)
++#define FT_PX_TO_GRID(x) ((x) << 6)
++
++struct _ply_label_plugin_control
++{
++        ply_pixel_display_t   *display;
++        ply_rectangle_t        area;
++
++        ply_label_alignment_t  alignment;
++        long                   width; /* For alignment */
++
++        FT_Library             library;
++        FT_Face                face;
++
++        char                  *text;
++        float                  red;
++        float                  green;
++        float                  blue;
++        float                  alpha;
++
++        bool                   is_hidden;
++};
++
++ply_label_plugin_interface_t *ply_label_plugin_get_interface (void);
++
++/* Query fontconfig, if available, for the default font. */
++static const char *
++query_fc_match ()
++{
++        FILE *fp;
++        static char fc_match_out[PATH_MAX];
++
++        fp = popen ("/usr/bin/fc-match -f %{file}", "r");
++        if (!fp)
++                return NULL;
++
++        fgets (fc_match_out, sizeof (fc_match_out), fp);
++
++        pclose (fp);
++
++        return fc_match_out;
++}
++
++static ply_label_plugin_control_t *
++create_control (void)
++{
++        FT_Error error;
++        ply_label_plugin_control_t *label;
++        const char                 *font_path;
++
++        label = calloc (1, sizeof (ply_label_plugin_control_t));
++        if (!label)
++                return NULL;
++
++        label->is_hidden = true;
++        label->width = -1;
++        label->text = NULL;
++
++        error = FT_Init_FreeType (&label->library);
++        if (error) {
++                free (label);
++                return NULL;
++        }
++
++        font_path = query_fc_match ();
++
++        if (font_path)
++                error = FT_New_Face (label->library, font_path, 0, &label->face);
++
++        if (!font_path || error) {
++                font_path = FONT_FALLBACK;
++                error = FT_New_Face (label->library, font_path, 0, &label->face);
++
++                if (error) {
++                    FT_Done_FreeType (label->library);
++                    free (label);
++                    return NULL;
++                }
++        }
++
++        /* 12pt/100dpi as default */
++        error = FT_Set_Char_Size (label->face, FT_PX_TO_GRID(12), 0, 100, 0);
++        if (error) {
++                FT_Done_Face (label->face);
++                FT_Done_FreeType (label->library);
++                free (label);
++                return NULL;
++        }
++
++        return label;
++}
++
++static void
++destroy_control (ply_label_plugin_control_t *label)
++{
++        if (label == NULL)
++                return;
++
++        free (label->text);
++        FT_Done_Face (label->face);
++        FT_Done_FreeType (label->library);
++
++        free (label);
++}
++
++static long
++get_width_of_control (ply_label_plugin_control_t *label)
++{
++        return label->area.width;
++}
++
++static long
++get_height_of_control (ply_label_plugin_control_t *label)
++{
++        return label->area.height;
++}
++
++static FT_Int
++width_of_line (ply_label_plugin_control_t *label,
++               const char                 *text)
++{
++        FT_Int width = 0;
++        FT_Int last_left = 0;
++
++        while (*text != '\0' && *text != '\n') {
++            if (FT_Load_Char (label->face, *text, FT_LOAD_RENDER))
++                continue;
++
++            width += FT_GRID_TO_PX(label->face->glyph->advance.x);
++            last_left = label->face->glyph->bitmap_left;
++
++            ++text;
++        }
++
++        return width + last_left;
++}
++
++static void
++size_control (ply_label_plugin_control_t *label)
++{
++        FT_Int      width;
++        const char *text = label->text;
++
++        if (label->is_hidden)
++                return;
++
++        label->area.width = 0;
++        label->area.height = 0;
++
++        /* Go through each line */
++        while (text && *text) {
++                width = width_of_line (label, text);
++                if ((uint32_t) width > label->area.width)
++                        label->area.width = width;
++
++                label->area.height += FT_GRID_TO_PX(label->face->size->metrics.ascender - label->face->size->metrics.descender);
++
++                text = strchr (text, '\n');
++        }
++
++        /* If centered, area.x is not the origin anymore */
++        if ((long) label->area.width < label->width)
++            label->area.width = label->width;
++}
++
++static void trigger_redraw (ply_label_plugin_control_t *label,
++                            bool                        adjust_size)
++{
++        ply_rectangle_t dirty_area = label->area;
++
++        if (label->is_hidden || label->display == NULL)
++                return;
++
++        if (adjust_size)
++                size_control (label);
++
++        ply_pixel_display_draw_area (label->display,
++                                     dirty_area.x, dirty_area.y,
++                                     dirty_area.width, dirty_area.height);
++}
++
++static void
++draw_bitmap (ply_label_plugin_control_t *label,
++             uint32_t                   *target,
++             ply_rectangle_t             target_size,
++             FT_Bitmap                  *source,
++             FT_Int                      x_start,
++             FT_Int                      y_start)
++{
++        FT_Int x, y, xs, ys;
++        FT_Int x_end = MIN (x_start + source->width, target_size.width);
++        FT_Int y_end = MIN (y_start + source->rows, target_size.height);
++
++        if ((uint32_t) x_start >= target_size.width || (uint32_t) y_start >= target_size.height)
++            return;
++
++        uint8_t rs, gs, bs, rd, gd, bd, ad;
++        rs = 255 * label->red;
++        gs = 255 * label->green;
++        bs = 255 * label->blue;
++
++        for (y = y_start, ys = 0; y < y_end; ++y, ++ys)
++                for (x = x_start, xs = 0; x < x_end; ++x, ++xs) {
++                        float alpha = label->alpha * (source->buffer[xs + source->pitch * ys] / 255.0f);
++                        float invalpha = 1.0f - alpha;
++                        uint32_t dest = target[x + target_size.width * y];
++
++                        /* Separate colors */
++                        rd = dest >> 16;
++                        gd = dest >> 8;
++                        bd = dest;
++
++                        /* Alpha blending */
++                        rd = invalpha * rd + alpha * rs;
++                        gd = invalpha * gd + alpha * gs;
++                        bd = invalpha * bd + alpha * bs;
++                        /* Semi-correct: Disregard the target alpha */
++                        ad = alpha * 255;
++
++                        target[x + target_size.width * y] = (ad << 24) | (rd << 16) | (gd << 8) | bd;
++                }
++}
++
++static void
++draw_control (ply_label_plugin_control_t *label,
++              ply_pixel_buffer_t         *pixel_buffer,
++              long                        x,
++              long                        y,
++              unsigned long               width,
++              unsigned long               height)
++{
++        FT_Error        error;
++        FT_Vector       pen;
++        FT_GlyphSlot    slot;
++        const char     *cur_c;
++        uint32_t       *target;
++        ply_rectangle_t target_size;
++
++        if (label->is_hidden)
++                return;
++
++        /* Check for overlap.
++           TODO: Don't redraw everything if only a part should be drawn! */
++        if (label->area.x > x + (long) width || label->area.y > y + (long) height
++            || label->area.x + (long) label->area.width < x
++            || label->area.y + (long) label->area.height < y)
++            return;
++
++        slot = label->face->glyph;
++
++        cur_c = label->text;
++
++        target = ply_pixel_buffer_get_argb32_data (pixel_buffer);
++        ply_pixel_buffer_get_size (pixel_buffer, &target_size);
++
++        if (target_size.height == 0)
++                return; /* This happens sometimes. */
++
++        pen.y = FT_PX_TO_GRID(label->area.y);
++
++        /* Make sure that the first row fits */
++        pen.y += label->face->size->metrics.ascender;
++
++        /* Go through each line */
++        while (*cur_c) {
++                pen.x = FT_PX_TO_GRID(label->area.x);
++
++                /* Start at start position (alignment) */
++                if (label->alignment == PLY_LABEL_ALIGN_CENTER)
++                    pen.x += FT_PX_TO_GRID(label->width - width_of_line (label, cur_c)) / 2;
++                else if (label->alignment == PLY_LABEL_ALIGN_RIGHT)
++                    pen.x += FT_PX_TO_GRID(label->width - width_of_line (label, cur_c));
++
++                while (*cur_c && *cur_c != '\n')
++                {
++                    /* TODO: Unicode support. */
++                    error = FT_Load_Char (label->face, *cur_c, FT_LOAD_RENDER | FT_LOAD_TARGET_LIGHT);
++                    if (error)
++                        continue;
++
++                    draw_bitmap (label, target, target_size, &slot->bitmap,
++                                FT_GRID_TO_PX(pen.x) + slot->bitmap_left,
++                                FT_GRID_TO_PX(pen.y) - slot->bitmap_top);
++
++                    pen.x += slot->advance.x;
++                    pen.y += slot->advance.y;
++
++                    ++cur_c;
++                }
++
++                /* Next line */
++                pen.y += label->face->size->metrics.height;
++        }
++}
++
++static void
++set_alignment_for_control (ply_label_plugin_control_t *label,
++                           ply_label_alignment_t       alignment)
++{
++        if (label->alignment != alignment) {
++                label->alignment = alignment;
++                trigger_redraw (label, true);
++        }
++}
++
++static void
++set_width_for_control (ply_label_plugin_control_t *label,
++                       long                        width)
++{
++        if (label->width != width) {
++                label->width = width;
++                trigger_redraw (label, true);
++        }
++}
++
++static void
++set_text_for_control (ply_label_plugin_control_t *label,
++                      const char                 *text)
++{
++        if (label->text != text) {
++                free (label->text);
++                label->text = strdup (text);
++                trigger_redraw (label, true);
++        }
++}
++
++static void
++set_font_for_control (ply_label_plugin_control_t *label,
++                      const char                 *fontdesc)
++{
++        /* Only able to set size */
++
++        char          *size_str_after;
++        const char    *size_str;
++        unsigned long  size;
++        bool           size_in_pixels;
++
++        size = 25; /* Default, if not set. */
++        size_in_pixels = false;
++
++        /* Format is "Family 1[,Family 2[,..]] [25[px]]" .
++           [] means optional. */
++        size_str = strrchr (fontdesc, ' ');
++
++        if (size_str) {
++            size = strtoul (size_str, &size_str_after, 10);
++            if (size_str_after == size_str)
++                size = 25; /* Not a number */
++            else if (strcmp (size_str_after, "px") == 0)
++                size_in_pixels = true;
++        }
++
++        if (size_in_pixels)
++                FT_Set_Pixel_Sizes (label->face, 0, size);
++        else
++                FT_Set_Char_Size (label->face, FT_PX_TO_GRID(size), 0, 100, 0);
++
++        /* Ignore errors, to keep the current size. */
++
++        trigger_redraw (label, true);
++}
++
++static void
++set_color_for_control (ply_label_plugin_control_t *label,
++                       float                       red,
++                       float                       green,
++                       float                       blue,
++                       float                       alpha)
++{
++        label->red = red;
++        label->green = green;
++        label->blue = blue;
++        label->alpha = alpha;
++
++        trigger_redraw (label, false);
++}
++
++static bool
++show_control (ply_label_plugin_control_t *label,
++              ply_pixel_display_t        *display,
++              long                        x,
++              long                        y)
++{
++        ply_rectangle_t dirty_area;
++
++        dirty_area = label->area;
++        label->display = display;
++        label->area.x = x;
++        label->area.y = y;
++
++        label->is_hidden = false;
++
++        size_control (label);
++
++        if (!label->is_hidden && label->display != NULL)
++                ply_pixel_display_draw_area (label->display,
++                                             dirty_area.x, dirty_area.y,
++                                             dirty_area.width, dirty_area.height);
++
++        label->is_hidden = false;
++
++        return true;
++}
++
++static void
++hide_control (ply_label_plugin_control_t *label)
++{
++        label->is_hidden = true;
++        if (label->display != NULL)
++                ply_pixel_display_draw_area (label->display,
++                                             label->area.x, label->area.y,
++                                             label->area.width, label->area.height);
++
++        label->display = NULL;
++}
++
++static bool
++is_control_hidden (ply_label_plugin_control_t *label)
++{
++        return label->is_hidden;
++}
++
++ply_label_plugin_interface_t *
++ply_label_plugin_get_interface (void)
++{
++        static ply_label_plugin_interface_t plugin_interface =
++        {
++                .create_control            = create_control,
++                .destroy_control           = destroy_control,
++                .show_control              = show_control,
++                .hide_control              = hide_control,
++                .draw_control              = draw_control,
++                .is_control_hidden         = is_control_hidden,
++                .set_text_for_control      = set_text_for_control,
++                .set_alignment_for_control = set_alignment_for_control,
++                .set_width_for_control     = set_width_for_control,
++                .set_font_for_control      = set_font_for_control,
++                .set_color_for_control     = set_color_for_control,
++                .get_width_of_control      = get_width_of_control,
++                .get_height_of_control     = get_height_of_control
++        };
++
++        return &plugin_interface;
++}
++
++/* vim: set ts=4 sw=4 expandtab autoindent cindent cino={.5s,(0: */
+-- 
+2.11.0
+

--- a/pkgs/os-specific/linux/plymouth/v3-0004-Add-HiDPI-support-to-label-ft-plugin.patch
+++ b/pkgs/os-specific/linux/plymouth/v3-0004-Add-HiDPI-support-to-label-ft-plugin.patch
@@ -1,0 +1,113 @@
+From 2932570460af0b47584cea2bde537476147d1f36 Mon Sep 17 00:00:00 2001
+From: Fabian Vogt <fvogt@suse.com>
+Date: Fri, 20 Jan 2017 14:02:30 +0100
+Subject: [PATCH v3 4/4] Add HiDPI support to label-ft plugin
+
+FreeType allows us to specify horizontal and vertical resolutions,
+so do just that.
+As we only know the scale factor in the drawing function, the current
+setting is saved to avoid unnecessary calls to FT_Set_Char_Size.
+---
+ src/plugins/controls/label-ft/plugin.c | 51 ++++++++++++++++++++++++++++------
+ 1 file changed, 42 insertions(+), 9 deletions(-)
+
+diff --git a/src/plugins/controls/label-ft/plugin.c b/src/plugins/controls/label-ft/plugin.c
+index 7872d8b..6d186e2 100644
+--- a/src/plugins/controls/label-ft/plugin.c
++++ b/src/plugins/controls/label-ft/plugin.c
+@@ -56,6 +56,11 @@ struct _ply_label_plugin_control
+         FT_Library             library;
+         FT_Face                face;
+ 
++        unsigned long          size;
++        /* If size is not in px, scaling for HiDPI is applied. */
++        bool                   size_in_px;
++        uint32_t               cur_scale;
++
+         char                  *text;
+         float                  red;
+         float                  green;
+@@ -85,6 +90,32 @@ query_fc_match ()
+         return fc_match_out;
+ }
+ 
++/* If size_in_px is false, this adjusts for DPI. */
++static bool
++set_font_size (ply_label_plugin_control_t *label,
++               unsigned long size,
++               bool size_in_px,
++               uint32_t scale)
++{
++        if (label->size == size && label->size_in_px == size_in_px && label->cur_scale == scale)
++                return true;
++
++        if (label->size_in_px) {
++                if (FT_Set_Pixel_Sizes (label->face, 0, size) != 0)
++                        return false;
++        }
++        else {
++                if (FT_Set_Char_Size (label->face, FT_PX_TO_GRID(size), 0, 100 * scale, 0) != 0)
++                        return false;
++        }
++
++        label->size = size;
++        label->size_in_px = size_in_px;
++        label->cur_scale = scale;
++
++        return true;
++}
++
+ static ply_label_plugin_control_t *
+ create_control (void)
+ {
+@@ -122,9 +153,8 @@ create_control (void)
+                 }
+         }
+ 
+-        /* 12pt/100dpi as default */
+-        error = FT_Set_Char_Size (label->face, FT_PX_TO_GRID(12), 0, 100, 0);
+-        if (error) {
++        /* 12pt as default */
++        if (!set_font_size (label, 12, false, 1)) {
+                 FT_Done_Face (label->face);
+                 FT_Done_FreeType (label->library);
+                 free (label);
+@@ -279,6 +309,7 @@ draw_control (ply_label_plugin_control_t *label,
+         const char     *cur_c;
+         uint32_t       *target;
+         ply_rectangle_t target_size;
++        uint32_t        scale;
+ 
+         if (label->is_hidden)
+                 return;
+@@ -290,6 +321,12 @@ draw_control (ply_label_plugin_control_t *label,
+             || label->area.y + (long) label->area.height < y)
+             return;
+ 
++        /* The display scale could have changed. */
++        scale = ply_pixel_buffer_get_device_scale (pixel_buffer);
++
++        /* This could fail, but it's better to draw with wrong scaling than not at all. */
++        set_font_size (label, label->size, label->size_in_px, scale);
++
+         slot = label->face->glyph;
+ 
+         cur_c = label->text;
+@@ -394,12 +431,8 @@ set_font_for_control (ply_label_plugin_control_t *label,
+                 size_in_pixels = true;
+         }
+ 
+-        if (size_in_pixels)
+-                FT_Set_Pixel_Sizes (label->face, 0, size);
+-        else
+-                FT_Set_Char_Size (label->face, FT_PX_TO_GRID(size), 0, 100, 0);
+-
+-        /* Ignore errors, to keep the current size. */
++        /* If this fails, the current size is kept */
++        set_font_size (label, size, size_in_pixels, label->cur_scale);
+ 
+         trigger_redraw (label, true);
+ }
+-- 
+2.11.0
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

If you rig up some plymouth prompts it should work fine for decryption and messages now. Patches are a big mess.

Not sure what's actually needed in stage-1 for this to run as early as possible.
###### Motivation for this change
label-ft: https://gitlab.freedesktop.org/plymouth/plymouth/-/merge_requests/91

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
