### PR TITLE
jupp: 31 -> 39

### DIFF
--- a/pkgs/applications/editors/jupp/default.nix
+++ b/pkgs/applications/editors/jupp/default.nix
@@ -1,18 +1,16 @@
-{ stdenv, fetchurl
-, ncurses, gpm
-}:
+{ stdenv, fetchurl, ncurses, gpm }:
 
 stdenv.mkDerivation rec {
 
   pname = "jupp";
-  version = "3.1";
-  srcName = "joe-3.1jupp31";
+  version = "39";
+  srcName = "joe-3.1${pname}${version}";
 
   src = fetchurl {
     urls = [
       "https://www.mirbsd.org/MirOS/dist/jupp/${srcName}.tgz"
       "https://pub.allbsd.org/MirOS/dist/jupp/${srcName}.tgz" ];
-    sha256 = "1fnf9jsd6p4jyybkhjjs328qx38ywy8w029ngc7j7kqp0ixn0l0s";
+    sha256 = "14gys92dy3kq9ikigry7q2x4w5v2z76d97vp212bddrxiqy5np8d";
   };
 
   preConfigure = "chmod +x ./configure";
@@ -37,7 +35,7 @@ stdenv.mkDerivation rec {
       and has a lot of bugs fixed. It is based upon an older version of joe
       because these behave better overall.
     '';
-    homepage = "http://mirbsd.de/jupp";
+    homepage = "http://www.mirbsd.org/jupp.htm";
     license = licenses.gpl1;
     maintainers = with maintainers; [ AndersonTorres ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
