### PR TITLE
arcanist: bring back php with curl and json

### DIFF
--- a/pkgs/development/tools/misc/arcanist/default.nix
+++ b/pkgs/development/tools/misc/arcanist/default.nix
@@ -13,13 +13,14 @@ let
     rev = "21a1828ea06cf031e93082db8664d73efc88290a";
     sha256 = "05rq9l9z7446ks270viay57r5ibx702b5bnlf4ck529zc4abympx";
   };
+  php' = php.withExtensions (e: with e; [ curl json ]);
 in
 stdenv.mkDerivation {
   pname = "arcanist";
   version = "20200127";
 
   src = [ arcanist libphutil ];
-  buildInputs = [ php makeWrapper flex ];
+  buildInputs = [ php' makeWrapper flex ];
 
   unpackPhase = ''
     cp -aR ${libphutil} libphutil
@@ -45,7 +46,7 @@ stdenv.mkDerivation {
 
     ln -s $out/libexec/arcanist/bin/arc $out/bin
     wrapProgram $out/bin/arc \
-      --prefix PATH : "${php}/bin"
+      --prefix PATH : "${php'}/bin"
   '';
 
   meta = {


### PR DESCRIPTION
arcanist needs this these two extensions to work.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
