### PR TITLE
git-cinnabar: init at 0.5.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -68,6 +68,8 @@ let
   # support for bugzilla
   git-bz = callPackage ./git-bz { };
 
+  git-cinnabar = callPackage ./git-cinnabar { };
+
   git-codeowners = callPackage ./git-codeowners { };
 
   git-codereview = callPackage ./git-codereview { };

--- a/pkgs/applications/version-management/git-and-tools/git-cinnabar/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cinnabar/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, lib, fetchFromGitHub, autoconf, makeWrapper
+, curl, libiconv, mercurial, zlib
+}:
+
+let
+  python3 = mercurial.python;
+in
+
+stdenv.mkDerivation rec {
+  pname = "git-cinnabar";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "glandium";
+    repo = "git-cinnabar";
+    rev = version;
+    sha256 = "1cjn2cc6mj4m736wxab9s6qx83p5n5ha8cr3x84s9ra6rxs8d7pi";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ autoconf makeWrapper ];
+  buildInputs = [ curl zlib ] ++ lib.optional stdenv.isDarwin libiconv;
+
+  # Ignore submodule status failing due to no git in environment.
+  makeFlags = [ "SUBMODULE_STATUS=yes" ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/libexec
+    install git-cinnabar-helper $out/bin
+    install git-cinnabar git-remote-hg $out/libexec
+    cp -r cinnabar mercurial $out/libexec
+
+    for pythonBin in git-cinnabar git-remote-hg; do
+        makeWrapper $out/libexec/$pythonBin $out/bin/$pythonBin \
+            --prefix PATH : ${lib.getBin python3}/bin \
+            --prefix GIT_CINNABAR_EXPERIMENTS , python3 \
+            --set PYTHONPATH ${mercurial}/${python3.sitePackages}
+    done
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/glandium/git-cinnabar";
+    description = "git remote helper to interact with mercurial repositories";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ qyliss ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
git-cinnabar calls into Mercurial as a library, so we make use the
same version of Python as Mercurial.

Support for Python 3 is an experimental feature in git-cinnabar, but
we unconditionally use it here because:

* Mercurial in Nixpkgs only supports Python 3.
* git-cinnabar touches a network, and for that purpose it's good to use a version of Python that is going to get security updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
