### PR TITLE
python3Packages.PyGithub: 1.45 -> 1.47

### DIFF
--- a/pkgs/development/python-modules/pyGithub/default.nix
+++ b/pkgs/development/python-modules/pyGithub/default.nix
@@ -1,22 +1,35 @@
-{ stdenv, fetchFromGitHub
-, buildPythonPackage, python-jose, pyjwt, requests, deprecated, httpretty }:
+{ stdenv
+, buildPythonPackage
+, cryptography
+, deprecated
+, fetchFromGitHub
+, httpretty
+, isPy3k
+, parameterized
+, pyjwt
+, pytestCheckHook
+, requests }:
 
 buildPythonPackage rec {
   pname = "PyGithub";
-  version = "1.45";
+  version = "1.47";
+  disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "PyGithub";
     repo = "PyGithub";
     rev = "v${version}";
-    sha256 = "1aiyqwdxpcr7yzz7aqmmjn1g2ajs5bpbln4sax5zw19dqi6qgp9z";
+    sha256 = "0zvp1gib2lryw698vxkbdv40n3lsmdlhwp7vdcg41dqqa5nfryhn";
   };
 
-  propagatedBuildInputs = [ python-jose pyjwt requests deprecated httpretty ];
+  checkInputs = [ httpretty parameterized pytestCheckHook ];
+  propagatedBuildInputs = [ cryptography deprecated pyjwt requests ];
+
+  # Test suite makes REST calls against github.com
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/PyGithub/PyGithub;
+    homepage = "https://github.com/PyGithub/PyGithub";
     description = "A Python (2 and 3) library to access the GitHub API v3";
     platforms = platforms.all;
     license = licenses.gpl3;


### PR DESCRIPTION
Upstream dropped python2 support in 1.45, so the `nixpkgs-update` bot has not
been successful in bumping it.

While this still does not run the test suite, it gets us closer.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).