### PR TITLE
just: 0.4.5 -> 0.5.10

### DIFF
--- a/pkgs/development/tools/just/default.nix
+++ b/pkgs/development/tools/just/default.nix
@@ -2,16 +2,26 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "just";
-  version = "0.4.5";
+  version = "0.5.10";
 
   src = fetchFromGitHub {
     owner = "casey";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0a4bml9nxvyh110a60l4lc11yr2ds5r8d3iplslccrkq1ka96av9";
+    sha256 = "0s8np28glzn3kmh59dwk86yc9fb2lm9fq2325kzmy7rkb5jsdcl1";
   };
 
-  cargoSha256 = "0wp61zjws9r1aapkapvq2vmad5kylkpw03wa82qhhq30knkpvr7b";
+  cargoSha256 = "05mrzav3aydvwac9jjckdmlxvxnlcncmkfsdb9z7zvxia4k89w1l";
+
+  postInstall = ''
+    # generate completion scripts for just
+
+    mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
+
+    $out/bin/just --completions bash > "$out/share/bash-completion/completions/just"
+    $out/bin/just --completions fish > "$out/share/fish/vendor_completions.d/just.fish"
+    $out/bin/just --completions zsh  > "$out/share/zsh/site-functions/_just"
+  '';
 
   checkInputs = [ coreutils bash dash ];
 
@@ -20,20 +30,25 @@ rustPlatform.buildRustPackage rec {
     export USER=just-user
     export USERNAME=just-user
 
-    sed -i tests/integration.rs \
-        -e "s@/bin/echo@${coreutils}/bin/echo@g" \
-        -e "s@#!/usr/bin/env sh@#!${bash}/bin/sh@g" \
-        -e "s@#!/usr/bin/env cat@#!${coreutils}/bin/cat@g"
-
-    sed -i tests/interrupts.rs \
-        -e "s@/bin/echo@${coreutils}/bin/echo@g" \
-        -e "s@#!/usr/bin/env sh@#!${bash}/bin/sh@g" \
-        -e "s@#!/usr/bin/env cat@#!${coreutils}/bin/cat@g"
-
     sed -i src/justfile.rs \
+        -i tests/*.rs \
         -e "s@/bin/echo@${coreutils}/bin/echo@g" \
         -e "s@#!/usr/bin/env sh@#!${bash}/bin/sh@g" \
-        -e "s@#!/usr/bin/env cat@#!${coreutils}/bin/cat@g"
+        -e "s@#!/usr/bin/env cat@#!${coreutils}/bin/cat@g" \
+        -e "s@#!/usr/bin/env bash@#!${bash}/bin/sh@g"
+  '';
+
+  # Skip "edit" when running "cargo test",
+  # since this test case needs "cat".
+  checkPhase = ''
+    runHook preCheck
+    echo "Running cargo test --
+        --skip edit
+        ''${checkFlags} ''${checkFlagsArray+''${checkFlagsArray[@]}}"
+    cargo test -- \
+        --skip edit \
+        ''${checkFlags} ''${checkFlagsArray+"''${checkFlagsArray[@]}"}
+    runHook postCheck
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `just` to the latest release.
- https://github.com/casey/just/releases/tag/v0.5.10
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
