### PR TITLE
Unmark nix-diff as broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2479,6 +2479,8 @@ package-maintainers:
     - termonad
   rkrzr:
     - icepeak
+  terlar:
+    - nix-diff
 
 unsupported-platforms:
   alsa-mixer:                                   [ x86_64-darwin ]
@@ -7822,7 +7824,6 @@ broken-packages:
   - nitro
   - nix-delegate
   - nix-deploy
-  - nix-diff
   - nix-eval
   - nix-freeze-tree
   - nix-tools


### PR DESCRIPTION
###### Motivation for this change
nix-diff is currently marked as broken, but it builds cleanly. See #84116

###### Things done

- Unmarked nix-diff as broken
- Put myself as maintainer for this package since I am using it

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
