### PR TITLE
treewide: use runtimeShell in nixos/

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -30,7 +30,7 @@ let
   phpOptionsStr = toKeyValue phpOptions;
 
   occ = pkgs.writeScriptBin "nextcloud-occ" ''
-    #! ${pkgs.stdenv.shell}
+    #! ${pkgs.runtimeShell}
     cd ${cfg.package}
     sudo=exec
     if [[ "$USER" != nextcloud ]]; then

--- a/nixos/tests/dovecot.nix
+++ b/nixos/tests/dovecot.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix {
     services.dovecot2.protocols = [ "imap" "pop3" ];
     environment.systemPackages = let
       sendTestMail = pkgs.writeScriptBin "send-testmail" ''
-        #!${pkgs.stdenv.shell}
+        #!${pkgs.runtimeShell}
         exec sendmail -vt <<MAIL
         From: root@localhost
         To: alice@localhost
@@ -19,7 +19,7 @@ import ./make-test-python.nix {
       '';
 
       sendTestMailViaDeliveryAgent = pkgs.writeScriptBin "send-lda" ''
-        #!${pkgs.stdenv.shell}
+        #!${pkgs.runtimeShell}
 
         exec ${pkgs.dovecot}/libexec/dovecot/deliver -d bob <<MAIL
         From: root@localhost

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -32,7 +32,7 @@ in {
 
   testScript = let
     withRcloneEnv = pkgs.writeScript "with-rclone-env" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
       export RCLONE_CONFIG_NEXTCLOUD_URL="http://nextcloud/remote.php/webdav/"
       export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
@@ -41,12 +41,12 @@ in {
       "''${@}"
     '';
     copySharedFile = pkgs.writeScript "copy-shared-file" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       echo 'hi' | ${withRcloneEnv} ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file
     '';
 
     diffSharedFile = pkgs.writeScript "diff-shared-file" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       diff <(echo 'hi') <(${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file)
     '';
   in ''

--- a/nixos/tests/nextcloud/with-mysql-and-memcached.nix
+++ b/nixos/tests/nextcloud/with-mysql-and-memcached.nix
@@ -61,14 +61,14 @@ in {
 
   testScript = let
     configureMemcached = pkgs.writeScript "configure-memcached" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       nextcloud-occ config:system:set memcached_servers 0 0 --value 127.0.0.1 --type string
       nextcloud-occ config:system:set memcached_servers 0 1 --value 11211 --type integer
       nextcloud-occ config:system:set memcache.local --value '\OC\Memcache\APCu' --type string
       nextcloud-occ config:system:set memcache.distributed --value '\OC\Memcache\Memcached' --type string
     '';
     withRcloneEnv = pkgs.writeScript "with-rclone-env" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
       export RCLONE_CONFIG_NEXTCLOUD_URL="http://nextcloud/remote.php/webdav/"
       export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
@@ -76,12 +76,12 @@ in {
       export RCLONE_CONFIG_NEXTCLOUD_PASS="$(${pkgs.rclone}/bin/rclone obscure ${adminpass})"
     '';
     copySharedFile = pkgs.writeScript "copy-shared-file" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       echo 'hi' | ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file
     '';
 
     diffSharedFile = pkgs.writeScript "diff-shared-file" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       diff <(echo 'hi') <(${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file)
     '';
   in ''

--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -60,14 +60,14 @@ in {
 
   testScript = let
     configureRedis = pkgs.writeScript "configure-redis" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       nextcloud-occ config:system:set redis 'host' --value 'localhost' --type string
       nextcloud-occ config:system:set redis 'port' --value 6379 --type integer
       nextcloud-occ config:system:set memcache.local --value '\OC\Memcache\Redis' --type string
       nextcloud-occ config:system:set memcache.locking --value '\OC\Memcache\Redis' --type string
     '';
     withRcloneEnv = pkgs.writeScript "with-rclone-env" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
       export RCLONE_CONFIG_NEXTCLOUD_URL="http://nextcloud/remote.php/webdav/"
       export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
@@ -76,12 +76,12 @@ in {
       "''${@}"
     '';
     copySharedFile = pkgs.writeScript "copy-shared-file" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       echo 'hi' | ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file
     '';
 
     diffSharedFile = pkgs.writeScript "diff-shared-file" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       diff <(echo 'hi') <(${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file)
     '';
   in ''

--- a/nixos/tests/rabbitmq.nix
+++ b/nixos/tests/rabbitmq.nix
@@ -15,7 +15,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
     machine.wait_for_unit("rabbitmq.service")
     machine.wait_until_succeeds(
-        'su -s ${pkgs.stdenv.shell} rabbitmq -c "rabbitmqctl status"'
+        'su -s ${pkgs.runtimeShell} rabbitmq -c "rabbitmqctl status"'
     )
   '';
 })

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -22,7 +22,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     # Ensures failures pass through using pipefail, otherwise failing to
     # switch-to-configuration is hidden by the success of `tee`.
     stderrRunner = pkgs.writeScript "stderr-runner" ''
-      #! ${pkgs.stdenv.shell}
+      #! ${pkgs.runtimeShell}
       set -e
       set -o pipefail
       exec env -i "$@" | tee /dev/stderr

--- a/nixos/tests/systemd-confinement.nix
+++ b/nixos/tests/systemd-confinement.nix
@@ -3,14 +3,14 @@ import ./make-test.nix {
 
   machine = { pkgs, lib, ... }: let
     testServer = pkgs.writeScript "testserver.sh" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       export PATH=${lib.escapeShellArg "${pkgs.coreutils}/bin"}
-      ${lib.escapeShellArg pkgs.stdenv.shell} 2>&1
+      ${lib.escapeShellArg pkgs.runtimeShell} 2>&1
       echo "exit-status:$?"
     '';
 
     testClient = pkgs.writeScriptBin "chroot-exec" ''
-      #!${pkgs.stdenv.shell} -e
+      #!${pkgs.runtimeShell} -e
       output="$(echo "$@" | nc -NU "/run/test$(< /teststep).sock")"
       ret="$(echo "$output" | sed -nre '$s/^exit-status:([0-9]+)$/\1/p')"
       echo "$output" | head -n -1

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -22,7 +22,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     test-support.displayManager.auto.user = "alice";
 
     systemd.shutdown.test = pkgs.writeScript "test.shutdown" ''
-      #!${pkgs.stdenv.shell}
+      #!${pkgs.runtimeShell}
       PATH=${lib.makeBinPath (with pkgs; [ utillinux coreutils ])}
       mount -t 9p shared -o trans=virtio,version=9p2000.L /tmp/shared
       touch /tmp/shared/shutdown-test

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -23,7 +23,7 @@ let
     guestAdditions = pkgs.linuxPackages.virtualboxGuestAdditions;
 
     miniInit = ''
-      #!${pkgs.stdenv.shell} -xe
+      #!${pkgs.runtimeShell} -xe
       export PATH="${lib.makeBinPath [ pkgs.coreutils pkgs.utillinux ]}"
 
       mkdir -p /run/dbus
@@ -80,7 +80,7 @@ let
       touch /mnt-root/boot-done
       hostname "${vmName}"
       mkdir -p /nix/store
-      unshare -m ${escapeShellArg pkgs.stdenv.shell} -c '
+      unshare -m ${escapeShellArg pkgs.runtimeShell} -c '
         mount -t vboxsf nixstore /nix/store
         exec "$stage2Init"
       '


### PR DESCRIPTION
This is needed for cross-compilation.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
