### PR TITLE
stella: 4.1.1 -> 6.1.1

### DIFF
--- a/pkgs/misc/emulators/stella/default.nix
+++ b/pkgs/misc/emulators/stella/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl, pkgconfig, SDL2 }:
+{ stdenv, fetchFromGitHub, pkgconfig, SDL2 }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
 
   pname = "stella";
-  version = "4.6.1";
+  version = "6.1.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/stella/stella/${version}/${pname}-${version}-src.tar.gz";
-    sha256 = "126jph21b70jlxapzmll8pq36i53lb304hbsiap25160vdqid4n1";
+  src = fetchFromGitHub {
+    owner = "stella-emu";
+    repo = "stella";
+    rev = version;
+    sha256 = "1iwhslrkq887v035j68lhblybww8r792515rp2m5qzmdgnjzsvbb";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
     maintained by Stephen Anthony.
     As of its 3.5 release, Stella is officially donationware. 
     '';
-    homepage = http://stella.sourceforge.net/;
+    homepage = "http://stella-emu.github.io/";
     license = licenses.gpl2;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;

--- a/pkgs/misc/emulators/stella/default.nix
+++ b/pkgs/misc/emulators/stella/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ SDL2 ];
+  
+  enableParallelBuild = true;
 
   meta = {
     description = "An open-source Atari 2600 VCS emulator";

--- a/pkgs/misc/emulators/stella/default.nix
+++ b/pkgs/misc/emulators/stella/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ SDL2 ];
   
-  enableParallelBuild = true;
+  enableParallelBuilding = true;
 
   meta = {
     description = "An open-source Atari 2600 VCS emulator";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
