### PR TITLE
k3s: fix build for aarch64

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -1,6 +1,22 @@
-{ stdenv, lib, makeWrapper, socat, iptables, iproute, bridge-utils
-, conntrack-tools, buildGoPackage, git, runc, libseccomp, pkgconfig
-, ethtool, utillinux, ipset, fetchFromGitHub, fetchurl, fetchzip
+{ stdenv
+, lib
+, makeWrapper
+, socat
+, iptables
+, iproute
+, bridge-utils
+, conntrack-tools
+, buildGoPackage
+, git
+, runc
+, libseccomp
+, pkgconfig
+, ethtool
+, utillinux
+, ipset
+, fetchFromGitHub
+, fetchurl
+, fetchzip
 , fetchgit
 }:
 
@@ -47,7 +63,7 @@ let
     # Note: marked as apache 2.0 license
     url = "https://github.com/rancher/k3s-root/releases/download/v${k3sRootVersion}/k3s-root-amd64.tar";
     sha256 = "12xafn5jivl8lqdcs25b28xrc4mf7yf1xif5np169nvvxgvmpdxp";
-    stripRoot=false;
+    stripRoot = false;
   };
   k3sPlugins = buildGoPackage rec {
     name = "k3s-cni-plugins";
@@ -153,6 +169,12 @@ let
     nativeBuildInputs = [ git pkgconfig ];
     buildInputs = [ k3sBuildStage1 k3sPlugins runc ];
 
+    # k3s appends a suffix to the final distribution binary for some arches
+    archSuffix =
+      if stdenv.hostPlatform.system == "x86_64-linux" then ""
+      else if stdenv.hostPlatform.system == "aarch64-linux" then "-arm64"
+      else throw "k3s isn't being built for ${stdenv.hostPlatform.system} yet.";
+
     # In order to build the thick k3s binary (which is what
     # ./scripts/package-cli does), we need to get all the binaries that script
     # expects in place.
@@ -182,7 +204,7 @@ let
       pushd go/src/${goPackagePath}
 
       mkdir -p "$out/bin"
-      install -m 0755 -t "$out/bin" ./dist/artifacts/k3s
+      install -m 0755 -T ./dist/artifacts/k3s${archSuffix} "$out/bin/k3s"
 
       popd
     '';
@@ -202,12 +224,20 @@ stdenv.mkDerivation rec {
   # Important utilities used by  the kubelet, see
   # https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-237202494
   # Note the list in that issue is stale and some aren't relevant for k3s.
-  k3sRuntimeDeps = [ 
-    socat iptables iproute bridge-utils ethtool utillinux ipset conntrack-tools
+  k3sRuntimeDeps = [
+    socat
+    iptables
+    iproute
+    bridge-utils
+    ethtool
+    utillinux
+    ipset
+    conntrack-tools
   ];
 
-  buildInputs = [ 
-    k3sBuild makeWrapper
+  buildInputs = [
+    k3sBuild
+    makeWrapper
   ] ++ k3sRuntimeDeps;
 
   unpackPhase = "true";
@@ -225,11 +255,11 @@ stdenv.mkDerivation rec {
       --prefix PATH : "$out/bin"
   '';
 
-    meta = {
-      description = "A lightweight Kubernetes distribution.";
-      license = licenses.asl20;
-      homepage = "https://k3s.io";
-      maintainers = [ maintainers.euank ];
-      platforms = platforms.linux;
-    };
+  meta = {
+    description = "A lightweight Kubernetes distribution.";
+    license = licenses.asl20;
+    homepage = "https://k3s.io";
+    maintainers = [ maintainers.euank ];
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/applications/networking/cluster/k3s/patches/00-k3s.patch
+++ b/pkgs/applications/networking/cluster/k3s/patches/00-k3s.patch
@@ -55,10 +55,17 @@ index 72d3c07ece..3e5455b262 100755
  echo Building containerd-shim
  make -C ./vendor/github.com/containerd/containerd bin/containerd-shim
 diff --git a/scripts/package-cli b/scripts/package-cli
-index 4c66ce32df..6d1e0c03cb 100755
+index 4c66ce32df..280b428bb8 100755
 --- a/scripts/package-cli
 +++ b/scripts/package-cli
-@@ -55,10 +55,10 @@ LDFLAGS="
+@@ -49,16 +49,16 @@ fi
+ 
+ CMD_NAME=dist/artifacts/k3s${BIN_SUFFIX}
+ 
+-go generate
++CGO_ENABLED=0 env -u GOARCH go generate
+ LDFLAGS="
+     -X github.com/rancher/k3s/pkg/version.Version=$VERSION
      -X github.com/rancher/k3s/pkg/version.GitCommit=${COMMIT:0:8}
      -w -s
  "


### PR DESCRIPTION
The upstream project already builds and releases for aarch64. This makes
the couple small tweaks that I found necessary for the nix package to also cross-compile
for aarch64.

###### Things done

I cross-compiled on an x86_64 nixos machine with `nix-build  --arg crossSystem '(import <nixpkgs/lib>).systems.examples.aarch64-multiplatform' -A k3s`

I did not verify that the resulting binary runs, but I'm quite optimistic it should!

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
