### PR TITLE
freerdp: 2.0.0-rc4 -> 2.0.0

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       --replace "Requires:" "Requires: @WINPR_PKG_CONFIG_FILENAME@"
   '' + lib.optionalString (pcsclite != null) ''
     substituteInPlace "winpr/libwinpr/smartcard/smartcard_pcsc.c" \
-      --replace "libpcsclite.so" "${stdenv.lib.getLib pcsclite}/lib/libpcsclite.so"
+      --replace "libpcsclite.so" "${lib.getLib pcsclite}/lib/libpcsclite.so"
   '' + lib.optionalString nocaps ''
     substituteInPlace "libfreerdp/locale/keyboard_xkbfile.c" \
       --replace "RDP_SCANCODE_CAPSLOCK" "RDP_SCANCODE_LCONTROL"
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
       FreeRDP is a client-side implementation of the Remote Desktop Protocol (RDP)
       following the Microsoft Open Specifications.
     '';
-    homepage = http://www.freerdp.com/;
+    homepage = "http://www.freerdp.com/";
     license = licenses.asl20;
     maintainers = with maintainers; [ peterhoeg lheckemann ];
     platforms = platforms.unix;

--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -1,9 +1,10 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkgconfig
 , alsaLib, ffmpeg, glib, openssl, pcre, zlib
-, libX11, libXcursor, libXdamage, libXext, libXi, libXinerama, libXrandr, libXrender, libXv
+, libX11, libXcursor, libXdamage, libXext, libXi, libXinerama, libXrandr, libXrender, libXv, libXtst
 , libxkbcommon, libxkbfile
 , wayland
 , gstreamer, gst-plugins-base, gst-plugins-good, libunwind, orc
+, libxslt
 , libusb1
 , libpulseaudio ? null
 , cups ? null
@@ -41,9 +42,10 @@ stdenv.mkDerivation rec {
   buildInputs = with lib; [
     alsaLib cups ffmpeg glib openssl pcre pcsclite libpulseaudio zlib
     gstreamer gst-plugins-base gst-plugins-good libunwind orc
-    libX11 libXcursor libXdamage libXext libXi libXinerama libXrandr libXrender libXv
+    libX11 libXcursor libXdamage libXext libXi libXinerama libXrandr libXrender libXv libXtst
     libxkbcommon libxkbfile
     wayland libusb1
+    libxslt
   ] ++ optional stdenv.isLinux systemd;
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -4,6 +4,7 @@
 , libxkbcommon, libxkbfile
 , wayland
 , gstreamer, gst-plugins-base, gst-plugins-good, libunwind, orc
+, libusb1
 , libpulseaudio ? null
 , cups ? null
 , pcsclite ? null
@@ -14,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "freerdp";
-  version = "2.0.0-rc4";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner  = "FreeRDP";
     repo   = "FreeRDP";
     rev    = version;
-    sha256 = "0546i0m2d4nz5jh84ngwzpcm3c43fp987jk6cynqspsmvapab6da";
+    sha256 = "0d2559v0z1jnq6jlrvsgdf8p6gd27m8kwdnxckl1x0ygaxs50bqc";
   };
 
   # outputs = [ "bin" "out" "dev" ];
@@ -42,7 +43,7 @@ stdenv.mkDerivation rec {
     gstreamer gst-plugins-base gst-plugins-good libunwind orc
     libX11 libXcursor libXdamage libXext libXi libXinerama libXrandr libXrender libXv
     libxkbcommon libxkbfile
-    wayland
+    wayland libusb1
   ] ++ optional stdenv.isLinux systemd;
 
   nativeBuildInputs = [
@@ -71,7 +72,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.freerdp.com/;
     license = licenses.asl20;
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg lheckemann ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- [x] Built on NixOS
- [x] Tested `wlfreerdp` client
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
