### PR TITLE
python3Packages.monty: fix tests

### DIFF
--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -29,6 +29,13 @@ buildPythonPackage rec {
   checkInputs = [ lsof nose numpy msgpack coverage coveralls pymongo];
   propagatedBuildInputs = [ six ruamel_yaml ];
 
+  # test suite tries to decode bytes, but msgpack now returns a str
+  # https://github.com/materialsvirtuallab/monty/pull/121
+  postPatch = ''
+    substituteInPlace tests/test_serialization.py \
+      --replace ".decode('utf-8')" ""
+  '';
+
   preCheck = ''
     substituteInPlace tests/test_os.py \
       --replace 'self.assertEqual("/usr/bin/find", which("/usr/bin/find"))' '#'


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing in #84463

upstreamed to:
https://github.com/materialsvirtuallab/monty/pull/121

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[12 built, 6 copied (14.5 MiB), 2.9 MiB DL]
https://github.com/NixOS/nixpkgs/pull/84503
1 package marked as broken and skipped:
python38Packages.sunpy

12 package built:
python37Packages.dftfit python37Packages.lammps-cython python37Packages.monty python37Packages.pymatgen python37Packages.pymatgen-lammps python37Packages.sumo python38Packages.dftfit python38Packages.lammps-cython python38Packages.monty python38Packages.pymatgen python38Packages.pymatgen-lammps python38Packages.sumo
```