### PR TITLE
Gnome 3.36.1

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -39,11 +39,11 @@
 
 stdenv.mkDerivation rec {
   pname = "shotwell";
-  version = "0.31.0";
+  version = "0.31.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1pwq953wl7h9cvw7rvlr6pcbq9w28kkr7ddb8x2si81ngp0imwyx";
+    sha256 = "0mbgrad4d4snffw2z3rkhwqq1bkxdgy52pblx99vjadvpgspb034";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -35,13 +35,13 @@
 
 buildPythonApplication rec {
   pname = "orca";
-  version = "3.36.0";
+  version = "3.36.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0yrkl0j1mm4fd5zib8jvbfgm2iyanlx05vhhnmjcmvpm464c7pf9";
+    sha256 = "07w3k0f791zd1pj9j6d27k7gk7c6hx112ngrdz18h573df5n9b61";
   };
 
   patches = [

--- a/pkgs/data/documentation/gnome-user-docs/default.nix
+++ b/pkgs/data/documentation/gnome-user-docs/default.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-user-docs";
-  version = "3.34.1";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-docs/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "11m9fv8k2hynrcgah4jvbm6yczg0s1ly302mipysbwpn6gbdkvf2";
+    sha256 = "0vnwya5g7fg0jhdrg9drxnx83lhk8qa2nvcrmd1sdfanlz4qfhjf";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/apps/evolution/default.nix
@@ -43,11 +43,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0ylqvg52s6vc9xmyizcv3im66ra8xixzrfgn7hsmp12fg47na5vj";
+    sha256 = "1f3cwc05gw75yqficcxns95r96lv7an4aih6d7hng3n3pqfwyfl7";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome-3/apps/file-roller/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "file-roller";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/file-roller/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0y04y58sbggsgqzmxkb6q7300bdzf30w40yp57n87x9nypl4s55r";
+    sha256 = "0p22jxcagamvp08xfglz4cz1sp8w4p101npw0ggrkhh7vm8yb9bh";
   };
 
   LANG = "en_US.UTF-8"; # postinstall.py

--- a/pkgs/desktops/gnome-3/apps/gedit/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gedit/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gedit";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gedit/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0dclapyghbkg15cjcf6nljcyy4980ipjw1m3mbqpmnz9lh9dv0y9";
+    sha256 = "11z3lhc5i3z0gqw0qmprsm4rmvhbbm4gz6wy0f73c73x4bd8xhvd";
   };
 
   nativeBuildInputs = [
@@ -49,6 +49,6 @@ stdenv.mkDerivation rec {
     description = "Official text editor of the GNOME desktop environment";
     maintainers = gnome3.maintainers;
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -51,11 +51,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-boxes";
-  version = "3.36.0";
+  version = "3.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-boxes/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0saxz2mwp7y348izzgp7mmp6vnv5zi57x5rbsyag8s7pd7yp211n";
+    sha256 = "01hjlz9hljk2skrwfqxpy3934wjs6figs71sw8bm8g2vnyaqwq7a";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-getting-started-docs/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-getting-started-docs/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-getting-started-docs";
-  version = "3.34.1";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-getting-started-docs/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "00in6yc02pdalyx8g0fncmch0l7nr819587ngjm83ara9qa8z6fa";
+    sha256 = "09bf9r6brmll14z87ljgivw0nr0nggcgjpbx6lg2835zq36vfmi9";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "gnome-maps";
-  version = "3.36.0";
+  version = "3.36.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0kyd4f15bj409mhs97i94ggzwqdj3r3yjdmvvkn80pym0vw1xik5";
+    sha256 = "1yajq2pxd4fbzngwhn92h55rn02psxih8bbdcdxgg66qdbcyychs";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
@@ -30,13 +30,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "3.36.0";
+  version = "3.36.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "01vjcaabd5m8vmicax7vaybsaml3wik4r85g4q8avdkzs8h4gz9h";
+    sha256 = "0cn33r9v2raizq1b8s7s0kb506y91iarc0knm0sljcsqs4qgd03v";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/gnome-notes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-notes/default.nix
@@ -23,7 +23,7 @@
 }:
 
 let
-  version = "3.36.0";
+  version = "3.36.1";
 in
 stdenv.mkDerivation {
   pname = "gnome-notes";
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://gnome/sources/bijiben/${stdenv.lib.versions.majorMinor version}/bijiben-${version}.tar.xz";
-    sha256 = "1pz53hdd888si7vfy6d9h8cwarsdm4wwn7ni7f3az9638h3ilmfv";
+    sha256 = "0421g9czdahk2w2kv7zg4gd9b4q8g1hl483jsfrxy5y7saincbr1";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-weather";
-  version = "3.34.0";
+  version = "3.36.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-weather/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1g63xzs17i36if923b36k9fwbk0nqa5vz6zh1k6q2axrzhhpx1i4";
+    sha256 = "15ahfgqj0rz16y2bdxb7sa4b3b3larg8hn3b41pc5ddnwf9x63zi";
   };
 
   nativeBuildInputs = [ pkgconfig meson ninja wrapGAppsHook python3 ];

--- a/pkgs/desktops/gnome-3/apps/polari/default.nix
+++ b/pkgs/desktops/gnome-3/apps/polari/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "polari";
-  version = "3.36.0";
+  version = "3.36.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0wi7bpscm4rghlwljilsgrls5dy9p0b27k246a1vrdadjghc69l4";
+    sha256 = "1rmmq74g22qrmsg0mjvpzk5403kkpfw0iznvnwxfqbi0dfkamhn4";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/eog/default.nix
+++ b/pkgs/desktops/gnome-3/core/eog/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "eog";
-  version = "3.36.0";
+  version = "3.36.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0gnfpjp3ldvcij557dga4skj4ykb2idkyif7n1d758x42z2hh0s0";
+    sha256 = "15cwghcbx9x1xmv1dwmwcdxplnhf25w6f4dhx8hk6fjymaks2m74";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook libxml2 gobject-introspection python3 ];

