### PR TITLE
qtemu: init at 2.1

### DIFF
--- a/pkgs/applications/virtualization/qtemu/default.nix
+++ b/pkgs/applications/virtualization/qtemu/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, mkDerivation, fetchFromGitLab, pkgconfig, qmake, qtbase, qemu, makeWrapper }:
+
+mkDerivation rec {
+  pname = "qtemu";
+  version = "2.1";
+
+  src = fetchFromGitLab {
+    owner = "qtemu";
+    repo = "gui";
+    rev = version;
+    sha256 = "1555178mkfw0gwmw8bsxmg4339j2ifp0yb4b2f39nxh9hwshg07j";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    qtbase
+    qemu
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # upstream lacks an install method
+    install -D -t $out/share/applications qtemu.desktop
+    install -D -t $out/share/pixmaps qtemu.png
+    install -D -t $out/bin qtemu
+
+    # make sure that the qemu-* executables are found
+    wrapProgram $out/bin/qtemu --prefix PATH : ${stdenv.lib.makeBinPath [ qemu ]}
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Qt-based front-end for QEMU emulator";
+    homepage = "https://qtemu.org";
+    license = licenses.gpl2;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21421,6 +21421,8 @@ in
 
   qtchan = libsForQt5.callPackage ../applications/networking/browsers/qtchan { };
 
+  qtemu = libsForQt5.callPackage ../applications/virtualization/qtemu { };
+
   qtox = libsForQt5.callPackage ../applications/networking/instant-messengers/qtox { };
 
   qtpass = libsForQt5.callPackage ../applications/misc/qtpass { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [QtEmu](https://gitlab.com/qtemu/gui).

> QtEmu is a graphical user interface for QEMU written in Qt. 
It has the ability to run virtual operating systems on native systems. 
This way you can easily test a new operating system or try a Live CD on your system without any troubles and dangers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).