### PR TITLE
hactool: init at 1.3.2

### DIFF
--- a/pkgs/tools/compression/hactool/default.nix
+++ b/pkgs/tools/compression/hactool/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "hactool";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "SciresM";
+    repo = pname;
+    rev = version;
+    sha256 = "19sn91xm72sl05rj918vihm1g8a7bp03mw397japiq3x6jfd6n14";
+  };
+
+  preBuild = ''
+    mv config.mk.template config.mk
+  '';
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv hactool $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/SciresM/hactool";
+    description = "A tool to view information about, decrypt, and extract common file formats for the Nintendo Switch";
+    license = licenses.isc;
+    maintainers = with maintainers; [ ivar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26134,6 +26134,8 @@ in
 
   zopfli = callPackage ../tools/compression/zopfli { };
 
+  hactool = callPackage ../tools/compression/hactool { };
+
   myEnvFun = callPackage ../misc/my-env {
     inherit (stdenv) mkDerivation;
   };


### PR DESCRIPTION
###### Motivation for this change
Add [hactool](https://github.com/SciresM/hactool)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
