### PR TITLE
timezonemap: init at 0.4.5

### DIFF
--- a/pkgs/development/libraries/timezonemap/default.nix
+++ b/pkgs/development/libraries/timezonemap/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, autoreconfHook
+, fetchbzr
+, pkgconfig
+, gtk3
+, glib
+, file
+, gobject-introspection
+, json-glib
+, libsoup
+}:
+
+stdenv.mkDerivation rec {
+  pname = "timezonemap";
+  version = "0.4.5";
+
+  src = fetchbzr {
+    url = "lp:timezonemap";
+    rev = "58";
+    sha256 = "1qdp5f9zd8c02bf0mq4w15rlhz2g51phml5qg9asdyfd1715f8n0";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    autoreconfHook
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    json-glib
+    libsoup
+  ];
+
+  configureFlags = [
+    "CFLAGS=-Wno-error"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+  ];
+
+  installFlags = [
+    "sysconfdir=${placeholder "out"}/etc"
+    "localstatedir=\${TMPDIR}"
+  ];
+
+  preConfigure = ''
+    for f in {configure,m4/libtool.m4}; do
+      substituteInPlace $f\
+        --replace /usr/bin/file ${file}/bin/file
+    done
+  '';
+
+  postPatch = ''
+    sed "s|/usr/share/libtimezonemap|$out/share/libtimezonemap|g" -i ./src/tz.h
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://launchpad.net/timezonemap";
+    description = "A GTK+3 Timezone Map Widget";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6914,6 +6914,8 @@ in
 
   timetable = callPackage ../applications/office/timetable { };
 
+  timezonemap = callPackage ../development/libraries/timezonemap { };
+
   tzupdate = callPackage ../applications/misc/tzupdate { };
 
   tinc = callPackage ../tools/networking/tinc { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Needed for cinnamon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
