### PR TITLE
couchdb: add support for version 3.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4882,6 +4882,12 @@
     githubId = 1202012;
     name = "Ignat Loskutov";
   };
+  lostnet = {
+    email = "lost.networking@gmail.com";
+    github = "lostnet";
+    githubId = 1422781;
+    name = "Will Young";
+  };
   louisdk1 = {
     email = "louis@louis.dk";
     github = "louisdk1";

--- a/nixos/modules/services/databases/couchdb.nix
+++ b/nixos/modules/services/databases/couchdb.nix
@@ -11,7 +11,13 @@ let
       database_dir = ${cfg.databaseDir}
       uri_file = ${cfg.uriFile}
       view_index_dir = ${cfg.viewIndexDir}
-    '' + (if useVersion2 then
+    '' + (if cfg.adminPass != null then
+    ''
+      [admins]
+      ${cfg.adminUser} = ${cfg.adminPass}
+    '' else
+    ''
+    '') + (if useVersion2 then
     ''
       [chttpd]
     '' else
@@ -54,6 +60,23 @@ in {
         '';
       };
 
+      adminUser = mkOption {
+        type = types.str;
+        default = "admin";
+        description = ''
+          Couchdb (i.e. fauxton) account with permission for all dbs and
+          tasks.
+        '';
+      };
+
+      adminPass = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Couchdb (i.e. fauxton) account with permission for all dbs and
+          tasks.
+        '';
+      };
 
       user = mkOption {
         type = types.str;

--- a/nixos/tests/couchdb.nix
+++ b/nixos/tests/couchdb.nix
@@ -1,4 +1,19 @@
-import ./make-test-python.nix ({ pkgs, lib, ...}:
+let
+
+  makeNode = couchpkg: user: passwd:
+    { pkgs, ... } :
+
+      { environment.systemPackages = with pkgs; [ jq ];
+        services.couchdb.enable = true;
+        services.couchdb.package = couchpkg;
+        services.couchdb.adminUser = user;
+        services.couchdb.adminPass = passwd;
+      };
+  testuser = "testadmin";
+  testpass = "cowabunga";
+  testlogin = "${testuser}:${testpass}@";
+
+in import ./make-test-python.nix ({ pkgs, lib, ...}:
 
 with lib;
 
@@ -9,26 +24,15 @@ with lib;
   };
 
   nodes = {
-    couchdb1 =
-      { pkgs, ... }:
-
-      { environment.systemPackages = with pkgs; [ jq ];
-        services.couchdb.enable = true;
-      };
-
-    couchdb2 =
-      { pkgs, ... }:
-
-      { environment.systemPackages = with pkgs; [ jq ];
-        services.couchdb.enable = true;
-        services.couchdb.package = pkgs.couchdb2;
-      };
+    couchdb1 = makeNode pkgs.couchdb testuser testpass;
+    couchdb2 = makeNode pkgs.couchdb2 testuser testpass;
+    couchdb3 = makeNode pkgs.couchdb3 testuser testpass;
   };
 
   testScript = let
-    curlJqCheck = action: path: jqexpr: result:
+    curlJqCheck = login: action: path: jqexpr: result:
       pkgs.writeScript "curl-jq-check-${action}-${path}.sh" ''
-        RESULT=$(curl -X ${action} http://127.0.0.1:5984/${path} | jq -r '${jqexpr}')
+        RESULT=$(curl -X ${action} http://${login}127.0.0.1:5984/${path} | jq -r '${jqexpr}')
         echo $RESULT >&2
         if [ "$RESULT" != "${result}" ]; then
           exit 1
@@ -39,38 +43,56 @@ with lib;
 
     couchdb1.wait_for_unit("couchdb.service")
     couchdb1.wait_until_succeeds(
-        "${curlJqCheck "GET" "" ".couchdb" "Welcome"}"
+        "${curlJqCheck "" "GET" "" ".couchdb" "Welcome"}"
     )
     couchdb1.wait_until_succeeds(
-        "${curlJqCheck "GET" "_all_dbs" ". | length" "2"}"
+        "${curlJqCheck "" "GET" "_all_dbs" ". | length" "2"}"
     )
-    couchdb1.succeed("${curlJqCheck "PUT" "foo" ".ok" "true"}")
+    couchdb1.succeed("${curlJqCheck testlogin "PUT" "foo" ".ok" "true"}")
     couchdb1.succeed(
-        "${curlJqCheck "GET" "_all_dbs" ". | length" "3"}"
-    )
-    couchdb1.succeed(
-        "${curlJqCheck "DELETE" "foo" ".ok" "true"}"
+        "${curlJqCheck "" "GET" "_all_dbs" ". | length" "3"}"
     )
     couchdb1.succeed(
-        "${curlJqCheck "GET" "_all_dbs" ". | length" "2"}"
+        "${curlJqCheck testlogin "DELETE" "foo" ".ok" "true"}"
+    )
+    couchdb1.succeed(
+        "${curlJqCheck "" "GET" "_all_dbs" ". | length" "2"}"
     )
 
     couchdb2.wait_for_unit("couchdb.service")
     couchdb2.wait_until_succeeds(
-        "${curlJqCheck "GET" "" ".couchdb" "Welcome"}"
+        "${curlJqCheck "" "GET" "" ".couchdb" "Welcome"}"
     )
     couchdb2.wait_until_succeeds(
-        "${curlJqCheck "GET" "_all_dbs" ". | length" "0"}"
+        "${curlJqCheck "" "GET" "_all_dbs" ". | length" "0"}"
     )
-    couchdb2.succeed("${curlJqCheck "PUT" "foo" ".ok" "true"}")
+    couchdb2.succeed("${curlJqCheck testlogin "PUT" "foo" ".ok" "true"}")
     couchdb2.succeed(
-        "${curlJqCheck "GET" "_all_dbs" ". | length" "1"}"
-    )
-    couchdb2.succeed(
-        "${curlJqCheck "DELETE" "foo" ".ok" "true"}"
+        "${curlJqCheck "" "GET" "_all_dbs" ". | length" "1"}"
     )
     couchdb2.succeed(
-        "${curlJqCheck "GET" "_all_dbs" ". | length" "0"}"
+        "${curlJqCheck testlogin "DELETE" "foo" ".ok" "true"}"
+    )
+    couchdb2.succeed(
+        "${curlJqCheck "" "GET" "_all_dbs" ". | length" "0"}"
+    )
+
+    couchdb3.wait_for_unit("couchdb.service")
+    couchdb3.wait_until_succeeds(
+        "${curlJqCheck testlogin "GET" "" ".couchdb" "Welcome"}"
+    )
+    couchdb3.wait_until_succeeds(
+        "${curlJqCheck testlogin "GET" "_all_dbs" ". | length" "0"}"
+    )
+    couchdb3.succeed("${curlJqCheck testlogin "PUT" "foo" ".ok" "true"}")
+    couchdb3.succeed(
+        "${curlJqCheck testlogin "GET" "_all_dbs" ". | length" "1"}"
+    )
+    couchdb3.succeed(
+        "${curlJqCheck testlogin "DELETE" "foo" ".ok" "true"}"
+    )
+    couchdb3.succeed(
+        "${curlJqCheck testlogin "GET" "_all_dbs" ". | length" "0"}"
     )
   '';
 })

--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey
+, coreutils, bash, makeWrapper, python3 }:
+
+stdenv.mkDerivation rec {
+  pname = "couchdb";
+  version = "3.1.0";
+
+
+  # when updating this, please consider bumping the erlang/OTP version
+  # in all-packages.nix
+  src = fetchurl {
+    url = "mirror://apache/couchdb/source/${version}/apache-${pname}-${version}.tar.gz";
+    sha256 = "1vgqj3zsrkdqgnwzji3mqkapnfd6kq466f5xnya0fvzzl6bcfrs8";
+  };
+
+  buildInputs = [ erlang icu openssl spidermonkey (python3.withPackages(ps: with ps; [ requests ]))];
+  postPatch = ''
+    substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-68' "${spidermonkey.dev}/include/mozjs-68"
+    patchShebangs bin/rebar
+  '';
+
+  dontAddPrefix= "True";
+  configureFlags = ["--spidermonkey-version=68"];
+  buildFlags = ["release"];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r rel/couchdb/* $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A database that uses JSON for documents, JavaScript for MapReduce queries, and regular HTTP for an API";
+    homepage = "http://couchdb.apache.org";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ lostnet ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16185,6 +16185,11 @@ in
     erlang = erlangR21;
   };
 
+  couchdb3 = callPackage ../servers/http/couchdb/3.nix {
+    spidermonkey = spidermonkey_68;
+    erlang = erlangR22;
+  };
+
   couchpotato = callPackage ../servers/couchpotato {};
 
   dex-oidc = callPackage ../servers/dex { };


### PR DESCRIPTION
###### Motivation for this change
couchdb 3 has been released as a major cleanup release.

###### Things done

- Add couchdb3 package as a choice for the service
- Use its spidermonkey 60 support to not depend on older versions
- Add adminUser/adminPass options since 3.0 finally fully disabled admin-party mode
- Refactor tests a little for 3 versions and the lack of admin-party mode

tasks:
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  (None were reported by the wip review)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
(I think the only relevant documentation is autogenerated from option descriptions, etc?)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
