### PR TITLE
razergenie: init at 0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2470,6 +2470,12 @@
     githubId = 2817965;
     name = "f--t";
   };
+  f4814n = {
+    email = "me@f4814n.de";
+    github = "f4814";
+    githubId = 11909469;
+    name = "Fabian Geiselhart";
+  };
   fadenb = {
     email = "tristan.helmich+nixos@gmail.com";
     github = "fadenb";

--- a/pkgs/applications/misc/razergenie/default.nix
+++ b/pkgs/applications/misc/razergenie/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, lib, meson, ninja, pkgconfig, qtbase, qttools
+, wrapQtAppsHook
+, enableExperimental ? false
+, includeMatrixDiscovery ? false
+}:
+
+let
+  version = "0.8.1";
+  pname = "razergenie";
+
+in stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "z3ntu";
+    repo = "RazerGenie";
+    rev = "v${version}";
+    sha256 = "1ggxnaidxbbpkv1h3zwwyci6886sssgslk5adbikbhz9kc9qg239";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig meson ninja wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase qttools
+  ];
+
+  mesonFlags = [
+    "-Denable_experimental=${if enableExperimental then "true" else "false"}"
+    "-Dinclude_matrix_discovery=${if includeMatrixDiscovery then "true" else "false"}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/z3ntu/RazerGenie";
+    description = "Qt application for configuring your Razer devices under GNU/Linux";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ f4814n ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2153,6 +2153,8 @@ in
 
   rav1e = callPackage ../tools/video/rav1e { };
 
+  razergenie = libsForQt5.callPackage ../applications/misc/razergenie { };
+
   ring-daemon = callPackage ../applications/networking/instant-messengers/ring-daemon { };
 
   riot-desktop = callPackage ../applications/networking/instant-messengers/riot/riot-desktop.nix { };
@@ -5707,7 +5709,7 @@ in
   padthv1 = libsForQt5.callPackage ../applications/audio/padthv1 { };
 
   page = callPackage ../tools/misc/page { };
-  
+
   pagmo2 = callPackage ../development/libraries/pagmo2 { };
 
   pakcs = callPackage ../development/compilers/pakcs { };


### PR DESCRIPTION
###### Motivation for this change
Add razergenie, a frontend for the openrazer daemon. To the best of my knowledge there is no openrazer frontend in nixpkgs at the moment, which renders nixos `hardware.openrazer` functionality almost useless. I also added myself as contributor and notified the RazerGenie maintainers here: https://github.com/z3ntu/RazerGenie/issues/70

I attempted this here https://github.com/NixOS/nixpkgs/pull/83106 but screwed up my PR. So here is a new, clean PR.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
