### PR TITLE
kwallet-pam: just provide plugin path for qtbase

### DIFF
--- a/pkgs/desktops/plasma-5/kwallet-pam.nix
+++ b/pkgs/desktops/plasma-5/kwallet-pam.nix
@@ -7,8 +7,15 @@ mkDerivation {
   postPatch = ''
     sed -i pam_kwallet_init -e "s|socat|${lib.getBin socat}/bin/socat|"
   '';
+
+  # We get a crash when QT_PLUGIN_PATH is more than 1000 characters.
+  # pam_kwallet_init passes its environment to kwalletd5, but
+  # wrapQtApps gives our environment a huge QT_PLUGIN_PATH value. We
+  # are able to unset it here since kwalletd5 will have its own
+  # QT_PLUGIN_PATH.
   postFixup = ''
-    wrapQtApp $out/libexec/pam_kwallet_init
+    wrapProgram $out/libexec/pam_kwallet_init --unset QT_PLUGIN_PATH
   '';
+
   dontWrapQtApps = true;
 }


### PR DESCRIPTION
kwallet sets a limit of 1000 for a single characters for environment
variables read from the socket[[1]]. wrapQtApps gives us a huge value
for QT_PLUGIN_PATH (up to 13000 bytes on my system!) Since this was
overflowing, the Qt plugin loading mechanism was hitting a segfault
when it was trying to parse the truncated QT_PLUGIN_PATH.

So for now, we can just unset QT_PLUGIN_PATH in the pam_kwallet_init
script. kwalletd5 has its own QT_PLUGIN_PATH which it can use.

This problem occured on 20.03, but not 19.09. It’s unclear what
changes were made in that time, but likely that previously we weren’t
getting a QT_PLUGIN_PATH set in the plasma5 startup at all. This means
that in 19.09 our QT_PLUGIN_PATH value must have been small enough to
fit into the 1000 char limit.

Fixes #77290

[1]: https://github.com/KDE/kwallet/blob/bc9713e2725ab1c4311866f751c674a38584bd92/src/runtime/kwalletd/main.cpp#L44

/cc @ttuegel
