### PR TITLE
gst-plugins-bad: disable zbar by default

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -10,7 +10,7 @@
 , gst-plugins-base
 , orc
 , gobject-introspection
-, enableZbar ? true
+, enableZbar ? false
 , faacSupport ? false
 , faac ? null
 , faad2

--- a/pkgs/tools/security/gnome-keysign/default.nix
+++ b/pkgs/tools/security/gnome-keysign/default.nix
@@ -53,7 +53,7 @@ python3.pkgs.buildPythonApplication rec {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     (gst_all_1.gst-plugins-good.override { gtkSupport = true; })
-    gst_all_1.gst-plugins-bad # for zbar plug-in
+    (gst_all_1.gst-plugins-bad.override { enableZbar = true; }) # for zbar plug-in
   ];
 
   propagatedBuildInputs = with python3.pkgs; [


### PR DESCRIPTION
###### Motivation for this change

gst-plugins-bad by default used to pull in gtk3 and qtbase and qtx11extras because of the default dependency on zbar.
As zbar is a rarely needed gstreamer plugin, this unnecessarily
increased the closure size.
I am only aware of gnome-keysign actually using the zbar plugin, so that
uses a zbar-enabled gst-plugins-bad.

closes #84845


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

Several packages failed to build, but these failures seem unrelated to this PR.

1. The mopidy-* packages have already been fixed in master, someone needs to pull in the latest master to staging. see #79692
2. all other packages failed due to *No space left on device* errors, as my /tmp tmpfs wasn't large enough.

Full build log:

<details>

```console
builder for '/nix/store/q3nx85a7b871n4k54lx0ccbw9nr1wshw-Mopidy-Moped-0.7.1.drv' failed with exit code 1; last 10 log lines:
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  glibPreInstallPhase
  installing
  Executing pipInstallPhase
  /build/Mopidy-Moped-0.7.1/dist /build/Mopidy-Moped-0.7.1
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support                                           
  Processing ./Mopidy_Moped-0.7.1-py2-none-any.whl
  ERROR: Could not find a version that satisfies the requirement Mopidy>=1.0.0 (from Mopidy-Moped==0.7.1) (from versions: none)
  ERROR: No matching distribution found for Mopidy>=1.0.0 (from Mopidy-Moped==0.7.1)
builder for '/nix/store/cnvzdxk4p38sd5jzc894f97g4pzmbckc-ibtws_9542.jar.drv' failed with exit code 1; last 10 log lines:
  
  ***
  This nix expression requires that ibtws_9542.jar is already part of the store.
  Download the TWS from
  https://download2.interactivebrokers.com/download/unixmacosx_latest.jar,
  rename the file to ibtws_9542.jar, and add it to the nix store with
  "nix-prefetch-url file://$PWD/ibtws_9542.jar".
  
  ***
builder for '/nix/store/2al69y8i24v861bpslzrnl6qyxjj01b1-jdk-8u241-linux-x64.tar.gz.drv' failed with exit code 1; last 10 log lines:
  ***
  Unfortunately, we cannot download file jdk-8u241-linux-x64.tar.gz automatically.
  Please go to http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html to download it yourself, and add it to the Nix store
  using either
    nix-store --add-fixed sha256 jdk-8u241-linux-x64.tar.gz
  or
    nix-prefetch-url --type sha256 file:///path/to/jdk-8u241-linux-x64.tar.gz
  
  ***
cannot build derivation '/nix/store/j27z9qz766mn8210dj90yx0ks0k9if7m-oraclejdk-8u241.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/3z2b1fx5l05dbd1whwb2dnksf31gs5y7-ib-tws-9542.drv': 2 dependencies couldn't be built
builder for '/nix/store/1rhd4bp2958n9kcyj2vb8xnh5rra132f-Mopidy-Mopify-1.6.1.drv' failed with exit code 1; last 10 log lines:
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  glibPreInstallPhase
  installing
  Executing pipInstallPhase
  /build/Mopidy-Mopify-1.6.1/dist /build/Mopidy-Mopify-1.6.1
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support                                           
  Processing ./Mopidy_Mopify-1.6.1-py2.py3-none-any.whl
  ERROR: Could not find a version that satisfies the requirement Mopidy>=0.19 (from Mopidy-Mopify==1.6.1) (from versions: none)
  ERROR: No matching distribution found for Mopidy>=0.19 (from Mopidy-Mopify==1.6.1)
builder for '/nix/store/1z027k2n2rxiszsnk67dngvjacjhi243-mopidy-gmusic-3.0.0.drv' failed with exit code 1; last 10 log lines:
  Finished executing setuptoolsBuildPhase
  glibPreInstallPhase
  installing
  Executing pipInstallPhase
  /build/mopidy-gmusic-3.0.0/dist /build/mopidy-gmusic-3.0.0
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support                                           
  Processing ./Mopidy_GMusic-3.0.0-py2.py3-none-any.whl
  Requirement already satisfied: setuptools in /nix/store/05nffwz5i8gpsn0a5fszwcj6ghibl8p6-python2.7-setuptools-44.0.0/lib/python2.7/site-packages (from Mopidy-GMusic==3.0.0) (44.0.0.post20200329)
  ERROR: Could not find a version that satisfies the requirement Pykka>=1.1 (from Mopidy-GMusic==3.0.0) (from versions: none)
  ERROR: No matching distribution found for Pykka>=1.1 (from Mopidy-GMusic==3.0.0)
builder for '/nix/store/cis4kbk7sbnsaxn36b8pljwna4djhrrh-mopidy-soundcloud-2.1.0.drv' failed with exit code 1; last 10 log lines:
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  glibPreInstallPhase
  installing
  Executing pipInstallPhase
  /build/source/dist /build/source
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support                                           
  Processing ./Mopidy_SoundCloud-2.1.0-py2.py3-none-any.whl
  ERROR: Could not find a version that satisfies the requirement Mopidy>=1.0 (from Mopidy-SoundCloud==2.1.0) (from versions: none)
  ERROR: No matching distribution found for Mopidy>=1.0 (from Mopidy-SoundCloud==2.1.0)
builder for '/nix/store/h0a1yamp066s9p91cbj3hq45jwn29ivh-mopidy-musicbox-webclient-2.3.0.drv' failed with exit code 1; last 10 log lines:
  Finished executing setuptoolsBuildPhase
  glibPreInstallPhase
  installing
  Executing pipInstallPhase
  /build/source/dist /build/source
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support                                           
  Processing ./Mopidy_MusicBox_Webclient-2.3.0-py2.py3-none-any.whl
  Requirement already satisfied: setuptools in /nix/store/05nffwz5i8gpsn0a5fszwcj6ghibl8p6-python2.7-setuptools-44.0.0/lib/python2.7/site-packages (from Mopidy-MusicBox-Webclient==2.3.0) (44.0.0.post20200329)
  ERROR: Could not find a version that satisfies the requirement Mopidy>=1.1.0 (from Mopidy-MusicBox-Webclient==2.3.0) (from versions: none)
  ERROR: No matching distribution found for Mopidy>=1.1.0 (from Mopidy-MusicBox-Webclient==2.3.0)
builder for '/nix/store/3v52ncqnpna70kb8k468qlq59lpq8i6v-mopidy-youtube-2.0.2.drv' failed with exit code 1; last 10 log lines:
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  glibPreInstallPhase
  installing
  Executing pipInstallPhase
  /build/source/dist /build/source
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support                                           
  Processing ./Mopidy_Youtube-2.0.2-py2.py3-none-any.whl
  ERROR: Could not find a version that satisfies the requirement Pykka>=1.1 (from Mopidy-Youtube==2.0.2) (from versions: none)
  ERROR: No matching distribution found for Pykka>=1.1 (from Mopidy-Youtube==2.0.2)
builder for '/nix/store/gk61l799s1hx7lqzjkwdgkmphkflarv0-pandoc-citeproc-0.16.4.1.drv' failed with exit code 1; last 10 log lines:
  Building library for pandoc-citeproc-0.16.4.1..
  [ 1 of 22] Compiling Paths_pandoc_citeproc ( dist/build/autogen/Paths_pandoc_citeproc.hs, dist/build/Paths_pandoc_citeproc.o )
  [ 2 of 22] Compiling Text.CSL.Compat.Pandoc ( compat/Text/CSL/Compat/Pandoc.hs, dist/build/Text/CSL/Compat/Pandoc.o )
  [ 3 of 22] Compiling Text.CSL.Data    ( src/Text/CSL/Data.hs, dist/build/Text/CSL/Data.o )
  [ 4 of 22] Compiling Text.CSL.Exception ( src/Text/CSL/Exception.hs, dist/build/Text/CSL/Exception.o )
  [ 5 of 22] Compiling Text.CSL.Util    ( src/Text/CSL/Util.hs, dist/build/Text/CSL/Util.o )
  
  <no location info>: error:
      dist/build/Text/CSL/Util.hi: hPutBuf: resource exhausted (No space left on device)
  
note: build failure may have been caused by lack of free disk space
builder for '/nix/store/i8kpdbxpwi93w384718ck88i7234w472-kbookmarks-5.68.0.drv' failed with exit code 1; last 10 log lines:
  tar: kbookmarks-5.68.0/src/kbookmarkimporter_ns.h: Cannot write: No space left on device
  tar: kbookmarks-5.68.0/src/kbookmarkimporter_ie.cpp: Cannot write: No space left on device
  tar: kbookmarks-5.68.0/src/kbookmarkimporter.h: Cannot write: No space left on device
  tar: kbookmarks-5.68.0/src/Messages.sh: Cannot write: No space left on device
  tar: kbookmarks-5.68.0/src/konqbookmarkmenu.h: Cannot write: No space left on device
  tar: kbookmarks-5.68.0/src/kbookmarkimporter_opera.h: Cannot write: No space left on device
  tar: kbookmarks-5.68.0/src/kbookmarkimporter_opera_p.h: Cannot write: No space left on device
  tar: kbookmarks-5.68.0/.gitignore: Cannot write: No space left on device
  tar: Exiting with failure status due to previous errors
  do not know how to unpack source archive /nix/store/sy7ndq71g0mxkgnlayfr0s8nw75kivdg-kbookmarks-5.68.0.tar.xz
note: build failure may have been caused by lack of free disk space
cannot build derivation '/nix/store/8f2099dvwllz923hmf97l186vdg3w9hl-kio-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/h9y48yw3h4hxr6bd2ggvnzr3ygdahggm-baloo-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/1gqbp5xkkwqhiik62vhmsz66sg7dcrjc-kactivities-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/zdadizncrdm3bgf3vihsm712aiwkw1ri-kdeclarative-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/vky5pwkvmqg6n63yfp9k643bkzk0wzb6-kdesignerplugin-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/lwn852ahc3a9p20ll5l3zns9hzrzcvyc-knewstuff-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/vlrhfsj3ajij8f9icl31ma498037nzs5-knotifyconfig-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/9pgsz6li31x552x0zi1p3dsj228lbam7-kparts-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/s08xwn4lyalf3n4n6sjcw9sg40l35jik-purpose-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/na6wklarmzmrb50q11wy2cnqbzx3qc1p-frameworkintegration-5.68.0.drv': 3 dependencies couldn't be built
cannot build derivation '/nix/store/6x26bkijmnb7w3hzxgh83xjfxhwhpb0c-kcmutils-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/lsmlyzcjg3kii0z7blw0vdlbvbl5w03l-plasma-framework-5.68.0.drv': 3 dependencies couldn't be built
cannot build derivation '/nix/store/vni457ih30pa265mrz4sa60zg643qq7c-breeze-qt5-5.17.5.drv': 3 dependencies couldn't be built
cannot build derivation '/nix/store/hzp4j45v6vwhn5s32as6mbg48hwk8cj2-kinit-5.68.0.drv': 3 dependencies couldn't be built
cannot build derivation '/nix/store/6hzzdv5b8nk7gvnamad8xk4x65v0z2g2-kded-5.68.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/cpnyk5a14k2fnw41rq0zy6q9gnmxnhwk-kdenlive-19.12.3.drv': 6 dependencies couldn't be built
cannot build derivation '/nix/store/vjdfjq1gfay7g3m7hb9kmzrkg0r6h7ad-kdelibs4support-5.68.0.drv': 5 dependencies couldn't be built
cannot build derivation '/nix/store/mk3wwzglkzfzpp9z37xzlh33svv349na-baloo-widgets-19.12.3.drv': 3 dependencies couldn't be built
cannot build derivation '/nix/store/gk05maa4bbddyzzf88gqqwfv3z9b4ng2-kscreenlocker-5.17.5.drv': 4 dependencies couldn't be built
cannot build derivation '/nix/store/mbvhwpha23syqp1yr7lq5zrf1fa1w718-kwin-5.17.5.drv': 9 dependencies couldn't be built
builder for '/nix/store/1gqmx3bln6hdhfazz5yk9imiww0xa6s5-packages3d.drv' failed with exit code 1; last 10 log lines:
  tar: kicad-packages3D-8d233cdcb109aa1c3b8ba4c934ee31f6a3b6e1f4/Varistor.3dshapes/RV_Disc_D9mm_W5.5mm_P5mm.step: Cannot write: No space left on device
  tar: kicad-packages3D-8d233cdcb109aa1c3b8ba4c934ee31f6a3b6e1f4/Varistor.3dshapes/RV_Disc_D9mm_W5.5mm_P5mm.wrl: Cannot write: No space left on device
  tar: kicad-packages3D-8d233cdcb109aa1c3b8ba4c934ee31f6a3b6e1f4/Varistor.3dshapes/RV_Disc_D9mm_W5.7mm_P5mm.step: Cannot write: No space left on device
  tar: kicad-packages3D-8d233cdcb109aa1c3b8ba4c934ee31f6a3b6e1f4/Varistor.3dshapes/RV_Disc_D9mm_W5.7mm_P5mm.wrl: Cannot write: No space left on device
  tar: kicad-packages3D-8d233cdcb109aa1c3b8ba4c934ee31f6a3b6e1f4/Vrml_materials_doc/KiCad_3D-Viewer_Illumination_model_and_materials-MarioLuzeiro.odp: Cannot write: No space left on device
  tar: kicad-packages3D-8d233cdcb109aa1c3b8ba4c934ee31f6a3b6e1f4/Vrml_materials_doc/KiCad_3D-Viewer_Illumination_model_and_materials-MarioLuzeiro.pdf: Cannot write: No space left on device
  tar: kicad-packages3D-8d233cdcb109aa1c3b8ba4c934ee31f6a3b6e1f4/Vrml_materials_doc/KiCad_3D-Viewer_component-materials-reference-list_MarioLuzeiro.odp: Cannot write: No space left on device
  tar: kicad-packages3D-8d233cdcb109aa1c3b8ba4c934ee31f6a3b6e1f4/Vrml_materials_doc/KiCad_3D-Viewer_component-materials-reference-list_MarioLuzeiro.pdf: Cannot write: No space left on device
  tar: Exiting with failure status due to previous errors
  do not know how to unpack source archive /tmp/nix-build-packages3d.drv-0/8d233cdcb109aa1c3b8ba4c934ee31f6a3b6e1f4.tar.gz
note: build failure may have been caused by lack of free disk space
cannot build derivation '/nix/store/vzp21mngdk7b9bvvc3b342fz9lw0qw9b-kicad-packages3d-5.1.5.drv': 1 dependencies couldn't be built
builder for '/nix/store/0m6nlk6wwxfig701z6vyhkj9bi8nr4yx-papirus-icon-theme-20200405.drv' failed with exit code 1; last 10 log lines:
  cp: error writing 'source/Papirus-Light/22x22/panel/indicator-keyboard-Bn.svg': No space left on device
  cp: error writing 'source/Papirus-Light/22x22/panel/indicator-keyboard-Br.svg': No space left on device
  cp: error writing 'source/Papirus-Light/22x22/panel/indicator-keyboard-Bs.svg': No space left on device
  cp: error writing 'source/Papirus-Light/22x22/panel/indicator-keyboard-By.svg': No space left on device
  cp: error writing 'source/Papirus-Light/22x22/panel/indicator-keyboard-Ch.svg': No space left on device
  cp: error writing 'source/Papirus-Light/22x22/panel/indicator-keyboard-Cm.svg': No space left on device
  cp: error writing 'source/Papirus-Light/22x22/panel/indicator-keyboard-Cr.svg': No space left on device
  cp: error writing 'source/Papirus-Light/22x22/panel/indicator-keyboard-Cs.svg': No space left on device
  cp: error writing 'source/Papirus-Light/22x22/panel/indicator-keyboard-Da.svg': No space left on device
  do not know how to unpack source archive /nix/store/d96rmbkm3aimqksi313n7q8avd8knsgb-source
cannot build derivation '/nix/store/a2v993cxww4jcm0ksdy7qg1g5b7b0d9f-deepin-icon-theme-15.12.71.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/565w6hlz9kk546j4q2kzm4pl7rb48bnh-deepin-desktop-schemas-3.13.9.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/8w9vzkzj4x4bccvccdyp0sslz5y2krpl-dde-daemon-5.0.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/x8ax2vyycw57nck901hgdrakfbvgpdzs-dde-dock-5.0.0.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/90d1cqnc98v4881saiyar9ix1mzvrams-dde-file-manager-5.0.0.drv': 3 dependencies couldn't be built
builder for '/nix/store/jy6wc04kjdza5q238mf7lfwlx9inw695-packages3d.drv' failed with exit code 1; last 10 log lines:
  tar: kicad-packages3D-de368eb739abe41dfc3163e0e370477e857f9cc1/Connector_PinSocket_1.27mm.3dshapes/PinSocket_2x38_P1.27mm_Vertical.wrl: Cannot write: No space left on device
  tar: kicad-packages3D-de368eb739abe41dfc3163e0e370477e857f9cc1/Connector_PinSocket_1.27mm.3dshapes/PinSocket_2x38_P1.27mm_Vertical_SMD.step: Cannot write: No space left on device
  tar: kicad-packages3D-de368eb739abe41dfc3163e0e370477e857f9cc1/Connector_PinSocket_1.27mm.3dshapes/PinSocket_2x38_P1.27mm_Vertical_SMD.wrl: Cannot write: No space left on device
  tar: kicad-packages3D-de368eb739abe41dfc3163e0e370477e857f9cc1/Connector_PinSocket_1.27mm.3dshapes/PinSocket_2x39_P1.27mm_Horizontal.step: Cannot write: No space left on device
  tar: kicad-packages3D-de368eb739abe41dfc3163e0e370477e857f9cc1/Connector_PinSocket_1.27mm.3dshapes/PinSocket_2x39_P1.27mm_Horizontal.wrl: Cannot write: No space left on device
  tar: kicad-packages3D-de368eb739abe41dfc3163e0e370477e857f9cc1/Connector_PinSocket_1.27mm.3dshapes/PinSocket_2x39_P1.27mm_Vertical.step: Cannot write: No space left on device
  tar: kicad-packages3D-de368eb739abe41dfc3163e0e370477e857f9cc1/Connector_PinSocket_1.27mm.3dshapes/PinSocket_2x39_P1.27mm_Vertical.wrl: Cannot write: No space left on device
  tar: kicad-packages3D-de368eb739abe41dfc3163e0e370477e857f9cc1/Connector_PinSocket_1.27mm.3dshapes/PinSocket_2x39_P1.27mm_Vertical_SMD.step: Cannot write: No space left on device
  tar: Exiting with failure status due to previous errors
  do not know how to unpack source archive /tmp/nix-build-packages3d.drv-1/de368eb739abe41dfc3163e0e370477e857f9cc1.tar.gz
cannot build derivation '/nix/store/i2gz10d564wnjyybmpfrbd6cy3l96q64-kicad-packages3d-2020-02-10.drv': 1 dependencies couldn't be built
builder for '/nix/store/gihdbcd9m7g4i0f4y6cv37kxjfj1c7ja-fractal-4.2.2.drv' failed with exit code 1; last 10 log lines:
  warning: build failed, waiting for other jobs to finish...
  error: failed to write bytecode to /build/source/build/target/release/deps/regex-ed934e69c8092a76.regex.cl35l7y3-cgu.9.rcgu.bc.z: No space left on device (os error 28)
  
  error: could not compile `regex`.
  warning: build failed, waiting for other jobs to finish...
  error: build failed
  [3/4] Generating org.gnome.Fractal.appdata.xml_fractal-gtk@res_merge with a custom command.
  FAILED: fractal-gtk/src/fractal 
  /build/source/scripts/cargo.sh .. fractal-gtk/src/fractal /build/source/build ''
  ninja: build stopped: subcommand failed.
cannot build derivation '/nix/store/zzizbkcrrdsnim4xcw38abkiwwrngqfa-ktexteditor-5.68.0.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/0r35vpah7h2fli9iik22fg6lq1mhmiwd-dragon-19.12.3.drv': 11 dependencies couldn't be built
cannot build derivation '/nix/store/s81i69fmykflayklqf5xdlc89dqq2wrb-python3.7-pypandoc-unstable-2018-06-18.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/8hadqqfk598p0hzpfbih064pv4cvlfdj-python3-3.7.7-env.drv': 1 dependencies couldn't be built
waiting for locks or build slots...
builder for '/nix/store/gpw7f9vm8w1m4b2kn7mz9cfwkgbr68a3-mopidy-spotify-tunigo-1.0.0.drv' failed with exit code 1; last 10 log lines:
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  glibPreInstallPhase
  installing
  Executing pipInstallPhase
  /build/source/dist /build/source
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support                                           
  Processing ./Mopidy_Spotify_Tunigo-1.0.0-py2.py3-none-any.whl
  ERROR: Could not find a version that satisfies the requirement Mopidy>=0.19.0 (from Mopidy-Spotify-Tunigo==1.0.0) (from versions: none)
  ERROR: No matching distribution found for Mopidy>=0.19.0 (from Mopidy-Spotify-Tunigo==1.0.0)
waiting for locks or build slots...
cannot build derivation '/nix/store/zjmpwb0jipcgmfyzvcp46g4y8bv3a08y-ib-controller-2.14.0.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/wdh4cdg4frkrb0gv0lxg08rijaq1ffbv-apostrophe-unstable-2020-03-29.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/ivmqybp7cn0cwy0ck21iqsrriq5q1all-dde-session-ui-5.0.0.drv': 3 dependencies couldn't be built
cannot build derivation '/nix/store/6npd9yk3sy3wbgm6fv6rfpsb4b9y8nrf-dde-kwin-5.0.0.drv': 3 dependencies couldn't be built
cannot build derivation '/nix/store/17dmpn4disbl3q27hzys7banwzrnc9s2-dde-launcher-5.0.0.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/5w71hzm8qcfpmfg99qcavy1xjbqajyhn-startdde-5.0.1.drv': 6 dependencies couldn't be built
cannot build derivation '/nix/store/r89k1f1x84a0hmvayh8302bg1ca79a81-kicad-5.1.5.drv': 1 dependencies couldn't be built
builder for '/nix/store/mackjdcds4gas85g7ibrsg2jcrq3m6wr-kicad-unstable-base-2020-02-10.drv' failed with exit code 2; last 10 log lines:
  make[2]: *** [pcbnew/CMakeFiles/pcbnew_kiface_objects.dir/build.make:1779: pcbnew/CMakeFiles/pcbnew_kiface_objects.dir/exporters/export_d356.cpp.o] Error 1
  make[2]: *** Waiting for unfinished jobs....
  make[2]: *** [pcbnew/CMakeFiles/pcbnew_kiface_objects.dir/build.make:1766: pcbnew/CMakeFiles/pcbnew_kiface_objects.dir/exporters/export_hyperlynx.cpp.o] Error 1
  /build/source/pcbnew/exporters/export_gencad.cpp:1306:1: fatal error: error writing to /build/ccDlQYhc.s: No space left on device
   1306 | }
        | ^
  compilation terminated.
  make[2]: *** [pcbnew/CMakeFiles/pcbnew_kiface_objects.dir/build.make:1805: pcbnew/CMakeFiles/pcbnew_kiface_objects.dir/exporters/export_gencad.cpp.o] Error 1
  make[1]: *** [CMakeFiles/Makefile2:2194: pcbnew/CMakeFiles/pcbnew_kiface_objects.dir/all] Error 2
  make: *** [Makefile:163: all] Error 2
cannot build derivation '/nix/store/v7l3dvvh8h8axl4z2di52s11x0s8wx17-kicad-unstable-2020-02-10.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/i31scs5a7g8nr6q8w8q516if7iwld3px-env.drv': 18 dependencies couldn't be built
[246 built (16 failed)]
error: build of '/nix/store/i31scs5a7g8nr6q8w8q516if7iwld3px-env.drv' failed
12 package marked as broken and skipped:
gnomeExtensions.system-monitor ipsecTools mailpile mopidy-local-images mopidy-local-sqlite python27Packages.pyunbound python37Packages.pyunbound python38Packages.pyunbound sbagen telepathy-salut telepathy_salut vogl                                                                                                                                                                   

18 package failed to build:
apostrophe deepin.dde-kwin deepin.dde-launcher deepin.dde-session-ui deepin.startdde dragon fractal ib-controller kdeApplications.kdenlive kicad kicad-unstable mopidy-gmusic mopidy-moped mopidy-mopify mopidy-musicbox-webclient mopidy-soundcloud mopidy-spotify-tunigo mopidy-youtube                                                                                                 

210 package built:
adapta-gtk-theme almanah aravis areca astroid audio-recorder azureus balsa baresip birdfont bookworm brasero brasero-original byzanz calls cawbird chrome-gnome-shell cinnamon.cinnamon-control-center claws-mail-gtk3 deja-dup denemo dropbox-cli eclipses.eclipse-cpp eclipses.eclipse-java eclipses.eclipse-modeling eclipses.eclipse-platform eclipses.eclipse-scala-sdk eclipses.eclipse-sdk elementary-planner empathy enlightenment.rage eolie ephemeral epiphany evince evolution-data-server farstream feedreader folks gajim gcompris gfbgraph glom gmrender-resurrect gnome-builder gnome-online-accounts gnome-photos gnome-podcasts gnome-recipes gnome3.bijiben gnome3.cheese gnome3.devhelp gnome3.evolution gnome3.file-roller gnome3.geary gnome3.gnome-applets gnome3.gnome-books gnome3.gnome-boxes gnome3.gnome-calendar gnome3.gnome-contacts gnome3.gnome-control-center gnome3.gnome-documents gnome3.gnome-flashback gnome3.gnome-initial-setup gnome3.gnome-maps gnome3.gnome-music gnome3.gnome-online-miners gnome3.gnome-panel gnome3.gnome-session gnome3.gnome-shell gnome3.gnome-software gnome3.gnome-sound-recorder gnome3.gnome-terminal gnome3.gnome-todo gnome3.gnome-tweak-tool gnome3.gnome-user-share gnome3.grilo-plugins gnome3.gvfs gnome3.libgdata gnome3.libgepub gnome3.libzapojit gnome3.nautilus gnome3.nautilus-python gnome3.polari gnome3.pomodoro gnome3.rygel gnome3.shotwell gnome3.sushi gnome3.totem gnome3.tracker-miners webkit gnome3.yelp gnomeExtensions.gsconnect gnucash gnvim gnvim-unwrapped gscrabble gst_all_1.gst-plugins-bad gst_all_1.gst-rtsp-server gst_all_1.gst-vaapi gthumb gtkd ipscan kicad-small libsForQt5.phonon-backend-gstreamer telepathy_qt5 liferea lollypop luakit lutris lutris-free lutris-unwrapped mailnag mate.mate-user-guide mavproxy meteo midori midori-unwrapped mmex mopidy mopidy-iris mopidy-mpd mopidy-spotify next notes-up onboard osmo pantheon.elementary-calendar pantheon.elementary-camera pantheon.elementary-capnet-assist pantheon.elementary-code pantheon.elementary-greeter pantheon.elementary-gsettings-schemas pantheon.elementary-music pantheon.elementary-photos pantheon.elementary-session-settings pantheon.elementary-videos pantheon.extra-elementary-contracts pantheon.notes-up pantheon.switchboard-plug-a11y pantheon.switchboard-plug-onlineaccounts pantheon.switchboard-with-plugs pantheon.wingpanel-indicator-datetime pantheon.wingpanel-with-indicators parlatype picard pidgin pidgin-carbons pidginlatex pidgin-mra pidginmsnpecan pidgin-opensteamworks pidginosd pidginotr pidginsipe pidgin-skypeweb pidginwindowmerge pidgin-xmpp-receipts pithos pitivi pulseeffects purple-discord purple-facebook purple-hangouts purple-lurch purple-matrix purple-plugin-pack purple-slack purple-vk-plugin purple-xmpp-http-upload python27Packages.wxPython_4_0 python37Packages.wxPython_4_0 python38Packages.wxPython_4_0 pytrainer quilter quodlibet quodlibet-full quodlibet-without-gst-plugins quodlibet-xine quodlibet-xine-full qutebrowser radiotray-ng rednotebook remmina run-scaled sayonara shortwave skype4pidgin sound-juicer surf surf-display swt telegram-purple telepathy-farstream telepathy-haze telepathy-qt termplay tilix toxprpl tuxguitar ulauncher vimb vimb-unwrapped vocal vuze xfce.parole xiphos xmonad_log_applet xpra yaxg

[0.0 MiB DL]
error: build log of '/nix/store/wdh4cdg4frkrb0gv0lxg08rijaq1ffbv-apostrophe-unstable-2020-03-29.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/6npd9yk3sy3wbgm6fv6rfpsb4b9y8nrf-dde-kwin-5.0.0.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/17dmpn4disbl3q27hzys7banwzrnc9s2-dde-launcher-5.0.0.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/ivmqybp7cn0cwy0ck21iqsrriq5q1all-dde-session-ui-5.0.0.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/5w71hzm8qcfpmfg99qcavy1xjbqajyhn-startdde-5.0.1.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/0r35vpah7h2fli9iik22fg6lq1mhmiwd-dragon-19.12.3.drv' is not available
[0.0 MiB DL]
[0.0 MiB DL]
error: build log of '/nix/store/zjmpwb0jipcgmfyzvcp46g4y8bv3a08y-ib-controller-2.14.0.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/cpnyk5a14k2fnw41rq0zy6q9gnmxnhwk-kdenlive-19.12.3.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/r89k1f1x84a0hmvayh8302bg1ca79a81-kicad-5.1.5.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/v7l3dvvh8h8axl4z2di52s11x0s8wx17-kicad-unstable-2020-02-10.drv' is not available
```
</details>

- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
