### PR TITLE
csv2latex: init at 0.22

### DIFF
--- a/pkgs/tools/misc/csv2latex/default.nix
+++ b/pkgs/tools/misc/csv2latex/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "csv2latex";
+  version = "0.22";
+
+  src = fetchurl {
+    url = "http://brouits.free.fr/csv2latex/csv2latex-${version}.tar.gz";
+    sha256 = "09qih2zx6cvlii1n5phiinvm9xw1l8f4i60b5hg56pymzjhn97vy";
+  };
+
+  installPhase = ''
+  mkdir -p $out/bin
+  make PREFIX=$out install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Command-line CSV to LaTeX file converter";
+    homepage = http://brouits.free.fr/csv2latex/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.catern ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1569,6 +1569,8 @@ in
 
   csvkit = callPackage ../tools/text/csvkit { };
 
+  csv2latex = callPackage ../tools/misc/csv2latex { };
+
   csvs-to-sqlite = with python3Packages; toPythonApplication csvs-to-sqlite;
 
   cucumber = callPackage ../development/tools/cucumber {};


### PR DESCRIPTION
###### Motivation for this change
Package is in Debian/Ubuntu and not Nix. https://repology.org/project/csv2latex/versions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
