### PR TITLE
hack: invoke wrapper hook manually

### DIFF
--- a/pkgs/development/tools/electron/generic.nix
+++ b/pkgs/development/tools/electron/generic.nix
@@ -56,6 +56,8 @@ let
         --set-rpath "${atomEnv.libPath}:${stdenv.lib.makeLibraryPath [ libuuid at-spi2-atk at-spi2-core ]}:$out/lib/electron" \
         $out/lib/electron/electron
 
+      gappsWrapperArgsHook
+
       wrapProgram $out/lib/electron/electron \
         --prefix LD_PRELOAD : ${stdenv.lib.makeLibraryPath [ libXScrnSaver ]}/libXss.so.1 \
         "''${gappsWrapperArgs[@]}"


### PR DESCRIPTION
This is less of a PR, more of an issue - why was `gappsWrapperArgsHook` not invoked automatically? this used to work a while back and stopped at some point..

noticed as the file open dialog has stopped working again.. ie crashes the program 