### PR TITLE
nixos/xonsh: source NixOS environment

### DIFF
--- a/nixos/modules/programs/xonsh.nix
+++ b/nixos/modules/programs/xonsh.nix
@@ -45,7 +45,32 @@ in
 
   config = mkIf cfg.enable {
 
-    environment.etc.xonshrc.text = cfg.config;
+    environment.etc.xonshrc.text = ''
+      # /etc/xonshrc: DO NOT EDIT -- this file has been generated automatically.
+
+
+      if not ''${...}.get('__NIXOS_SET_ENVIRONMENT_DONE'):
+          # The NixOS environment and thereby also $PATH
+          # haven't been fully set up at this point. But
+          # `source-bash` below requires `bash` to be on $PATH,
+          # so add an entry with bash's location:
+          $PATH.add('${pkgs.bash}/bin')
+
+          # Stash xonsh's ls alias, so that we don't get a collision
+          # with Bash's ls alias from environment.shellAliases:
+          _ls_alias = aliases.pop('ls', None)
+
+          # Source the NixOS environment config.
+          source-bash "${config.system.build.setEnvironment}"
+
+          # Restore xonsh's ls alias, overriding that from Bash (if any).
+          if _ls_alias is not None:
+              aliases['ls'] = _ls_alias
+          del _ls_alias
+
+
+      ${cfg.config}
+    '';
 
     environment.systemPackages = [ cfg.package ];
 


### PR DESCRIPTION
Without doing that, xonsh is unusable as login shell.

~~:warning: Note that even with that change, setting `users.users.<name?>.shell` to `xonsh` for my user **prevents me from successfully logging into GNOME 3 from GDM** (and maybe prevents any graphical login - didn't test with other login managers or DEs / WMs, yet). But at least I get a usable xonsh shell in text mode (virtual terminal accessible with Ctrl-Alt-F1 etc.), which I didn't get without this change. (Without the change, xonsh _would_ start on login, but would be nearly unusable as almost all external commands would have to be invoked through their absolute path, because they wouldn't be on `$PATH`.)~~


###### Motivation for this change

If a shell can be allowed as an interactive login shell (and NixOS option [`programs.xonsh.enable`](https://nixos.org/nixos/options.html#programs.xonsh.enable) does that, if I understand correctly), it should be usable as a login shell, and logging into it should yield that shell in a usable state.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix run nixpkgs.nixpkgs-review -c nixpkgs-review pr 84330`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

----

Result of `nixpkgs-review pr 84330` [1](https://github.com/Mic92/nixpkgs-review)
[empty]