### PR TITLE
[WIP] sky: 2.1.7369 -> 2.1.7520

### DIFF
--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, file, libX11, libXScrnSaver
 , libGL, qt5, SDL, libpulseaudio
 , libXrandr, libXext, libXcursor, libXinerama, libXi
-, curl, sqlite, openssl
+, curl, sqlite, openssl_1_0_2
 , libuuid, openh264, libv4l, libxkbfile, libXv, zlib, libXmu
 , libXtst, libXdamage, pam, libXfixes, libXrender, libjpeg_original
-, ffmpeg
+, ffmpeg_2
 }:
  let
    # Sky is linked to the libjpeg 8 version and checks for the version number in the code.
@@ -16,22 +16,22 @@
   });
 in
 stdenv.mkDerivation rec {
-  version_major = "2.1.7369";
+  version_major = "2.1.7520";
   version_minor = "1";
   version = version_major + "." + version_minor;
   pname = "sky";
   unpackCmd = "ar x $curSrc; tar -xf data.tar.xz";
   src = fetchurl {
     url = "https://tel.red/repos/ubuntu/pool/non-free/sky_${version_major + "-" + version_minor}ubuntu+xenial_amd64.deb";
-    sha256 = "0b3j90km3rp5bgaklxw881g0gcy09mqzbhjdfrq4s2np026ql3d9";
+    sha256 = "078gdk4dbw7aqfrrc5xlhhzpiy3br8wpn0mbfbqfxrnbpgn5ya2w";
   };
-  buildInputs = [ 
+  buildInputs = [
     file
     qt5.qtbase
     SDL
-    ffmpeg
+    ffmpeg_2
     sqlite
-    openssl
+    openssl_1_0_2  # sky needs legacy openssl
     openh264
     pam
     curl
@@ -68,6 +68,11 @@ stdenv.mkDerivation rec {
     patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libxfreerdp-client.so.2.0.0
     patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/sky
     patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/sky_sender
+    # map libavcodec-ffmpeg.so.56 to libavcodec.so.56
+    ln -s ${ffmpeg_2.out}/lib/libavcodec.so.56 $out/lib/libavcodec-ffmpeg.so.56
+    ln -s ${ffmpeg_2.out}/lib/libavformat.so.56 $out/lib/libavformat-ffmpeg.so.56
+    ln -s ${ffmpeg_2.out}/lib/libswscale.so.3 $out/lib/libswscale-ffmpeg.so.3
+    ln -s ${ffmpeg_2.out}/lib/libavutil.so.54 $out/lib/libavutil-ffmpeg.so.54
     sed -i "s#/usr/bin/sky#$out/bin/sky#g" $out/share/applications/sky.desktop
     sed -i "s#/usr/lib/sky#$out/bin/#g" $out/share/applications/sky.desktop
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
another approach of https://github.com/NixOS/nixpkgs/pull/80022

it builds, but i get
```
sky: /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libavformat-ffmpeg.so.56: version `LIBAVFORMAT_FFMPEG_56' not found (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libsipw.so.1)
sky: /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libavcodec-ffmpeg.so.56: version `LIBAVCODEC_FFMPEG_56' not found (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libsipw.so.1)
sky: /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libswscale-ffmpeg.so.3: version `LIBSWSCALE_FFMPEG_3' not found (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libsipw.so.1)
sky: /nix/store/8zxiz4i59h1c7qfk5zg23x1bfzzyykiq-curl-7.68.0/lib/libcurl.so.4: no version information available (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libsipw.so.1)
sky: /nix/store/9qk1xv6l74cvrkfv70zam3s30b6v6nmr-openssl-1.0.2u/lib/libssl.so.1.0.0: no version information available (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libsipw.so.1)
sky: /nix/store/9qk1xv6l74cvrkfv70zam3s30b6v6nmr-openssl-1.0.2u/lib/libcrypto.so.1.0.0: no version information available (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libsipw.so.1)
sky: /nix/store/9qk1xv6l74cvrkfv70zam3s30b6v6nmr-openssl-1.0.2u/lib/libcrypto.so.1.0.0: no version information available (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libfreerdp.so.2.0)
sky: /nix/store/9qk1xv6l74cvrkfv70zam3s30b6v6nmr-openssl-1.0.2u/lib/libssl.so.1.0.0: no version information available (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libfreerdp.so.2.0)
sky: /nix/store/mvw8vp580089x2zmkx4k90lyzc6wvnv6-ffmpeg-2.8.15/lib/libavutil.so.54: version `LIBAVUTIL_FFMPEG_54' not found (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libfreerdp-client.so.2.0)
sky: /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libavcodec-ffmpeg.so.56: version `LIBAVCODEC_FFMPEG_56' not found (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libfreerdp-client.so.2.0)
sky: /nix/store/9qk1xv6l74cvrkfv70zam3s30b6v6nmr-openssl-1.0.2u/lib/libcrypto.so.1.0.0: no version information available (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libfreerdp-shadow.so.2.0)
sky: /nix/store/9qk1xv6l74cvrkfv70zam3s30b6v6nmr-openssl-1.0.2u/lib/libssl.so.1.0.0: no version information available (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libwinpr.so.1.1)
sky: /nix/store/9qk1xv6l74cvrkfv70zam3s30b6v6nmr-openssl-1.0.2u/lib/libcrypto.so.1.0.0: no version information available (required by /nix/store/c9fjz7f99bcspnsiw3jlvnr66w2jfczn-sky-2.1.7520.1/lib/libwinpr.so.1.1)
```
and I have no idea, how to work around this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
