### PR TITLE
python3Packages.hydra-check: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/hydra-check/default.nix
+++ b/pkgs/development/python-modules/hydra-check/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, docopt
+, requests
+, beautifulsoup4
+, black
+, mypy
+, flake8
+}:
+
+buildPythonPackage rec {
+  pname = "hydra-check";
+  version = "1.1.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "hydra-check";
+    rev = version;
+    sha256 = "1dmsscsib8ckp496gsfqxmq8d35zs71n99xmziq9iprvy7n5clq2";
+  };
+
+  propagatedBuildInputs = [
+    docopt
+    requests
+    beautifulsoup4
+  ];
+
+  checkInputs = [ mypy ];
+
+  checkPhase = ''
+    echo -e "\x1b[32m## run mypy\x1b[0m"
+    mypy hydracheck
+  '';
+
+  meta = with lib;{
+    description = "check hydra for the build status of a package";
+    homepage = "https://github.com/nix-community/hydra-check";
+    license = licenses.mit;
+    maintainers = with maintainers; [ makefu ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12112,6 +12112,8 @@ in
 
   hydraAntLogger = callPackage ../development/libraries/java/hydra-ant-logger { };
 
+  hydra-check = with python3.pkgs; toPythonApplication hydra-check;
+
   hyena = callPackage ../development/libraries/hyena { };
 
   hyperscan = callPackage ../development/libraries/hyperscan { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4004,6 +4004,8 @@ in {
 
   hypothesis = callPackage ../development/python-modules/hypothesis { };
 
+  hydra-check = callPackage ../development/python-modules/hydra-check { };
+
   colored = callPackage ../development/python-modules/colored { };
 
   xdg = callPackage ../development/python-modules/xdg { };


### PR DESCRIPTION
##### Motivation for this change
Add hydra-check into upstream nixpkgs. closes https://github.com/nix-community/hydra-check/issues/6


###### Things done



- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
