### PR TITLE
cataclysm-dda: 0.D -> 0.E

### DIFF
--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, lua, CoreFoundation
+{ stdenv, callPackage, CoreFoundation
 , tiles ? true, Cocoa
 , debug ? false
 }:
@@ -9,27 +9,15 @@ let
 in
 
 stdenv.mkDerivation (common // rec {
-  version = "0.D";
+  version = "0.E";
   name = "cataclysm-dda-${version}";
 
   src = fetchFromCleverRaven {
     rev = version;
-    sha256 = "00zzhx1mh1qjq668cga5nbrxp2qk6b82j5ak65skhgnlr6ii4ysc";
+    sha256 = "0pbi0fw37zimzdklfj58s1ql0wlqq7dy6idkcsib3hn910ajaxan";
   };
 
-  buildInputs = common.buildInputs ++ [ lua ];
-
   patches = [ ./patches/fix_locale_dir.patch ];
-
-  postPatch = common.postPatch + ''
-    substituteInPlace lua/autoexec.lua --replace "/usr/share" "$out/share"
-  '';
-
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isGNU "-Wno-error=deprecated-copy";
-
-  makeFlags = common.makeFlags ++ [
-    "LUA=1"
-  ];
 
   meta = with stdenv.lib.maintainers; common.meta // {
     maintainers = common.meta.maintainers ++ [ skeidel ];

--- a/pkgs/games/cataclysm-dda/patches/fix_locale_dir.patch
+++ b/pkgs/games/cataclysm-dda/patches/fix_locale_dir.patch
@@ -1,15 +1,13 @@
-diff --git a/src/translations.cpp b/src/translations.cpp
-index 2585b7ec56..7bb005823c 100644
 --- a/src/translations.cpp
 +++ b/src/translations.cpp
-@@ -195,14 +195,12 @@ void set_language()
+@@ -212,14 +212,12 @@ void set_language()
      auto env = getenv( "LANGUAGE" );
-     locale_dir = std::string( FILENAMES["base_path"] + "lang/mo/" + ( env ? env : "none" ) +
+     locale_dir = std::string( PATH_INFO::base_path() + "lang/mo/" + ( env ? env : "none" ) +
                                "/LC_MESSAGES/cataclysm-dda.mo" );
--#elif (defined __linux__ || (defined MACOSX && !defined TILES))
+-#elif (defined(__linux__) || (defined(MACOSX) && !defined(TILES)))
 +#else
-     if( !FILENAMES["base_path"].empty() ) {
-         locale_dir = FILENAMES["base_path"] + "share/locale";
+     if( !PATH_INFO::base_path().empty() ) {
+         locale_dir = PATH_INFO::base_path() + "share/locale";
      } else {
          locale_dir = "lang/mo";
      }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New release, just released a few days ago. Ran it and played briefly, seems to work fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
