### PR TITLE
pew: 1.1.2 -> 1.2.0, fix build

### DIFF
--- a/pkgs/development/tools/pew/default.nix
+++ b/pkgs/development/tools/pew/default.nix
@@ -1,34 +1,30 @@
-{ stdenv, python3Packages }:
-with python3Packages; buildPythonApplication rec {
-    pname = "pew";
-    version = "1.1.2";
+{ stdenv, python3 }:
 
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "04anak82p4v9w0lgfs55s7diywxil6amq8c8bhli143ca8l2fcdq";
-    };
+with python3.pkgs;
 
-    propagatedBuildInputs = [ virtualenv virtualenv-clone setuptools ];
+buildPythonApplication rec {
+  pname = "pew";
+  version = "1.2.0";
 
-    LC_ALL = "en_US.UTF-8";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04anak82p4v9w0lgfs55s7diywxil6amq8c8bhli143ca8l2fcdq";
+  };
 
-    postFixup = ''
-      set -euo pipefail
-      PEW_SITE="$out/lib/${python.libPrefix}/site-packages"
-      SETUPTOOLS="${setuptools}/lib/${python.libPrefix}/site-packages"
-      SETUPTOOLS_SITE=$SETUPTOOLS/$(cat $SETUPTOOLS/setuptools.pth)
-      CLONEVENV_SITE="${virtualenv-clone}/lib/${python.libPrefix}/site-packages"
-      SITE_PACKAGES="[\'$PEW_SITE\',\'$SETUPTOOLS_SITE\',\'$CLONEVENV_SITE\']"
-      substituteInPlace $PEW_SITE/pew/pew.py \
-        --replace "from pew.pew" "import sys; sys.path.extend($SITE_PACKAGES); from pew.pew" \
-        --replace 'sys.executable, "-m", "virtualenv"' "'${virtualenv}/bin/virtualenv'"
-    '';
+  propagatedBuildInputs = [ virtualenv virtualenv-clone setuptools ];
 
-    meta = with stdenv.lib; {
-      homepage = https://github.com/berdario/pew;
-      description = "Tools to manage multiple virtualenvs written in pure python";
-      license = licenses.mit;
-      platforms = platforms.all;
-      maintainers = with maintainers; [ berdario ];
-    };
-  }
+  # no tests are packaged
+  checkPhase = ''
+    $out/bin/pew > /dev/null
+  '';
+
+  pythonImportsCheck = [ "pew" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/berdario/pew";
+    description = "Tools to manage multiple virtualenvs written in pure python";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ berdario ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing #84598

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/84632
1 package built:
pew
```