### PR TITLE
luminance-hdr: use Qt5's mkDerivation

### DIFF
--- a/pkgs/applications/graphics/luminance-hdr/default.nix
+++ b/pkgs/applications/graphics/luminance-hdr/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, cmake, fetchFromGitHub, pkgconfig, boost, exiv2, fftwFloat, gsl
+{ stdenv, mkDerivation, cmake, fetchFromGitHub, pkgconfig
+, boost, exiv2, fftwFloat, gsl
 , ilmbase, lcms2, libraw, libtiff, openexr
 , qtbase, qtdeclarative, qttools, qtwebengine, eigen
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "luminance-hdr";
   version = "2.6.0";
 


### PR DESCRIPTION
###### Motivation for this change

Fix luminance-hdr as per https://github.com/NixOS/nixpkgs/issues/65399

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
