### PR TITLE
comedilib: init at 0.11.0

### DIFF
--- a/pkgs/development/libraries/comedilib/default.nix
+++ b/pkgs/development/libraries/comedilib/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, flex
+, yacc
+, xmlto
+, docbook_xsl
+, docbook_xml_dtd_44
+, swig
+, perl
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "comedilib";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "Linux-Comedi";
+    repo = "comedilib";
+    rev = "r${stdenv.lib.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "159sv4jdgmcaqz76vazkyxxb85ni7pg14p1qv7y94hib3kspc195";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    flex
+    yacc
+    swig
+    xmlto
+    docbook_xml_dtd_44
+    docbook_xsl
+    python3
+    perl
+  ];
+
+  preConfigure = ''
+    patchShebangs --build doc/mkref doc/mkdr perl/Comedi.pm
+  '';
+
+  configureFlags = [
+    "--with-udev-hotplug=${placeholder "out"}/lib"
+    "--sysconfdir=${placeholder "out"}/etc"
+  ];
+
+  outputs = [ "out" "dev" "man" "doc" ];
+
+  meta = with stdenv.lib; {
+    description = "The Linux Control and Measurement Device Interface Library";
+    homepage = "https://github.com/Linux-Comedi/comedilib";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.doronbehar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -173,6 +173,8 @@ in
 
   colorz = callPackage ../tools/misc/colorz { };
 
+  comedilib = callPackage ../development/libraries/comedilib {  };
+
   cpu-x = callPackage ../applications/misc/cpu-x { };
 
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Optional dependency for GNUradio (see #82263 ).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
