### PR TITLE
hydra: 2020-03-24 -> 2020-04-07

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -748,10 +748,10 @@ auth required pam_succeed_if.so uid >= 1000 quiet
       </listitem>
       <listitem>
        <para>
-        Deploy a newer version of Hydra to activate the DB optimizations. You can choose from
-        either <package>hydra-unstable</package> (latest <literal>master</literal> compiled
-        against <package>nixUnstable</package>) and <package>hydra-flakes</package> (latest
-        version with flake-support).
+        Deploy a newer version of Hydra to activate the DB optimizations. This can be done by
+        using <package>hydra-unstable</package>. This package already includes
+        <link xlink:href="https://github.com/nixos/rfcs/pull/49">flake-support</link> and is
+        therefore compiled against <package>pkgs.nixFlakes</package>.
         <warning>
          <para>
           If your <link linkend="opt-system.stateVersion">stateVersion</link> is set to

--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -198,8 +198,8 @@ in
     warnings = optional (cfg.package.migration or false) ''
       You're currently deploying an older version of Hydra which is needed to
       make some required database changes[1]. As soon as this is done, it's recommended
-      to run `hydra-backfill-ids` and set `services.hydra.package` to either `pkgs.hydra-unstable`
-      or `pkgs.hydra-flakes` after that.
+      to run `hydra-backfill-ids` and set `services.hydra.package` to `pkgs.hydra-unstable`
+      after that.
 
       [1] https://github.com/NixOS/hydra/pull/711
     '';
@@ -212,7 +212,7 @@ in
             due to an overlay. To upgrade Hydra, you need to take two steps as some
             bigger changes in the database schema were implemented recently[1]. You first
             need to deploy `pkgs.hydra-migration`, run `hydra-backfill-ids` on the server
-            and then deploy either `pkgs.hydra-unstable` or `pkgs.hydra-flakes`.
+            and then deploy `pkgs.hydra-unstable`.
 
             If you want to use `pkgs.hydra` from your overlay, please set `services.hydra.package`
             explicitly to `pkgs.hydra` and make sure you know what you're doing.

--- a/nixos/tests/hydra/default.nix
+++ b/nixos/tests/hydra/default.nix
@@ -11,7 +11,7 @@ let
   inherit (import ./common.nix { inherit system; }) baseConfig;
 
   hydraPkgs = {
-    inherit (pkgs) hydra-migration hydra-unstable hydra-flakes;
+    inherit (pkgs) hydra-migration hydra-unstable;
   };
 
   makeHydraTest = with pkgs.lib; name: package: makeTest {

--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -4,7 +4,7 @@
 , guile, perl, postgresql, nukeReferences, git, boehmgc, nlohmann_json
 , docbook_xsl, openssh, gnused, coreutils, findutils, gzip, lzma, gnutar
 , rpm, dpkg, cdrkit, pixz, lib, boost, autoreconfHook, src ? null, version ? null
-, migration ? false
+, migration ? false, patches ? []
 }:
 
 with stdenv;
@@ -74,7 +74,7 @@ let
 in stdenv.mkDerivation rec {
   pname = "hydra";
 
-  inherit stdenv src version;
+  inherit stdenv src version patches;
 
   buildInputs =
     [ makeWrapper autoconf automake libtool unzip nukeReferences sqlite libpqxx

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, nixStable, nixUnstable, callPackage, nixFlakes }:
+{ fetchFromGitHub, nixStable, callPackage, nixFlakes, fetchpatch }:
 
 {
   # Package for phase-1 of the db migration for Hydra.
@@ -15,28 +15,24 @@
     migration = true;
   };
 
-  # Hydra from latest master (or flakes) branch. Contains breaking changes,
+  # Hydra from latest master branch. Contains breaking changes,
   # so when having an older version, `pkgs.hydra-migration` should be deployed first.
 
   hydra-unstable = callPackage ./common.nix {
-    version = "2020-03-24";
+    version = "2020-04-07";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "12cc46cdb36321acd4c982429a86eb0f8f3cc969";
-      sha256 = "10ipxzdxr47c8w5jg69mbax2ykc7lb5fs9bbdd3iai9wzyfz17ln";
+      rev = "4cabb37ebdeade1435ad8ebf1913cdd603b9c452";
+      sha256 = "1ccy639x6yyrqqqqli7vlqm6pcvcq5dx1w3ckba77rl8pd5h31f7";
     };
-    nix = nixUnstable;
-  };
-
-  hydra-flakes = callPackage ./common.nix {
-    version = "2020-03-27";
-    src = fetchFromGitHub {
-      owner = "NixOS";
-      repo = "hydra";
-      rev = "a7540b141d085a7e78c21fda8e8c05907c659b34";
-      sha256 = "08fs7593w5zs8vh4c66gvrxk6s840pp6hj8nwf51wsa27kg5a943";
-    };
+    patches = [
+      # https://github.com/NixOS/hydra/pull/732
+      (fetchpatch {
+        url = "https://github.com/NixOS/hydra/commit/2f9d422172235297759f2b224fe0636cad07b6fb.patch";
+        sha256 = "0152nsqqc5d85qdygmwrsk88i9y6nk1b639fj2n042pjvr0kpz6k";
+      })
+    ];
     nix = nixFlakes;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12100,7 +12100,12 @@ in
   hwloc = callPackage ../development/libraries/hwloc {};
 
   inherit (callPackage ../development/tools/misc/hydra { })
-    hydra-migration hydra-unstable hydra-flakes;
+    hydra-migration hydra-unstable;
+
+  hydra-flakes = throw ''
+    Flakes support has been merged into Hydra's master. Please use
+    `pkgs.hydra-unstable` now.
+  '';
 
   hydra-cli = callPackage ../development/tools/misc/hydra-cli { };
 


### PR DESCRIPTION

###### Motivation for this change

Upgrades Hydra to the latest git revs, also fixes the build of `hydra-unstable` (https://hydra.nixos.org/build/116209553).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
