### PR TITLE
gnome3.gnome-color-manager: 3.32.0 -> 3.36.0

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, fetchpatch
 , meson
 , ninja
 , pkgconfig
@@ -9,24 +10,26 @@
 , gnome3
 , glib
 , gtk3
-, libexif
-, libtiff
 , colord
-, colord-gtk
-, libcanberra-gtk3
 , lcms2
-, vte
-, exiv2
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-color-manager";
-  version = "3.32.0";
+  version = "3.36.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1vpxa2zjz3lkq9ldjg0fl65db9s6b4kcs8nyaqfz3jygma7ifg3w";
+    sha256 = "nduea2Ry4RmAE4H5CQUzLsHUJYmBchu6gxyiRs6zrTs=";
   };
+
+  patches = [
+    # Drop forgotten include
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-color-manager/commit/66aea36411477f284fa8a379b3bde282385d281c.patch";
+      sha256 = "m44XfVPGZV9kgm/vIvF9SbsilXNKl2ZwE8SwrhAbU1A=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -40,14 +43,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     gtk3
-    libexif
-    libtiff
     colord
-    colord-gtk
-    libcanberra-gtk3
     lcms2
-    vte
-    exiv2
   ];
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change
It removes calibration but rest of GNOME is not ready for it yet:

https://gitlab.gnome.org/GNOME/gnome-control-center/-/issues/951

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
