### PR TITLE
nodejs: use python3 if possible

### DIFF
--- a/nixos/modules/programs/npm.nix
+++ b/nixos/modules/programs/npm.nix
@@ -13,7 +13,14 @@ in
     programs.npm = {
       enable = mkEnableOption "<command>npm</command> global config";
 
-      npmrc = lib.mkOption {
+      package = mkOption {
+        type = types.path;
+        description = "The npm package version / flavor to use";
+        default = pkgs.nodePackages.npm;
+        example = literalExample "pkgs.nodePackages_13_x.npm";
+      };
+
+      npmrc = mkOption {
         type = lib.types.lines;
         description = ''
           The system-wide npm configuration.
@@ -40,7 +47,7 @@ in
 
     environment.variables.NPM_CONFIG_GLOBALCONFIG = "/etc/npmrc";
 
-    environment.systemPackages = [ pkgs.nodePackages.npm ];
+    environment.systemPackages = [ cfg.package ];
   };
 
 }

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, python2, zlib, libuv, utillinux, http-parser
+{ stdenv, fetchurl, openssl, python, zlib, libuv, utillinux, http-parser
 , pkgconfig, which
 # Updater dependencies
 , writeScript, coreutils, gnugrep, jq, curl, common-updater-scripts, nix, runtimeShell
@@ -55,7 +55,7 @@ in
     buildInputs = optionals stdenv.isDarwin [ CoreServices ApplicationServices ]
       ++ [ zlib libuv openssl http-parser icu ];
 
-    nativeBuildInputs = [ which utillinux pkgconfig python2 ]
+    nativeBuildInputs = [ which utillinux pkgconfig python ]
       ++ optionals stdenv.isDarwin [ xcbuild ];
 
     configureFlags = let
@@ -145,5 +145,5 @@ in
       platforms = platforms.linux ++ platforms.darwin;
     };
 
-    passthru.python = python2; # to ensure nodeEnv uses the same version
+    passthru.python = python; # to ensure nodeEnv uses the same version
 }

--- a/pkgs/development/web/nodejs/v10.nix
+++ b/pkgs/development/web/nodejs/v10.nix
@@ -1,7 +1,10 @@
-{ callPackage, openssl, enableNpm ? true }:
+{ callPackage, openssl, icu, python2, enableNpm ? true }:
 
 let
-  buildNodejs = callPackage ./nodejs.nix { inherit openssl; };
+  buildNodejs = callPackage ./nodejs.nix { 
+    inherit openssl icu;
+    python = python2;
+  };
 in
   buildNodejs {
     inherit enableNpm;

--- a/pkgs/development/web/nodejs/v12.nix
+++ b/pkgs/development/web/nodejs/v12.nix
@@ -1,7 +1,10 @@
-{ callPackage, openssl, icu, enableNpm ? true }:
+{ callPackage, openssl, icu, python2, enableNpm ? true }:
 
 let
-  buildNodejs = callPackage ./nodejs.nix { inherit openssl icu; };
+  buildNodejs = callPackage ./nodejs.nix { 
+    inherit openssl icu;
+    python = python2;
+  };
 in
   buildNodejs {
     inherit enableNpm;

--- a/pkgs/development/web/nodejs/v13.nix
+++ b/pkgs/development/web/nodejs/v13.nix
@@ -1,7 +1,10 @@
-{ callPackage, openssl, icu, enableNpm ? true }:
+{ callPackage, openssl, icu, python3, enableNpm ? true }:
 
 let
-  buildNodejs = callPackage ./nodejs.nix { inherit openssl icu; };
+  buildNodejs = callPackage ./nodejs.nix { 
+    inherit openssl icu;
+    python = python3;
+  };
 in
   buildNodejs {
     inherit enableNpm;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

1. Python 2 is EOL so I think we should use python3 by default for the nodejs versions that support it.
2. Allow choosing a nodejs build flavor / version with the `programs.npm.` nixos config.

cc @cillianderoiste @gilligan @cko 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).