### PR TITLE
python2Packages.cryptography: add missing ipaddress dependency

### DIFF
--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -2,6 +2,8 @@
 , buildPythonPackage
 , fetchPypi
 , fetchpatch
+, isPy27
+, ipaddress
 , openssl
 , cryptography_vectors
 , darwin
@@ -33,7 +35,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     packaging
     six
-  ] ++ stdenv.lib.optional (!isPyPy) cffi;
+  ] ++ stdenv.lib.optional (!isPyPy) cffi
+  ++ stdenv.lib.optionals isPy27 [ ipaddress ];
 
   checkInputs = [
     cryptography_vectors


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing #84437

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
