### PR TITLE
ardour: clean up the expression

### DIFF
--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -1,14 +1,53 @@
-{ stdenv, fetchgit, alsaLib, aubio, boost, cairomm, curl, doxygen
-, fftwSinglePrec, flac, glibc, glibmm, graphviz, gtkmm2, libjack2
-, libgnomecanvas, libgnomecanvasmm, liblo, libmad, libogg
-, librdf_raptor, librdf_rasqal, libsamplerate, libsigcxx, libsndfile
-, libusb, libuuid, libxml2, libxslt, lilv, lrdf, lv2, makeWrapper
-, perl, pkgconfig, python2, rubberband, serd, sord, sratom
-, taglib, vamp-plugin-sdk, dbus, fftw, pango, suil, libarchive
-, wafHook }:
-
+{ stdenv
+, fetchgit
+, alsaLib
+, aubio
+, boost
+, cairomm
+, curl
+, doxygen
+, fftwSinglePrec
+, flac
+, glibc
+, glibmm
+, graphviz
+, gtkmm2
+, libjack2
+, libgnomecanvas
+, libgnomecanvasmm
+, liblo
+, libmad
+, libogg
+, librdf_raptor
+, librdf_rasqal
+, libsamplerate
+, libsigcxx
+, libsndfile
+, libusb
+, libuuid
+, libxml2
+, libxslt
+, lilv
+, lrdf
+, lv2
+, makeWrapper
+, perl
+, pkgconfig
+, python2
+, rubberband
+, serd
+, sord
+, sratom
+, taglib
+, vamp-plugin-sdk
+, dbus
+, fftw
+, pango
+, suil
+, libarchive
+, wafHook
+}:
 let
-
   # Ardour git repo uses a mix of annotated and lightweight tags. Annotated
   # tags are used for MAJOR.MINOR versioning, and lightweight tags are used
   # in-between; MAJOR.MINOR.REV where REV is the number of commits since the
@@ -18,10 +57,7 @@ let
 
   # Version to build.
   tag = "5.12";
