### PR TITLE
[WIP] {help wanted} twolame: 2017-09-27 -> 0.4.0

### DIFF
--- a/pkgs/development/libraries/twolame/default.nix
+++ b/pkgs/development/libraries/twolame/default.nix
@@ -1,25 +1,27 @@
 { stdenv, fetchFromGitHub
-, autoreconfHook, pkgconfig
-, libsndfile }:
+, autoreconfHook
+, pkgconfig
+, libsndfile, xmlto, asciidoc }:
 
-stdenv.mkDerivation {
+with stdenv.lib;
+stdenv.mkDerivation rec {
 
   pname = "twolame";
-  version = "2017-09-27";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "njh";
     repo = "twolame";
-    rev = "977c8ac55d8ca6d5f35d1d413a119dac2b3b0333";
-    sha256 = "1rq3yc8ygzdqid9zk6pixmm4w9sk2vrlx217lhn5bjaglv7iyf7x";
+    rev = version;
+    sha256 = "0ckwdx5kmgmh1jq2wl6c9d57pf6z6p2wjdy6fw01a8f3clg21a8g";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig xmlto asciidoc ];
   buildInputs = [ libsndfile ];
 
   doCheck = false; # fails with "../build-scripts/test-driver: line 107: -Mstrict: command not found"
 
-  meta = with stdenv.lib;{
+  meta = {
     description = "A MP2 encoder";
     longDescription = ''
       TwoLAME is an optimised MPEG Audio Layer 2 (MP2) encoder based on


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
