### PR TITLE
libtap: 1.12.0 -> 1.14.0

### DIFF
--- a/pkgs/development/libraries/libtap/default.nix
+++ b/pkgs/development/libraries/libtap/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 stdenv.mkDerivation rec{
 
   pname = "libtap";
-  version = "1.12.0";
+  version = "1.14.0";
 
   src = fetchurl {
-    url = "https://web-cpan.shlomifish.org/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "1ms1770cx8c6q3lhn1chkzy12vzmjgvlms7cqhd2d3260j2wwv5s";
+    url = "https://web-cpan.shlomifish.org/downloads/${pname}-${version}.tar.xz";
+    sha256 = "1ga7rqmppa8ady665736cx443icscqlgflkqmxd4xbkzypmdj9bk";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec{
       C originally created by Nik Clayton. This is a maintenance
       branch by Shlomi Fish.
     '';
-    homepage = https://www.shlomifish.org/open-source/projects/libtap/;
+    homepage = "https://www.shlomifish.org/open-source/projects/libtap/";
     license = licenses.bsd3;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.unix;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
