### PR TITLE
electron: fix wrapGAppsHook usage

### DIFF
--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchFromGitHub
 , makeWrapper, makeDesktopItem, mkYarnPackage
-, electron_7, riot-web, gtk3
-, wrapGAppsHook, glib
+, electron_7, riot-web
 }:
 # Notes for maintainers:
 # * versions of `riot-web` and `riot-desktop` should be kept in sync.
@@ -27,14 +26,7 @@ in mkYarnPackage rec {
   packageJSON = ./riot-desktop-package.json;
   yarnNix = ./riot-desktop-yarndeps.nix;
 
-  nativeBuildInputs = [ wrapGAppsHook ];
-
-  extraBuildInputs = [
-    glib
-    gtk3
-  ];
-
-  dontWrapGApps = true;
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     # resources
@@ -54,13 +46,10 @@ in mkYarnPackage rec {
     # desktop item
     mkdir -p "$out/share"
     ln -s "${desktopItem}/share/applications" "$out/share/applications"
-  '';
 
-  postFixup = ''
     # executable wrapper
     makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
-      --add-flags "$out/share/riot/electron" \
-      "''${gappsWrapperArgs[@]}"
+      --add-flags "$out/share/riot/electron"
   '';
 
   # Do not attempt generating a tarball for riot-web again.

--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, libXScrnSaver, makeWrapper, fetchurl, wrapGAppsHook, gtk3, unzip, atomEnv, libuuid, at-spi2-atk, at-spi2-core }@args:
+{ stdenv, libXScrnSaver, makeWrapper, fetchurl, wrapGAppsHook, glib, gtk3, unzip, atomEnv, libuuid, at-spi2-atk, at-spi2-core }@args:
 
 let
   mkElectron = import ./generic.nix args;

--- a/pkgs/development/tools/electron/generic.nix
+++ b/pkgs/development/tools/electron/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, libXScrnSaver, makeWrapper, fetchurl, wrapGAppsHook, gtk3, unzip, atomEnv, libuuid, at-spi2-atk, at-spi2-core}:
+{ stdenv, libXScrnSaver, makeWrapper, fetchurl, wrapGAppsHook, glib, gtk3, unzip, atomEnv, libuuid, at-spi2-atk, at-spi2-core}:
 
 version: hashes:
 let
@@ -34,7 +34,7 @@ let
   };
 
   linux = {
-    buildInputs = [ gtk3 ];
+    buildInputs = [ glib gtk3 ];
 
     nativeBuildInputs = [
       unzip
@@ -44,13 +44,16 @@ let
 
     dontWrapGApps = true; # electron is in lib, we need to wrap it manually
 
-    buildCommand = ''
+    dontUnpack = true;
+    dontBuild = true;
+
+    installPhase = ''
       mkdir -p $out/lib/electron $out/bin
       unzip -d $out/lib/electron $src
       ln -s $out/lib/electron/electron $out/bin
+    '';
 
-      fixupPhase
-
+    postFixup = ''
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "${atomEnv.libPath}:${stdenv.lib.makeLibraryPath [ libuuid at-spi2-atk at-spi2-core ]}:$out/lib/electron" \


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/84913 by:

1. reverting the riot-desktop change
2. fixing wrapGAppsHook in electron

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
