### PR TITLE
gitAndTools.git-bug: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
@@ -2,21 +2,21 @@
 
 buildGoModule rec {
   pname = "git-bug";
-  version = "0.7.0";
-  rev = "71580c41a931a1ad2c04682e0fd701661b716c95";
+  version = "0.7.1"; # the `rev` below pins the version of the source to get
+  rev = "2d64b85db71a17ff3277bbbf7ac9d8e81f8e416c";
   goPackagePath = "github.com/MichaelMure/git-bug";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "MichaelMure";
     repo = "git-bug";
-    sha256 = "0mhqvcwa6y3hrrv88vbp22k7swzr8xw6ipm80gdpx85yp8j2wdkh";
+    sha256 = "01ab3mlwh5g1vr3x85fppflg18gb8ip9mjfsp2b5rfigd9lxyyns";
   };
 
-  modSha256 = "1cfn49cijiarzzczrpd28x1k7ib98xyzlvn3zghwk2ngfgiah3ld";
+  modSha256 = "05wxvzsbhvz15596019vs7h09kynfsfjx3i5xyrl5xjzdxbaqbrq";
 
   buildFlagsArray = ''
-    -ldflags= 
+    -ldflags=
       -X ${goPackagePath}/commands.GitCommit=${rev}
       -X ${goPackagePath}/commands.GitLastTag=${version}
       -X ${goPackagePath}/commands.GitExactTag=${version}


### PR DESCRIPTION
###### Motivation for this change

https://github.com/MichaelMure/git-bug/releases/tag/0.7.1

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc maintainer @royneary 