### PR TITLE
vcs: init at 1.13.4

### DIFF
--- a/pkgs/applications/video/vcs/default.nix
+++ b/pkgs/applications/video/vcs/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   unpackCmd = "mkdir src; cp $curSrc src/vcs";
   patches = [ ./fonts.patch ];
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
   doBuild = false;
 
   inherit dejavu_fonts;

--- a/pkgs/applications/video/vcs/default.nix
+++ b/pkgs/applications/video/vcs/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, makeWrapper
+, coreutils, ffmpeg, gawk, gnugrep, gnused, imagemagick, mplayer, utillinux
+, dejavu_fonts
+}:
+with stdenv.lib;
+let
+  version = "1.13.4";
+  runtimeDeps = [ coreutils ffmpeg gawk gnugrep gnused imagemagick mplayer utillinux ];
+in
+stdenv.mkDerivation {
+  name = "vcs-${version}";
+  src = fetchurl {
+    url = "http://p.outlyer.net/files/vcs/vcs-${version}.bash";
+    sha256 = "0nhwcpffp3skz24kdfg4445i6j37ks6a0qsbpfd3dbi4vnpa60a0";
+  };
+
+  unpackCmd = "mkdir src; cp $curSrc src/vcs";
+  patches = [ ./fonts.patch ];
+  buildInputs = [ makeWrapper ];
+  doBuild = false;
+
+  inherit dejavu_fonts;
+  installPhase = ''
+    mkdir -p $out/bin
+    mv vcs $out/bin/vcs
+    substituteAllInPlace $out/bin/vcs
+    chmod +x $out/bin/vcs
+    wrapProgram $out/bin/vcs --argv0 vcs --set PATH "${makeBinPath runtimeDeps}"
+  '';
+
+  meta = {
+    description = "Generates contact sheets from video files";
+    homepage = "http://p.outlyer.net/vcs";
+    license = licenses.cc-by-nc-sa-30;
+    maintainers = with maintainers; [ elitak ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/applications/video/vcs/default.nix
+++ b/pkgs/applications/video/vcs/default.nix
@@ -8,7 +8,8 @@ let
   runtimeDeps = [ coreutils ffmpeg gawk gnugrep gnused imagemagick mplayer utillinux ];
 in
 stdenv.mkDerivation {
-  name = "vcs-${version}";
+  pname = "vcs";
+  inherit version;
   src = fetchurl {
     url = "http://p.outlyer.net/files/vcs/vcs-${version}.bash";
     sha256 = "0nhwcpffp3skz24kdfg4445i6j37ks6a0qsbpfd3dbi4vnpa60a0";

--- a/pkgs/applications/video/vcs/fonts.patch
+++ b/pkgs/applications/video/vcs/fonts.patch
@@ -1,0 +1,23 @@
+--- a/vcs	2020-04-04 14:37:53.531095977 -0700
++++ b/vcs	2020-04-04 14:40:46.459407878 -0700
+@@ -3669,18 +3669,8 @@
+ 	[[ ( -z $USR_FONT_TITLE ) && ( $FONT_TITLE != 'DejaVu-Sans-Book' ) ]] && return
+ 	[[ ( -z $USR_FONT_TSTAMPS ) && ( $FONT_TSTAMPS != 'DejaVu-Sans-Book' ) ]] && return
+ 	[[ ( -z $USR_FONT_SIGN ) && ( $FONT_SIGN != 'DejaVu-Sans-Book' ) ]] && return
+-	# Try to locate DejaVu Sans
+-	local dvs=''
+-	if [[ -d /usr/local/share/fonts ]]; then
+-		dvs=$(find /usr/local/share/fonts/ -type f -iname 'dejavusans.ttf')
+-	fi
+-	if [[ ( -z $dvs ) && ( -d /usr/share/fonts ) ]]; then
+-		dvs=$(find /usr/share/fonts/ -type f -iname 'dejavusans.ttf')
+-	fi
+-	if [[ -z $dvs ]]; then
+-		warn "Unable to locate DejaVu Sans font. Falling back to helvetica."
+-		dvs=helvetica
+-	fi
++	# Use DejaVu Sans, by default
++	local dvs='@dejavu_fonts@/share/fonts/truetype/DejaVuSans.ttf'
+ 	[[ -z $USR_FONT_HEADING ]] && FONT_HEADING="$dvs"
+ 	[[ -z $USR_FONT_TITLE ]] && FONT_TITLE="$dvs"
+ 	[[ -z $USR_FONT_TSTAMPS ]] && FONT_TSTAMPS="$dvs"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22262,6 +22262,8 @@ in
 
   vcprompt = callPackage ../applications/version-management/vcprompt { };
 
+  vcs = callPackage ../applications/video/vcs { };
+
   vcv-rack = callPackage ../applications/audio/vcv-rack { };
 
   vdirsyncer = callPackage ../tools/misc/vdirsyncer {


### PR DESCRIPTION
###### Motivation for this change
Adding package Video Contact Sheet (`vcs`), a bash script that generates contact sheets from video files.
###### Things done
- I've fixed all runtime binaries using `wrapProgram`, including `coreutils` and `utillinux`. Is that appropriate?
- The script also pulls in `dejavu_fonts` to use as its default at runtime, increasing its closure size.
- This has the same executable name, "vcs", as one provided by package `vcstool`. Is that a problem?


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
