### PR TITLE
polyphone: init at 2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4703,6 +4703,12 @@
     githubId = 136037;
     name = "Matthew Maurer";
   };
+  maxdamantus = {
+    email = "maxdamantus@gmail.com";
+    github = "Maxdamantus";
+    githubId = 502805;
+    name = "Max Zerzouri";
+  };
   mbakke = {
     email = "mbakke@fastmail.com";
     github = "mbakke";

--- a/pkgs/applications/audio/polyphone/default.nix
+++ b/pkgs/applications/audio/polyphone/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, mkDerivation, fetchFromGitHub, qmake, pkgconfig, alsaLib, libjack2, portaudio, libogg, flac, libvorbis, rtmidi, qtsvg }:
+
+mkDerivation rec {
+  version = "2.2.0";
+  pname = "polyphone";
+
+  src = fetchFromGitHub {
+    owner = "davy7125";
+    repo = "polyphone";
+    rev = version;
+    sha256 = "0w5pidzhpwpggjn5la384fvjzkvprvrnidb06068whci11kgpbp7";
+  };
+
+  buildInputs = [
+    alsaLib
+    libjack2
+    portaudio
+    libogg
+    flac
+    libvorbis
+    rtmidi
+    qtsvg
+  ];
+
+  nativeBuildInputs = [ qmake pkgconfig ];
+
+  preConfigure = ''
+    cd ./sources/
+  '';
+
+  installPhase = ''
+    install -d $out/bin
+    install -m755 bin/polyphone $out/bin/
+  '';
+
+  qmakeFlags = [
+    "DEFINES+=USE_LOCAL_STK"
+    "DEFINES+=USE_LOCAL_QCUSTOMPLOT"
+    "INCLUDEPATH+=${libjack2}/include/jack"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A soundfont editor for creating musical instruments";
+    homepage = https://www.polyphone-soundfonts.com/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.maxdamantus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20844,6 +20844,8 @@ in
     i3GapsSupport = false;
   };
 
+  polyphone = libsForQt5.callPackage ../applications/audio/polyphone { };
+
   ptex = callPackage ../development/libraries/ptex {};
 
   qbec = callPackage ../applications/networking/cluster/qbec { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
