### PR TITLE
gnome3.gnome-remote-desktop: 0.1.7 -> 0.1.8

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-remote-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-remote-desktop/default.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitLab, meson, ninja, pkgconfig, python3, wrapGAppsHook
-, glib, pipewire_0_2, systemd, libvncserver, libsecret, libnotify, gdk-pixbuf, gnome3 }:
+, glib, pipewire, systemd, libvncserver, libsecret, libnotify, gdk-pixbuf, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "0.1.7";
+  version = "0.1.8";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "jadahl";
     repo = "gnome-remote-desktop";
     rev = version;
-    sha256 = "0gmazc8ww0lyhx9iclhi982bkpjsnflrzv4qfm3q6hcy0il21fsc";
+    sha256 = "1wcvk0w4p0wnqnrjkbwvqcby9dd4nj0cm9cz0fqna31qfjrvb913";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig python3 wrapGAppsHook ];
 
   buildInputs = [
-    glib pipewire_0_2 systemd libvncserver libsecret libnotify
+    glib pipewire systemd libvncserver libsecret libnotify
     gdk-pixbuf # For libnotify
   ];
 


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New release which supports newer pipewire.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
