### PR TITLE
gcc: copy windows library file to the lib output

### DIFF
--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -214,6 +214,8 @@ preInstall() {
 postInstall() {
     # Move runtime libraries to $lib.
     moveToOutput "${targetConfig+$targetConfig/}lib/lib*.so*" "$lib"
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dll" "$lib"
+    moveToOutput "${targetConfig+$targetConfig/}lib/lib*.a" "$lib"
     moveToOutput "${targetConfig+$targetConfig/}lib/lib*.la"  "$lib"
     moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dylib" "$lib"
     moveToOutput "share/gcc-*/python" "$lib"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I think interesing to ability of nixos to crosscompile for windows. I tried to do this for gnash, where an old version exist for windows. However, there was an error compiling gettext. This solver the issue, allowing gettext to compile for windows.

###### Things done
copy *.dll and *.a file to the lib output of gcc. I'm not sure if I should copy *.a file, however.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Note: I just tested compilation of pkgsCross.mingwW64.gettext, and every thing that depend on it. It should impact other platform version of the gcc library. Further testing show this also allow pkgsCross.mingwW64.gmp to compile.

I'm a bit worried to this do a full rebuild of gcc for every user, but I can't add a conditional instruction that do this for windows only without changing the hash of the builder.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
