### PR TITLE
docker-credential-gcr: 1.4.3 -> 2.0.1

### DIFF
--- a/pkgs/tools/admin/docker-credential-gcr/default.nix
+++ b/pkgs/tools/admin/docker-credential-gcr/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "docker-credential-gcr";
-  version = "1.4.3";
+  version = "2.0.1";
 
   goPackagePath = "github.com/GoogleCloudPlatform/docker-credential-gcr";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "GoogleCloudPlatform";
     repo = "docker-credential-gcr";
     rev = "v${version}";
-    sha256 = "1xb88xjyyrdmjcgfv7fqdkv1ip3dpzsdif5vm7vkqvn83s5wj5df";
+    sha256 = "0zazbfjbwclkz848vsyb6zhn95gngwrdhivaiw0m9f8a9xm4bp9r";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Bump to latest release.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
