### PR TITLE
tcsh: 6.21.00 -> 6.22.02

### DIFF
--- a/pkgs/shells/tcsh/default.nix
+++ b/pkgs/shells/tcsh/default.nix
@@ -1,9 +1,10 @@
 { stdenv, fetchurl, fetchpatch
 , ncurses }:
 
+with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "tcsh";
-  version = "6.21.00";
+  version = "6.22.02";
 
   src = fetchurl {
     urls = [
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
       "ftp://ftp.astron.com/pub/tcsh/${pname}-${version}.tar.gz"
       "ftp://ftp.funet.fi/pub/unix/shells/tcsh/${pname}-${version}.tar.gz"
     ];
-    sha256 = "0wp9cqkzdj5ahfyg9bn5z1wnyblqyv9vz4sc5aqmj7rp91a34f64";
+    sha256 = "0nw8prz1n0lmr82wnpyhrzmki630afn7p9cfgr3vl00vr9c72a7d";
   };
 
   buildInputs = [ ncurses ];
@@ -23,7 +24,7 @@ stdenv.mkDerivation rec {
       sha256 = "1qc6ydxhdfizsbkaxhpn3wib8sfphrw10xnnsxx2prvzg9g2zp67";
     });
 
-  meta = with stdenv.lib;{
+  meta = {
     description = "An enhanced version of the Berkeley UNIX C shell (csh)";
     longDescription = ''
       tcsh is an enhanced but completely compatible version of the
@@ -37,7 +38,7 @@ stdenv.mkDerivation rec {
       - history mechanism
       - job control
     '';
-    homepage = https://www.tcsh.org/;
+    homepage = "https://www.tcsh.org/";
     license = licenses.bsd2;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux ++ platforms.darwin;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
