### PR TITLE
kscreen: Fix #82141

### DIFF
--- a/pkgs/desktops/plasma-5/kscreen-417316.patch
+++ b/pkgs/desktops/plasma-5/kscreen-417316.patch
@@ -1,0 +1,76 @@
+https://phabricator.kde.org/file/data/dyr2qr4wrhxg4eahkgd3/PHID-FILE-7d4og3zr4mk53u6lzkk2/D27442.diff
+https://bugs.kde.org/show_bug.cgi?id=417316
+
+diff -ru kscreen-5.17.5-orig/kcm/package/contents/ui/main.qml kscreen-5.17.5/kcm/package/contents/ui/main.qml
+--- kscreen-5.17.5-orig/kcm/package/contents/ui/main.qml	2020-01-07 16:28:39.000000000 +0100
++++ kscreen-5.17.5/kcm/package/contents/ui/main.qml	2020-04-03 17:54:26.097809557 +0200
+@@ -24,8 +24,8 @@
+ KCM.SimpleKCM {
+     id: root
+ 
+-    implicitWidth: units.gridUnit * 30
+-    implicitHeight: units.gridUnit * 38
++    implicitWidth: Kirigami.Units.gridUnit * 32
++    implicitHeight: Kirigami.Units.gridUnit * 38
+ 
+     property int selectedOutput: 0
+ 
+@@ -113,7 +113,7 @@
+             id: screen
+ 
+             Layout.alignment: Qt.AlignHCenter
+-            Layout.preferredWidth: Math.max(root.width * 0.8, units.gridUnit * 26)
++            Layout.preferredWidth: Math.max(root.width * 0.8, Kirigami.Units.gridUnit * 26)
+             Layout.topMargin: Kirigami.Units.smallSpacing
+             Layout.bottomMargin: Kirigami.Units.largeSpacing * 2
+ 
+diff -ru kscreen-5.17.5-orig/kcm/package/contents/ui/Output.qml kscreen-5.17.5/kcm/package/contents/ui/Output.qml
+--- kscreen-5.17.5-orig/kcm/package/contents/ui/Output.qml	2020-01-07 16:28:39.000000000 +0100
++++ kscreen-5.17.5/kcm/package/contents/ui/Output.qml	2020-04-03 17:53:22.491686708 +0200
+@@ -19,6 +19,7 @@
+ import QtQuick.Layouts 1.1
+ import QtQuick.Controls 2.3 as Controls
+ import QtGraphicalEffects 1.0
++import org.kde.kirigami 2.4 as Kirigami
+ 
+ Rectangle {
+     id: output
+@@ -77,7 +78,7 @@
+ 
+             Controls.Label {
+                 Layout.fillWidth: true
+-                Layout.margins: units.smallSpacing
++                Layout.margins: Kirigami.Units.smallSpacing
+ 
+                 text: model.display
+                 wrapMode: Text.Wrap
+@@ -87,7 +88,7 @@
+ 
+             Controls.Label {
+                 Layout.fillWidth: true
+-                Layout.bottomMargin: units.smallSpacing
++                Layout.bottomMargin: Kirigami.Units.smallSpacing
+ 
+                 text: "(" + model.size.width + "x" + model.size.height + ")"
+                 horizontalAlignment: Text.AlignHCenter
+diff -ru kscreen-5.17.5-orig/kcm/package/contents/ui/Screen.qml kscreen-5.17.5/kcm/package/contents/ui/Screen.qml
+--- kscreen-5.17.5-orig/kcm/package/contents/ui/Screen.qml	2020-01-07 16:28:39.000000000 +0100
++++ kscreen-5.17.5/kcm/package/contents/ui/Screen.qml	2020-04-03 17:53:22.491686708 +0200
+@@ -45,7 +45,7 @@
+     property int xOffset: (width - totalSize.width / relativeFactor) / 2;
+     property int yOffset: (height - totalSize.height / relativeFactor) / 2;
+ 
+-    implicitHeight: Math.max(root.height * 0.4, units.gridUnit * 13)
++    implicitHeight: Math.max(root.height * 0.4, Kirigami.Units.gridUnit * 13)
+ 
+     Component.onCompleted: background.visible = true;
+ 
+@@ -54,7 +54,7 @@
+         anchors {
+             bottom: parent.bottom
+             horizontalCenter: parent.horizontalCenter
+-            margins: units.smallSpacing
++            margins: Kirigami.Units.smallSpacing
+         }
+         spacing: units.smallSpacing
+         Controls.Button {

--- a/pkgs/desktops/plasma-5/kscreen.nix
+++ b/pkgs/desktops/plasma-5/kscreen.nix
@@ -8,6 +8,7 @@
 
 mkDerivation {
   name = "kscreen";
+  patches = [ ./kscreen-417316.patch ];
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     kconfig kcmutils kconfigwidgets kdbusaddons kglobalaccel ki18n


### PR DESCRIPTION
This fixes #82141 (kscreen not showing display layout, upstream issue https://bugs.kde.org/show_bug.cgi?id=417316).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
