### PR TITLE
case-kak: init at unrelease-2020-04-06

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/case.kak.nix
+++ b/pkgs/applications/editors/kakoune/plugins/case.kak.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitLab }:
+
+stdenv.mkDerivation {
+  name = "case.kak";
+  version = "unstable-2020-04-06";
+
+  src = fetchFromGitLab {
+    owner = "FlyingWombat";
+    repo = "case.kak";
+    rev = "6f1511820aa3abfa118e0f856118adc8113e2185";
+    sha256 = "002njrlwgakqgp74wivbppr9qyn57dn4n5bxkr6k6nglk9qndwdp";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/kak/autoload/plugins
+    cp -r rc/case.kak $out/share/kak/autoload/plugins
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Ease navigation between opened buffers in Kakoune";
+    homepage = "https://gitlab.com/FlyingWombat/case.kak";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ eraserhd ];
+    platform = platforms.all;
+  };
+}
+

--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -3,6 +3,7 @@
 {
   inherit parinfer-rust;
 
+  case-kak = pkgs.callPackage ./case.kak.nix { };
   kak-ansi = pkgs.callPackage ./kak-ansi.nix { };
   kak-auto-pairs = pkgs.callPackage ./kak-auto-pairs.nix { };
   kak-buffers = pkgs.callPackage ./kak-buffers.nix { };


### PR DESCRIPTION
###### Motivation for this change

This plugin is useful, so package it.  It converts words betweeen different cases
in the Kakoune editor (e.g. snake_case -> PascalCase).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  New package, +4984
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).