### PR TITLE
musikcube: init at 0.90.1

### DIFF
--- a/pkgs/applications/audio/musikcube/default.nix
+++ b/pkgs/applications/audio/musikcube/default.nix
@@ -1,0 +1,56 @@
+{ cmake
+, pkg-config
+, alsaLib
+, boost
+, curl
+, fetchFromGitHub
+, ffmpeg
+, lame
+, libev
+, libmicrohttpd
+, ncurses
+, pulseaudio
+, stdenv
+, taglib
+, systemdSupport ? stdenv.isLinux, systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "musikcube";
+  version = "0.90.1";
+
+  src = fetchFromGitHub {
+    owner = "clangen";
+    repo = pname;
+    rev = version;
+    sha256 = "1ff2cgbllrl2pl5zfbf0cd9qbf6hqpwr395sa1k245ar4f1rfwpg";
+  };
+
+  # https://github.com/clangen/musikcube/issues/339
+  patches = [ ./dont-strip.patch ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    alsaLib
+    boost
+    curl
+    ffmpeg
+    lame
+    libev
+    libmicrohttpd
+    ncurses
+    pulseaudio
+    taglib
+  ] ++ stdenv.lib.optional systemdSupport systemd;
+
+  meta = with stdenv.lib; {
+    description = "A fully functional terminal-based music player, library, and streaming audio server";
+    homepage = "https://musikcube.com/";
+    maintainers = [ maintainers.aanderse ];
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/audio/musikcube/dont-strip.patch
+++ b/pkgs/applications/audio/musikcube/dont-strip.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a3e02666..7c43c7e6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -370,9 +370,3 @@ endif()
+ # they don't yet exist!
+ add_custom_target(postbuild ALL DEPENDS musikcube musikcubed)
+ add_custom_command(TARGET postbuild POST_BUILD COMMAND cmake .)
+-
+-# strip binaries in release mode
+-if (CMAKE_BUILD_TYPE MATCHES Release)
+-  message(STATUS "stripping binaries...")
+-  add_custom_command(TARGET postbuild POST_BUILD COMMAND "${CMAKE_SOURCE_DIR}/strip-nix.sh")
+-endif()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20035,6 +20035,8 @@ in
 
   leftwm = callPackage ../applications/window-managers/leftwm { };
 
+  musikcube = callPackage ../applications/audio/musikcube {};
+
   pinboard-notes-backup = haskell.lib.overrideCabal
     (haskell.lib.generateOptparseApplicativeCompletion "pnbackup"
       haskellPackages.pinboard-notes-backup)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/84318

###### Things not yet done
- [x] test (beyond ensuring this compiles and runs, I didn't even test that there was audio output :man_shrugging:)
- [x] find a maintainer \*nudge\* @evertedsphere \*nudge\* :man_shrugging: 
- [ ] ensure it actually compiles on `darwin` (I have no access to a mac)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
