### PR TITLE
xonotic: use svg icons

### DIFF
--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -48,7 +48,7 @@ let
     exec = "$out/bin/xonotic";
     comment = meta.description;
     desktopName = "Xonotic";
-    categories = "Game;";
+    categories = "Game;Shooter;";
     icon = "xonotic";
     startupNotify = "false";
   };
@@ -84,7 +84,10 @@ let
     enableParallelBuilding = true;
 
     installPhase = ''
-      install -Dm644 ../../misc/logos/icons_png/xonotic_128.png $out/share/pixmaps/xonotic.png
+      for size in 16x16 24x24 32x32 48x48 64x64 72x72 96x96 128x128 192x192 256x256 512x512 1024x1024 scalable; do
+        install -Dm644 ../../misc/logos/xonotic_icon.svg \
+          $out/share/icons/hicolor/$size/xonotic.svg
+      done
     '' + lib.optionalString withDedicated ''
       install -Dm755 darkplaces-dedicated "$out/bin/xonotic-dedicated"
     '' + lib.optionalString withGLX ''
@@ -147,7 +150,7 @@ in rec {
     ln -sf $out/bin/xonotic-sdl $out/bin/xonotic
   '' + lib.optionalString (withSDL || withGLX) ''
     mkdir -p $out/share
-    ln -s ${xonotic-unwrapped}/share/pixmaps $out/share/pixmaps
+    ln -s ${xonotic-unwrapped}/share/icons $out/share/icons
     ${desktopItem.buildCommand}
   '' + ''
     for binary in $out/bin/xonotic-*; do


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

~~Add desktop entries to Xonotic.~~

Use SVG icons in Xonotic. (I first did a bit larger PR but most of it had already been done, so this minor suggestion was left.)

cc: maintainers @astsmtl @umazalakain 

By the way, `xonotic-glx` is failing on my machine:

```
Loading OpenGL driver libGL.so.1
Unable to open symbol list for libGL.so.1
Unable to load GL driver "libGL.so.1"
Desired video mode fail, trying fallbacks...
Loading OpenGL driver libGL.so.1
Unable to open symbol list for libGL.so.1
Unable to load GL driver "libGL.so.1"
Loading OpenGL driver libGL.so.1
Unable to open symbol list for libGL.so.1
Unable to load GL driver "libGL.so.1"
Loading OpenGL driver libGL.so.1
Unable to open symbol list for libGL.so.1
Unable to load GL driver "libGL.so.1"
Loading OpenGL driver libGL.so.1
Unable to open symbol list for libGL.so.1
Unable to load GL driver "libGL.so.1"
Loading OpenGL driver libGL.so.1
Unable to open symbol list for libGL.so.1
Unable to load GL driver "libGL.so.1"
Loading OpenGL driver libGL.so.1
Unable to open symbol list for libGL.so.1
Unable to load GL driver "libGL.so.1"
Quake Error: Video modes failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
