### PR TITLE
ocrfeeder: init at 0.8.3

### DIFF
--- a/pkgs/applications/graphics/ocrfeeder/default.nix
+++ b/pkgs/applications/graphics/ocrfeeder/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, fetchurl
+, pkg-config
+, gtk3
+, gtkspell3
+, isocodes
+, goocanvas2
+, intltool
+, itstool
+, libxml2
+, gnome3
+, python3
+, gobject-introspection
+, wrapGAppsHook
+, tesseract4
+, extraOcrEngines ? [] # other supported engines are: ocrad gocr cuneiform
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ocrfeeder";
+  version = "0.8.3";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "12f5gnq92ffnd5zaj04df7jrnsdz1zn4zcgpbf5p9qnd21i2y529";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook
+    intltool
+    itstool
+    libxml2
+  ];
+
+  buildInputs = [
+    gtk3
+    gobject-introspection
+    goocanvas2
+    gtkspell3
+    isocodes
+    (python3.withPackages(ps: with ps; [
+      pyenchant
+      sane
+      pillow
+      reportlab
+      odfpy
+      pygobject3
+    ]))
+  ];
+
+  # https://gitlab.gnome.org/GNOME/ocrfeeder/-/issues/22
+  postConfigure = ''
+    substituteInPlace src/ocrfeeder/util/constants.py \
+      --replace /usr/share/xml/iso-codes ${isocodes}/share/xml/iso-codes
+  '';
+
+  enginesPath = stdenv.lib.makeBinPath ([
+    tesseract4
+  ] ++ extraOcrEngines);
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix PATH : "${enginesPath}")
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://wiki.gnome.org/Apps/OCRFeeder";
+    description = "Complete Optical Character Recognition and Document Analysis and Recognition program";
+    maintainers = with maintainers; [ doronbehar ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/sane/default.nix
+++ b/pkgs/development/python-modules/sane/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, saneBackends
+}:
+
+buildPythonPackage rec {
+  pname = "sane";
+  version = "2.8.2";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "python-sane";
+    sha256 = "0sri01h9sld6w7vgfhwp29n5w19g6idz01ba2giwnkd99k1y2iqg";
+  };
+
+  buildInputs = [
+    saneBackends
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/python-pillow/Sane";
+    description = "Python interface to the SANE scanner and frame grabber ";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2460,6 +2460,8 @@ in
 
   ocrmypdf = callPackage ../tools/text/ocrmypdf { };
 
+  ocrfeeder = callPackage ../applications/graphics/ocrfeeder { };
+
   onboard = callPackage ../applications/misc/onboard { };
 
   oneshot = callPackage ../tools/networking/oneshot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6452,6 +6452,10 @@ in {
 
   salmon-mail = callPackage ../development/python-modules/salmon-mail { };
 
+  sane = callPackage ../development/python-modules/sane {
+    inherit (pkgs) saneBackends;
+  };
+
   sampledata = callPackage ../development/python-modules/sampledata { };
 
   samplerate = callPackage ../development/python-modules/samplerate { };


### PR DESCRIPTION
###### Motivation for this change

Useful, gnome3 official application for interactive OCR.

~~NOTE: This depends on #84935 .~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
