### PR TITLE
libmicrodns: 0.1.0 -> 0.1.2

### DIFF
--- a/pkgs/development/libraries/libmicrodns/default.nix
+++ b/pkgs/development/libraries/libmicrodns/default.nix
@@ -1,28 +1,30 @@
 { stdenv
 , fetchFromGitHub
-, autoreconfHook
+, meson
+, ninja
 , pkgconfig
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.1.0";
+  version = "0.1.2";
   pname = "libmicrodns";
 
   src = fetchFromGitHub {
     owner = "videolabs";
     repo = pname;
     rev = version;
-    sha256 = "1pmf461zn35spbpbls1ih68ki7f8g8xjwhzr2csy63nnyq2k9jji";
+    sha256 = "1yb0j0acidp494d28wqhzhrfski2qjb2a5mp5bq5qrpcg38zyz6i";
   };
 
   nativeBuildInputs = [
-    autoreconfHook
+    meson
+    ninja
     pkgconfig
   ];
 
   meta = with stdenv.lib; {
     description = "Minimal mDNS resolver library, used by VLC";
-    homepage = https://github.com/videolabs/libmicrodns;
+    homepage = "https://github.com/videolabs/libmicrodns";
     license = licenses.lgpl21;
     platforms = platforms.linux;
     maintainers = [ maintainers.shazow ];


### PR DESCRIPTION
Buildsystem switched to Meson+Ninja. Will backport to 20.03 after this PR is merged.

https://github.com/videolabs/libmicrodns/releases/tag/0.1.1
https://github.com/videolabs/libmicrodns/releases/tag/0.1.2

###### Motivation for this change

- [CVE-2020-6071](https://nvd.nist.gov/vuln/detail/CVE-2020-6071)
- [CVE-2020-6072](https://nvd.nist.gov/vuln/detail/CVE-2020-6072)
- [CVE-2020-6073](https://nvd.nist.gov/vuln/detail/CVE-2020-6073)
- [CVE-2020-6077](https://nvd.nist.gov/vuln/detail/CVE-2020-6077)
- [CVE-2020-6078](https://nvd.nist.gov/vuln/detail/CVE-2020-6078)
- [CVE-2020-6079](https://nvd.nist.gov/vuln/detail/CVE-2020-6079)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>

  - obs-ndi
</details>
<details>
  <summary>16 package built:</summary>

  - elisa
  - libmicrodns
  - libsForQt5.phonon-backend-vlc
  - libsForQt5.vlc
  - megaglest
  - minitube
  - netease-cloud-music
  - obs-linuxbrowser
  - obs-studio
  - obs-wlrobs
  - pympress
  - python27Packages.python-vlc
  - python37Packages.python-vlc
  - python38Packages.python-vlc
  - strawberry
  - tribler
</details>

obs-ndi doesn't build because it seems to require manual source download?
