### PR TITLE
nodePackages.clean-css: rename to clean-css-cli

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -16,7 +16,7 @@
 , "bower2nix"
 , "browserify"
 , "castnow"
-, "clean-css"
+, "clean-css-cli"
 , "coc-css"
 , "coc-emmet"
 , "coc-eslint"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -53570,21 +53570,34 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  clean-css = nodeEnv.buildNodePackage {
-    name = "clean-css";
-    packageName = "clean-css";
-    version = "4.2.3";
+  clean-css-cli = nodeEnv.buildNodePackage {
+    name = "clean-css-cli";
+    packageName = "clean-css-cli";
+    version = "4.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz";
-      sha512 = "0ad50l577m99sgpcdd49zspq8h9n9i3hhngapg9y5q76s7zwdz3hmaw2kc2jg30lk4z3wlyp9kgiyg71dvg0fg89g1xyr3qvq61dhsm";
+      url = "https://registry.npmjs.org/clean-css-cli/-/clean-css-cli-4.3.0.tgz";
+      sha512 = "8GHZfr+mG3zB/Lgqrr27qHBFsPSn0fyEI3f2rIZpxPxUbn2J6A8xyyeBRVTW8duDuXigN0s80vsXiXJOEFIO5Q==";
     };
     dependencies = [
+      sources."balanced-match-1.0.0"
+      sources."brace-expansion-1.1.11"
+      sources."clean-css-4.2.3"
+      sources."commander-2.20.3"
+      sources."concat-map-0.0.1"
+      sources."fs.realpath-1.0.0"
+      sources."glob-7.1.6"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
+      sources."minimatch-3.0.4"
+      sources."once-1.4.0"
+      sources."path-is-absolute-1.0.1"
       sources."source-map-0.6.1"
+      sources."wrappy-1.0.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A well-tested CSS minifier";
-      homepage = https://github.com/jakubpawlowicz/clean-css;
+      description = "A command-line interface to clean-css CSS optimization library";
+      homepage = "https://github.com/jakubpawlowicz/clean-css-cli#readme";
       license = "MIT";
     };
     production = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix #82527 . (cc @JustinLovinger ).

###### Things done

- [x] Followed https://nixos.org/nixpkgs/manual/#node.js - used `git add -p` to add only relevant updates.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