--- a/pkgs/desktops/gnome-3/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome-3/core/epiphany/default.nix
@@ -3,7 +3,6 @@
 , ninja
 , gettext
 , fetchurl
-, fetchpatch
 , pkgconfig
 , gtk3
 , glib
@@ -36,21 +35,12 @@
 
 stdenv.mkDerivation rec {
   pname = "epiphany";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/epiphany/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1xjn6jk4dx2kl2llalydcyvibnpwjahp9z3210pflyy4k68pfw6l";
+    sha256 = "1dpgp1fqkn6azdrkw9imbrxi5d6mznrhfisrsiv88cf68gxk7wpn";
   };
-
-  patches = [
-    # Fix downloading files
-    # https://gitlab.gnome.org/GNOME/epiphany/issues/1127
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/epiphany/commit/8682a084bab7e758a9b8efe1deaf0cb8d55fcf44.patch";
-      sha256 = "bep+Q8Wpu84KA13a5T3JCz8nyeC13HT/QkMKvWT6vLk=";
-    })
-  ];
 
   # Tests need an X display
   mesonFlags = [

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.36.0";
+  version = "3.36.1";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1v4qjnggpwvafyqnkl1avsi3mpfxpcaz7kwxcf2iz7pvb1k0xmyl";
+    sha256 = "15k7k225jfv5a45hmjk94xq90np2r9f5v8yj0xi3166vvlp2n4hk";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/gnome-bluetooth/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-bluetooth/default.nix
@@ -6,14 +6,14 @@ let
   pname = "gnome-bluetooth";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "3.34.0";
+  version = "3.34.1";
 
   # TODO: split out "lib"
   outputs = [ "out" "dev" "devdoc" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1bvbxcsjkyl0givy8nfm7112bq3c0vn1v89fdk2pip714dsfcrz8";
+    sha256 = "11nk8nvz5yrbx7wp75vsiaf4rniv7ik2g3nwmgwx2b42q9v11j9y";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
@@ -1,21 +1,54 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, itstool, desktop-file-utils, gnome3, glib, gtk3, libexif, libtiff, colord, colord-gtk, libcanberra-gtk3, lcms2, vte, exiv2 }:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, gettext
+, itstool
+, desktop-file-utils
+, gnome3
+, glib
+, gtk3
+, libexif
+, libtiff
+, colord
+, colord-gtk
+, libcanberra-gtk3
+, lcms2
+, vte
+, exiv2
+}:
 
-let
+stdenv.mkDerivation rec {
   pname = "gnome-color-manager";
   version = "3.32.0";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1vpxa2zjz3lkq9ldjg0fl65db9s6b4kcs8nyaqfz3jygma7ifg3w";
   };
 
   nativeBuildInputs = [
-    meson ninja pkgconfig gettext itstool desktop-file-utils
+    meson
+    ninja
+    pkgconfig
+    gettext
+    itstool
+    desktop-file-utils
   ];
 
