### PR TITLE
tydra: init at 1.0.2

### DIFF
--- a/pkgs/tools/misc/tydra/default.nix
+++ b/pkgs/tools/misc/tydra/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, rustPlatform, fetchFromGitHub, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tydra";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "Mange";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kvyski3qy2lwlpipynq894i0g9x2j4a1iy2mgdwfibfyfkv2jnm";
+  };
+
+  cargoSha256 = "11l3fvym16wrrpm9vy4asmqdh8qynwjy0w4gx2bbcnc6300ag43a";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage doc/{tydra.1,tydra-actions.5}
+
+    $out/bin/tydra --generate-completions bash > tydra.bash
+    $out/bin/tydra --generate-completions fish > tydra.fish
+    $out/bin/tydra --generate-completions zsh > _tydra
+
+    installShellCompletion tydra.{bash,fish} _tydra
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Shortcut menu-based task runner, inspired by Emacs Hydra";
+    homepage = "https://github.com/Mange/tydra";
+    license = licenses.mit;
+    maintainers = with maintainers; [ filalex77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7096,6 +7096,8 @@ in
 
   txtw = callPackage ../tools/misc/txtw { };
 
+  tydra = callPackage ../tools/misc/tydra { };
+
   u9fs = callPackage ../servers/u9fs { };
 
   ua = callPackage ../tools/networking/ua { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/Mange/tydra/releases/tag/v1.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
