### PR TITLE
subsurface: 4.8.2 -> 4.9.3

### DIFF
--- a/pkgs/applications/misc/subsurface/0001-core-fix-libgit-ifdef-to-handle-libgit2-v1.0-and-onw.patch
+++ b/pkgs/applications/misc/subsurface/0001-core-fix-libgit-ifdef-to-handle-libgit2-v1.0-and-onw.patch
@@ -1,0 +1,41 @@
+From dfa4bcafec4425659a409550085417af3c5c787b Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Sat, 11 Apr 2020 12:38:38 +0200
+Subject: [PATCH] core: fix libgit ifdef to handle libgit2 v1.0 and onwards
+
+Conditional code for older libgit versions was removed in
+https://github.com/Subsurface-divelog/subsurface/pull/2737,
+but it's a non-trivial backport, and master currently isn't really ready
+for a release.
+
+So instead ship a patch fixing the one broken libgit2 conditional until
+a 4.10 release has been made.
+
+Note the inverted logic - the if branch now handles the old libgit
+condition, and the else branch the newer versions, consistent with how
+it's done in the rest of the subsurface codebase.
+---
+ core/git-access.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/core/git-access.c b/core/git-access.c
+index 3688cb90c..9997fc8fd 100644
+--- a/core/git-access.c
++++ b/core/git-access.c
+@@ -359,10 +359,10 @@ static int try_to_git_merge(git_repository *repo, git_reference **local_p, git_r
+ 	}
+ 
+ 	git_merge_init_options(&merge_options, GIT_MERGE_OPTIONS_VERSION);
+-#if !LIBGIT2_VER_MAJOR && LIBGIT2_VER_MINOR > 23
+-	merge_options.flags = GIT_MERGE_FIND_RENAMES;
+-#else
++#if !LIBGIT2_VER_MAJOR && LIBGIT2_VER_MINOR <= 22
+ 	merge_options.tree_flags = GIT_MERGE_TREE_FIND_RENAMES;
++#else
++	merge_options.flags = GIT_MERGE_FIND_RENAMES;
+ #endif
+ 	merge_options.file_favor = GIT_MERGE_FILE_FAVOR_UNION;
+ 	merge_options.rename_threshold = 100;
+-- 
+2.25.1
+

--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -4,16 +4,22 @@
 }:
 
 let
-  version = "4.8.2";
+  version = "4.9.3";
+
+  subsurfaceSrc = (fetchFromGitHub {
+    owner = "Subsurface-divelog";
+    repo = "subsurface";
+    rev = "v${version}";
+    sha256 = "1i07f7appifx9j205x5a7ng01wsipxr6n9a3692pm60jli2nsir5";
+    fetchSubmodules = true;
+  });
 
   libdc = stdenv.mkDerivation {
     pname = "libdivecomputer-ssrf";
     inherit version;
 
-    src = fetchurl {
-      url = "https://subsurface-divelog.org/downloads/libdivecomputer-subsurface-branch-${version}.tgz";
-      sha256 = "167qan59raibmilkc574gdqxfjg2f5ww2frn86xzk2kn4qg8190w";
-    };
+    src = subsurfaceSrc;
+    sourceRoot = "source/libdivecomputer";
 
     nativeBuildInputs = [ autoreconfHook ];
 
@@ -70,10 +76,10 @@ in stdenv.mkDerivation {
   pname = "subsurface";
   inherit version;
 
-  src = fetchurl {
-    url = "https://subsurface-divelog.org/downloads/Subsurface-${version}.tgz";
-    sha256 = "1fzrq6rqb6pzs36wxar2453cl509dqpcy9w7nq4gw7b1v2331wfy";
-  };
+  src = subsurfaceSrc;
+
+  # remove with the 4.10 release
+  patches = [ ./0001-core-fix-libgit-ifdef-to-handle-libgit2-v1.0-and-onw.patch ];
 
   buildInputs = [
     libdc googlemaps


### PR DESCRIPTION
This bumps subsurface to the latest release, and applies a patch to make
it work with libgit2 v1.0.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
