### PR TITLE
broadcom_sta: fix build on 5.6

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation {
     ./linux-4.12.patch
     ./linux-4.15.patch
     ./linux-5.1.patch
+    # source: https://salsa.debian.org/Herrie82-guest/broadcom-sta/-/commit/247307926e5540ad574a17c062c8da76990d056f
+    ./linux-5.6.patch
     ./null-pointer-fix.patch
     ./gcc.patch
   ];

--- a/pkgs/os-specific/linux/broadcom-sta/linux-5.6.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/linux-5.6.patch
@@ -1,0 +1,87 @@
+From dd057e40a167f4febb1a7c77dd32b7d36056952c Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Tue, 31 Mar 2020 17:09:55 +0200
+Subject: [PATCH] Add fixes for 5.6 kernel
+
+Use ioremap instead of ioremap_nocache and proc_ops instead of file_operations on Linux kernel 5.6 and above.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ src/shared/linux_osl.c |  6 +++++-
+ src/wl/sys/wl_linux.c  | 21 ++++++++++++++++++++-
+ 2 files changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/src/shared/linux_osl.c b/src/shared/linux_osl.c
+index 6157d18..dcfc075 100644
+--- a/src/shared/linux_osl.c
++++ b/src/shared/linux_osl.c
+@@ -942,7 +942,11 @@ osl_getcycles(void)
+ void *
+ osl_reg_map(uint32 pa, uint size)
+ {
+-	return (ioremap_nocache((unsigned long)pa, (unsigned long)size));
++	#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++		return (ioremap((unsigned long)pa, (unsigned long)size));
++	#else
++		return (ioremap_nocache((unsigned long)pa, (unsigned long)size));
++	#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) */
+ }
+ 
+ void
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index 0d05100..6d9dd0d 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -582,10 +582,17 @@ wl_attach(uint16 vendor, uint16 device, ulong regs,
+ 	}
+ 	wl->bcm_bustype = bustype;
+ 
++	#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++	if ((wl->regsva = ioremap(dev->base_addr, PCI_BAR0_WINSZ)) == NULL) {
++		WL_ERROR(("wl%d: ioremap() failed\n", unit));
++		goto fail;
++	}
++	#else 
+ 	if ((wl->regsva = ioremap_nocache(dev->base_addr, PCI_BAR0_WINSZ)) == NULL) {
+ 		WL_ERROR(("wl%d: ioremap() failed\n", unit));
+ 		goto fail;
+ 	}
++	#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) */
+ 
+ 	wl->bar1_addr = bar1_addr;
+ 	wl->bar1_size = bar1_size;
+@@ -772,8 +779,13 @@ wl_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 	if ((val & 0x0000ff00) != 0)
+ 		pci_write_config_dword(pdev, 0x40, val & 0xffff00ff);
+ 		bar1_size = pci_resource_len(pdev, 2);
++		#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++		bar1_addr = (uchar *)ioremap(pci_resource_start(pdev, 2),
++			bar1_size);
++		#else
+ 		bar1_addr = (uchar *)ioremap_nocache(pci_resource_start(pdev, 2),
+ 			bar1_size);
++		#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) */
+ 	wl = wl_attach(pdev->vendor, pdev->device, pci_resource_start(pdev, 0), PCI_BUS, pdev,
+ 		pdev->irq, bar1_addr, bar1_size);
+ 
+@@ -3335,12 +3347,19 @@ wl_proc_write(struct file *filp, const char __user *buff, size_t length, loff_t
+ }
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++static const struct proc_ops wl_fops = {
++	.proc_read	= wl_proc_read,
++	.proc_write	= wl_proc_write,
++};
++#else
+ static const struct file_operations wl_fops = {
+ 	.owner	= THIS_MODULE,
+ 	.read	= wl_proc_read,
+ 	.write	= wl_proc_write,
+ };
+-#endif
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) */
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0) */
+ 
+ static int
+ wl_reg_proc_entry(wl_info_t *wl)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
necessary on my 8 year old macbook. I haven't rebooted yet hence the draft status.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
