### PR TITLE
flat-remix-icon-theme: 20191122 -> 20200116

### DIFF
--- a/pkgs/data/icons/flat-remix-icon-theme/default.nix
+++ b/pkgs/data/icons/flat-remix-icon-theme/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec  {
   pname = "flat-remix-icon-theme";
-  version = "20191122";
+  version = "20200116";
 
   src = fetchFromGitHub  {
     owner = "daniruiz";
     repo = "flat-remix";
     rev = version;
-    sha256 = "1rv35r52l7xxjpajwli0md07k3xl7xplbw919vjmsb1hhrzavzzg";
+    sha256 = "14n5wydhd5ifmsbj770s2qg2ksd3xa3m61qxydid6jq39k0lxbd8";
   };
 
   nativeBuildInputs = [ gtk3 ];
@@ -32,4 +32,3 @@ stdenv.mkDerivation rec  {
     maintainers = with maintainers; [ mschneider ];
   };
 }
- 


### PR DESCRIPTION
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
