### PR TITLE
[20.03] xorg.xorgserver: 1.20.7 -> 1.20.8

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2692,11 +2692,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xorgserver = callPackage ({ stdenv, pkgconfig, fetchurl, xorgproto, openssl, libX11, libXau, libXaw, libxcb, xcbutil, xcbutilwm, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, libXdmcp, libXfixes, libxkbfile, libXmu, libXpm, libXrender, libXres, libXt }: stdenv.mkDerivation {
-    name = "xorg-server-1.20.7";
+    name = "xorg-server-1.20.8";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/xserver/xorg-server-1.20.7.tar.bz2;
-      sha256 = "18bfl04ihw1jr3h0fs522nnxxq5ixjay77y9dcymnkzk23q8cndx";
+      url = "mirror://xorg/individual/xserver/xorg-server-1.20.8.tar.bz2";
+      sha256 = "0ih15m7gh1z1ly6z7g82bkni719yisqmbk61a1wgp82bxrmn8yyi";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -218,4 +218,4 @@ mirror://xorg/individual/util/lndir-1.0.3.tar.bz2
 mirror://xorg/individual/util/makedepend-1.0.6.tar.bz2
 mirror://xorg/individual/util/util-macros-1.19.2.tar.bz2
 mirror://xorg/individual/util/xorg-cf-files-1.0.6.tar.bz2
-mirror://xorg/individual/xserver/xorg-server-1.20.7.tar.bz2
+mirror://xorg/individual/xserver/xorg-server-1.20.8.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2020-March/003041.html

This release contains a fix for Xwayland which removes a buffer swap
race between XWayland and the compositor. This resulted in flickering in
previous versions.

Backport of https://github.com/NixOS/nixpkgs/pull/83995. Flicker-free XWayland for release users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
