### PR TITLE
zsh-syntax-highlighting: add -share script

### DIFF
--- a/doc/builders/packages/shell-helpers.xml
+++ b/doc/builders/packages/shell-helpers.xml
@@ -16,6 +16,16 @@
      <literal>fzf</literal>: <command>fzf-share</command>
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <literal>zsh-autoenv</literal>: <command>zsh-autoenv-share</command>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <literal>zsh-syntax-highlighting</literal>: <command>zsh-syntax-highlighting-share</command>
+    </para>
+   </listitem>
   </itemizedlist>
   E.g. <literal>autojump</literal> can then used in the .bashrc like this:
 <screen>

--- a/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh/zsh-syntax-highlighting/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, zsh }:
+{ stdenv, fetchFromGitHub, runtimeShell, zsh }:
 
 # To make use of this derivation, use the `programs.zsh.enableSyntaxHighlighting` option
 
@@ -16,6 +16,17 @@ stdenv.mkDerivation rec {
   buildInputs = [ zsh ];
 
   installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    mkdir -p $out/bin
+    cat <<SCRIPT > $out/bin/zsh-syntax-highlighting-share
+    #!${runtimeShell}
+    # Run this script to find the zsh-syntax-highlighting shared folder where
+    # all the shell integration scripts are living.
+    echo $out/share/zsh-syntax-highlighting
+    SCRIPT
+    chmod +x $out/bin/zsh-syntax-highlighting-share
+  '';
 
   meta = with stdenv.lib; {
     description = "Fish shell like syntax highlighting for Zsh";


### PR DESCRIPTION
Add a `zsh-syntax-highlighting-share` helper and update documentation
for [Interactive shell helpers]
(https://nixos.org/nixpkgs/manual/#sec-shell-helpers)

###### Motivation for this change
Use the zsh plugin `zsh-synstax-highlighting` from nixpkgs in dotfiles like documented (https://nixos.org/nixpkgs/manual/#sec-shell-helpers), i.e.
```
source "$(zsh-syntax-highlighting-share)/zsh-syntax-highlighting.zsh"
```
instead of something like
```
source "$(nix-build -Q '<nixpkgs>' -A zsh-syntax-highlighting)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
