### PR TITLE
pythonPackages.ofxtools: unbreak

### DIFF
--- a/pkgs/development/python-modules/ofxtools/default.nix
+++ b/pkgs/development/python-modules/ofxtools/default.nix
@@ -1,30 +1,35 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, nose
 , python
-, sqlalchemy
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "ofxtools";
   version = "0.8.20";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "87245679911c0c12429a476fd269611512d3e4b44cb8871159bb76ba70f8a46f";
+  disabled = pythonOlder "3.7";
+
+  # PyPI distribution does not include tests
+  src = fetchFromGitHub {
+    owner = "csingley";
+    repo = pname;
+    rev = version;
+    sha256 = "1s3fhhmj1acnmqglh39003db0bi451m4hcrkcpyrkqf5m32lslz8";
   };
 
+  checkInputs = [ nose ];
+  # override $HOME directory:
+  #   error: [Errno 13] Permission denied: '/homeless-shelter'
   checkPhase = ''
-    ${python.interpreter} -m unittest discover -s ofxtools
+    HOME=$TMPDIR nosetests tests/*.py
   '';
-
-  buildInputs = [ sqlalchemy ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/csingley/ofxtools";
     description = "Library for working with Open Financial Exchange (OFX) formatted data used by financial institutions";
     license = licenses.mit;
-    broken = true;
   };
-
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Remove `sqlalchemy` from `buildInputs`. This dependency was removed in
  [0.7.0]. Per the project's readme, `ofxtools` only depends on the
  standard library.

- Disable for Python versions older than 3.7, the minimum Python version
  supported by `ofxtools` starting with the [0.8.17] release.

- Fix the `checkPhase` by fetching from GitHub instead of PyPI to get a
  distribution that includes tests, overriding the home directory to
  allow tests that depend on it being writeable, and switching to
  `nosetests` to match the upstream project's test setup.

[0.7.0]: https://github.com/csingley/ofxtools/commit/8a795787d96244912fd62deda6c2c2c6e92245e8
[0.8.17]: https://github.com/csingley/ofxtools/commit/ddeda980ed5603570bff63f7a5b52c83ff713bdd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
