### PR TITLE
pythonPackages.{aadict,,globre,pxml}: init at 0.2.3, 0.1.5, 0.2.13 respectively

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2804,6 +2804,16 @@
     githubId = 615606;
     name = "Glenn Searby";
   };
+  glittershark = {
+    name = "Griffin Smith";
+    email = "root@gws.fyi";
+    github = "glittershark";
+    githubId = 1481027;
+    keys = [{
+      longkeyid = "rsa2048/0x44EF5B5E861C09A7";
+      fingerprint = "0F11 A989 879E 8BBB FDC1  E236 44EF 5B5E 861C 09A7";
+    }];
+  };
   gloaming = {
     email = "ch9871@gmail.com";
     github = "gloaming";

--- a/pkgs/development/python-modules/aadict/default.nix
+++ b/pkgs/development/python-modules/aadict/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, six
+, nose
+, coverage
+}:
+
+buildPythonPackage rec {
+  pname = "aadict";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "013pn9ii6mkql6khgdvsd1gi7zmya418fhclm5fp7dfvann2hwx7";
+  };
+
+  propagatedBuildInputs = [ six ];
+  checkInputs = [ nose coverage ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/metagriffin/aadict";
+    description = "An auto-attribute dict (and a couple of other useful dict functions).";
+    maintainers = with maintainers; [ glittershark ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/development/python-modules/globre/default.nix
+++ b/pkgs/development/python-modules/globre/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, pythonAtLeast
+, buildPythonPackage
+, fetchPypi
+, nose
+, coverage
+}:
+
+buildPythonPackage rec {
+  pname = "globre";
+  version = "0.1.5";
+  # https://github.com/metagriffin/globre/issues/7
+  disabled = pythonAtLeast "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qhjpg0722871dm5m7mmldf6c7mx58fbdvk1ix5i3s9py82448gf";
+  };
+
+  checkInputs = [ nose coverage ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/metagriffin/globre";
+    description = "A python glob-like regular expression generation library.";
+    maintainers = with maintainers; [ glittershark ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/development/python-modules/pxml/default.nix
+++ b/pkgs/development/python-modules/pxml/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, pythonAtLeast
+, isPy27
+, buildPythonPackage
+, fetchPypi
+, blessings
+, six
+, nose
+, coverage
+}:
+
+buildPythonPackage rec {
+  pname = "pxml";
+  version = "0.2.13";
+  disabled = pythonAtLeast "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0c9zzfv6ciyf9qm7556wil45xxgykg1cj8isp1b88gimwcb2hxg4";
+  };
+
+  propagatedBuildInputs = [ blessings six ];
+  checkInputs = [ nose coverage ];
+
+  # test_prefixedWhitespace fails due to a python3 StringIO issue requiring
+  # bytes rather than str
+  checkPhase = ''
+    nosetests -e 'test_prefixedWhitespace'
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/metagriffin/pxml";
+    description = ''A python library and command-line tool to "prettify" and colorize XML.'';
+    maintainers = with maintainers; [ glittershark ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3231,6 +3231,8 @@ in {
     inherit (pkgs) lzo;
   };
 
+  pxml = callPackage ../development/python-modules/pxml { };
+
   junos-eznc = callPackage ../development/python-modules/junos-eznc {};
 
   raven = callPackage ../development/python-modules/raven { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -134,6 +134,8 @@ in {
 
   pynamodb = callPackage ../development/python-modules/pynamodb { };
 
+  aadict = callPackage ../development/python-modules/aadict { };
+
   absl-py = callPackage ../development/python-modules/absl-py { };
 
   adb-homeassistant = callPackage ../development/python-modules/adb-homeassistant { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -741,6 +741,8 @@ in {
 
   glob2 = callPackage ../development/python-modules/glob2 { };
 
+  globre = callPackage ../development/python-modules/globre { };
+
   glom = callPackage ../development/python-modules/glom { };
 
   goocalendar = callPackage ../development/python-modules/goocalendar { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Needed by asset (coming soon) which is needed by passwordmeter (coming soon) which I need in my application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
