### PR TITLE
[20.03] processing: fix sha256 of reference.zip

### DIFF
--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ajniy3a0i0rx7is46r85yh3ah4zm4ra1gbllmihw9pmnfjgfajn";
   };
 
-  nativeBuildInputs = [ ant rsync makeWrapper ];
+  nativeBuildInputs = [ ant rsync makeWrapper xmlstarlet ];
   buildInputs = [ jdk ];
 
   buildPhase = ''
@@ -20,10 +20,10 @@ stdenv.mkDerivation rec {
     cp ${javaPackages.jogl_2_3_2}/share/java/*.jar core/library/
 
     # do not download a file during build
-    ${xmlstarlet}/bin/xmlstarlet ed --inplace -P -d '//get[@src="http://download.processing.org/reference.zip"]' build/build.xml
+    xmlstarlet ed --inplace -P -d '//get[@src="http://download.processing.org/reference.zip"]' build/build.xml
     install -D -m0444 ${fetchurl {
-                          url    = http://download.processing.org/reference.zip;
-                          sha256 = "198bpk8mzns6w5h0zdf50wr6iv7sgdi6v7jznj5rbsnpgyilxz35";
+                          url    = http://web.archive.org/web/20200406132357/http://download.processing.org/reference.zip;
+                          sha256 = "093hc7kc9wfxqgf5dzfmfp68pbsy8x647cj0a25vgjm1swi61zbi";
                         }
                        } ./java/reference.zip
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
     ( cd build
       substituteInPlace build.xml --replace "jre-download," ""  # do not download jre1.8.0_144
-      mkdir -p linux/jre1.8.0_144                               # fake dir to avoid error
+      mkdir -p linux/jre1.8.0_202                               # fake dir to avoid error
       ant build )
   '';
 

--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     # do not download a file during build
     xmlstarlet ed --inplace -P -d '//get[@src="http://download.processing.org/reference.zip"]' build/build.xml
     install -D -m0444 ${fetchurl {
-                          url    = http://web.archive.org/web/20200406132357/http://download.processing.org/reference.zip;
+                          url    = https://web.archive.org/web/20200406132357/http://download.processing.org/reference.zip;
                           sha256 = "093hc7kc9wfxqgf5dzfmfp68pbsy8x647cj0a25vgjm1swi61zbi";
                         }
                        } ./java/reference.zip


### PR DESCRIPTION
The file at `http://download.processing.org/reference.zip` is changing often, so use wayback machine to get a link to a stable file

ZHF https://github.com/NixOS/nixpkgs/issues/80379