### PR TITLE
 python3Packages.cvxpy: 1.0.25 -> 1.0.31

### DIFF
--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "cvxpy";
-  version = "1.0.25";
+  version = "1.0.31";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04zalvc8lckjfzm3i2ir32ib5pd6v7hxqqcnsnq6fw40vffm4dc5";
+    sha256 = "17g6xcy99icrdcmb4pa793kqvzchbzl5lsw00xms9slwkr7pb65k";
   };
 
   propagatedBuildInputs = [
@@ -38,13 +38,13 @@ buildPythonPackage rec {
 
   checkInputs = [ nose ];
   checkPhase = ''
-    nosetests
+    nosetests cvxpy
   '';
 
   meta = with lib; {
     description = "A domain-specific language for modeling convex optimization problems in Python.";
     homepage = "https://www.cvxpy.org/";
-    downloadPage = "https://github.com/cvxgrp/cvxpy/";
+    downloadPage = "https://github.com/cvxgrp/cvxpy/releases";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Package bump: ``python3Packages.cvxpy``

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
