### PR TITLE
zfs: Linux 5.6 compatibility

### DIFF
--- a/pkgs/os-specific/linux/zfs/0001-Linux-5.6-compat-struct-proc_ops.patch
+++ b/pkgs/os-specific/linux/zfs/0001-Linux-5.6-compat-struct-proc_ops.patch
@@ -1,0 +1,255 @@
+From d47a2c3d6026ecc06edfe4d594937c0ec9e6ccee Mon Sep 17 00:00:00 2001
+From: Brian Behlendorf <behlendorf1@llnl.gov>
+Date: Thu, 6 Feb 2020 10:30:41 -0800
+Subject: [PATCH 1/4] Linux 5.6 compat: struct proc_ops
+
+The proc_ops structure was introduced to replace the use of of the
+file_operations structure when registering proc handlers.  This
+change creates a new kstat_proc_op_t typedef for compatibility
+which can be used to pass around the correct structure.
+
+This change additionally adds the 'const' keyword to all of the
+existing proc operations structures.
+
+Reviewed-by: Tony Hutter <hutter2@llnl.gov>
+Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Closes #9961
+---
+ config/kernel-proc-operations.m4 | 41 ++++++++++++++++++++++++++++++++
+ config/kernel.m4                 |  2 ++
+ include/spl/sys/kstat.h          |  8 ++++++-
+ module/spl/spl-kstat.c           | 14 ++++++++---
+ module/spl/spl-proc.c            | 33 ++++++++++++++++++++-----
+ module/spl/spl-procfs-list.c     | 11 +++++++--
+ 6 files changed, 97 insertions(+), 12 deletions(-)
+ create mode 100644 config/kernel-proc-operations.m4
+
+diff --git a/config/kernel-proc-operations.m4 b/config/kernel-proc-operations.m4
+new file mode 100644
+index 000000000..df216222e
+--- /dev/null
++++ b/config/kernel-proc-operations.m4
+@@ -0,0 +1,41 @@
++dnl #
++dnl # 5.6 API Change
++dnl # The proc_ops structure was introduced to replace the use of
++dnl # of the file_operations structure when registering proc handlers.
++dnl #
++AC_DEFUN([ZFS_AC_KERNEL_SRC_PROC_OPERATIONS], [
++	ZFS_LINUX_TEST_SRC([proc_ops_struct], [
++		#include <linux/proc_fs.h>
++
++		int test_open(struct inode *ip, struct file *fp) { return 0; }
++		ssize_t test_read(struct file *fp, char __user *ptr,
++		    size_t size, loff_t *offp) { return 0; }
++		ssize_t test_write(struct file *fp, const char __user *ptr,
++		    size_t size, loff_t *offp) { return 0; }
++		loff_t test_lseek(struct file *fp, loff_t off, int flag)
++		    { return 0; }
++		int test_release(struct inode *ip, struct file *fp)
++		    { return 0; }
++
++		const struct proc_ops test_ops __attribute__ ((unused)) = {
++			.proc_open      = test_open,
++			.proc_read      = test_read,
++			.proc_write	= test_write,
++			.proc_lseek     = test_lseek,
++			.proc_release   = test_release,
++		};
++	], [
++		struct proc_dir_entry *entry __attribute__ ((unused)) =
++		    proc_create_data("test", 0444, NULL, &test_ops, NULL);
++	])
++])
++
++AC_DEFUN([ZFS_AC_KERNEL_PROC_OPERATIONS], [
++	AC_MSG_CHECKING([whether proc_ops structure exists])
++	ZFS_LINUX_TEST_RESULT([proc_ops_struct], [
++		AC_MSG_RESULT(yes)
++		AC_DEFINE(HAVE_PROC_OPS_STRUCT, 1, [proc_ops structure exists])
++	], [
++		AC_MSG_RESULT(no)
++	])
++])
+diff --git a/config/kernel.m4 b/config/kernel.m4
+index dce619729..780de3318 100644
+--- a/config/kernel.m4
++++ b/config/kernel.m4
+@@ -54,6 +54,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_SRC], [
+ 	ZFS_AC_KERNEL_SRC_CURRENT_BIO_TAIL
+ 	ZFS_AC_KERNEL_SRC_SUPER_USER_NS
+ 	ZFS_AC_KERNEL_SRC_SUBMIT_BIO
++	ZFS_AC_KERNEL_SRC_PROC_OPERATIONS
+ 	ZFS_AC_KERNEL_SRC_BLOCK_DEVICE_OPERATIONS
+ 	ZFS_AC_KERNEL_SRC_BLKDEV_GET_BY_PATH
+ 	ZFS_AC_KERNEL_SRC_BLKDEV_REREAD_PART
+@@ -170,6 +171,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_RESULT], [
+ 	ZFS_AC_KERNEL_CURRENT_BIO_TAIL
+ 	ZFS_AC_KERNEL_SUPER_USER_NS
+ 	ZFS_AC_KERNEL_SUBMIT_BIO
++	ZFS_AC_KERNEL_PROC_OPERATIONS
+ 	ZFS_AC_KERNEL_BLOCK_DEVICE_OPERATIONS
+ 	ZFS_AC_KERNEL_BLKDEV_GET_BY_PATH
+ 	ZFS_AC_KERNEL_BLKDEV_REREAD_PART
+diff --git a/include/spl/sys/kstat.h b/include/spl/sys/kstat.h
+index 3ce474248..c93c53171 100644
+--- a/include/spl/sys/kstat.h
++++ b/include/spl/sys/kstat.h
+@@ -152,6 +152,12 @@ typedef struct kstat_named_s {
+ #define	KSTAT_NAMED_STR_PTR(knptr) ((knptr)->value.string.addr.ptr)
+ #define	KSTAT_NAMED_STR_BUFLEN(knptr) ((knptr)->value.string.len)
+ 
++#ifdef HAVE_PROC_OPS_STRUCT
++typedef struct proc_ops kstat_proc_op_t;
++#else
++typedef struct file_operations kstat_proc_op_t;
++#endif
++
+ typedef struct kstat_intr {
+ 	uint_t intrs[KSTAT_NUM_INTRS];
+ } kstat_intr_t;
+@@ -197,7 +203,7 @@ extern void kstat_proc_entry_init(kstat_proc_entry_t *kpep,
+     const char *module, const char *name);
+ extern void kstat_proc_entry_delete(kstat_proc_entry_t *kpep);
+ extern void kstat_proc_entry_install(kstat_proc_entry_t *kpep, mode_t mode,
+-    const struct file_operations *file_ops, void *data);
++    const kstat_proc_op_t *file_ops, void *data);
+ 
+ extern void __kstat_install(kstat_t *ksp);
+ extern void __kstat_delete(kstat_t *ksp);
+diff --git a/module/spl/spl-kstat.c b/module/spl/spl-kstat.c
+index c97b6d6cb..c54378ace 100644
+--- a/module/spl/spl-kstat.c
++++ b/module/spl/spl-kstat.c
+@@ -507,12 +507,20 @@ proc_kstat_write(struct file *filp, const char __user *buf, size_t len,
+ 	return (len);
+ }
+ 
+-static struct file_operations proc_kstat_operations = {
++static const kstat_proc_op_t proc_kstat_operations = {
++#ifdef HAVE_PROC_OPS_STRUCT
++	.proc_open	= proc_kstat_open,
++	.proc_write	= proc_kstat_write,
++	.proc_read	= seq_read,
++	.proc_lseek	= seq_lseek,
++	.proc_release	= seq_release,
++#else
+ 	.open		= proc_kstat_open,
+ 	.write		= proc_kstat_write,
+ 	.read		= seq_read,
+ 	.llseek		= seq_lseek,
+ 	.release	= seq_release,
++#endif
+ };
+ 
+ void
+@@ -656,7 +664,7 @@ kstat_detect_collision(kstat_proc_entry_t *kpep)
+  */
+ void
+ kstat_proc_entry_install(kstat_proc_entry_t *kpep, mode_t mode,
+-    const struct file_operations *file_ops, void *data)
++    const kstat_proc_op_t *proc_ops, void *data)
+ {
+ 	kstat_module_t *module;
+ 	kstat_proc_entry_t *tmp = NULL;
+@@ -690,7 +698,7 @@ kstat_proc_entry_install(kstat_proc_entry_t *kpep, mode_t mode,
+ 
+ 	kpep->kpe_owner = module;
+ 	kpep->kpe_proc = proc_create_data(kpep->kpe_name, mode,
+-	    module->ksm_proc, file_ops, data);
++	    module->ksm_proc, proc_ops, data);
+ 	if (kpep->kpe_proc == NULL) {
+ 		list_del_init(&kpep->kpe_list);
+ 		if (list_empty(&module->ksm_kstat_list))
+diff --git a/module/spl/spl-proc.c b/module/spl/spl-proc.c
+index c0c13913c..40315ede3 100644
+--- a/module/spl/spl-proc.c
++++ b/module/spl/spl-proc.c
+@@ -532,11 +532,18 @@ proc_slab_open(struct inode *inode, struct file *filp)
+ 	return (seq_open(filp, &slab_seq_ops));
+ }
+ 
+-static struct file_operations proc_slab_operations = {
+-	.open	   = proc_slab_open,
+-	.read	   = seq_read,
+-	.llseek	 = seq_lseek,
++static const kstat_proc_op_t proc_slab_operations = {
++#ifdef HAVE_PROC_OPS_STRUCT
++	.proc_open	= proc_slab_open,
++	.proc_read	= seq_read,
++	.proc_lseek	= seq_lseek,
++	.proc_release	= seq_release,
++#else
++	.open		= proc_slab_open,
++	.read		= seq_read,
++	.llseek		= seq_lseek,
+ 	.release	= seq_release,
++#endif
+ };
+ 
+ static void
+@@ -571,18 +578,32 @@ proc_taskq_open(struct inode *inode, struct file *filp)
+ 	return (seq_open(filp, &taskq_seq_ops));
+ }
+ 
+-static struct file_operations proc_taskq_all_operations = {
++static const kstat_proc_op_t proc_taskq_all_operations = {
++#ifdef HAVE_PROC_OPS_STRUCT
++	.proc_open	= proc_taskq_all_open,
++	.proc_read	= seq_read,
++	.proc_lseek	= seq_lseek,
++	.proc_release	= seq_release,
++#else
+ 	.open		= proc_taskq_all_open,
+ 	.read		= seq_read,
+ 	.llseek		= seq_lseek,
+ 	.release	= seq_release,
++#endif
+ };
+ 
+-static struct file_operations proc_taskq_operations = {
++static const kstat_proc_op_t proc_taskq_operations = {
++#ifdef HAVE_PROC_OPS_STRUCT
++	.proc_open	= proc_taskq_open,
++	.proc_read	= seq_read,
++	.proc_lseek	= seq_lseek,
++	.proc_release	= seq_release,
++#else
+ 	.open		= proc_taskq_open,
+ 	.read		= seq_read,
+ 	.llseek		= seq_lseek,
+ 	.release	= seq_release,
++#endif
+ };
+ 
+ static struct ctl_table spl_kmem_table[] = {
+diff --git a/module/spl/spl-procfs-list.c b/module/spl/spl-procfs-list.c
+index f6a00da5c..189d6a7c6 100644
+--- a/module/spl/spl-procfs-list.c
++++ b/module/spl/spl-procfs-list.c
+@@ -185,13 +185,20 @@ procfs_list_write(struct file *filp, const char __user *buf, size_t len,
+ 	return (len);
+ }
+ 
+-static struct file_operations procfs_list_operations = {
+-	.owner		= THIS_MODULE,
++static const kstat_proc_op_t procfs_list_operations = {
++#ifdef HAVE_PROC_OPS_STRUCT
++	.proc_open	= procfs_list_open,
++	.proc_write	= procfs_list_write,
++	.proc_read	= seq_read,
++	.proc_lseek	= seq_lseek,
++	.proc_release	= seq_release_private,
++#else
+ 	.open		= procfs_list_open,
+ 	.write		= procfs_list_write,
+ 	.read		= seq_read,
+ 	.llseek		= seq_lseek,
+ 	.release	= seq_release_private,
++#endif
+ };
+ 
+ /*
+-- 
+2.25.1
+

--- a/pkgs/os-specific/linux/zfs/0002-Linux-5.6-compat-timestamp_truncate.patch
+++ b/pkgs/os-specific/linux/zfs/0002-Linux-5.6-compat-timestamp_truncate.patch
@@ -1,0 +1,139 @@
+From 06ee3bf97e810ee3c4e944d27bc32df4fd438c3a Mon Sep 17 00:00:00 2001
+From: Brian Behlendorf <behlendorf1@llnl.gov>
+Date: Thu, 6 Feb 2020 12:37:25 -0800
+Subject: [PATCH 2/4] Linux 5.6 compat: timestamp_truncate()
+
+The timestamp_truncate() function was added, it replaces the existing
+timespec64_trunc() function.  This change renames our wrapper function
+to be consistent with the upstream name and updates the compatibility
+code for older kernels accordingly.
+
+Reviewed-by: Tony Hutter <hutter2@llnl.gov>
+Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Closes #9956
+Closes #9961
+---
+ config/kernel-inode-times.m4 | 31 +++++++++++++++++++++++++++----
+ include/sys/zpl.h            | 13 +++++++------
+ module/zfs/zfs_vnops.c       |  8 ++++----
+ module/zfs/zpl_inode.c       |  6 ++----
+ 4 files changed, 40 insertions(+), 18 deletions(-)
+
+diff --git a/config/kernel-inode-times.m4 b/config/kernel-inode-times.m4
+index 57e7f31fd..8a79c299e 100644
+--- a/config/kernel-inode-times.m4
++++ b/config/kernel-inode-times.m4
+@@ -1,8 +1,22 @@
+-dnl #
+-dnl # 4.18 API change
+-dnl # i_atime, i_mtime, and i_ctime changed from timespec to timespec64.
+-dnl #
+ AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_TIMES], [
++
++	dnl #
++	dnl # 5.6 API change
++	dnl # timespec64_trunc() replaced by timestamp_truncate() interface.
++	dnl #
++	ZFS_LINUX_TEST_SRC([timestamp_truncate], [
++		#include <linux/fs.h>
++	],[
++		struct timespec64 ts;
++		struct inode ip;
++
++		ts = timestamp_truncate(ts, &ip);
++	])
++
++	dnl #
++	dnl # 4.18 API change
++	dnl # i_atime, i_mtime, and i_ctime changed from timespec to timespec64.
++	dnl #
+ 	ZFS_LINUX_TEST_SRC([inode_times], [
+ 		#include <linux/fs.h>
+ 	],[
+@@ -15,6 +29,15 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_INODE_TIMES], [
+ ])
+ 
+ AC_DEFUN([ZFS_AC_KERNEL_INODE_TIMES], [
++	AC_MSG_CHECKING([whether timestamp_truncate() exists])
++	ZFS_LINUX_TEST_RESULT([timestamp_truncate], [
++		AC_MSG_RESULT(yes)
++		AC_DEFINE(HAVE_INODE_TIMESTAMP_TRUNCATE, 1,
++		    [timestamp_truncate() exists])
++	],[
++		AC_MSG_RESULT(no)
++	])
++
+ 	AC_MSG_CHECKING([whether inode->i_*time's are timespec64])
+ 	ZFS_LINUX_TEST_RESULT([inode_times], [
+ 		AC_MSG_RESULT(no)
+diff --git a/include/sys/zpl.h b/include/sys/zpl.h
+index 2766269f3..f88ccd540 100644
+--- a/include/sys/zpl.h
++++ b/include/sys/zpl.h
+@@ -188,13 +188,14 @@ zpl_dir_emit_dots(struct file *file, zpl_dir_context_t *ctx)
+ }
+ #endif /* HAVE_VFS_ITERATE */
+ 
+-/*
+- * Linux 4.18, inode times converted from timespec to timespec64.
+- */
+-#if defined(HAVE_INODE_TIMESPEC64_TIMES)
+-#define	zpl_inode_timespec_trunc(ts, gran)	timespec64_trunc(ts, gran)
++#if defined(HAVE_INODE_TIMESTAMP_TRUNCATE)
++#define	zpl_inode_timestamp_truncate(ts, ip)	timestamp_truncate(ts, ip)
++#elif defined(HAVE_INODE_TIMESPEC64_TIMES)
++#define	zpl_inode_timestamp_truncate(ts, ip)	\
++	timespec64_trunc(ts, (ip)->i_sb->s_time_gran)
+ #else
+-#define	zpl_inode_timespec_trunc(ts, gran)	timespec_trunc(ts, gran)
++#define	zpl_inode_timestamp_truncate(ts, ip)	\
++	timespec_trunc(ts, (ip)->i_sb->s_time_gran)
+ #endif
+ 
+ #endif	/* _SYS_ZPL_H */
+diff --git a/module/zfs/zfs_vnops.c b/module/zfs/zfs_vnops.c
+index 03a8c4a50..c322edf6a 100644
+--- a/module/zfs/zfs_vnops.c
++++ b/module/zfs/zfs_vnops.c
+@@ -3415,8 +3415,8 @@ top:
+ 
+ 	if (mask & (ATTR_MTIME | ATTR_SIZE)) {
+ 		ZFS_TIME_ENCODE(&vap->va_mtime, mtime);
+-		ZTOI(zp)->i_mtime = zpl_inode_timespec_trunc(vap->va_mtime,
+-		    ZTOI(zp)->i_sb->s_time_gran);
++		ZTOI(zp)->i_mtime = zpl_inode_timestamp_truncate(
++		    vap->va_mtime, ZTOI(zp));
+ 
+ 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(zfsvfs), NULL,
+ 		    mtime, sizeof (mtime));
+@@ -3424,8 +3424,8 @@ top:
+ 
+ 	if (mask & (ATTR_CTIME | ATTR_SIZE)) {
+ 		ZFS_TIME_ENCODE(&vap->va_ctime, ctime);
+-		ZTOI(zp)->i_ctime = zpl_inode_timespec_trunc(vap->va_ctime,
+-		    ZTOI(zp)->i_sb->s_time_gran);
++		ZTOI(zp)->i_ctime = zpl_inode_timestamp_truncate(vap->va_ctime,
++		    ZTOI(zp));
+ 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs), NULL,
+ 		    ctime, sizeof (ctime));
+ 	}
+diff --git a/module/zfs/zpl_inode.c b/module/zfs/zpl_inode.c
+index 5660f8b0e..1f228dcf8 100644
+--- a/module/zfs/zpl_inode.c
++++ b/module/zfs/zpl_inode.c
+@@ -390,10 +390,8 @@ zpl_setattr(struct dentry *dentry, struct iattr *ia)
+ 	vap->va_mtime = ia->ia_mtime;
+ 	vap->va_ctime = ia->ia_ctime;
+ 
+-	if (vap->va_mask & ATTR_ATIME) {
+-		ip->i_atime = zpl_inode_timespec_trunc(ia->ia_atime,
+-		    ip->i_sb->s_time_gran);
+-	}
++	if (vap->va_mask & ATTR_ATIME)
++		ip->i_atime = zpl_inode_timestamp_truncate(ia->ia_atime, ip);
+ 
+ 	cookie = spl_fstrans_mark();
+ 	error = -zfs_setattr(ip, vap, 0, cr);
+-- 
+2.25.1
+

--- a/pkgs/os-specific/linux/zfs/0003-Linux-5.6-compat-ktime_get_raw_ts64.patch
+++ b/pkgs/os-specific/linux/zfs/0003-Linux-5.6-compat-ktime_get_raw_ts64.patch
@@ -1,0 +1,155 @@
+From 0501d80aec68714d6846a4af8a110ff805ae81d2 Mon Sep 17 00:00:00 2001
+From: Brian Behlendorf <behlendorf1@llnl.gov>
+Date: Wed, 26 Feb 2020 12:42:33 -0800
+Subject: [PATCH 3/4] Linux 5.6 compat: ktime_get_raw_ts64()
+
+The getrawmonotonic() and getrawmonotonic64() interfaces have been
+fully retired.  Update gethrtime() to use the replacement interface
+ktime_get_raw_ts64() which was introduced in the 4.18 kernel.
+
+Reviewed-by: Tony Hutter <hutter2@llnl.gov>
+Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Closes #10052
+Closes #10064
+---
+ config/kernel-ktime.m4                      | 55 +++++++++++++++++++++
+ config/kernel-ktime_get_coarse_real_ts64.m4 | 23 ---------
+ config/kernel.m4                            |  4 +-
+ include/spl/sys/time.h                      |  5 ++
+ 4 files changed, 62 insertions(+), 25 deletions(-)
+ create mode 100644 config/kernel-ktime.m4
+ delete mode 100644 config/kernel-ktime_get_coarse_real_ts64.m4
+
+diff --git a/config/kernel-ktime.m4 b/config/kernel-ktime.m4
+new file mode 100644
+index 000000000..64c3b5f90
+--- /dev/null
++++ b/config/kernel-ktime.m4
+@@ -0,0 +1,55 @@
++dnl #
++dnl # 4.18: ktime_get_coarse_real_ts64() replaces current_kernel_time64().
++dnl #
++AC_DEFUN([ZFS_AC_KERNEL_SRC_KTIME_GET_COARSE_REAL_TS64], [
++	ZFS_LINUX_TEST_SRC([ktime_get_coarse_real_ts64], [
++		#include <linux/mm.h>
++	], [
++		struct timespec64 ts;
++		ktime_get_coarse_real_ts64(&ts);
++	])
++])
++
++AC_DEFUN([ZFS_AC_KERNEL_KTIME_GET_COARSE_REAL_TS64], [
++	AC_MSG_CHECKING([whether ktime_get_coarse_real_ts64() exists])
++	ZFS_LINUX_TEST_RESULT([ktime_get_coarse_real_ts64], [
++		AC_MSG_RESULT(yes)
++		AC_DEFINE(HAVE_KTIME_GET_COARSE_REAL_TS64, 1,
++		    [ktime_get_coarse_real_ts64() exists])
++	], [
++		AC_MSG_RESULT(no)
++	])
++])
++
++dnl #
++dnl # 4.18: ktime_get_raw_ts64() replaces getrawmonotonic64().
++dnl #
++AC_DEFUN([ZFS_AC_KERNEL_SRC_KTIME_GET_RAW_TS64], [
++	ZFS_LINUX_TEST_SRC([ktime_get_raw_ts64], [
++		#include <linux/mm.h>
++	], [
++		struct timespec64 ts;
++		ktime_get_raw_ts64(&ts);
++	])
++])
++
++AC_DEFUN([ZFS_AC_KERNEL_KTIME_GET_RAW_TS64], [
++	AC_MSG_CHECKING([whether ktime_get_raw_ts64() exists])
++	ZFS_LINUX_TEST_RESULT([ktime_get_raw_ts64], [
++		AC_MSG_RESULT(yes)
++		AC_DEFINE(HAVE_KTIME_GET_RAW_TS64, 1,
++		    [ktime_get_raw_ts64() exists])
++	], [
++		AC_MSG_RESULT(no)
++	])
++])
++
++AC_DEFUN([ZFS_AC_KERNEL_SRC_KTIME], [
++	ZFS_AC_KERNEL_SRC_KTIME_GET_COARSE_REAL_TS64
++	ZFS_AC_KERNEL_SRC_KTIME_GET_RAW_TS64
++])
++
++AC_DEFUN([ZFS_AC_KERNEL_KTIME], [
++	ZFS_AC_KERNEL_KTIME_GET_COARSE_REAL_TS64
++	ZFS_AC_KERNEL_KTIME_GET_RAW_TS64
++])
+diff --git a/config/kernel-ktime_get_coarse_real_ts64.m4 b/config/kernel-ktime_get_coarse_real_ts64.m4
+deleted file mode 100644
+index 28492bf04..000000000
+--- a/config/kernel-ktime_get_coarse_real_ts64.m4
++++ /dev/null
+@@ -1,23 +0,0 @@
+-dnl #
+-dnl # 4.18: ktime_get_coarse_real_ts64() added.  Use it in place of
+-dnl # current_kernel_time64().
+-dnl #
+-AC_DEFUN([ZFS_AC_KERNEL_SRC_KTIME_GET_COARSE_REAL_TS64], [
+-	ZFS_LINUX_TEST_SRC([ktime_get_coarse_real_ts64], [
+-		#include <linux/mm.h>
+-	], [
+-		struct timespec64 ts;
+-		ktime_get_coarse_real_ts64(&ts);
+-	])
+-])
+-
+-AC_DEFUN([ZFS_AC_KERNEL_KTIME_GET_COARSE_REAL_TS64], [
+-	AC_MSG_CHECKING([whether ktime_get_coarse_real_ts64() exists])
+-	ZFS_LINUX_TEST_RESULT([ktime_get_coarse_real_ts64], [
+-		AC_MSG_RESULT(yes)
+-		AC_DEFINE(HAVE_KTIME_GET_COARSE_REAL_TS64, 1,
+-		    [ktime_get_coarse_real_ts64() exists])
+-	], [
+-		AC_MSG_RESULT(no)
+-	])
+-])
+diff --git a/config/kernel.m4 b/config/kernel.m4
+index 780de3318..994865fdb 100644
+--- a/config/kernel.m4
++++ b/config/kernel.m4
+@@ -137,7 +137,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_SRC], [
+ 	ZFS_AC_KERNEL_SRC_CURRENT_TIME
+ 	ZFS_AC_KERNEL_SRC_USERNS_CAPABILITIES
+ 	ZFS_AC_KERNEL_SRC_IN_COMPAT_SYSCALL
+-	ZFS_AC_KERNEL_SRC_KTIME_GET_COARSE_REAL_TS64
++	ZFS_AC_KERNEL_SRC_KTIME
+ 	ZFS_AC_KERNEL_SRC_TOTALRAM_PAGES_FUNC
+ 	ZFS_AC_KERNEL_SRC_TOTALHIGH_PAGES
+ 	ZFS_AC_KERNEL_SRC_KSTRTOUL
+@@ -254,7 +254,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_RESULT], [
+ 	ZFS_AC_KERNEL_CURRENT_TIME
+ 	ZFS_AC_KERNEL_USERNS_CAPABILITIES
+ 	ZFS_AC_KERNEL_IN_COMPAT_SYSCALL
+-	ZFS_AC_KERNEL_KTIME_GET_COARSE_REAL_TS64
++	ZFS_AC_KERNEL_KTIME
+ 	ZFS_AC_KERNEL_TOTALRAM_PAGES_FUNC
+ 	ZFS_AC_KERNEL_TOTALHIGH_PAGES
+ 	ZFS_AC_KERNEL_KSTRTOUL
+diff --git a/include/spl/sys/time.h b/include/spl/sys/time.h
+index 312415b7b..56fd725c0 100644
+--- a/include/spl/sys/time.h
++++ b/include/spl/sys/time.h
+@@ -105,8 +105,13 @@ gethrestime_sec(void)
+ static inline hrtime_t
+ gethrtime(void)
+ {
++#if defined(HAVE_KTIME_GET_RAW_TS64)
++	struct timespec64 ts;
++	ktime_get_raw_ts64(&ts);
++#else
+ 	struct timespec ts;
+ 	getrawmonotonic(&ts);
++#endif
+ 	return (((hrtime_t)ts.tv_sec * NSEC_PER_SEC) + ts.tv_nsec);
+ }
+ 
+-- 
+2.25.1
+

--- a/pkgs/os-specific/linux/zfs/0004-Linux-5.6-compat-time_t.patch
+++ b/pkgs/os-specific/linux/zfs/0004-Linux-5.6-compat-time_t.patch
@@ -1,0 +1,120 @@
+From 0b13e2ae0e2de6a2217984cc1f56aa3d1e5db587 Mon Sep 17 00:00:00 2001
+From: Brian Behlendorf <behlendorf1@llnl.gov>
+Date: Wed, 26 Feb 2020 13:18:07 -0800
+Subject: [PATCH 4/4] Linux 5.6 compat: time_t
+
+As part of the Linux kernel's y2038 changes the time_t type has been
+fully retired.  Callers are now required to use the time64_t type.
+
+Rather than move to the new type, I've removed the few remaining
+places where a time_t is used in the kernel code.  They've been
+replaced with a uint64_t which is already how ZFS internally
+handled these values.
+
+Going forward we should work towards updating the remaining user
+space time_t consumers to the 64-bit interfaces.
+
+Reviewed-by: Matthew Macy <mmacy@freebsd.org>
+Reviewed-by: Tony Hutter <hutter2@llnl.gov>
+Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Closes #10052
+Closes #10064
+---
+ include/spl/sys/time.h        | 2 +-
+ include/sys/vdev_impl.h       | 4 ++--
+ lib/libspl/include/sys/time.h | 2 +-
+ module/zfs/vdev_initialize.c  | 2 +-
+ module/zfs/vdev_trim.c        | 2 +-
+ module/zfs/zfs_debug.c        | 2 +-
+ 6 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/include/spl/sys/time.h b/include/spl/sys/time.h
+index 56fd725c0..4309c300b 100644
+--- a/include/spl/sys/time.h
++++ b/include/spl/sys/time.h
+@@ -85,7 +85,7 @@ gethrestime(inode_timespec_t *ts)
+ #endif
+ }
+ 
+-static inline time_t
++static inline uint64_t
+ gethrestime_sec(void)
+ {
+ #if defined(HAVE_INODE_TIMESPEC64_TIMES)
+diff --git a/include/sys/vdev_impl.h b/include/sys/vdev_impl.h
+index f6f7bbb4b..090ba3fbc 100644
+--- a/include/sys/vdev_impl.h
++++ b/include/sys/vdev_impl.h
+@@ -274,7 +274,7 @@ struct vdev {
+ 	range_tree_t	*vdev_initialize_tree;	/* valid while initializing */
+ 	uint64_t	vdev_initialize_bytes_est;
+ 	uint64_t	vdev_initialize_bytes_done;
+-	time_t		vdev_initialize_action_time;	/* start and end time */
++	uint64_t	vdev_initialize_action_time;	/* start and end time */
+ 
+ 	/* TRIM related */
+ 	boolean_t	vdev_trim_exit_wanted;
+@@ -295,7 +295,7 @@ struct vdev {
+ 	uint64_t	vdev_trim_rate;		/* requested rate (bytes/sec) */
+ 	uint64_t	vdev_trim_partial;	/* requested partial TRIM */
+ 	uint64_t	vdev_trim_secure;	/* requested secure TRIM */
+-	time_t		vdev_trim_action_time;	/* start and end time */
++	uint64_t	vdev_trim_action_time;	/* start and end time */
+ 
+ 	/* for limiting outstanding I/Os (initialize and TRIM) */
+ 	kmutex_t	vdev_initialize_io_lock;
+diff --git a/lib/libspl/include/sys/time.h b/lib/libspl/include/sys/time.h
+index 291f2190a..c9f616504 100644
+--- a/lib/libspl/include/sys/time.h
++++ b/lib/libspl/include/sys/time.h
+@@ -88,7 +88,7 @@ gethrestime(inode_timespec_t *ts)
+ 	ts->tv_nsec = tv.tv_usec * NSEC_PER_USEC;
+ }
+ 
+-static inline time_t
++static inline uint64_t
+ gethrestime_sec(void)
+ {
+ 	struct timeval tv;
+diff --git a/module/zfs/vdev_initialize.c b/module/zfs/vdev_initialize.c
+index 9958a2958..8a3635969 100644
+--- a/module/zfs/vdev_initialize.c
++++ b/module/zfs/vdev_initialize.c
+@@ -700,7 +700,7 @@ vdev_initialize_restart(vdev_t *vd)
+ 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_INITIALIZE_ACTION_TIME,
+ 		    sizeof (timestamp), 1, &timestamp);
+ 		ASSERT(err == 0 || err == ENOENT);
+-		vd->vdev_initialize_action_time = (time_t)timestamp;
++		vd->vdev_initialize_action_time = timestamp;
+ 
+ 		if (vd->vdev_initialize_state == VDEV_INITIALIZE_SUSPENDED ||
+ 		    vd->vdev_offline) {
+diff --git a/module/zfs/vdev_trim.c b/module/zfs/vdev_trim.c
+index 5ad47cccd..b7548fc4c 100644
+--- a/module/zfs/vdev_trim.c
++++ b/module/zfs/vdev_trim.c
+@@ -1046,7 +1046,7 @@ vdev_trim_restart(vdev_t *vd)
+ 		    vd->vdev_leaf_zap, VDEV_LEAF_ZAP_TRIM_ACTION_TIME,
+ 		    sizeof (timestamp), 1, &timestamp);
+ 		ASSERT(err == 0 || err == ENOENT);
+-		vd->vdev_trim_action_time = (time_t)timestamp;
++		vd->vdev_trim_action_time = timestamp;
+ 
+ 		if (vd->vdev_trim_state == VDEV_TRIM_SUSPENDED ||
+ 		    vd->vdev_offline) {
+diff --git a/module/zfs/zfs_debug.c b/module/zfs/zfs_debug.c
+index 538533d27..cf8bbb3ce 100644
+--- a/module/zfs/zfs_debug.c
++++ b/module/zfs/zfs_debug.c
+@@ -27,7 +27,7 @@
+ 
+ typedef struct zfs_dbgmsg {
+ 	procfs_list_node_t	zdm_node;
+-	time_t			zdm_timestamp;
++	uint64_t		zdm_timestamp;
+ 	int			zdm_size;
+ 	char			zdm_msg[1]; /* variable length allocation */
+ } zfs_dbgmsg_t;
+-- 
+2.25.1
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I cherry-picked the Linux 5.6 compatibility patches from the latest OpenZFS master. This builds, boots, and passes tests for me with 5.6.2 (and the installer test exercises a pre-5.6 version). The backported patches are all quite simple, mostly dealing with the fallout of the [32-bit timepocalypse](https://lwn.net/Kernel/Index/#Year_2038_problem).

I've omitted https://github.com/openzfs/zfs/commit/bd0d24e09b089af589ebaecd9e85d9fd4ac31deb (https://github.com/openzfs/zfs/pull/10072) because it depends on https://github.com/openzfs/zfs/commit/066e825221012e1e81ccf46b0448772bdd7e5483, which is a much more invasive change, and the PR message implies that it only breaks a non-NixOS-default kernel configuration, for a kernel version we don't ship as default/latest/testing, due to an upstream change that was an accident to begin with.

I initially wanted to bump zfsUnstable so that there'd be a pristine (albeit unreleased) upstream option for current kernels, but unfortunately the couple commits I checked broke the test with an ominous `cannot mount 'rpool': Input/output error`. In the spirit of procrastination, let's hope whatever that is goes away by the time of the next upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).