### PR TITLE
vimPlugins.nvim-markdown-preview:init at2019-01-29

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2311,6 +2311,17 @@ let
     };
   };
 
+  nvim-markdown-preview = buildVimPluginFrom2Nix {
+    pname = "nvim-markdown-preview";
+    version = "2019-01-29";
+    src = fetchFromGitHub {
+      owner = "davidgranstrom";
+      repo = "nvim-markdown-preview";
+      rev = "9914aae9c1736212f88f1893d14bfe69400443f0";
+      sha256 = "1kc74y9wd6ipz82ry7c3vzi4r65b817wiwcgf7q0632qxxczqdxr";
+    };
+  };
+
   nvim-terminal-lua = buildVimPluginFrom2Nix {
     pname = "nvim-terminal-lua";
     version = "2019-10-17";

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -12,6 +12,9 @@
 , buildVimPluginFrom2Nix
 , nodePackages
 
+# required by plenty of markdown viewers
+, pandoc
+
 # coc-go dependency
 , go
 
@@ -414,6 +417,17 @@ self: super: {
 
   ncm2-ultisnips = super.ncm2-ultisnips.overrideAttrs(old: {
     dependencies = with super; [ ultisnips ];
+  });
+
+  nvim-markdown-preview = super.nvim-markdown-preview.overrideAttrs(old: {
+    buildInputs = [ nodePackages.live-server pandoc ];
+    preFixup = ''
+      substituteInPlace $out/share/vim-plugins/nvim-markdown-preview/ftplugin/markdown.vim --replace "executable('live-server')" \
+          "executable('${nodePackages.live-server}/bin/live-server')"
+
+      substituteInPlace $out/share/vim-plugins/nvim-markdown-preview/autoload/markdown.vim --replace "live-server" \
+          "${nodePackages.live-server}/bin/live-server"
+      '';
   });
 
   fzf-vim = super.fzf-vim.overrideAttrs(old: {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -64,6 +64,7 @@ dannyob/quickfixstatus
 darfink/starsearch.vim
 dart-lang/dart-vim-plugin
 david-a-wheeler/vim-metamath
+davidgranstrom/nvim-markdown-preview
 davidhalter/jedi-vim
 dcharbon/vim-flatbuffers
 dense-analysis/ale


### PR DESCRIPTION
relies on pandoc + live-server

I wanted a live markdown viewer and made this list. They mostly rely on node and hence can be tough to configure (tried packaging markdown-preview.nvim but had some issue). I managed to package vim-livedown too but one markdown viewer is enough.
```
davidgranstrom/nvim-markdown-preview
euclio/vim-markdown-composer
iamcco/markdown-preview.nvim
JamshedVesuna/vim-markdown-preview
shime/vim-livedown
```


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
