### PR TITLE
rtkit: 0.11 -> 0.13

### DIFF
--- a/pkgs/os-specific/linux/rtkit/default.nix
+++ b/pkgs/os-specific/linux/rtkit/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, dbus, libcap }:
 
 stdenv.mkDerivation rec {
-  name = "rtkit-0.11";
+  pname = "rtkit";
+  version = "0.11";
 
   src = fetchurl {
     url = "http://0pointer.de/public/${name}.tar.xz";

--- a/pkgs/os-specific/linux/rtkit/default.nix
+++ b/pkgs/os-specific/linux/rtkit/default.nix
@@ -1,44 +1,46 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, dbus, libcap }:
+{ stdenv, fetchFromGitHub, fetchpatch
+, meson, ninja, pkgconfig, unixtools
+, dbus, libcap, polkit, systemd
+}:
 
 stdenv.mkDerivation rec {
   pname = "rtkit";
-  version = "0.11";
+  version = "0.13";
 
-  src = fetchurl {
-    url = "http://0pointer.de/public/${name}.tar.xz";
-    sha256 = "1l5cb1gp6wgpc9vq6sx021qs6zb0nxg3cn1ba00hjhgnrw4931b8";
+  src = fetchFromGitHub {
+    owner = "heftig";
+    repo = "rtkit";
+    rev = "c295fa849f52b487be6433e69e08b46251950399";
+    sha256 = "0yfsgi3pvg6dkizrww1jxpkvcbhzyw9110n1dypmzq0c5hlzjxcd";
   };
 
-  configureFlags = [
-    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
-  ];
-
   patches = [
-    # Drop removed ControlGroup stanza
     (fetchpatch {
-      url = "http://git.0pointer.net/rtkit.git/patch/?id=6c28e20c0be2f616a025059fda0ffac84e7f4f17";
-      sha256 = "0lsxk5nv08i1wjb4xh20i5fcwg3x0qq0k4f8bc0r9cczph2sv7ck";
+      url = "https://github.com/heftig/rtkit/commit/7d62095b94f8df3891c984a1535026d2658bb177.patch";
+      sha256 = "17acv549zqcgh7sgprfagbf6drqsr0zdwvf1dsqda7wlqc2h9zn7";
     })
 
-    # security patch: Pass uid of caller to polkit
     (fetchpatch {
-      url = "http://git.0pointer.net/rtkit.git/patch/?id=88d4082ef6caf6b071d749dca1c50e7edde914cc";
-      sha256 = "0hp1blbi359qz8fmr6nj4w9yc0jf3dd176f8pn25wdj38n13qkix";
-    })
-
-    # Fix format string errors due to -Werror=format-security
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/r/rtkit/0.11-6/debian/patches/0006-fix-format-strings.patch";
-      sha256 = "09mr89lh16jvz6cqw00zmh0xk919bjfhjkvna1czwmafwy9p7kgp";
+      url = "https://github.com/heftig/rtkit/commit/98f70edd8f534c371cb4308b9720739c5178918d.patch";
+      sha256 = "18mnjjsdjfr184nkzi01xyphpdngi31ry4bmkv9ysjxf9wilv4nl";
     })
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ dbus libcap ];
-  NIX_LDFLAGS = "-lrt";
+  nativeBuildInputs = [ meson ninja pkgconfig unixtools.xxd ];
+  buildInputs = [ dbus libcap polkit systemd ];
+
+  mesonFlags = [
+    "-Dinstalled_tests=false"
+
+    "-Ddbus_systemservicedir=${placeholder "out"}/share/dbus-1/system-services"
+    "-Ddbus_interfacedir=${placeholder "out"}/share/dbus-1/interfaces"
+    "-Ddbus_rulesdir=${placeholder "out"}/etc/dbus-1/system.d"
+    "-Dpolkit_actiondir=${placeholder "out"}/share/polkit-1/actions"
+    "-Dsystemd_systemunitdir=${placeholder "out"}/etc/systemd/system"
+  ];
 
   meta = with stdenv.lib; {
-    homepage = "http://0pointer.de/blog/projects/rtkit";
+    homepage = "https://github.com/heftig/rtkit";
     description = "A daemon that hands out real-time priority to processes";
     license = with licenses; [ gpl3 bsd0 ]; # lib is bsd license
     platforms = platforms.linux;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