-  buildInputs = [ glib gtk3 libexif libtiff colord colord-gtk libcanberra-gtk3 lcms2 vte exiv2 ];
+  buildInputs = [
+    glib
+    gtk3
+    libexif
+    libtiff
+    colord
+    colord-gtk
+    libcanberra-gtk3
+    lcms2
+    vte
+    exiv2
+  ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -68,11 +68,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-control-center";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0gdadbkynldxqffdlw760039ci1vv9wsi5i0mdq4q9dblmb79q1b";
+    sha256 = "1466swjyw5vjym001qda94x6sisd4xhpyb6vq91grhkyzwf2vqzk";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-desktop";
-  version = "3.36.0";
+  version = "3.36.1";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-desktop/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "05awmswzd4qa0vg23np0s7z6qks73j3sfj71y8azpvyxricw612b";
+    sha256 = "1058h1ndl6pmlh8rmbqq5lw15glws3anin88cm7lw4vzasgfavwc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-disk-utility";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-disk-utility/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "00xi9m8vklwska1k3sdcfyba3mhwx7clrh522dgksn7v0ja9l1zl";
+    sha256 = "055l29z99f4ybgf2plz3biz1bwhlpsjpr0zk3aa6vg5w67r1h6vr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-initial-setup/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-initial-setup/default.nix
@@ -36,11 +36,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-initial-setup";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "08di7n26qhjfr0p1dvya2xfqwx37k8xbya97a8ccz3j0fzw0my4a";
+    sha256 = "1sfn6bdz8snc2qmi3nzb07vlkdhy9s1ipwxxj0v2i36a7n0gv6ci";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-terminal";
-  version = "3.36.0.1";
+  version = "3.36.1.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-terminal/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1qj0zggig6iwahjvj9wcqpf9xj6aw6ar5pgnmrhbhc90cb7c2ccb";
+    sha256 = "0xm3g3kanfhs1q3xh3x58r55v8906806wvqjbg4c2xvdwyhhimzk";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome-3/core/nautilus/default.nix
@@ -32,11 +32,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nautilus";
-  version = "3.36.0";
+  version = "3.36.1.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1pynxxcpk4idp4fmsdgv5qwvaw0l93r68b5pks372fhjff4qcjr6";
+    sha256 = "1pkvxyfm2fl06fpyq2jr147hhpc91y4rgdlxlilg7n8ih982y9gr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/simple-scan/default.nix
+++ b/pkgs/desktops/gnome-3/core/simple-scan/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "simple-scan";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/simple-scan/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "198l3yhqhb2wzfdcgi8fzbwycr0njn44583dazz6wy1gqbiqnzgm";
+    sha256 = "0bprm9gfnlrs0k8jvy9pqm1rjq47z5pgahqjjj1i7q2k4a8g09vl";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "devhelp";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/devhelp/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0d2fvd7p08qfv21cxpjl3rh5cl0bzk3fj2msvyz49fqmc69k5z93";
+    sha256 = "0gcakbq2fci6cf5z8lakydqnynasp74djfy53bh7jjmw0a9yry2c";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/games/five-or-more/default.nix
+++ b/pkgs/desktops/gnome-3/games/five-or-more/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "five-or-more";
-  version = "3.32.1";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/five-or-more/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0xw05dd2dwi9vsph9h158b4n89s5k07xrh6bjz1icm0pdmjwhpgk";
+    sha256 = "19pf8wzbf3ciqf2k4bj9sddvyhckfd62x86pnqr6s8h4vn9jc6ii";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/games/gnome-robots/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-robots/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-robots";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-robots/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "10l7dlbqa2f0z6g76r9n87pc1zm11qmxsmfp3908v9g5lf11vzrs";
+    sha256 = "0qmdwrl70ccs3blgwmpcf3sg9k8mcvsl1dr1gds4ba3fq9ca8ipb";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/games/tali/default.nix
+++ b/pkgs/desktops/gnome-3/games/tali/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "tali";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/tali/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0knq2vwnbkzhb6yc0f8iznaz76yf5hwgg2z2xr079nz407p46v22";
+    sha256 = "1klnxk49rr1m2lr4zj1wvfl0iaxzdh2k8ngrcmfmcq39vlxnn94y";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "geary";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "jiaq+dwdARLaSnttY2chwJrclFjxrukuk80yT0LgvfY=";
+    sha256 = "07rhmzznfa4asx5gbmvnfpybd5czy7xmzk75xrk4r1qcnr24ml03";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/gnome-applets/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-applets/default.nix
@@ -24,13 +24,13 @@
 
 let
   pname = "gnome-applets";
-  version = "3.36.0";
+  version = "3.36.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "096n0ji478hfdrbi8illsyvdsgxznxfayr826pr9jdgzg1s0x9xs";
+    sha256 = "1hlblnajjkvlcd45lxfdxscx7j51nwyvri5jci6ylgpaxlwwm1s8";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , autoreconfHook
 , fetchurl
-, fetchpatch
 , gettext
 , glib
 , gnome-bluetooth
@@ -31,7 +30,7 @@
 
 let
   pname = "gnome-flashback";
-  version = "3.36.0";
+  version = "3.36.1";
 
   # From data/sessions/Makefile.am
   requiredComponentsCommon = [
@@ -62,32 +61,8 @@ let
 
     src = fetchurl {
       url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-      sha256 = "qwlTFs4wn6PpB7uZkpvnmECsSTa62OQMpgiIXoZoMRk=";
+      sha256 = "16gknn5mj29i8svlncarj92qi0swdlziggxpg9rryqslsy896a2x";
     };
-
-    patches = [
-      # Fix locking screen from log out dialogue
-      # https://gitlab.gnome.org/GNOME/gnome-flashback/issues/43
-      (fetchpatch {
-        url = "https://gitlab.gnome.org/GNOME/gnome-flashback/-/commit/7b151e0a947e4b49e1cee80097c1f8946ba46af9.patch";
-        sha256 = "pJcJb6EGlInlWpLbbBajWydBtbiWK3AMHzsFQ26bmwA=";
-      })
-
-      # Hide GNOME Shell Extensions manager from menu
-      # https://gitlab.gnome.org/GNOME/gnome-flashback/issues/42
-      (fetchpatch {
-        url = "https://gitlab.gnome.org/GNOME/gnome-flashback/-/commit/75f95379779c24d42d1e72cdcd4c16a9c6db7657.patch";
-        sha256 = "cwKZSQTFi0f/T1Ld6vJceQFHBsikOhkp//J1IY5aMKA=";
-      })
-      (fetchpatch {
-        url = "https://gitlab.gnome.org/GNOME/gnome-flashback/-/commit/12cacf25b1190d9c9bba42f085e54895de7a076e.patch";
-        sha256 = "mx37kLs3x/e9RJCGN6z8/7b5Tz6yzxeN/14NFi8IWfA=";
-      })
-      (fetchpatch {
-        url = "https://gitlab.gnome.org/GNOME/gnome-flashback/-/commit/7954376f32348028a3bdba0ea182b0000c4fcb0a.patch";
-        sha256 = "ZEQcg9OoIOIMh/yUYQ9R1Ky8DElteaDQrSdwFtA4Yno=";
-      })
-    ];
 
     # make .desktop Execs absolute
     postPatch = ''

--- a/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
@@ -22,7 +22,7 @@
 
 let
   pname = "gnome-panel";
-  version = "3.36.0";
+  version = "3.36.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "08x0xjrg36h6x5c68w5jf8gg57767p2m3ljgzyglx2ij0nfbpc8d";
+    sha256 = "1lxba8syy9gb50zxdk13gr1f62dfphwbb7njg6p26x9rvlkbf88y";
   };
 
   # make .desktop Exec absolute

--- a/pkgs/desktops/gnome-3/misc/libgnome-games-support/default.nix
+++ b/pkgs/desktops/gnome-3/misc/libgnome-games-support/default.nix
@@ -3,13 +3,13 @@
 
 let
   pname = "libgnome-games-support";
-  version = "1.6.0.1";
+  version = "1.6.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0xifkj5dg4n3cy0hi76zy1ixyssxxpgy4yi4li7iq39cqbnkc9d8";
+    sha256 = "1gq8p38k92lsr6dbav6pgmw0adnzzhcs06jqdkr37p145vv6ls7v";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext vala ];

