### PR TITLE
nixos/systemd-nspawn: reload or restart machines on config change

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -7,6 +7,7 @@ use File::Slurp;
 use Net::DBus;
 use Sys::Syslog qw(:standard :macros);
 use Cwd 'abs_path';
+use experimental 'smartmatch';
 
 my $out = "@out@";
 
@@ -150,6 +151,37 @@ $unitsToRestart{$_} = 1 foreach
 $unitsToReload{$_} = 1 foreach
     split '\n', read_file($reloadListFile, err_mode => 'quiet') // "";
 
+my @currentNspawnUnits = glob("/etc/systemd/nspawn/*.nspawn");
+my @upcomingNspawnUnits = glob("$out/etc/systemd/nspawn/*.nspawn");
+foreach (@upcomingNspawnUnits) {
+    my $unit = basename($_);
+    $unit =~ s/\.nspawn//;
+    my $unitName = "systemd-nspawn\@$unit.service";
+    my $orig = $_;
+    $orig =~ s/^$out//;
+    if ($orig ~~ @currentNspawnUnits) {
+        if (fingerprintUnit($_) ne fingerprintUnit($orig)) {
+            my $info = parseUnit($_);
+            if ($info->{'X-ReloadOnChange'}) {
+                $unitsToReload{$unitName} = 1;
+            } elsif ($info->{'X-RestartOnChange'}) {
+                $unitsToRestart{$unitName} = 1;
+            }
+        }
+    } else {
+        $unitsToStart{$unitName} = 1;
+    }
+}
+
+foreach (@currentNspawnUnits) {
+    unless ("$out$_" ~~ @upcomingNspawnUnits) {
+        my $unit = basename($_);
+        $unit =~ s/\.nspawn//;
+        my $unitName = "systemd-nspawn\@$unit.service";
+        $unitsToStop{$unitName} = 1;
+    }
+}
+
 my $activePrev = getActiveUnits;
 while (my ($unit, $state) = each %{$activePrev}) {
     my $baseUnit = $unit;
@@ -259,7 +291,10 @@ while (my ($unit, $state) = each %{$activePrev}) {
                             recordUnit($startListFile, $unit);
                         }
 
-                        $unitsToStop{$unit} = 1;
+                        # FIXME find a better solution than this hack
+                        if (index($unit, "systemd-nspawn@") == -1) {
+                            $unitsToStop{$unit} = 1;
+                        }
                     }
                 }
             }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -296,6 +296,7 @@ in
   systemd-networkd-vrf = handleTest ./systemd-networkd-vrf.nix {};
   systemd-networkd = handleTest ./systemd-networkd.nix {};
   systemd-nspawn = handleTest ./systemd-nspawn.nix {};
+  systemd-nspawn-reload = handleTest ./systemd-nspawn-reload {};
   pdns-recursor = handleTest ./pdns-recursor.nix {};
   taskserver = handleTest ./taskserver.nix {};
   telegraf = handleTest ./telegraf.nix {};

