### PR TITLE
zenith: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/tools/system/zenith/cargo-lock.patch
+++ b/pkgs/tools/system/zenith/cargo-lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 3f4eec6..2f565c6 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1297,7 +1297,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+ 
+ [[package]]
+ name = "zenith"
+-version = "0.8.0"
++version = "0.8.1"
+ dependencies = [
+  "battery",
+  "bincode",

--- a/pkgs/tools/system/zenith/default.nix
+++ b/pkgs/tools/system/zenith/default.nix
@@ -2,22 +2,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "zenith";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "bvaisvil";
     repo = pname;
     rev = version;
-    sha256 = "1m709mnhhjs30s91542rhri3xbzsb3kw8zablvn11rwp2iq1lxxx";
+    sha256 = "12wbx4zhf1rf13g3mw8vcn8aqk9vcza61vi42y6c1pb2km73qw1h";
   };
 
-  cargoSha256 = "1j6pww4mpssnr9zsbfy74llv7336kjrif1qiph998b82qj63vdlg";
+  cargoPatches = [ ./cargo-lock.patch ];
+  cargoSha256 = "1nyci2vjwsyfscsd520d1r5vyazb33hv4mrsysy6amss4jdf2dlq";
 
   meta = with stdenv.lib; {
     description = "Sort of like top or htop but with zoom-able charts, network, and disk usage";
     homepage = "https://github.com/bvaisvil/zenith";
     license = licenses.mit;
     maintainers = with maintainers; [ bbigras ];
+    # doesn't build on aarch64 https://github.com/bvaisvil/zenith/issues/19
     platforms = platforms.x86;
   };
 }

--- a/pkgs/tools/system/zenith/default.nix
+++ b/pkgs/tools/system/zenith/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, rustPlatform, fetchFromGitHub }:
+{ stdenv, rustPlatform, fetchFromGitHub, IOKit }:
 
 rustPlatform.buildRustPackage rec {
   pname = "zenith";
@@ -13,6 +13,8 @@ rustPlatform.buildRustPackage rec {
 
   cargoPatches = [ ./cargo-lock.patch ];
   cargoSha256 = "1nyci2vjwsyfscsd520d1r5vyazb33hv4mrsysy6amss4jdf2dlq";
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
 
   meta = with stdenv.lib; {
     description = "Sort of like top or htop but with zoom-able charts, network, and disk usage";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7720,7 +7720,9 @@ in
 
   zdelta = callPackage ../tools/compression/zdelta { };
 
-  zenith = callPackage ../tools/system/zenith {};
+  zenith = callPackage ../tools/system/zenith {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
 
   zerotierone = callPackage ../tools/networking/zerotierone { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
0.8.1 has support for the htop's "p mode"  @Evils-Devils . It behaves almost exactly but for some reason I see things like "Web Content" instead of the "firefox" process. https://github.com/bvaisvil/zenith/issues/15

###### Things done
~~I removed `platforms.x86` temporary just to see if it builds for aarch64 this time and if not so I can report the exact error message upstream at https://github.com/bvaisvil/zenith/issues/19~~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/cj484xb1pqp8k7fs2p68lilfn0zgyyb7-zenith-0.8.0	  34.8M
/nix/store/q2p6ylffsvpvqxf5p648nj7s3b4zw5f6-zenith-0.8.1	  34.8M