### PR TITLE
gitAndTools.stgit: Fix broken package.

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/stgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/stgit/default.nix
@@ -1,11 +1,8 @@
-{ stdenv, fetchFromGitHub, python2, git }:
+{ stdenv, python3, python3Packages, fetchFromGitHub, git }:
 
-let
-  name = "stgit-${version}";
+python3Packages.buildPythonApplication rec {
+  pname = "stgit";
   version = "0.22";
-in
-stdenv.mkDerivation {
-  inherit name;
 
   src = fetchFromGitHub {
     owner = "ctmarinas";
@@ -14,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0xpvs5fa50rrvl2c8naha1nblk5ip2mgg63a9srqqxfx6z8qmrfz";
   };
 
-  buildInputs = [ python2 git ];
+  nativeBuildInputs = [ git ];
 
   makeFlags = [ "prefix=$$out" ];
 


### PR DESCRIPTION


###### Motivation for this change
Repair broken package stgit.

The stgit package is installing using make, which leaves the application in a state where it can not properly find the installed package stgit.

---
File "/run/current-system/sw/bin/stg", line 35, in <module>
    from stgit.main import main
ImportError: No module named stgit.main
---

This is fixed by using buildPythonApplication instead of stdenv.mkDerivation.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
