### PR TITLE
ocamlPackages.dns-client: init at 4.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/dns/client.nix
+++ b/pkgs/development/ocaml-modules/dns/client.nix
@@ -1,0 +1,12 @@
+{ lib, buildDunePackage, dns, ocaml_lwt, mirage-clock, mirage-random, mirage-stack, mtime, randomconv }:
+
+buildDunePackage {
+  pname = "dns-client";
+  inherit (dns) src version;
+
+  propagatedBuildInputs = [ dns mtime ocaml_lwt mirage-clock mirage-random mirage-stack randomconv ];
+
+  meta = dns.meta // {
+    description = "Pure DNS resolver API";
+  };
+}

--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildDunePackage, fetchurl, alcotest
+, cstruct, domain-name, duration, gmap, ipaddr, logs, lru, metrics, ptime, rresult
+}:
+
+buildDunePackage rec {
+  pname = "dns";
+  version = "4.4.1";
+
+  minimumOCamlVersion = "4.07";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-v${version}.tbz";
+    sha256 = "18c09jf0kicv2xz40n367y774rg8qs07rr1vdk8bx8f7hnaa9cn8";
+  };
+
+  propagatedBuildInputs = [ cstruct domain-name duration gmap ipaddr logs lru metrics ptime rresult ];
+
+  doCheck = true;
+  checkInputs = lib.optional doCheck alcotest;
+
+  meta = {
+    description = "An Domain Name System (DNS) library";
+    homepage = "https://github.com/mirage/ocaml-dns";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/duration/default.nix
+++ b/pkgs/development/ocaml-modules/duration/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, fetchurl, alcotest }:
+
+buildDunePackage rec {
+  pname = "duration";
+  version = "0.1.3";
+
+  src = fetchurl {
+    url = "https://github.com/hannesm/duration/releases/download/${version}/duration-${version}.tbz";
+    sha256 = "0m9r0ayhpl98g9vdxrbjdcllns274jilic5v8xj1x7dphw21p95h";
+  };
+
+  doCheck = true;
+  checkInputs = lib.optional doCheck alcotest;
+
+  meta = {
+    homepage = "https://github.com/hannesm/duration";
+    description = "Conversions to various time units";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/mirage-clock/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-clock/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, fetchurl }:
+
+buildDunePackage rec {
+  pname = "mirage-clock";
+  version = "3.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-clock/releases/download/v${version}/mirage-clock-v${version}.tbz";
+    sha256 = "12m2dph69r843clrbcgfjj2gcxmq2kdb7g5d91kfj16g13b0vsa3";
+  };
+
+  meta = {
+    description = "Libraries and module types for portable clocks";
+    homepage = "https://github.com/mirage/mirage-clock";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}
+
+

--- a/pkgs/development/ocaml-modules/mirage-device/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-device/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, fetchurl, fmt, ocaml_lwt }:
+
+buildDunePackage rec {
+  pname = "mirage-device";
+  version = "2.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-device/releases/download/v${version}/mirage-device-v${version}.tbz";
+    sha256 = "18alxyi6wlxqvb4lajjlbdfkgcajsmklxi9xqmpcz07j51knqa04";
+  };
+
+  propagatedBuildInputs = [ fmt ocaml_lwt ];
+
+  meta = {
+    description = "Abstract devices for MirageOS";
+    homepage = "https://github.com/mirage/mirage-device";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}
+
+

--- a/pkgs/development/ocaml-modules/mirage-flow/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, fetchurl, cstruct, fmt, ocaml_lwt }:
+
+buildDunePackage rec {
+  pname = "mirage-flow";
+  version = "2.0.1";
+
+  minimumOCamlVersion = "4.05";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-flow/releases/download/v${version}/mirage-flow-v${version}.tbz";
+    sha256 = "13v05x34six0z6bc2is8qhvbxk4knxh80ardi5x4rl738vlq3mn9";
+  };
+
+  propagatedBuildInputs = [ cstruct fmt ocaml_lwt ];
+
+  meta = {
+    description = "Flow implementations and combinators for MirageOS";
+    homepage = "https://github.com/mirage/mirage-flow";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}
+
+

--- a/pkgs/development/ocaml-modules/mirage-protocols/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-protocols/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, fetchurl, duration, ipaddr, mirage-device, mirage-flow }:
+
+buildDunePackage rec {
+  pname = "mirage-protocols";
+  version = "4.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-protocols/releases/download/v${version}/mirage-protocols-v${version}.tbz";
+    sha256 = "188m8x6xdw1bllwrpa8f8bqbdqy20kjfk7q8p8jf8j0daf7kl3mi";
+  };
+
+  propagatedBuildInputs = [ duration ipaddr mirage-device mirage-flow ];
+
+  meta = {
+    description = "MirageOS signatures for network protocols";
+    homepage = "https://github.com/mirage/mirage-protocols";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}
+
+

