### PR TITLE
swaylock-effects: init at v1.6-0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2839,6 +2839,12 @@
     githubId = 12064730;
     name = "Alex Ivanov";
   };
+  gnxlxnxx = {
+    email = "gnxlxnxx@web.de";
+    github = "gnxlxnxx";
+    githubId = 25820499;
+    name = "Roman Kretschmer";
+  };
   goibhniu = {
     email = "cillian.deroiste@gmail.com";
     github = "cillianderoiste";

--- a/pkgs/applications/window-managers/sway/lock-effects.nix
+++ b/pkgs/applications/window-managers/sway/lock-effects.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub,
+  meson, ninja, pkgconfig, scdoc,
+  wayland, wayland-protocols, libxkbcommon,
+  cairo, gdk-pixbuf, pam
+}:
+
+stdenv.mkDerivation rec {
+  pname = "swaylock-effects";
+  version = "v1.6-0";
+
+  src = fetchFromGitHub {
+    owner = "mortie";
+    repo = "swaylock-effects";
+    rev = version;
+    sha256 = "15lshqq3qj9m3yfac65hjcciaf9zdfh3ir7hgh0ach7gpi3rbk13";
+
+  };
+
+  postPatch = ''
+    sed -iE "s/version: '1\.3',/version: '${version}',/" meson.build
+  '';
+
+  nativeBuildInputs = [ meson ninja pkgconfig scdoc ];
+  buildInputs = [ wayland wayland-protocols libxkbcommon cairo gdk-pixbuf pam ];
+
+  mesonFlags = [
+    "-Dpam=enabled" "-Dgdk-pixbuf=enabled" "-Dman-pages=enabled"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Screen locker for Wayland";
+    longDescription = ''
+      swaylock-effects is a screen locking utility for Wayland compositors.
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ gnxlxnxx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19923,6 +19923,8 @@ in
 
   swaylock-fancy = callPackage ../applications/window-managers/sway/lock-fancy.nix { };
 
+  swaylock-effects = callPackage ../applications/window-managers/sway/lock-effects.nix { };
+
   waybar = callPackage ../applications/misc/waybar {
     pulseSupport = config.pulseaudio or false;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
