### PR TITLE
ocamlPackages.sedlex: fix dependencies

### DIFF
--- a/pkgs/development/ocaml-modules/sedlex/default.nix
+++ b/pkgs/development/ocaml-modules/sedlex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, gen, ppx_tools_versioned }:
+{ stdenv, fetchzip, ocaml, findlib, gen, ppx_tools_versioned, ocaml-migrate-parsetree }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.02"
 then throw "sedlex is not available for OCaml ${ocaml.version}"
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "0phnqyn6mpv5byr1kkphl24y9q9fb2k3xg9yb457h5816q6ya72n";
   };
 
-  buildInputs = [ ocaml findlib ppx_tools_versioned ];
+  buildInputs = [ ocaml findlib ];
 
-  propagatedBuildInputs = [ gen ];
+  propagatedBuildInputs = [ gen ocaml-migrate-parsetree ppx_tools_versioned ];
 
   buildFlags = [ "all" "opt" ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Using this library as a dependency could fail at Dune files internal to Sedlex.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
