### PR TITLE
nixos/zoneminder: fix evaluation with new php refactor

### DIFF
--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -63,10 +63,6 @@ let
     ${cfg.extraConfig}
   '';
 
-  phpExtensions = with pkgs.phpPackages; [
-    { pkg = apcu; name = "apcu"; }
-  ];
-
 in {
   options = {
     services.zoneminder = with lib; {
@@ -289,11 +285,9 @@ in {
       phpfpm = lib.mkIf useNginx {
         pools.zoneminder = {
           inherit user group;
+          phpPackage = pkgs.php.withExtensions ({ enabled, all }: enabled ++ [ all.apcu ]);
           phpOptions = ''
             date.timezone = "${config.time.timeZone}"
-
-            ${lib.concatStringsSep "\n" (map (e:
-            "extension=${e.pkg}/lib/php/extensions/${e.name}.so") phpExtensions)}
           '';
           settings = lib.mapAttrs (name: lib.mkDefault) {
             "listen.owner" = user;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -348,6 +348,7 @@ in
   yabar = handleTest ./yabar.nix {};
   yggdrasil = handleTest ./yggdrasil.nix {};
   zfs = handleTest ./zfs.nix {};
-  zsh-history = handleTest ./zsh-history.nix {};
+  zoneminder = handleTest ./zoneminder.nix {};
   zookeeper = handleTest ./zookeeper.nix {};
+  zsh-history = handleTest ./zsh-history.nix {};
 }

--- a/nixos/tests/zoneminder.nix
+++ b/nixos/tests/zoneminder.nix
@@ -1,0 +1,23 @@
+import ./make-test-python.nix ({ lib, ...}:
+
+{
+  name = "zoneminder";
+  meta.maintainers = with lib.maintainers; [ danielfullmer ];
+
+  machine = { ... }:
+  {
+    services.zoneminder = {
+      enable = true;
+      database.createLocally = true;
+      database.username = "zoneminder";
+    };
+    time.timeZone = "America/New_York";
+  };
+
+  testScript = ''
+    machine.wait_for_unit("zoneminder.service")
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(8095)
+    machine.succeed("curl --fail http://localhost:8095/")
+  '';
+})

--- a/pkgs/servers/zoneminder/default.nix
+++ b/pkgs/servers/zoneminder/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, fetchurl, substituteAll, cmake, makeWrapper, pkgconfig
 , curl, ffmpeg, glib, libjpeg, libselinux, libsepol, mp4v2, libmysqlclient, mysql, pcre, perl, perlPackages
 , polkit, utillinuxMinimal, x264, zlib
-, coreutils, procps, psmisc }:
+, coreutils, procps, psmisc, nixosTests }:
 
 # NOTES:
 #
@@ -172,7 +172,10 @@ in stdenv.mkDerivation rec {
     "-DZM_WEB_GROUP=${user}"
   ];
 
-  passthru = { inherit dirName; };
+  passthru = {
+    inherit dirName;
+    tests = nixosTests.zoneminder;
+  };
 
   postInstall = ''
     PERL5LIB="$PERL5LIB''${PERL5LIB:+:}$out/${perl.libPrefix}"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Zoneminder is currently broken in master, I believe as a result of recently merging https://github.com/NixOS/nixpkgs/pull/83896. In this PR I've fixed the evaluation and also added a test to hopefully catch regressions in the future.

This PR should be ready to merge after #84993.

---
Original issue (now fixed thanks to @talyz below):

However, the phpfm service still does not yet work.

The included test fails with:
```
machine: must succeed: curl --fail http://localhost:8095/
machine # [   15.334307] nginx[778]: 2020/04/10 19:14:14 [error] 779#779: *2 FastCGI sent in stderr: "PHP message: Unable to connect to ZM DB SQLSTATE[HY000] [2002] No such file or directoryPHP message: PHP Fatal error:  Uncaught Error: Call to a member function query() on null in /nix/store/cj1xaxbwisjm3vj3nwnc408b50l7l7m8-zoneminder-1.34.3/share/zoneminder/www/includes/config.php:165
machine # [   15.336875] nginx[778]: Stack trace:
machine # [   15.337622] nginx[778]: curl: (22) The reque#0 /nix/store/cj1xaxbwisjm3vj3nwnc408b50l7l7m8-zoneminder-1.34.3/share/zoneminder/www/includes/config.php(140): loadConfig()
machine # [   15.339833] sted URL returned enginx[778]: #1 /nix/store/cj1xaxbwisjm3vj3nwnc408b50l7l7m8-zoneminder-1.34.3/share/zoneminder/www/index.php(46): require_once('/nix/store/cj1x...')
machine # [   15.342032] nginx[778]: #2 {main}
machine # [   15.342566] nginx[778]:   thrown in /nix/store/cj1xaxbwisjm3vj3nwnc408b50l7l7m8-zoneminder-1.34.3/share/zoneminder/www/includes/config.php on line 165" while reading response header from upstream, client: 127.0.0.1, server: localhost, request: "GET / HTTP/1.1", upstream: "fastcgi://unix:/run/phpfpm/zoneminder.sock:", host: "localhost:8095"rror: 500 Internal Server Error
```

It appears to fail here:
https://github.com/ZoneMinder/zoneminder/blob/689956bba738de157ebf31f2e9e22f02bc574686/web/includes/database.php#L59
However, as far as I can tell, the DB connection parameters are set correctly.

I'm not very familiar with PHP to properly debug this. I was hoping I could get some feedback from @etu or @talyz if they have any ideas if this is a result of their PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
