### PR TITLE
chromium: 80.0.3987.163 -> 81.0.4044.92

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -149,9 +149,6 @@ let
       #
       # ++ optionals (channel == "dev") [ ( githubPatch "<patch>" "0000000000000000000000000000000000000000000000000000000000000000" ) ]
       # ++ optional (versionRange "68" "72") ( githubPatch "<patch>" "0000000000000000000000000000000000000000000000000000000000000000" )
-    ] ++ optionals (versionRange "80" "81.0.4044.56") [
-      # fix race condition in the interaction with pulseaudio
-      (githubPatch "704dc99bd05a94eb61202e6127df94ddfd571e85" "0nzwzfwliwl0959j35l0gn94sbsnkghs3dh1b9ka278gi7q4648z")
     ] ++ optionals (useVaapi) [
       # source: https://aur.archlinux.org/cgit/aur.git/tree/vaapi-fix.patch?h=chromium-vaapi
       ./patches/vaapi-fix.patch

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -11,8 +11,8 @@
     version = "83.0.4100.3";
   };
   stable = {
-    sha256 = "0ikk4cgz3jgjhyncsvlqvlc03y7jywjpa6v34fwsjxs88flyzpdn";
-    sha256bin64 = "1ks0i6vdxbmixnfz2b128yf9hsk5pm9x2j17nm3xg3245k0z22xr";
-    version = "80.0.3987.163";
+    sha256 = "0i0szd749ihb08rxnsmsbxq75b6x952wpk94jwc0ncv6gb83zkx2";
+    sha256bin64 = "1ig899cpahw1xfhdff5xj6w4k8jja5smxvrcbw6b0jcjmawdrf72";
+    version = "81.0.4044.92";
   };
 }


### PR DESCRIPTION
https://chromereleases.googleblog.com/2020/04/stable-channel-update-for-desktop_7.html

This update includes 32 security fixes.

CVEs:
CVE-2020-6454 CVE-2020-6423 CVE-2020-6455 CVE-2020-6430 CVE-2020-6456
CVE-2020-6431 CVE-2020-6432 CVE-2020-6433 CVE-2020-6434 CVE-2020-6435
CVE-2020-6436 CVE-2020-6437 CVE-2020-6438 CVE-2020-6439 CVE-2020-6440
CVE-2020-6441 CVE-2020-6442 CVE-2020-6443 CVE-2020-6444 CVE-2020-6445
CVE-2020-6446 CVE-2020-6447 CVE-2020-6448

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Test status

| platform | attribute | status | tester |
| --- | --- | --- | --- |
| x86_64 | chromium | :heavy_check_mark: | @danielfullmer |
| x86_64 | nixosTests.chromium | :heavy_check_mark: | @danielfullmer  |
| x86_64 | google-chrome | :heavy_check_mark: | @primeos |
| aarch64 | chromium | :heavy_check_mark: | @thefloweringash |


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
