### PR TITLE
qimgv: enable video support

### DIFF
--- a/pkgs/applications/graphics/qimgv/default.nix
+++ b/pkgs/applications/graphics/qimgv/default.nix
@@ -1,6 +1,15 @@
-{ mkDerivation, fetchFromGitHub, lib
-, pkgconfig, cmake
-, exiv2, qtbase, qtimageformats, qtsvg
+{ mkDerivation
+, lib
+, fetchFromGitHub
+
+, cmake
+, pkgconfig
+
+, exiv2
+, mpv
+, qtbase
+, qtimageformats
+, qtsvg
 }:
 
 mkDerivation rec {
@@ -14,33 +23,32 @@ mkDerivation rec {
     sha256 = "0cmya06j466v0pirhxbzbj1vbz0346y7rbc1gbv4n9xcp6c6bln6";
   };
 
-  cmakeFlags = [
-    # Video support appears to be broken; the following gets printed upon
-    # attempting to view an mp4, webm, or mkv (and probably all video formats):
-    #
-    #   [VideoPlayerInitProxy] Error - could not load player library
-    #   "qimgv_player_mpv"
-    #
-    # GIFs are unaffected. If this ever gets addressed, all that is necessary is
-    # to add `mpv` to the arguments list and to `buildInputs`, and to remove
-    # `cmakeFlags`.
-    "-DVIDEO_SUPPORT=OFF"
-  ];
-
   nativeBuildInputs = [
-    pkgconfig
     cmake
+    pkgconfig
   ];
 
   buildInputs = [
     exiv2
+    mpv
     qtbase
     qtimageformats
     qtsvg
   ];
 
+  postPatch = ''
+    sed -i "s@/usr/bin/mpv@${mpv}/bin/mpv@" \
+      qimgv/settings.cpp
+  '';
+
+  # Wrap the library path so it can see `libqimgv_player_mpv.so`, which is used
+  # to play video files within qimgv itself.
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${placeholder "out"}/lib"
+  ];
+
   meta = with lib; {
-    description = "Qt5 image viewer with optional video support";
+    description = "A Qt5 image viewer with optional video support";
     homepage = "https://github.com/easymodo/qimgv";
     license = licenses.gpl3;
     platforms = platforms.linux;


### PR DESCRIPTION
I actually went back and `strace`'d the binary when it complained about
being unable to load the library it uses for playing videos. Turns out,
it wasn't finding the library because it wasn't in any of its library
paths. I added the lib path to `LD_LIBRARY_PATH` so it can find the
library it uses to play videos, and now things are peachy.

There is a (seemingly innocuous) error that gets displayed from Exiv2
being unable to determine its image type. Since it's actually a video, I
think it's fine. Another issue that pops up in the output is missing
`libcuda.so.1`, but that doesn't seem to affect functionality, and using
`addOpenGLRunpath` on both the binary and libraries didn't silence it.

Also did a little formatting.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I had a bit of free time (read: was procrastinating) and decided to try and figure out why `qimgv` was missing the library it needs to play videos (which it compiles itself). You can read my commit message above, but suffice to say it needs to be able to find the library to load it...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (courtesy MichaelRaskin on IRC)
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