--- a/pkgs/desktops/gnome-3/misc/metacity/default.nix
+++ b/pkgs/desktops/gnome-3/misc/metacity/default.nix
@@ -16,13 +16,13 @@
 
 let
   pname = "metacity";
-  version = "3.36.0";
+  version = "3.36.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1a06763x9hshymmq36w7c588q4rbzq0w5rkyam5l6yi8p75ic016";
+    sha256 = "08xkq5i6czvms0ygbj7ywzl70q1l0z44nfh6b43q8rmjwa9pdw0i";
   };
 
   patches = [

--- a/pkgs/development/libraries/clutter/default.nix
+++ b/pkgs/development/libraries/clutter/default.nix
@@ -5,14 +5,14 @@
 
 let
   pname = "clutter";
-  version = "1.26.2";
+  version = "1.26.4";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0mif1qnrpkgxi43h7pimim6w6zwywa16ixcliw0yjm9hk0a368z7";
+    sha256 = "1rn4cd1an6a9dfda884aqpcwcgq8dgydpqvb19nmagw4b70zlj4b";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/geocode-glib/default.nix
+++ b/pkgs/development/libraries/geocode-glib/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "geocode-glib";
-  version = "3.26.1";
+  version = "3.26.2";
 
   outputs = [ "out" "dev" "devdoc" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/geocode-glib/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "076ydfpyc4n5c9dbqmf26i4pilfi5jpw6cjcgrbgrjbndavnmajv";
+    sha256 = "1l8g0f13xgkrk335afr9w8k46mziwb2jnyhl07jccl5yl37q9zh1";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext gtk-doc docbook_xsl gobject-introspection ];

--- a/pkgs/development/libraries/gjs/default.nix
+++ b/pkgs/development/libraries/gjs/default.nix
@@ -28,11 +28,11 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "gjs";
-  version = "1.64.0";
+  version = "1.64.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0vynivp1d10jkxfcgb5vcjkba5dvi7amkm8axmyad7l4dfy4qf36";
+    sha256 = "0z4qx4s3174b1w5b0slnn6jwpy2c18s4fvx4xii2kflr7s4q7bsm";
   };
 
   outputs = [ "out" "dev" "installedTests" ];
