### PR TITLE
zeek: 3.0.3 -> 3.1.1

### DIFF
--- a/pkgs/applications/networking/ids/zeek/default.nix
+++ b/pkgs/applications/networking/ids/zeek/default.nix
@@ -1,24 +1,34 @@
 {stdenv, fetchurl, cmake, flex, bison, openssl, libpcap, zlib, file, curl
-, libmaxminddb, gperftools, python, swig, rocksdb }:
+, libmaxminddb, gperftools, python, swig, fetchpatch }:
 let
   preConfigure = (import ./script.nix);
 in
 stdenv.mkDerivation rec {
   pname = "zeek";
-  version = "3.0.3";
+  version = "3.1.1";
 
   src = fetchurl {
     url = "https://old.zeek.org/downloads/zeek-${version}.tar.gz";
-    sha256 = "0xlw5v83qbgy23wdcddmvan2pid28mw745g4fc1z5r18kp67i8a2";
+    sha256 = "0siybzdp8w62jqk5vdi5fxwvj6cn4r6c2d4z2axd4rj5vhv5zvx2";
   };
 
   nativeBuildInputs = [ cmake flex bison file ];
-  buildInputs = [ openssl libpcap zlib curl libmaxminddb gperftools python swig rocksdb ];
+  buildInputs = [ openssl libpcap zlib curl libmaxminddb gperftools python swig ];
 
   #see issue https://github.com/zeek/zeek/issues/804 to modify hardlinking duplicate files.
   inherit preConfigure;
-  
+
   enableParallelBuilding = true;
+
+  patches = stdenv.lib.optionals stdenv.cc.isClang [
+    # Fix pybind c++17 build with Clang. See: https://github.com/pybind/pybind11/issues/1604
+    (fetchpatch {
+      url = "https://github.com/pybind/pybind11/commit/759221f5c56939f59d8f342a41f8e2d2cacbc8cf.patch";
+      sha256 = "0l8z7d7chq1awd8dnfarj4c40wx36hkhcan0702p5l89x73wqk54";
+      extraPrefix = "aux/broker/bindings/python/3rdparty/pybind11/";
+      stripLen = 1;
+    })
+  ];
 
   cmakeFlags = [
     "-DPY_MOD_INSTALL_DIR=${placeholder "out"}/${python.sitePackages}"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
