### PR TITLE
[backport] haskell shellFor: Fix hoogle

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -315,10 +315,10 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
 
           in self.mkDerivation genericBuilderArgs;
 
-        envFuncArgs = builtins.removeAttrs args [ "packages" ];
-      in (combinedPackageFor packages).env.overrideAttrs (old: envFuncArgs // {
-        nativeBuildInputs = old.nativeBuildInputs ++ envFuncArgs.nativeBuildInputs or [];
-        buildInputs = old.buildInputs ++ envFuncArgs.buildInputs or [];
+        mkDerivationArgs = builtins.removeAttrs args [ "packages" "withHoogle" ];
+      in ((combinedPackageFor packages).envFunc { inherit withHoogle; }).overrideAttrs (old: mkDerivationArgs // {
+        nativeBuildInputs = old.nativeBuildInputs ++ mkDerivationArgs.nativeBuildInputs or [];
+        buildInputs = old.buildInputs ++ mkDerivationArgs.buildInputs or [];
       });
 
     ghc = ghc // {


### PR DESCRIPTION
(cherry picked from commit 1c07ee79255bb3fe8a7eb382cd5a8348e0b85893)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

backport of #80845 to fix #83783 in stable release-20.03 as well.

fixes #83783

###### Things done

- rebuilt my nix-shell environment based on this PR
- tested my code in the new environment
- observed that during build of the environment, a hoogle DB gets created
- successfully tried the `hoogle` command

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
