### PR TITLE
protobuf: do a release build (without -g)

### DIFF
--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -35,6 +35,10 @@ mkProtobufDerivation = buildProtobuf: stdenv: stdenv.mkDerivation {
   buildInputs = [ zlib ];
   configureFlags = if buildProtobuf == null then [] else [ "--with-protoc=${buildProtobuf}/bin/protoc" ];
 
+  # Enable a release build without "-g"
+  # see https://github.com/protocolbuffers/protobuf/issues/6941
+  CXXFLAGS="-O2 -std=c++11 -DNDEBUG";
+
   enableParallelBuilding = true;
 
   doCheck = true;


### PR DESCRIPTION
This removes parts of the compiler from the closure.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes: #73919

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
** on darwin:***
```
# nix path-info -Sh $(readlink before)
/nix/store/5vm6cpfhmcdnrp69shllns4qqij213y4-protobuf-3.7.1       693.1M
# nix path-info -Sh $(readlink after)
/nix/store/jd6igaiad4qzjb6salcq7pjgixk2jl2c-protobuf-3.7.1        59.8M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
