### PR TITLE
nerdfonts: update.sh: use releases api to generate shas

### DIFF
--- a/pkgs/data/fonts/nerdfonts/shas.nix
+++ b/pkgs/data/fonts/nerdfonts/shas.nix
@@ -24,6 +24,8 @@
 	"iA-Writer" = "0clksrxw6xcv5c1pbd8rl2rc3r15iak1qv8v6bn0j2mccjcss64z";
 	"IBMPlexMono" = "0xkfkpnkkrvjfiv624l7lpmfji107y7645w6ah47ijyg47yxkmsg";
 	"Inconsolata" = "14gbwc0k3d1j496w6pv9kry1pglswzd0armsdb0g1mqgzfdf1ci1";
+	"InconsolataGo" = "0c6yhx242d82dalyjas42qniy0jagqs47cfsfarwmzar6zg3lj5m";
+	"InconsolataLGC" = "1746nl1rz4hscfgbmd8642wq3z1wizvfjb50y3yyjsc1ixc1f0pd";
 	"Iosevka" = "1qqd4xh98vxb99rh2a2qv9gjclilhaw84pyqdpbx225qhvw9xlkb";
 	"JetBrainsMono" = "1kc8fyk1aczxkmn8dzv1gy6xfi2jywgahd8np576v2dn8kx16844";
 	"Lekton" = "0mny5j9bns9104wg2wmabdw0sl80c7i3dzp4j5mxh8jybx929d3i";
@@ -45,5 +47,6 @@
 	"Terminus" = "0g2ybs225fwxmvwfnanc32jc2lfnag3agmliv1vrb5mxyqzm53gj";
 	"Tinos" = "077n4k6yh4qbirfkl02zqn3057kymspr10zcbfkf4ldvifa36pjd";
 	"Ubuntu" = "1lzdrgb8vk5dwicxhvkgbain5phf88g3zgv5ya2ihh052xsl3qih";
+	"UbuntuMono" = "0wa8ri7f3g8vwd194q812qh8nzplnmhl5ak0yhgilmm44s46ad0h";
 	"VictorMono" = "18z92kwggfqwrd5m09yda55hcb4b159278lps6f9hr8icwki6v9q";
 }

--- a/pkgs/data/fonts/nerdfonts/update.sh
+++ b/pkgs/data/fonts/nerdfonts/update.sh
@@ -1,73 +1,21 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p rsstail nix-prefetch
+#! nix-shell -i bash -p nix-prefetch jq
 
-# NOTE: Before running this script, please make sure this list is up-to-date -
-# meaning there are no new fonts they provide at https://github.com/ryanoasis/nerd-fonts/releases/
-fonts=(
-	"3270"
-	Agave
-	AnonymousPro
-	Arimo
-	AurulentSansMono
-	BigBlueTerminal
-	BitstreamVeraSansMono
-	CascadiaCode
-	CodeNewRoman
-	Cousine
-	DaddyTimeMono
-	DejaVuSansMono
-	DroidSansMono
-	FantasqueSansMono
-	FiraCode
-	FiraMono
-	Go-Mono
-	Gohu
-	Hack
-	Hasklig
-	HeavyData
-	Hermit
-	iA-Writer
-	IBMPlexMono
-	Inconsolata
-	Iosevka
-	JetBrainsMono
-	Lekton
-	LiberationMono
-	Meslo
-	Monofur
-	Monoid
-	Mononoki
-	MPlus
-	Noto
-	OpenDyslexic
-	Overpass
-	ProFont
-	ProggyClean
-	RobotoMono
-	ShareTechMono
-	SourceCodePro
-	SpaceMono
-	Terminus
-	Tinos
-	Ubuntu
-	VictorMono
-)
+latest_release=$(curl --silent https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest)
+version=$(jq -r '.tag_name' <<<"$latest_release")
 
-releases_url="https://github.com/ryanoasis/nerd-fonts/releases.atom"
-
-version="$(rsstail -1 -u "$releases_url" -H -l -r | sed -e '/^Title: /d' -e 's:.*/::' -e 's/^v//g' | sort -V | tail -1)"
+dirname="$(dirname "$0")"
+echo \""${version#v}"\" >"$dirname/version.nix"
 
 echo Using version "$version"
 
-dirname="$(dirname "$0")"
-echo \""$version"\" > "$dirname/version.nix"
-
-base_url="https://github.com/ryanoasis/nerd-fonts/releases/download/v${version}"
-
 printf '{\n' > "$dirname/shas.nix"
 
-for font in "${fonts[@]}"; do
-	printf '\t"%s" = "%s";\n' "$font" "$(nix-prefetch-url "${base_url}/${font}.zip")" >> "$dirname/shas.nix"
-done
+while
+  read -r name
+  read -r url
+do
+    printf '\t"%s" = "%s";\n' "${name%.*}" "$(nix-prefetch-url "$url")" >>"$dirname/shas.nix"
+done < <(jq -r '.assets[] | .name, .browser_download_url' <<<"$latest_release")
 
 printf '}\n' >> "$dirname/shas.nix"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix #84947 and make sure issues like these won't arise again. /cc @worldofpeace @albakham .

###### Things done

- [x] Improved `update.sh` to parse the HTML in order to fetch the list of fonts.
- [x] Updated `shas.nix`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
