### PR TITLE
ocamlPackages.fmt: 0.8.5 → 0.8.6

### DIFF
--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -4,12 +4,12 @@ if !lib.versionAtLeast (cstruct.version or "1") "3"
 then cstruct
 else
 
-buildDunePackage {
+buildDunePackage rec {
 	pname = "cstruct-sexp";
 	inherit (cstruct) version src meta;
 
 	doCheck = true;
-	buildInputs = [ alcotest ];
+	checkInputs = lib.optional doCheck alcotest;
 
 	propagatedBuildInputs = [ cstruct sexplib ];
 }

--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, alcotest, cstruct, sexplib }:
+{ lib, buildDunePackage, ocaml, alcotest, cstruct, sexplib }:
 
 if !lib.versionAtLeast (cstruct.version or "1") "3"
 then cstruct
@@ -8,7 +8,7 @@ buildDunePackage rec {
 	pname = "cstruct-sexp";
 	inherit (cstruct) version src meta;
 
-	doCheck = true;
+	doCheck = lib.versionAtLeast ocaml.version "4.03";
 	checkInputs = lib.optional doCheck alcotest;
 
 	propagatedBuildInputs = [ cstruct sexplib ];

--- a/pkgs/development/ocaml-modules/fmt/default.nix
+++ b/pkgs/development/ocaml-modules/fmt/default.nix
@@ -1,16 +1,21 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, cmdliner, result, uchar }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, cmdliner, seq, stdlib-shims }:
 
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-fmt-0.8.5";
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "fmt is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  version = "0.8.6";
+  pname = "ocaml${ocaml.version}-fmt";
 
   src = fetchurl {
-    url = "https://erratique.ch/software/fmt/releases/fmt-0.8.5.tbz";
-    sha256 = "1zj9azcxcn6skmb69ykgmi9z8c50yskwg03wqgh87lypgjdcz060";
+    url = "https://erratique.ch/software/fmt/releases/fmt-${version}.tbz";
+    sha256 = "1jlw5izgvqw1adzqi87rp0383j0vj52wmacy3rqw87vxkf7a3xin";
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild ];
   buildInputs = [ findlib topkg cmdliner ];
-  propagatedBuildInputs = [ result uchar ];
+  propagatedBuildInputs = [ seq stdlib-shims ];
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/ppx_blob/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_blob/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage, alcotest, ocaml-migrate-parsetree }:
+{ lib, fetchurl, buildDunePackage, ocaml, alcotest, ocaml-migrate-parsetree }:
 
 buildDunePackage rec {
   pname = "ppx_blob";
@@ -11,7 +11,7 @@ buildDunePackage rec {
 
   checkInputs = lib.optional doCheck alcotest;
   buildInputs = [ ocaml-migrate-parsetree ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.03";
 
   meta = with lib; {
     homepage = "https://github.com/johnwhitington/ppx_blob";

--- a/pkgs/development/ocaml-modules/ppx_blob/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_blob/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildDunePackage, alcotest, ocaml-migrate-parsetree }:
+{ lib, fetchurl, buildDunePackage, alcotest, ocaml-migrate-parsetree }:
 
 buildDunePackage rec {
   pname = "ppx_blob";
@@ -9,10 +9,11 @@ buildDunePackage rec {
     sha256 = "1xmslk1mwdzhy1bydgsjlcb7h544c39hvxa8lywp8w72gaggjl16";
   };
 
-  buildInputs = [ alcotest ocaml-migrate-parsetree ];
+  checkInputs = lib.optional doCheck alcotest;
+  buildInputs = [ ocaml-migrate-parsetree ];
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/johnwhitington/ppx_blob";
     description = "OCaml ppx to include binary data from a file as a string";
     license = licenses.unlicense;


### PR DESCRIPTION
###### Motivation for this change

Needed to update alcotest

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
