### PR TITLE
rs: init at 20200313

### DIFF
--- a/pkgs/tools/text/rs/default.nix
+++ b/pkgs/tools/text/rs/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchurl, libbsd }:
+
+stdenv.mkDerivation rec {
+  pname = "rs";
+  version = "20200313";
+
+  src = fetchurl {
+    url = "https://www.mirbsd.org/MirOS/dist/mir/rs/${pname}-${version}.tar.gz";
+    sha256 = "0gxwlfk7bzivpp2260w2r6gkyl7vdi05cggn1fijfnp8kzf1b4li";
+  };
+
+  buildInputs = [ libbsd ];
+
+  buildPhase = ''
+    ${stdenv.cc}/bin/cc utf8.c rs.c -o rs -lbsd
+  '';
+
+  installPhase = ''
+    install -Dm 755 rs -t $out/bin
+    install -Dm 644 rs.1 -t $out/share/man/man1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Reshape a data array from standard input";
+    longDescription = ''
+      rs reads the standard input, interpreting each line as a row of blank-
+      separated entries in an array, transforms the array according to the op-
+      tions, and writes it on the standard output. With no arguments (argc < 2)
+      it transforms stream input into a columnar format convenient for terminal
+      viewing, i.e. if the length (in bytes!) of the first line is smaller than
+      the display width, -et is implied, -t otherwise.
+
+      The shape of the input array is deduced from the number of lines and the
+      number of columns on the first line. If that shape is inconvenient, a more
+      useful one might be obtained by skipping some of the input with the -k
+      option. Other options control interpretation of the input columns.
+
+      The shape of the output array is influenced by the rows and cols specifi-
+      cations, which should be positive integers. If only one of them is a po-
+      sitive integer, rs computes a value for the other which will accommodate
+      all of the data. When necessary, missing data are supplied in a manner
+      specified by the options and surplus data are deleted. There are options
+      to control presentation of the output columns, including transposition of
+      the rows and columns.
+    '';
+
+    homepage = "https://www.mirbsd.org/htman/i386/man1/rs.htm";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6203,6 +6203,8 @@ in
 
   richgo = callPackage ../development/tools/richgo {  };
 
+  rs = callPackage ../tools/text/rs { };
+
   rst2html5 = callPackage ../tools/text/rst2html5 { };
 
   rt = callPackage ../servers/rt { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

rs is a small utility from BSD world. It formats the input as a table.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
