### PR TITLE
spring: 104.0.1-1477-g8ecf38a -> 104.0.1-1480-gc9377ac

### DIFF
--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -8,17 +8,17 @@
 stdenv.mkDerivation rec {
   pname = "spring";
   version = "104.0.1-${buildId}-g${shortRev}";
-  # usually the latest in https://github.com/spring/spring/commits/maintenance 
-  rev = "8ecf38a784ed3c4e3d67bc8d59839a77e0f0b83e";
+  # usually the latest in https://github.com/spring/spring/commits/maintenance
+  rev = "c9377ac3d5779eca811080e1c98a3ac668a22b18";
   shortRev = builtins.substring 0 7 rev;
-  buildId = "1477";
+  buildId = "1480";
 
   # taken from https://github.com/spring/spring/commits/maintenance
   src = fetchFromGitHub {
     owner = "spring";
     repo = "spring";
     inherit rev;
-    sha256 = "0iai1wnd7msabgw2979cp2k54sgcfvidfmymhnck31jwbfa6y021";
+    sha256 = "0iha1bnb72hqijm41jppipqgghh15cw3rbyyzfal1b516431848p";
     fetchSubmodules = true;
   };
 

--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     homepage = https://springrts.com/;
     description = "A powerful real-time strategy (RTS) game engine";
     license = licenses.gpl2;
-    maintainers = [ maintainers.phreedom maintainers.qknight maintainers.domenkozar ];
+    maintainers = [ maintainers.phreedom maintainers.qknight maintainers.domenkozar maintainers.sorki ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version bump, adding myself as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
