### PR TITLE
shellcheck: don't build locally

### DIFF
--- a/pkgs/development/tools/shellcheck/default.nix
+++ b/pkgs/development/tools/shellcheck/default.nix
@@ -16,13 +16,12 @@ let
     in drv' // { meta = meta' // overrideFn meta'; };
 
   bin = haskell.lib.justStaticExecutables haskellPackages.ShellCheck;
-  src = haskellPackages.ShellCheck.src;
 
   shellcheck = stdenv.mkDerivation {
     pname = "shellcheck";
     version = bin.version;
 
-    inherit src;
+    inherit (haskellPackages.ShellCheck) meta src;
 
     nativeBuildInputs = [ pandoc ];
 

--- a/pkgs/development/tools/shellcheck/default.nix
+++ b/pkgs/development/tools/shellcheck/default.nix
@@ -40,10 +40,6 @@ let
       install -Dm644 shellcheck.1 $man/share/man/man1/shellcheck.1
       mkdir $out
     '';
-
-    # just some file copying
-    preferLocalBuild = true;
-    allowSubstitutes = false;
   };
 
 in


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Not installing pandoc+ghc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @marsam @cdepillabout 