### PR TITLE
osu-lazer: init at 2020.714.0

### DIFF
--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -13,13 +13,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "osu-lazer";
-  version = "2020.707.0";
+  version = "2020.712.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     rev = version;
-    sha256 = "0n270gv841567q1j3xj7hpnnqwbgj0yai5wf58kwj0f0spkcy8vz";
+    sha256 = "0j1zg4wm2f7hwj9i6f7mgy22gdw12cakj2qsz4jz6l28d9ykjqc0";
   };
 
   nativeBuildInputs = [ dotnet-sdk dotnetPackages.Nuget makeWrapper ];

--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -13,13 +13,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "osu-lazer";
-  version = "2020.712.0";
+  version = "2020.714.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     rev = version;
-    sha256 = "0j1zg4wm2f7hwj9i6f7mgy22gdw12cakj2qsz4jz6l28d9ykjqc0";
+    sha256 = "1dh3krvs7mfiyyr3cjkp396zaipcibw2s45smfzr9aqrznsqx64v";
   };
 
   nativeBuildInputs = [ dotnet-sdk dotnetPackages.Nuget makeWrapper ];

--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -1,0 +1,104 @@
+{ lib, stdenv, fetchFromGitHub, fetchurl, makeWrapper, makeDesktopItem, linkFarmFromDrvs
+, dotnet-sdk, dotnet-netcore, dotnetPackages
+, ffmpeg_4, alsaLib, SDL2, lttng-ust, numactl, alsaPlugins
+}:
+
+let
+  runtimeDeps = [
+    ffmpeg_4 alsaLib SDL2 lttng-ust numactl
+  ];
+
+  # https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#using-rids
+  runtimeId = "linux-x64";
+
+in stdenv.mkDerivation rec {
+  pname = "osu-lazer";
+  version = "2020.707.0";
+
+  src = fetchFromGitHub {
+    owner = "ppy";
+    repo = "osu";
+    rev = version;
+    sha256 = "0n270gv841567q1j3xj7hpnnqwbgj0yai5wf58kwj0f0spkcy8vz";
+  };
+
+  nativeBuildInputs = [ dotnet-sdk dotnetPackages.Nuget makeWrapper ];
+
+  nugetDeps = linkFarmFromDrvs "${pname}-nuget-deps" (import ./deps.nix {
+    fetchNuGet = { name, version, sha256 }: fetchurl {
+      name = "nuget-${name}-${version}.nupkg";
+      url = "https://www.nuget.org/api/v2/package/${name}/${version}";
+      inherit sha256;
+    };
+  });
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
+    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+    nuget sources Add -Name nixos -Source "$PWD/nixos"
+    nuget init "$nugetDeps" "$PWD/nixos"
+
+    # FIXME: https://github.com/NuGet/Home/issues/4413
+    mkdir -p $HOME/.nuget/NuGet
+    cp $HOME/.config/NuGet/NuGet.Config $HOME/.nuget/NuGet
+
+    dotnet restore --source nixos osu.Desktop
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    dotnet build osu.Desktop \
+      --no-restore \
+      --configuration Release \
+      -p:Version=${version}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dotnet publish osu.Desktop \
+      --no-build \
+      --configuration Release \
+      --no-self-contained \
+      --output $out/lib/osu
+    shopt -s extglob
+    rm -r $out/lib/osu/runtimes/!(${runtimeId})
+
+    makeWrapper $out/lib/osu/osu\! $out/bin/osu\! \
+      --set DOTNET_ROOT "${dotnet-netcore}" \
+      --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDeps}"
+    for i in 16 32 48 64 96 128 256 512 1024; do
+      install -D ./assets/lazer.png $out/share/icons/hicolor/''${i}x$i/apps/osu\!.png
+    done
+    cp -r ${makeDesktopItem {
+      desktopName = "osu!";
+      name = "osu";
+      exec = "osu!";
+      icon = "osu!";
+      comment = meta.description;
+      type = "Application";
+      categories = "Game;";
+    }}/share/applications $out/share
+
+    runHook postInstall
+  '';
+
+  # Strip breaks the executable.
+  dontStrip = true;
+
+  meta = with lib; {
+    description = "Rhythm is just a *click* away";
+    homepage = "https://osu.ppy.sh";
+    license = with licenses; [ mit cc-by-nc-40 ];
+    maintainers = with maintainers; [ oxalica ];
+    platforms = [ "x86_64-linux" ];
+  };
+  passthru.updateScript = ./update.sh;
+}

