### PR TITLE
php.buildEnv: Don't inherit dev from the original php

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -189,7 +189,7 @@ let
         in
           symlinkJoin {
             name = "php-with-extensions-${version}";
-            inherit (php) version dev;
+            inherit (php) version;
             nativeBuildInputs = [ makeWrapper ];
             passthru = {
               inherit buildEnv withExtensions enabledExtensions;

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, which
 , withPython2 ? false, python2
 , withPython3 ? true, python3, ncurses
-, withPHP72 ? false, php72
-, withPHP73 ? true, php73
+, withPHP72 ? false, php72base
+, withPHP73 ? true, php73base
 , withPerl528 ? false, perl528
 , withPerl530 ? true, perl530
 , withPerldevel ? false, perldevel
@@ -26,8 +26,8 @@ let
     config.php.fpm = false;
   };
 
-  php72-unit = php72.override phpConfig;
-  php73-unit = php73.override phpConfig;
+  php72-unit = php72base.override phpConfig;
+  php73-unit = php73base.override phpConfig;
 in stdenv.mkDerivation rec {
   version = "1.16.0";
   pname = "unit";


### PR DESCRIPTION
###### Motivation for this change
`mkDerivation` uses the `dev` output in `buildInputs` if it exits, hence the `php-with-extensions` package was never built or put into the path of packages dependent on it during build.

With this fix, the php packages built with `buildEnv` or `withExtensions` don't have any `dev` outputs; packages which need the `dev` output can refer to the `phpXXbase` packages instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
