### PR TITLE
device-tree_rpi: fix platforms

### DIFF
--- a/pkgs/os-specific/linux/device-tree/raspberrypi.nix
+++ b/pkgs/os-specific/linux/device-tree/raspberrypi.nix
@@ -30,4 +30,7 @@ stdenvNoCC.mkDerivation {
     # Compatible overlays that may be used
     overlays = "${raspberrypifw}/share/raspberrypi/boot/overlays";
   };
+  meta = with stdenvNoCC.lib; {
+    platforms = [ "armv6l-linux" "armv7l-linux" "aarch64-linux" ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change
```
in job ‘nixpkgs.device-tree_rpi.x86_64-linux’:
Failed to evaluate raspberrypi-firmware-1.20190925: «unsupported»: is not supported on ‘x86_64-linux’
```
hydra wrongly believed the job could be build on x86, but its deps cant be built on x86

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
