### PR TITLE
openarena: add community map pack

### DIFF
--- a/pkgs/games/openarena/default.nix
+++ b/pkgs/games/openarena/default.nix
@@ -10,6 +10,13 @@ stdenv.mkDerivation {
     sha256 = "0jmc1cmdz1rcvqc9ilzib1kilpwap6v0d331l6q53wsibdzsz3ss";
   };
 
+  # https://openarena.fandom.com/wiki/OACMP/Volume_1
+  communityMaps = fetchurl {
+    name = "oacmp-volume1-v3.zip";
+    urls = ["https://archive.org/download/openarena/oacmp-volume1-v3.zip"];
+    sha256 = "06z4cxp6mrcdxx3lra0v5n295a8mz6q13n173jcdlqyd1zgmqwvv";
+  };
+
   nativeBuildInputs = [ pkgs.unzip patchelf makeWrapper];
 
   installPhase = let
@@ -31,6 +38,10 @@ stdenv.mkDerivation {
     makeWrapper "${gameDir}/openarena.${arch}" "$out/bin/openarena" \
       --prefix LD_LIBRARY_PATH : "${libPath}"
     makeWrapper "${gameDir}/oa_ded.${arch}" "$out/bin/oa_ded"
+
+    cd openarena-0.8.8
+    unzip $communityMaps
+    rm -rf sources
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

More maps in Openarena!

To test, install openarena and start a game using one of the community maps from https://openarena.fandom.com/wiki/OACMP/Volume_1 , e.g. `oacmpdm1`.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
