### PR TITLE
itstool: fix double-shebang backport

### DIFF
--- a/pkgs/development/tools/misc/itstool/default.nix
+++ b/pkgs/development/tools/misc/itstool/default.nix
@@ -8,22 +8,12 @@ stdenv.mkDerivation rec {
     sha256 = "1acjgf8zlyk7qckdk19iqaca4jcmywd7vxjbcs1mm6kaf8icqcv2";
   };
 
-  buildInputs = [ (python3.withPackages(ps: with ps; [ libxml2 ])) ];
+  pythonPath = [ python3.pkgs.libxml2 ];
+  buildInputs = [ python3 python3.pkgs.libxml2 ];
+  nativeBuildInputs = [ python3.pkgs.wrapPython ];
 
-  # bin/itstool's shebang is "#!${python3.withPackages(...)/bin/python} -s"
-  # withPackages' shebang is "#!#{bash}/bin/bash -e
-  #
-  # macOS won't allow the target of a shebang to be an interpreted script,
-  # causing bin/itstool to get interpreted as bash.
-  #
-  # By prefixing /usr/bin/env to the shebang, we have env fork/exec the python
-  # wrapper, which is perfectly happy to execute an interpreted script.
-  #
-  # However, we don't want to do this on Linux, which only allows one argument
-  # in a shebang.
-  postFixup = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace $out/bin/itstool \
-      --replace "#!/" "#!/usr/bin/env /"
+  postFixup = ''
+    wrapPythonPrograms
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
