### PR TITLE
ninjas2: init at 0.2.0

### DIFF
--- a/pkgs/applications/audio/ninjas2/default.nix
+++ b/pkgs/applications/audio/ninjas2/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, libjack2, libGL, pkgconfig, xorg, mesa, libsndfile, libsamplerate }:
+
+stdenv.mkDerivation rec {
+  pname = "ninjas2";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "clearly-broken-software";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kwp6pmnfar2ip9693gprfbcfscklgri1k1ycimxzlqr61nkd2k9";
+    fetchSubmodules = true;
+  };
+
+  patchPhase = ''
+    patchShebangs dpf/utils/generate-ttl.sh
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    libjack2 xorg.libX11 libGL mesa libsndfile libsamplerate
+  ];
+
+  installPhase = ''
+    install -dD bin/ninjas2.lv2 $out/lib/lv2/ninjas2.lv2
+    install -D bin/ninjas2-vst.so  $out/lib/vst/ninjas2-vst.so
+    install -D bin/ninjas2 $out/bin/ninjas2
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/clearly-broken-software/ninjas2";
+    description = "sample slicer plugin for LV2, VST, and jack standalone";
+    license = with licenses; [ gpl3 ];
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20860,6 +20860,8 @@ in
 
   node-problem-detector = callPackage ../applications/networking/cluster/node-problem-detector { };
 
+  ninjas2 = callPackage ../applications/audio/ninjas2 {};
+
   notion = callPackage ../applications/window-managers/notion { };
 
   nootka = qt5.callPackage ../applications/audio/nootka { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
