### PR TITLE
prevo: init at 0.2

### DIFF
--- a/pkgs/applications/misc/prevo/data.nix
+++ b/pkgs/applications/misc/prevo/data.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, prevo-tools }:
+
+stdenv.mkDerivation rec {
+  pname = "prevo-data";
+  version = "2020-03-08";
+
+  src = fetchFromGitHub {
+    owner = "bpeel";
+    repo = "revo";
+    rev = "1e8d7197c0bc831e2127909e77e64dfc26906bdd";
+    sha256 = "1ldhzpi3d5cbssv8r7acsn7qwxcl8qpqi8ywpsp7cbgx3w7hhkyz";
+  };
+
+  nativeBuildInputs = [ prevo-tools ];
+
+  dontUnpack = true;
+
+  buildPhase = ''
+    prevodb -s -i $src -o prevo.db
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/prevo
+    cp prevo.db $out/share/prevo/
+  '';
+
+  meta = with stdenv.lib; {
+    description =
+      "data for offline version of the Esperanto dictionary Reta Vortaro";
+    longDescription = ''
+      PReVo is the "portable" ReVo, i.e., the offline version
+      of the Esperanto dictionary Reta Vortaro.
+
+      This package provides the ReVo database for the prevo command line application.
+    '';
+    homepage = "https://github.com/bpeel/revo";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.das-g ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/prevo/data.nix
+++ b/pkgs/applications/misc/prevo/data.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       This package provides the ReVo database for the prevo command line application.
     '';
     homepage = "https://github.com/bpeel/revo";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.das-g ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/prevo/default.nix
+++ b/pkgs/applications/misc/prevo/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, symlinkJoin, prevo-tools, prevo-data, makeWrapper }:
+
+symlinkJoin rec {
+  name = "prevo-${version}";
+  inherit (prevo-tools) version;
+
+  paths = [ prevo-tools ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/prevo \
+      --prefix XDG_DATA_DIRS : "${prevo-data}/share"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "offline version of the Esperanto dictionary Reta Vortaro";
+    longDescription = ''
+      PReVo is the "portable" ReVo, i.e., the offline version
+      of the Esperanto dictionary Reta Vortaro.
+    '';
+    homepage = "https://github.com/bpeel/prevodb";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.das-g ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/prevo/tools.nix
+++ b/pkgs/applications/misc/prevo/tools.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkg-config, glib, expat
+, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "prevo-tools";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "bpeel";
+    repo = "prevodb";
+    rev = version;
+    sha256 = "1fyrc4g9qdq04nxs4g8x0krxfani5xady6v9m0qfqpbh4xk2ry2d";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config installShellFiles ];
+  buildInputs = [ glib expat ];
+
+  postInstall = ''
+    installShellCompletion --bash $out/etc/bash_completion.d/prevo-completion
+  '';
+
+  meta = with stdenv.lib; {
+    description =
+      "CLI tools for the offline version of the Esperanto dictionary Reta Vortaro";
+    longDescription = ''
+      PReVo is the "portable" ReVo, i.e., the offline version
+      of the Esperanto dictionary Reta Vortaro.
+
+      This package provides the command line application prevo to query a local
+      ReVo database, as well as the command line tool revodb to create such a
+      database for this application or for the Android app of the same name.
+    '';
+    homepage = "https://github.com/bpeel/prevodb";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.das-g ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/prevo/tools.nix
+++ b/pkgs/applications/misc/prevo/tools.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       database for this application or for the Android app of the same name.
     '';
     homepage = "https://github.com/bpeel/prevodb";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.das-g ];
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21163,6 +21163,7 @@ in
     jre = openjdk11;
   };
 
+  prevo-data = callPackage ../applications/misc/prevo/data.nix { };
   prevo-tools = callPackage ../applications/misc/prevo/tools.nix { };
 
   ptex = callPackage ../development/libraries/ptex {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21163,6 +21163,8 @@ in
     jre = openjdk11;
   };
 
+  prevo-tools = callPackage ../applications/misc/prevo/tools.nix { };
+
   ptex = callPackage ../development/libraries/ptex {};
 
   qbec = callPackage ../applications/networking/cluster/qbec { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21163,6 +21163,7 @@ in
     jre = openjdk11;
   };
 
+  prevo = callPackage ../applications/misc/prevo { };
   prevo-data = callPackage ../applications/misc/prevo/data.nix { };
   prevo-tools = callPackage ../applications/misc/prevo/tools.nix { };
 


### PR DESCRIPTION
##### Motivation for this change

Make `prevo` (CLI offline version of the Esperanto online dictionary [ReVo](http://www.reta-vortaro.de/)) available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
