### PR TITLE
pcsc-cyberjack: 3.99.5_SP12 -> 3.99.5_SP13

### DIFF
--- a/pkgs/tools/security/pcsc-cyberjack/default.nix
+++ b/pkgs/tools/security/pcsc-cyberjack/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, libusb1, pcsclite }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libusb1, pcsclite }:
 
 stdenv.mkDerivation rec {
   pname = "pcsc-cyberjack";
-  version = "3.99.5_SP12";
+  version = "3.99.5_SP13";
 
   src = with stdenv.lib; let
     splittedVer = splitString "_" version;
@@ -11,13 +11,13 @@ stdenv.mkDerivation rec {
     tarballVersion = "${mainVer}final${spVer}";
   in fetchurl {
     url = "http://support.reiner-sct.de/downloads/LINUX/V${version}"
-        + "/pcsc-cyberjack-${tarballVersion}.tar.bz2";
-    sha256 = "04pkmybal56s5xnjld09vl1s1h6qf8mvhm41b758d6hi240kgp1j";
+        + "/pcsc-cyberjack_${tarballVersion}.tar.gz";
+    sha256 = "1lx4bfz4riz7j77sl65akyxzww0ygm63w0c1b75knr1pijlv8d3b";
   };
 
   outputs = [ "out" "tools" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ libusb1 pcsclite ];
 
   configureFlags = [


### PR DESCRIPTION
Unfortunately, the upstream changelog consists of just the following:

  * Update to the Reiner-SCT repository rev cyberJack@1374

This is not very helpful since I haven't found a public SVN (I assume, since it's using integer revisions) repository, so I decided to diff the tarball against the old one, here's what I've found:

  * No longer ship generated files from autotools
  * Add support for REINER SCT cyberJack comfort PL
  * Add support for tanJack USB
  * Allow to override secoder information
  * Lots of whitespace and coding style changes

As mentioned above, the autotools-generated files are no longer shipped, so I've added `autoreconfHook` to `nativeBuildInputs`.

I also verified the source tarball using the upstream hashes found here:

http://downloads.reiner-sct.de/LINUX/Hashwerte/Hashwerte.txt