### PR TITLE
opencl-clhpp: fix install directory

### DIFF
--- a/pkgs/development/libraries/opencl-clhpp/default.nix
+++ b/pkgs/development/libraries/opencl-clhpp/default.nix
@@ -15,9 +15,10 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ opencl-headers ];
 
-  preConfigure = ''
-    cmakeFlags="-DCMAKE_INSTALL_PREFIX=$out/include -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF"
-  '';
+  cmakeFlags = [
+    "-DBUILD_EXAMPLES=OFF"
+    "-DBUILD_TESTS=OFF"
+  ];
 
   meta = with stdenv.lib; {
     description = "OpenCL Host API C++ bindings";


### PR DESCRIPTION
Previously, it was installing to `$out/include/include`. Now it's correct:

```
/nix/store/alw8idc8qhfhzw98banq2l5hmrdaglgm-opencl-clhpp-2.0.11
├── include
│   └── CL
│       ├── cl2.hpp
│       └── cl.hpp
└── nix-support
    └── propagated-build-inputs

3 directories, 3 files
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).