@@ -69,29 +69,6 @@ in stdenv.mkDerivation rec {
   patches = [
     # Hard-code various paths
     ./fix-paths.patch
-
-    # Clean-ups to make installing installed tests separately easier.
-    # https://gitlab.gnome.org/GNOME/gjs/merge_requests/403
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gjs/commit/14bae0e2bc7e817f53f0dcd8ecd032f554d12e6f.patch";
-      sha256 = "4eaNl2ddRMlUfBoOUnRy10+RlQR4f/mDMhjQ2txmRcg=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gjs/commit/075f015d7980dc94fff48a1c4021cb50691dddb1.patch";
-      sha256 = "Iw0XfGiOUazDbpT5SqFx3UVvBRtNm3Fds1gCsdxKucw=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gjs/commit/5cfd2c2ffd2d8c002d40f658e1c54027dc5d8506.patch";
-      sha256 = "rJ5Je1zcfthIl7+hRoWw3cwzz/ZkS2rtjvFOQ8znBi8=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gjs/commit/1a81f40e8783fe97dd00f009eb0d9ad45297e831.patch";
-      sha256 = "+k4Xv3sJ//iDqkVTkO51IA7FPtWsS0P9YUVTWnIym4I=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gjs/commit/361a319789310292787d9c62665cef9e386a9b20.patch";
-      sha256 = "ofOP1OFs9q5nW9rE/2ovbwZR6gTrDDh8cczdYipoWNE=";
-    })
 
     # Allow installing installed tests to a separate output.
     ./installed-tests-path.patch

--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gtksourceview";
-  version = "4.4.0";
+  version = "4.6.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtksourceview/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "16k8kqw9w775f1ijsk898hp210an5mv4yfyrmik9m8khxx593nwx";
+    sha256 = "11csdnb5xj1gkn1shynp3jdsfhhi7ks3apgmavfan0p6n85f64sc";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -41,11 +41,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gvfs";
-  version = "1.44.0";
+  version = "1.44.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "165fa81v7b4ca6brsjxmhkv0r542f93204zvckhqsjswwsp6195w";
+    sha256 = "0ipv0jgzim6glsgizmfjkx0m3gd1l9lr242m0jj6cdmhs52k5vsh";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/libmanette/default.nix
+++ b/pkgs/development/libraries/libmanette/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libmanette";
-  version = "0.2.3";
+  version = "0.2.4";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1zxh7jn2zg7hivmal5zxam6fxvjsd1w6hlw0m2kysk76b8anbw60";
+    sha256 = "T+Ckvta0w65ySdNBAxwnsy+Nng/7UzfXHLzscWA2LPc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -32,7 +32,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "pipewire";
-  version = "0.3.1";
+  version = "0.3.2";
 
   outputs = [ "out" "lib" "dev" "doc" ];
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     owner = "pipewire";
     repo = "pipewire";
     rev = version;
