### PR TITLE
nixos/release-combined.nix: test hibernate only on x86_64

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -73,7 +73,7 @@ in rec {
         (onFullSupported "nixos.tests.fontconfig-default-fonts")
         (onFullSupported "nixos.tests.gnome3")
         (onFullSupported "nixos.tests.gnome3-xorg")
-        (onFullSupported "nixos.tests.hibernate")
+        (onSystems ["x86_64-linux"] "nixos.tests.hibernate")
         (onFullSupported "nixos.tests.i3wm")
         (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSimple")
         (onSystems ["x86_64-linux"] "nixos.tests.installer.btrfsSubvolDefault")


### PR DESCRIPTION
Backport 918cb88d1f4710b8014c94f2c879f7f381506051, the second part of #83249.
First part of #83249 was already merged as part of #82886.