### PR TITLE
Gnome shell 3.36.1

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extensions";
-  version = "3.36.0";
+  version = "3.36.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1rmi6ccqfdisvmmzaiqr2r031r0f3h8qxgw5qwq62x859nbrzcmm";
+    sha256 = "0fah7cc22g55w6w7ia3kr2wpdrc45h83xw4pimi54mhggmx9466y";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gnome-shell/fix-bash-completion.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/fix-bash-completion.patch
@@ -1,0 +1,10 @@
+--- a/subprojects/extensions-tool/meson.build
++++ a/subprojects/extensions-tool/meson.build
+@@ -39,6 +39,6 @@ subdir('src')
+ 
+ if bash_completion.found()
+   install_data('completion/bash/gnome-extensions',
+-    install_dir: bash_completion.get_pkgconfig_variable('completionsdir')
++    install_dir: bash_completion.get_pkgconfig_variable('completionsdir', define_variable: ['prefix', prefix])
+   )
+ endif

--- a/pkgs/desktops/gnome-3/core/gnome-shell/shew-gir-path.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/shew-gir-path.patch
@@ -1,0 +1,11 @@
+--- a/subprojects/shew/src/meson.build
++++ b/subprojects/shew/src/meson.build
+@@ -13,7 +13,7 @@ shew_sources = [
+ libshew = library(full_name,
+   sources: shew_sources,
+   dependencies: [gtk_dep],
+-  install_dir: pkglibdir,
++  install_dir: get_option('prefix') / pkglibdir,
+   install: true,
+ )
+ 

--- a/pkgs/desktops/gnome-3/core/gnome-shell/wrap-services.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/wrap-services.patch
@@ -1,0 +1,57 @@
+diff --git a/js/dbusServices/dbus-service.in b/js/dbusServices/dbus-service.in
+old mode 100644
+new mode 100755
+index 524166102..100b81a63
+--- a/js/dbusServices/dbus-service.in
++++ b/js/dbusServices/dbus-service.in
+@@ -1,3 +1,9 @@
++#!@gjs@
++
++// gjs determines the package name from argv[0], which is .*-wrapped
++// so we need to override it to the original one.
++imports.package._findEffectiveEntryPointName = () => '@service@'
++
+ imports.package.start({
+     name: '@PACKAGE_NAME@',
+     prefix: '@prefix@',
+diff --git a/js/dbusServices/dbus-service.service.in b/js/dbusServices/dbus-service.service.in
+index 3b0d09abe..4fd4bb66d 100644
+--- a/js/dbusServices/dbus-service.service.in
++++ b/js/dbusServices/dbus-service.service.in
+@@ -1,3 +1,3 @@
+ [D-BUS Service]
+ Name=@service@
+-Exec=@gjs@ @pkgdatadir@/@service@
++Exec=@pkgdatadir@/@service@
+diff --git a/js/dbusServices/meson.build b/js/dbusServices/meson.build
+index c749f45dc..11bcb0c9e 100644
+--- a/js/dbusServices/meson.build
++++ b/js/dbusServices/meson.build
+@@ -2,6 +2,7 @@ launcherconf = configuration_data()
+ launcherconf.set('PACKAGE_NAME', meson.project_name())
+ launcherconf.set('prefix', prefix)
+ launcherconf.set('libdir', libdir)
++launcherconf.set('gjs', gjs.path())
+ 
+ dbus_services = {
+   'org.gnome.Shell.Extensions': 'extensions',
+@@ -11,16 +12,17 @@ dbus_services = {
+ config_dir = '@0@/..'.format(meson.current_build_dir())
+ 
+ foreach service, dir : dbus_services
++  svc_launcherconf = launcherconf
++  svc_launcherconf.set('service', service)
+   configure_file(
+     input: 'dbus-service.in',
+     output: service,
+-    configuration: launcherconf,
++    configuration: svc_launcherconf,
+     install_dir: pkgdatadir,
+   )
+ 
+   serviceconf = configuration_data()
+   serviceconf.set('service', service)
+-  serviceconf.set('gjs', gjs.path())
+   serviceconf.set('pkgdatadir', pkgdatadir)
+ 
+   configure_file(

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -44,13 +44,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mutter";
-  version = "3.36.0";
+  version = "3.36.1";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "18lvj158w6gwc6xpvn699v8ykh1r5szry7sqascl6f1i8g628v2x";
+    sha256 = "09fqs9805d07c60a2ibskqffsb5wn72l8grwzb9fic5sl574b0im";
   };
 
   mesonFlags = [
@@ -120,13 +120,6 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit zenity;
-    })
-
-    # Fix crash when opening submenus from «always on visible workspace» windows
-    # https://gitlab.gnome.org/GNOME/mutter/issues/1083
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/commit/7e32cc05ce2e5b3931ddcf46ce9ead603a0de39e.patch";
-      sha256 = "5ZzOMizucfrSnHNYjHIUObLHCvAIjrE6fY/CxLp4c7k=";
     })
   ];
 

--- a/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     owner = "micheleg";
     repo = "dash-to-dock";
     # rev = "extensions.gnome.org-v" + version;
-    rev = "c58004802b2eedfde96966a4ec0151fea2a1bd98";
-    sha256 = "IjunykPFP2CbGcd8XVqhPuNUOUOOgDAQFIytLaoyqRg=";
+    rev = "8c94a8d6db47ebc1273e690f4e0ba5e592f7f268";
+    sha256 = "7nNfxAINqOIJCgYXYaPck2EJ1IOmzt6AkfDFknZ8GaI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bump gnome-shell. This unfortunately breaks the extension app, as they've introduced a new internal library ([`libshew`](https://gitlab.gnome.org/GNOME/gnome-shell/-/tree/master/subprojects%2Fshew)) which gets an incorrect path in its typelib ala. eog.

Not sure if we've found a good way to deal with these failures (I seem to recall we've fixed something like this before, but can't quite remember). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
