### PR TITLE
drm_info: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/development/tools/drm_info/default.nix
+++ b/pkgs/development/tools/drm_info/default.nix
@@ -1,21 +1,21 @@
 { stdenv, fetchFromGitHub
-, libdrm, json_c
+, libdrm, json_c, pciutils
 , meson, ninja, pkgconfig
 }:
 
 stdenv.mkDerivation rec {
   pname = "drm_info";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "ascent12";
     repo = "drm_info";
     rev = "v${version}";
-    sha256 = "1i5bzkgqxjjw34jpj1x1gfdl3sz0sl6i7s787a6mjjslsc5g422l";
+    sha256 = "0s4zp8xz21zcpinbcwdvg48rf0xr7rs0dqri28q093vfmllsk36f";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];
-  buildInputs = [ libdrm json_c ];
+  buildInputs = [ libdrm json_c pciutils ];
 
   meta = with stdenv.lib; {
     description = "Small utility to dump info about DRM devices.";


### PR DESCRIPTION
###### Motivation for this change
New upstream release from January.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
