### PR TITLE
[nixos-20.03] pingus: 0.7.6 -> unstable

### DIFF
--- a/pkgs/games/pingus/default.nix
+++ b/pkgs/games/pingus/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation rec {
   pname = "pingus";
   version = "unstable-0.7.6.0.20191104";
 
-  nativeBuildInputs = [ pkgconfig git ];
-  buildInputs = [ cmake SDL2 SDL2_image boost libpng SDL2_mixer libGLU libGL jsoncpp ];
+  nativeBuildInputs = [ cmake pkgconfig git ];
+  buildInputs = [ SDL2 SDL2_image boost libpng SDL2_mixer libGLU libGL jsoncpp ];
   src = fetchgit {
     url = "https://gitlab.com/pingus/pingus/";
     rev = "709546d9b9c4d6d5f45fc9112b45ac10c7f9417d";

--- a/pkgs/games/pingus/default.nix
+++ b/pkgs/games/pingus/default.nix
@@ -1,34 +1,19 @@
-{stdenv, fetchurl, fetchpatch, scons, SDL, SDL_image, boost, libpng, SDL_mixer
-, pkgconfig, libGLU, libGL}:
-let
-  s = # Generated upstream information
-  {
-    baseName="pingus";
-    version="0.7.6";
-    name="pingus-0.7.6";
-    hash="0q34d2k6anzqvb0mf67x85q92lfx9jr71ry13dlp47jx0x9i573m";
-    url="http://pingus.googlecode.com/files/pingus-0.7.6.tar.bz2";
-    sha256="0q34d2k6anzqvb0mf67x85q92lfx9jr71ry13dlp47jx0x9i573m";
+{stdenv, fetchgit, cmake, SDL2, SDL2_image, boost, libpng, SDL2_mixer
+, pkgconfig, libGLU, libGL, git, jsoncpp }:
+stdenv.mkDerivation rec {
+  pname = "pingus";
+  version = "unstable-0.7.6.0.20191104";
+
+  nativeBuildInputs = [ pkgconfig git ];
+  buildInputs = [ cmake SDL2 SDL2_image boost libpng SDL2_mixer libGLU libGL jsoncpp ];
+  src = fetchgit {
+    url = "https://gitlab.com/pingus/pingus/";
+    rev = "709546d9b9c4d6d5f45fc9112b45ac10c7f9417d";
+    sha256 = "sha256:11mmzk0766riaw5qyd1r5i7s7vczbbzfccm92bvgrm99iy1sj022";
+    fetchSubmodules = true;
   };
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [scons SDL SDL_image boost libpng SDL_mixer libGLU libGL];
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
-  patches = [
-    # fix build with gcc7
-    (fetchpatch {
-      url = https://github.com/Pingus/pingus/commit/df6e2f445d3e2925a94d22faeb17be9444513e92.patch;
-      sha256 = "0nqyhznnnvpgfa6rfv8rapjfpw99b67n97jfqp9r3hpib1b3ja6p";
-    })
-  ];
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
-  dontUseSconsInstall = true;
+
   meta = {
-    inherit (s) version;
     description = ''A puzzle game with mechanics similar to Lemmings'';
     platforms = stdenv.lib.platforms.linux;
     maintainers = [stdenv.lib.maintainers.raskin];

--- a/pkgs/games/pingus/default.upstream
+++ b/pkgs/games/pingus/default.upstream
@@ -1,1 +1,0 @@
-url http://pingus.seul.org/download.html


### PR DESCRIPTION

###### Motivation for this change
Backport #83706 to fix pingus in nixos-20.03

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
