### PR TITLE
python3Packages.cryptography: 2.8 -> 2.9

### DIFF
--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -8,8 +8,6 @@
 , packaging
 , six
 , pythonOlder
-, enum34
-, ipaddress
 , isPyPy
 , cffi
 , pytest
@@ -21,11 +19,11 @@
 
 buildPythonPackage rec {
   pname = "cryptography";
-  version = "2.8"; # Also update the hash in vectors.nix
+  version = "2.9"; # Also update the hash in vectors.nix
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0l8nhw14npknncxdnp7n4hpmjyscly6g7fbivyxkjwvlv071zniw";
+    sha256 = "0vlqy2pki0fh1h6l6cbb43z3g2n9fv0849dzb5gqwjv0bkpx7b0c";
   };
 
   outputs = [ "out" "dev" ];
@@ -35,9 +33,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     packaging
     six
-  ] ++ stdenv.lib.optional (pythonOlder "3.4") enum34
-  ++ stdenv.lib.optional (pythonOlder "3.3") ipaddress
-  ++ stdenv.lib.optional (!isPyPy) cffi;
+  ] ++ stdenv.lib.optional (!isPyPy) cffi;
 
   checkInputs = [
     cryptography_vectors
@@ -48,9 +44,8 @@ buildPythonPackage rec {
     pytz
   ];
 
-  # remove when https://github.com/pyca/cryptography/issues/4998 is fixed
   checkPhase = ''
-    py.test --disable-pytest-warnings tests -k 'not load_ecdsa_no_named_curve'
+    py.test --disable-pytest-warnings tests
   '';
 
   # IOKit's dependencies are inconsistent between OSX versions, so this is the best we
@@ -64,9 +59,11 @@ buildPythonPackage rec {
       common cryptographic algorithms such as symmetric ciphers, message
       digests, and key derivation functions.
       Our goal is for it to be your "cryptographic standard library". It
-      supports Python 2.7, Python 3.4+, and PyPy 5.3+.
+      supports Python 2.7, Python 3.5+, and PyPy 5.4+.
     '';
-    homepage = https://github.com/pyca/cryptography;
+    homepage = "https://github.com/pyca/cryptography";
+    changelog = "https://cryptography.io/en/latest/changelog/#v"
+      + replaceStrings [ "." ] [ "-" ] version;
     license = with licenses; [ asl20 bsd3 psfl ];
     maintainers = with maintainers; [ primeos ];
   };

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "05pi3shqz0fgvy0d5yazza67bbnam8fkrx2ayrrclgkaqms23lvc";
+    sha256 = "1h7dcgwrjxqk1bzkangbvlhhlgyqd7cfi894dv1cd5m2sp7csblc";
   };
 
   # No tests included
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Test vectors for the cryptography package";
-    homepage = https://cryptography.io/en/latest/development/test-vectors/;
+    homepage = "https://cryptography.io/en/latest/development/test-vectors/";
     # Source: https://github.com/pyca/cryptography/tree/master/vectors;
     license = with licenses; [ asl20 bsd3 ];
     maintainers = with maintainers; [ primeos ];


### PR DESCRIPTION
Backwards incompatible changes:
- Support for Python 3.4 has been removed due to low usage and
  maintenance burden.
- Support for OpenSSL 1.0.1 has been removed. Users on older version of
  OpenSSL will need to upgrade.
- Support for LibreSSL 2.6.x has been removed.
- Reversed the order in which rfc4514_string() returns the RDNs as
  required by RFC 4514.

Note: The first three changes should have no impact on Nixpkgs as we
already removed Python 3.4 and OpenSSL 1.0.1. Additionally we don't
support LibreSSL for this package.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
