### PR TITLE
nixos/k3s: add initial k3s service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -238,6 +238,7 @@
   ./services/backup/zfs-replication.nix
   ./services/backup/znapzend.nix
   ./services/cluster/hadoop/default.nix
+  ./services/cluster/k3s/default.nix
   ./services/cluster/kubernetes/addons/dns.nix
   ./services/cluster/kubernetes/addons/dashboard.nix
   ./services/cluster/kubernetes/addon-manager.nix

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -60,6 +60,17 @@ in
   # implementation
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.role != "agent" -> cfg.serverAdr == "";
+        message = "serverAddr should only be set if role is 'agent'";
+      }
+      {
+        assertion = cfg.role != "agent" -> cfg.token == "";
+        message = "token should only be set if role is 'agent'";
+      }
+    ];
+
     virtualisation.docker = mkIf cfg.docker {
       enable = mkDefault true;
     };
@@ -78,10 +89,6 @@ in
         Type = "notify";
         KillMode = "process";
         Delegate = "yes";
-        LimitNOFILE = "infinity";
-        LimitNPROC = "infinity";
-        LimitCORE = "infinity";
-        TasksMax = "infinity";
         Restart = "always";
         RestartSec = "5s";
         ExecStart = concatStringsSep " \\\n " (
@@ -94,7 +101,5 @@ in
         );
       };
     };
-
-    environment.systemPackages = [ cfg.package ];
   };
 }

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -14,8 +14,7 @@ in
       default = pkgs.k3s;
       defaultText = "pkgs.k3s";
       example = literalExample "pkgs.k3s";
-      description = ''
-      '';
+      description = "Package that should be used for k3s";
     };
 
     role = mkOption {

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -62,7 +62,7 @@ in
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.role != "agent" -> cfg.serverAdr == "";
+        assertion = cfg.role != "agent" -> cfg.serverAddr == "";
         message = "serverAddr should only be set if role is 'agent'";
       }
       {

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -30,11 +30,13 @@ in
       type = types.str;
       description = "The k3s server to connect to. This option only makes sense for an agent.";
       example = "https://10.0.0.10:6443";
+      default = "";
     };
 
     token = mkOption {
       type = types.str;
       description = "The k3s token to use when connecting to the server. This option only makes sense for an agent.";
+      default = "";
     };
 
     docker = mkOption {
@@ -61,22 +63,17 @@ in
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.role != "agent" -> cfg.serverAddr == "";
-        message = "serverAddr should only be set if role is 'agent'";
+        assertion = cfg.role == "agent" -> cfg.serverAddr != "";
+        message = "serverAddr should be set if role is 'agent'";
       }
       {
-        assertion = cfg.role != "agent" -> cfg.token == "";
-        message = "token should only be set if role is 'agent'";
+        assertion = cfg.role == "agent" -> cfg.token != "";
+        message = "token should be set if role is 'agent'";
       }
     ];
 
     virtualisation.docker = mkIf cfg.docker {
       enable = mkDefault true;
-    };
-
-    services.k3s = mkIf (cfg.role == "server") {
-      serverAddr = "";
-      token = "";
     };
 
     systemd.services.k3s = {

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -1,0 +1,104 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.k3s;
+in
+{
+  # interface
+  options.services.k3s = {
+    enable = mkEnableOption "k3s";
+
+    role = mkOption {
+      description = ''
+        Whether k3s should run as a server or agent.
+        Note that the server, by default, also runs as an agent.
+      '';
+      default = "server";
+      type = types.enum [ "server" "agent" ];
+    };
+
+    serverAddr = mkOption {
+      type = types.str;
+      description = "The k3s server to connect to. This option only makes sense for an agent.";
+      example = "https://10.0.0.10:6443";
+      default = "";
+    };
+    token = mkOption {
+      type = types.str;
+      description = "The k3s token to use when connecting to the server. This option only makes sense for an agent.";
+    };
+
+    docker = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Use docker to run containers rather than the built-in containerd.";
+    };
+
+    extraFlags = mkOption {
+      description = "Extra flags to pass to the k3s command.";
+      default = "";
+      example = "--no-deplooy traefik --cluster-cidr 10.24.0.0/16";
+    };
+
+    disableAgent = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Only run the server. This option only makes sense for a server.";
+    };
+  };
+
+  # implementation
+  config = mkMerge [
+    (
+      mkIf (cfg.role == "server") {
+        services.k3s.serverAddr = "";
+        services.k3s.token = "";
+      }
+    )
+    (
+      mkIf cfg.docker {
+        virtualisation.docker = {
+          enable = mkDefault true;
+        };
+      }
+    )
+    (
+      mkIf cfg.enable {
+        systemd.services.k3s = let
+          flags = concatStrings (
+            intersperse " " (
+              remove "" [
+                (if cfg.docker then "--docker" else "")
+                (if (cfg.serverAddr != "") then "--server ${cfg.serverAddr}" else "")
+                (if (cfg.token != "") then "--token ${cfg.token}" else "")
+                (if cfg.disableAgent then "--disable-agent" else "")
+                cfg.extraFlags
+              ]
+            )
+          );
+        in
+          {
+            description = "k3s service";
+            after = if cfg.docker then [ "docker.service" ] else [];
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              # Taken from https://github.com/rancher/k3s/blob/v1.17.4+k3s1/contrib/ansible/roles/k3s/node/templates/k3s.service.j2
+              Type = "notify";
+              KillMode = "process";
+              Delegate = "yes";
+              LimitNOFILE = "infinity";
+              LimitNPROC = "infinity";
+              LimitCORE = "infinity";
+              TasksMax = "infinity";
+              Restart = "always";
+              RestartSec = "5s";
+              ExecStart = "${pkgs.k3s}/bin/k3s ${cfg.role} ${flags}";
+            };
+          };
+
+        environment.systemPackages = [ pkgs.k3s ] ++ (if cfg.docker then [ pkgs.docker ] else []);
+      }
+    )
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -146,6 +146,7 @@ in
   jellyfin = handleTest ./jellyfin.nix {};
   jenkins = handleTest ./jenkins.nix {};
   jirafeau = handleTest ./jirafeau.nix {};
