### PR TITLE
python3Packages.py3to2: fix metadata for repology

### DIFF
--- a/pkgs/development/python-modules/3to2/default.nix
+++ b/pkgs/development/python-modules/3to2/default.nix
@@ -5,12 +5,11 @@
 }:
 
 buildPythonPackage rec {
-  pname = "py3to2";
+  pname = "3to2";
   version = "1.1.1";
 
   src = fetchPypi {
-    inherit version;
-    pname = "3to2";
+    inherit version pname;
     extension = "zip";
     sha256 = "fef50b2b881ef743f269946e1090b77567b71bb9a9ce64b7f8e699b562ff685c";
   };
@@ -25,7 +24,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    homepage = https://bitbucket.org/amentajo/lib3to2;
+    homepage = "https://bitbucket.org/amentajo/lib3to2";
     description = "Refactors valid 3.x syntax into valid 2.x syntax, if a syntactical conversion is possible";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ mt-caret ];


### PR DESCRIPTION
###### Motivation for this change
fixing for repology, should point to https://repology.org/project/python:3to2/versions but instead:
 ```
2020-04-07 07:37:29   python27Packages.py3to2: ERROR: dropping python2.7-3to2-1.1.1, "3to2" does not belong to version
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
