### PR TITLE
beluga: 20180403 -> unstable-2020-03-11

### DIFF
--- a/pkgs/applications/science/logic/beluga/default.nix
+++ b/pkgs/applications/science/logic/beluga/default.nix
@@ -1,34 +1,40 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, omake }:
+{ lib, fetchFromGitHub, ocamlPackages, rsync }:
 
-stdenv.mkDerivation {
-  name = "beluga-20180403";
+ocamlPackages.buildDunePackage {
+  pname = "beluga";
+  version = "unstable-2020-03-11";
 
   src = fetchFromGitHub {
     owner  = "Beluga-lang";
     repo   = "Beluga";
-    rev    = "046aa59f008be70a7c4700b723bed0214ea8b687";
-    sha256 = "0m68y0r0wdw3mg2jks68bihaww7sg305zdfnic1rkndq2cxv0mld";
+    rev    = "6133b2f572219333f304bb4f77c177592324c55b";
+    sha256 = "0sy6mi50z3mvs5z7dx38piydapk89all81rh038x3559b5fsk68q";
   };
 
-  nativeBuildInputs = with ocamlPackages; [ findlib ocamlbuild omake ];
-  buildInputs = with ocamlPackages; [ ocaml ulex ocaml_extlib ];
+  useDune2 = true;
 
-  installPhase = ''
-    mkdir -p $out
-    cp -r bin $out/
+  buildInputs = with ocamlPackages; [
+    gen sedlex_2 ocaml_extlib dune-build-info linenoise
+  ];
 
-    mkdir -p $out/share/beluga
-    cp -r tools/ examples/ $out/share/beluga
+  postPatch = ''
+    patchShebangs ./TEST ./run_harpoon_test.sh
+  '';
 
+  checkPhase = "./TEST";
+  checkInputs = [ rsync ];
+  doCheck = true;
+
+  postInstall = ''
     mkdir -p $out/share/emacs/site-lisp/beluga/
     cp -r tools/beluga-mode.el $out/share/emacs/site-lisp/beluga
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A functional language for reasoning about formal systems";
     homepage    = "http://complogic.cs.mcgill.ca/beluga/";
-    license     = stdenv.lib.licenses.gpl3Plus;
-    maintainers = [ stdenv.lib.maintainers.bcdarwin ];
-    platforms   = stdenv.lib.platforms.unix;
+    license     = licenses.gpl3Plus;
+    maintainers = [ maintainers.bcdarwin ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/ocaml-modules/dune-build-info/default.nix
+++ b/pkgs/development/ocaml-modules/dune-build-info/default.nix
@@ -1,0 +1,17 @@
+{ lib, buildDunePackage, dune_2 }:
+
+buildDunePackage rec {
+  pname = "dune-build-info";
+  inherit (dune_2) src version;
+
+  useDune2 = true;
+
+  dontAddPrefix = true;
+
+  meta = with lib; {
+    inherit (dune_2.meta) homepage;
+    description = "Embed build information inside executables";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/ocaml-modules/linenoise/default.nix
+++ b/pkgs/development/ocaml-modules/linenoise/default.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "linenoise";
-  version = "1.1.0";
+  version = "1.3.0";
 
   minimumOCamlVersion = "4.02";
 
@@ -10,7 +10,7 @@ buildDunePackage rec {
     owner = "fxfactorial";
     repo = "ocaml-${pname}";
     rev = "v${version}";
-    sha256 = "1h6rqfgmhmd7p5z8yhk6zkbrk4yzw1v2fgwas2b7g3hqs6y0xj0q";
+    sha256 = "0m9mm1arsawi5w5aqm57z41sy1wfxvhfgbdiw7hzy631i391144g";
   };
 
   propagatedBuildInputs = [ result ];

--- a/pkgs/development/ocaml-modules/sedlex/2.nix
+++ b/pkgs/development/ocaml-modules/sedlex/2.nix
@@ -38,9 +38,9 @@ buildDunePackage rec {
     sha256 = "05f6qa8x3vhpdz1fcnpqk37fpnyyq13icqsk2gww5idjnh6kng26";
   };
 
-  buildInputs = [ ppx_tools_versioned ocaml-migrate-parsetree ];
-
-  propagatedBuildInputs = [ gen uchar ];
+  propagatedBuildInputs = [
+    gen uchar ocaml-migrate-parsetree ppx_tools_versioned
+  ];
 
   preBuild = ''
     ln -s ${DerivedCoreProperties} src/generator/data/DerivedCoreProperties.txt

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -230,6 +230,8 @@ let
 
     dune_2 = callPackage ../development/tools/ocaml/dune/2.nix { };
 
+    dune-build-info = callPackage ../development/ocaml-modules/dune-build-info { };
+
     dune-configurator = callPackage ../development/ocaml-modules/dune-configurator { };
 
     dune-private-libs = callPackage ../development/ocaml-modules/dune-private-libs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update a package and perform some necesary dependency updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
