### PR TITLE
hdapsgl: 0.5.0 -> 0.7.0

### DIFF
--- a/pkgs/tools/misc/hdaps-gl/default.nix
+++ b/pkgs/tools/misc/hdaps-gl/default.nix
@@ -1,24 +1,22 @@
-{ stdenv, fetchzip, freeglut, libGL, libGLU }:
+{ stdenv, fetchFromGitHub, autoreconfHook, freeglut, libGL, libGLU }:
 
-let version = "0.0.5"; in
+let version = "0.0.7"; in
 stdenv.mkDerivation {
       pname = "hdaps-gl";
       inherit version;
-      src = fetchzip {
-            url = "mirror://sourceforge/project/hdaps/hdaps-gl/hdaps-gl-${version}/hdaps-gl-${version}.tar.gz";
-            sha256 = "16fk4k0lvr4c95vd6c7qdylcqa1h5yjp3xm4xwipdjbp0bvsgxq4";
+      src = fetchFromGitHub {
+            owner = "linux-thinkpad";
+            repo = "hdaps-gl";
+            rev = version;
+            sha256 = "0jywsrcr1wzkjig5cvz014c3r026sbwscbkv7zh1014lkjm0kyyh";
       };
 
+      nativeBuildInputs = [ autoreconfHook ];
       buildInputs = [ freeglut libGL libGLU ];
-
-      # the Makefile has no install target
-      installPhase = ''
-            install -Dt $out/bin ./hdaps-gl
-      '';
 
       meta = with stdenv.lib; {
             description = "GL-based laptop model that rotates in real-time via hdaps";
-            homepage = "https://sourceforge.net/projects/hdaps/";
+            homepage = "https://github.com/linux-thinkpad/hdaps-gl";
             license = licenses.gpl2;
             platforms = platforms.linux;
             maintainers = [ maintainers.symphorien ];


### PR DESCRIPTION
We now package a fork on github because:
* gentoo does it
* the fork is owned by the same organisation as the one we take hdapsd from.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
