### PR TITLE
zsh-autoenv: fix zsh-autoenv-share description

### DIFF
--- a/pkgs/tools/misc/zsh-autoenv/default.nix
+++ b/pkgs/tools/misc/zsh-autoenv/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
     cat <<SCRIPT > $out/bin/zsh-autoenv-share
     #!${runtimeShell}
-    # Run this script to find the fzf shared folder where all the shell
+    # Run this script to find the zsh-autoenv shared folder where all the shell
     # integration scripts are living.
     echo $out/share/zsh-autoenv
     SCRIPT


### PR DESCRIPTION
Fix a copy & paste error in zsh-autoenv-share documentation

###### Motivation for this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Ensured that relevant documentation is up to date
