### PR TITLE
mlkit: init at 4.5.0

### DIFF
--- a/pkgs/development/compilers/mlkit/default.nix
+++ b/pkgs/development/compilers/mlkit/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, mlton }:
+
+stdenv.mkDerivation rec {
+  pname = "mlkit";
+  version = "4.5.0";
+
+  src = fetchFromGitHub {
+    owner = "melsman";
+    repo = "mlkit";
+    rev = "v${version}";
+    sha256 = "0fc0y40qphn02857fv2dvhwzzsvgixzchx9i6i0x80xfv7z68fbh";
+  };
+
+  nativeBuildInputs = [ autoreconfHook mlton ];
+
+  buildFlags = ["mlkit" "mlkit_libs"];
+
+  meta = with stdenv.lib; {
+    description = "Standard ML Compiler and Toolkit";
+    homepage = "https://elsman.com/mlkit/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ athas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9041,6 +9041,8 @@ in
 
   mkcl = callPackage ../development/compilers/mkcl {};
 
+  mlkit = callPackage ../development/compilers/mlkit {};
+
   inherit (callPackage ../development/compilers/mlton {})
     mlton20130715
     mlton20180207Binary


### PR DESCRIPTION
###### Motivation for this change

I don't think Nixpkgs contains quite enough Standard ML compilers.  Here's one more.  It's actively maintained and in use.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
