### PR TITLE
perlPackages.AuthenKrb5Admin and dep

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -814,6 +814,34 @@ let
     };
   };
 
+  AuthenKrb5Admin = buildPerlPackage rec {
+    pname = "Authen-Krb5-Admin";
+    version = "0.17";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SJ/SJQUINNEY/${pname}-${version}.tar.gz";
+      sha256 = "5dd49cacd983efd61a8c3f1a56571bb73785eb155908b5d7bec97eed78df0c54";
+    };
+    propagatedBuildInputs = [ pkgs.krb5Full.dev AuthenKrb5 ];
+    # The following ENV variables are required by Makefile.PL to find
+    # programs in krb5Full.dev. It is not enough to just specify the
+    # path to krb5-config as this tool returns the prefix of krb5Full,
+    # which implies a working value for KRB5_LIBDIR, but not the others.
+    perlPreHook = ''
+      export KRB5_CONFTOOL=${pkgs.krb5Full.dev}/bin/krb5-config
+      export KRB5_BINDIR=${pkgs.krb5Full.dev}/bin
+      export KRB5_INCDIR=${pkgs.krb5Full.dev}/include
+    '';
+    # Tests require working Kerberos infrastructure so replace with a
+    # simple attempt to exercise the module.
+    checkPhase = ''
+      perl -I blib/lib -I blib/arch -MAuthen::Krb5::Admin -e 'print "1..1\nok 1\n"'
+    '';
+    meta = {
+      description = "Perl extension for MIT Kerberos 5 admin interface";
+      license = stdenv.lib.licenses.bsd3;
+    };
+  };
+
   AuthenModAuthPubTkt = buildPerlPackage {
     pname = "Authen-ModAuthPubTkt";
     version = "0.1.1";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -799,6 +799,21 @@ let
     };
   };
 
+  AuthenKrb5 = buildPerlModule {
+    pname = "Authen-Krb5";
+    version = "1.905";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/I/IO/IOANR/Authen-Krb5-1.905.tar.gz";
+      sha256 = "0kgpl0x1qxq1p2ccxy8qqkrvqba2gq6aq6p931qnz9812nxh0yyp";
+    };
+    perlPreHook = "export LD=$CC";
+    propagatedBuildInputs = [ pkgs.libkrb5 DevelChecklib FileWhich PkgConfig ];
+    meta = {
+      description = "XS bindings for Kerberos 5";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   AuthenModAuthPubTkt = buildPerlPackage {
     pname = "Authen-ModAuthPubTkt";
     version = "0.1.1";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
