### PR TITLE
linuxPackages.nvidia_x11: 440.59 -> 440.64

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, fetchurl, stdenv }:
+{ lib, callPackage, fetchpatch, fetchurl, stdenv }:
 
 let
 
@@ -22,10 +22,25 @@ rec {
   # Policy: use the highest stable version as the default (on our master).
   stable = if stdenv.hostPlatform.system == "x86_64-linux"
     then generic {
-      version = "440.59";
-      sha256_64bit = "162gq6w44l8sgnn4qnl2rdlx8c008p04zv4c3i1ps20p21n1mjv1";
-      settingsSha256 = "0vxhmirqzyav5ljf0f04yk0az48ir5v0817dq9z9kyqfdvnby93g";
-      persistencedSha256 = "0npjh7nashasydp8q6bbcp21w8fc1dycgjy50ics775hjnvm61qn";
+      version = "440.64";
+      sha256_64bit = "0xbm1dh95kz8h4d62pql2wmvw2gbgc7iif2bkixbnqijl4dryg71";
+      settingsSha256 = "1vdir8a8cky4kmipqsbyjhjn0aqbwgzsxq73hafikrp5n4nbclfh";
+      persistencedSha256 = "0lcnila7xyl5r87c88sq2fn5k6ylmdf1bk2wcvm6aw5x6pmnrkgi";
+
+      patches = [
+        (fetchpatch {
+          url = "https://raw.githubusercontent.com/Frogging-Family/nvidia-all/master/patches/linux-version.diff";
+          sha256 = "0c7ildivgv0ncic43mlj92jn2pf5plw5nbw5minb8lp23glkfm84";
+          stripLen = 2;
+          extraPrefix = "kernel/";
+        })
+        (fetchpatch {
+          url = "https://raw.githubusercontent.com/Frogging-Family/nvidia-all/master/patches/kernel-5.6.patch";
+          sha256 = "1i0lj1jzwbpzd9vf424aylacwidqxa990qbi12jxxfvabbjq5fhi";
+          stripLen = 2;
+          extraPrefix = "kernel/";
+        })
+      ];
     }
     else legacy_390;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Unbreaks nvidia with kernel 5.6.x

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
