### PR TITLE
Olive snapshot

### DIFF
--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -4,13 +4,13 @@
 
 mkDerivation rec {
   pname = "olive-editor";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "olive-editor";
     repo = "olive";
     rev = version;
-    sha256 = "15q4qwf5rc3adssywl72jrhkpqk55ihpd5h5wf07baw0s47vv5kq";
+    sha256 = "151g6jwhipgbq4llwib92sq23p1s9hm6avr7j4qq3bvykzrm8z1a";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -1,29 +1,33 @@
-{ stdenv, fetchFromGitHub, pkgconfig, which, qmake, mkDerivation,
-  qtbase, qtmultimedia, frei0r, opencolorio, ffmpeg-full,
-  CoreFoundation  }:
+{ stdenv, fetchFromGitHub, pkgconfig, which, cmake, mkDerivation,
+  qtbase, qtmultimedia, qt5,
+  frei0r, opencolorio, openimageio, openexr, ffmpeg-full, CoreFoundation  }:
 
 mkDerivation rec {
   pname = "olive-editor";
-  version = "0.1.2";
+  version = "snapshot-2020-04-08";
 
-  src = fetchFromGitHub {
+  src = /home/aengelen/dev/olive;
+  /*fetchFromGitHub {
     owner = "olive-editor";
     repo = "olive";
     rev = version;
     sha256 = "151g6jwhipgbq4llwib92sq23p1s9hm6avr7j4qq3bvykzrm8z1a";
-  };
+  };*/
 
   nativeBuildInputs = [
     pkgconfig
     which
-    qmake
+    cmake
   ];
 
   buildInputs = [
     ffmpeg-full
     frei0r
     opencolorio
+    openimageio
+    openexr
     qtbase
+    qt5.qttools.dev
     qtmultimedia
     qtmultimedia.dev
   ] ++ stdenv.lib.optional stdenv.isDarwin CoreFoundation;


### PR DESCRIPTION
Not for merge, only to share the changes needed to build latest master and try it out.

Master has a number of interesting improvements, but also crashes sometimes ;).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
