### PR TITLE
libturbojpeg: init at 2.0.4

### DIFF
--- a/pkgs/development/libraries/libturbojpeg/default.nix
+++ b/pkgs/development/libraries/libturbojpeg/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, nasm }:
+
+stdenv.mkDerivation rec {
+  pname = "libturbojpeg";
+  version = "2.0.4";
+
+  src = fetchFromGitHub {
+    owner = "libjpeg-turbo";
+    repo = "libjpeg-turbo";
+    rev = version;
+    sha256 = "0p19xhsydl582swlvj6lsiql7x7kqjn03m2ryrzivr0pxqkzaaf9";
+  };
+
+  nativeBuildInputs = [ cmake nasm ];
+
+  meta = with stdenv.lib; {
+    description = "libjpeg-turbo is a JPEG image codec that uses SIMD instructions (MMX, SSE2, AVX2, NEON, AltiVec) to accelerate baseline JPEG compression and decompression on x86, x86-64, ARM, and PowerPC systems, as well as progressive JPEG compression on x86 and x86-64 systems.";
+    inherit (src.meta) homepage;
+    license     = [ licenses.ijg licenses.bsd3 licenses.zlib ];
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4886,6 +4886,8 @@ in
 
   libtins = callPackage ../development/libraries/libtins { };
 
+  libturbojpeg = callPackage ../development/libraries/libturbojpeg { };
+
   libshout = callPackage ../development/libraries/libshout { };
 
   libqb = callPackage ../development/libraries/libqb { };


### PR DESCRIPTION
###### Motivation for this change

Init `libturbojpeg` at current stable release.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
