### PR TITLE
coqPackages.dpdgraph: fix build with OCaml ≥ 4.08

### DIFF
--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -36,6 +36,8 @@ let params = {
 param = params.${coq.coq-version};
 in
 
+let hasWarning = stdenv.lib.versionAtLeast coq.ocamlPackages.ocaml.version "4.08"; in
+
 stdenv.mkDerivation {
   name = "coq${coq.coq-version}-dpdgraph-${param.version}";
   src = fetchFromGitHub {
@@ -48,6 +50,14 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ coq ]
   ++ (with coq.ocamlPackages; [ ocaml camlp5 findlib ocamlgraph ]);
+
+  # dpd_compute.ml uses deprecated Pervasives.compare
+  # Versions prior to 0.6.5 do not have the WARN_ERR build flag
+  preConfigure = stdenv.lib.optionalString hasWarning ''
+    substituteInPlace Makefile.in --replace "-warn-error +a " ""
+  '';
+
+  buildFlags = stdenv.lib.optional hasWarning "WARN_ERR=";
 
   preInstall = ''
     mkdir -p $out/bin


### PR DESCRIPTION
###### Motivation for this change

dpdgraph currently does not build for Coq ≥ 8.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
