### PR TITLE
rofi-mpd: 2.0.1 -> 2.2.0

### DIFF
--- a/pkgs/applications/audio/rofi-mpd/default.nix
+++ b/pkgs/applications/audio/rofi-mpd/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "rofi-mpd";
-  version = "2.0.1";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "JakeStanger";
     repo = "Rofi_MPD";
     rev = "v${version}";
-    sha256 = "12zzx0m2nwyzxzzqgzq30a27k015kcw4ylvs7cyalf5gf6sg27kl";
+    sha256 = "1b0y8706mmrxhiyz8g6znisllc35j8g7sz8gfjll9svysjmvb6lc";
   };
 
   propagatedBuildInputs = with python3Packages; [ mutagen mpd2 toml appdirs ];


### PR DESCRIPTION
###### Motivation for this change

Updates package to latest version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