--- a/pkgs/development/ocaml-modules/mirage-random/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-random/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, fetchurl, cstruct }:
+
+buildDunePackage rec {
+  pname = "mirage-random";
+  version = "2.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-random/releases/download/v${version}/mirage-random-v${version}.tbz";
+    sha256 = "0qj41d5smkkkbjwsnz71bhhj94d2cwv53rf3j4rhky0pqbkidnv1";
+  };
+
+  propagatedBuildInputs = [ cstruct ];
+
+  meta = {
+    description = "Random signatures for MirageOS";
+    homepage = "https://github.com/mirage/mirage-random";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-stack/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-stack/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildDunePackage, fetchurl, mirage-protocols }:
+
+buildDunePackage rec {
+  pname = "mirage-stack";
+  version = "2.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-stack/releases/download/v${version}/mirage-stack-v${version}.tbz";
+    sha256 = "1xdy59bxnki1r0jwm3s8fwarhhbxr0lsqqiag5b1j41hciiqp9jq";
+  };
+
+  propagatedBuildInputs = [ mirage-protocols ];
+
+  meta = {
+    description = "MirageOS signatures for network stacks";
+    homepage = "https://github.com/mirage/mirage-stack";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}
+

--- a/pkgs/development/ocaml-modules/randomconv/default.nix
+++ b/pkgs/development/ocaml-modules/randomconv/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildDunePackage, fetchurl, cstruct }:
+
+buildDunePackage rec {
+  pname = "randomconv";
+  version = "0.1.3";
+
+  src = fetchurl {
+    url = "https://github.com/hannesm/randomconv/releases/download/v${version}/randomconv-v${version}.tbz";
+    sha256 = "1iv3r0s5kqxs893b0d55f0r62k777haiahfkkvvfbqwgqsm6la4v";
+  };
+
+  propagatedBuildInputs = [ cstruct ];
+
+  meta = {
+    homepage = "https://github.com/hannesm/randomconv";
+    description = "Convert from random bytes to random native numbers";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -234,6 +234,8 @@ let
 
     dune-private-libs = callPackage ../development/ocaml-modules/dune-private-libs { };
 
+    duration =  callPackage ../development/ocaml-modules/duration { };
+
     earley = callPackage ../development/ocaml-modules/earley { };
 
     earlybird = callPackage ../development/ocaml-modules/earlybird { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -216,6 +216,8 @@ let
 
     dns =  callPackage ../development/ocaml-modules/dns { };
 
+    dns-client =  callPackage ../development/ocaml-modules/dns/client.nix { };
+
     dolmen =  callPackage ../development/ocaml-modules/dolmen { };
 
     dolog = callPackage ../development/ocaml-modules/dolog { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -829,6 +829,8 @@ let
 
     qtest = callPackage ../development/ocaml-modules/qtest { };
 
+    randomconv = callPackage ../development/ocaml-modules/randomconv { };
+
     re = callPackage ../development/ocaml-modules/re { };
 
     react = callPackage ../development/ocaml-modules/react { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -544,6 +544,8 @@ let
 
     mirage-random = callPackage ../development/ocaml-modules/mirage-random { };
 
+    mirage-stack = callPackage ../development/ocaml-modules/mirage-stack { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -214,6 +214,8 @@ let
 
     dispatch =  callPackage ../development/ocaml-modules/dispatch { };
 
+    dns =  callPackage ../development/ocaml-modules/dns { };
+
     dolmen =  callPackage ../development/ocaml-modules/dolmen { };
 
     dolog = callPackage ../development/ocaml-modules/dolog { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -534,6 +534,8 @@ let
 
     minisat = callPackage ../development/ocaml-modules/minisat { };
 
+    mirage-clock = callPackage ../development/ocaml-modules/mirage-clock { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -542,6 +542,8 @@ let
 
     mirage-protocols = callPackage ../development/ocaml-modules/mirage-protocols { };
 
+    mirage-random = callPackage ../development/ocaml-modules/mirage-random { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -536,6 +536,8 @@ let
 
     mirage-clock = callPackage ../development/ocaml-modules/mirage-clock { };
 
+    mirage-device = callPackage ../development/ocaml-modules/mirage-device { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -538,6 +538,8 @@ let
 
     mirage-device = callPackage ../development/ocaml-modules/mirage-device { };
 
+    mirage-flow = callPackage ../development/ocaml-modules/mirage-flow { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -540,6 +540,8 @@ let
 
     mirage-flow = callPackage ../development/ocaml-modules/mirage-flow { };
 
+    mirage-protocols = callPackage ../development/ocaml-modules/mirage-protocols { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };


### PR DESCRIPTION
###### Motivation for this change

dns-client is a needed to update jackline

This PR also adds the dependencies of dns-client

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
