### PR TITLE
Gnome 3.36.1 staging

### DIFF
--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -4,7 +4,7 @@
 
 let
   pname = "atk";
-  version = "2.35.1";
+  version = "2.36.0";
 in
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "111qajn7kxwmh40drc8i6jc3hnril2rp63n207q92pl47zx614xy";
+    sha256 = "1217cmmykjgkkim0zr1lv5j13733m4w5vipmy4ivw0ll6rz28xpv";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "glib-networking";
-  version = "2.64.0";
+  version = "2.64.1";
 
   outputs = [ "out" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1fm1462v7z556qivlwflvc3qpz36jwpzqxxvsihh45j7aka2gnjw";
+    sha256 = "0wmg5n2h0r1rcdmp4w48akqlsbpjrjrj6p59g5ylc5yqyzg4dhx4";
   };
 
   patches = [

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -10,11 +10,11 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "gobject-introspection";
-  version = "1.64.0";
+  version = "1.64.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "10pwykfnk7pw8k9k8iz3p72phxvyrh5q4d7gr3ysv08w15immh7a";
+    sha256 = "19vz7vp10h0zj3f491yk72dp89bix6rgkzxg4qcm4d6151ksxgl0";
   };
 
   outputs = [ "out" "dev" "man" ];

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -73,6 +73,21 @@ stdenv.mkDerivation rec {
 
     # https://gitlab.gnome.org/GNOME/gtk/merge_requests/1002
     ./patches/01-build-Fix-path-handling-in-pkgconfig.patch
+
+    # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/1634
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/79732da1ed8cb167440fb047c72cfc0d888a187b.patch";
+      sha256 = "1ynrx81dkwjfqhvg80q28qbb6jabg4x73fkbrnligzgkzimfjpx3";
+    })
+    # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/1633
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/12fc9a45efcbb546eb7de13c5c4d3183f2f5a3b8.patch";
+      sha256 = "00zrm77qk39p1hgn207az82cgvqiyp6is7dk0ssjxkc34403r78v";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/5a52af20cba76474e631b2a7548963bcad22d66d.patch";
+      sha256 = "0sbzzwa0si1w83m5abyf312f4w445wwlms53m5hb7kdgkjbhaa3f";
+    })
   ] ++ optionals stdenv.isDarwin [
     # X11 module requires <gio/gdesktopappinfo.h> which is not installed on Darwin
     # let’s drop that dependency in similar way to how other parts of the library do it

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -4,14 +4,14 @@
 
 let
   pname = "librsvg";
-  version = "2.48.0";
+  version = "2.48.2";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "19ndf9l99wcrmkwcrk20vd1ggrwgldksfz1kkj786ljcrxv8nd2a";
+    sha256 = "1jmxd03fs8vkwycxpmx69kdfmgq52g64bhv82gmj3kjgw2h5h9i7";
   };
 
   outputs = [ "out" "dev" "installedTests" ];

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libsecret";
-  version = "0.20.1";
+  version = "0.20.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0ir4ynpf8b64xss1azvsi5x6697lik7hkf3z0xxa2qv2xja3xxsp";
+    sha256 = "1hzz34gmsxxf1jm1b7qin390rkwbg8sx198xdkwxqp3q6cw19sc1";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Gnome 3.36.1 bump which needs to go to staging.

###### Things done

Running with these currently on my system.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

News:

```
247bddd3116917c00470c4da296f1c1c2fd38136: gobject-introspection: 1.64.0 -> 1.64.1
	(https://ftp.gnome.org/pub/GNOME/sources/gobject-introspection/1.64/gobject-introspection-1.64.1.news)
	1.64.1 - 2020-04-05
	-------------------
	
	* Replace calls to deprecated xml.etree.cElementTree removed in Python 3.9 :mr:`202` (:user:`Stephen Gallagher <sgallagher>`)
	* gimarshallingtests: Use g_assert_cmpfloat_with_epsilon. Fixes tests on some architectures :mr:`200` (:user:`Iain Lane <iainl>`)
	
	
	
29f47af27390a0ea5b6739515c315e5993bef55c: glib-networking: 2.64.0 -> 2.64.1
	(https://ftp.gnome.org/pub/GNOME/sources/glib-networking/2.64/glib-networking-2.64.1.news)
	2.64.1 - March 27, 2020
	=======================
	
	- Warn when server-identity property is missing (#130)
	- Fix crashes in debug logs (#131)
	- Fix write loop in OpenSSL backend (!117)
	
	
34a0147072498354d9ff5dfcdad74c6c2d498569: libsecret: 0.20.1 -> 0.20.2
	(https://ftp.gnome.org/pub/GNOME/sources/libsecret/0.20/libsecret-0.20.2.news)
	0.20.2
	 * secret-file-collection: force little-endian in GVariant [!49, #42]
	 * Prefer g_info() over g_message() [!48, #40]
	 * meson: Don't specify shared_library() [!47]
	 * docs: Make sure to set install: true [!46]
	
	
95abd75a5940e2e066bbe6ced2cdb9300a722607: librsvg: 2.48.0 -> 2.48.2
	(https://ftp.gnome.org/pub/GNOME/sources/librsvg/2.48/librsvg-2.48.1.news)
	Version 2.48.1
	
	- #129 - Fix baseline-shift for simple subscripts/superscripts and
	  absolute offsets.  This should fix a lot of Wikimedia images with
	  formulas.
	
	- #548 - Support images with data: URLs that don't have a MIME-type.
	  This fixes some Open Clip Art images generated by old versions
	  of Adobe Illustrator.
	
	- Fix build of the test suite on Windows (Chun-wei Fan).
	
	- Support running the rsvg_internals tests on Windows (Chun-wei Fan).
	
	
	
	(https://ftp.gnome.org/pub/GNOME/sources/librsvg/2.48/librsvg-2.48.2.news)
	Version 2.48.2
	
	- Fix linking of the test suite against Harfbuzz.
	
	
cd00bc2ccd329744228be9ef3f979258947ccf4c: atk: 2.35.1 -> 2.36.0
	(https://ftp.gnome.org/pub/GNOME/sources/atk/2.36/atk-2.36.0.news)
	Changes in version 2.36
	=========================
	
	* New API
	   * Added ATK_ROLE_MARK and ATK_ROLE_SUGGESTION
	   * Add ATK_TEX_ATTR_TEXT_POSITION to the list of possible AtkText
	     attributes (MR!33)
	
	* Documentation
	   * Updated documentation for atk_text_set_caret_offset (MR!18)
	
	* Building - meson
	   * Fix building atk as subproject
	   * Add Meson wrap file for GLib (MR!37)
	
	* Building - visual studio
	   * Use -utf-8 if available (MR!38)
	
	Contributors
	   Luca Bacci, Joanmarie Diggs, Samuel Thibault
	
	Translations
	
	   Fran Dieguez (gl), Ryuta Fujii (ja), Daniel Korostil (uk), Jwtiyar
