### PR TITLE
[20.03] haskell.compiler.ghc822Binary: propagate llvm dependency

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.2-binary.nix
@@ -1,12 +1,15 @@
 { stdenv, substituteAll
 , fetchurl, perl, gcc, llvm
 , ncurses5, gmp, glibc, libiconv
+, llvmPackages
 }:
 
 # Prebuilt only does native
 assert stdenv.targetPlatform == stdenv.hostPlatform;
 
 let
+  useLLVM = !stdenv.targetPlatform.isx86;
+
   libPath = stdenv.lib.makeLibraryPath ([
     ncurses5 gmp
   ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
@@ -53,7 +56,7 @@ stdenv.mkDerivation rec {
     or (throw "cannot bootstrap GHC on this platform"));
 
   nativeBuildInputs = [ perl ];
-  buildInputs = stdenv.lib.optionals (stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64) [ llvm ];
+  propagatedBuildInputs = stdenv.lib.optionals useLLVM [ llvmPackages.llvm ];
 
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
   # the final install location/


### PR DESCRIPTION
This is a backport of #80355

```
Fixes the following error when attempting to build packages using this
compiler:

  <no location info>: error:
      Warning: Couldn't figure out LLVM version!
               Make sure you have installed LLVM 3.9

  <no location info>: error: ghc: could not execute: opt

(cherry picked from commit 31f557c88feb8e6547805727e193881e35f4c495)
```

ZHF: #80379

/cc @peti @domenkozar