### PR TITLE
k3s: fix https://hydra.nixos.org/build/116132269

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -1,6 +1,8 @@
-with import <nixpkgs> {};
-
-{ stdenv, lib, makeWrapper, fetchFromGitHub, fetchurl, fetchzip }:
+{ stdenv, lib, makeWrapper, socat, iptables, iproute, bridge-utils
+, conntrack-tools, buildGoPackage, git, runc, libseccomp, pkgconfig
+, autoPatchelfHook, breakpointHook, ethtool, utillinux, ipset
+, fetchFromGitHub, fetchurl, fetchzip, fetchgit
+}:
 
 with lib;
 


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/116132269 was failing

###### Things done

removed the `with import <nixpkgs>{};`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
