### PR TITLE
facetimehd: update src to build with linux >= 5.6

### DIFF
--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, kernel }:
+{ stdenv, lib, fetchFromGitHub, kernel }:
 
 # facetimehd is not supported for kernels older than 3.19";
 assert stdenv.lib.versionAtLeast kernel.version "3.19";
@@ -44,8 +44,13 @@ stdenv.mkDerivation rec {
   '';
 
   hardeningDisable = [ "pic" ];
-  
+
   nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preBuild = lib.optionalString (stdenv.lib.versionAtLeast kernel.version "5.6")
+  ''
+    sed -i 's/ioremap_nocache/ioremap_cache/g' fthd_drv.c
+  '';
 
   makeFlags = [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
@@ -55,7 +60,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/patjak/bcwc_pcie;
     description = "Linux driver for the Facetime HD (Broadcom 1570) PCIe webcam";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ womfoo grahamc ];
+    maintainers = with maintainers; [ womfoo grahamc kraem ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
## Motivation for this change

When building `facetimehd` with Linux > `5.6` I'm getting this error
```
  /nix/store/mal5kzg5h23mha321kj59ai9ckz7ldvr-nixos-system-frigate-20.09pre-git.drv
building '/nix/store/dyr4pvy1kh8j3wi652kmzxipppmr3pcp-facetimehd-unstable-2019-12-10-5.6.2.drv'...
unpacking sources
unpacking source archive /nix/store/n4bm3asc6360z7ba4ip7257czwg677hl-source
source root is source
patching sources
configuring
no configure script, doing nothing
building
build flags: SHELL=/nix/store/z4ajipns0l1s8b2lrgpy6nng4cys7h99-bash-4.4-p23/bin/bash KDIR=/nix/store/hz13cyz8nkyjpyfszppyhf0idiszyj91-linux-5.6.2-dev/lib/modules/5.6.2/build
make -C /nix/store/hz13cyz8nkyjpyfszppyhf0idiszyj91-linux-5.6.2-dev/lib/modules/5.6.2/build M=/build/source modules
make[1]: Entering directory '/nix/store/hz13cyz8nkyjpyfszppyhf0idiszyj91-linux-5.6.2-dev/lib/modules/5.6.2/build'
  CC [M]  /build/source/fthd_ddr.o
  CC [M]  /build/source/fthd_hw.o
  CC [M]  /build/source/fthd_drv.o
/build/source/fthd_drv.c: In function 'fthd_pci_reserve_mem':
/build/source/fthd_drv.c:73:20: error: implicit declaration of function 'ioremap_nocache'; did you mean 'ioremap_cache'? [-Werror=implicit-function-declaration]
   73 |  dev_priv->s2_io = ioremap_nocache(start, len);
      |                    ^~~~~~~~~~~~~~~
      |                    ioremap_cache
```

###### Things done

Successfully built with https://github.com/NixOS/nixpkgs/pull/84303

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
