### PR TITLE
gst_all_1.gst-plugins-good: enable jack plugin

### DIFF
--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -29,9 +29,7 @@
 , mpg123
 , twolame
 , gtkSupport ? false, gtk3 ? null
-  # As of writing, jack2 incurs a Qt dependency (big!) via `ffado`.
-  # In the future we should probably split `ffado`.
-, enableJack ? false, jack2
+, enableJack ? true, libjack2
 , libXdamage
 , libXext
 , libXfixes
@@ -104,8 +102,8 @@ stdenv.mkDerivation rec {
     libavc1394
     libiec61883
     libgudev
-  ] ++ optionals (stdenv.isLinux && enableJack) [
-    jack2
+  ] ++ optionals enableJack [
+    libjack2
   ];
 
   mesonFlags = [
@@ -113,8 +111,8 @@ stdenv.mkDerivation rec {
     "-Dqt5=disabled" # not clear as of writing how to correctly pass in the required qt5 deps
   ] ++ optionals (!gtkSupport) [
     "-Dgtk3=disabled"
-  ] ++ optionals (!stdenv.isLinux || !enableJack) [
-    "-Djack=disabled" # unclear whether Jack works on Darwin
+  ] ++ optionals (!enableJack) [
+    "-Djack=disabled"
   ] ++ optionals (!stdenv.isLinux) [
     "-Ddv1394=disabled" # Linux only
     "-Doss4=disabled" # Linux only


### PR DESCRIPTION
#### Motivation for this change

On Linux this adds two dependencies to the closure, libjack2 and celt, which
increases its size from 163.5 MB to 164.4 MB.

This should not cause any issues on macOS since jack supports it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
