### PR TITLE
Update boost

### DIFF
--- a/pkgs/development/libraries/boost/1.72.nix
+++ b/pkgs/development/libraries/boost/1.72.nix
@@ -1,0 +1,16 @@
+{ stdenv, callPackage, fetchurl, fetchpatch, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.72.0";
+
+  src = fetchurl {
+    #url = "mirror://sourceforge/boost/boost_1_72_0.tar.bz2";
+    urls = [
+      "mirror://sourceforge/boost/boost_1_72_0.tar.bz2"
+      "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2"
+    ];
+    # SHA256 from http://www.boost.org/users/history/version_1_72_0.html
+    sha256 = "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722";
+  };
+})
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11177,7 +11177,7 @@ in
   boost170 = callPackage ../development/libraries/boost/1.70.nix { };
   boost171 = callPackage ../development/libraries/boost/1.71.nix { };
   boost172 = callPackage ../development/libraries/boost/1.72.nix { };
-  boost17x = boost171;
+  boost17x = boost172;
   boost = boost16x;
 
   boost_process = callPackage ../development/libraries/boost-process { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11176,6 +11176,7 @@ in
   boost16x = boost169;
   boost170 = callPackage ../development/libraries/boost/1.70.nix { };
   boost171 = callPackage ../development/libraries/boost/1.71.nix { };
+  boost172 = callPackage ../development/libraries/boost/1.72.nix { };
   boost17x = boost171;
   boost = boost16x;
 


### PR DESCRIPTION
###### Motivation for this change

Required for updating pulseeffects, which is what I'm working on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Of course, the second patch is to be discussed whether it should land on master or whether it should be moved to staging.