### PR TITLE
lightdm-mini-greeter: 0.3.4 -> 0.4.0

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/mini.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/mini.nix
@@ -14,7 +14,9 @@ let
     user = ${cfg.user}
     show-password-label = true
     password-label-text = Password:
+    invalid-password-text = Invalid Password
     show-input-cursor = true
+    password-alignment = right
 
     [greeter-hotkeys]
     mod-key = meta
@@ -26,6 +28,8 @@ let
     [greeter-theme]
     font = Sans
     font-size = 1em
+    font-weight = bold
+    font-style = normal
     text-color = "#080800"
     error-color = "#F8F8F0"
     background-image = "${ldmcfg.background}"
@@ -36,6 +40,8 @@ let
     layout-space = 15
     password-color = "#F8F8F0"
     password-background-color = "#1B1D1E"
+    password-border-color = "#080800"
+    password-border-width = 2px
 
     ${cfg.extraConfig}
     '';

--- a/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-mini-greeter";
-  version = "0.3.4";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "prikhi";
     repo = "lightdm-mini-greeter";
     rev = version;
-    sha256 = "1qi0bsqi8z2zv3303ww0kd7bciz6qx8na5bkvgrqlwyvq31czai5";
+    sha256 = "10hga7pmfyjdvj4xwm3djwrhk50brcpycj3p3c57pa0vnx4ill3s";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook ];

--- a/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ mnacamura prikhi ];
     platforms = platforms.linux;
+    changelog = "https://github.com/prikhi/lightdm-mini-greeter/blob/master/CHANGELOG.md";
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
