### PR TITLE
tremc: init at 0.9.1

### DIFF
--- a/pkgs/applications/networking/p2p/transmission-remote-cli/default.nix
+++ b/pkgs/applications/networking/p2p/transmission-remote-cli/default.nix
@@ -5,7 +5,8 @@ stdenv.mkDerivation rec {
   version = "1.7.1";
 
   src = fetchurl {
-    url = "https://github.com/fagga/transmission-remote-cli/archive/v${version}.tar.gz";
+    url =
+      "https://github.com/fagga/transmission-remote-cli/archive/v${version}.tar.gz";
     sha256 = "1y0hkpcjf6jw9xig8yf484hbhy63nip0pkchx401yxj81m25l4z9";
   };
 
@@ -17,10 +18,11 @@ stdenv.mkDerivation rec {
     wrapPythonPrograms
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Curses interface for the Transmission BitTorrent daemon";
-    homepage = https://github.com/fagga/transmission-remote-cli;
+    homepage = "https://github.com/fagga/transmission-remote-cli";
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.unix;
+    maintainers = with maintainers; [ snglth ];
   };
 }

--- a/pkgs/applications/networking/p2p/tremc/default.nix
+++ b/pkgs/applications/networking/p2p/tremc/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, python3Packages }:
+
+stdenv.mkDerivation rec {
+  pname = "tremc";
+  version = "0.9.1";
+
+  src = fetchurl {
+    url = "https://github.com/tremc/tremc/archive/${version}.tar.gz";
+    sha256 = "0bs168hn5q6kpz5aiifmkwfwfkhjlnv6l7v29yy05h096bj3f6zc";
+  };
+
+  buildInputs = with python3Packages; [ python wrapPython ];
+
+  buildPhase = "echo skip";
+
+  installPhase = ''
+    install -D tremc $out/bin/tremc
+    install -D tremc.1 $out/share/man/man1/tremc.1
+    wrapPythonPrograms
+  '';
+
+  meta = {
+    description = "Curses interface for the Transmission BitTorrent daemon";
+    homepage = "https://github.com/tremc/tremc";
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22146,6 +22146,8 @@ in
 
   tree-from-tags = callPackage ../applications/audio/tree-from-tags { };
 
+  tremc = callPackage ../applications/networking/p2p/tremc {};
+
   tdrop = callPackage ../applications/misc/tdrop { };
 
   tre-command = callPackage ../tools/system/tre-command {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#84238 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
