### PR TITLE
palp: correct metadata for repology

### DIFF
--- a/pkgs/applications/science/math/palp/default.nix
+++ b/pkgs/applications/science/math/palp/default.nix
@@ -4,10 +4,12 @@
 , doSymlink ? true # symlink the executables to the default location (without dimension postfix)
 }:
 
-stdenv.mkDerivation rec {
-  version = "2.1";
+let
   dim = toString dimensions;
-  name = "palp-${dim}d-${version}";
+in
+stdenv.mkDerivation rec {
+  pname = "palp";
+  version = "2.1";
 
   src = fetchurl {
     url = "http://hep.itp.tuwien.ac.at/~kreuzer/CY/palp/palp-${version}.tar.gz";
@@ -75,7 +77,7 @@ stdenv.mkDerivation rec {
       algorithms work in any dimension and our key routine for vertex and
       facet enumeration compares well with existing packages.
     '';
-    homepage = http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html;
+    homepage = "http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html";
     # Just a link on the website pointing to gpl -- now gplv3. When the last
     # version was released that pointed to gplv2 however, so thats probably
     # the right license.


### PR DESCRIPTION
###### Motivation for this change
should correlate with https://repology.org/project/palp/versions but instead fails during parsing:
```
2020-04-07 07:37:26   palp: ERROR: dropping, garbage name "palp-6d-2.1"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
