### PR TITLE
[WIP] protobuf: build with cmake instead of autoconf

### DIFF
--- a/pkgs/development/libraries/protobuf/protobuf-3.6-cmake-versionrc.patch
+++ b/pkgs/development/libraries/protobuf/protobuf-3.6-cmake-versionrc.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/protoc.cmake b/cmake/protoc.cmake
+index 9bf6f5a92..6c579f61e 100644
+--- a/cmake/protoc.cmake
++++ b/cmake/protoc.cmake
+@@ -2,6 +2,8 @@ set(protoc_files
+   ${protobuf_source_dir}/src/google/protobuf/compiler/main.cc
+ )
+ 
++configure_file(${protobuf_source_dir}/cmake/version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
++
+ set(protoc_rc_files
+   ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+ )

--- a/pkgs/development/libraries/protobuf/protobuf-cmake.patch
+++ b/pkgs/development/libraries/protobuf/protobuf-cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index 9b2ae93cf..cef1f5c00 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -137,7 +137,7 @@ install(EXPORT protobuf-targets
+   NAMESPACE protobuf::
+   COMPONENT protobuf-export)
+ 
+-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/
++install(DIRECTORY ${CMAKE_INSTALL_CMAKEDIR}/
+   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+   COMPONENT protobuf-export
+   PATTERN protobuf-targets.cmake EXCLUDE


### PR DESCRIPTION
###### Motivation for this change
Protobuf has both cmake and autoconf/Make based build systems. The CMake build system will install both pkgconfig and cmake packages for other builds using protobuf to import, while the autoconf build system only installs the pkgconfig files.

In particular, this is a prerequisite for packaging the onnx library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
