### PR TITLE
vault: disable_mlock option

### DIFF
--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -25,6 +25,9 @@ let
           ${cfg.telemetryConfig}
         }
       ''}
+    ${optionalString (cfg.disableMlock == true) ''
+    disable_mlock = true
+      ''}
     ${cfg.extraConfig}
   '';
 in
@@ -93,6 +96,12 @@ in
         description = "Telemetry configuration";
       };
 
+      disableMlock = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Disables the server from executing the mlock syscall.";
+      };
+
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -140,7 +149,11 @@ in
         PrivateTmp = true;
         ProtectSystem = "full";
         ProtectHome = "read-only";
-        AmbientCapabilities = "cap_ipc_lock";
+        AmbientCapabilities =
+          if cfg.disableMlock == false then
+            "cap_ipc_lock"
+          else 
+            "";
         NoNewPrivileges = true;
         KillSignal = "SIGINT";
         TimeoutStopSec = "30s";
@@ -151,6 +164,7 @@ in
 
       unitConfig.RequiresMountsFor = optional (cfg.storagePath != null) cfg.storagePath;
     };
+
   };
 
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Implements a disable_mlock configuration option and sets capabilities based on whether it's set.
Motivated by official documentation: https://www.vaultproject.io/docs/configuration/#disable_mlock

Not sure if this is the best/right way to do this, but I'm still new to nix :sweat_smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
