### PR TITLE
ecryptfs: enable building without python2 support

### DIFF
--- a/pkgs/tools/security/ecryptfs/default.nix
+++ b/pkgs/tools/security/ecryptfs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, perl, utillinux, keyutils, nss, nspr, python2, pam
+{ stdenv, fetchurl, pkgconfig, perl, utillinux, keyutils, nss, nspr, python2, pam, enablePython ? false
 , intltool, makeWrapper, coreutils, bash, gettext, cryptsetup, lvm2, rsync, which, lsof }:
 
 stdenv.mkDerivation rec {
@@ -33,8 +33,15 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ perl nss nspr python2 pam intltool makeWrapper ];
+  configureFlags = stdenv.lib.optionals (!enablePython) [ "--disable-pywrap" ];
+
+  nativeBuildInputs = [ pkgconfig ]
+  # if python2 support is requested, it is needed at builtime as well as runtime.
+  ++ stdenv.lib.optionals (enablePython) [ python2 ]
+  ;
+  buildInputs = [ perl nss nspr pam intltool makeWrapper ]
+  ++ stdenv.lib.optionals (enablePython) [ python2 ]
+  ;
   propagatedBuildInputs = [ coreutils gettext cryptsetup lvm2 rsync keyutils which ];
 
   postInstall = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Since Python2 is EOL I think packages which don't absolutely need python2 shouldn't require them. Specifically for ecryptfs, I opened a bug regarding Python 3 support: https://bugs.launchpad.net/ecryptfs/+bug/1871236

###### Things done

- [x] Add a `enablePython` flag set to `false` by default that enables building ecryptfs without needing python at all.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of ~~all~~ some binary files (usually in `./result/bin/`)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
