### PR TITLE
Redmine server options

### DIFF
--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -71,6 +71,10 @@ let
 in
 
 {
+  imports = [
+    (lib.mkRenamedOptionModule [ "services" "redmine" "port" ] [ "services" "redmine" "listen" "port" ])
+  ];
+
   options = {
     services.redmine = {
       enable = mkEnableOption "Redmine";
@@ -94,10 +98,19 @@ in
         description = "Group under which Redmine is ran.";
       };
 
-      port = mkOption {
-        type = types.int;
-        default = 3000;
-        description = "Port on which Redmine is ran.";
+      listen = {
+        address = mkOption {
+          type = types.str;
+          default = "0.0.0.0";
+          example = "127.0.0.1";
+          description = "Address on which the Redmine HTTP server listens.";
+        };
+
+        port = mkOption {
+          type = types.int;
+          default = 3000;
+          description = "Port on which the Redmine HTTP server listens.";
+        };
       };
 
       prefix = mkOption {
@@ -388,7 +401,8 @@ in
         SyslogIdentifier = "redmine";
         TimeoutSec = "300";
         WorkingDirectory = "${cfg.package}/share/redmine";
-        ExecStart="${bundle} exec rails server webrick -e production -p ${toString cfg.port}"
+        ExecStart="${bundle} exec rails server webrick -e production"
+                  + " -b '${cfg.listen.address}' -p ${toString cfg.listen.port}"
                   + " -c '${configRu}' -P '${cfg.stateDir}/redmine.pid'";
       };
 


### PR DESCRIPTION
###### Motivation for this change

This PR consists of three commits:

1. The primary enhancement that is introduced here is the `prefix` option that allows to specify the URL prefix where Redmine will be served. To allow it to work under, say, https://example.org/redmine instead of https://example.org/ . This commit also includes quality-of-life enhancements: the `serverAccessLog` option that allows to disable access logging that WEBrick (HTTP server that runs/hosts Redmine) performs, and addition of the `SyslogIdentifier` setting for the systemd service.
2. The `listen.address` option was added to allow specifying the IP address to listen to (which is quite desirable for security purposes); for unification, the `port` option was renamed to `listen.port`.
3. The `server` option was introduced, which allows to use the Puma HTTP server instead of WEBrick. There is a wide-spread opinion that WEBrick is badly suited for production - although I don't know if it's actually true. Also, in my configuration WEBrick had a specific problem: its access logs show IP address of reverse proxy, rather than IP address of the actual client, whereas Puma shows the client's IP address reported by reverse proxy.

The third commit has a potential problem. It relies on the `puma` gem, but its presence is not guaranteed. The Gemfile of Redmine's package includes it in the `:test` group, with the comment "For running system tests". At the minimum, this gem's specification needs to be moved to the root level of the Gemfile with the appropriate comment. It would be even better to somehow ensure its presence in the `redmine` module; I don't know if it's possible or not.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
