### PR TITLE
dia: 2017-06-22 → 2020-04-07

### DIFF
--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -1,7 +1,24 @@
-{ stdenv, fetchgit, autoconf, automake, libtool, gtk2, pkgconfig, perlPackages,
-libxml2, gettext, python, libxml2Python, docbook5, docbook_xsl,
-libxslt, intltool, libart_lgpl, withGNOME ? false, libgnomeui,
-gtk-mac-integration-gtk2 }:
+{ stdenv
+, fetchgit
+, autoconf
+, automake
+, libtool
+, gtk2
+, pkgconfig
+, perlPackages
+, libxml2
+, gettext
+, python
+, libxml2Python
+, docbook5
+, docbook_xsl
+, libxslt
+, intltool
+, libart_lgpl
+, withGNOME ? false
+, libgnomeui
+, gtk-mac-integration-gtk2
+}:
 
 stdenv.mkDerivation {
   pname = "dia";
@@ -13,19 +30,40 @@ stdenv.mkDerivation {
     sha256 = "1fyxfrzdcs6blxhkw3bcgkksaf3byrsj4cbyrqgb4869k3ynap96";
   };
 
-  buildInputs =
-    [ gtk2 libxml2 gettext python libxml2Python docbook5
-      libxslt docbook_xsl libart_lgpl ]
-      ++ stdenv.lib.optional withGNOME libgnomeui
-      ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration-gtk2;
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    pkgconfig
+    intltool
+  ] ++ (with perlPackages; [
+    perl
+    XMLParser
+  ]);
 
-  nativeBuildInputs = [ autoconf automake libtool pkgconfig intltool ]
-    ++ (with perlPackages; [ perl XMLParser ]);
+  buildInputs = [
+    gtk2
+    libxml2
+    gettext
+    python
+    libxml2Python
+    docbook5
+    libxslt
+    docbook_xsl
+    libart_lgpl
+  ] ++ stdenv.lib.optionals withGNOME [
+    libgnomeui
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    gtk-mac-integration-gtk2
+  ];
+
+  configureFlags = stdenv.lib.optionals withGNOME [
+    "--enable-gnome"
+  ];
 
   preConfigure = ''
     NOCONFIGURE=1 ./autogen.sh # autoreconfHook is not enough
   '';
-  configureFlags = stdenv.lib.optional withGNOME "--enable-gnome";
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -1,75 +1,69 @@
 { stdenv
-, fetchgit
-, autoconf
-, automake
-, libtool
-, gtk2
-, pkgconfig
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
 , perlPackages
+, glib
+, gtk2
 , libxml2
-, gettext
-, python
-, libxml2Python
-, docbook5
-, docbook_xsl
+, python2
+, docbook_xml_dtd_45
+, docbook-xsl-nons
 , libxslt
-, intltool
-, libart_lgpl
-, withGNOME ? false
-, libgnomeui
+, gettext
+, python3
+, desktop-file-utils
+, zlib
+, cairo
 , gtk-mac-integration-gtk2
 }:
 
 stdenv.mkDerivation {
   pname = "dia";
-  version = "0.97.3.20170622";
+  version = "unstable-2020-04-07";
 
-  src = fetchgit {
-    url = https://gitlab.gnome.org/GNOME/dia.git;
-    rev = "b86085dfe2b048a2d37d587adf8ceba6fb8bc43c";
-    sha256 = "1fyxfrzdcs6blxhkw3bcgkksaf3byrsj4cbyrqgb4869k3ynap96";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "dia";
+    rev = "475bceff3f445f3fe691593a3003527a0d8bf0d9";
+    sha256 = "mxP2FJl77SEURO6AUlLusMLHW0EeBw4hI5gw7egt3HE=";
   };
 
   nativeBuildInputs = [
-    autoconf
-    automake
-    libtool
-    pkgconfig
-    intltool
-  ] ++ (with perlPackages; [
-    perl
-    XMLParser
-  ]);
+    meson
+    ninja
+    pkg-config
+    gettext
+    python3 # for install script
+    gtk2 # for gtk-update-icon-cache
+    libxslt # for xsltproc
+    desktop-file-utils
+    docbook_xml_dtd_45
+    docbook-xsl-nons
+  ];
 
   buildInputs = [
+    glib
     gtk2
     libxml2
-    gettext
-    python
-    libxml2Python
-    docbook5
-    libxslt
-    docbook_xsl
-    libart_lgpl
-  ] ++ stdenv.lib.optionals withGNOME [
-    libgnomeui
+    python2
+    zlib
+    cairo
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     gtk-mac-integration-gtk2
   ];
 
-  configureFlags = stdenv.lib.optionals withGNOME [
-    "--enable-gnome"
-  ];
-
-  preConfigure = ''
-    NOCONFIGURE=1 ./autogen.sh # autoreconfHook is not enough
+  postPatch = ''
+    patchShebangs \
+      generate_run_with_dia_env.sh \
+      build-aux/post-install.py
   '';
 
-  hardeningDisable = [ "format" ];
-
   meta = with stdenv.lib; {
-    description = "Gnome Diagram drawing software";
-    homepage = http://live.gnome.org/Dia;
+    description = "GNOME Diagram drawing software";
+    homepage = "https://wiki.gnome.org/Apps/Dia";
     maintainers = with maintainers; [ raskin ];
     license = licenses.gpl2;
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18929,9 +18929,7 @@ in
 
   dfilemanager = libsForQt5.callPackage ../applications/misc/dfilemanager { };
 
-  dia = callPackage ../applications/graphics/dia {
-    inherit (pkgs.gnome2) libart_lgpl libgnomeui;
-  };
+  dia = callPackage ../applications/graphics/dia { };
 
   direwolf = callPackage ../applications/misc/direwolf { };
 


### PR DESCRIPTION
###### Motivation for this change
Getting rid of GNOME 2 package set https://github.com/NixOS/nixpkgs/issues/39976

cc @viric

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
