### PR TITLE
uhd: 3.14.0.0 -> 3.15.0.0

### DIFF
--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -4,7 +4,6 @@
 , cmake
 , pkgconfig
 , python
-, orc
 , libusb1
 , boost
 }:
@@ -49,7 +48,6 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     (python.withPackages (ps: with ps; [ Mako six requests ]))
-    orc
     libusb1
     boost
   ];

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -152,7 +152,7 @@ stdenv.mkDerivation rec {
       USRP devices are designed and sold by Ettus Research, LLC and its parent
       company, National Instruments.
     '';
-    homepage = https://uhd.ettus.com/;
+    homepage = "https://uhd.ettus.com/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor fpletz tomberek ];

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -1,5 +1,13 @@
-{ stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig
-, python, orc, libusb1, boost }:
+{ stdenv
+, fetchurl
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, python
+, orc
+, libusb1
+, boost
+}:
 
 # You need these udev rules to not have to run as root (copied from
 # ${uhd}/share/uhd/utils/uhd-usrp.rules):
@@ -27,13 +35,18 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # ABI differences GCC 7.1
-  # /nix/store/wd6r25miqbk9ia53pp669gn4wrg9n9cj-gcc-7.3.0/include/c++/7.3.0/bits/vector.tcc:394:7: note: parameter passing for argument of type 'std::vector<uhd::range_t>::iterator {aka __gnu_cxx::__normal_iterator<uhd::range_t*, std::vector<uhd::range_t> >}' changed in GCC 7.1
+  cmakeFlags = [
+    "-DLIBUSB_INCLUDE_DIRS=${libusb1.dev}/include/libusb-1.0"
+  ]
+    # ABI differences GCC 7.1
+    # /nix/store/wd6r25miqbk9ia53pp669gn4wrg9n9cj-gcc-7.3.0/include/c++/7.3.0/bits/vector.tcc:394:7: note: parameter passing for argument of type 'std::vector<uhd::range_t>::iterator {aka __gnu_cxx::__normal_iterator<uhd::range_t*, std::vector<uhd::range_t> >}' changed in GCC 7.1
+    ++ [ (stdenv.lib.optionalString stdenv.isAarch32 "-DCMAKE_CXX_FLAGS=-Wno-psabi") ]
+  ;
 
-  cmakeFlags = [ "-DLIBUSB_INCLUDE_DIRS=${libusb1.dev}/include/libusb-1.0"] ++
-               [ (stdenv.lib.optionalString stdenv.isAarch32 "-DCMAKE_CXX_FLAGS=-Wno-psabi") ];
-
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+  ];
   buildInputs = [
     (python.withPackages (ps: with ps; [ Mako six requests ]))
     orc

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -36,8 +36,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   cmakeFlags = [
-    "-DLIBUSB_INCLUDE_DIRS=${libusb1.dev}/include/libusb-1.0"
   ]
+    # TODO: Check if this still needed
     # ABI differences GCC 7.1
     # /nix/store/wd6r25miqbk9ia53pp669gn4wrg9n9cj-gcc-7.3.0/include/c++/7.3.0/bits/vector.tcc:394:7: note: parameter passing for argument of type 'std::vector<uhd::range_t>::iterator {aka __gnu_cxx::__normal_iterator<uhd::range_t*, std::vector<uhd::range_t> >}' changed in GCC 7.1
     ++ [ (stdenv.lib.optionalString stdenv.isAarch32 "-DCMAKE_CXX_FLAGS=-Wno-psabi") ]
@@ -56,6 +56,8 @@ stdenv.mkDerivation rec {
 
   # Build only the host software
   preConfigure = "cd host";
+  # TODO: Check if this still needed, perhaps relevant:
+  # https://files.ettus.com/manual_archive/v3.15.0.0/html/page_build_guide.html#build_instructions_unix_arm
   patches = if stdenv.isAarch32 then ./neon.patch else null;
 
   postPhases = [ "installFirmware" ];

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -3,9 +3,32 @@
 , fetchFromGitHub
 , cmake
 , pkgconfig
-, python
-, libusb1
+# See https://files.ettus.com/manual_archive/v3.15.0.0/html/page_build_guide.html for dependencies explanations
 , boost
+, enableLibuhd_C_api ? true
+# requires numpy
+, enableLibuhd_Python_api ? false
+, python ? null
+, enableExamples ? false
+, enableUtils ? false
+, enableLiberio ? false
+, liberio ? null
+, libusb1 ? null
+, enableDpdk ? false
+, dpdk ? null
+# Devices
+, enableOctoClock ? true
+, enableMpmd ? true
+, enableB100 ? true
+, enableB200 ? true
+, enableUsrp1 ? true
+, enableUsrp2 ? true
+, enableX300 ? true
+, enableN230 ? true
+, enableN300 ? true
+, enableN320 ? true
+, enableE300 ? true
+, enableE320 ? true
 }:
 
 # You need these udev rules to not have to run as root (copied from
@@ -13,6 +36,11 @@
 #
 #   SUBSYSTEMS=="usb", ATTRS{idVendor}=="fffe", ATTRS{idProduct}=="0002", MODE:="0666"
 #   SUBSYSTEMS=="usb", ATTRS{idVendor}=="2500", ATTRS{idProduct}=="0002", MODE:="0666"
+
+let
+  onOffBool = b: if b then "ON" else "OFF";
+  inherit (stdenv.lib) optionals;
+in
 
 stdenv.mkDerivation rec {
   pname = "uhd";
@@ -35,6 +63,28 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   cmakeFlags = [
+    "-DENABLE_LIBUHD=ON"
+    "-DENABLE_USB=ON"
+    "-DENABLE_TESTS=ON" # This installs tests as well so we delete them via postPhases
+    "-DENABLE_EXAMPLES=${onOffBool enableExamples}"
+    "-DENABLE_UTILS=${onOffBool enableUtils}"
+    "-DENABLE_LIBUHD_C_API=${onOffBool enableLibuhd_C_api}"
+    "-DENABLE_LIBUHD_PYTHON_API=${onOffBool enableLibuhd_Python_api}"
+    "-DENABLE_LIBERIO=${onOffBool enableLiberio}"
+    "-DENABLE_DPDK=${onOffBool enableDpdk}"
+    # Devices
+    "-DENABLE_OCTOCLOCK=${onOffBool enableOctoClock}"
+    "-DENABLE_MPMD=${onOffBool enableMpmd}"
+    "-DENABLE_B100=${onOffBool enableB100}"
+    "-DENABLE_B200=${onOffBool enableB200}"
+    "-DENABLE_USRP1=${onOffBool enableUsrp1}"
+    "-DENABLE_USRP2=${onOffBool enableUsrp2}"
+    "-DENABLE_X300=${onOffBool enableX300}"
+    "-DENABLE_N230=${onOffBool enableN230}"
+    "-DENABLE_N300=${onOffBool enableN300}"
+    "-DENABLE_N320=${onOffBool enableN320}"
+    "-DENABLE_E300=${onOffBool enableE300}"
+    "-DENABLE_E320=${onOffBool enableE320}"
   ]
     # TODO: Check if this still needed
     # ABI differences GCC 7.1
@@ -42,16 +92,34 @@ stdenv.mkDerivation rec {
     ++ [ (stdenv.lib.optionalString stdenv.isAarch32 "-DCMAKE_CXX_FLAGS=-Wno-psabi") ]
   ;
 
+  # Python + Mako are always required for the build itself but not necessary for runtime.
+  pythonEnv = python.withPackages (ps: with ps; [ Mako ]
+    ++ optionals (enableLibuhd_Python_api) [ numpy setuptools ]
+    ++ optionals (enableUtils) [ requests six ]
+  );
+
   nativeBuildInputs = [
     cmake
     pkgconfig
-    # Python + Mako are always required for the build itself but not necessary for runtime
-    (python.withPackages (ps: with ps; [ Mako ]))
-  ];
+  ]
+    # If both enableLibuhd_Python_api and enableUtils are off, we don't need
+    # pythonEnv in buildInputs as it's a 'build' dependency and not a runtime
+    # dependency
+    ++ optionals (!enableLibuhd_Python_api && !enableUtils) [ pythonEnv ]
+  ;
   buildInputs = [
-    libusb1
     boost
-  ];
+    libusb1
+  ]
+    # However, if enableLibuhd_Python_api *or* enableUtils is on, we need
+    # pythonEnv for runtime as well. The utilities' runtime dependencies are
+    # handled at the environment
+    ++ optionals (enableLibuhd_Python_api || enableUtils) [ pythonEnv ]
+    ++ optionals (enableLiberio) [ liberio ]
+    ++ optionals (enableDpdk) [ dpdk ]
+  ;
+
+  doCheck = true;
 
   # Build only the host software
   preConfigure = "cd host";
@@ -59,12 +127,17 @@ stdenv.mkDerivation rec {
   # https://files.ettus.com/manual_archive/v3.15.0.0/html/page_build_guide.html#build_instructions_unix_arm
   patches = if stdenv.isAarch32 then ./neon.patch else null;
 
-  postPhases = [ "installFirmware" ];
+  postPhases = [ "installFirmware" "removeInstalledTests" ];
 
   # UHD expects images in `$CMAKE_INSTALL_PREFIX/share/uhd/images`
   installFirmware = ''
     mkdir -p "$out/share/uhd/images"
     tar --strip-components=1 -xvf "${uhdImagesSrc}" -C "$out/share/uhd/images"
+  '';
+
+  # -DENABLE_TESTS=ON installs the tests, we don't need them in the output
+  removeInstalledTests = ''
+    rm -r $out/lib/uhd/tests
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -8,7 +8,7 @@
 , enableLibuhd_C_api ? true
 # requires numpy
 , enableLibuhd_Python_api ? false
-, python ? null
+, python3 ? null
 , enableExamples ? false
 , enableUtils ? false
 , enableLiberio ? false
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
   ;
 
   # Python + Mako are always required for the build itself but not necessary for runtime.
-  pythonEnv = python.withPackages (ps: with ps; [ Mako ]
+  pythonEnv = python3.withPackages (ps: with ps; [ Mako ]
     ++ optionals (enableLibuhd_Python_api) [ numpy setuptools ]
     ++ optionals (enableUtils) [ requests six ]
   );

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -7,28 +7,22 @@
 #   SUBSYSTEMS=="usb", ATTRS{idVendor}=="fffe", ATTRS{idProduct}=="0002", MODE:="0666"
 #   SUBSYSTEMS=="usb", ATTRS{idVendor}=="2500", ATTRS{idProduct}=="0002", MODE:="0666"
 
-let
-  uhdVer = "v" + version;
-
+stdenv.mkDerivation rec {
+  pname = "uhd";
   # UHD seems to use three different version number styles: x.y.z, xxx_yyy_zzz
   # and xxx.yyy.zzz. Hrmpf... style keeps changing
-  version = "3.14.0.0";
-
-  # Firmware images are downloaded (pre-built) from the respective release on Github
-  uhdImagesSrc = fetchurl {
-    url = "https://github.com/EttusResearch/uhd/releases/download/${uhdVer}/uhd-images_${version}.tar.xz";
-    sha256 = "1fp37wgqkbr14cxg9l7ghfd4r92y2bxwgb7cfjzs96hbpd9s6al0";
-  };
-
-in stdenv.mkDerivation {
-  pname = "uhd";
-  inherit version;
+  version = "3.15.0.0";
 
   src = fetchFromGitHub {
     owner = "EttusResearch";
     repo = "uhd";
-    rev = uhdVer;
-    sha256 = "0y1hff4vslfv36vxgvjqajg4862a11d4wgr0vcb0visgh1bi8qgy";
+    rev = "v${version}";
+    sha256 = "0jknln88a69fh244670nb7qrflbyv0vvdxfddb5g8ncpb6hcg8qf";
+  };
+  # Firmware images are downloaded (pre-built) from the respective release on Github
+  uhdImagesSrc = fetchurl {
+    url = "https://github.com/EttusResearch/uhd/releases/download/v${version}/uhd-images_${version}.tar.xz";
+    sha256 = "1fir1a13ac07mqhm4sr34cixiqj2difxq0870qv1wr7a7cbfw6vp";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -45,9 +45,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkgconfig
+    # Python + Mako are always required for the build itself but not necessary for runtime
+    (python.withPackages (ps: with ps; [ Mako ]))
   ];
   buildInputs = [
-    (python.withPackages (ps: with ps; [ Mako six requests ]))
     libusb1
     boost
   ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update + Make uhd's build more configurable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
