### PR TITLE
maturin: 0.7.9 -> 0.8.0

### DIFF
--- a/pkgs/development/tools/rust/maturin/Cargo.lock.patch
+++ b/pkgs/development/tools/rust/maturin/Cargo.lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 09ecb81..c37c646 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -733,7 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "maturin"
+-version = "0.8.0-beta.1"
++version = "0.8.0"
+ dependencies = [
+  "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkgs/development/tools/rust/maturin/default.nix
+++ b/pkgs/development/tools/rust/maturin/default.nix
@@ -5,16 +5,21 @@ let
   inherit (darwin.apple_sdk.frameworks) Security;
 in rustPlatform.buildRustPackage rec {
   name = "maturin-${version}";
-  version = "0.7.9";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "PyO3";
     repo = "maturin";
     rev = "v${version}";
-    sha256 = "1l8i1mz97zsc8kayvryv6xznwpby9k9jxy7lsx45acs5yksqchrv";
+    sha256 = "1fjai0c0j8zzaj4c186dkbvx6cpj0vi3sc1qbjbgn2cm8azsd6m6";
   };
 
-  cargoSha256 = "0ly0f64acn1hxnj7vg1m860xpl06rklwqh545c386nnxaj839b0r";
+  # The maturin 0.8.0 lockfile has an incorrect version for maturin
+  # itself. The upstream lockfiles are normally correct, so this
+  # should be removed post-0.8.0.
+  cargoPatches = [ ./Cargo.lock.patch ];
+
+  cargoSha256 = "01sh523fi46k5xwdslhnmjz128jkdw47gp9bd8gim3ay13zkcn1i";
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changelog:

https://github.com/PyO3/maturin/blob/v0.8.0/Changelog.md#080---2020-04-03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
