### PR TITLE
Revert "tessera: 0.10.2 -> 0.10.4"

### DIFF
--- a/pkgs/applications/blockchains/tessera.nix
+++ b/pkgs/applications/blockchains/tessera.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "tessera";
-  version = "0.10.4";
+  version = "0.10.2";
 
   src = fetchurl {
     url = "https://oss.sonatype.org/service/local/repositories/releases/content/com/jpmorgan/quorum/${pname}-app/${version}/${pname}-app-${version}-app.jar";
-    sha256 = "1sqj0mc80922yavx9hlwnl1kpmavpza2g2aycz1qd0zv0s31z9wj";
+    sha256 = "1zn8w7q0q5man0407kb82lw4mlvyiy9whq2f6izf2b5415f9s0m4";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#84025

The updated app doesn't run with JRE that is in master.

```$ /nix/store/67ri95bhffqlpamfs2a0hmbcr69181iq-tessera-0.10.4/bin/tessera rror: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.UnsupportedClassVersionError: com/quorum/tessera/launcher/Main has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:495)
```
