### PR TITLE
hobbits: init at 0.52.0

### DIFF
--- a/pkgs/tools/graphics/hobbits/default.nix
+++ b/pkgs/tools/graphics/hobbits/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, mkDerivation, fetchFromGitHub
+, cmake, pkg-config, fftw, libpcap, libusb1, python3
+}:
+
+mkDerivation rec {
+  pname = "hobbits";
+  version = "0.52.0";
+
+  src = fetchFromGitHub {
+    owner = "Mahlet-Inc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-GZHBkBRt1ySItV+h5rdvey7KwdUWh5+rgztXh6HW3Js=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/hobbits-core/settingsdata.cpp \
+      --replace "pythonHome = \"/usr\"" "pythonHome = \"${python3}\""
+    substituteInPlace cmake/gitversion.cmake \
+      --replace "[Mystery Build]" "${version}"
+  '';
+
+  buildInputs = [ fftw libpcap libusb1 python3 ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  meta = with lib; {
+    description = "A multi-platform GUI for bit-based analysis, processing, and visualization";
+    homepage = "https://github.com/Mahlet-Inc/hobbits";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6073,6 +6073,8 @@ with pkgs;
 
   hivemind = callPackage ../applications/misc/hivemind { };
 
+  hobbits = libsForQt5.callPackage ../tools/graphics/hobbits { };
+
   hfsprogs = callPackage ../tools/filesystems/hfsprogs { };
 
   highlight = callPackage ../tools/text/highlight ({


### PR DESCRIPTION
#### Motivation for this change
[Hobbits](https://github.com/Mahlet-Inc/hobbits) - A multi-platform GUI for bit-based analysis, processing, and visualization.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
