### PR TITLE
[20.03] haskellPackages.pandoc-crossref: downgrade to latest working

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -348,7 +348,6 @@ self: super: {
   optional = dontCheck super.optional;
   orgmode-parse = dontCheck super.orgmode-parse;
   os-release = dontCheck super.os-release;
-  pandoc-crossref = dontCheck super.pandoc-crossref;  # (most likely change when no longer 0.3.2.1) https://github.com/lierdakil/pandoc-crossref/issues/199
   persistent-redis = dontCheck super.persistent-redis;
   pipes-extra = dontCheck super.pipes-extra;
   pipes-websockets = dontCheck super.pipes-websockets;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -69,6 +69,9 @@ core-packages:
 default-package-overrides:
   # pandoc-2.9 does not accept the 0.3 version yet
   - doclayout < 0.3
+  # latest version does not support pandoc 2.8, remove once 2.9
+  # is available in LTS
+  - pandoc-crossref ==0.3.4.2
   # LTS Haskell 14.23
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
@@ -7832,7 +7835,6 @@ broken-packages:
   - pan-os-syslog
   - panda
   - pandoc-citeproc-preamble
-  - pandoc-crossref
   - pandoc-include
   - pandoc-include-code
   - pandoc-japanese-filters


### PR DESCRIPTION
###### Motivation for this change
I'm moving #80556 to target 20.03 since pandoc-crossref was fixed in master and 20.03 is not getting a haskell update, it seems.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