--- a/pkgs/games/osu-lazer/deps.nix
+++ b/pkgs/games/osu-lazer/deps.nix
@@ -581,8 +581,8 @@
   })
   (fetchNuGet {
     name = "ppy.osu.Framework";
-    version = "2020.710.0";
-    sha256 = "1mk6b4ndfkdf43a3b8m3x187ydhpxrn8yygd301qw2gxs2vj4zl5";
+    version = "2020.714.1";
+    sha256 = "0x3f9grxi9ww151n9bppzrjf2s2bqfggv2chj0fhi9lm3ai2wvqc";
   })
   (fetchNuGet {
     name = "ppy.osu.Framework.NativeLibs";
@@ -591,8 +591,8 @@
   })
   (fetchNuGet {
     name = "ppy.osu.Game.Resources";
-    version = "2020.622.1";
-    sha256 = "09la8blsgd9w7gzsvj1n5q261n0pfpr9j1kdkqymfa58224rblab";
+    version = "2020.714.0";
+    sha256 = "15papgd97pjvdx951hjm9w0d99rscvq2i5l98f746c6w87l1fk2n";
   })
   (fetchNuGet {
     name = "ppy.osuTK.NS20";

--- a/pkgs/games/osu-lazer/deps.nix
+++ b/pkgs/games/osu-lazer/deps.nix
@@ -581,8 +581,8 @@
   })
   (fetchNuGet {
     name = "ppy.osu.Framework";
-    version = "2020.707.0";
-    sha256 = "0vbdd1lmrdgw44j7vsbg350cwy7al7l0i5kcdx3g1bssr4250scx";
+    version = "2020.710.0";
+    sha256 = "1mk6b4ndfkdf43a3b8m3x187ydhpxrn8yygd301qw2gxs2vj4zl5";
   })
   (fetchNuGet {
     name = "ppy.osu.Framework.NativeLibs";

--- a/pkgs/games/osu-lazer/deps.nix
+++ b/pkgs/games/osu-lazer/deps.nix
@@ -1,0 +1,1492 @@
+{ fetchNuGet }: [
+  (fetchNuGet {
+    name = "Dapper";
+    version = "2.0.35";
+    sha256 = "0465i2p5kjj0hmadyw0xrpn43zpc4bnbid9mg561739fyjyjwmfm";
+  })
+  (fetchNuGet {
+    name = "DeltaCompressionDotNet";
+    version = "2.0.0.0";
+    sha256 = "0zhj7m3zaf9wcg51385in9qg1xgkvp8yyzgq3r5k4sagm7y68aqy";
+  })
+  (fetchNuGet {
+    name = "DiffPlex";
+    version = "1.6.3";
+    sha256 = "0yi72afddddz0s8phx855rnjrga7n51bcma10dc91l0ffcwf5xwz";
+  })
+  (fetchNuGet {
+    name = "DiscordRichPresence";
+    version = "1.0.150";
+    sha256 = "0qmbi4sccia3w80q8xfvj3bw62nvz047wq198n2b2aflkf47bq79";
+  })
+  (fetchNuGet {
+    name = "FFmpeg.AutoGen";
+    version = "4.3.0.1";
+    sha256 = "0n6x57mnnvcjnrs8zyvy07h5zm4bcfy9gh4n4bvd9fx5ys4pxkvv";
+  })
+  (fetchNuGet {
+    name = "Humanizer";
+    version = "2.8.26";
+    sha256 = "11kddzyzqpq9gkz0hmrblq494nh86va6wxx6z89xi6w1f4vj15ak";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core";
+    version = "2.2.0";
+    sha256 = "08mzg65y9d3zvq16rsmpapcdan71ggq2mpks6k777h3wlm2sh3p5";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core";
+    version = "2.8.26";
+    sha256 = "1v8xd12yms4qq1md4vh6faxicmqrvahqdd7sdkyzrphab9v44nsm";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.af";
+    version = "2.8.26";
+    sha256 = "0znrq4frlkq1qi20301hlzxa6mdc275fa1i1a1i8ldgk9cjq94k9";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.ar";
+    version = "2.8.26";
+    sha256 = "1hi7mln48p1nmxlgdq725s4cvla9nlkvbmrsql1rfjjlsy8hn6n7";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.az";
+    version = "2.8.26";
+    sha256 = "0av7ycrqwvmikqia3z3qkp9967zilrhayny17zkm0d0mnjq62vs6";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.bg";
+    version = "2.8.26";
+    sha256 = "13j6zk2cmk7a119azxlpjhfwykrzk0vkf5a799fb2fzkvhnj4hkg";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.bn-BD";
+    version = "2.8.26";
+    sha256 = "0h619sksggfi7dnaycz6bj9aiqdgn0d8dpgjgdl73crw52lr70p9";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.cs";
+    version = "2.8.26";
+    sha256 = "11bh3k15388bi5wizaihnwqk7wb4n7q636fqjllwdhjggqrsc3f6";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.da";
+    version = "2.8.26";
+    sha256 = "09b3x3bw3cgby9qvaccnqz2y6d8gl3497dh7q0dk1iznsxbk4x4m";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.de";
+    version = "2.8.26";
+    sha256 = "1pyp2a9my20wlwjjzv563kshl9fpjb2kd4cw41l4wvsz1bsq3l22";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.el";
+    version = "2.8.26";
+    sha256 = "0v3sdcxca4dam1y5yjh9n6v711ys0zdv38hr4kij35s6277ls6lb";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.es";
+    version = "2.8.26";
+    sha256 = "0wh9qvqf80cngwsz2jnrsjpmaax4xa2xp8bbk5xs480kp071z37q";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.fa";
+    version = "2.8.26";
+    sha256 = "00v56ddjfv6sr6w5246gn5z0padwswvnngp8mdl7gjfg5ycmbkl1";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.fi-FI";
+    version = "2.8.26";
+    sha256 = "1pgs0j5ri50a6vhljplhrlc8jj1hrd9ggxkj60d9v5kk9xibzzyd";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.fr";
+    version = "2.8.26";
+    sha256 = "0kkhgy3yn8vfqlx3dhb9m3cazkgfxarknam4macng9y17l7wj83m";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.fr-BE";
+    version = "2.8.26";
+    sha256 = "13spcx07hph366qk073pz63s56nadaac7l4mr4a66gbpqd3814kb";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.he";
+    version = "2.8.26";
+    sha256 = "1ccn82aj3rhrhsa3kvkrmjw0p687icxlfja8ngbh7sby4cszx9bk";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.hr";
+    version = "2.8.26";
+    sha256 = "12ii79bhai3kv7zr3k9k9dh569r6p3m4l4gj25cln2isr4wdi5r9";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.hu";
+    version = "2.8.26";
+    sha256 = "0cibbdxiqhwrjmxlr805mg3l9v0fl2ydx4m50608rkysjq6vxx7y";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.hy";
+    version = "2.8.26";
+    sha256 = "15aikm04f74abm4ak8rvnnkrlcz155gibn1y81pbgsyn7yrh84v3";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.id";
+    version = "2.8.26";
+    sha256 = "1i9gpzdfhmbvrqg858kqz5461sp3sh60g16dmcmyi1ik0qlspijn";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.it";
+    version = "2.8.26";
+    sha256 = "01j7qskmqcxsakbx3bkxcjyzrh6nxi2v6kfzsfb0vf980qqq331l";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.ja";
+    version = "2.8.26";
+    sha256 = "07d19ns4a4pa2k4vdc1af7wj10gaflq1ny4mx6y574afkdi8v6d5";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.lv";
+    version = "2.8.26";
+    sha256 = "1pm64sj65nmngyfa3hjcw67icfmlzr232hmgpnw7306sb7dxmnfv";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.ms-MY";
+    version = "2.8.26";
+    sha256 = "1yx4cc023kc4k14abk2ycmjy6y2xaknaz4zria7xsadf0fabd1jc";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.mt";
+    version = "2.8.26";
+    sha256 = "0iai35pzka9g6c3sgswki06fk6gdnq8kc88wyb4pcciivazz31px";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.nb";
+    version = "2.8.26";
+    sha256 = "0xprhiyjyq6mpha2lrav59n1f48508ddvm9nmdk5sm5k26ff3l90";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.nb-NO";
+    version = "2.8.26";
+    sha256 = "160c98wfh7d2xlvlra4x5rdj4klgcjwcy3gkb4ipg655byn2m1j2";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.nl";
+    version = "2.8.26";
+    sha256 = "067pqm4i1mk83fqqr0bvzrchrvxwdnff18z3djgagclh1i4xqlvk";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.pl";
+    version = "2.8.26";
+    sha256 = "1r1bbqb990war1hiag5f88yxw0k9jiid1ihb4s5bc1lzs3vfsb6x";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.pt";
+    version = "2.8.26";
+    sha256 = "1bik0vjjdzw51yl11ng9gsi3ihz50ibwh1gdhh2vd13jxjzb512p";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.ro";
+    version = "2.8.26";
+    sha256 = "12f2hry6x1p1mgx6g4kpig2jpybx52ibghvhdhjbbfhy32gv8dr0";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.ru";
+    version = "2.8.26";
+    sha256 = "1hri12kwymzvdqcr66l8yiqiw3pmf9fk492z10yqljm576kyshgg";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.sk";
+    version = "2.8.26";
+    sha256 = "07jfgk67axw97b85dn4bwpjwf3swd74j9hdd870qps12xfp98i9j";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.sl";
+    version = "2.8.26";
+    sha256 = "060xbzwb7p9ypbqfklih2zal2rh6h55gq4hv3i6alvlbd3vsx29n";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.sr";
+    version = "2.8.26";
+    sha256 = "0i2c24qmqnhp85b088qlbagxd48hcl0v1ly4m7hfbvx5s7fg8riv";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.sr-Latn";
+    version = "2.8.26";
+    sha256 = "1911a69sqssh9f007vmxbgyj4ym2ym4423xvw6cmbfhjcrhkfpbi";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.sv";
+    version = "2.8.26";
+    sha256 = "056h8n9i18yl78f9ppzn2kkrz2cs46aqv0j5y8xq360zarggh0nm";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.tr";
+    version = "2.8.26";
+    sha256 = "0dk8ga3fpxifxxkz0n68654h65cvrx00hy7q00m5vgvmcp70gxxn";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.uk";
+    version = "2.8.26";
+    sha256 = "0bnj5xqlcqp4n8i04ra78dax4854zbf2jsygvb4lpiayyyaj2bxw";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.uz-Cyrl-UZ";
+    version = "2.8.26";
+    sha256 = "1bbf6mxas6brjw7rjljq5saz6v3ic6zbvm1b3c1jbk0hc0qkd7c8";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.uz-Latn-UZ";
+    version = "2.8.26";
+    sha256 = "1bfgfihpynax30g9kq8kra7c4jxps2ccxsxrs9gls47xbs35cw2f";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.vi";
+    version = "2.8.26";
+    sha256 = "1vm765nvkp6wyfwlcgppimjrk04lkg8lscch3n1i1i5hlqxrs9ch";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.zh-CN";
+    version = "2.8.26";
+    sha256 = "1qyl12rdh4iv1k1qcivcmxxnh8y93ainf22pmch8vvw9yjhs1y7s";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.zh-Hans";
+    version = "2.8.26";
+    sha256 = "1gqv3dyk236wlp5wb7kd4qnyrmp3cy36ycykl7zr91s25cdls5vy";
+  })
+  (fetchNuGet {
+    name = "Humanizer.Core.zh-Hant";
+    version = "2.8.26";
+    sha256 = "1rhzbiqbx04l3kvzjklix90fxyc6vvmmw0p564ajdiximivs0pbh";
+  })
+  (fetchNuGet {
+    name = "JetBrains.Annotations";
+    version = "2020.1.0";
+    sha256 = "13fqcr6bs4x9rn0mpx110xl5apwh8ds1h0lx208znrm178ywqm8y";
+  })
+  (fetchNuGet {
+    name = "ManagedBass";
+    version = "2.0.4";
+    sha256 = "13hwd0yany4j52abbaaqsgq8lag2w9vjxxsj4qfbgwp4qs39x003";
+  })
+  (fetchNuGet {
+    name = "ManagedBass.Fx";
+    version = "2.0.1";
+    sha256 = "1rbjpgpm0ri7l2gqdy691rsv3visna2nbxawgvhdqljw068r8a8d";
+  })
+  (fetchNuGet {
+    name = "managed-midi";
+    version = "1.9.14";
+    sha256 = "025jh146zy98699y4civ7nxlkx312lwkl4sr8pha626q7q1kg89h";
+  })
+  (fetchNuGet {
+    name = "Markdig";
+    version = "0.20.0";
+    sha256 = "19qhvyj59i8zcxblpl4vqabb55y5xrk3iipmb656mid1b1m4jfkn";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Bcl.AsyncInterfaces";
+    version = "1.1.0";
+    sha256 = "1dq5yw7cy6s42193yl4iqscfw5vzkjkgv0zyy32scr4jza6ni1a1";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Build.Framework";
+    version = "15.3.409";
+    sha256 = "1dhanwb9ihbfay85xj7cwn0byzmmdz94hqfi3q6r1ncwdjd8y1s2";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Build.Locator";
+    version = "1.2.6";
+    sha256 = "1rnfd7wq2bkynqj767xmq9ha38mz010fmqvvvrgb4v86gd537737";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.Analyzers";
+    version = "3.0.0";
+    sha256 = "0bbl0jpqywqmzz2gagld1p2gvdfldjfjmm25hil9wj2nq1zc4di8";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.BannedApiAnalyzers";
+    version = "3.0.0";
+    sha256 = "19zfz84c1860na8qpkzv6va6d7dh1md9wkrb7c6x3brhjnj859hk";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.Common";
+    version = "3.6.0";
+    sha256 = "0i8x90700jr30j580mpawj6d90fngrb2zpkjjbn7f8r2p1mz75y7";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.CSharp";
+    version = "3.6.0";
+    sha256 = "0c44qp7lfpja6cq5nk7851qrswm2z1k2pnvsw43j9ybf10a27jrn";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.CSharp.Workspaces";
+    version = "3.6.0";
+    sha256 = "1zc9328invqqpisdljw5vpm1kk416prfczakakw1vwkv9r54sd73";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+    version = "3.0.0";
+    sha256 = "0a17vb6jnj6kch70d7vki84728hlc3zpffsbv533yji6kf6x6d24";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.VersionCheckAnalyzer";
+    version = "3.0.0";
+    sha256 = "11g3hj3p885zj7bn99qzh68m1xifbwzrgmx1pkvpi10rmgkpyh8j";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.Workspaces.Common";
+    version = "3.6.0";
+    sha256 = "176faadh1k9xcc8cc2qpkka9j1n426fdff1ax5ikmz2hbrspmigz";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.Workspaces.MSBuild";
+    version = "3.6.0";
+    sha256 = "0hxs9x5gpi7yvqf46bxh9niipb0jif7ak5baxw5l920787vysdhc";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeQuality.Analyzers";
+    version = "3.0.0";
+    sha256 = "1x3yf21m41w2iv9nlwp03q6byqgivd48h2dlm5vgv5bd53xjfz77";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.0.1";
+    sha256 = "0zxc0apx1gcx361jlq8smc9pfdgmyjh6hpka8dypc9w23nlsh6yj";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.5.0";
+    sha256 = "01i28nvzccxbqmiz217fxs6hnjwmd5fafs37rd49a6qp53y6623l";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Data.Sqlite.Core";
+    version = "2.2.6";
+    sha256 = "0fx8698k71vzr8pdc6q8bsbzg6r8a42s4hkzmiyv13ibmyb5q68k";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Diagnostics.Runtime";
+    version = "1.1.127808";
+    sha256 = "14xhiw6h5ck444vrmj79r0ral4dvcrak02ib0v7z0qx2c69vkdmc";
+  })
+  (fetchNuGet {
+    name = "Microsoft.DotNet.PlatformAbstractions";
+    version = "2.1.0";
+    sha256 = "1qydvyyinj3b5mraazjal3n2k7jqhn05b6n1a2f3qjkqkxi63dmy";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore";
+    version = "2.2.6";
+    sha256 = "18j2cr50wsikwv7gy3vrjvmpdxckvv537qma8afdpr3yn2klayh5";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Abstractions";
+    version = "2.2.6";
+    sha256 = "1dyxb5ibx24frlgbqy7zch0falq9p1189zvlbxgl94m0hvpml5j3";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Analyzers";
+    version = "2.2.6";
+    sha256 = "10f2lxxmh0xrdjvnam31fqfnjkaick23mpfvahj3ca5l07bph0rc";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Design";
+    version = "2.2.6";
+    sha256 = "0kjjkh1yfb56wnkmciqzfn9vymqfjap364y5amia0lmqmhfz8g7f";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Relational";
+    version = "2.2.6";
+    sha256 = "0c0z4mrqldjfslyxywb2ydk8hn9ybhkvz6lxx3idrfalq3ni5f1z";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Sqlite";
+    version = "2.2.6";
+    sha256 = "0z8k5ns841imaqha5abb1ka0rsfzy90k6qkrvix11sp6k9i7lsam";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Sqlite.Core";
+    version = "2.2.6";
+    sha256 = "0jzqw4672mzxjvzas09sl0zyzzayfgkv003a7bw5g2gjyiphf630";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Caching.Abstractions";
+    version = "2.2.0";
+    sha256 = "0hhxc5dp52faha1bdqw0k426zicsv6x1kfqi30m9agr0b2hixj52";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Caching.Memory";
+    version = "2.2.0";
+    sha256 = "0bzrsn5vas86w66bd04xilnlb21nx4l6lz7d3acvy6y8ir2vb5dv";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration";
+    version = "2.2.0";
+    sha256 = "02250qrs3jqqbggfvd0mkim82817f79x6jh8fx2i7r58d0m66qkl";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Abstractions";
+    version = "2.2.0";
+    sha256 = "1fv5277hyhfqmc0gqszyqb1ilwnijm8kc9606yia6hwr8pxyg674";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Binder";
+    version = "2.2.0";
+    sha256 = "10qyjdkymdmag3r807kvbnwag4j3nz65i4cwikbd77jjvz92ya3j";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyInjection";
+    version = "2.2.0";
+    sha256 = "0lvv45rvq1xbf47lz818rjydc776zk8mf7svpzh1dml4qwlx9zck";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyInjection.Abstractions";
+    version = "2.2.0";
+    sha256 = "1jyzfdr9651h3x6pxwhpfbb9mysfh8f8z1jvy4g117h9790r9zx5";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyModel";
+    version = "2.1.0";
+    sha256 = "0dl4qhjgifm6v3jsfzvzkvddyic77ggp9fq49ah661v45gk6ilgd";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging";
+    version = "2.2.0";
+    sha256 = "0bx3ljyvvcbikradq2h583rl72h8bxdz33aghk026cxzpv2mm3wm";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Abstractions";
+    version = "2.2.0";
+    sha256 = "02w7hp6jicr7cl5p456k2cmrjvvhm6spg5kxnlncw3b72358m5wl";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.ObjectPool";
+    version = "3.0.3";
+    sha256 = "0zxsdwh9mhy3wsbjyfr4k0r10s1h06dzw8hcck9aknv155q26zqk";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Options";
+    version = "2.2.0";
+    sha256 = "1b20yh03fg4nmmi3vlf6gf13vrdkmklshfzl3ijygcs4c2hly6v0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Primitives";
+    version = "2.2.0";
+    sha256 = "0znah6arbcqari49ymigg3wiy2hgdifz8zsq8vdc3ynnf45r7h0c";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Net.Compilers.Toolset";
+    version = "3.1.0";
+    sha256 = "1csf8hgwvyxjlxdygacrk3pp0xkzydc1kvsv68cxy8h7gd62k0w0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NetCore.Analyzers";
+    version = "3.0.0";
+    sha256 = "0b8biyw7nymqfbg08g2vmpf1xm6g1mm6hz4gjxc5f3g72kd2nswj";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.0.1";
+    sha256 = "01al6cfxp68dscl15z7rxfw9zvhm64dncsw09a1vmdkacsa2v6lr";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.1.0";
+    sha256 = "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "2.1.2";
+    sha256 = "1507hnpr9my3z4w1r6xk5n0s1j3y6a2c2cnynj76za7cphxi1141";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "3.1.0";
+    sha256 = "1gc1x8f95wk8yhgznkwsg80adk1lc65v9n5rx4yaa4bc5dva0z3j";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "3.1.1";
+    sha256 = "05hmaygd5131rnqi6ipv7agsbpi7ka18779vw45iw6b385l7n987";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Targets";
+    version = "1.0.1";
+    sha256 = "0ppdkwy6s9p7x9jix3v4402wb171cdiibq7js7i13nxpdky7074p";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Targets";
+    version = "1.1.0";
+    sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NetFramework.Analyzers";
+    version = "3.0.0";
+    sha256 = "09dqizym3bca4281714yxrhhgryxpjhjfjnyfswlhyh42qi3ix2k";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Primitives";
+    version = "4.0.1";
+    sha256 = "1n8ap0cmljbqskxpf8fjzn7kh1vvlndsa75k01qig26mbw97k2q7";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Primitives";
+    version = "4.3.0";
+    sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "4.7.0";
+    sha256 = "0bx21jjbs7l5ydyw4p6cn07chryxpmchq2nl5pirzz4l3b0q4dgs";
+  })
+  (fetchNuGet {
+    name = "Mono.Cecil";
+    version = "0.9.6.1";
+    sha256 = "1fr7969h5q611l5227xw6nvv5rzap76vbpk0wg9hxbcxk3hn7szf";
+  })
+  (fetchNuGet {
+    name = "NETStandard.Library";
+    version = "1.6.0";
+    sha256 = "0nmmv4yw7gw04ik8ialj3ak0j6pxa9spih67hnn1h2c38ba8h58k";
+  })
+  (fetchNuGet {
+    name = "NETStandard.Library";
+    version = "1.6.1";
+    sha256 = "1z70wvsx2d847a2cjfii7b83pjfs34q05gb037fdjikv5kbagml8";
+  })
+  (fetchNuGet {
+    name = "NETStandard.Library";
+    version = "2.0.0";
+    sha256 = "1bc4ba8ahgk15m8k4nd7x406nhi0kwqzbgjk2dmw52ss553xz7iy";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "12.0.2";
+    sha256 = "0w2fbji1smd2y7x25qqibf1qrznmv4s6s0jvrbvr6alb7mfyqvh5";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "12.0.3";
+    sha256 = "17dzl305d835mzign8r15vkmav2hq8l6g7942dfjpnzr17wwl89x";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "9.0.1";
+    sha256 = "0mcy0i7pnfpqm4pcaiyzzji4g0c8i3a5gjz28rrr28110np8304r";
+  })
+  (fetchNuGet {
+    name = "NUnit";
+    version = "3.12.0";
+    sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+  })
+  (fetchNuGet {
+    name = "ppy.osu.Framework";
+    version = "2020.707.0";
+    sha256 = "0vbdd1lmrdgw44j7vsbg350cwy7al7l0i5kcdx3g1bssr4250scx";
+  })
+  (fetchNuGet {
+    name = "ppy.osu.Framework.NativeLibs";
+    version = "2020.213.0";
+    sha256 = "1yzrx7bji2163dzvyqri42byc7lgxlm59xbwgi312dw5714snmxy";
+  })
+  (fetchNuGet {
+    name = "ppy.osu.Game.Resources";
+    version = "2020.622.1";
+    sha256 = "09la8blsgd9w7gzsvj1n5q261n0pfpr9j1kdkqymfa58224rblab";
+  })
+  (fetchNuGet {
+    name = "ppy.osuTK.NS20";
+    version = "1.0.159";
+    sha256 = "0k69vc8f0vvyf49c5xb1brnw1a1g8s4k2ljw3za1dq1ilqxw7wm2";
+  })
+  (fetchNuGet {
+    name = "ppy.SDL2-CS";
+    version = "1.0.15";
+    sha256 = "0qld7sp7y7hwwxsdxc8m17nyb2zwfxym63j50icvf0rlawmrl7ca";
+  })
+  (fetchNuGet {
+    name = "ppy.squirrel.windows";
+    version = "1.9.0.4";
+    sha256 = "1m8shcmgs0fs225qd0navr1qr6csqjin9sg2x0d7xpfk04nd2hi7";
+  })
+  (fetchNuGet {
+    name = "Remotion.Linq";
+    version = "2.2.0";
+    sha256 = "1y46ni0xswmmiryp8sydjgryafwn458dr91f9xn653w73kdyk4xf";
+  })
+  (fetchNuGet {
+    name = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "16rnxzpk5dpbbl1x354yrlsbvwylrq456xzpsha1n9y3glnhyx9d";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0hkg03sgm2wyq8nqk6dbm9jh5vcq57ry42lkqdmfklrw89lsmr59";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0c2p354hjx58xhhz7wv6div8xpi90sc6ibdm40qin21bvi7ymcaa";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
+    version = "4.0.0";
+    sha256 = "1ppk69xk59ggacj9n7g6fyxvzmk1g5p4fkijm0d7xqfkig98qrkf";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
+    version = "4.3.0";
+    sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.IO.Compression";
+    version = "4.1.0";
+    sha256 = "0d720z4lzyfcabmmnvh0bnj76ll7djhji2hmfh3h44sdkjnlkknk";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.IO.Compression";
+    version = "4.3.0";
+    sha256 = "1vvivbqsk6y4hzcid27pqpm5bsi6sc50hvqwbcx8aap5ifrxfs8d";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Http";
+    version = "4.0.1";
+    sha256 = "1hgv2bmbaskx77v8glh7waxws973jn4ah35zysnkxmf0196sfxg6";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Http";
+    version = "4.3.0";
+    sha256 = "1n6rgz5132lcibbch1qlf0g9jk60r0kqv087hxc0lisy50zpm7kk";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography";
+    version = "4.0.0";
+    sha256 = "0k57aa2c3b10wl3hfqbgrl7xq7g8hh3a3ir44b31dn5p61iiw3z9";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    sha256 = "1b61p6gw1m02cc1ry996fl49liiwky6181dzr873g9ds92zl326q";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0qyynf9nz5i7pc26cwhgi8j62ps27sqmf78ijcfgzab50z9g8ay3";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "1klrs545awhayryma6l7g2pvnp9xy4z0r1i40r80zb45q3i9nbyf";
+  })
+  (fetchNuGet {
+    name = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    sha256 = "10yc8jdrwgcl44b4g93f1ds76b176bajd3zqi2faf5rvh1vy9smi";
+  })
+  (fetchNuGet {
+    name = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0zcxjv5pckplvkg0r6mw3asggm7aqzbdjimhvsasb0cgm59x09l3";
+  })
+  (fetchNuGet {
+    name = "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0vhynn79ih7hw7cwjazn87rm9z9fj0rvxgzlab36jybgcpcgphsn";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "160p68l2c7cqmyqjwxydcvgw7lvl1cr0znkw8fp24d1by9mqc8p3";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "15zrc8fgd8zx28hdghcj5f5i34wf3l6bq5177075m2bc2j34jrqy";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "1p4dgxax6p7rlgj4q73k73rslcnz4wdcv8q2flg1s8ygwcm58ld5";
+  })
+  (fetchNuGet {
+    name = "Sentry";
+    version = "2.1.4";
+    sha256 = "11pb6zpgjypfjy5g51anznngr8hcspkj1swgj9rhz8y1dcv5aba7";
+  })
+  (fetchNuGet {
+    name = "Sentry.PlatformAbstractions";
+    version = "1.1.0";
+    sha256 = "19grscddh2ipp1q7hx3a3bckpxgpfxfffp2shc32jryqyxsba87y";
+  })
+  (fetchNuGet {
+    name = "Sentry.Protocol";
+    version = "2.1.4";
+    sha256 = "0mm1a7vxl4raka1917sqshbbxvrf5sxmcba7hjwrmz13cx86l6v0";
+  })
+  (fetchNuGet {
+    name = "SharpCompress";
+    version = "0.17.1";
+    sha256 = "1ffiacghbcnr3fkgvdcad7b1nky54nhmmn2sm43sks9zm8grvva4";
+  })
+  (fetchNuGet {
+    name = "SharpCompress";
+    version = "0.25.1";
+    sha256 = "0nkfflf1wnwgx1n52scnvq38q25khimjz67nwralipgrmwnynnr9";
+  })
+  (fetchNuGet {
+    name = "SharpFNT";
+    version = "2.0.0";
+    sha256 = "1bgacgh9hbck0qvji6frbb50sdiqfdng2fvvfgfw8b9qaql91mx0";
+  })
+  (fetchNuGet {
+    name = "SixLabors.Core";
+    version = "1.0.0-beta0008";
+    sha256 = "1yqcv5d2igsrmi9hf8xzikn0fms47skqpr552yzbj4z4wnraahaw";
+  })
+  (fetchNuGet {
+    name = "SixLabors.ImageSharp";
+    version = "1.0.0-beta0007";
+    sha256 = "1k3hrp26imyqjarkrcsrhvamlmynzv6cakzq68yx69c0h8lmscaf";
+  })
+  (fetchNuGet {
+    name = "Splat";
+    version = "1.6.2";
+    sha256 = "154w9q0z8697rcpqs4x233crx5ap1z4pl4xc21hsd3csbhw13ykf";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.bundle_green";
+    version = "1.1.12";
+    sha256 = "0jbyd25ag15fyn9nawjikv0v5ylk2zh5pxgr6gm4kpbpqys86sq9";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.core";
+    version = "1.1.12";
+    sha256 = "03gflsn2wl6v0a8zvh6y5xdhx0xxmfrn6jfldiy829x3fx74zgdl";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.lib.e_sqlite3.linux";
+    version = "1.1.12";
+    sha256 = "10mlq914d3zggdjf4bv27w6jx0gqqjf6f91y5ri6pbvaqyhi28h5";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.lib.e_sqlite3.osx";
+    version = "1.1.12";
+    sha256 = "1hixg6n9sqllfrcihj145lh1l38inv827808difvazd4zr3mi0z1";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.lib.e_sqlite3.v110_xp";
+    version = "1.1.12";
+    sha256 = "107sivk5p38dg1kyvqrxgp67dj89s8l6brf9l52k6s4vrn4hrrk7";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.provider.e_sqlite3.netstandard11";
+    version = "1.1.12";
+    sha256 = "0qr2d7ka6f5c7bybdhiyq7nl90c9575szmi0nfpknd9c0w024if4";
+  })
+  (fetchNuGet {
+    name = "StbiSharp";
+    version = "1.0.12";
+    sha256 = "044lyc6522s8q4kgvly0rsxghkiv4dwzycl2ibxf7q5dvws02qvp";
+  })
+  (fetchNuGet {
+    name = "System.AppContext";
+    version = "4.1.0";
+    sha256 = "0fv3cma1jp4vgj7a8hqc9n7hr1f1kjp541s6z0q1r6nazb4iz9mz";
+  })
+  (fetchNuGet {
+    name = "System.AppContext";
+    version = "4.3.0";
+    sha256 = "1649qvy3dar900z3g817h17nl8jp4ka5vcfmsr05kh0fshn7j3ya";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.0.0";
+    sha256 = "13s659bcmg9nwb6z78971z1lr6bmh2wghxi1ayqyzl4jijd351gr";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.3.0";
+    sha256 = "0fgns20ispwrfqll4q1zc1waqcmylb3zc50ys9x8zlwxh9pmd9jy";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.4.0";
+    sha256 = "183f8063w8zqn99pv0ni0nnwh7fgx46qzxamwnans55hhs2l0g19";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.5.0";
+    sha256 = "1ywfqn4md6g3iilpxjn5dsr0f5lx6z0yvhqp4pgjcamygg73cz2c";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
+    version = "4.0.11";
+    sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
+    version = "4.3.0";
+    sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Concurrent";
+    version = "4.0.12";
+    sha256 = "07y08kvrzpak873pmyxs129g1ch8l27zmg51pcyj2jvq03n0r0fc";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Concurrent";
+    version = "4.3.0";
+    sha256 = "0wi10md9aq33jrkh2c24wr2n9hrpyamsdhsxdcnf43b7y86kkii8";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Immutable";
+    version = "1.5.0";
+    sha256 = "1d5gjn5afnrf461jlxzawcvihz195gayqpcfbv6dd7pxa9ialn06";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.Annotations";
+    version = "4.5.0";
+    sha256 = "1jj6f6g87k0iwsgmg3xmnn67a14mq88np0l1ys5zkxhkvbc8976p";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.Annotations";
+    version = "4.7.0";
+    sha256 = "06x1m46ddxj0ng28d7gry9gjkqdg2kp89jyf480g5gznyybbs49z";
+  })
+  (fetchNuGet {
+    name = "System.Composition";
+    version = "1.0.31";
+    sha256 = "0aa27jz73qb0xm6dyxv22qhfrmyyqjyn2dvvsd9asi82lcdh9i61";
+  })
+  (fetchNuGet {
+    name = "System.Composition.AttributedModel";
+    version = "1.0.31";
+    sha256 = "1ipyb86hvw754kmk47vjmzyilvj5hymg9nqabz70sbgsz1fygrdv";
+  })
+  (fetchNuGet {
+    name = "System.Composition.Convention";
+    version = "1.0.31";
+    sha256 = "00gqcdrql7vhynxh4xq0s9j5nw27kghmn2n773v7lhzjh3ash18r";
+  })
+  (fetchNuGet {
+    name = "System.Composition.Hosting";
+    version = "1.0.31";
+    sha256 = "1f1bnk3j7ndx9r7zpzibmrhw78clys1pspl20j2dhnmkiwhl23vy";
+  })
+  (fetchNuGet {
+    name = "System.Composition.Runtime";
+    version = "1.0.31";
+    sha256 = "1shfybfzsn4g6aim4pggb5ha31g0fz2kkk0519c4vj6m166g39ws";
+  })
+  (fetchNuGet {
+    name = "System.Composition.TypedParts";
+    version = "1.0.31";
+    sha256 = "1m4j19zx50lbbdx1xxbgpsd1dai2r3kzkyapw47kdvkb89qjkl63";
+  })
+  (fetchNuGet {
+    name = "System.Console";
+    version = "4.0.0";
+    sha256 = "0ynxqbc3z1nwbrc11hkkpw9skw116z4y9wjzn7id49p9yi7mzmlf";
+  })
+  (fetchNuGet {
+    name = "System.Console";
+    version = "4.3.0";
+    sha256 = "1flr7a9x920mr5cjsqmsy9wgnv3lvd0h1g521pdr1lkb2qycy7ay";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Debug";
+    version = "4.0.11";
+    sha256 = "0gmjghrqmlgzxivd2xl50ncbglb7ljzb66rlx8ws6dv8jm0d5siz";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Debug";
+    version = "4.3.0";
+    sha256 = "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.0.0";
+    sha256 = "1n6c3fbz7v8d3pn77h4v5wvsfrfg7v1c57lg3nff3cjyh597v23m";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.3.0";
+    sha256 = "0z6m3pbiy0qw6rn3n209rrzf9x1k4002zh90vwcrsym09ipm2liq";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.5.0";
+    sha256 = "1y8m0p3127nak5yspapfnz25qc9x53gqpvwr3hdpsvrcd2r1pgyj";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tools";
+    version = "4.0.1";
+    sha256 = "19cknvg07yhakcvpxg3cxa0bwadplin6kyxd8mpjjpwnp56nl85x";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tools";
+    version = "4.3.0";
+    sha256 = "0in3pic3s2ddyibi8cvgl102zmvp9r9mchh82ns9f0ms4basylw1";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tracing";
+    version = "4.1.0";
+    sha256 = "1d2r76v1x610x61ahfpigda89gd13qydz6vbwzhpqlyvq8jj6394";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tracing";
+    version = "4.3.0";
+    sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
+  })
+  (fetchNuGet {
+    name = "System.Dynamic.Runtime";
+    version = "4.0.11";
+    sha256 = "1pla2dx8gkidf7xkciig6nifdsb494axjvzvann8g2lp3dbqasm9";
+  })
+  (fetchNuGet {
+    name = "System.Globalization";
+    version = "4.0.11";
+    sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
+  })
+  (fetchNuGet {
+    name = "System.Globalization";
+    version = "4.3.0";
+    sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Calendars";
+    version = "4.0.1";
+    sha256 = "0bv0alrm2ck2zk3rz25lfyk9h42f3ywq77mx1syl6vvyncnpg4qh";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Calendars";
+    version = "4.3.0";
+    sha256 = "1xwl230bkakzzkrggy1l1lxmm3xlhk4bq2pkv790j5lm8g887lxq";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Extensions";
+    version = "4.0.1";
+    sha256 = "0hjhdb5ri8z9l93bw04s7ynwrjrhx2n0p34sf33a9hl9phz69fyc";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Extensions";
+    version = "4.3.0";
+    sha256 = "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls";
+  })
+  (fetchNuGet {
+    name = "System.Interactive.Async";
+    version = "3.2.0";
+    sha256 = "0y5r5y7dlccjpgg17rjrrzi3jya4ysyydamxs33qckkv4jb3534d";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.1.0";
+    sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.3.0";
+    sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression";
+    version = "4.1.0";
+    sha256 = "0iym7s3jkl8n0vzm3jd6xqg9zjjjqni05x45dwxyjr2dy88hlgji";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression";
+    version = "4.3.0";
+    sha256 = "084zc82yi6yllgda0zkgl2ys48sypiswbiwrv7irb3r0ai1fp4vz";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression.ZipFile";
+    version = "4.0.1";
+    sha256 = "0h72znbagmgvswzr46mihn7xm7chfk2fhrp5krzkjf29pz0i6z82";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression.ZipFile";
+    version = "4.3.0";
+    sha256 = "1yxy5pq4dnsm9hlkg9ysh5f6bf3fahqqb6p8668ndy5c0lk7w2ar";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.0.1";
+    sha256 = "0kgfpw6w4djqra3w5crrg8xivbanh1w9dh3qapb28q060wb9flp1";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.3.0";
+    sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem.Primitives";
+    version = "4.0.1";
+    sha256 = "1s0mniajj3lvbyf7vfb5shp4ink5yibsx945k6lvxa96r8la1612";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem.Primitives";
+    version = "4.3.0";
+    sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
+  })
+  (fetchNuGet {
+    name = "System.IO.Packaging";
+    version = "4.7.0";
+    sha256 = "1vivvf158ilcpp6bq70zyafimi0lng546b34csmjb09k19wgxpiv";
+  })
+  (fetchNuGet {
+    name = "System.Linq";
+    version = "4.1.0";
+    sha256 = "1ppg83svb39hj4hpp5k7kcryzrf3sfnm08vxd5sm2drrijsla2k5";
+  })
+  (fetchNuGet {
+    name = "System.Linq";
+    version = "4.3.0";
+    sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
+  })
+  (fetchNuGet {
+    name = "System.Linq.Expressions";
+    version = "4.1.0";
+    sha256 = "1gpdxl6ip06cnab7n3zlcg6mqp7kknf73s8wjinzi4p0apw82fpg";
+  })
+  (fetchNuGet {
+    name = "System.Linq.Expressions";
+    version = "4.3.0";
+    sha256 = "0ky2nrcvh70rqq88m9a5yqabsl4fyd17bpr63iy2mbivjs2nyypv";
+  })
+  (fetchNuGet {
+    name = "System.Linq.Queryable";
+    version = "4.0.1";
+    sha256 = "11jn9k34g245yyf260gr3ldzvaqa9477w2c5nhb1p8vjx4xm3qaw";
+  })
+  (fetchNuGet {
+    name = "System.Memory";
+    version = "4.5.1";
+    sha256 = "0f07d7hny38lq9w69wx4lxkn4wszrqf9m9js6fh9is645csm167c";
+  })
+  (fetchNuGet {
+    name = "System.Memory";
+    version = "4.5.3";
+    sha256 = "0naqahm3wljxb5a911d37mwjqjdxv9l0b49p5dmfyijvni2ppy8a";
+  })
+  (fetchNuGet {
+    name = "System.Net.Http";
+    version = "4.1.0";
+    sha256 = "1i5rqij1icg05j8rrkw4gd4pgia1978mqhjzhsjg69lvwcdfg8yb";
+  })
+  (fetchNuGet {
+    name = "System.Net.Http";
+    version = "4.3.0";
+    sha256 = "1i4gc757xqrzflbk7kc5ksn20kwwfjhw9w7pgdkn19y3cgnl302j";
+  })
+  (fetchNuGet {
+    name = "System.Net.Primitives";
+    version = "4.0.11";
+    sha256 = "10xzzaynkzkakp7jai1ik3r805zrqjxiz7vcagchyxs2v26a516r";
+  })
+  (fetchNuGet {
+    name = "System.Net.Primitives";
+    version = "4.3.0";
+    sha256 = "0c87k50rmdgmxx7df2khd9qj7q35j9rzdmm2572cc55dygmdk3ii";
+  })
+  (fetchNuGet {
+    name = "System.Net.Sockets";
+    version = "4.1.0";
+    sha256 = "1385fvh8h29da5hh58jm1v78fzi9fi5vj93vhlm2kvqpfahvpqls";
+  })
+  (fetchNuGet {
+    name = "System.Net.Sockets";
+    version = "4.3.0";
+    sha256 = "1ssa65k6chcgi6mfmzrznvqaxk8jp0gvl77xhf1hbzakjnpxspla";
+  })
+  (fetchNuGet {
+    name = "System.Numerics.Vectors";
+    version = "4.4.0";
+    sha256 = "0rdvma399070b0i46c4qq1h2yvjj3k013sqzkilz4bz5cwmx1rba";
+  })
+  (fetchNuGet {
+    name = "System.Numerics.Vectors";
+    version = "4.5.0";
+    sha256 = "1kzrj37yzawf1b19jq0253rcs8hsq1l2q8g69d7ipnhzb0h97m59";
+  })
+  (fetchNuGet {
+    name = "System.ObjectModel";
+    version = "4.0.12";
+    sha256 = "1sybkfi60a4588xn34nd9a58png36i0xr4y4v4kqpg8wlvy5krrj";
+  })
+  (fetchNuGet {
+    name = "System.ObjectModel";
+    version = "4.3.0";
+    sha256 = "191p63zy5rpqx7dnrb3h7prvgixmk168fhvvkkvhlazncf8r3nc2";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.1.0";
+    sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.3.0";
+    sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.0.1";
+    sha256 = "0ydqcsvh6smi41gyaakglnv252625hf29f7kywy2c70nhii2ylqp";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.3.0";
+    sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.ILGeneration";
+    version = "4.0.1";
+    sha256 = "1pcd2ig6bg144y10w7yxgc9d22r7c7ww7qn1frdfwgxr24j9wvv0";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.ILGeneration";
+    version = "4.3.0";
+    sha256 = "0w1n67glpv8241vnpz1kl14sy7zlnw414aqwj4hcx5nd86f6994q";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.0.1";
+    sha256 = "1s4b043zdbx9k39lfhvsk68msv1nxbidhkq6nbm27q7sf8xcsnxr";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.3.0";
+    sha256 = "0ql7lcakycrvzgi9kxz1b3lljd990az1x6c4jsiwcacrvimpib5c";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.7.0";
+    sha256 = "0mbjfajmafkca47zr8v36brvknzks5a7pgb49kfq2d188pyv6iap";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Extensions";
+    version = "4.0.1";
+    sha256 = "0m7wqwq0zqq9gbpiqvgk3sr92cbrw7cp3xn53xvw7zj6rz6fdirn";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Extensions";
+    version = "4.3.0";
+    sha256 = "02bly8bdc98gs22lqsfx9xicblszr2yan7v2mmw3g7hy6miq5hwq";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Metadata";
+    version = "1.6.0";
+    sha256 = "1wdbavrrkajy7qbdblpbpbalbdl48q3h34cchz24gvdgyrlf15r4";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Primitives";
+    version = "4.0.1";
+    sha256 = "1bangaabhsl4k9fg8khn83wm6yial8ik1sza7401621jc6jrym28";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Primitives";
+    version = "4.3.0";
+    sha256 = "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.TypeExtensions";
+    version = "4.1.0";
+    sha256 = "1bjli8a7sc7jlxqgcagl9nh8axzfl11f4ld3rjqsyxc516iijij7";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.TypeExtensions";
+    version = "4.3.0";
+    sha256 = "0y2ssg08d817p0vdag98vn238gyrrynjdj4181hdg780sif3ykp1";
+  })
+  (fetchNuGet {
+    name = "System.Resources.ResourceManager";
+    version = "4.0.1";
+    sha256 = "0b4i7mncaf8cnai85jv3wnw6hps140cxz8vylv2bik6wyzgvz7bi";
+  })
+  (fetchNuGet {
+    name = "System.Resources.ResourceManager";
+    version = "4.3.0";
+    sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.1.0";
+    sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.3.0";
+    sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.5.1";
+    sha256 = "1xcrjx5fwg284qdnxyi2d0lzdm5q4frlpkp0nf6vvkx1kdz2prrf";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.5.2";
+    sha256 = "1vz4275fjij8inf31np78hw50al8nqkngk04p3xv5n4fcmf1grgi";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.7.0";
+    sha256 = "16r6sn4czfjk8qhnz7bnqlyiaaszr0ihinb7mq9zzr1wba257r54";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.7.1";
+    sha256 = "119br3pd85lq8zcgh4f60jzmv1g976q1kdgi3hvqdlhfbw6siz2j";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Extensions";
+    version = "4.1.0";
+    sha256 = "0rw4rm4vsm3h3szxp9iijc3ksyviwsv6f63dng3vhqyg4vjdkc2z";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Extensions";
+    version = "4.3.0";
+    sha256 = "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Handles";
+    version = "4.0.1";
+    sha256 = "1g0zrdi5508v49pfm3iii2hn6nm00bgvfpjq1zxknfjrxxa20r4g";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Handles";
+    version = "4.3.0";
+    sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.1.0";
+    sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.3.0";
+    sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.0.0";
+    sha256 = "0glmvarf3jz5xh22iy3w9v3wyragcm4hfdr17v90vs7vcrm7fgp6";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.3.0";
+    sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Numerics";
+    version = "4.0.1";
+    sha256 = "1y308zfvy0l5nrn46mqqr4wb4z1xk758pkk8svbz8b5ij7jnv4nn";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Numerics";
+    version = "4.3.0";
+    sha256 = "19rav39sr5dky7afygh309qamqqmi9kcwvz3i0c5700v0c5cg61z";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Primitives";
+    version = "4.1.1";
+    sha256 = "042rfjixknlr6r10vx2pgf56yming8lkjikamg3g4v29ikk78h7k";
+  })
+  (fetchNuGet {
+    name = "System.Security.AccessControl";
+    version = "4.7.0";
+    sha256 = "0n0k0w44flkd8j0xw7g3g3vhw7dijfm51f75xkm1qxnbh4y45mpz";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Algorithms";
+    version = "4.2.0";
+    sha256 = "148s9g5dgm33ri7dnh19s4lgnlxbpwvrw2jnzllq2kijj4i4vs85";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Algorithms";
+    version = "4.3.0";
+    sha256 = "03sq183pfl5kp7gkvq77myv7kbpdnq3y0xj7vi4q1kaw54sny0ml";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Cng";
+    version = "4.2.0";
+    sha256 = "118jijz446kix20blxip0f0q8mhsh9bz118mwc2ch1p6g7facpzc";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Cng";
+    version = "4.3.0";
+    sha256 = "1k468aswafdgf56ab6yrn7649kfqx2wm9aslywjam1hdmk5yypmv";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Csp";
+    version = "4.0.0";
+    sha256 = "1cwv8lqj8r15q81d2pz2jwzzbaji0l28xfrpw29kdpsaypm92z2q";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Csp";
+    version = "4.3.0";
+    sha256 = "1x5wcrddf2s3hb8j78cry7yalca4lb5vfnkrysagbn6r9x6xvrx1";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Encoding";
+    version = "4.0.0";
+    sha256 = "0a8y1a5wkmpawc787gfmnrnbzdgxmx1a14ax43jf3rj9gxmy3vk4";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Encoding";
+    version = "4.3.0";
+    sha256 = "1jr6w70igqn07k5zs1ph6xja97hxnb3mqbspdrff6cvssgrixs32";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.OpenSsl";
+    version = "4.0.0";
+    sha256 = "16sx3cig3d0ilvzl8xxgffmxbiqx87zdi8fc73i3i7zjih1a7f4q";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0givpvvj8yc7gv4lhb6s1prq6p2c4147204a0wib89inqzd87gqc";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Primitives";
+    version = "4.0.0";
+    sha256 = "0i7cfnwph9a10bm26m538h5xcr8b36jscp9sy1zhgifksxz4yixh";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Primitives";
+    version = "4.3.0";
+    sha256 = "0pyzncsv48zwly3lw4f2dayqswcfvdwq2nz0dgwmi7fj3pn64wby";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.X509Certificates";
+    version = "4.1.0";
+    sha256 = "0clg1bv55mfv5dq00m19cp634zx6inm31kf8ppbq1jgyjf2185dh";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.X509Certificates";
+    version = "4.3.0";
+    sha256 = "0valjcz5wksbvijylxijjxb1mp38mdhv03r533vnx1q3ikzdav9h";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "4.7.0";
+    sha256 = "1a56ls5a9sr3ya0nr086sdpa9qv0abv31dd6fp27maqa9zclqq5d";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.0.11";
+    sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.3.0";
+    sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.CodePages";
+    version = "4.5.1";
+    sha256 = "1z21qyfs6sg76rp68qdx0c9iy57naan89pg7p6i3qpj8kyzn921w";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.CodePages";
+    version = "4.7.1";
+    sha256 = "1y1hdap9qbl7vp74j8s9zcbh3v1rnrrvcc55wj1hl6has2v3qh1r";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.Extensions";
+    version = "4.0.11";
+    sha256 = "08nsfrpiwsg9x5ml4xyl3zyvjfdi4mvbqf93kjdh11j4fwkznizs";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.Extensions";
+    version = "4.3.0";
+    sha256 = "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy";
+  })
+  (fetchNuGet {
+    name = "System.Text.RegularExpressions";
+    version = "4.1.0";
+    sha256 = "1mw7vfkkyd04yn2fbhm38msk7dz2xwvib14ygjsb8dq2lcvr18y7";
+  })
+  (fetchNuGet {
+    name = "System.Text.RegularExpressions";
+    version = "4.3.0";
+    sha256 = "1bgq51k7fwld0njylfn7qc5fmwrk2137gdq7djqdsw347paa9c2l";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.0.11";
+    sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.3.0";
+    sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.0.11";
+    sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.3.0";
+    sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.0.0";
+    sha256 = "1cb51z062mvc2i8blpzmpn9d9mm4y307xrwi65di8ri18cz5r1zr";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.3.0";
+    sha256 = "1xxcx2xh8jin360yjwm4x4cf5y3a2bwpn2ygkfkwkicz7zk50s2z";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.5.3";
+    sha256 = "0g7r6hm572ax8v28axrdxz1gnsblg6kszq17g51pj14a5rn2af7i";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Thread";
+    version = "4.0.0";
+    sha256 = "1gxxm5fl36pjjpnx1k688dcw8m9l7nmf802nxis6swdaw8k54jzc";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Timer";
+    version = "4.0.1";
+    sha256 = "15n54f1f8nn3mjcjrlzdg6q3520571y012mx7v991x2fvp73lmg6";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Timer";
+    version = "4.3.0";
+    sha256 = "1nx773nsx6z5whv8kaa1wjh037id2f1cxhb69pvgv12hd2b6qs56";
+  })
+  (fetchNuGet {
+    name = "System.Xml.ReaderWriter";
+    version = "4.0.11";
+    sha256 = "0c6ky1jk5ada9m94wcadih98l6k1fvf6vi7vhn1msjixaha419l5";
+  })
+  (fetchNuGet {
+    name = "System.Xml.ReaderWriter";
+    version = "4.3.0";
+    sha256 = "0c47yllxifzmh8gq6rq6l36zzvw4kjvlszkqa9wq3fr59n0hl3s1";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XDocument";
+    version = "4.0.11";
+    sha256 = "0n4lvpqzy9kc7qy1a4acwwd7b7pnvygv895az5640idl2y9zbz18";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XDocument";
+    version = "4.3.0";
+    sha256 = "08h8fm4l77n0nd4i4fk2386y809bfbwqb7ih9d7564ifcxr5ssxd";
+  })
+]

--- a/pkgs/games/osu-lazer/update.sh
+++ b/pkgs/games/osu-lazer/update.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts dotnet-sdk_3
+set -eo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+deps_file="$(realpath "./deps.nix")"
+
+new_version="$(curl -s "https://api.github.com/repos/ppy/osu/releases" | jq -r '.[0].name')"
+old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
+if [[ "$new_version" == "$old_version" ]]; then
+  echo "Up to date"
+  exit 0
+fi
+
+cd ../../..
+update-source-version osu-lazer "$new_version"
+store_src="$(nix-build . -A osu-lazer.src --no-out-link)"
+src="$(mktemp -d /tmp/osu-src.XXX)"
+echo "Temp src dir: $src"
+cp -rT "$store_src" "$src"
+chmod -R +w "$src"
+
+pushd "$src"
+
+# Setup empty nuget package folder to force reinstall.
+mkdir ./nuget_tmp.packages
+cat >./nuget_tmp.config <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <config>
+    <add key="globalPackagesFolder" value="$(realpath ./nuget_tmp.packages)" />
+  </config>
+</configuration>
+EOF
+
+dotnet restore osu.Desktop --configfile ./nuget_tmp.config
+
+echo "{ fetchNuGet }: [" >"$deps_file"
+while read pkg_spec; do
+  { read pkg_name; read pkg_version; } < <(
+    # Build version part should be ignored: `3.0.0-beta2.20059.3+77df2220` -> `3.0.0-beta2.20059.3`
+    sed -nE 's/.*<id>([^<]*).*/\1/p; s/.*<version>([^<+]*).*/\1/p' "$pkg_spec")
+  pkg_sha256="$(nix-hash --type sha256 --flat --base32 "$(dirname "$pkg_spec")"/*.nupkg)"
+  cat >>"$deps_file" <<EOF
+  (fetchNuGet {
+    name = "$pkg_name";
+    version = "$pkg_version";
+    sha256 = "$pkg_sha256";
+  })
+EOF
+done < <(find ./nuget_tmp.packages -name '*.nuspec' | sort)
+echo "]" >>"$deps_file"
+
+popd
+rm -r "$src"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21584,6 +21584,11 @@ in
 
   osmium-tool = callPackage ../applications/misc/osmium-tool { };
 
+  osu-lazer = callPackage ../games/osu-lazer {
+    dotnet-sdk = dotnetCorePackages.sdk_3_1;
+    dotnet-netcore = dotnetCorePackages.netcore_3_1;
+  };
+
   owamp = callPackage ../applications/networking/owamp { };
 
   vivaldi = callPackage ../applications/networking/browsers/vivaldi {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add a new package `osu-lazer`, a rhythm game.
Home page: https://osu.ppy.sh
Repository (osu!lazer): https://github.com/ppy/osu

~It seems to have darwin releases, but I'm not familiar with it. Anyone help?~
Now it is built from source, targeting only x86_64-linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - 441.2M
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