+  k3s = handleTest ./k3s.nix {};
   kafka = handleTest ./kafka.nix {};
   keepalived = handleTest ./keepalived.nix {};
   kerberos = handleTest ./kerberos/default.nix {};

--- a/nixos/tests/k3s.nix
+++ b/nixos/tests/k3s.nix
@@ -1,0 +1,80 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+let
+  # A suitable k3s pause image, also used for the test pod
+  pauseImage = pkgs.dockerTools.buildImage {
+    name = "test.local/pause";
+    tag = "local";
+    contents = with pkgs; [ tini coreutils busybox ];
+    config.Entrypoint = [ "/bin/tini" "--" "/bin/sleep" "inf" ];
+  };
+  testPodYaml = pkgs.writeText "test.yml" ''
+    # Don't use the default service account because there's a race where it may
+    # not be created yet; make our own instead.
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: test
+    ---
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: test
+    spec:
+      serviceAccountName: test
+      containers:
+      - name: test
+        image: test.local/pause:local
+        imagePullPolicy: Never
+        command: ["sh", "-c", "sleep inf"]
+  '';
+in
+{
+  name = "k3s";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ euank ];
+  };
+
+  nodes = {
+    k3s =
+      { pkgs, ... }: {
+        environment.systemPackages = [ pkgs.k3s pkgs.gzip ];
+
+        # k3s uses enough resources the default vm fails.
+        virtualisation.memorySize = pkgs.lib.mkDefault 1536;
+        virtualisation.diskSize = pkgs.lib.mkDefault 4096;
+
+        services.k3s.enable = true;
+        services.k3s.role = "server";
+        services.k3s.package = pkgs.k3s;
+        # Slightly reduce resource usage
+        services.k3s.extraFlags = "--no-deploy coredns,servicelb,traefik,local-storage,metrics-server --pause-image test.local/pause:local";
+
+        users.users = {
+          noprivs = {
+            isNormalUser = true;
+            description = "Can't access k3s by default";
+            password = "*";
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    k3s.wait_for_unit("k3s")
+    k3s.succeed("sudo k3s kubectl cluster-info")
+    k3s.fail("sudo -u noprivs k3s kubectl cluster-info")
+    # k3s.succeed("k3s check-config") # fails with the current nixos kernel config, uncomment once this passes
+
+    k3s.succeed(
+        "zcat ${pauseImage} | sudo k3s ctr image import -"
+    )
+
+    k3s.succeed(
+        "sudo k3s kubectl apply -f ${testPodYaml}"
+    )
+    k3s.succeed("sudo k3s kubectl wait --for 'condition=Ready' pod/test")
+  '';
+})

--- a/nixos/tests/k3s.nix
+++ b/nixos/tests/k3s.nix
@@ -64,17 +64,15 @@ in
     start_all()
 
     k3s.wait_for_unit("k3s")
-    k3s.succeed("sudo k3s kubectl cluster-info")
+    k3s.succeed("k3s kubectl cluster-info")
     k3s.fail("sudo -u noprivs k3s kubectl cluster-info")
     # k3s.succeed("k3s check-config") # fails with the current nixos kernel config, uncomment once this passes
 
     k3s.succeed(
-        "zcat ${pauseImage} | sudo k3s ctr image import -"
+        "zcat ${pauseImage} | k3s ctr image import -"
     )
 
-    k3s.succeed(
-        "sudo k3s kubectl apply -f ${testPodYaml}"
-    )
-    k3s.succeed("sudo k3s kubectl wait --for 'condition=Ready' pod/test")
+    k3s.succeed("k3s kubectl apply -f ${testPodYaml}")
+    k3s.succeed("k3s kubectl wait --for 'condition=Ready' pod/test")
   '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I thought that others might find this service definition handy! I'll use it whether we land it in the tree or not.

###### Things done

I added a k3s service with a few options that I personally find handy.

Note that this is my first nixos module, so it's _very_ likely I'm missing something I should do. I don't know if I need to do more for docs, or if there's more testing I need to do.

I would definitely appreciate any pointers for stuff I might have missed or should do for a new module. If there's an exemplary pull request I could mimic, I'd be happy to take inspiration from that.

###### Testing done
I tested this on my nixos machine with the following config:

```
  services.k3s.enable = true;
  services.k3s.role = "server";
  services.k3s.docker = true;
```

With that configuration, running `sudo k3s kubectl get pod` and such worked as I'd expect.