### PR TITLE
pingus: move cmake to nativeBuildInputs

### DIFF
--- a/pkgs/games/pingus/default.nix
+++ b/pkgs/games/pingus/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation rec {
   pname = "pingus";
   version = "unstable-0.7.6.0.20191104";
 
-  nativeBuildInputs = [ pkgconfig git ];
-  buildInputs = [ cmake SDL2 SDL2_image boost libpng SDL2_mixer libGLU libGL jsoncpp ];
+  nativeBuildInputs = [ cmake pkgconfig git ];
+  buildInputs = [ SDL2 SDL2_image boost libpng SDL2_mixer libGLU libGL jsoncpp ];
   src = fetchgit {
     url = "https://gitlab.com/pingus/pingus/";
     rev = "709546d9b9c4d6d5f45fc9112b45ac10c7f9417d";


### PR DESCRIPTION
###### Motivation for this change
resolve comment by @aanderse in #84918

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
