### PR TITLE
liblinphone: fix missing vcard_grammar

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -223,7 +223,6 @@ mkDerivation rec {
     cp linphone.desktop $out/share/applications/
     cp -r ../assets/icons $out/share/
     mkdir -p $out/share/belr/grammars
-    ln -s ${belcard}/share/belr/grammars/* $out/share/belr/grammars/
     ln -s ${liblinphone}/share/belr/grammars/* $out/share/belr/grammars/
     mkdir -p $out/share/linphone
     ln -s ${liblinphone}/share/linphone/* $out/share/linphone/

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -140,6 +140,15 @@ stdenv.mkDerivation rec {
     pkgconfig
   ];
 
+  # Some grammar files needed to be copied too from some dependencies. I suppose
+  # if one define a dependency in such a way that its share directory is found,
+  # then this copying would be unnecessary. Instead of actually copying these
+  # files, create a symlink.
+  postInstall = ''
+    mkdir -p $out/share/belr/grammars
+    ln -s ${belcard}/share/belr/grammars/* $out/share/belr/grammars/
+  '';
+
   meta = with stdenv.lib; {
     homepage = "https://www.linphone.org/technical-corner/liblinphone";
     description = "Library for SIP calls and instant messaging";


### PR DESCRIPTION
###### Motivation for this change

Fixes #84488

@tohl Could you test this? FYI too, @7c6f434c.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