-
-in
-
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   name = "ardour-${tag}";
 
   src = fetchgit {
@@ -30,15 +66,56 @@ stdenv.mkDerivation rec {
     sha256 = "0mla5lm51ryikc2rrk53max2m7a5ds6i1ai921l2h95wrha45nkr";
   };
 
-  nativeBuildInputs = [ wafHook ];
-  buildInputs =
-    [ alsaLib aubio boost cairomm curl doxygen dbus fftw fftwSinglePrec flac
-      glibmm graphviz gtkmm2 libjack2 libgnomecanvas libgnomecanvasmm liblo
-      libmad libogg librdf_raptor librdf_rasqal libsamplerate
-      libsigcxx libsndfile libusb libuuid libxml2 libxslt lilv lrdf lv2
-      makeWrapper pango perl pkgconfig python2 rubberband serd sord
-      sratom suil taglib vamp-plugin-sdk libarchive
-    ];
+  nativeBuildInputs = [
+    wafHook
+  ];
+
+  buildInputs = [
+    alsaLib
+    aubio
+    boost
+    cairomm
+    curl
+    doxygen
+    dbus
+    fftw
+    fftwSinglePrec
+    flac
+    glibmm
+    graphviz
+    gtkmm2
+    libjack2
+    libgnomecanvas
+    libgnomecanvasmm
+    liblo
+    libmad
+    libogg
+    librdf_raptor
+    librdf_rasqal
+    libsamplerate
+    libsigcxx
+    libsndfile
+    libusb
+    libuuid
+    libxml2
+    libxslt
+    lilv
+    lrdf
+    lv2
+    makeWrapper
+    pango
+    perl
+    pkgconfig
+    python2
+    rubberband
+    serd
+    sord
+    sratom
+    suil
+    taglib
+    vamp-plugin-sdk
+    libarchive
+  ];
 
   # ardour's wscript has a "tarball" target but that required the git revision
   # be available. Since this is an unzipped tarball fetched from github we

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -13,26 +13,24 @@
 , graphviz
 , gtkmm2
 , libjack2
-, libgnomecanvas
-, libgnomecanvasmm
 , liblo
-, libmad
 , libogg
-, librdf_raptor
-, librdf_rasqal
 , libsamplerate
 , libsigcxx
 , libsndfile
-, libusb
-, libuuid
+, libusb1
+, fluidsynth_1
+, hidapi
+, libltc
+, qm-dsp
 , libxml2
-, libxslt
 , lilv
 , lrdf
 , lv2
 , makeWrapper
 , perl
-, pkgconfig
+, pkg-config
+, itstool
 , python2
 , rubberband
 , serd
@@ -68,6 +66,13 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     wafHook
+    makeWrapper
+    pkg-config
+    itstool
+    doxygen
+    graphviz # for dot
+    perl
+    python2
   ];
 
   buildInputs = [
@@ -76,37 +81,28 @@ in stdenv.mkDerivation rec {
     boost
     cairomm
     curl
-    doxygen
     dbus
     fftw
     fftwSinglePrec
     flac
     glibmm
-    graphviz
     gtkmm2
     libjack2
-    libgnomecanvas
-    libgnomecanvasmm
     liblo
-    libmad
     libogg
-    librdf_raptor
-    librdf_rasqal
     libsamplerate
     libsigcxx
     libsndfile
-    libusb
-    libuuid
+    libusb1
+    fluidsynth_1
+    hidapi
+    libltc
+    qm-dsp
     libxml2
-    libxslt
     lilv
     lrdf
     lv2
-    makeWrapper
     pango
-    perl
-    pkgconfig
-    python2
     rubberband
     serd
     sord
@@ -117,36 +113,35 @@ in stdenv.mkDerivation rec {
     libarchive
   ];
 
-  # ardour's wscript has a "tarball" target but that required the git revision
-  # be available. Since this is an unzipped tarball fetched from github we
-  # have to do that ourself.
-  patchPhase = ''
-    printf '#include "libs/ardour/ardour/revision.h"\nnamespace ARDOUR { const char* revision = \"${tag}-${builtins.substring 0 8 src.rev}\"; }\n' > libs/ardour/revision.cc
-    sed 's|/usr/include/libintl.h|${glibc.dev}/include/libintl.h|' -i wscript
-    patchShebangs ./tools/
-  '';
-
   wafConfigureFlags = [
     "--optimize"
     "--docs"
+    "--use-external-libs"
+    "--freedesktop"
     "--with-backends=jack,alsa,dummy"
   ];
 
+  NIX_CFLAGS_COMPILE = "-I${qm-dsp}/include/qm-dsp";
+
+  # ardour's wscript has a "tarball" target but that required the git revision
+  # be available. Since this is an unzipped tarball fetched from github we
+  # have to do that ourself.
+  postPatch = ''
+    printf '#include "libs/ardour/ardour/revision.h"\nnamespace ARDOUR { const char* revision = \"${tag}-${builtins.substring 0 8 src.rev}\"; }\n' > libs/ardour/revision.cc
+    patchShebangs ./tools/
+  '';
+
   postInstall = ''
-    # Install desktop file
-    mkdir -p "$out/share/applications"
-    cat > "$out/share/applications/ardour.desktop" << EOF
-    [Desktop Entry]
-    Name=Ardour 5
-    GenericName=Digital Audio Workstation
-    Comment=Multitrack harddisk recorder
-    Exec=$out/bin/ardour5
-    Icon=$out/share/ardour5/resources/Ardour-icon_256px.png
-    Terminal=false
-    Type=Application
-    X-MultipleArgs=false
-    Categories=GTK;Audio;AudioVideoEditing;AudioVideo;Video;
-    EOF
+    # wscript does not install these for some reason
+    install -vDm 644 "build/gtk2_ardour/ardour.xml" \
+      -t "$out/share/mime/packages"
+    install -vDm 644 "build/gtk2_ardour/ardour5.desktop" \
+      -t "$out/share/applications"
+    for size in 16 22 32 48 256 512; do
+      install -vDm 644 "gtk2_ardour/resources/Ardour-icon_''${size}px.png" \
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour5.png"
+    done
+    install -vDm 644 "ardour.1"* -t "$out/share/man/man1"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/audio/qm-dsp/default.nix
+++ b/pkgs/development/libraries/audio/qm-dsp/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, kissfft
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qm-dsp";
+  version = "1.7.1";
+
+  src = fetchFromGitHub {
+    owner = "c4dm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "e1PtCIzp7zIz+KKRxEGlAXTNqZ35vPgQ4opJKHIPa+4=";
+  };
+
+  patches = [
+    # Make installable
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/qm-dsp/raw/6eb385e2f970c4150f9c8eba73b558318475ed15/f/qm-dsp-install.patch";
+      sha256 = "7JDg9yOECWG7Ql5lIoC4L++R1gUlKfztvED5Ey4YLxw=";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/qm-dsp/raw/6eb385e2f970c4150f9c8eba73b558318475ed15/f/qm-dsp-flags.patch";
+      sha256 = "2HRSbSFxC8DPXOgcflyBYeJI3NwO/1CFmyRdvYo09og=";
+      postFetch = ''
+        sed -i 's~/Makefile~/build/linux/Makefile.linux32~g' "$out"
+      '';
+    })
+  ];
+
+  buildInputs = [
+    kissfft
+  ];
+
+  makefile = "build/linux/Makefile.linux32";
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "LIBDIR=${placeholder "out"}/lib"
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${kissfft}/include/kissfft";
+
+  meta = with stdenv.lib; {
+    description = "A C++ library of functions for DSP and Music Informatics purposes";
+    homepage = "https://code.soundsoftware.ac.uk/projects/qm-dsp";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.goibhniu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/kissfft/default.nix
+++ b/pkgs/development/libraries/kissfft/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kissfft";
+  version = "131";
+
+  src = fetchFromGitHub {
+    owner = "mborgerding";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "4lmRyBzW4H5wXb0EpgAp/hbaE2SslB6rAJyyLLbCtSs=";
+  };
+
+  patches = [
+    # Allow installation into our prefix
+    # Fix installation on Darwin
+    # Create necessary directories
+    # Make datatype configurable
+    (fetchpatch {
+      url = "https://github.com/mborgerding/kissfft/pull/38.patch";
+      sha256 = "Rsrob1M+lxwEag6SV5FqaTeyiJaOpspZxVtkeihX4TI=";
+    })
+    # Install headers as well
+    (fetchpatch {
+      url = "https://github.com/mborgerding/kissfft/commit/71df949992d2dbbe15ce707cf56c3fa1e43b1080.patch";
+      sha256 = "9ap6ZWyioBiut9UQM3v6W1Uv+iP3Kmt27xWhIfWfBI4=";
+    })
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "DATATYPE=double"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A mixed-radix Fast Fourier Transform based up on the KISS principle";
+    homepage = "https://github.com/mborgerding/kissfft";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.goibhniu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14212,6 +14212,8 @@ in
 
   lvtk = callPackage ../development/libraries/audio/lvtk { };
 
+  qm-dsp = callPackage ../development/libraries/audio/qm-dsp { };
+
   qradiolink = callPackage ../applications/radio/qradiolink { };
 
   qrupdate = callPackage ../development/libraries/qrupdate { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14182,6 +14182,8 @@ in
 
   readosm = callPackage ../development/libraries/readosm { };
 
+  kissfft = callPackage ../development/libraries/kissfft { };
+
   lambdabot = callPackage ../development/tools/haskell/lambdabot {
     haskellLib = haskell.lib;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18405,9 +18405,7 @@ in
 
   aqemu = libsForQt5.callPackage ../applications/virtualization/aqemu { };
 
-  ardour = callPackage ../applications/audio/ardour {
-    inherit (gnome2) libgnomecanvas libgnomecanvasmm;
-  };
+  ardour = callPackage ../applications/audio/ardour { };
 
   arelle = with python3Packages; toPythonApplication arelle;
 


### PR DESCRIPTION
###### Motivation for this change
Wanted to clean up gnome2 packages for https://github.com/NixOS/nixpkgs/issues/39976 but it got out of hand.

cc @cillianderoiste @fps 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
