### PR TITLE
python3Packages.matplotlib: 3.1.3 -> 3.2.1, and various cleanups

### DIFF
--- a/pkgs/development/python-modules/matplotlib/2.nix
+++ b/pkgs/development/python-modules/matplotlib/2.nix
@@ -93,7 +93,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Python plotting library, making publication quality plots";
     homepage    = "https://matplotlib.org/";
-    maintainers = with maintainers; [ lovek323 ];
+    maintainers = with maintainers; [ lovek323 veprbl ];
   };
 
 }

--- a/pkgs/development/python-modules/matplotlib/2.nix
+++ b/pkgs/development/python-modules/matplotlib/2.nix
@@ -28,6 +28,15 @@ buildPythonPackage rec {
     sha256 = "7355bf757ecacd5f0ac9dd9523c8e1a1103faadf8d33c22664178e17533f8ce5";
   };
 
+  patches = [
+    # https://github.com/matplotlib/matplotlib/pull/12478
+    (fetchpatch {
+      name = "numpy-1.16-compat.patch";
+      url = "https://github.com/matplotlib/matplotlib/commit/2980184d092382a40ab21f95b79582ffae6e19d6.patch";
+      sha256 = "1c0wj28zy8s5h6qiavx9zzbhlmhjwpzbc3fyyw9039mbnqk0spg2";
+    })
+  ];
+
   XDG_RUNTIME_DIR = "/tmp";
 
   nativeBuildInputs = [ pkgconfig ];
@@ -45,16 +54,10 @@ buildPythonPackage rec {
     ++ stdenv.lib.optionals enableQt [ pyqt4 ]
     ++ stdenv.lib.optionals python.isPy2 [ functools32 subprocess32 ];
 
-  patches = [
-    ./basedirlist.patch
-
-    # https://github.com/matplotlib/matplotlib/pull/12478
-    (fetchpatch {
-      name = "numpy-1.16-compat.patch";
-      url = "https://github.com/matplotlib/matplotlib/commit/2980184d092382a40ab21f95b79582ffae6e19d6.patch";
-      sha256 = "1c0wj28zy8s5h6qiavx9zzbhlmhjwpzbc3fyyw9039mbnqk0spg2";
-    })
-  ];
+  setup_cfg = ./setup.cfg;
+  preBuild = ''
+    cp "$setup_cfg" ./setup.cfg
+  '';
 
   # Matplotlib tries to find Tcl/Tk by opening a Tk window and asking the
   # corresponding interpreter object for its library paths. This fails if

--- a/pkgs/development/python-modules/matplotlib/2.nix
+++ b/pkgs/development/python-modules/matplotlib/2.nix
@@ -7,7 +7,6 @@
 # darwin has its own "MacOSX" backend
 , enableTk ? !stdenv.isDarwin, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
 , enableQt ? false, pyqt4
-, libcxx
 , Cocoa
 , pythonOlder
 }:
@@ -28,8 +27,6 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "7355bf757ecacd5f0ac9dd9523c8e1a1103faadf8d33c22664178e17533f8ce5";
   };
-
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
   XDG_RUNTIME_DIR = "/tmp";
 

--- a/pkgs/development/python-modules/matplotlib/2.nix
+++ b/pkgs/development/python-modules/matplotlib/2.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ python which sphinx stdenv ]
+  buildInputs = [ which sphinx ]
     ++ stdenv.lib.optional enableGhostscript ghostscript
     ++ stdenv.lib.optional stdenv.isDarwin [ Cocoa ];
 

