### PR TITLE
samba: Fix path to krb5kdc

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -120,7 +120,7 @@ stdenv.mkDerivation rec {
          else "--without-ad-dc")
     ++ optionals enableKerberos [
     "--with-system-mitkrb5"
-    "--with-system-mitkdc=${krb5Full}"
+    "--with-system-mitkdc=${krb5Full}/bin/krb5kdc"
   ] ++ optionals (!enableLDAP) [
     "--without-ldap"
     "--without-ads"


### PR DESCRIPTION
This is supposed to be the path to the krb5 executable.
Otherwise you'll get something like:

`/nix/store/39g2c748b1y2ja98m1g9jwdg8xhzdzfi-krb5-1.17: Failed to exec child - Permission denied`

cc @Izorkin 