-    sha256 = "DfUgXTSSCl+JszFEKwBha67nauQi4noR25m00auXDnA=";
+    sha256 = "U7lqvn2vMIxARNplzNX9H3Ztlfv1IH8LozJsq7JSEKs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/totem-pl-parser/default.nix
+++ b/pkgs/development/libraries/totem-pl-parser/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "totem-pl-parser";
-  version = "3.26.4";
+  version = "3.26.5";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1w34hdr09v3wy1cfvzhcmxc6b5p9ngcabgix59iv7hk739anymy1";
+    sha256 = "132jihnf51zs98yjkc6jxyqib4f3dawpjm17g4bj4j78y93dww2k";
   };
 
   passthru = {

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vte";
-  version = "0.60.0";
+  version = "0.60.1";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "06rs356lpyq60r3szhms152f7kj5jnki6a49b2w7ai0bnig9blbj";
+    sha256 = "1i7h1jvsg115l5djn29n06xsqvygpfagczxy0i9f39zq6dr809ay";
   };
 
   passthru = {

--- a/pkgs/development/python-modules/pyatspi/default.nix
+++ b/pkgs/development/python-modules/pyatspi/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "pyatspi";
-  version = "2.34.0";
+  version = "2.36.0";
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0j3f75j0zd6ca8msg7yr19qsfirqkn9fk8pqbjnlhqrpri455g4p";
+    sha256 = "UTbBv5GeEB1OyQGiduhupg5Ygaj/d2PjVvGYQOX/4d0=";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/networking/network-manager/openvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/openvpn/default.nix
@@ -1,26 +1,21 @@
 { stdenv, fetchurl, substituteAll, openvpn, intltool, libxml2, pkgconfig, file, networkmanager, libsecret
-, gtk3, withGnome ? true, gnome3, kmod, fetchpatch, libnma }:
+, gtk3, withGnome ? true, gnome3, kmod, libnma }:
 
 let
   pname = "NetworkManager-openvpn";
-  version = "1.8.10";
+  version = "1.8.12";
 in stdenv.mkDerivation {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1vri49yff4lj13dnzkpq9nx3a4z1bmbrv807r151plj8m1mwhg5g";
+    sha256 = "062kh4zj7jfbwy4zzcwpq2m457bzbpm3l18s0ysnw3mgia3siz8f";
   };
 
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
       inherit kmod openvpn;
-    })
-    # Don't use etc/dbus-1/system.d
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/NetworkManager-openvpn/merge_requests/13.patch";
-      sha256 = "06cvqi28v72dd53fw8ix95mqj885xhwi8qcs2q7hvm5bvnhwn704";
     })
   ];
 
@@ -30,7 +25,6 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ intltool pkgconfig file libxml2 ];
 
   configureFlags = [
-    "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"
     "--localstatedir=/" # needed for the management socket under /run/NetworkManager
     "--enable-absolute-paths"

--- a/pkgs/tools/text/gtranslator/default.nix
+++ b/pkgs/tools/text/gtranslator/default.nix
@@ -13,6 +13,7 @@
 , json-glib
 , gspell
 , glib
+, libdazzle
 , gtk3
 , gtksourceview4
 , gnome3
@@ -21,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gtranslator";
-  version = "3.34.0";
+  version = "3.36.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "05zvpx330h9k7b12p07bhcy47vq66260fmiph2b6h97xpl15rwmj";
+    sha256 = "LaodO1m0o171TfCHNFsD4XA+clCB+drFQ1OSKKcVrdM=";
   };
 
   nativeBuildInputs = [
@@ -42,6 +43,7 @@ stdenv.mkDerivation rec {
     libxml2
     glib
     gtk3
+    libdazzle
     gtksourceview4
     libgda
     libsoup


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Things from the 3.36.1 bump that can go straight to master (~250 rebuilds).

This excludes gnome-shell and mutter, as there's some complications with a new internal library with incorrect shared-library path in the typelib, causing the extension app to crash. 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
