### PR TITLE
tmuxPlugins: upgrade all to latest

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1,6 +1,5 @@
-{ fetchgit
+{ lib
 , fetchFromGitHub
-, lib
 , pkgs
 , reattach-to-user-namespace
 , stdenv
@@ -30,7 +29,7 @@ let
     ...
   }:
     addRtp "${rtpPath}/${path}" rtpFilePath a (stdenv.mkDerivation (a // {
-      name = namePrefix + pluginName;
+      pname = namePrefix + pluginName;
 
       inherit pluginName unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;
 
@@ -56,54 +55,66 @@ in rec {
 
   battery = mkDerivation {
     pluginName = "battery";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-battery";
-      rev = "09be78c35ee84f858f724442b94ad045ade23eb0";
-      sha256 = "0gm6qiay0k5b3yzrabfmh4inyh9r6rfhja2l3r4cixcvc8sgvh8l";
+    version = "unstable-2019-07-04";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-battery";
+      rev = "f8b8e8451990365e0c98c38c184962e4f83b793b";
+      sha256 = "1bhdzsx3kdjqjmm1q4j8937lrpkzf71irr3fqhdbddsghwrrmwim";
     };
   };
 
   continuum = mkDerivation {
     pluginName = "continuum";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-continuum";
-      rev = "90f4a00c41de094864dd4e29231253bcd80d4409";
-      sha256 = "1hviqz62mnq5h4vgcy9bl5004q18yz5b90bnih0ibsna877x3nbc";
+    version = "unstable-2018-02-23";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-continuum";
+      rev = "1531b3770a7cf7373d15fedd239c5331b99342d1";
+      sha256 = "1w3f7gzvv1k25yfr6d1snr2z88p8f87cahrbaslmyphdxpy0fa4m";
     };
     dependencies = [ resurrect ];
   };
 
   copycat = mkDerivation {
     pluginName = "copycat";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-copycat";
-      rev = "6f9b9cd2d93872cef60e3ea7f7ae89598569ed25";
-      sha256 = "12dgn5wnzrhd6sqa64w875ld3lrrny8xvdq6b6lzxyain9q49mrf";
+    version = "unstable-2020-01-09";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-copycat";
+      rev = "77ca3aab2aed8ede3e2b941079b1c92dd221cf5f";
+      sha256 = "1bchwzhai8k5rk32n4lrmh56rw944jqxr8imjk74hyaa7bbn81ds";
     };
   };
 
   cpu = mkDerivation {
     pluginName = "cpu";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-cpu";
-      rev = "12f7a74e25bf59701456e2c0d98b39bb19ec7039";
-      sha256 = "0qxn8ngg297980lj6w8ih2m8m8bxxdbcz5hsjmlia92h5rdkm5kl";
+    version = "unstable-2020-04-05";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-cpu";
+      rev = "8858050756e1fc3c081d37894b441f05ea893a67";
+      sha256 = "1bydzrnd9y5y46hjr844p4ylx2dpijn6pv3w94yyvwbyswmirhff";
     };
   };
 
