### PR TITLE
nixos/lib/test-driver: Fix require_unit_state hardcoded formatting

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -387,7 +387,7 @@ class Machine:
             if state != require_state:
                 raise Exception(
                     "Expected unit ‘{}’ to to be in state ".format(unit)
-                    + "'active' but it is in state ‘{}’".format(state)
+                    + "'{}' but it is in state ‘{}’".format(require_state, state)
                 )
 
     def execute(self, command: str) -> Tuple[int, str]:


### PR DESCRIPTION
###### Motivation for this change

Noticed this mistake when using this function

Ping @tfc 

###### Things done

- [x] Tested it with my own test to make sure it works