### PR TITLE
hy: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -3,6 +3,7 @@
 python3Packages.buildPythonApplication rec {
   pname = "hy";
   version = "0.18.0";
+
   src = python3Packages.fetchPypi {
     inherit pname version;
     sha256 = "04dfwm336gw61fmgwikvh0cnxk682p19b4w555wl5d7mlym4rwj2";

--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -21,12 +21,10 @@ python3Packages.buildPythonApplication rec {
     pygments
   ];
 
+  # Hy does not include tests in the source distribution from PyPI, so only test executable.
   checkPhase = ''
-    PATH=$out/bin:$PATH pytest
+    $out/bin/hy --help > /dev/null
   '';
-
-  # Hy does not include tests in the source distribution from PyPI, so skip testing.
-  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "A LISP dialect embedded in Python";

--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -1,22 +1,32 @@
-{ stdenv, fetchurl, python2Packages }:
+{ stdenv, python3Packages }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "hy";
-  version = "0.17.0";
-
-  src = python2Packages.fetchPypi {
+  version = "0.18.0";
+  src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1gdbqsirsdxj320wnp7my5awzs1kfs6m4fqmkzbd1zd47qzj0zfi";
+    sha256 = "04dfwm336gw61fmgwikvh0cnxk682p19b4w555wl5d7mlym4rwj2";
   };
 
-  propagatedBuildInputs = with python2Packages; [
+  checkInputs = with python3Packages; [ flake8 pytest ];
+
+  propagatedBuildInputs = with python3Packages; [
     appdirs
     astor
     clint
+    colorama
     fastentrypoints
     funcparserlib
     rply
+    pygments
   ];
+
+  checkPhase = ''
+    PATH=$out/bin:$PATH pytest
+  '';
+
+  # Hy does not include tests in the source distribution from PyPI, so skip testing.
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "A LISP dialect embedded in Python";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Hy is out of date in nixpkgs and hy has deprecated Python 2 support, so we can update to 0.18.0 and make it a Python 3 application.

###### Things done
Updated hy package to latest release and to use python3Package.
Setup tests with checkPhase and can run them manually in a nix-shell, but they don't seem to get run properly during nix-build, so set `doCheck  = false`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
