### PR TITLE
notmuch: set emacs off by default

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -1,12 +1,15 @@
 { fetchurl, stdenv
 , pkgconfig, gnupg
 , xapian, gmime, talloc, zlib
-, doxygen, perl, texinfo
-, pythonPackages
-, emacs
-, ruby
 , which, dtach, openssl, bash, gdb, man
-, withEmacs ? false
+, texinfo
+, perl
+, python3
+, withDocs ? true
+, withRuby ? true
+, ruby ? null
+, withEmacs ? true
+, emacs ? null
 }:
 
 with stdenv.lib;
@@ -27,16 +30,18 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkgconfig
-    texinfo                   # (optional) documentation -> doc/INSTALL
-  ] ++ optional withEmacs [ emacs ];
+    python3
+    perl
+    texinfo
+  ];
 
   buildInputs = [
     gnupg                     # undefined dependencies
     xapian gmime talloc zlib  # dependencies described in INSTALL
-    perl
-    pythonPackages.python
-    ruby
-  ];
+  ]
+    ++ optional withRuby [ ruby ]
+    ++ optional withEmacs [ emacs ]
+  ;
 
   postPatch = ''
     patchShebangs configure
@@ -54,8 +59,11 @@ stdenv.mkDerivation rec {
     "--zshcompletiondir=${placeholder "out"}/share/zsh/site-functions"
     "--bashcompletiondir=${placeholder "out"}/share/bash-completion/completions"
     "--infodir=${placeholder "info"}"
-  ] ++ optional (!withEmacs) "--without-emacs"
-    ++ optional (isNull ruby) "--without-ruby";
+  ]
+    ++ optionals (!withEmacs) [ "--without-emacs" ]
+    ++ optionals (!withDocs) [ "--without-docs" ]
+    ++ optionals (!withRuby) [ "--without-ruby" ]
+  ;
 
   # Notmuch doesn't use autoconf and consequently doesn't tag --bindir and
   # friends

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -3,7 +3,6 @@
 , xapian, gmime, talloc, zlib
 , doxygen, perl, texinfo
 , pythonPackages
-, bash-completion
 , emacs
 , ruby
 , which, dtach, openssl, bash, gdb, man
@@ -31,7 +30,6 @@ stdenv.mkDerivation rec {
     doxygen                   # (optional) api docs
     pythonPackages.sphinx     # (optional) documentation -> doc/INSTALL
     texinfo                   # (optional) documentation -> doc/INSTALL
-    bash-completion           # (optional) dependency to install bash completion
   ] ++ optional withEmacs [ emacs ];
 
   buildInputs = [
@@ -56,6 +54,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--zshcompletiondir=${placeholder "out"}/share/zsh/site-functions"
+    "--bashcompletiondir=${placeholder "out"}/share/bash-completion/completions"
     "--infodir=${placeholder "info"}"
   ] ++ optional (!withEmacs) "--without-emacs"
     ++ optional (isNull ruby) "--without-ruby";

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -71,9 +71,6 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   makeFlags = [ "V=1" ];
 
-
-  outputs = [ "out" "man" "info" ];
-
   preCheck = let
     test-database = fetchurl {
       url = "https://notmuchmail.org/releases/test-databases/database-v1.tar.xz";
@@ -89,7 +86,9 @@ stdenv.mkDerivation rec {
     gdb man emacs
   ];
 
-  installTargets = [ "install" "install-man" "install-info" ];
+  installTargets = [ "install" ]
+  ++ optionals (withDocs) [ "install-man" "install-info" ]
+  ;
 
   dontGzipMan = true; # already compressed
 

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkgconfig
-    doxygen                   # (optional) api docs
-    pythonPackages.sphinx     # (optional) documentation -> doc/INSTALL
     texinfo                   # (optional) documentation -> doc/INSTALL
   ] ++ optional withEmacs [ emacs ];
 

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -7,7 +7,7 @@
 , emacs
 , ruby
 , which, dtach, openssl, bash, gdb, man
-, withEmacs ? true
+, withEmacs ? false
 }:
 
 with stdenv.lib;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20763,7 +20763,9 @@ in
 
   neap = callPackage ../applications/misc/neap { };
 
-  neomutt = callPackage ../applications/networking/mailreaders/neomutt { };
+  neomutt = callPackage ../applications/networking/mailreaders/neomutt {
+    notmuch = notmuch-lib;
+  };
 
   natron = callPackage ../applications/video/natron { };
 
@@ -20991,20 +20993,22 @@ in
 
   notmuch = callPackage ../applications/networking/mailreaders/notmuch {
     gmime = gmime3;
-    pythonPackages = python3Packages;
   };
-  notmuch-emacs = callPackage ../applications/networking/mailreaders/notmuch {
-    withEmacs = true;
-    pythonPackages = python3Packages;
+  # Use this as a library for e.g neomutt
+  notmuch-lib = callPackage ../applications/networking/mailreaders/notmuch {
+    gmime = gmime3;
+    withDocs = false;
+    withRuby = false;
+    withEmacs = false;
   };
 
   notmuch-mutt = callPackage ../applications/networking/mailreaders/notmuch/mutt.nix { };
 
+  muchsync = callPackage ../applications/networking/mailreaders/notmuch/muchsync.nix { };
+
   notmuch-addrlookup = callPackage ../applications/networking/mailreaders/notmuch-addrlookup { };
 
   notejot = callPackage ../applications/misc/notejot { };
-
-  muchsync = callPackage ../applications/networking/mailreaders/notmuch/muchsync.nix { };
 
   nova-filters =  callPackage ../applications/audio/nova-filters { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20993,14 +20993,18 @@ in
     gmime = gmime3;
     pythonPackages = python3Packages;
   };
-
-  notejot = callPackage ../applications/misc/notejot { };
+  notmuch-emacs = callPackage ../applications/networking/mailreaders/notmuch {
+    withEmacs = true;
+    pythonPackages = python3Packages;
+  };
 
   notmuch-mutt = callPackage ../applications/networking/mailreaders/notmuch/mutt.nix { };
 
-  muchsync = callPackage ../applications/networking/mailreaders/notmuch/muchsync.nix { };
-
   notmuch-addrlookup = callPackage ../applications/networking/mailreaders/notmuch-addrlookup { };
+
+  notejot = callPackage ../applications/misc/notejot { };
+
+  muchsync = callPackage ../applications/networking/mailreaders/notmuch/muchsync.nix { };
 
   nova-filters =  callPackage ../applications/audio/nova-filters { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Emacs takes around 150Mb in closure size. `neomutt` is a package which uses notmuch as a library and users that don't use Emacs don't need this feature enabled. Hence to reduce closure size, ~~while still supporting Emacs users of notmuch I turned that feature to off by default and added a `notmuch-emacs` package targeting these users of notmuch.~~ I created a `notmuch-lib` package that is used by `neomutt` which has a much lower closure size - 560Kb because it is compiled with less features enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