--- a/nixos/tests/systemd-nspawn-reload.nix
+++ b/nixos/tests/systemd-nspawn-reload.nix
@@ -1,0 +1,138 @@
+let
+  initialContainer = extra: import <nixpkgs/nixos/lib/eval-config.nix> {
+    modules = [
+      ({...}: {
+        config = {
+          boot.isContainer = true;
+          networking.useDHCP = false;
+          networking.hostName = "test-container";
+        };
+      })
+    ] ++ extra;
+  };
+in import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "systemd-config-reload";
+  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ ma27 ];
+
+  nodes = let
+    baseCfg = extra: { ... }: {
+      systemd.services."systemd-nspawn@test-container".preStart = ''
+        mkdir -p /var/lib/machines/test-container/{var,etc}
+        [ -e "/var/lib/machines/test-container/etc/os-release" ] || \
+          touch /var/lib/machines/test-container/etc/{os-release,machine-id} || true
+      '';
+      systemd.nspawn.test-container = {
+        execConfig = {
+          Boot = false;
+          Parameters = "${(initialContainer extra).config.system.build.toplevel}/init";
+          KillSignal = "SIGRTMIN+3";
+        };
+        filesConfig = {
+          BindReadOnly = [ "/nix/store" "/nix/var/nix/db" "/nix/var/nix/daemon-socket" ];
+        };
+      };
+    };
+  in {
+    base = baseCfg [];
+    configUpdate = baseCfg [
+      ({ pkgs, ... }: {
+        environment.systemPackages = [ pkgs.hello ];
+      })
+    ];
+    removed = { ... }: {
+    };
+    reloadScriptForContainer = { ... }: let
+      extra = ({ pkgs, ... }: {
+        environment.systemPackages = [ pkgs.hello ];
+      });
+    in {
+      imports = [
+        (baseCfg [
+          extra
+        ])
+      ];
+      systemd.nspawn.test-container.reloadOnChange = true;
+      systemd.nspawn.test-container.restartOnChange = false;
+      systemd.services."systemd-nspawn@test-container".serviceConfig.ExecReload = "${pkgs.writeScriptBin "activate" ''
+        #! ${pkgs.runtimeShell} -xe
+        systemd-run --machine test-container --pty --quiet -- /bin/sh --login -c \
+          '${(initialContainer [extra]).config.system.build.toplevel}/bin/switch-to-configuration test'
+      ''}/bin/activate";
+    };
+  };
+
+  testScript = { nodes, ... }: let
+    modified = nodes.configUpdate.config.system.build.toplevel;
+    removed = nodes.removed.config.system.build.toplevel;
+    reload = nodes.reloadScriptForContainer.config.system.build.toplevel;
+  in ''
+    base.start()
+    base.wait_for_unit("systemd-nspawn@test-container.service")
+    assert "test-container" in base.succeed("machinectl")
+
+    base.wait_until_succeeds(
+        "systemd-run --machine test-container --pty --quiet -- /bin/sh -c 'echo container shell is accessible' >&2"
+    )
+
+    base.fail(
+        "systemd-run --machine test-container --pty --quiet -- /bin/sh -c '/run/current-system/sw/bin/hello' >&2"
+    )
+
+    out = base.succeed(
+        "${modified}/bin/switch-to-configuration test 2>&1 | tee /dev/stderr"
+    )
+
+    assert (
+        "restarting the following units: network-addresses-eth1.service, systemd-nspawn@test-container.service"
+        in out
+    )
+
+    base.succeed("machinectl show test-container")
+    base.wait_until_succeeds(
+        "systemd-run --machine test-container --pty --quiet -- /bin/sh -c '/run/current-system/sw/bin/hello' >&2"
+    )
+
+    base.succeed(
+        "${removed}/bin/switch-to-configuration test 2>&1 | tee /dev/stderr"
+    )
+
+    base.fail("machinectl show test-container")
+
+    out = base.succeed(
+        "${modified}/bin/switch-to-configuration test 2>&1 | tee /dev/stderr"
+    )
+
+    assert (
+        "starting the following units: nscd.service, systemd-nspawn@test-container.service"
+        in out
+    )
+
+    base.require_unit_state("systemd-nspawn@test-container", "active")
+
+    assert "test-container" in base.succeed("machinectl")
+    base.wait_until_succeeds(
+        "systemd-run --machine test-container --pty --quiet -- /bin/sh -c 'echo container shell is accessible' >&2"
+    )
+
+    base.require_unit_state("systemd-nspawn@test-container", "active")
+
+    out = base.succeed(
+        "${reload}/bin/switch-to-configuration test 2>&1 | tee /dev/stderr"
+    )
+    assert (
+        "restarting the following units: network-addresses-eth1.service, systemd-nspawn@test-container.service"
+        not in out
+    )
+    assert "systemd-nspawn@test-container.service is not active, cannot reload." not in out
+    base.require_unit_state("systemd-nspawn@test-container", "active")
+    base.wait_until_succeeds(
+        "systemd-run --machine test-container --pty --quiet -- /bin/sh -c 'echo container shell is accessible' >&2"
+    )
+
+    base.wait_until_succeeds(
+        "systemd-run --machine test-container --pty --quiet -- /bin/sh -c '/run/current-system/sw/bin/hello' >&2"
+    )
+
+    base.shutdown()
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

I started working on a draft for improved nixos-containers (using
`networkd` and `.nspawn` units) after the networkd hackathon[1] which
isn't published yet.

Quite recently I realized that when changing a `.nspawn`-unit, the
`switch-to-configuration.pl` doesn't activate those changes. This patch
takes care of it with the following changes:

* It's possible to declare whether to restart or reload such a unit. The
  restart option is the default. In that case the
  `systemd-nspawn@<machine-name>.service`[2]-unit will be restarted or reloaded.

* By default, all `.nspawn`-units are part of the `machines.target`.

* A VM-test covers all those cases including a custom reload-script to
  activate a new configuration in the machine.

* I had to remove the `--keep-unit` flag on startup to fix the restart
  of the unit. This is a known issue[3].

It's also possible to use a reload to activate a new configuration
inside a nspawn-machine with a config like this:

``` nix
{ pkgs, ... }: {
  systemd.nspawn.test-container.reloadOnChange = true;
  systemd.nspawn.test-container.restartOnChange = false;
  systemd.services."systemd-nspawn@test-container".serviceConfig.ExecReload = "${pkgs.writeScriptBin "activate" ''
    #! ${pkgs.runtimeShell} -xe
    systemd-run --machine test-container --pty --quiet -- /bin/sh --login -c \
      '${containerCfg}/bin/switch-to-configuration test'
  ''}/bin/activate";
}
```

[1] https://discourse.nixos.org/t/networkd-sprint-2019-11-23-24-in-munich/4578
[2] https://github.com/systemd/systemd/blob/v243/units/systemd-nspawn@.service.in
[3] https://github.com/NixOS/nixpkgs/pull/80169

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
