### PR TITLE
csxcad: init at 0.6.2

### DIFF
--- a/pkgs/applications/science/electronics/csxcad/default.nix
+++ b/pkgs/applications/science/electronics/csxcad/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, fparser
+, tinyxml
+, hdf5
+, cgal_5
+, vtk
+, boost
+, gmp
+, mpfr
+}:
+
+stdenv.mkDerivation rec {
+  pname = "csxcad";
+  version = "unstable-2020-02-08";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "CSXCAD";
+    rev = "ef6e40931dbd80e0959f37c8e9614c437bf7e518";
+    sha256 = "072s765jyzpdq8qqysdy0dld17m6sr9zfcs0ip2zk8c4imxaysnb";
+  };
+
+  patches = [./searchPath.patch ];
+
+  buildInputs = [
+    cgal_5
+    boost
+    gmp
+    mpfr
+    vtk
+    fparser
+    tinyxml
+    hdf5
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A C++ library to describe geometrical objects";
+    homepage = "https://github.com/thliebig/CSXCAD";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/science/electronics/csxcad/searchPath.patch
+++ b/pkgs/applications/science/electronics/csxcad/searchPath.patch
@@ -1,0 +1,11 @@
+--- CSXCAD/matlab/searchBinary.m	2019-07-14 09:24:02.154291745 -0700
++++ CSXCAD/matlab/searchBinary.m	2019-07-14 09:20:20.900248280 -0700
+@@ -33,7 +33,7 @@
+
+ % try all search paths
+ for n=1:numel(searchpath)
+-    binary_location = [searchpath{n} name];
++    binary_location = [searchpath{n} filesep name];
+     if exist(binary_location, 'file')
+         return
+     end

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5707,7 +5707,7 @@ in
   padthv1 = libsForQt5.callPackage ../applications/audio/padthv1 { };
 
   page = callPackage ../tools/misc/page { };
-  
+
   pagmo2 = callPackage ../development/libraries/pagmo2 { };
 
   pakcs = callPackage ../development/compilers/pakcs { };
@@ -24820,6 +24820,8 @@ in
   eagle = libsForQt5.callPackage ../applications/science/electronics/eagle/eagle.nix { };
 
   caneda = libsForQt5.callPackage ../applications/science/electronics/caneda { };
+
+  csxcad = callPackage ../applications/science/electronics/csxcad { };
 
   fparser = callPackage ../applications/science/electronics/fparser { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Please see [PR 69262](https://github.com/NixOS/nixpkgs/pull/69262) for details. We've decided to break up that PR into smaller pieces to make it easier to review. [CSXCAD](https://github.com/thliebig/CSXCAD) implements the geometry capabilities of [OpenEMS](https://openems.de/start/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
