### PR TITLE
g15daemon: init at 1.9.5.3

### DIFF
--- a/pkgs/os-specific/linux/g15daemon/default.nix
+++ b/pkgs/os-specific/linux/g15daemon/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchurl
+, fetchpatch
+, patchelf
+, freetype
+, libusb
+}:
+let
+  license = lib.licenses.gpl2;
+  maintainers = with lib.maintainers; [ peterhoeg ];
+
+  g15src = { pname, version, sha256 }: fetchurl {
+    url = "mirror://sourceforge/g15tools/${pname}/${version}/${pname}-${version}.tar.bz2";
+    inherit sha256;
+  };
+
+  libg15 = stdenv.mkDerivation rec {
+    pname = "libg15";
+    version = "1.2.7";
+
+    src = g15src {
+      inherit pname version;
+      sha256 = "1mkrf622n0cmz57lj8w9q82a9dcr1lmyyxbnrghrxzb6gvifnbqk";
+    };
+
+    buildInputs = [ libusb ];
+
+    enableParallelBuilding = true;
+
+    meta = {
+      description = "Provides low-level access to Logitech G11/G15 keyboards and Z10 speakers";
+      inherit license maintainers;
+    };
+  };
+
+  libg15render = stdenv.mkDerivation rec {
+    pname = "libg15render";
+    version = "1.2";
+
+    src = g15src {
+      inherit pname version;
+      sha256 = "03yjb78j1fnr2fwklxy54sdljwi0imvp29m8kmwl9v0pdapka8yj";
+    };
+
+    buildInputs = [ libg15 ];
+
+    enableParallelBuilding = true;
+
+    meta = {
+      description = "A small graphics library optimised for drawing on an LCD";
+      inherit license maintainers;
+    };
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "g15daemon";
+  version = "1.9.5.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/G15Daemon%201.9x/${version}/${pname}-${version}.tar.bz2";
+    sha256 = "1613gsp5dgilwbshqxxhiyw73ksngnam7n1iw6yxdjkp9fyd2a3d";
+  };
+
+  patches = let
+    patch = fname: sha256: fetchurl rec {
+      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/${pname}-${version}-${fname}.patch?h=packages/${pname}";
+      name = "${fname}.patch";
+      inherit sha256;
+    };
+  in
+    [
+      (patch "uinput" "1misfff7a1vg0qgfk3n25y7drnm86a4gq96iflpcwr5x3lw7q0h7")
+      (patch "config-write" "0jkrbqvzqrvxr14h5qi17cb4d32caq7vw9kzlz3qwpxdgxjrjvy2")
+      (patch "recv-oob-answer" "1f67iqpj5hcgpakagi7gbw1xviwhy5vizs546l9bfjimx8r2d29g")
+      ./pid_location.patch
+    ];
+
+  buildInputs = [ libg15 libg15render ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A daemon that makes it possible to use the Logitech keyboard G-Buttons and draw on various Logitech LCDs";
+    inherit license maintainers;
+  };
+}

--- a/pkgs/os-specific/linux/g15daemon/pid_location.patch
+++ b/pkgs/os-specific/linux/g15daemon/pid_location.patch
@@ -1,0 +1,25 @@
+diff --git a/g15daemon/main.c b/g15daemon/main.c
+index e674475..97b8242 100644
+--- a/g15daemon/main.c
++++ b/g15daemon/main.c
+@@ -574,7 +574,7 @@ exitnow:
+     g15daemon_quit_refresh();
+     uf_conf_write(lcdlist,"/etc/g15daemon.conf");
+     uf_conf_free(lcdlist);
+-    unlink("/var/run/g15daemon.pid");
++    unlink("/run/g15daemon/g15daemon.pid");
+     }
+     return 0;
+ }
+diff --git a/g15daemon/utility_funcs.c b/g15daemon/utility_funcs.c
+index c93d164..2e9c679 100644
+--- a/g15daemon/utility_funcs.c
++++ b/g15daemon/utility_funcs.c
+@@ -48,7 +48,7 @@
+
+ extern unsigned int g15daemon_debug;
+ extern volatile int leaving;
+-#define G15DAEMON_PIDFILE "/var/run/g15daemon.pid"
++#define G15DAEMON_PIDFILE "/run/g15daemon/g15daemon.pid"
+
+ pthread_cond_t lcd_refresh = PTHREAD_COND_INITIALIZER;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17738,6 +17738,8 @@ in
 
   freepats = callPackage ../data/misc/freepats { };
 
+  g15daemon = callPackage ../os-specific/linux/g15daemon {};
+
   gentium = callPackage ../data/fonts/gentium {};
 
   gentium-book-basic = callPackage ../data/fonts/gentium-book-basic {};


### PR DESCRIPTION
Just the packaging parts of #78166 to at least get some things upstreamed while
I get my act together to clean up the pending items for the NixOS module.

A number of (old) Logitech devices have LCDs built-in and this adds support for them.

There are a number of dependencies which are all contained inside a single file. As the last releases of those dependencies were all more than 10 years ago and the hardware is no longer being produced, I didn't think it was worth it to pollute the the global attribute set.

This all works here but as I don't have all the hardware, it would be great if somebody else could try it out as well.

In order to really make use of it, the NixOS module is needed too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).