### PR TITLE
nextcloud: Review installation upgrade warning wording

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -322,12 +322,21 @@ in {
           Please migrate your configuration to config.services.nextcloud.poolSettings.
         '')
         ++ (optional (versionOlder cfg.package.version "18") ''
-          You're currently deploying an older version of Nextcloud. This may be needed
-          since Nextcloud doesn't allow major version upgrades across multiple versions (i.e. an
-          upgrade from 16 is possible to 17, but not to 18).
+          A legacy Nextcloud install (from before NixOS 20.03) may be installed.
 
-          Please deploy this to your server and wait until the migration is finished. After
-          that you can deploy to the latest Nextcloud version available.
+          You're currently deploying an older version of Nextcloud. This may be needed
+          since Nextcloud doesn't allow major version upgrades that skip multiple
+          versions (i.e. an upgrade from 16 is possible to 17, but not 16 to 18).
+
+          It is assumed that Nextcloud will be upgraded from version 16 to 17.
+
+           * If this is a fresh install, there will be no upgrade to do now.
+
+           * If this server already had Nextcloud installed, first deploy this to your
+             server, and wait until the upgrade to 17 is finished.
+
+          Then, set `services.nextcloud.package` to `pkgs.nextcloud18` to upgrade to
+          Nextcloud version 18.
         '');
 
       services.nextcloud.package = with pkgs;


### PR DESCRIPTION
The new wording does not assume the user is upgrading.

This is because a user could be setting up a new installation on 20.03
on a server that has a 19.09 or before stateVersion!!

The new wording ensures that confusion is reduced by stating that they
do not have to care about the assumed 16→17 transition.

Then, the wording explains that they should, and how to upgrade to
version 18.

It also reviews the confusing wording about "multiple" upgrades.

* * *

The only thing we cannot really do is stop a fresh install of 17 if
there was no previous install, as it cannot be detected. That makes a
useless upgrade forced for new users with old state versions.

It is also important to state that they must set their package to
Nextcloud 18, as future upgrades to Nextcloud will not allow an uprade
from 17!

I assume future warning messages will exist specifically stating what to
do to go from 18 to 19, then 19 to 20, etc...

* * *

cc @Ma27 @worldofpeace 

I don't think this is a *blocker* for 20.03, but something to apply ASAP to 20.03 once approved.