### PR TITLE
gpsbabel-gui: init at 1.6.0

### DIFF
--- a/pkgs/applications/misc/gpsbabel/gui.nix
+++ b/pkgs/applications/misc/gpsbabel/gui.nix
@@ -1,0 +1,49 @@
+{ stdenv, mkDerivation, qmake, qttools, qtwebkit, qttranslations, gpsbabel }:
+
+mkDerivation {
+  pname = "gpsbabel-gui";
+
+  inherit (gpsbabel) src version;
+
+  sourceRoot = "source/gui";
+
+  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [ qtwebkit ];
+
+  postPatch = ''
+    substituteInPlace mainwindow.cc \
+      --replace "QApplication::applicationDirPath() + \"/" "\"" \
+      --replace "QApplication::applicationDirPath() + '/' + " "" \
+      --replace "translator.load(full_filename)" "translator.load(filename)" \
+      --replace "gpsbabelfe_%1.qm" "$out/share/gpsbabel/translations/gpsbabelfe_%1.qm" \
+      --replace "gpsbabel_%1.qm" "$out/share/gpsbabel/translations/gpsbabel_%1.qm" \
+      --replace "qt_%1.qm" "${qttranslations}/translations/qt_%1.qm"
+    substituteInPlace formatload.cc \
+      --replace "QApplication::applicationDirPath() + \"/" "\""
+    substituteInPlace gpsbabel.desktop \
+      --replace "gpsbabelfe-bin" "gpsbabelfe"
+  '';
+
+  preConfigure = ''
+    lrelease *.ts coretool/*.ts
+  '';
+
+  qtWrapperArgs = [
+    "--prefix PATH : ${stdenv.lib.makeBinPath [ gpsbabel ]}"
+  ];
+
+  postInstall = ''
+    install -Dm755 objects/gpsbabelfe -t $out/bin
+    install -Dm644 gpsbabel.desktop -t $out/share/applications
+    install -Dm644 images/appicon.png $out/share/icons/hicolor/512x512/apps/gpsbabel.png
+    install -Dm644 *.qm coretool/*.qm -t $out/share/gpsbabel/translations
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Qt-based GUI for gpsbabel";
+    homepage = "http://www.gpsbabel.org/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19707,6 +19707,8 @@ in
     inherit (darwin) IOKit;
   };
 
+  gpsbabel-gui = libsForQt5.callPackage ../applications/misc/gpsbabel/gui.nix { };
+
   gpscorrelate = callPackage ../applications/misc/gpscorrelate { };
 
   gpsd = callPackage ../servers/gpsd { };


### PR DESCRIPTION
###### Motivation for this change
Qt-based GUI for GPSBabel - https://www.gpsbabel.org/screenshots.html

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @rycee