### PR TITLE
pcsc-cyberjack: minor cleanups

### DIFF
--- a/pkgs/tools/security/pcsc-cyberjack/default.nix
+++ b/pkgs/tools/security/pcsc-cyberjack/default.nix
@@ -1,24 +1,27 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libusb1, pcsclite }:
 
-stdenv.mkDerivation rec {
-  pname = "pcsc-cyberjack";
-  version = "3.99.5_SP13";
+let
+  version = "3.99.5";
+  suffix = "SP13";
+  tarBall = "${version}final.${suffix}";
 
-  src = with stdenv.lib; let
-    splittedVer = splitString "_" version;
-    mainVer = if length splittedVer >= 1 then head splittedVer else version;
-    spVer = optionalString (length splittedVer >= 1) ("." + last splittedVer);
-    tarballVersion = "${mainVer}final${spVer}";
-  in fetchurl {
-    url = "http://support.reiner-sct.de/downloads/LINUX/V${version}"
-        + "/pcsc-cyberjack_${tarballVersion}.tar.gz";
+in stdenv.mkDerivation rec {
+  pname = "pcsc-cyberjack";
+  inherit version;
+
+  src = fetchurl {
+    url =
+      "http://support.reiner-sct.de/downloads/LINUX/V${version}_${suffix}/${pname}_${tarBall}.tar.gz";
     sha256 = "1lx4bfz4riz7j77sl65akyxzww0ygm63w0c1b75knr1pijlv8d3b";
   };
 
   outputs = [ "out" "tools" ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
   buildInputs = [ libusb1 pcsclite ];
+
+  enableParallelBuilding = true;
 
   configureFlags = [
     "--with-usbdropdir=${placeholder "out"}/pcsc/drivers"
@@ -31,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "REINER SCT cyberJack USB chipcard reader user space driver";
     homepage = "https://www.reiner-sct.com/";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ aszlig ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Previously, pulling in libusb meant that you would get libusb1 as well as it was
propagated by libusb which meant that derivations incorrectly depending on
libusb when they should be depending on libusb1 would work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).