--- a/pkgs/development/python-modules/matplotlib/2.nix
+++ b/pkgs/development/python-modules/matplotlib/2.nix
@@ -70,22 +70,9 @@ buildPythonPackage rec {
     stdenv.lib.optionalString enableTk
       "sed -i '/self.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py";
 
-  checkPhase = ''
-    ${python.interpreter} tests.py
-  '';
-
-  # Test data is not included in the distribution (the `tests` folder
-  # is missing)
+  # Matplotlib needs to be built against a specific version of freetype in
+  # order for all of the tests to pass.
   doCheck = false;
-
-  prePatch = ''
-    # Failing test: ERROR: matplotlib.tests.test_style.test_use_url
-    sed -i 's/test_use_url/fails/' lib/matplotlib/tests/test_style.py
-    # Failing test: ERROR: test suite for <class 'matplotlib.sphinxext.tests.test_tinypages.TestTinyPages'>
-    sed -i 's/TestTinyPages/fails/' lib/matplotlib/sphinxext/tests/test_tinypages.py
-    # Transient errors
-    sed -i 's/test_invisible_Line_rendering/noop/' lib/matplotlib/tests/test_lines.py
-  '';
 
   meta = with stdenv.lib; {
     description = "Python plotting library, making publication quality plots";

--- a/pkgs/development/python-modules/matplotlib/basedirlist.patch
+++ b/pkgs/development/python-modules/matplotlib/basedirlist.patch
@@ -1,8 +1,0 @@
-diff --git a/setup.cfg b/setup.cfg
-new file mode 100644
-index 0000000..6f81985
---- /dev/null
-+++ b/setup.cfg
-@@ -0,0 +1,2 @@
-+[directories]
-+basedirlist = .

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -40,7 +40,6 @@ buildPythonPackage rec {
   propagatedBuildInputs =
     [ cycler dateutil numpy pyparsing tornado freetype kiwisolver
       libpng mock pytz ]
-    ++ stdenv.lib.optional (pythonOlder "3.3") backports_functools_lru_cache
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobject-introspection pygobject3 ]
     ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ]
     ++ stdenv.lib.optionals enableQt [ pyqt5 ];

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -19,14 +19,14 @@ assert enableTk -> (tcl != null)
 assert enableQt -> pyqt5 != null;
 
 buildPythonPackage rec {
-  version = "3.1.3";
+  version = "3.2.1";
   pname = "matplotlib";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "db3121f12fb9b99f105d1413aebaeb3d943f269f3d262b45586d12765866f0c6";
+    sha256 = "ffe2f9cdcea1086fc414e82f42271ecf1976700b8edd16ca9d376189c6d93aee";
   };
 
   XDG_RUNTIME_DIR = "/tmp";

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -85,7 +85,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Python plotting library, making publication quality plots";
     homepage    = "https://matplotlib.org/";
-    maintainers = with maintainers; [ lovek323 ];
+    maintainers = with maintainers; [ lovek323 veprbl ];
   };
 
 }

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -61,22 +61,9 @@ buildPythonPackage rec {
     stdenv.lib.optionalString enableTk
       "sed -i '/self.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py";
 
-  checkPhase = ''
-    ${python.interpreter} tests.py
-  '';
-
-  # Test data is not included in the distribution (the `tests` folder
-  # is missing)
+  # Matplotlib needs to be built against a specific version of freetype in
+  # order for all of the tests to pass.
   doCheck = false;
-
-  prePatch = ''
-    # Failing test: ERROR: matplotlib.tests.test_style.test_use_url
-    sed -i 's/test_use_url/fails/' lib/matplotlib/tests/test_style.py
-    # Failing test: ERROR: test suite for <class 'matplotlib.sphinxext.tests.test_tinypages.TestTinyPages'>
-    sed -i 's/TestTinyPages/fails/' lib/matplotlib/sphinxext/tests/test_tinypages.py
-    # Transient errors
-    sed -i 's/test_invisible_Line_rendering/noop/' lib/matplotlib/tests/test_lines.py
-  '';
 
   meta = with stdenv.lib; {
     description = "Python plotting library, making publication quality plots";

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -44,8 +44,10 @@ buildPythonPackage rec {
     ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ]
     ++ stdenv.lib.optionals enableQt [ pyqt5 ];
 
-  patches =
-    [ ./basedirlist.patch ];
+  setup_cfg = ./setup.cfg;
+  preBuild = ''
+    cp "$setup_cfg" ./setup.cfg
+  '';
 
   # Matplotlib tries to find Tcl/Tk by opening a Tk window and asking the
   # corresponding interpreter object for its library paths. This fails if

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -6,7 +6,6 @@
 # darwin has its own "MacOSX" backend
 , enableTk ? !stdenv.isDarwin, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
 , enableQt ? false, pyqt5 ? null
-, libcxx
 , Cocoa
 , pythonOlder
 }:
@@ -29,8 +28,6 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "db3121f12fb9b99f105d1413aebaeb3d943f269f3d262b45586d12765866f0c6";
   };
-
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
   XDG_RUNTIME_DIR = "/tmp";
 

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ python which sphinx stdenv ]
+  buildInputs = [ which sphinx ]
     ++ stdenv.lib.optional enableGhostscript ghostscript
     ++ stdenv.lib.optional stdenv.isDarwin [ Cocoa ];
 

--- a/pkgs/development/python-modules/matplotlib/setup.cfg
+++ b/pkgs/development/python-modules/matplotlib/setup.cfg
@@ -1,0 +1,2 @@
+[directories]
+basedirlist = .


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
