### PR TITLE
babashka: 0.0.78 -> 0.0.89

### DIFF
--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -3,17 +3,17 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "babashka";
-  version = "0.0.78";
+  version = "0.0.89";
 
   reflectionJson = fetchurl {
     name = "reflection.json";
     url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-reflection.json";
-    sha256 = "1m1nwdxjsc6bkdzkbsll316ly0c3qxaimjzyfph1220irjxnm7xf";
+    sha256 = "0bc5rbizd2lg7qfh733yiip8m9zqrwgjf5ca09sdibxp7nhhsjby";
   };
 
   src = fetchurl {
     url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
-    sha256 = "01w990zk5qjrbnc846snh6na002kdyrlrfnqwg03ibx20g3mr7if";
+    sha256 = "11jhqbm3svvikr9glz8wwps1267y25g3384ijw6avn267s7d7l8c";
   };
 
   dontUnpack = true;
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
       --no-fallback \
       --no-server \
       --report-unsupported-elements-at-runtime \
+      "--initialize-at-run-time=org.postgresql.sspi.SSPIClient" \
       "-J-Xmx3g"
   '';
 

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, graalvm8 }:
+{ stdenv, fetchurl, graalvm8, glibcLocales }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  buildInputs = [ graalvm8 ];
+  LC_ALL = "en_US.UTF-8";
+  nativeBuildInputs = [ graalvm8 glibcLocales ];
 
   buildPhase = ''
     native-image \

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
       --no-server \
       --report-unsupported-elements-at-runtime \
       "--initialize-at-run-time=org.postgresql.sspi.SSPIClient" \
-      "-J-Xmx3g"
+      "-J-Xmx4500m"
   '';
 
   installPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@AndersonTorres 