### PR TITLE
kmon: init at 1.0.0

### DIFF
--- a/pkgs/tools/system/kmon/default.nix
+++ b/pkgs/tools/system/kmon/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, rustPlatform, python3, libxcb }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kmon";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "orhun";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zsgyigr6k0zqhhv0icpvvfij7r7fj0l2f77i5zh1vyb89pni50h";
+  };
+
+  cargoSha256 = "15lj6ryll24xdmv8gil04prhcri2d3b1rxqjrwx70blfrlvvhxa8";
+
+  nativeBuildInputs = [ python3 ];
+
+  buildInputs = [ libxcb ];
+
+  meta = with stdenv.lib; {
+    description = "Linux Kernel Manager and Activity Monitor";
+    homepage = "https://github.com/orhun/kmon";
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ misuzu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25373,6 +25373,8 @@ in
 
   keynav = callPackage ../tools/X11/keynav { };
 
+  kmon = callPackage ../tools/system/kmon { };
+
   kompose = callPackage ../applications/networking/cluster/kompose { };
 
   kontemplate = callPackage ../applications/networking/cluster/kontemplate { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/orhun/kmon/releases/tag/v1.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
