### PR TITLE
platformio: 4.1.0 -> 4.3.1

### DIFF
--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -34,6 +34,8 @@ let
     "commands/test_test.py::test_local_env"
     "test_builder.py::test_build_flags"
     "test_builder.py::test_build_unflags"
+    "test_builder.py::test_debug_default_build_flags"
+    "test_builder.py::test_debug_custom_build_flags"
     "test_misc.py::test_api_cache"
     "test_misc.py::test_ping_internet_ips"
     "test_misc.py::test_platformio_cli"
@@ -49,14 +51,14 @@ let
 
 in buildPythonApplication rec {
   pname = "platformio";
-  version = "4.1.0";
+  version = "4.3.1";
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
   src = fetchFromGitHub {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    sha256 = "10v9jw1zjfqr3wl6kills3cfp0ky7xbm1gc3z0n57wrqbc6cmz95";
+    sha256 = "1dxnjy60zpkgyrbvbf6b9qi6m37gm8gwjmxwfj30npr1y7rvxwrw";
   };
 
   propagatedBuildInputs =  [
@@ -79,11 +81,6 @@ in buildPythonApplication rec {
 
   patches = [
     ./fix-searchpath.patch
-    (fetchpatch {
-      url = "https://github.com/platformio/platformio-core/commit/442a7e357636522e844d95375c246644b21a7802.patch";
-      sha256 = "0a3kj3k02237gr2yk30gpwc6vm04dsd1wxldj4dsbzs4a9yyi70m";
-      excludes = ["HISTORY.rst"];
-    })
     ./use-local-spdx-license-list.patch
   ];
 

--- a/pkgs/development/arduino/platformio/use-local-spdx-license-list.patch
+++ b/pkgs/development/arduino/platformio/use-local-spdx-license-list.patch
@@ -1,14 +1,14 @@
 diff --git a/platformio/package/manifest/schema.py b/platformio/package/manifest/schema.py
-index f1d68e08..9b7b1da8 100644
+index be49b3ee..d1390a88 100644
 --- a/platformio/package/manifest/schema.py
 +++ b/platformio/package/manifest/schema.py
-@@ -174,9 +174,5 @@ class ManifestSchema(Schema):
+@@ -240,9 +240,5 @@ class ManifestSchema(BaseSchema):
      @staticmethod
      @memoized(expire="1h")
      def load_spdx_licenses():
 -        r = requests.get(
 -            "https://raw.githubusercontent.com/spdx/license-list-data"
--            "/v3.7/json/licenses.json"
+-            "/v3.8/json/licenses.json"
 -        )
 -        r.raise_for_status()
 -        return r.json()


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update PlatformIO to its latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
