### PR TITLE
notmuch: add separate `emacs` output

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -215,7 +215,13 @@ environment.systemPackages = [
 
   <itemizedlist>
    <listitem>
-    <para />
+    <para>
+     The <package>notmuch</package> package move its emacs-related binaries and
+     emacs lisp files to a separate output. They're not part
+     of the default <literal>out<literal> output anymore - if you relied on the
+     <literal>notmuch-emacs-mua</literal> binary or the emacs lisp files, access them via
+     the <literal>notmuch.emacs</literal> output.
+    </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation rec {
     "--zshcompletiondir=${placeholder "out"}/share/zsh/site-functions"
     "--infodir=${placeholder "info"}"
   ] ++ optional (!withEmacs) "--without-emacs"
+    ++ optional (withEmacs) "--emacslispdir=${placeholder "emacs"}/share/emacs/site-lisp"
     ++ optional (isNull ruby) "--without-ruby";
 
   # Notmuch doesn't use autoconf and consequently doesn't tag --bindir and
@@ -67,7 +68,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "V=1" ];
 
 
-  outputs = [ "out" "man" "info" ];
+  outputs = [ "out" "man" "info" ] ++ stdenv.lib.optional withEmacs "emacs";
 
   preCheck = let
     test-database = fetchurl {
@@ -85,6 +86,10 @@ stdenv.mkDerivation rec {
   ];
 
   installTargets = [ "install" "install-man" "install-info" ];
+
+  postInstall = stdenv.lib.optionalString withEmacs ''
+    moveToOutput bin/notmuch-emacs-mua $emacs
+  '';
 
   dontGzipMan = true; # already compressed
 

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -3,7 +3,6 @@
 , xapian, gmime, talloc, zlib
 , doxygen, perl, texinfo
 , pythonPackages
-, bash-completion
 , emacs
 , ruby
 , which, dtach, openssl, bash, gdb, man
@@ -31,7 +30,6 @@ stdenv.mkDerivation rec {
     doxygen                   # (optional) api docs
     pythonPackages.sphinx     # (optional) documentation -> doc/INSTALL
     texinfo                   # (optional) documentation -> doc/INSTALL
-    bash-completion           # (optional) dependency to install bash completion
   ] ++ optional withEmacs [ emacs ];
 
   buildInputs = [
@@ -56,6 +54,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--zshcompletiondir=${placeholder "out"}/share/zsh/site-functions"
+    "--bashcompletiondir=${placeholder "out"}/share/bash-completion/completions"
     "--infodir=${placeholder "info"}"
   ] ++ optional (!withEmacs) "--without-emacs"
     ++ optional (withEmacs) "--emacslispdir=${placeholder "emacs"}/share/emacs/site-lisp"


### PR DESCRIPTION
###### Motivation for this change
Emacs takes around 150Mb in closure size. `neomutt` is a package which uses notmuch as a library and users that don't use Emacs don't need this feature enabled. Hence to reduce closure size, while still supporting Emacs users of notmuch the emacs-related binary and emacs lisp files were moved to a `notmuch.emacs` output.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Supersedes #84610.