### PR TITLE
libpoly: fix src

### DIFF
--- a/pkgs/applications/science/logic/poly/default.nix
+++ b/pkgs/applications/science/logic/poly/default.nix
@@ -7,8 +7,9 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "SRI-CSL";
     repo = "libpoly";
-    rev = "v${version}";
-    sha256 = "19ddzrir20571zqg720ajqpl59lhpc6c18bp763r6rw68d9zbjch";
+    # they've pushed to the release branch, use explicit tag
+    rev = "refs/tags/v${version}";
+    sha256 = "1n3gijksnl2ybznq4lkwm2428f82423sxq18gnb2g1kiwqlzdaa3";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
they've pushed to the release branch, use explicit tag

accidently merged  #83416
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/84834
11 package built:
bluespec glasgow libpoly maude python37Packages.nmigen python37Packages.nmigen-boards python37Packages.nmigen-soc python38Packages.nmigen python38Packages.nmigen-boards python38Packages.nmigen-soc yices
```