### PR TITLE
pythonPackages.pint: 0.9 -> 0.11

### DIFF
--- a/pkgs/development/python-modules/datasette/default.nix
+++ b/pkgs/development/python-modules/datasette/default.nix
@@ -1,49 +1,52 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, aiofiles
 , click
 , click-default-group
+, janus
 , jinja2
 , hupper
 , pint
 , pluggy
-, pytest
+, uvicorn
+# Check Inputs
+, pytestCheckHook
 , pytestrunner
 , pytest-asyncio
 , black
 , aiohttp
 , beautifulsoup4
-, uvicorn
 , asgiref
-, aiofiles
 }:
 
 buildPythonPackage rec {
   pname = "datasette";
-  version = "0.35";
+  version = "0.39";
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "datasette";
     rev = version;
-    sha256 = "0v6af7agg27lapz1nbab07595v4hl2x5wm2f03drj81f7pm8y7hc";
+    sha256 = "07d46512bc9sdan9lv39sf1bwlf7vf1bfhcsm825vk7sv7g9kczd";
   };
 
   nativeBuildInputs = [ pytestrunner ];
 
   propagatedBuildInputs = [
+    aiofiles
     click
     click-default-group
+    janus
     jinja2
     hupper
     pint
     pluggy
     uvicorn
-    aiofiles
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
     pytest-asyncio
     aiohttp
     beautifulsoup4
@@ -53,24 +56,32 @@ buildPythonPackage rec {
 
   postConfigure = ''
     substituteInPlace setup.py \
-      --replace "click-default-group==1.2" "click-default-group" \
-      --replace "Sanic==0.7.0" "Sanic" \
-      --replace "hupper==1.0" "hupper" \
-      --replace "pint~=0.8.1" "pint" \
-      --replace "pluggy~=0.12.0" "pint" \
-      --replace "Jinja2==2.10.1" "Jinja2" \
-      --replace "uvicorn~=0.8.4" "uvicorn"
+      --replace "click~=7.1.1" "click" \
+      --replace "click-default-group~=1.2.2" "click-default-group" \
+      --replace "Jinja2~=2.10.3" "Jinja2" \
+      --replace "hupper~=1.9" "hupper" \
+      --replace "pint~=0.9" "pint" \
+      --replace "pluggy~=0.13.0" "pint" \
+      --replace "uvicorn~=0.11" "uvicorn" \
+      --replace "aiofiles~=0.4.0" "aiofiles" \
+      --replace "janus~=0.4.0" "janus" \
+      --replace "PyYAML~=5.3" "PyYAML"
   '';
 
   # many tests require network access
   # test_black fails on darwin
-  checkPhase = ''
-    pytest --ignore tests/test_api.py \
-           --ignore tests/test_csv.py \
-           --ignore tests/test_html.py \
-           --ignore tests/test_black.py \
-           -k 'not facet'
-  '';
+  dontUseSetuptoolsCheck = true;
+  pytestFlagsArray = [
+    "--ignore=tests/test_api.py"
+    "--ignore=tests/test_csv.py"
+    "--ignore=tests/test_html.py"
+    "--ignore=tests/test_docs.py"
+    "--ignore=tests/test_black.py"
+  ];
+  disabledTests = [
+    "facet"
+    "_invalid_database" # checks error message when connecting to invalid database
+  ];
 
   meta = with lib; {
     description = "An instant JSON API for your SQLite databases";

--- a/pkgs/development/python-modules/pint/default.nix
+++ b/pkgs/development/python-modules/pint/default.nix
@@ -2,20 +2,40 @@
 , buildPythonPackage
 , fetchPypi
 , isPy27
+, pythonOlder
 , funcsigs
+, setuptools_scm
+# Check Inputs
+, pytestCheckHook
+, numpy
+, matplotlib
+, uncertainties
 }:
 
 buildPythonPackage rec {
   pname = "pint";
-  version = "0.9";
+  version = "0.11";
 
   src = fetchPypi {
     inherit version;
     pname = "Pint";
-    sha256 = "32d8a9a9d63f4f81194c0014b3b742679dce81a26d45127d9810a68a561fe4e2";
+    sha256 = "0kfgnmcs6z9ndhzvwg2xzhpwxgyyagdsdz5dns1jy40fa1q113rh";
   };
 
-  propagatedBuildInputs = lib.optional isPy27 funcsigs;
+  disabled = pythonOlder "3.6";
+
+  propagatedBuildInputs = [
+    setuptools_scm
+  ] ++ lib.optional isPy27 funcsigs;
+
+  # Test suite explicitly requires pytest
+  checkInputs = [
+    pytestCheckHook
+    numpy
+    matplotlib
+    uncertainties
+  ];
+  dontUseSetuptoolsCheck = true;
 
   meta = with lib; {
     description = "Physical quantities module";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bump ``pythonPackages.pint`` version. Also fixes build issue on Hydra: https://hydra.nixos.org/build/115315938.

Will backport to [20.03].

ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
