### PR TITLE
mnemosyne: Fix Qt related segfault and OpenGL warning

### DIFF
--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -44,7 +44,11 @@ buildPythonPackage rec {
   # Disable doctest plugin because times out
   checkPhase = ''
     substituteInPlace pytest.ini --replace "--doctest-modules" ""
-    pytest --deselect=cherrypy/test/test_static.py::StaticTest::test_null_bytes ${stdenv.lib.optionalString stdenv.isDarwin "--deselect=cherrypy/test/test_bus.py::BusMethodTests::test_block"}
+    pytest \
+      --deselect=cherrypy/test/test_static.py::StaticTest::test_null_bytes \
+      --deselect=cherrypy/test/test_tools.py::ToolTests::testCombinedTools \
+      ${stdenv.lib.optionalString stdenv.isDarwin
+        "--deselect=cherrypy/test/test_bus.py::BusMethodTests::test_block"}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/games/mnemosyne/default.nix
+++ b/pkgs/games/mnemosyne/default.nix
@@ -17,13 +17,14 @@ python.pkgs.buildPythonApplication rec {
   buildInputs = [ anki ];
 
   propagatedBuildInputs = with python.pkgs; [
+    cheroot
+    cherrypy
     googletrans
     gtts
-    pyqtwebengine
-    pyqt5
     matplotlib
-    cherrypy
-    cheroot
+    pyopengl
+    pyqt5
+    pyqtwebengine
     webob
   ];
 

--- a/pkgs/games/mnemosyne/default.nix
+++ b/pkgs/games/mnemosyne/default.nix
@@ -37,8 +37,9 @@ python.pkgs.buildPythonApplication rec {
   doCheck = false;
 
   postInstall = ''
-    mkdir -p $out/share
+    mkdir -p $out/share/applications
     mv $out/${python.sitePackages}/$out/share/locale $out/share
+    mv mnemosyne.desktop $out/share/applications
     rm -r $out/${python.sitePackages}/nix
   '';
 

--- a/pkgs/games/mnemosyne/default.nix
+++ b/pkgs/games/mnemosyne/default.nix
@@ -12,7 +12,7 @@ python.pkgs.buildPythonApplication rec {
     sha256 = "0dhvg9cxc6m6kzk75h363h1g0bl80cqz11cijh0zpz9f4w6lnqsq";
   };
 
-  nativeBuildInputs = with python.pkgs; [ wrapPython pyqtwebengine.wrapQtAppsHook ];
+  nativeBuildInputs = with python.pkgs; [ pyqtwebengine.wrapQtAppsHook ];
 
   buildInputs = [ anki ];
 
@@ -43,9 +43,9 @@ python.pkgs.buildPythonApplication rec {
 
   dontWrapQtApps = true;
 
-  preFixup = ''
-    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
-  '';
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
+  ];
 
   meta = {
     homepage = "https://mnemosyne-proj.org/";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Mnemosyne fails to launch with:
```
Warning: Could not import OpenGL. Might cause a black screen on some Linux distributions. Try installing python3-opengl in that case.
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

abort (core dumped)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc #65399