### PR TITLE
armagetronad: 0.2.8.3.4 -> 0.2.8.3.5

### DIFF
--- a/pkgs/games/armagetronad/default.nix
+++ b/pkgs/games/armagetronad/default.nix
@@ -2,7 +2,7 @@
 
 let
   versionMajor = "0.2.8";
-  versionMinor = "3.4";
+  versionMinor = "3.5";
   version = "${versionMajor}.${versionMinor}";
 in
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = "https://launchpad.net/armagetronad/${versionMajor}/${versionMajor}.${versionMinor}/+download/armagetronad-${version}.src.tar.bz2";
-    sha256 = "157pp84wf0q3bdb72rnbm3ck0czwx2ply6lyhj8z7kfdc7csdbr3";
+    sha256 = "1vyja7mzivs3pacxb7kznndsgqhq4p0f7x2zg55dckvzqwprdhqx";
   };
 
   NIX_LDFLAGS = "-lSDL_image";
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   buildInputs = [ SDL SDL_image libxml2 libjpeg libpng libGLU libGL zlib ];
 
   meta = with stdenv.lib; {
-    homepage = http://armagetronad.org;
+    homepage = "http://armagetronad.org";
     description = "An multiplayer networked arcade racing game in 3D similar to Tron";
     license = licenses.gpl2;
     platforms = platforms.linux;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version (security) update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
