### PR TITLE
youtube-viewer: 3.3.0 -> 3.7.5

### DIFF
--- a/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
+++ b/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
@@ -2,13 +2,13 @@
 
 buildPerlPackage rec {
   pname = "WWW-YoutubeViewer";
-  version = "3.3.0";
+  version = "3.7.5";
 
   src = fetchFromGitHub {
     owner  = "trizen";
     repo   = "youtube-viewer";
     rev    = version;
-    sha256 = "15xyrwv08fw8jmpydwzks26ipxnzliwddgyjcfqiaj0p7lwlhmx1";
+    sha256 = "1caz56sxy554avz2vdv9gm7gyqcq0gyixzrh5v9ixmg6vxif5d4f";
   };
 
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin shortenPerlShebang;


### PR DESCRIPTION
###### Motivation for this change
Recently [YouTube API Services team has disabled youtube-viewer API key](https://github.com/trizen/youtube-viewer/issues/308) (they reduced quota limit of queries per day for a single API key). [youtube-viewer repository has been updated](https://github.com/trizen/youtube-viewer/commit/3292f49c55c054bb39a58a68e0b02284357fef33) to allow setting your [personally obtained API key](https://github.com/trizen/youtube-viewer/blob/e2a9878dddb7ed6051bc4929e87cba1c6861b293/README.md#logging-in).
So, for now, without updating youtube-viewer you're not able to view YouTube videos with it.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell --pure -I nixpkgs=https://github.com/alexoundos/nixpkgs/archive/52ad14bbee1c44688acdffc6a3ac595b80adca15.tar.gz -p youtube-viewer --run "youtube-viewer"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

#### test the functionality in NixOS
1. Temporarily set the API key (please, do not overuse my).
  `$ cp `[api.txt](https://github.com/NixOS/nixpkgs/files/4451034/api.txt)` ~/.config/youtube-viewer/api.json`

2. Run.
```console
$ export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
$ nix-shell --pure -I nixpkgs=https://github.com/alexoundos/nixpkgs/archive/52ad14bbee1c44688acdffc6a3ac595b80adca15.tar.gz --keep NIX_SSL_CERT_FILE -p youtube-viewer --run "youtube-viewer starcraft remastered"
```
SSL certificate trick is mandatory for pure nix-shell and partially described in https://github.com/NixOS/nixpkgs/issues/13744#issuecomment-198779626.