### PR TITLE
pythonPackages.HAP-python: init at 2.7.0

### DIFF
--- a/pkgs/development/python-modules/HAP-python/default.nix
+++ b/pkgs/development/python-modules/HAP-python/default.nix
@@ -1,0 +1,46 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, curve25519-donna, ed25519
+, cryptography, ecdsa, zeroconf, pytest }:
+
+buildPythonPackage rec {
+  pname = "HAP-python";
+  version = "2.8.1";
+
+  # pypi package does not include tests
+  src = fetchFromGitHub {
+    owner = "ikalchev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "182s3dk7y29wql9bazlnw840xqgsbr44ad72m668qgxd82jl6y9c";
+  };
+
+  disabled = !isPy3k;
+
+  propagatedBuildInputs = [
+    curve25519-donna
+    ed25519
+    cryptography
+    ecdsa
+    zeroconf
+  ];
+
+  checkInputs = [ pytest ];
+
+  #disable tests needing network
+  checkPhase = ''
+    pytest -k 'not test_persist \
+    and not test_setup_endpoints \
+    and not test_auto_add_aid_mac \
+    and not test_service_callbacks \
+    and not test_send_events \
+    and not test_not_standalone_aid \
+    and not test_start_stop_async_acc \
+    and not test_start_stop_sync_acc'
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ikalchev/HAP-python";
+    description = "HomeKit Accessory Protocol implementation in python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ oro ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -327,7 +327,7 @@
     "hive" = ps: with ps; [ ]; # missing inputs: pyhiveapi
     "hlk_sw16" = ps: with ps; [ ]; # missing inputs: hlk-sw16
     "homeassistant" = ps: with ps; [ ];
-    "homekit" = ps: with ps; [ ]; # missing inputs: HAP-python
+    "homekit" = ps: with ps; [ HAP-python];
     "homekit_controller" = ps: with ps; [ ]; # missing inputs: aiohomekit[IP]
     "homematic" = ps: with ps; [ pyhomematic];
     "homematicip_cloud" = ps: with ps; [ ]; # missing inputs: homematicip

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -795,6 +795,8 @@ in {
 
   handout = callPackage ../development/python-modules/handout { };
 
+  HAP-python = callPackage ../development/python-modules/HAP-python { };
+
   helper = callPackage ../development/python-modules/helper { };
 
   hdmedians = callPackage ../development/python-modules/hdmedians { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Homekit connectivity for Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
