### PR TITLE
apfs-fuse: Let mount find apfs-fuse

### DIFF
--- a/pkgs/tools/filesystems/apfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/apfs-fuse/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation {
   buildInputs = [ fuse3 bzip2 zlib attr ];
   nativeBuildInputs = [ cmake ];
 
+  postFixup = ''
+    ln -s $out/bin/apfs-fuse $out/bin/mount.fuse.apfs-fuse
+  '';
+
   meta = with stdenv.lib; {
     homepage    = "https://github.com/sgan81/apfs-fuse";
     description = "FUSE driver for APFS (Apple File System)";


### PR DESCRIPTION
###### Motivation for this change

On other distros, using `fuse.apfs-fuse` as mount type should work since `mount.fuse` will then call `apfs-fuse`, but on nixos the `PATH` exposed to `mount.fuse` is restricted. The symlink makes this work directly, by having `mount` find `mount.fuse.apfs-fuse` in its `PATH`.

In particular, this let's us use `fuse.apfs-fuse` as `fsType` when defining mounts in `nixos`. The
current alternative is to specify: `fuse./run/current-system/sw/bin/apfs-fuse`
as `fsType`.

I'm following https://github.com/NixOS/nixpkgs/pull/14302 for this fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
