### PR TITLE
dasm: init at 2.20.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3765,6 +3765,12 @@
     githubId = 2396926;
     name = "Justin Woo";
   };
+  jwatt = {
+    email = "jwatt@broken.watch";
+    github = "jjwatt";
+    githubId = 2397327;
+    name = "Jesse Wattenbarger";
+  };
   jwiegley = {
     email = "johnw@newartisans.com";
     github = "jwiegley";

--- a/pkgs/development/compilers/dasm/default.nix
+++ b/pkgs/development/compilers/dasm/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 	'';
 
 	preCheck = ''
-		patchShebangs ./tests/
+		patchShebangs ./test/
 	'';
 
 	checkTarget = "test";

--- a/pkgs/development/compilers/dasm/default.nix
+++ b/pkgs/development/compilers/dasm/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
 		patchShebangs ./tests/
 	'';
 
-	checkTarget = "tests";
+	checkTarget = "test";
+	doCheck = true;
 
 	meta = with stdenv.lib; {
 		homepage = "https://dasm-assembler.github.io";

--- a/pkgs/development/compilers/dasm/default.nix
+++ b/pkgs/development/compilers/dasm/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+	pname = "dasm";
+	version = "2.20.13";
+
+	src = fetchFromGitHub {
+		owner = "dasm-assembler";
+		repo = "dasm";
+		rev = version;
+		sha256 = "1nr4kvw42vyc6i4p1c06jlih11rhbjjxc27dc7cx5qj635xf4jcf";
+	};
+
+	configurePhase = false;
+	installPhase = ''
+		mkdir -p $out/bin
+		install bin/* $out/bin
+	'';
+
+	preCheck = ''
+		patchShebangs ./tests/
+	'';
+
+	checkTarget = "tests";
+
+	meta = with stdenv.lib; {
+		homepage = "https://dasm-assembler.github.io";
+		description = "Assembler for 6502 and other 8-bit microprocessors";
+		license = licenses.gpl2;
+		maintainers = [ maintainers.jwatt ];
+		platforms = platforms.all;
+	};
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8067,6 +8067,8 @@ in
 
   scry = callPackage ../development/tools/scry {};
 
+  dasm = callPackage ../development/compilers/dasm/default.nix { };
+
   dbmate = callPackage ../development/tools/database/dbmate { };
 
   devpi-client = python3Packages.callPackage ../development/tools/devpi-client {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add the "dasm" assembler to nixpkgs.

###### Things done
- Added dasm package
- Added dasm to top-level/all-packages.nix
- Added myself, "jjwatt" to the maintainers-list
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
