### PR TITLE
ocamlPackages.ocaml_gettext: 0.3.8 → 0.4.1

### DIFF
--- a/pkgs/applications/virtualization/virt-top/default.nix
+++ b/pkgs/applications/virtualization/virt-top/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = with ocamlPackages; [ ocaml findlib ocaml_extlib ocaml_libvirt ocaml_gettext curses csv xml-light ];
+  buildInputs = with ocamlPackages; [ ocaml findlib ocaml_extlib ocaml_libvirt gettext-stub curses csv xml-light ];
 
   buildPhase = "make opt";
 

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     systemd fuse yajl libvirt gmp readline file hivex
     numactl xen libapparmor getopt perlPackages.ModuleBuild
   ] ++ (with perlPackages; [ perl libintl_perl GetoptLong SysVirt ])
-    ++ (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml_libvirt ocaml_gettext ounit ])
+    ++ (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml_libvirt gettext-stub ounit ])
     ++ stdenv.lib.optional javaSupport jdk;
 
   prePatch = ''

--- a/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
@@ -1,38 +1,28 @@
-{ stdenv, fetchurl, ocaml, findlib, camlp4, ounit, gettext, fileutils, camomile }:
+{ lib, fetchurl, buildDunePackage, gettext, fileutils, ounit }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-gettext-${version}";
-  version = "0.3.8";
+buildDunePackage rec {
+  pname = "gettext";
+  version = "0.4.1";
+
+  minimumOCamlVersion = "4.03";
 
   src = fetchurl {
-    url = "https://forge.ocamlcore.org/frs/download.php/1731/ocaml-gettext-${version}.tar.gz";
-    sha256 = "05wnpxwzzpn2qinah2wb5wzfh5iz8gyf8jyihdbjxc8mk4hf70qv";
+    url = "https://github.com/gildor478/ocaml-gettext/releases/download/v${version}/gettext-v${version}.tbz";
+    sha256 = "0pwy6ym5fd77mdbgyas8x86vbrri9cgk79g8wxdjplhyi7zhh158";
   };
 
-  propagatedBuildInputs = [ gettext fileutils camomile ];
+  propagatedBuildInputs = [ gettext fileutils ];
 
-  buildInputs = [ ocaml findlib camlp4 ounit ];
+  doCheck = true;
 
-  postPatch = stdenv.lib.optionalString (camlp4 != null) ''
-    substituteInPlace test/test.ml                  --replace "+camlp4" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib/camlp4"
-    substituteInPlace ocaml-gettext/OCamlGettext.ml --replace "+camlp4" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib/camlp4"
-    substituteInPlace ocaml-gettext/Makefile        --replace "+camlp4" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib/camlp4"
-    substituteInPlace ocaml-gettext/Makefile        --replace "unix.cma" ""
-    substituteInPlace libgettext-ocaml/Makefile     --replace "+camlp4" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib/camlp4"
-    substituteInPlace libgettext-ocaml/Makefile     --replace "\$(shell ocamlc -where)" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib"
-  '';
-
-  configureFlags = [ "--disable-doc" ];
-
-  createFindlibDestdir = true;
+  checkInputs = lib.optional doCheck ounit;
 
   dontStrip = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "OCaml Bindings to gettext";
-    homepage = https://forge.ocamlcore.org/projects/ocaml-gettext;
-    license = licenses.gpl2;
+    homepage = "https://github.com/gildor478/ocaml-gettext";
+    license = licenses.lgpl21;
     maintainers = [ maintainers.volth ];
-    platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
@@ -1,0 +1,14 @@
+{ lib, buildDunePackage, ocaml_gettext, ounit }:
+
+buildDunePackage rec {
+
+  pname = "gettext-stub";
+
+  inherit (ocaml_gettext) src version meta;
+
+  propagatedBuildInputs = [ ocaml_gettext ];
+
+  doCheck = true;
+
+  checkInputs = lib.optional doCheck ounit;
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -587,6 +587,8 @@ let
 
     ocaml_gettext = callPackage ../development/ocaml-modules/ocaml-gettext { };
 
+    gettext-stub = callPackage ../development/ocaml-modules/ocaml-gettext/stub.nix { };
+
     ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };
 
     ocaml_http = callPackage ../development/ocaml-modules/http { };


### PR DESCRIPTION
###### Motivation for this change

Do not depend on deprecated camlp4

Fixes #84416

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
