### PR TITLE
nixos/manual: fix build

### DIFF
--- a/nixos/modules/services/networking/rxe.nix
+++ b/nixos/modules/services/networking/rxe.nix
@@ -17,7 +17,7 @@ in {
         example = [ "eth0" ];
         description = ''
           Enable RDMA on the listed interfaces. The corresponding virtual
-          RDMA interfaces will be named rxe_<interface>.
+          RDMA interfaces will be named rxe_&lt;interface&gt;.
           UDP port 4791 must be open on the respective ethernet interfaces.
         '';
       };


### PR DESCRIPTION
###### Motivation for this change

NixOS manual doesn't build.

###### Things done

Built the NixOS manual, rendered option description below:

![options networking rxe interfaces](https://user-images.githubusercontent.com/157610/78511468-cdcf4700-7794-11ea-8e0d-5fc73c3b4851.png)


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
