### PR TITLE
pythonPackages.limnoria: Add optional dependencies and enable tests

### DIFF
--- a/pkgs/development/python-modules/limnoria/default.nix
+++ b/pkgs/development/python-modules/limnoria/default.nix
@@ -56,5 +56,4 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ goibhniu ];
     broken = stdenv.isDarwin;
   };
-
 }

--- a/pkgs/development/python-modules/limnoria/default.nix
+++ b/pkgs/development/python-modules/limnoria/default.nix
@@ -2,7 +2,16 @@
 , buildPythonPackage
 , fetchPypi
 , isPy27
-, pkgs
+, procps
+, chardet
+, pytz
+, python-dateutil
+, python-gnupg
+, feedparser
+, sqlalchemy
+, pysocks
+, mock
+, cryptography
 }:
 
 buildPythonPackage rec {
@@ -17,10 +26,28 @@ buildPythonPackage rec {
 
   patchPhase = ''
     sed -i 's/version=version/version="${version}"/' setup.py
-  '';
-  buildInputs = [ pkgs.git ];
 
-  doCheck = false;
+    # Unix's test suite assumes /bin/ls and /boot exists
+    sed -i 's|/bin/ls|ls|' plugins/Unix/test.py
+    sed -i 's|boot|bin|' plugins/Unix/test.py
+  '';
+
+  checkInputs = [
+    procps
+    chardet
+    pytz
+    python-dateutil
+    python-gnupg
+    feedparser
+    sqlalchemy
+    pysocks
+    mock
+    cryptography
+  ];
+
+  checkPhase = ''
+    python scripts/supybot-test --no-network test --plugins-dir=./plugins/
+  '';
 
   meta = with lib; {
     description = "A modified version of Supybot, an IRC bot";

--- a/pkgs/development/python-modules/limnoria/default.nix
+++ b/pkgs/development/python-modules/limnoria/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/ProgVal/Limnoria";
     license = licenses.bsd3;
     maintainers = with maintainers; [ goibhniu ];
+    broken = stdenv.isDarwin;
   };
 
 }

--- a/pkgs/development/python-modules/limnoria/default.nix
+++ b/pkgs/development/python-modules/limnoria/default.nix
@@ -12,6 +12,7 @@
 , pysocks
 , mock
 , cryptography
+, stdenv
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/limnoria/default.nix
+++ b/pkgs/development/python-modules/limnoria/default.nix
@@ -24,12 +24,13 @@ buildPythonPackage rec {
     sha256 = "c13dd7a84eddfcf9c3068d57f3c9da90ea7c0d11688dc3f78f9265f3f093c6ea";
   };
 
-  patchPhase = ''
-    sed -i 's/version=version/version="${version}"/' setup.py
+  postPhase = ''
+    substituteInPlace setup.py \
+      --replace "version=version" 'version="${version}"'
 
-    # Unix's test suite assumes /bin/ls and /boot exists
-    sed -i 's|/bin/ls|ls|' plugins/Unix/test.py
-    sed -i 's|boot|bin|' plugins/Unix/test.py
+    substituteInPlace plugins/Unix/test.py \
+      --replace "/bin/ls" "ls" \
+      --replace "boot" "bin"
   '';
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change

Limnoria has optional features enabled when these dependencies are available.

###### Things done

I copied dependencies from the source requirements.txt file.
I also enabled tests while I was at it, but I can remove them if you think it's too much overhead (5 to 10 min on an average PC)

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): **109MB -> 171MB**
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @cillianderoiste 