-  ctrlw = mkDerivation {
+  ctrlw = mkDerivation rec {
     pluginName = "ctrlw";
-    src = fetchgit {
-      url = "https://github.com/eraserhd/tmux-ctrlw";
-      rev = "b456977125c640cd587b786c6a79cb5c7b0f900d";
+    version = "0.1.1";
+    src = fetchFromGitHub {
+      owner = "eraserhd";
+      repo = "tmux-ctrlw";
+      rev = "v${version}";
       sha256 = "1kv5pqfjczd6z7i9jf6j5xmcai50l9bn5p2p1w1l5fi6cj8cz1k1";
     };
   };
 
   fpp = mkDerivation {
     pluginName = "fpp";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-fpp";
+    version = "unstable-2016-03-08";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-fpp";
       rev = "ca125d5a9c80bb156ac114ac3f3d5951a795c80e";
       sha256 = "1b89s6mfzifi7s5iwf22w7niddpq28w48nmqqy00dv38z4yga5ws";
     };
@@ -116,18 +127,22 @@ in rec {
   fzf-tmux-url = mkDerivation {
     pluginName = "fzf-tmux-url";
     rtpFilePath = "fzf-url.tmux";
-    src = fetchgit {
-      url = "https://github.com/wfxr/tmux-fzf-url";
-      rev = "ecd518eec1067234598c01e655b048ff9d06ef2f";
-      sha256 = "0png8hdv91y2nivq5vdii2192mb2qcrkwwn69lzxrdnbfa27qrgv";
+    version = "unstable-2019-12-02";
+    src = fetchFromGitHub {
+      owner = "wfxr";
+      repo = "tmux-fzf-url";
+      rev = "2baa410bf7a0f6ceb62a83770baf90d570406ac0";
+      sha256 = "0rjzzlmxgjrr8g19bg2idcqr9ny07mrq2s39vndg24n0m7znh3fz";
     };
   };
 
   gruvbox = mkDerivation {
     pluginName = "gruvbox";
     rtpFilePath = "gruvbox-tpm.tmux";
-    src = fetchgit {
-      url = "https://github.com/egel/tmux-gruvbox";
+    version = "unstable-2019-05-05";
+    src = fetchFromGitHub {
+      owner = "egel";
+      repo = "tmux-gruvbox";
       rev = "6149fd8b5d6924925b4d5aa6935039780e94f3d6";
       sha256 = "1ykr4yardavd0x7yfrnshd4b0gi8p31pji7i79ib0nss134zncpb";
     };
@@ -135,26 +150,32 @@ in rec {
 
   logging = mkDerivation {
     pluginName = "logging";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-logging";
-      rev = "b2706119cd587230beae02980d3d7fa2d5afebe9";
-      sha256 = "1w1ymscfbz87lypaxgjdva1rg7jw2jyf7nnfgyngghw9m1l2xk2c";
+    version = "unstable-2019-04-19";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-logging";
+      rev = "b085ad423b5d59a2c8b8d71772352e7028b8e1d0";
+      sha256 = "0p0sawysalhi8k2a5hdxniqx6kb24kd8rnvfzkjqigzid5ik37js";
     };
   };
 
   net-speed = mkDerivation {
     pluginName = "net-speed";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-net-speed";
-      rev = "536d2bdd053a3bdfcc5cf7680c0dba76127c95ca";
-      sha256 = "1bly5f40dgiym378jkfwm7qag9xl6qvziqiqnj65yblqd5py325z";
+    version = "unstable-2018-12-02";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-net-speed";
+      rev = "58abb615971cb617821e2e7e41c660334f55a92d";
+      sha256 = "1aj06gdhzcxsydjzf21n9kyxigwf38kh2rg8hh7gnjk260ydqlrc";
     };
   };
 
   maildir-counter = mkDerivation {
     pluginName = "maildir-counter";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-maildir-counter";
+    version = "unstable-2016-11-25";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-maildir-counter";
       rev = "9415f0207e71e37cbd870c9443426dbea6da78b9";
       sha256 = "0dwvqhiv9bjwr01hsi5c57n55jyv5ha5m5q1aqgglf4wyhbnfms4";
     };
@@ -162,8 +183,10 @@ in rec {
 
   online-status = mkDerivation {
     pluginName = "online-status";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-online-status";
+    version = "unstable-2018-11-30";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-online-status";
       rev = "ea86704ced8a20f4a431116aa43f57edcf5a6312";
       sha256 = "1hy3vg8v2sir865ylpm2r4ip1zgd4wlrf24jbwh16m23qdcvc19r";
     };
@@ -171,28 +194,33 @@ in rec {
 
   open = mkDerivation {
     pluginName = "open";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-open";
-      rev = "f99d3189c445188eae5fa9bfeabc95df16deca92";
-      sha256 = "13q3zd5jv7akkjjwhgimmfylrvalxdn54fnpfb14g6xam6h8808m";
+    version = "unstable-2019-12-02";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-open";
+      rev = "cedb4584908bd8458fadc8d3e64101d3cbb48d46";
+      sha256 = "10s0xdhmg0dhpj13ybcq72pw3xgb2dq5v5h2mwidzqyh9g17wndh";
     };
   };
 
   pain-control = mkDerivation {
     pluginName = "pain-control";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-pain-control";
-      rev = "731667692da46d51a6a9dffb4c43384a5d68ff28";
-      sha256 = "1ihpl5wgjmhfgcrasgnydd7vpsar865sx2whra19gpfm4bglmdzl";
+    version = "unstable-2020-02-18";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-pain-control";
+      rev = "2db63de3b08fc64831d833240749133cecb67d92";
+      sha256 = "0w7a6n4n86ysiqcqj12j2hg9r5fznvbp3dz8pzas9q1k3avlk0zk";
     };
   };
 
-  plumb = mkDerivation {
+  plumb = mkDerivation rec {
     pluginName = "plumb";
+    version = "0.1.1";
     src = fetchFromGitHub {
       owner = "eraserhd";
       repo = "tmux-plumb";
-      rev = "v0.1.1";
+      rev = "v${version}";
       sha256 = "1c6k4fdl0az9811r6k164mgd4w5la75xr6x7nabmy046xc0z5i2r";
     };
     postInstall = ''
@@ -202,26 +230,32 @@ in rec {
 
   prefix-highlight = mkDerivation {
     pluginName = "prefix-highlight";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-prefix-highlight";
-      rev = "34f7125ae46e5123bedad03e08027332d1186186";
-      sha256 = "16z8sm8pifg1m9lmv0z50fb0ws9mk5zqs7a1ddl2bfwkqi7yc0c0";
+    version = "unstable-2020-03-26";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-prefix-highlight";
+      rev = "1db6e735aad54503b076391d791c56e1af213917";
+      sha256 = "0ws9blzg00zhz548m51cm6zbrkqlz7jazkr5029vka1f6qk36x0g";
     };
   };
 
   resurrect = mkDerivation {
     pluginName = "resurrect";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-resurrect";
-      rev = "7c77c70483b818d331e46c4cf64c716ded09a152";
-      sha256 = "08gjxwdmfy16xpgi87rp9dj5338imqsy392pixf7xcnr05413ap1";
+    version = "unstable-2020-03-21";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-resurrect";
+      rev = "327c0481ad20c429b4e692e092659f8b3346b08f";
+      sha256 = "0nxfqazww36wwv49dzd39kq4jfls20834hf1458sf5pvmv5cmbyw";
     };
   };
 
   sensible = mkDerivation {
     pluginName = "sensible";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-sensible";
+    version = "unstable-2017-09-05";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-sensible";
       rev = "e91b178ff832b7bcbbf4d99d9f467f63fd1b76b5";
       sha256 = "1z8dfbwblrbmb8sgb0k8h1q0dvfdz7gw57las8nwd5gj6ss1jyvx";
     };
@@ -232,8 +266,10 @@ in rec {
 
   sessionist = mkDerivation {
     pluginName = "sessionist";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-sessionist";
+    version = "unstable-2017-12-03";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-sessionist";
       rev = "09ec86be38eae98ffc27bd0dde605ed10ae0dc89";
       sha256 = "030q2mmj8akbc26jnqn8n7fckg1025p0ildx4wr401b6p1snnlw4";
     };
@@ -241,15 +277,18 @@ in rec {
 
   sidebar = mkDerivation {
     pluginName = "sidebar";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-sidebar";
-      rev = "23014524cab53f8d36373983500fe05a527a444d";
-      sha256 = "1w363587isdip1r81h0vkp5163lpa83lvasg8l04h43sbip2y6i8";
+    version = "unstable-2018-11-30";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-sidebar";
+      rev = "aacbdb45bc5ab69db448a72de4155d0b8dbac677";
+      sha256 = "1bp90zbv19kbbiik0bgb893ybss1jqsnk3353a631993xjwsih7c";
     };
   };
 
   sysstat = mkDerivation {
     pluginName = "sysstat";
+    version = "unstable-2017-12-12";
     src = fetchFromGitHub {
       owner = "samoshkin";
       repo = "tmux-plugin-sysstat";
@@ -260,6 +299,7 @@ in rec {
 
   tmux-colors-solarized = mkDerivation {
     pluginName = "tmuxcolors";
+    version = "unstable-2019-07-14";
     src = fetchFromGitHub {
       owner = "seebi";
       repo = "tmux-colors-solarized";
@@ -270,8 +310,10 @@ in rec {
 
   urlview = mkDerivation {
     pluginName = "urlview";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-urlview";
+    version = "unstable-2016-01-06";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-urlview";
       rev = "b84c876cffdd22990b4ab51247e795cbd7813d53";
       sha256 = "1jp4jq57cn116b3i34v6yy69izd8s6mp2ijr260cw86g0470k0fn";
     };
@@ -284,19 +326,23 @@ in rec {
   vim-tmux-navigator = mkDerivation {
     pluginName = "vim-tmux-navigator";
     rtpFilePath = "vim-tmux-navigator.tmux";
-    src = fetchgit {
-      url = "https://github.com/christoomey/vim-tmux-navigator";
-      rev = "4e1a877f51a17a961b8c2a285ee80aebf05ccf42";
-      sha256 = "1b8sgbzl4pcpaabqk254n97mjz767ganrmqbsr6rqzz3j9a3s1fv";
+    version = "unstable-2019-12-10";
+    src = fetchFromGitHub {
+      owner = "christoomey";
+      repo = "vim-tmux-navigator";
+      rev = "8fdf78292bb3aed1c9de880be7e03efdbf23d306";
+      sha256 = "0y92na4dcfcsj5zbs3m7y6csl3sd46a9968id78cdn9cgg8iwzac";
     };
   };
 
   yank = mkDerivation {
     pluginName = "yank";
-    src = fetchgit {
-      url = "https://github.com/tmux-plugins/tmux-yank";
-      rev = "feb9611b7d1c323ca54cd8a5111a53e3e8265b59";
-      sha256 = "1ywbm09jfh6cm2m6gracmdc3pp5p2dwraalbhfaafqaydjr22qc3";
+    version = "unstable-2019-12-02";
+    src = fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-yank";
+      rev = "648005db64d9bf3c4650eff694ecb6cf3e42b0c8";
+      sha256 = "1zg9k8yk1iw01vl8m44w4sv20lln4l0lq9dafc09lxmgxm9dllj4";
     };
   };
 


### PR DESCRIPTION
Many of the tmux plugins had not been updated in some time. This PR:

- Updates all of them to the latest version. This is notable because `tmux 3.0`
  has come out recently, and some of them have compatibility fixes for the new
  version (e.g., `vim-tmux-navigator`), as well as general performance
  improvements and bugfixes for many of them.

- Uses `fetchFromGitHub`, which is both more performant and hashed mirror friendly.

- Adds the standard `version = "unstable-YYYY-MM-DD"`, which makes it easy to
  determine at a glance how old/unmaintained some of these are.

- Adds the standard `pname` for overlay friendliness