### PR TITLE
pythonPackages.psycopg2cffi: init at 2.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1067,6 +1067,12 @@
     githubId = 3465841;
     name = "Boris Sukholitko";
   };
+  bqv = {
+    email = "nixpkgs@fron.io";
+    github = "bqv";
+    githubId = 822863;
+    name = "Tony Olagbaiye";
+  };
   bradediger = {
     email = "brad@bradediger.com";
     github = "bradediger";

--- a/pkgs/development/python-modules/psycopg2cffi/default.nix
+++ b/pkgs/development/python-modules/psycopg2cffi/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi, cffi, postgresql, openssl, six }:
+
+buildPythonPackage rec {
+  pname = "psycopg2cffi";
+  version = "2.8.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0yc0cxxkfr35kd959wsagxfhy6ikbix71rp9x0rmn858fxa4vapw";
+  };
+
+  buildInputs = [ six ] ++ lib.optional stdenv.isDarwin openssl;
+  nativeBuildInputs = [ cffi postgresql ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "PostgreSQL database adapter for the Python programming language";
+    license = with licenses; [ lgpl3 ];
+    homepage = "http://github.com/chtd/psycopg2cffi/";
+    maintainers = with maintainers; [ bqv ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4986,6 +4986,8 @@ in {
 
   psycopg2 = callPackage ../development/python-modules/psycopg2 {};
 
+  psycopg2cffi = callPackage ../development/python-modules/psycopg2cffi {};
+
   ptpython = callPackage ../development/python-modules/ptpython {
     prompt_toolkit = self.prompt_toolkit;
   };


### PR DESCRIPTION
###### Motivation for this change
psycopg2cffi for pypy3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
