### PR TITLE
ttyd: 1.5.2 -> 1.6.0

### DIFF
--- a/pkgs/servers/ttyd/default.nix
+++ b/pkgs/servers/ttyd/default.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitHub
 , pkgconfig, cmake, xxd
-, openssl, libwebsockets, json_c, libuv
+, openssl, libwebsockets, json_c, libuv, zlib
 }:
 
 with builtins;
 
 stdenv.mkDerivation rec {
   pname = "ttyd";
-  version = "1.5.2";
+  version = "1.6.0";
   src = fetchFromGitHub {
     owner = "tsl0922";
     repo = pname;
     rev = "refs/tags/${version}";
-    sha256 = "16nngc3dqrsgpapzvl34c0msgdd1fyp3k8r1jj1m9bch6z2p50bl";
+    sha256 = "08skw3h897jb71sbnglj571h35pcb1mikzlh71sx5imjgi4hfczr";
   };
 
   nativeBuildInputs = [ pkgconfig cmake xxd ];
-  buildInputs = [ openssl libwebsockets json_c libuv ];
+  buildInputs = [ openssl libwebsockets json_c libuv zlib ];
   enableParallelBuilding = true;
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
###### Motivation for this change

This is just a regular version bump. The version which is currently in nixpkgs, 1.5.2, bundles a version of xterm.js which [causes noticeable lag](https://github.com/tsl0922/ttyd/issues/137). Thank you for packaging ttyd, your work is very much appreciated :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
