### PR TITLE
treewide: Fix types of stripDebugList attrs (and fix doc)

### DIFF
--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -1295,7 +1295,7 @@ installTargets = "install-bin install-doc";</programlisting>
      </term>
      <listitem>
       <para>
-       List of directories to search for libraries and executables from which only debugging-related symbols should be stripped. It defaults to <literal>lib bin sbin</literal>.
+       List of directories to search for libraries and executables from which only debugging-related symbols should be stripped. It defaults to <literal>lib lib32 lib64 libexec bin sbin</literal>.
       </para>
      </listitem>
     </varlistentry>

--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/far2l --argv0 $out/bin/far2l
   '';
 
-  stripDebugList = "bin share";
+  stripDebugList = [ "bin" "share" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     "--without-ldb-lmdb"
   ];
 
-  stripDebugList = "bin lib modules";
+  stripDebugList = [ "bin" "lib" "modules" ];
 
   meta = with stdenv.lib; {
     description = "A LDAP-like embedded database";

--- a/pkgs/development/misc/avr/libc/default.nix
+++ b/pkgs/development/misc/avr/libc/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ automake autoconf ];
 
   # Make sure we don't strip the libraries in lib/gcc/avr.
-  stripDebugList = "bin";
+  stripDebugList = [ "bin" ];
   dontPatchELF = true;
 
   passthru = {

--- a/pkgs/os-specific/linux/syslinux/default.nix
+++ b/pkgs/os-specific/linux/syslinux/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = false; # Fails very rarely with 'No rule to make target: ...'
   hardeningDisable = [ "pic" "stackprotector" "fortify" ];
 
-  stripDebugList = "bin sbin share/syslinux/com32";
+  stripDebugList = [ "bin" "sbin" "share/syslinux/com32" ];
 
   makeFlags = [
     "BINDIR=$(out)/bin"

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  stripDebugList = "lib modules bin";
+  stripDebugList = [ "lib" "modules" "bin" ];
 
   postInstall = ''
     mkdir -p $doc/share/doc/httpd


### PR DESCRIPTION
###### Motivation for this change

The documentation says this should be a list, and it already is in about half the expressions that set it.
    
The difference doesn't matter at present, because the elements of these are all space-free literals.  But it will in a future with __structuredAttrs .
    
(The similar attr stripAllList has no users in the nixpkgs tree, so there's nothing to do to fix any of those up.)

Also fix the default value mentioned in the doc, as I noticed when grepping that it was out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - (This finds nothing to rebuild, as intended.)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
