### PR TITLE
herbstluftwm: 0.7.2 -> 0.8.1

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -31,6 +31,7 @@
 <xref linkend="opt-services.xserver.windowManager.twm.enable"/> = true;
 <xref linkend="opt-services.xserver.windowManager.icewm.enable"/> = true;
 <xref linkend="opt-services.xserver.windowManager.i3.enable"/> = true;
+<xref linkend="opt-services.xserver.windowManager.herbstluftwm.enable"/> = true;
 </programlisting>
  </para>
  <para>

--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, fetchurl, cmake, pkgconfig, glib, libX11, libXext, libXinerama, libXrandr, asciidoc }:
+{ stdenv, fetchurl, cmake, pkgconfig, glib, libX11, libXext, libXinerama, libXrandr
+, withDoc ? stdenv.buildPlatform == stdenv.targetPlatform, asciidoc ? null }:
+
+# Doc generation is disabled by default when cross compiling because asciidoc
+# does not cross compile for now
+
+assert withDoc -> asciidoc != null;
 
 stdenv.mkDerivation rec {
   pname = "herbstluftwm";
@@ -11,19 +17,19 @@ stdenv.mkDerivation rec {
 
   outputs = [
     "out"
+  ] ++ stdenv.lib.optionals withDoc [
     "doc"
     "man"
   ];
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_SYSCONF_PREFIX=${placeholder "out"}/etc"
-  ];
+  ] ++ stdenv.lib.optional (!withDoc) "-DWITH_DOCUMENTATION=OFF";
 
   nativeBuildInputs = [
     cmake
     pkgconfig
-    asciidoc
-  ];
+  ] ++ stdenv.lib.optional withDoc asciidoc;
 
   buildInputs = [
     glib

--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional withDoc asciidoc;
 
   buildInputs = [
-    glib
     libX11
     libXext
     libXinerama

--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -8,11 +8,11 @@ assert withDoc -> asciidoc != null;
 
 stdenv.mkDerivation rec {
   pname = "herbstluftwm";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchurl {
     url = "https://herbstluftwm.org/tarballs/herbstluftwm-${version}.tar.gz";
-    sha256 = "04n8cmrgb490kfn70x9kgxp286mrrn7nb4irhi7nvbm6lv0z28sq";
+    sha256 = "0c1lf82z6a56g8asin91cmqhzk3anw0xwc44b31bpjixadmns57y";
   };
 
   outputs = [

--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -1,27 +1,41 @@
-{ stdenv, fetchurl, pkgconfig, glib, libX11, libXext, libXinerama }:
+{ stdenv, fetchurl, cmake, pkgconfig, glib, libX11, libXext, libXinerama, libXrandr, asciidoc }:
 
 stdenv.mkDerivation rec {
-  name = "herbstluftwm-0.7.2";
+  pname = "herbstluftwm";
+  version = "0.8.0";
 
   src = fetchurl {
-    url = "https://herbstluftwm.org/tarballs/${name}.tar.gz";
-    sha256 = "1kc18aj9j3nfz6fj4qxg9s3gg4jvn6kzi3ii24hfm0vqdpy17xnz";
+    url = "https://herbstluftwm.org/tarballs/herbstluftwm-${version}.tar.gz";
+    sha256 = "04n8cmrgb490kfn70x9kgxp286mrrn7nb4irhi7nvbm6lv0z28sq";
   };
 
-  patchPhase = ''
-    substituteInPlace config.mk \
-      --replace "/usr/local" "$out" \
-      --replace "/etc" "$out/etc" \
-      --replace "/zsh/functions/Completion/X" "/zsh/site-functions" \
-      --replace "/usr/share" "\$(PREFIX)/share"
-  '';
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libX11 libXext libXinerama ];
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_SYSCONF_PREFIX=${placeholder "out"}/etc"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+    asciidoc
+  ];
+
+  buildInputs = [
+    glib
+    libX11
+    libXext
+    libXinerama
+    libXrandr
+  ];
 
   meta = {
     description = "A manual tiling window manager for X";
-    homepage = "http://herbstluftwm.org/";
+    homepage = "https://herbstluftwm.org/";
     license = stdenv.lib.licenses.bsd2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ the-kenny ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19786,7 +19786,9 @@ in
 
   heme = callPackage ../applications/editors/heme { };
 
-  herbstluftwm = callPackage ../applications/window-managers/herbstluftwm { };
+  herbstluftwm = callPackage ../applications/window-managers/herbstluftwm {
+    asciidoc = asciidoc-full;
+  };
 
   hercules = callPackage ../applications/virtualization/hercules { };
 


### PR DESCRIPTION
###### Motivation for this change

Update herbstluftwm.
`CMAKE_INSTALL_SYSCONF_PREFIX` needs to be explicitly set for bash completion.
I put the documentation and man pages in their respective outputs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
