### PR TITLE
pico-8: init at 0.1.12c

### DIFF
--- a/pkgs/games/pico-8/default.nix
+++ b/pkgs/games/pico-8/default.nix
@@ -6,8 +6,8 @@ let
     else "i386";
 
   sha = if stdenv.system == "x86_64-linux"
-    then "b9d2e793dc6fee94ba4e5e202129dac40491df15dfd19dfe3d9e8884d624d384"
-    else "1cd578f6c50acb7ea95dcedc87c37f088aad8a5e5212e3a78c3d0d37cc70a780";
+    then "9925ad06770a71854b1fee7dc6c69ca0760565ad5f3c0c8d11500f7ad39a445d"
+    else "d83062db0a2df78799ebe590593a215b470a27b834fb71a54052b65217add7af";
 
   desktopItem = makeDesktopItem {
     desktopName = "pico-8";
@@ -23,7 +23,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "pico-8";
-  version = "0.1.12c";
+  version = "0.2.0i";
 
   helpMsg = ''
     We cannot download the full version automatically, as you require a license.

--- a/pkgs/games/pico-8/default.nix
+++ b/pkgs/games/pico-8/default.nix
@@ -1,0 +1,73 @@
+{ stdenv, requireFile, unzip, makeDesktopItem, SDL2, xorg, libpulseaudio, systemd }:
+
+let
+  arch = if stdenv.system == "x86_64-linux"
+    then "amd64"
+    else "i386";
+
+  sha = if stdenv.system == "x86_64-linux"
+    then "b9d2e793dc6fee94ba4e5e202129dac40491df15dfd19dfe3d9e8884d624d384"
+    else "1cd578f6c50acb7ea95dcedc87c37f088aad8a5e5212e3a78c3d0d37cc70a780";
+
+  desktopItem = makeDesktopItem {
+    desktopName = "pico-8";
+    genericName = "pico-8 virtual console";
+    categories = "Game;";
+    exec = "pico8";
+    icon = "lexaloffle-pico8";
+    name = "pico8";
+    type = "Application";
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "pico-8";
+  version = "0.1.12c";
+
+  helpMsg = ''
+    We cannot download the full version automatically, as you require a license.
+    Once you have bought a license, you need to add your downloaded version to the nix store.
+    You can do this by using "nix-prefetch-url file://\$PWD/${pname}_${version}_${arch}.zip"
+    in the directory where you saved it.
+  '';
+
+  src = requireFile {
+    message = helpMsg;
+    name = "${pname}_${version}_${arch}.zip";
+    sha256 = sha;
+  };
+
+  buildInputs = [ unzip ];
+  phases = [ "unpackPhase" "installPhase" ];
+
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib stdenv.cc.libc SDL2
+    xorg.libX11 xorg.libXinerama libpulseaudio ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib $out/share/applications $out/share/icons/hicolor/128x128/apps
+
+    install -t $out/bin -m755 -v pico8 
+    install -t $out/bin -m644 pico8.dat
+    install -t $out/share/icons/hicolor/128x128/apps -m644 lexaloffle-pico8.png
+
+    cp ${desktopItem}/share/applications/pico8.desktop \
+      $out/share/applications/pico8.desktop
+
+    ln -s ${systemd.lib}/lib/libudev.so.1 $out/lib/libudev.so.1
+
+    patchelf \
+      --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      --set-rpath ${libPath}:$out/lib \
+      $out/bin/pico8
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tiny 2D, 4-bit colour fantasy console.";
+    homepage = "https://www.lexaloffle.com/pico-8.php";
+    license = licenses.unfree;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ maxeaubrey ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4022,6 +4022,8 @@ in
 
   pgloader = callPackage ../development/tools/pgloader { };
 
+  pico-8 = callPackage ../games/pico-8 { };
+
   pigz = callPackage ../tools/compression/pigz { };
 
   pixz = callPackage ../tools/compression/pixz { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I wanted to get pico-8 running properly without needing e.g. steamrun.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
