### PR TITLE
LLVM: Always pass host/target info to compiler-rt/libstdcxxClang

### DIFF
--- a/pkgs/development/compilers/gcc/libstdc++-hook.sh
+++ b/pkgs/development/compilers/gcc/libstdc++-hook.sh
@@ -1,4 +1,4 @@
 # See pkgs/build-support/setup-hooks/role.bash
 getHostRole
 
-export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/$(@gcc@/bin/gcc -dumpmachine)"
+export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/@targetConfig@"

--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     "-DSCUDO_DEFAULT_OPTIONS=DeleteSizeMismatch=0:DeallocationTypeMismatch=0"
   ];
 
-  cmakeFlags = stdenv.lib.optionals (useLLVM || stdenv.isDarwin) [
+  cmakeFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"

--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -1,4 +1,4 @@
-{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+{ lowPrio, newScope, pkgs, stdenv, cmake, gcc, libstdcxxHook
 , libxml2, python3, isl, fetchurl, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
@@ -7,6 +7,7 @@
 let
   release_version = "10.0.0";
   version = release_version; # differentiating these (variables) is important for rc's
+  targetConfig = stdenv.targetPlatform.config;
 
   fetch = name: sha256: fetchurl {
     url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-${release_version}/${name}-${version}.src.tar.xz";
@@ -60,7 +61,12 @@ let
         libstdcxxHook
         targetLlvmLibraries.compiler-rt
       ];
-      extraBuildCommands = mkExtraBuildCommands cc;
+      extraBuildCommands = ''
+          echo "-target ${targetConfig}" >> $out/nix-support/cc-cflags
+          echo "-B${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-cflags
+          echo "-L${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-ldflags
+          echo "-L${gcc.cc.lib}/${targetConfig}/lib" >> $out/nix-support/cc-ldflags
+      '' + mkExtraBuildCommands cc;
     };
 
     libcxxClang = wrapCCWith rec {

--- a/pkgs/development/compilers/llvm/5/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt.nix
@@ -1,5 +1,13 @@
 { stdenv, version, fetch, cmake, python3, llvm, libcxxabi }:
-with stdenv.lib;
+
+let
+
+  useLLVM = stdenv.hostPlatform.useLLVM or false;
+  bareMetal = stdenv.hostPlatform.parsed.kernel.name == "none";
+  inherit (stdenv.hostPlatform) isMusl;
+
+in
+
 stdenv.mkDerivation {
   pname = "compiler-rt";
   inherit version;
@@ -8,16 +16,39 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake python3 llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
 
-  configureFlags = [
+  NIX_CFLAGS_COMPILE = [
+    "-DSCUDO_DEFAULT_OPTIONS=DeleteSizeMismatch=0:DeallocationTypeMismatch=0"
+  ];
+
+  cmakeFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
+    "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
+    "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
+  ] ++ stdenv.lib.optionals (useLLVM || bareMetal || isMusl) [
+    "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
+    "-DCOMPILER_RT_BUILD_XRAY=OFF"
+    "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF"
+    "-DCOMPILER_RT_BUILD_PROFILE=OFF"
+  ] ++ stdenv.lib.optionals (useLLVM || bareMetal) [
+    "-DCMAKE_C_COMPILER_WORKS=ON"
+    "-DCMAKE_CXX_COMPILER_WORKS=ON"
+    "-DCOMPILER_RT_BAREMETAL_BUILD=ON"
+    "-DCMAKE_SIZEOF_VOID_P=${toString (stdenv.hostPlatform.parsed.cpu.bits / 8)}"
+  ] ++ stdenv.lib.optionals (useLLVM) [
+    "-DCOMPILER_RT_BUILD_BUILTINS=ON"
+    "-DCMAKE_C_FLAGS=-nodefaultlibs"
+    #https://stackoverflow.com/questions/53633705/cmake-the-c-compiler-is-not-able-to-compile-a-simple-test-program
+    "-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY"
+  ] ++ stdenv.lib.optionals (bareMetal) [
+    "-DCOMPILER_RT_OS_DIR=baremetal"
   ];
 
   outputs = [ "out" "dev" ];
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-  ] ++ optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
-    ++ optional (stdenv.hostPlatform.libc == "glibc") ./compiler-rt-sys-ustat.patch;
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
+    ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "glibc") ./compiler-rt-sys-ustat.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
@@ -27,11 +58,23 @@ stdenv.mkDerivation {
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace cmake/config-ix.cmake \
       --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+  '' + stdenv.lib.optionalString (useLLVM) ''
+    substituteInPlace lib/builtins/int_util.c \
+      --replace "#include <stdlib.h>" ""
+    substituteInPlace lib/builtins/clear_cache.c \
+      --replace "#include <assert.h>" ""
+    substituteInPlace lib/builtins/cpu_model.c \
+      --replace "#include <assert.h>" ""
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = stdenv.lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
     ln -s "$out/lib"/*/* "$out/lib"
+  '' + stdenv.lib.optionalString (useLLVM) ''
+    ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/linux/crtbegin.o
+    ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/linux/crtend.o
+    ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/linux/crtbeginS.o
+    ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/linux/crtendS.o
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -1,4 +1,4 @@
-{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+{ lowPrio, newScope, pkgs, stdenv, cmake, gcc, libstdcxxHook
 , libxml2, python3, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
@@ -7,6 +7,7 @@
 let
   release_version = "5.0.2";
   version = release_version; # differentiating these is important for rc's
+  targetConfig = stdenv.targetPlatform.config;
 
   fetch = name: sha256: fetchurl {
     url = "https://releases.llvm.org/${release_version}/${name}-${version}.src.tar.xz";
@@ -56,7 +57,12 @@ let
       extraPackages = [
         targetLlvmLibraries.compiler-rt
       ];
-      extraBuildCommands = mkExtraBuildCommands cc;
+      extraBuildCommands = ''
+          echo "-target ${targetConfig}" >> $out/nix-support/cc-cflags
+          echo "-B${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-cflags
+          echo "-L${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-ldflags
+          echo "-L${gcc.cc.lib}/${targetConfig}/lib" >> $out/nix-support/cc-ldflags
+      '' + mkExtraBuildCommands cc;
     };
 
     libcxxClang = wrapCCWith rec {

--- a/pkgs/development/compilers/llvm/6/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/6/compiler-rt.nix
@@ -1,5 +1,13 @@
 { stdenv, version, fetch, cmake, python3, llvm, libcxxabi }:
-with stdenv.lib;
+
+let
+
+  useLLVM = stdenv.hostPlatform.useLLVM or false;
+  bareMetal = stdenv.hostPlatform.parsed.kernel.name == "none";
+  inherit (stdenv.hostPlatform) isMusl;
+
+in
+
 stdenv.mkDerivation {
   pname = "compiler-rt";
   inherit version;
@@ -8,15 +16,38 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake python3 llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
 
-  configureFlags = [
+  NIX_CFLAGS_COMPILE = [
+    "-DSCUDO_DEFAULT_OPTIONS=DeleteSizeMismatch=0:DeallocationTypeMismatch=0"
+  ];
+
+  cmakeFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
+    "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
+    "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
+  ] ++ stdenv.lib.optionals (useLLVM || bareMetal || isMusl) [
+    "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
+    "-DCOMPILER_RT_BUILD_XRAY=OFF"
+    "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF"
+    "-DCOMPILER_RT_BUILD_PROFILE=OFF"
+  ] ++ stdenv.lib.optionals (useLLVM || bareMetal) [
+    "-DCMAKE_C_COMPILER_WORKS=ON"
+    "-DCMAKE_CXX_COMPILER_WORKS=ON"
+    "-DCOMPILER_RT_BAREMETAL_BUILD=ON"
+    "-DCMAKE_SIZEOF_VOID_P=${toString (stdenv.hostPlatform.parsed.cpu.bits / 8)}"
+  ] ++ stdenv.lib.optionals (useLLVM) [
+    "-DCOMPILER_RT_BUILD_BUILTINS=ON"
+    "-DCMAKE_C_FLAGS=-nodefaultlibs"
+    #https://stackoverflow.com/questions/53633705/cmake-the-c-compiler-is-not-able-to-compile-a-simple-test-program
+    "-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY"
+  ] ++ stdenv.lib.optionals (bareMetal) [
+    "-DCOMPILER_RT_OS_DIR=baremetal"
   ];
 
   outputs = [ "out" "dev" ];
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-  ] ++ optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch;
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
@@ -26,11 +57,23 @@ stdenv.mkDerivation {
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace cmake/config-ix.cmake \
       --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+  '' + stdenv.lib.optionalString (useLLVM) ''
+    substituteInPlace lib/builtins/int_util.c \
+      --replace "#include <stdlib.h>" ""
+    substituteInPlace lib/builtins/clear_cache.c \
+      --replace "#include <assert.h>" ""
+    substituteInPlace lib/builtins/cpu_model.c \
+      --replace "#include <assert.h>" ""
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = stdenv.lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
     ln -s "$out/lib"/*/* "$out/lib"
+  '' + stdenv.lib.optionalString (useLLVM) ''
+    ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/linux/crtbegin.o
+    ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/linux/crtend.o
+    ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/linux/crtbeginS.o
+    ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/linux/crtendS.o
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -1,4 +1,4 @@
-{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+{ lowPrio, newScope, pkgs, stdenv, cmake, gcc, libstdcxxHook
 , libxml2, python3, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
@@ -7,6 +7,7 @@
 let
   release_version = "6.0.1";
   version = release_version; # differentiating these is important for rc's
+  targetConfig = stdenv.targetPlatform.config;
 
   fetch = name: sha256: fetchurl {
     url = "https://releases.llvm.org/${release_version}/${name}-${version}.src.tar.xz";
@@ -56,7 +57,12 @@ let
       extraPackages = [
         targetLlvmLibraries.compiler-rt
       ];
-      extraBuildCommands = mkExtraBuildCommands cc;
+      extraBuildCommands = ''
+          echo "-target ${targetConfig}" >> $out/nix-support/cc-cflags
+          echo "-B${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-cflags
+          echo "-L${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-ldflags
+          echo "-L${gcc.cc.lib}/${targetConfig}/lib" >> $out/nix-support/cc-ldflags
+      '' + mkExtraBuildCommands cc;
     };
 
     libcxxClang = wrapCCWith rec {

--- a/pkgs/development/compilers/llvm/7/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     "-DSCUDO_DEFAULT_OPTIONS=DeleteSizeMismatch=0:DeallocationTypeMismatch=0"
   ];
 
-  cmakeFlags = stdenv.lib.optionals (useLLVM || stdenv.isDarwin) [
+  cmakeFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
@@ -68,7 +68,7 @@ stdenv.mkDerivation {
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = stdenv.lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
     ln -s "$out/lib"/*/* "$out/lib"
   '' + stdenv.lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/linux/crtbegin.o

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -1,4 +1,4 @@
-{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+{ lowPrio, newScope, pkgs, stdenv, cmake, gcc, libstdcxxHook
 , libxml2, python3, isl, fetchurl, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
@@ -7,6 +7,7 @@
 let
   release_version = "7.1.0";
   version = release_version; # differentiating these is important for rc's
+  targetConfig = stdenv.targetPlatform.config;
 
   fetch = name: sha256: fetchurl {
     url = "https://releases.llvm.org/${release_version}/${name}-${version}.src.tar.xz";
@@ -63,7 +64,12 @@ let
       extraPackages = [
         targetLlvmLibraries.compiler-rt
       ];
-      extraBuildCommands = mkExtraBuildCommands cc;
+      extraBuildCommands = ''
+          echo "-target ${targetConfig}" >> $out/nix-support/cc-cflags
+          echo "-B${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-cflags
+          echo "-L${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-ldflags
+          echo "-L${gcc.cc.lib}/${targetConfig}/lib" >> $out/nix-support/cc-ldflags
+      '' + mkExtraBuildCommands cc;
     };
 
     libcxxClang = wrapCCWith rec {

--- a/pkgs/development/compilers/llvm/8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     "-DSCUDO_DEFAULT_OPTIONS=DeleteSizeMismatch=0:DeallocationTypeMismatch=0"
   ];
 
-  cmakeFlags = stdenv.lib.optionals (useLLVM || stdenv.isDarwin) [
+  cmakeFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"

--- a/pkgs/development/compilers/llvm/9/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/9/compiler-rt.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     "-DSCUDO_DEFAULT_OPTIONS=DeleteSizeMismatch=0:DeallocationTypeMismatch=0"
   ];
 
-  cmakeFlags = stdenv.lib.optionals (useLLVM || stdenv.isDarwin) [
+  cmakeFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"

--- a/pkgs/development/compilers/llvm/9/default.nix
+++ b/pkgs/development/compilers/llvm/9/default.nix
@@ -1,4 +1,4 @@
-{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+{ lowPrio, newScope, pkgs, stdenv, cmake, gcc, libstdcxxHook
 , libxml2, python3, isl, fetchurl, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
@@ -7,6 +7,7 @@
 let
   release_version = "9.0.1";
   version = release_version; # differentiating these is important for rc's
+  targetConfig = stdenv.targetPlatform.config;
 
   fetch = name: sha256: fetchurl {
     url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-${release_version}/${name}-${version}.src.tar.xz";
@@ -63,7 +64,12 @@ let
       extraPackages = [
         targetLlvmLibraries.compiler-rt
       ];
-      extraBuildCommands = mkExtraBuildCommands cc;
+      extraBuildCommands = ''
+          echo "-target ${targetConfig}" >> $out/nix-support/cc-cflags
+          echo "-B${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-cflags
+          echo "-L${gcc.cc}/lib/gcc/${targetConfig}/${gcc.version}" >> $out/nix-support/cc-ldflags
+          echo "-L${gcc.cc.lib}/${targetConfig}/lib" >> $out/nix-support/cc-ldflags
+      '' + mkExtraBuildCommands cc;
     };
 
     libcxxClang = wrapCCWith rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8182,7 +8182,11 @@ in
   }));
 
   libstdcxxHook = makeSetupHook
-    { substitutions = { gcc = gcc-unwrapped; }; }
+    { substitutions = {
+        gcc = gcc-unwrapped;
+        targetConfig = stdenv.targetPlatform.config;
+      };
+    }
     ../development/compilers/gcc/libstdc++-hook.sh;
 
   crossLibcStdenv = overrideCC stdenv


### PR DESCRIPTION
Here, for LLVM 5-10, information about the host platform is always passed to compiler-rt's build system (even if `stdenv.hostPlatform.useLLVM` isn't set) and to clang as `-target` and compiler-rt flags in libstdcxxClang's CC wrapper. These fixes allow `llvmPackages_*.stdenv` to be used for cross builds and fixes https://github.com/NixOS/nixpkgs/issues/40934

I'd appreciate review from @LnL7 and @ElvishJerricco, who I know have poked at this stuff before, as well as anyone else familiar with the cross build machinery.

I wasn't able to figure out how the clang-wrapper gets crtbegin.o, etc. in the _non cross_ case, so there's a good chance these flags should be added somewhere else.