### PR TITLE
lutris: 0.5.4 -> 0.5.5

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -1,7 +1,7 @@
 { buildPythonApplication, lib, fetchFromGitHub, fetchpatch
 , wrapGAppsHook, gobject-introspection, gnome-desktop, libnotify, libgnome-keyring, pango
 , gdk-pixbuf, atk, webkitgtk, gst_all_1
-, evdev, pyyaml, pygobject3, requests, pillow
+, dbus-python, evdev, pyyaml, pygobject3, requests, pillow
 , xrandr, pciutils, psmisc, glxinfo, vulkan-tools, xboxdrv, pulseaudio, p7zip, xgamma
 , libstrangle, wine, fluidsynth, xorgserver
 }:
@@ -31,21 +31,14 @@ let
 
 in buildPythonApplication rec {
   pname = "lutris-original";
-  version = "0.5.4";
+  version = "0.5.5";
 
   src = fetchFromGitHub {
     owner = "lutris";
     repo = "lutris";
     rev = "v${version}";
-    sha256 = "0i4i6g3pys1vf2q1pbs1fkywgapj4qfxrjrvim98hzw9al4l06y9";
+    sha256 = "1g093g0difnkjmnm91p20issdsxn9ri4c56zzddj5wfrbmhwdfag";
   };
-
-  patches = [(
-    fetchpatch {
-      url = "https://github.com/lutris/lutris/pull/2558.patch";
-      sha256 = "1wbsplri5ii06gzv6mzhiic61zkgsp9bkjkaknkd83203p0i9b2d";
-    }
-  )];
 
   buildInputs = [
     wrapGAppsHook gobject-introspection gnome-desktop libnotify libgnome-keyring pango
@@ -57,7 +50,7 @@ in buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = [
-    evdev pyyaml pygobject3 requests pillow
+    evdev pyyaml pygobject3 requests pillow dbus-python
   ];
 
   preCheck = "export HOME=$PWD";


### PR DESCRIPTION
###### Motivation for this change
just noticed it was out of date when investigating https://discourse.nixos.org/t/lutris-icons-are-broken/6553

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[91 built, 18 copied (20.6 MiB), 5.1 MiB DL]
https://github.com/NixOS/nixpkgs/pull/84289
3 package built:
lutris lutris-free lutris-unwrapped
```