### PR TITLE
dell-command-configure: init at 4.2.0 with module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4703,6 +4703,12 @@
     githubId = 136037;
     name = "Matthew Maurer";
   };
+  maxeaubrey = {
+    email = "maxeaubrey@gmail.com";
+    github = "maxeaubrey";
+    githubId = 35892750;
+    name = "Maxine Aubrey";
+  };
   mbakke = {
     email = "mbakke@fastmail.com";
     github = "mbakke";

--- a/nixos/modules/hardware/dell-command-configure.nix
+++ b/nixos/modules/hardware/dell-command-configure.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.dellCommandConfigure;
+
+  configFile = pkgs.writeTextFile {
+    name = "omreg.cfg";
+    text = ''
+      hapi.omilcore.version=9.3.0
+      hapi.configtool=${pkgs.dell-command-configure}/bin/dchcfg
+      hapi.installpath=${pkgs.dell-command-configure}
+      hapi.logpath=${cfg.logpath}
+      hapi.vardatapath=${cfg.vardatapath}
+
+      openmanage.openipmi.kernel.2.4.x.ver_min_major=35
+      openmanage.openipmi.kernel.2.4.x.ver_min_minor=13
+      openmanage.openipmi.kernel.2.6.x.ver_min_major=33
+      openmanage.openipmi.kernel.2.6.x.ver_min_minor=13
+      openmanage.openipmi.kernel.ver_min_major=2
+      openmanage.openipmi.kernel.ver_min_minor=6
+      openmanage.openipmi.kernel.ver_min_patch=15
+      openmanage.openipmi.rhel3.ver_min_major=35
+      openmanage.openipmi.rhel3.ver_min_minor=13
+      openmanage.openipmi.rhel4.ver_min_major=33
+      openmanage.openipmi.rhel4.ver_min_minor=13
+    '';
+  };
+in
+
+{
+  options = {
+    hardware.dellCommandConfigure = {
+      enable = mkEnableOption "Dell Command Configure";
+
+      logpath = mkOption {
+        type = types.path;
+        default = "/var/log/openmanage";
+        description = "Log path.";
+      };
+
+      vardatapath = mkOption {
+        type = types.path;
+        default = "/var/lib/openmanage";
+        description = "Data directory path.";
+      };
+    };
+  };
+
+  config = mkIf config.hardware.dellCommandConfigure.enable {
+    environment.systemPackages = [ pkgs.dell-command-configure ];
+
+    system.activationScripts.dellCommandConfigure =
+      ''
+        mkdir -p /opt/dell/srvadmin/etc
+        ln -fs ${configFile} /opt/dell/srvadmin/etc/omreg.cfg
+        mkdir -p ${cfg.logpath}
+        mkdir -p ${cfg.vardatapath}
+      '';
+  };
+
+  meta = {
+    maintainers = with maintainers; [ maxeaubrey ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -46,6 +46,7 @@
   ./hardware/cpu/amd-microcode.nix
   ./hardware/cpu/intel-microcode.nix
   ./hardware/digitalbitbox.nix
+  ./hardware/dell-command-configure.nix
   ./hardware/device-tree.nix
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix

--- a/pkgs/tools/system/dell-command-configure/default.nix
+++ b/pkgs/tools/system/dell-command-configure/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, dpkg }:
+
+stdenv.mkDerivation rec {
+  pname = "dell-command-configure";
+  version = "4.2.0";
+
+  src = fetchurl {
+    url = "https://downloads.dell.com/FOLDER05519670M/1/command-configure_4.2.0-553.ubuntu16_amd64.tar.gz";
+    sha256 = "0bwmrgz335sm1mfh890pjylcqg30q98vmgazcc4vc45sj13fvry1";
+  };
+
+  buildInputs = [ dpkg ];
+  sourceRoot = pname;
+  phases = [ "unpackPhase" "installPhase" ];
+
+  unpackPhase = ''
+    mkdir ${pname}
+    tar -C ${pname} -xzf ${src}
+    dpkg-deb -x ${pname}/command-configure_4.2.0-553.ubuntu16_amd64.deb ${pname}/command-configure
+    dpkg-deb -x ${pname}/srvadmin-hapi_9.3.0_amd64.deb ${pname}/srvadmin-hapi
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+
+    install -t $out/lib -m755 -v command-configure/opt/dell/dcc/libhapiintf.so
+    install -t $out/bin -m755 -v command-configure/opt/dell/dcc/cctk
+    install -t $out/bin -m755 -v srvadmin-hapi/opt/dell/srvadmin/sbin/dchcfg
+
+    for lib in $(find srvadmin-hapi/opt/dell/srvadmin/lib64 -type l); do
+        install -t $out/lib -m755 -v $lib
+    done
+
+    patchelf --set-rpath ${stdenv.cc.cc.lib}/lib:$out/lib $out/lib/libhapiintf.so
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${stdenv.cc.cc.lib}/lib:$out/lib $out/bin/cctk
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath $out/lib $out/bin/dchcfg
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Configure BIOS settings on Dell laptops.";
+    homepage = "https://www.dell.com/support/article/us/en/19/sln311302/dell-command-configure";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ maxeaubrey ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -871,6 +871,8 @@ in
 
   cue = callPackage ../development/tools/cue { };
 
+  dell-command-configure = callPackage ../tools/system/dell-command-configure { };
+
   deltachat-electron = callPackage
     ../applications/networking/instant-messengers/deltachat-electron { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
My motivation here was configuring UEFI/BIOS settings on Dell laptops without rebooting (specifically I wanted to avoid the touchscreen UEFI my XPS 13 has).

I am not confident that the module (specifically the use of `activationScripts`) is the best way to do what's needed. `cctk` has no way of specifying where the configuration file is and I couldn't really find a convenient precedent in the nixpkgs repository. Would appreciate help or hints on whether it's possible to improve this!

The package I wrote matches the way Dell distributes it, but if Openmanage was packaged for Nix, it would make sense to turn `srvadmin-hapi` into a dependency, and turn the module into a general `openmanage` module as all related services use the same configuration path. This felt like an ok approach considering the dependency is entirely unusable outside of it right now, and this meets the requirements.

If a test for this kind of package is relevant, I would be happy to write one! I'm unsure as to what the best way towards it is though. As this service depends on hardware access, the extent of the test would be running `cctk --Version` really.

The package also requires that a UEFI setting be disabled ahead of time (SMM Security Mitigation). I'm not sure if this is something that should be mentioned to the user during installation, or put somewhere in the module description, etc.

Hope the description helps with reviewing :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
