### PR TITLE
python3Packages.ftfy: Fix dependencies

### DIFF
--- a/pkgs/development/python-modules/ftfy/default.nix
+++ b/pkgs/development/python-modules/ftfy/default.nix
@@ -4,6 +4,7 @@
 , fetchPypi
 , html5lib
 , wcwidth
+, setuptools
 , pytest
 }:
 
@@ -26,6 +27,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     html5lib
     wcwidth
+    setuptools
   ];
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change
Without `setuptools` the package doesn't work.

```
$ nix run nixpkgs.python3Packages.ftfy -c ftfy
Traceback (most recent call last):
  File "/nix/store/mvikxjsy91xi29grfkmanvf8il4x9wl5-python3.7-ftfy-5.7/bin/.ftfy-wrapped", line 6, in <module>
    from ftfy.cli import main
  File "/nix/store/mvikxjsy91xi29grfkmanvf8il4x9wl5-python3.7-ftfy-5.7/lib/python3.7/site-packages/ftfy/__init__.py", line 11, in <module>
    from ftfy import fixes
  File "/nix/store/mvikxjsy91xi29grfkmanvf8il4x9wl5-python3.7-ftfy-5.7/lib/python3.7/site-packages/ftfy/fixes.py", line 11, in <module>
    from ftfy.badness import text_cost
  File "/nix/store/mvikxjsy91xi29grfkmanvf8il4x9wl5-python3.7-ftfy-5.7/lib/python3.7/site-packages/ftfy/badness.py", line 9, in <module>
    from ftfy.chardata import chars_to_classes
  File "/nix/store/mvikxjsy91xi29grfkmanvf8il4x9wl5-python3.7-ftfy-5.7/lib/python3.7/site-packages/ftfy/chardata.py", line 12, in <module>
    from pkg_resources import resource_string
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
