### PR TITLE
shellcheck: fix build

### DIFF
--- a/pkgs/development/tools/shellcheck/default.nix
+++ b/pkgs/development/tools/shellcheck/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, haskellPackages, haskell }:
+{ stdenv, lib, haskellPackages, haskell, pandoc }:
 
 # this wraps around the haskell package
 # and puts the documentation into place
@@ -24,9 +24,15 @@ let
 
     inherit src;
 
+    nativeBuildInputs = [ pandoc ];
+
     outputs = [ "bin" "man" "doc" "out" ];
 
-    phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+    phases = [ "unpackPhase" "buildPhase" "installPhase" "fixupPhase" ];
+
+    buildPhase = ''
+      pandoc -s -f markdown-smart -t man shellcheck.1.md -o shellcheck.1
+    '';
 
     installPhase = ''
       install -Dm755 ${bin}/bin/shellcheck $bin/bin/shellcheck


### PR DESCRIPTION
shellcheck no longer auto builds its manpage[1]

See: https://hydra.nixos.org/build/116511986

[1] https://github.com/koalaman/shellcheck/commit/2c026f1ec7c205c731ff2a0ccd85365f37245758

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
