### PR TITLE
biblesync: 1.1.2 -> 2.0.1

### DIFF
--- a/pkgs/development/libraries/biblesync/default.nix
+++ b/pkgs/development/libraries/biblesync/default.nix
@@ -1,21 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, cmake, libuuid }:
+{ stdenv, fetchFromGitHub
+, pkgconfig, cmake, libuuid }:
 
 with stdenv.lib;
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
 
   pname = "biblesync";
-  version = "1.1.2";
+  version = "2.0.1";
 
-  src = fetchurl{
-    url = "mirror://sourceforge/project/gnomesword/BibleSync/1.1.2/${pname}-${version}.tar.gz";
-    sha256 = "0190q2da0ppif2242lahl8xfz01n9sijy60aq1a0545qcp0ilvl8";
+  src = fetchFromGitHub{
+    owner = "karlkleinpaste";
+    repo = "biblesync";
+    rev = "${version}";
+    sha256 = "1baq2fwf6132i514xrvq05p2gy98mkg1rn5whf9q5k475q81nrlr";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake libuuid ];
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ libuuid ];
 
   meta = {
-    homepage = http://www.crosswire.org/wiki/BibleSync;
+    homepage = "http://www.crosswire.org/wiki/BibleSync";
     description = "A multicast protocol to Bible software shared conavigation";
     longDescription = ''
       BibleSync is a multicast protocol to support Bible software


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
