### PR TITLE
python3Packages.uvloop: enable on python3.8

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -6,16 +6,17 @@
 , libuv
 , psutil
 , isPy27
-, pythonAtLeast
 , CoreServices
 , ApplicationServices
+# Check Inputs
+, pytestCheckHook
+# , pytest-asyncio
 }:
 
 buildPythonPackage rec {
   pname = "uvloop";
   version = "0.14.0";
-  # python 3.8 hangs on tests, assuming it's subtly broken with race condition
-  disabled = isPy27 || pythonAtLeast "3.8";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
@@ -28,20 +29,44 @@ buildPythonPackage rec {
     libuv
   ] ++ lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];
 
-  postPatch = ''
-    # Removing code linting tests, which we don't care about
-    rm tests/test_sourcecode.py
-  '';
+  pythonImportsCheck = [
+    "uvloop"
+    "uvloop.loop"
+  ];
 
-  checkInputs = [ pyopenssl psutil ];
+  dontUseSetuptoolsCheck = true;
+  checkInputs = [ pytestCheckHook pyopenssl psutil ];
+
+  pytestFlagsArray = [
+    # from pytest.ini, these are NECESSARY to prevent failures
+    "--capture=no"
+    "--assert=plain"
+    "--tb=native"
+    # ignore code linting tests
+    "--ignore=tests/test_sourcecode.py"
+  ];
+
+  disabledTests = [
+    "test_sock_cancel_add_reader_race"  # asyncio version of test is supposed to be skipped but skip doesn't happen. uvloop version runs fine
+  ];
+
+  # force using installed/compiled uvloop vs source by moving tests to temp dir
+  preCheck = ''
+    export TEST_DIR=$(mktemp -d)
+    cp -r tests $TEST_DIR
+    pushd $TEST_DIR
+  '';
+  postCheck = ''
+    popd
+  '';
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Fast implementation of asyncio event loop on top of libuv";
-    homepage = https://github.com/MagicStack/uvloop;
+    homepage = "https://github.com/MagicStack/uvloop";
     license = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Allow build pass by disabling test. Isolated issue to test_sockets.py::TestAIOSockets::test_sock_close_add_reader_race.
This test is supposed to be skipped for asynico, but it isn't for some reason,
so we disable it instead.
See uvloop#284 (https://github.com/MagicStack/uvloop/pull/284) for full details. Don't know why this test isn't properly skipped.

Causing hydra build failure.
ZHF: #80379 
Will backport to 20.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
