### PR TITLE
sound-of-sorting: 2015-07-21 -> 2017-12-23

### DIFF
--- a/pkgs/misc/sound-of-sorting/default.nix
+++ b/pkgs/misc/sound-of-sorting/default.nix
@@ -1,26 +1,25 @@
-{ stdenv, fetchgit
-, SDL2, wxGTK }:
+{ stdenv, fetchFromGitHub, SDL2, wxGTK } :
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
 
   pname = "sound-of-sorting";
-  version = "unstable-2015-07-21";
+  version = "2017-12-23";
 
-  src = fetchgit {
-    url = "https://github.com/bingmann/sound-of-sorting.git";
-    rev = "05db428c796a7006d63efdbe314f976e0aa881d6";
-    sha256 = "0m2f1dym3hcar7784sjzkbf940b28r02ajhkjgyyw7715psifb8l";
-    fetchSubmodules = true;
+  src = fetchFromGitHub {
+    owner = "bingmann";
+    repo = "sound-of-sorting";
+    rev = "5884a357af5775fb57d89eb028d4bf150760db75";
+    sha256 = "01bpzn38cwn9zlydzvnfz9k7mxdnjnvgnbcpx7i4al8fha7x9lw8";
   };
 
-  buildInputs = with stdenv.lib;
+  buildInputs = 
   [ wxGTK SDL2 ];
 
   preConfigure = ''
     export SDL_CONFIG=${SDL2.dev}/bin/sdl2-config
   '';
 
-  meta = with stdenv.lib;{
+  meta = with stdenv.lib; {
     description = "Audibilization and Visualization of Sorting Algorithms";
     homepage = "http://panthema.net/2013/sound-of-sorting/";
     license = with licenses; gpl3;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
