### PR TITLE
[WIP] nixos/systemd-boot: boot counting and automatic fallback

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -24,6 +24,9 @@ let
 
     configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
 
+    countersEnable = if cfg.counters.enable then "True" else "False";
+    countersTries = cfg.counters.tries;
+
     inherit (cfg) consoleMode;
 
     inherit (efi) efiSysMountPoint canTouchEfiVariables;
@@ -43,6 +46,21 @@ in {
       type = types.bool;
 
       description = "Whether to enable the systemd-boot (formerly gummiboot) EFI boot manager";
+    };
+
+    counters = {
+      enable = mkEnableOption "boot counters tracking the boot status of each nixos generation";
+
+      tries = mkOption {
+        default = 3;
+
+        type = types.int;
+
+        description = ''
+          The default number of tries to boot new nixos generations before
+          falling back to a known working generation.
+        '';
+      };
     };
 
     editor = mkOption {

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -30,6 +30,7 @@ let
       "timers.target"
       "paths.target"
       "rpcbind.target"
+      "boot-complete.target"
 
       # Rescue mode.
       "rescue.target"
@@ -105,6 +106,9 @@ let
       "systemd-backlight@.service"
       "systemd-rfkill.service"
       "systemd-rfkill.socket"
+
+      #"systemd-boot-check-no-failures.service"
+      "systemd-bless-boot.service"
 
       # Hibernate / suspend.
       "hibernate.target"

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -125,7 +125,9 @@ let
       ${if cfg.useBootLoader then ''
         # Create a writable copy/snapshot of the boot disk.
         # A writable boot disk can be booted from automatically.
-        ${qemu}/bin/qemu-img create -f qcow2 -b ${bootDisk}/disk.img $TMPDIR/disk.img || exit 1
+        if ! test -e "$TMPDIR/disk.img"; then
+          ${qemu}/bin/qemu-img create -f qcow2 -b ${bootDisk}/disk.img $TMPDIR/disk.img || exit 1
+        fi
 
         NIX_EFI_VARS=$(readlink -f ''${NIX_EFI_VARS:-${cfg.efiVars}})
 

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -26,7 +26,7 @@ in
       machine.start()
       machine.wait_for_unit("multi-user.target")
 
-      machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+      machine.succeed("test -e /boot/loader/entries/nixos-generation-default-1.conf")
 
       # Ensure we actually booted using systemd-boot
       # Magic number is the vendor UUID used by systemd-boot.
@@ -53,7 +53,7 @@ in
       machine.start()
       machine.wait_for_unit("multi-user.target")
 
-      machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+      machine.succeed("test -e /boot/loader/entries/nixos-generation-default-1.conf")
 
       # Ensure we actually booted using systemd-boot
       # Magic number is the vendor UUID used by systemd-boot.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This draft PR adds support for `systemd-boot` "automatic boot assessment".
For background information, please first read the following document: https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/

Setting `boot.loader.systemd-boot.counters.enable = true` enables this optional functionality.
Since what a "successful boot" exactly means is somewhat context dependent, systemd provides `boot-complete.target` which serves as a synchronization point that an end user could order necessary services before. The boot entry will be marked as successfully booting only if this target succeeds.
For unattended boots, there are some other potentially useful options such as adding `panic=1` to `boot.kernelParams` or setting `FailureAction=reboot` for certain necessary services. However, these are end-user concerns that are somewhat orthogonal to boot counting and automatic fallback, and they probably do not belong in this PR.

This is a draft PR, as there are a few issues that still need to be resolved:
 - [x] The menu entries appear to be ordered incorrectly upstream: https://github.com/systemd/systemd/issues/15256 _(fixed upstream, should be in v246)_
 - [ ] The `systemd-boot` test needs a writable boot disk (since boot counters are state included in the entry filenames). I have a hack enabling this, which should be cleaned up somehow.
 - [ ] Documentation is needed

---

_(edit: the issue below has been resolved to my satisfaction)_

Perhaps the biggest current issue which could use some feedback on is how we set the "default" for `systemd-boot`. Normally, `systemd-boot-builder.py` sets the `default` entry in `loader.conf`. The logic in `systemd-boot` means that this entry would always be selected--overriding anything having to do with boot counters. I've disabled setting `default` in this draft PR, and so `systemd-boot` should select the latest generation which does not have 0 tries left. However, this would break the ability for the user to switch back to a previous generation, which is clearly undesirable. Perhaps we need to further patch `systemd-boot` to use `default` only if it has remaining tries left, and otherwise select the latest generation with remaining tries left.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
