### PR TITLE
[WIP] python3Packages.pulumi-* init

### DIFF
--- a/pkgs/development/python-modules/pulumi-aws/default.nix
+++ b/pkgs/development/python-modules/pulumi-aws/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pulumi
+, parver
+, semver
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pulumi-aws";
+  version = "1.29.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi-aws";
+    rev = "v${version}";
+    sha256 = "0qmaz3fqnwh6yrw3rr0hr5nkh9a0das37a40gybsxnzkdlg66zvi";
+  };
+
+  propagatedBuildInputs = [
+    pulumi
+    parver
+    semver
+  ];
+
+  preBuild = ''
+    cd sdk/python
+
+    substituteInPlace setup.py \
+      --replace "$" "" \
+      --replace "{VERSION}" "${version}" \
+      --replace "{PLUGIN_VERSION}" "v${version}"
+  '';
+
+  # checks require cloud resources
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pulumi python amazon web services provider";
+    homepage = "https://github.com/pulumi/pulumi-aws";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pulumi-azure/default.nix
+++ b/pkgs/development/python-modules/pulumi-azure/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pulumi
+, parver
+, semver
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pulumi-azure";
+  version = "2.4.1";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi-azure";
+    rev = "v${version}";
+    sha256 = "144c2xzr9mzlb6fkzzvsav1ljhsc8rqgx0mbs7k360nigsc7vw3x";
+  };
+
+  propagatedBuildInputs = [
+    pulumi
+    parver
+    semver
+  ];
+
+  preBuild = ''
+    cd sdk/python
+
+    substituteInPlace setup.py \
+      --replace "$" "" \
+      --replace "{VERSION}" "${version}" \
+      --replace "{PLUGIN_VERSION}" "v${version}"
+  '';
+
+  # checks require cloud resources
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pulumi python azure provider";
+    homepage = "https://github.com/pulumi/pulumi-azure";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pulumi-digitalocean/default.nix
+++ b/pkgs/development/python-modules/pulumi-digitalocean/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pulumi
+, parver
+, semver
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pulumi-digitalocean";
+  version = "1.9.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi-digitalocean";
+    rev = "v${version}";
+    sha256 = "1bd0qks159hsva0pl5c28pb3i812h0ib24l2pdfcf5q775m33i70";
+  };
+
+  propagatedBuildInputs = [
+    pulumi
+    parver
+    semver
+  ];
+
+  preBuild = ''
+    cd sdk/python
+
+    substituteInPlace setup.py \
+      --replace "$" "" \
+      --replace "{VERSION}" "${version}" \
+      --replace "{PLUGIN_VERSION}" "v${version}"
+  '';
+
+  # checks require cloud resources
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pulumi python digital ocean provider";
+    homepage = "https://github.com/pulumi/pulumi-digitalocean";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pulumi-gcp/default.nix
+++ b/pkgs/development/python-modules/pulumi-gcp/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pulumi
+, parver
+, semver
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pulumi-gcp";
+  version = "2.12.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi-gcp";
+    rev = "v${version}";
+    sha256 = "044s01zjjdia6x4ah51y0ln9nb9sl7g1zqcqakwxdfhr159dspb9";
+  };
+
+  propagatedBuildInputs = [
+    pulumi
+    parver
+    semver
+  ];
+
+  preBuild = ''
+    cd sdk/python
+
+    substituteInPlace setup.py \
+      --replace "$" "" \
+      --replace "{VERSION}" "${version}" \
+      --replace "{PLUGIN_VERSION}" "v${version}"
+  '';
+
+  # checks require cloud resources
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pulumi python google cloud platform provider";
+    homepage = "https://github.com/pulumi/pulumi-gcp";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pulumi-kubernetes/default.nix
+++ b/pkgs/development/python-modules/pulumi-kubernetes/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pulumi
+, parver
+, semver
+, requests
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pulumi-kubernetes";
+  version = "1.6.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi-kubernetes";
+    rev = "v${version}";
+    sha256 = "19q5xp6rjxg3j5xli8rd5v4jjm88bnbf837g3mgz538w1df0859v";
+  };
+
+  propagatedBuildInputs = [
+    pulumi
+    parver
+    semver
+    requests
+  ];
+
+  preBuild = ''
+    cp README.md sdk/python/
+    cd sdk/python
+
+    substituteInPlace setup.py \
+      --replace "$" "" \
+      --replace "{VERSION}" "${version}" \
+      --replace "{PLUGIN_VERSION}" "v${version}" \
+      --replace "requests>=2.21.0,<2.22.0" "requests"
+  '';
+
+  # checks require cloud resources
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pulumi python kubernetes provider";
+    homepage = "https://github.com/pulumi/pulumi-kubernetes";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pulumi-random/default.nix
+++ b/pkgs/development/python-modules/pulumi-random/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pulumi
+, parver
+, semver
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pulumi-random";
+  version = "1.6.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi-random";
+    rev = "v${version}";
+    sha256 = "18wyq7c0gi137j2bpjnbf6rwqflh6q4sp9xfmbd1dc31mbr834wf";
+  };
+
+  propagatedBuildInputs = [
+    pulumi
+    parver
+    semver
+  ];
+
+  preBuild = ''
+    cd sdk/python
+
+    substituteInPlace setup.py \
+      --replace "$" "" \
+      --replace "{VERSION}" "${version}" \
+      --replace "{PLUGIN_VERSION}" "v${version}"
+  '';
+
+  # checks require cloud resources
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pulumi python random provider";
+    homepage = "https://github.com/pulumi/pulumi-random";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, protobuf
+, dill
+, grpcio
+, pulumi-bin
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pulumi";
+  version = "1.14.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi";
+    rev = "v${version}";
+    sha256 = "1qx485dy5ixx83nfar146br021wlgswqp7ia8lpi5nk880v3izs7";
+  };
+
+  propagatedBuildInputs = [
+    protobuf
+    dill
+    grpcio
+  ];
+
+  checkInputs = [
+    pulumi-bin
+  ];
+
+  postConfigure = ''
+    cp README.md sdk/python/lib
+    cd sdk/python/lib
+
+    substituteInPlace setup.py \
+      --replace "$" "" \
+      --replace "{VERSION}" "${version}"
+  '';
+
+  checkPhase = ''
+    python -m unittest discover -s test
+  '';
+
+  meta = with lib; {
+    description = "Modern Infrastructure as Code. Any cloud, any language";
+    homepage = "https://github.com/pulumi/pulumi";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1060,6 +1060,7 @@ in {
 
   pulumi = callPackage ../development/python-modules/pulumi { };
 
+  pulumi-aws = callPackage ../development/python-modules/pulumi-aws { };
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1066,6 +1066,7 @@ in {
 
   pulumi-digitalocean = callPackage ../development/python-modules/pulumi-digitalocean { };
 
+  pulumi-gcp = callPackage ../development/python-modules/pulumi-gcp { };
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1061,6 +1061,8 @@ in {
   pulumi = callPackage ../development/python-modules/pulumi { };
 
   pulumi-aws = callPackage ../development/python-modules/pulumi-aws { };
+
+  pulumi-azure = callPackage ../development/python-modules/pulumi-azure { };
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1058,6 +1058,8 @@ in {
 
   babelgladeextractor = callPackage ../development/python-modules/babelgladeextractor { };
 
+  pulumi = callPackage ../development/python-modules/pulumi { };
+
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1067,6 +1067,8 @@ in {
   pulumi-digitalocean = callPackage ../development/python-modules/pulumi-digitalocean { };
 
   pulumi-gcp = callPackage ../development/python-modules/pulumi-gcp { };
+
+  pulumi-kubernetes = callPackage ../development/python-modules/pulumi-kubernetes { };
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1063,6 +1063,9 @@ in {
   pulumi-aws = callPackage ../development/python-modules/pulumi-aws { };
 
   pulumi-azure = callPackage ../development/python-modules/pulumi-azure { };
+
+  pulumi-digitalocean = callPackage ../development/python-modules/pulumi-digitalocean { };
+
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1069,6 +1069,9 @@ in {
   pulumi-gcp = callPackage ../development/python-modules/pulumi-gcp { };
 
   pulumi-kubernetes = callPackage ../development/python-modules/pulumi-kubernetes { };
+
+  pulumi-random = callPackage ../development/python-modules/pulumi-random { };
+
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Initializing basic pulumi python resources for devops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
