### PR TITLE
mono6: 6.0.0.313 -> 6.8.0.105

### DIFF
--- a/pkgs/development/compilers/mono/6.nix
+++ b/pkgs/development/compilers/mono/6.nix
@@ -2,8 +2,8 @@
 
 callPackage ./generic.nix ({
   inherit Foundation libobjc;
-  version = "6.0.0.313";
+  version = "6.8.0.105";
   srcArchiveSuffix = "tar.xz";
-  sha256 = "0l0cd6q5xh1vdm6zr78rkfqdsmrgzanjgpxvgig0pyd3glfyjim9";
+  sha256 = "0y11c7w6r96laqckfxnk1ya42hx2c1nfqvdgbpmsk1iw9k29k1sp";
   enableParallelBuilding = true;
 })


### PR DESCRIPTION
#### Motivation for this change

Update mono6

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Fedora)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
