### PR TITLE
cherrytree: 0.39.0 -> 0.39.2

### DIFF
--- a/pkgs/applications/misc/cherrytree/default.nix
+++ b/pkgs/applications/misc/cherrytree/default.nix
@@ -1,12 +1,15 @@
-{ lib, fetchurl, pythonPackages, gettext }:
+{ lib, fetchFromGitHub, pythonPackages, gettext }:
 
 pythonPackages.buildPythonApplication rec {
   pname = "cherrytree";
-  version = "0.39.1";
+  version = "0.39.2";
 
-  src = fetchurl {
-    url = "https://www.giuspen.com/software/${pname}-${version}.tar.xz";
-    sha256 = "0qhycblnixvbybzr8psgmgcpfs6jc9m0p2h9lmd5zmiaggqlcsv7";
+  src = fetchFromGitHub {
+    owner = "giuspen";
+    repo = "cherrytree";
+    rev = version;
+    sha256 = "1l6wh24bhp4yhmsfmc0r4n2n10nlilkv4cmv5sfl80i250fiw7xa";
+
   };
 
   nativeBuildInputs = [ gettext ];
@@ -20,17 +23,16 @@ pythonPackages.buildPythonApplication rec {
   meta = with lib; {
     description = "An hierarchical note taking application";
     longDescription = ''
-      Cherrytree is an hierarchical note taking application,
-      featuring rich text, syntax highlighting and powerful search
-      capabilities. It organizes all information in units called
-      "nodes", as in a tree, and can be very useful to store any piece
-      of information, from tables and links to pictures and even entire
-      documents. All those little bits of information you have scattered
-      around your hard drive can be conveniently placed into a
-      Cherrytree document where you can easily find it.
+      Cherrytree is an hierarchical note taking application, featuring rich
+      text, syntax highlighting and powerful search capabilities. It organizes
+      all information in units called "nodes", as in a tree, and can be very
+      useful to store any piece of information, from tables and links to
+      pictures and even entire documents. All those little bits of information
+      you have scattered around your hard drive can be conveniently placed into
+      a Cherrytree document where you can easily find it.
     '';
     homepage = "http://www.giuspen.com/cherrytree";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update and also unfortunatley orphaning it. Maybe some more desktopish guy would like it way more than me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
