### PR TITLE
python3Packages.nose2: 0.9.1 -> 0.9.2 and fix build for ZHF

### DIFF
--- a/pkgs/development/python-modules/nose2/default.nix
+++ b/pkgs/development/python-modules/nose2/default.nix
@@ -3,28 +3,29 @@
 , fetchPypi
 , six
 , pythonOlder
-, mock
 , coverage
 }:
 
 buildPythonPackage rec {
   pname = "nose2";
-  version = "0.9.1";
+  version = "0.9.2";
+
+  # Requires mock 2.0.0 if python < 3.6, but NixPkgs has mock 3.0.5.
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "16drs4bc2wvgwwi1pf6pmk6c00pl16vs1v7djc4a8kwpsxpibphf";
+    sha256 = "0pmbb6nk31yhgh4zkcblzxsznml7f7pf5q1ihgrwvbxv4mwzfql7";
   };
 
-  propagatedBuildInputs = [ six coverage ]
-    ++ stdenv.lib.optionals (pythonOlder "3.4") [ mock ];
+  propagatedBuildInputs = [ six coverage ];
 
   # AttributeError: 'module' object has no attribute 'collector'
   doCheck = false;
 
   meta = with stdenv.lib; {
     description = "nose2 is the next generation of nicer testing for Python";
-    homepage = https://github.com/nose-devs/nose2;
+    homepage = "https://github.com/nose-devs/nose2";
     license = licenses.bsd0;
   };
 


### PR DESCRIPTION
See inline comment; this is currently broken and not going to continue working
on python2 without significant effort, so mark it python >= 3.6 only.

https://hydra.nixos.org/build/114680648
https://hydra.nixos.org/build/115518949

CC @NixOS/nixos-release-managers

ZHF: #80379


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).