### PR TITLE
python3Packages.qiskit: 0.17.0 -> 0.18.2

### DIFF
--- a/pkgs/development/python-modules/fastjsonschema/default.nix
+++ b/pkgs/development/python-modules/fastjsonschema/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+  # Check inputs
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "fastjsonschema";
+  version = "2.14.4";
+
+  disabled = pythonOlder "3.3";
+
+  src = fetchFromGitHub {
+    owner = "horejsek";
+    repo = "python-fastjsonschema";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "0c3q31lqzrc52gacnqc271k5952qbyl0z4kagsqvl7fiwk84hqlz";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+  dontUseSetuptoolsCheck = true;
+  disabledTests = [
+    "benchmark"
+
+    # these tests require network access
+    "remote ref"
+    "definitions"
+  ];
+
+  meta = with lib; {
+    description = "Fast JSON schema validator for Python.";
+    homepage = "https://horejsek.github.io/python-fastjsonschema/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/development/python-modules/python-constraint/default.nix
+++ b/pkgs/development/python-modules/python-constraint/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+  # Check inputs
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "python-constraint";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "python-constraint";
+    repo = "python-constraint";
+    rev = version;
+    sha256 = "1dv11406yxmmgkkhwzqicajbg2bmla5xfad7lv57zyahxz8jzz94";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+  dontUseSetuptoolsCheck = true;
+
+  meta = with lib; {
+    description = "Constraint Solving Problem resolver for Python.";
+    homepage = "https://labix.org/doc/constraint/";
+    downloadPage = "https://github.com/python-constraint/python-constraint/releases";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -18,16 +18,16 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aer";
-  version = "0.4.1";
+  version = "0.5.0";
 
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "Qiskit";
-    repo = pname;
+    repo = "qiskit-aer";
     rev = version;
     fetchSubmodules = true; # fetch muparserx and other required libraries
-    sha256 = "1j2pv6jx5dlzanjp1qnf32s53d8jrlpv96nvymznkcnjvqn60gv9";
+    sha256 = "05lsirrdnnr5yqhwkgv08d9aib8xq4xpd6aq2pfqsi9qkii2fff1";
   };
 
   nativeBuildInputs = [
@@ -49,7 +49,7 @@ buildPythonPackage rec {
 
   prePatch = ''
     # remove dependency on PyPi cmake package, which isn't in Nixpkgs
-    substituteInPlace setup.py --replace "'cmake'" ""
+    substituteInPlace setup.py --replace "'cmake!=3.17,!=3.17.0'" ""
   '';
 
   dontUseCmakeConfigure = true;
@@ -92,7 +92,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "High performance simulators for Qiskit";
-    homepage = "https://github.com/QISKit/qiskit-aer";
+    homepage = "https://qiskit.org/aer";
+    downloadPage = "https://github.com/QISKit/qiskit-aer/releases";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
     # Doesn't build on aarch64 (libmuparserx issue).

--- a/pkgs/development/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/development/python-modules/qiskit-aqua/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aqua";
-  version = "0.6.5";
+  version = "0.6.6";
 
   disabled = pythonOlder "3.5";
 
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aqua";
     rev = version;
-    sha256 = "03c0gl2qxyngf3cccjghjb0bhp0w78sdbvhim08cimf3cd577ldz";
+    sha256 = "080m5nsy3ia6bcdypq5d3ijb7762yl1l9llygmxsi6si449zl2cp";
   };
 
   # Optional packages: pyscf (see below NOTE) & pytorch. Can install via pip/nix if needed.

--- a/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-ibmq-provider";
-  version = "0.6.0";
+  version = "0.6.1";
 
   disabled = pythonOlder "3.6";
 
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "0arbhwaa2kx04jbrj6hk3vvn92wdk6lrr9zx36pr6p22r0yyxnj9";
+    sha256 = "16c73m9gp1wcrygr6mnc0a9ps0i872bgc7v1zbqyh50kxbcrnpnz";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/qiskit-ignis/default.nix
+++ b/pkgs/development/python-modules/qiskit-ignis/default.nix
@@ -5,42 +5,37 @@
 , fetchpatch
 , numpy
 , qiskit-terra
+, scikitlearn
 , scipy
   # Check Inputs
+, ddt
 , pytestCheckHook
 , qiskit-aer
 }:
 
 buildPythonPackage rec {
   pname = "qiskit-ignis";
-  version = "0.2.0";
+  version = "0.3.0";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.6";
 
   # Pypi's tarball doesn't contain tests
   src = fetchFromGitHub {
     owner = "Qiskit";
-    repo = pname;
+    repo = "qiskit-ignis";
     rev = version;
-    sha256 = "08a60xk5dq5wmqc23r4hr2v2nsf9hs0ybz832vbnd6d80dl6izyc";
+    sha256 = "16h04n9hxw669nq2ii16l6h75x8afisvp3j062n4c62kcqci0x4x";
   };
 
-  patches = [
-    # Update tests for compatibility with qiskit-aer 0.4 (#342). Remove in version > 0.2.0
-    (fetchpatch {
-      url = "https://github.com/Qiskit/qiskit-ignis/commit/d78c494579f370058e68e360f10149db81b52477.patch";
-      sha256 = "0ygkllf95c0jfvjg7gn399a5fd0wshsjpcn279kj7855m8j306h6";
-    })
-    # Fix statevector test over-eager validation (PR #333)
-    (fetchpatch {
-      url = "https://github.com/Qiskit/qiskit-ignis/commit/7cc8eb2e852b383ea429233fa43d3728931f1707.patch";
-      sha256 = "0mdygykilg4qivdaa731z3y56l3ax4jp1sil9npqv0gn4p03c9g5";
-    })
-  ];
+  # Fixed qiskit-ignis PR #385, figured this is easier than fetchpatch
+  postPatch = ''
+    substituteInPlace qiskit/ignis/logging/ignis_logging.py --replace "self.configure_logger" "self._configure_logger"
+  '';
 
   propagatedBuildInputs = [
     numpy
     qiskit-terra
+    scikitlearn
     scipy
   ];
 
@@ -49,13 +44,18 @@ buildPythonPackage rec {
   dontUseSetuptoolsCheck = true;
   preCheck = ''export HOME=$TMPDIR'';
   checkInputs = [
+    ddt
     pytestCheckHook
     qiskit-aer
   ];
+  # Test is in test/verification/test_entanglemet.py. test fails due to out-of-date calls & bad logic with this file since qiskit-ignis#328
+  # see qiskit-ignis#386 for all issues. Should be able to re-enable in future.
+  disabledTests = [ "TestEntanglement" ];
 
   meta = with lib; {
     description = "Qiskit tools for quantum hardware verification, noise characterization, and error correction";
-    homepage = "https://github.com/QISKit/qiskit-ignis";
+    homepage = "https://qiskit.org/ignis";
+    downloadPage = "https://github.com/QISKit/qiskit-ignis/releases";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -2,35 +2,41 @@
 , pythonOlder
 , buildPythonPackage
 , fetchFromGitHub
+  # Python requirements
 , cython
 , dill
+, fastjsonschema
 , jsonschema
 , numpy
 , marshmallow
 , marshmallow-polyfield
-, matplotlib
 , networkx
 , ply
 , psutil
+, python-constraint
+, retworkx
 , scipy
 , sympy
+  # Python visualization requirements, semi-optional
+, ipywidgets
+, matplotlib
+, pillow
+, pydot
+, pygments
+, pylatexenc
+, seaborn
   # test requirements
 , ddt
 , hypothesis
-, ipywidgets
 , nbformat
 , nbconvert
-, pillow
-, pydot
-, python
-, pygraphviz
-, pylatexenc
 , pytestCheckHook
+, python
 }:
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
-  version = "0.12.0";
+  version = "0.13.0";
 
   disabled = pythonOlder "3.5";
 
@@ -38,13 +44,14 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "1yarfziy2w8n1d7zyyxykfs68608j8md4kwfyhbyc6wy483fk9sy";
+    sha256 = "03fgqmyahgmkf5dbw19n9c1v8p4kmpk50wxhhc8435cclvs26x9j";
   };
 
   nativeBuildInputs = [ cython ];
 
   propagatedBuildInputs = [
     dill
+    fastjsonschema
     jsonschema
     numpy
     marshmallow
@@ -53,34 +60,41 @@ buildPythonPackage rec {
     networkx
     ply
     psutil
+    python-constraint
+    retworkx
     scipy
     sympy
+    # Optional/visualization inputs
+    ipywidgets
+    matplotlib
+    pillow
+    pydot
+    pygments
+    pylatexenc
+    seaborn
   ];
 
+  postPatch = ''
+    # Fix relative imports in tests
+    touch test/python/dagcircuit/__init__.py
+  '';
 
   # *** Tests ***
   checkInputs = [
     ddt
     hypothesis
-    ipywidgets
     nbformat
     nbconvert
-    pillow
-    pydot
-    pygraphviz
-    pylatexenc
     pytestCheckHook
   ];
+  dontUseSetuptoolsCheck = true;  # can't find setup.py, so fails. tested by pytest
 
   pythonImportsCheck = [
     "qiskit"
     "qiskit.transpiler.passes.routing.cython.stochastic_swap.swap_trial"
   ];
 
-  dontUseSetuptoolsCheck = true;  # can't find setup.py, so fails. tested by pytest
-
   disabledTests = [
-    "test_long_name"  # generated circuit images differ for some reason
     "test_jupyter_jobs_pbars" # needs IBMQ provider package (qiskit-ibmq-provider), circular dependency
   ];
 
@@ -112,7 +126,8 @@ buildPythonPackage rec {
     longDescription = ''
       Allows the user to write quantum circuits easily, and takes care of the constraints of real hardware.
     '';
-    homepage = "https://github.com/QISKit/qiskit-terra";
+    homepage = "https://qiskit.org/terra";
+    downloadPage = "https://github.com/QISKit/qiskit-terra/releases";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -15,7 +15,7 @@
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "0.17.0";
+  version = "0.18.2";
 
   disabled = pythonOlder "3.5";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit";
     rev = version;
-    sha256 = "1cnjcvvzklyq102fipqnwd5ham0sp0451gp7j79cwwsxzvji6pcc";
+    sha256 = "05pwpcps1ksqx6m6hwq90l8sbak64fsz76yv4q3jplfjf6597k6p";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/retworkx/default.nix
+++ b/pkgs/development/python-modules/retworkx/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, pythonAtLeast
+, isPy37
+, isPy38
+, fetchFromGitHub
+, fetchPypi
+  # Check inputs
+, pytestCheckHook
+}:
+
+let
+  rx-version = "0.3.3";
+  wheel-args = if isPy37 then
+      { python = "cp37"; sha256 = "1gbz7sh9i4h41xs9c40lixfdigmvfykkgxgzwsrs8v0smx20dczy"; }
+    else if isPy38 then
+      { python = "cp38"; sha256 = "09xxgp4ac4q6mfkj6lsqqfrzz1cb02vxy7wlv0bq3z2hd0jcanxk"; }
+    else throw "python version & hash not included. Override attribute `wheel-args` with version & hash at https://pypi.org/project/retworkx";
+
+  github-source = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = "retworkx";
+    rev = rx-version;
+    sha256 = "160w5vkzrl5rzcrdwhjq820i5lmc527m6hg0kxx0k6n2bz9qn26g";
+  };
+in
+buildPythonPackage rec {
+  pname = "retworkx";
+  version = rx-version;
+  format = "wheel";
+
+  disabled = pythonOlder "3.5" || pythonAtLeast "3.9"; # compiled versions only included for 3.5 <= py <= 3.8
+
+  src = fetchPypi {
+    inherit pname version format;
+    inherit (wheel-args) python sha256;
+    abi = if pythonOlder "3.8" then "${wheel-args.python}m" else wheel-args.python;
+    platform = "manylinux2010_x86_64"; # i686, aarch64, and ppc64 also available, restricting to x86 for simplicity
+  };
+
+  pythonImportsCheck = [ "retworkx" ];
+
+  checkInputs = [ pytestCheckHook ];
+  preCheck = ''
+    pushd $(mktemp -d)
+    cp -r ${github-source}/$sourceRoot/tests .
+  '';
+  postCheck = "popd";
+
+  meta = with lib; {
+    description = "A python graph library implemented in Rust.";
+    homepage = "https://retworkx.readthedocs.io/en/latest/index.html";
+    downloadPage = "https://github.com/Qiskit/retworkx/releases";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3288,6 +3288,8 @@ in {
 
   pytools = callPackage ../development/python-modules/pytools { };
 
+  python-constraint = callPackage ../development/python-modules/python-constraint { };
+
   python-ctags3 = callPackage ../development/python-modules/python-ctags3 { };
 
   python-lzo = callPackage ../development/python-modules/python-lzo {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2761,6 +2761,8 @@ in {
 
   fastdtw = callPackage ../development/python-modules/fastdtw { };
 
+  fastjsonschema = callPackage ../development/python-modules/fastjsonschema { };
+
   faulthandler = if ! isPy3k
     then callPackage ../development/python-modules/faulthandler {}
     else throw "faulthandler is built into ${python.executable}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5526,6 +5526,8 @@ in {
 
   readchar = callPackage ../development/python-modules/readchar { };
 
+  retworkx = callPackage ../development/python-modules/retworkx { };
+
   rivet = disabledIf isPy3k (toPythonModule (pkgs.rivet.override {
     python2 = python;
   }));


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update qiskit to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
