### PR TITLE
easysnap: 2019-02-17 -> 2020-04-04

### DIFF
--- a/pkgs/tools/backup/easysnap/default.nix
+++ b/pkgs/tools/backup/easysnap/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "easysnap";
-  version = "unstable-2019-02-17";
+  version = "unstable-2020-04-04";
 
   src = fetchFromGitHub {
     owner = "sjau";
     repo = "easysnap";
-    rev = "9ef5d1ff51ccf9939a88b7b32b4959d27cf61ecc";
-    sha256 = "0m0217ni909nham15w5vxg8y7cw2zwjibnhvgnpxxsap8zkhv1m4";
+    rev = "26f89c0c3cda01e2595ee19ae5fb8518da25b4ef";
+    sha256 = "sha256:1k49k1m7y8s099wyiiz8411i77j1156ncirynmjfyvdhmhcyp5rw";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update to newer version with improved snapshot deletion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
