### PR TITLE
hydra: add dep on perlPackages.CatalystPluginSmartURI

### DIFF
--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -27,6 +27,7 @@ let
         CatalystPluginCaptcha
         CatalystPluginSessionStateCookie
         CatalystPluginSessionStoreFastMmap
+        CatalystPluginSmartURI
         CatalystPluginStackTrace
         CatalystRuntime
         CatalystTraitForRequestProxyBase


### PR DESCRIPTION
###### Motivation for this change

This plugin allows configuring the URLs generated by Catalyst (and
therefore by Hydra) to be relative instead of absolute, which makes it
automatically behave correctly when Hydra is accessed both directly
and behind a reverse proxy.

I've tested that Hydra continues to work correctly and that both relative and absolute URLs continue to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
