### PR TITLE
Revert "iso-image: normalize volumeID"

### DIFF
--- a/nixos/lib/make-iso9660-image.sh
+++ b/nixos/lib/make-iso9660-image.sh
@@ -107,7 +107,6 @@ xorriso="xorriso
  -publisher nixos
  -graft-points
  -full-iso9660-filenames
- -joliet
  ${isoBootFlags}
  ${usbBootFlags}
  ${efiBootFlags}

--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -18,6 +18,8 @@ with lib;
   # ISO naming.
   isoImage.isoName = "${config.isoImage.isoBaseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.iso";
 
+  isoImage.volumeID = substring 0 11 "NIXOS_ISO";
+
   # EFI booting
   isoImage.makeEfiBootable = true;
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -7,8 +7,6 @@ with lib;
 {
   imports = [ ./installation-cd-graphical-base.nix ];
 
-  isoImage.edition = "gnome";
-
   services.xserver.desktopManager.gnome3.enable = true;
 
   # Wayland can be problematic for some hardware like Nvidia graphics cards.

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix
@@ -8,8 +8,6 @@ with lib;
 {
   imports = [ ./installation-cd-graphical-base.nix ];
 
-  isoImage.edition = "plasma5";
-
   services.xserver = {
     desktopManager.plasma5 = {
       enable = true;

--- a/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
@@ -8,7 +8,5 @@
     [ ./installation-cd-base.nix
     ];
 
-  isoImage.edition = "minimal";
-
   fonts.fontconfig.enable = false;
 }

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -417,17 +417,8 @@ in
       '';
     };
 
-    isoImage.edition = mkOption {
-      default = "";
-      description = ''
-        Specifies which edition string to use in the volume ID of the generated
-        ISO image.
-      '';
-    };
-
     isoImage.volumeID = mkOption {
-      # nixos-$EDITION-$RELEASE-$ARCH
-      default = "nixos${optionalString (config.isoImage.edition != "") "-${config.isoImage.edition}"}-${config.system.nixos.release}-${pkgs.stdenv.hostPlatform.system}";
+      default = "NIXOS_BOOT_CD";
       description = ''
         Specifies the label or volume ID of the generated ISO image.
         Note that the label is used by stage 1 of the boot process to
@@ -524,19 +515,6 @@ in
   };
 
   config = {
-    assertions = [
-      {
-        assertion = !(stringLength config.isoImage.volumeID > 32);
-        # https://wiki.osdev.org/ISO_9660#The_Primary_Volume_Descriptor
-        # Volume Identifier can only be 32 bytes
-        message = let
-          length = stringLength config.isoImage.volumeID;
-          howmany = toString length;
-          toomany = toString (length - 32);
-        in
-        "isoImage.volumeID ${config.isoImage.volumeID} is ${howmany} characters. That is ${toomany} characters longer than the limit of 32.";
-      }
-    ];
 
     boot.loader.grub.version = 2;
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#83551

I was soo close, it broke aarch64-linux minimal image
```
error: 
Failed assertions:
- isoImage.volumeID nixos-minimal-20.03-aarch64-linux is 33 characters. That is 1 characters longer than the limit of 32.
(use '--show-trace' to show detailed location information)
```