### PR TITLE
scummvm: add broken-sword-25 and dreamweb games

### DIFF
--- a/pkgs/games/scummvm/default.nix
+++ b/pkgs/games/scummvm/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Program to run certain classic graphical point-and-click adventure games (such as Monkey Island)";
-    homepage = https://www.scummvm.org/;
+    homepage = "https://www.scummvm.org/";
     license = licenses.gpl2;
     maintainers = [ maintainers.peterhoeg ];
     platforms = platforms.linux;

--- a/pkgs/games/scummvm/games.nix
+++ b/pkgs/games/scummvm/games.nix
@@ -74,6 +74,21 @@ in {
     files = [ "sky.*" ];
   };
 
+  broken-sword-25 = generic rec {
+    plong = "Broken Sword 2.5";
+    pshort = "sword25";
+    pcode = "sword25";
+    description = "A fan game of the Broken Sword series";
+    version = "1.0";
+    src = fetchurl {
+      url = "mirror://sourceforge/scummvm/${pshort}-v${version}.zip";
+      sha256 = "0ivj1vflfpih5bs5a902mab88s4d77fwm3ya3fk7pammzc8gjqzz";
+    };
+    sourceRoot = ".";
+    docs = [ "README" "license-original.txt" ];
+    files = [ "data.b25c" ];
+  };
+
   drascula-the-vampire-strikes-back = generic rec {
     plong = "Drascula: The Vampire Strikes Back";
     pshort = "drascula";
@@ -93,6 +108,21 @@ in {
     sourceRoot = ".";
     docs = [ "readme.txt" "drascula.doc" ];
     files = [ "Packet.001" ];
+  };
+
+  dreamweb = generic rec {
+    plong = "Dreamweb";
+    pshort = "dreamweb";
+    pcode = "dreamweb";
+    description = "2D point-and-click cyberpunk top-down adventure game";
+    version = "1.1";
+    src = fetchurl {
+      url = "mirror://sourceforge/scummvm/${pshort}-cd-uk-${version}.zip";
+      sha256 = "0hh1p3rd7s0ckvri14lc6wdry9vv0vn4h4744v2n4zg63j8i6vsa";
+    };
+    sourceRoot = ".";
+    docs = [ "license.txt" ];
+    files = [ "DREAMWEB.*" "SPEECH" "track01.flac" ];
   };
 
   flight-of-the-amazon-queen = generic rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23784,7 +23784,9 @@ in
 
   inherit (callPackage ../games/scummvm/games.nix { })
     beneath-a-steel-sky
+    broken-sword-25
     drascula-the-vampire-strikes-back
+    dreamweb
     flight-of-the-amazon-queen
     lure-of-the-temptress;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add two more freeware games playable via ScummVM

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
