### PR TITLE
ly: 0.2.1 -> 0.5.0

### DIFF
--- a/pkgs/applications/display-managers/ly/default.nix
+++ b/pkgs/applications/display-managers/ly/default.nix
@@ -1,29 +1,41 @@
-{ stdenv, lib, fetchFromGitHub, linux-pam }:
+{ stdenv, lib, fetchgit, runCommand, path, git, linux-pam, libxcb }:
 
-stdenv.mkDerivation rec { 
+stdenv.mkDerivation rec {
   pname = "ly";
-  version = "0.2.1";
+  version = "0.5.0";
 
-  src = fetchFromGitHub {
-    owner = "cylgom";
-    repo = "ly";
-    rev = version;
-    sha256 = "16gjcrd4a6i4x8q8iwlgdildm7cpdsja8z22pf2izdm6rwfki97d";
-    fetchSubmodules = true;
-  }; 
+  src = let
+    # locally modify `nix-prefetch-git` to recursively use upstream’s .github as .gitmodules…
+    fetchgitMod = args: (fetchgit args).overrideAttrs (oldAttrs: {
+      fetcher = runCommand "nix-prefetch-git-mod" {} ''
+        cp ${path}/pkgs/build-support/fetchgit/nix-prefetch-git $out
+        sed '/^init_submodules\(\)/a [ -e .gitmodules ] || cp .github .gitmodules || true' -i $out
+        chmod 755 $out
+      '';
+    });
+  in
+    fetchgitMod {
+      url = "https://github.com/cylgom/ly.git";
+      rev = "v${version}";
+      sha256 = "05fqpinln1kbxb7cby1ska3nfw9xf60ig2h2nj0xv167fsrqlhly";
+    };
 
-  buildInputs = [ linux-pam ];
-  makeFlags = [ "FLAGS=-Wno-error" ];
+  buildInputs = [ linux-pam libxcb ];
+
+  preConfigure = ''
+    sed '/^FLAGS=/a FLAGS+= -Wno-error=unused-result' -i sub/termbox_next/makefile
+  '';
 
   installPhase = ''
     mkdir -p $out/bin
-    cp bin/ly $out/bin 
+    cp bin/ly $out/bin
   '';
 
   meta = with lib; {
     description = "TUI display manager";
     license = licenses.wtfpl;
     homepage = "https://github.com/cylgom/ly";
+    platforms = platforms.linux;
     maintainers = [ maintainers.spacekookie ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Version bump.

It’s been stale for a long of time, because upstream decided to break their `.gitmodules`… I fixed that by modifying `nix-prefetch-git` just for this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
