### PR TITLE
[20.03] nixos/network-interfaces: Assert that bridges can get an address via DHCP

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -977,6 +977,17 @@ in
         '';
       })) ++ [
         {
+          assertion = cfg.useDHCP -> cfg.bridges == {};
+          message = ''
+            There are the bridges [ ${builtins.toString (builtins.attrNames cfg.bridges)} ] configured while `networking.useDHCP` is enabled.
+            dhcpcd doesn't give IPv4 addresses to bridges by default anymore,
+            so you have to set `networking.useDHCP = false` and then whitelist
+            every interface you need DHCP on with
+            `networking.interfaces.<name?>.useDHCP = true`.
+          '';
+        }
+      ] ++ [
+        {
           assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);
           message = "Invalid value given to the networking.hostId option.";
         }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/82295 already warns users of `20.03` in the release notes about how `dhcpcd` changed its implicit behaviour regarding bridge interfaces. This PR proposes an assertion that blocks users from running into some unexpected network change.

**This change is primarily thought to be applied *before* the `20.03` release, as then probably quite a lot of people will run into this problem. This is why I target the `release-20.03` branch here. When merged, this should be still cherry-picked on `master`.**

To illustrate the problem once again: This configuration will result in a bridge without an IPv4 address:

```nix
{ config, pkgs, ... }:{
  networking = {
    bridges.br0 = {
      interfaces = [ "enp2s0" "enp3s0" ];
    };
    interfaces = {
      br0.useDHCP = true;
      enp2s0.useDHCP = false;
      enp3s0.useDHCP = false;
    };
  };
}
```

While this one works as expected:

```nix
{ config, pkgs, ... }:{
  networking = {
    useDHCP = false;
    bridges.br0 = {
      interfaces = [ "enp2s0" "enp3s0" ];
    };
    interfaces = {
      br0.useDHCP = true;
      enp2s0.useDHCP = false;
      enp3s0.useDHCP = false;
    };
  };
}
```

This is because `networking.useDHCP = false` causes an explicit listing of enabled interfaces in the dhcpcd config, while `networking.useDHCP = true` made dhcpcd implicitly discover the interfaces (which fails now).

###### Things done

Throw an error if `networking.useDHCP` is enabled and a bridge interface is defined.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
