### PR TITLE
monolith: init at 2.2.2

### DIFF
--- a/pkgs/tools/backup/monolith/default.nix
+++ b/pkgs/tools/backup/monolith/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "monolith";
+  version = "2.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Y2Z";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "08xbpn6kdfiyvz5pwx9hkzbgb40z6dicmiry7frclw0aibal9avi";
+  };
+
+  cargoSha256 = "10zwyg54f05m6ldpnchqzxjkb6rlpcl80crdnk8s6wkf18qny4i3";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  checkPhase = "cargo test -- --skip tests::cli";
+
+  meta = with stdenv.lib; {
+    description = "Bundle any web page into a single HTML file";
+    homepage = "https://github.com/Y2Z/monolith";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ filalex77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5186,6 +5186,8 @@ in
 
   monit = callPackage ../tools/system/monit { };
 
+  monolith = callPackage ../tools/backup/monolith { };
+
   moreutils = callPackage ../tools/misc/moreutils {
     docbook-xsl = docbook_xsl;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/Y2Z/monolith/releases/tag/v2.2.2


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
