### PR TITLE
stdenv: support __structuredAttrs, opt-in per package

### DIFF
--- a/pkgs/build-support/setup-hooks/move-docs.sh
+++ b/pkgs/build-support/setup-hooks/move-docs.sh
@@ -5,10 +5,17 @@
 preFixupHooks+=(_moveToShare)
 
 _moveToShare() {
-    forceShare=${forceShare:=man doc info}
+    if [ -n "$__structuredAttrs" ]; then
+        if [ -z "${forceShare-}" ]; then
+            forceShare=( man doc info )
+        fi
+    else
+        forceShare=( ${forceShare:-man doc info} )
+    fi
+
     if [ -z "$forceShare" -o -z "$out" ]; then return; fi
 
-    for d in $forceShare; do
+    for d in "${forceShare[@]}"; do
         if [ -d "$out/$d" ]; then
             if [ -d "$out/share/$d" ]; then
                 echo "both $d/ and share/$d/ exist!"
@@ -20,4 +27,3 @@ _moveToShare() {
         fi
     done
 }
-

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -74,10 +74,10 @@ _multioutConfig() {
         --libdir="${!outputLib}"/lib --libexecdir="${!outputLib}"/libexec \
         --localedir="${!outputLib}"/share/locale
 
-    installFlags="\
-        pkgconfigdir=${!outputDev}/lib/pkgconfig \
-        m4datadir=${!outputDev}/share/aclocal aclocaldir=${!outputDev}/share/aclocal \
-        $installFlags"
+    _prepend installFlags \
+        pkgconfigdir="${!outputDev}"/lib/pkgconfig \
+        m4datadir="${!outputDev}"/share/aclocal aclocaldir="${!outputDev}"/share/aclocal
+
 }
 
 

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -66,14 +66,13 @@ _multioutConfig() {
         fi
     fi
 
-    configureFlags="\
-        --bindir=${!outputBin}/bin --sbindir=${!outputBin}/sbin \
-        --includedir=${!outputInclude}/include --oldincludedir=${!outputInclude}/include \
-        --mandir=${!outputMan}/share/man --infodir=${!outputInfo}/share/info \
-        --docdir=${!outputDoc}/share/doc/${shareDocName} \
-        --libdir=${!outputLib}/lib --libexecdir=${!outputLib}/libexec \
-        --localedir=${!outputLib}/share/locale \
-        $configureFlags"
+    _prepend configureFlags \
+        --bindir="${!outputBin}"/bin --sbindir="${!outputBin}"/sbin \
+        --includedir="${!outputInclude}"/include --oldincludedir="${!outputInclude}"/include \
+        --mandir="${!outputMan}"/share/man --infodir="${!outputInfo}"/share/info \
+        --docdir="${!outputDoc}"/share/doc/"${shareDocName}" \
+        --libdir="${!outputLib}"/lib --libexecdir="${!outputLib}"/libexec \
+        --localedir="${!outputLib}"/share/locale
 
     installFlags="\
         pkgconfigdir=${!outputDev}/lib/pkgconfig \

--- a/pkgs/build-support/setup-hooks/strip.sh
+++ b/pkgs/build-support/setup-hooks/strip.sh
@@ -23,14 +23,23 @@ _doStrip() {
         if [[ "${dontStrip-}" || "${flag-}" ]] || ! type -f "${stripCmd-}" 2>/dev/null
         then continue; fi
 
-        stripDebugList=${stripDebugList:-lib lib32 lib64 libexec bin sbin}
+        # TODO(structured-attrs): This doesn't work correctly if one of
+        #   the items in strip*List or strip*Flags contains a space,
+        #   even with structured attrs enabled.  This is OK for now
+        #   because very few packages set any of these, and it doesn't
+        #   affect any of them.
+        #
+        #   After __structuredAttrs = true is universal, come back and
+        #   push arrays all the way through this logic.
+
+        stripDebugList=${stripDebugList[*]:-lib lib32 lib64 libexec bin sbin}
         if [ -n "$stripDebugList" ]; then
-            stripDirs "$stripCmd" "$stripDebugList" "${stripDebugFlags:--S}"
+            stripDirs "$stripCmd" "$stripDebugList" "${stripDebugFlags[*]:--S}"
         fi
 
-        stripAllList=${stripAllList:-}
+        stripAllList=${stripAllList[*]:-}
         if [ -n "$stripAllList" ]; then
-            stripDirs "$stripCmd" "$stripAllList" "${stripAllFlags:--s}"
+            stripDirs "$stripCmd" "$stripAllList" "${stripAllFlags[*]:--s}"
         fi
     done
 }

--- a/pkgs/stdenv/generic/default-builder.sh
+++ b/pkgs/stdenv/generic/default-builder.sh
@@ -1,2 +1,6 @@
+if [ -e .attrs.sh ]; then
+    . .attrs.sh
+fi
+
 source $stdenv/setup
 genericBuild

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -88,7 +88,8 @@ in rec {
 
     , patches ? []
 
-    # Experimental; enable only if prepared to debug.
+    # Experimental.  For simple packages mostly just works,
+    # but for anything complex, be prepared to debug if enabling.
     , __structuredAttrs ? false
 
     , ... } @ attrs:

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -88,6 +88,9 @@ in rec {
 
     , patches ? []
 
+    # Experimental; enable only if prepared to debug.
+    , __structuredAttrs ? false
+
     , ... } @ attrs:
 
     let
@@ -210,6 +213,7 @@ in rec {
 
           userHook = config.stdenv.userHook or null;
           __ignoreNulls = true;
+          inherit __structuredAttrs;
 
           inherit strictDeps;
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -969,9 +969,15 @@ patchPhase() {
                 uncompress="lzma -d"
                 ;;
         esac
+        local -a flagsArray
+        if [ -n "$__structuredAttrs" ]; then
+            flagsArray=( "${patchFlags[@]:--p1}" )
+        else
+            # shellcheck disable=SC2086
+            flagsArray=( ${patchFlags:--p1} )
+        fi
         # "2>&1" is a hack to make patch fail if the decompressor fails (nonexistent patch, etc.)
-        # shellcheck disable=SC2086
-        $uncompress < "$i" 2>&1 | patch ${patchFlags:--p1}
+        $uncompress < "$i" 2>&1 | patch "${flagsArray[@]}"
     done
 
     runHook postPatch

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -183,6 +183,25 @@ addToSearchPath() {
     addToSearchPathWithCustomDelimiter ":" "$@"
 }
 
+# Prepend elements to variable "$1", which may come from an attr.
+#
+# This is useful in generic setup code, which must (for now) support
+# both derivations with and without __structuredAttrs true, so the
+# variable may be an array or a space-separated string.
+#
+# Expressions for individual packages should simply switch to array
+# syntax when they switch to setting __structuredAttrs = true.
+_prepend() {
+    local varName="$1"; shift
+    if [ -n "$__structuredAttrs" ]; then
+        # e.g., buildFlags=( "$@" ${buildFlags+"${buildFlags[@]}"} )
+        eval $varName'=( "$@" ${'$varName'+"${'$varName'[@]}"} )'
+    else
+        # e.g., buildFlags="$* $buildFlags"
+        eval $varName'="$* ${'$varName'-}"'
+    fi
+}
+
 # Add $1/lib* into rpaths.
 # The function is used in multiple-outputs.sh hook,
 # so it is defined here but tried after the hook.

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1278,14 +1278,18 @@ genericBuild() {
         return
     fi
 
-    if [ -z "${phases:-}" ]; then
-        phases="${prePhases:-} unpackPhase patchPhase ${preConfigurePhases:-} \
-            configurePhase ${preBuildPhases:-} buildPhase checkPhase \
-            ${preInstallPhases:-} installPhase ${preFixupPhases:-} fixupPhase installCheckPhase \
-            ${preDistPhases:-} distPhase ${postPhases:-}";
+    if [ -z "${phases[*]:-}" ]; then
+        phases="${prePhases[*]:-} unpackPhase patchPhase ${preConfigurePhases[*]:-} \
+            configurePhase ${preBuildPhases[*]:-} buildPhase checkPhase \
+            ${preInstallPhases[*]:-} installPhase ${preFixupPhases[*]:-} fixupPhase installCheckPhase \
+            ${preDistPhases[*]:-} distPhase ${postPhases[*]:-}";
     fi
 
-    for curPhase in $phases; do
+    # The use of ${phases[*]} gives the correct behavior both with and
+    # without structured attrs.  This relies on the fact that each
+    # phase name is space-free, which it must be because it's the name
+    # of either a shell variable or a shell function.
+    for curPhase in ${phases[*]}; do
         if [[ "$curPhase" = unpackPhase && -n "${dontUnpack:-}" ]]; then continue; fi
         if [[ "$curPhase" = configurePhase && -n "${dontConfigure:-}" ]]; then continue; fi
         if [[ "$curPhase" = buildPhase && -n "${dontBuild:-}" ]]; then continue; fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1040,7 +1040,6 @@ configurePhase() {
 
     # set to empty if unset
     : ${configureScript=}
-    : ${configureFlags=}
 
     if [[ -z "$configureScript" && -x ./configure ]]; then
         configureScript=./configure
@@ -1073,11 +1072,9 @@ configurePhase() {
     fi
 
     if [ -n "$configureScript" ]; then
-        # Old bash empty array hack
-        # shellcheck disable=SC2086
-        local flagsArray=(
-            $configureFlags ${configureFlagsArray+"${configureFlagsArray[@]}"}
-        )
+        local -a flagsArray
+        _accumFlagsArray configureFlags configureFlagsArray
+
         echoCmd 'configure flags' "${flagsArray[@]}"
         # shellcheck disable=SC2086
         $configureScript "${flagsArray[@]}"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -202,6 +202,33 @@ _prepend() {
     fi
 }
 
+# Accumulate into `flagsArray` the flags from the named variables.
+#
+# If __structuredAttrs, the variables are all treated as arrays
+# and simply concatenated onto `flagsArray`.
+#
+# If not __structuredAttrs, then:
+#   * Each variable is treated as a string, and split on whitespace;
+#   * except variables whose names end in "Array", which are treated
+#     as arrays.
+_accumFlagsArray() {
+    local name
+    if [ -n "$__structuredAttrs" ]; then
+        for name in "$@"; do
+            eval 'flagsArray+=( ${'$name'+"${'$name'[@]}"} )'
+        done
+    else
+        for name in "$@"; do
+            case "$name" in
+                *Array)
+                    eval 'flagsArray+=( ${'$name'+"${'$name'[@]}"} )' ;;
+                *)
+                    eval 'flagsArray+=( ${'$name'-} )' ;;
+            esac
+        done
+    fi
+}
+
 # Add $1/lib* into rpaths.
 # The function is used in multiple-outputs.sh hook,
 # so it is defined here but tried after the hook.

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1028,20 +1028,20 @@ configurePhase() {
     fi
 
     if [[ -z "${dontAddPrefix:-}" && -n "$prefix" ]]; then
-        configureFlags="${prefixKey:---prefix=}$prefix $configureFlags"
+        _prepend configureFlags "${prefixKey:---prefix=}$prefix"
     fi
 
     # Add --disable-dependency-tracking to speed up some builds.
     if [ -z "${dontAddDisableDepTrack:-}" ]; then
         if [ -f "$configureScript" ] && grep -q dependency-tracking "$configureScript"; then
-            configureFlags="--disable-dependency-tracking $configureFlags"
+            _prepend configureFlags --disable-dependency-tracking
         fi
     fi
 
     # By default, disable static builds.
     if [ -z "${dontDisableStatic:-}" ]; then
         if [ -f "$configureScript" ] && grep -q enable-static "$configureScript"; then
-            configureFlags="--disable-static $configureFlags"
+            _prepend configureFlags --disable-static
         fi
     fi
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -876,6 +876,13 @@ unpackPhase() {
         srcs="$src"
     fi
 
+    local -a srcsArray
+    if [ -n "$__structuredAttrs" ]; then
+        srcsArray=( "${srcs[@]}" )
+    else
+        srcsArray=( $srcs )
+    fi
+
     # To determine the source directory created by unpacking the
     # source archives, we record the contents of the current
     # directory, then look below which directory got added.  Yeah,
@@ -888,7 +895,7 @@ unpackPhase() {
     done
 
     # Unpack all source archives.
-    for i in $srcs; do
+    for i in "${srcsArray[@]}"; do
         unpackFile "$i"
     done
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -11,7 +11,18 @@ else
     __structuredAttrs=
 fi
 
-: ${outputs:=out}
+# Set up shell-style variables for outputs.
+#
+# Output names are identifiers and values are store paths,
+# so they're all space-free and this style works cleanly.
+if [ -n "$__structuredAttrs" ]; then
+    for outputName in "${!outputs[@]}"; do
+        eval export\ "$outputName"="${outputs[$outputName]}"
+    done
+    export outputs="${!outputs[*]}"
+else
+    : ${outputs:=out}
+fi
 
 
 ######################################################################

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -945,7 +945,14 @@ unpackPhase() {
 patchPhase() {
     runHook prePatch
 
-    for i in ${patches:-}; do
+    local -a patchesArray
+    if [ -n "$__structuredAttrs" ]; then
+        patchesArray=( ${patches:+"${patches[@]}"} )
+    else
+        patchesArray=( ${patches:-} )
+    fi
+
+    for i in "${patchesArray[@]}"; do
         header "applying patch $i" 3
         local uncompress=cat
         case "$i" in

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -445,6 +445,10 @@ findInputs() {
     done
 }
 
+# The way we handle deps* and *Inputs works with structured attrs
+# either enabled or disabled.  For this it's convenient that the items
+# in each list must be store paths, and therefore space-free.
+
 # Make sure all are at least defined as empty
 : ${depsBuildBuild=} ${depsBuildBuildPropagated=}
 : ${nativeBuildInputs=} ${propagatedNativeBuildInputs=} ${defaultNativeBuildInputs=}
@@ -453,29 +457,29 @@ findInputs() {
 : ${buildInputs=} ${propagatedBuildInputs=} ${defaultBuildInputs=}
 : ${depsTargetTarget=} ${depsTargetTargetPropagated=}
 
-for pkg in $depsBuildBuild $depsBuildBuildPropagated; do
+for pkg in ${depsBuildBuild[@]} ${depsBuildBuildPropagated[@]}; do
     findInputs "$pkg" -1 -1
 done
-for pkg in $nativeBuildInputs $propagatedNativeBuildInputs; do
+for pkg in ${nativeBuildInputs[@]} ${propagatedNativeBuildInputs[@]}; do
     findInputs "$pkg" -1  0
 done
-for pkg in $depsBuildTarget $depsBuildTargetPropagated; do
+for pkg in ${depsBuildTarget[@]} ${depsBuildTargetPropagated[@]}; do
     findInputs "$pkg" -1  1
 done
-for pkg in $depsHostHost $depsHostHostPropagated; do
+for pkg in ${depsHostHost[@]} ${depsHostHostPropagated[@]}; do
     findInputs "$pkg"  0  0
 done
-for pkg in $buildInputs $propagatedBuildInputs ; do
+for pkg in ${buildInputs[@]} ${propagatedBuildInputs[@]} ; do
     findInputs "$pkg"  0  1
 done
-for pkg in $depsTargetTarget $depsTargetTargetPropagated; do
+for pkg in ${depsTargetTarget[@]} ${depsTargetTargetPropagated[@]}; do
     findInputs "$pkg"  1  1
 done
 # Default inputs must be processed last
-for pkg in $defaultNativeBuildInputs; do
+for pkg in ${defaultNativeBuildInputs[@]}; do
     findInputs "$pkg" -1  0
 done
-for pkg in $defaultBuildInputs; do
+for pkg in ${defaultBuildInputs[@]}; do
     findInputs "$pkg"  0  1
 done
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1307,7 +1307,7 @@ distPhase() {
         # Note: don't quote $tarballs, since we explicitly permit
         # wildcards in there.
         # shellcheck disable=SC2086
-        cp -pvd ${tarballs:-*.tar.gz} "$out/tarballs"
+        cp -pvd ${tarballs[*]:-*.tar.gz} "$out/tarballs"
     fi
 
     runHook postDist

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1273,15 +1273,14 @@ installCheckPhase() {
        && ! make -n ${makefile:+-f $makefile} ${installCheckTarget:-installcheck} >/dev/null 2>&1; then
         echo "no installcheck target in ${makefile:-Makefile}, doing nothing"
     else
-        # Old bash empty array hack
         # shellcheck disable=SC2086
         local flagsArray=(
             ${enableParallelChecking:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}
             SHELL=$SHELL
-            $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
-            $installCheckFlags ${installCheckFlagsArray+"${installCheckFlagsArray[@]}"}
-            ${installCheckTarget:-installcheck}
         )
+        _accumFlagsArray makeFlags makeFlagsArray \
+          installCheckFlags installCheckFlagsArray
+        flagsArray+=( ${installCheckTarget:-installcheck} )
 
         echoCmd 'installcheck flags' "${flagsArray[@]}"
         make ${makefile:+-f $makefile} "${flagsArray[@]}"
@@ -1295,11 +1294,9 @@ installCheckPhase() {
 distPhase() {
     runHook preDist
 
-    # Old bash empty array hack
-    # shellcheck disable=SC2086
-    local flagsArray=(
-        $distFlags ${distFlagsArray+"${distFlagsArray[@]}"} ${distTarget:-dist}
-    )
+    local flagsArray=()
+    _accumFlagsArray distFlags distFlagsArray
+    flagsArray+=( ${distTarget:-dist} )
 
     echo 'dist flags: %q' "${flagsArray[@]}"
     make ${makefile:+-f $makefile} "${flagsArray[@]}"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -5,6 +5,12 @@ if (( "${NIX_DEBUG:-0}" >= 6 )); then
     set -x
 fi
 
+if [ -f .attrs.sh ]; then
+    __structuredAttrs=1
+else
+    __structuredAttrs=
+fi
+
 : ${outputs:=out}
 
 

--- a/pkgs/tools/networking/netmask/default.nix
+++ b/pkgs/tools/networking/netmask/default.nix
@@ -3,6 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "netmask";
   version = "2.4.4";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "tlby";


### PR DESCRIPTION
###### Motivation for this change

This PR is inspired by #72074, and is
 * a short, simple, and (I hope) mergeable PR,
 * that enables individual packages to start opting into structured attrs,
 * and also smooths the path to merging the bulk of the changes in #72074.

The key design choice in this PR is that we craft our stdenv changes to make it work both with and without structured attrs enabled.  Happily, this only adds a modest amount of complexity relative to supporting only the structured-attrs case.

This PR replaces only a small fraction of the changes in #72074.  The majority of the work represented in that PR is about fixing individual packages (lots and lots of them!) to work correctly with structured attrs.  My hope is that merging this PR will in turn make it easier to merge many of those changes too.

I'd love to hear feedback from the people who've been authoring and reviewing #72074, including @globin @lheckemann @jtojnar @Ericson2314 @FRidh @teto @Ma27, as well as naturally anyone else interested.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've tested this PR from two angles:

 * **Clean as is**: With this PR as is, not yet turning on structured attrs, I believe it has no effect on how any package is built.  (Modulo unknown bugs.)

 * **Works when enabled**: For most of the simpler packages in the tree, turning on structured attrs on top of this PR should Just Work.  That means no further edits are necessary, and again no effect on how the package gets built.

   (More-complex packages will need edits of their own in order to migrate; #72074 includes many examples.)

I've tested each of these on a random sample of packages.  To find subtle differences that don't simply cause the build to fail, I compared the build log against baseline.

For comparing build logs, a plain diff shows a lot of noise -- due to the different output path, and to nondeterminism in e.g. the order sources get compiled in.  I wrote a little script to normalize these out.  In many cases that made the diff between logs completely empty; in the rest, I read through the remaining diff by hand.

<details>

<summary>The results were (expand here):</summary>

 * **Clean as is**: I sampled 10 packages using `grep -wl stdenv.mkDerivation | shuf` (skipping 1 unfree).  I also took the same sample of 25 simpler packages used for the other test, below.

   35/35 built successfully.  26/35 (5/10 of the broad sample, 21/25 of the simple-package sample) had identical build logs after normalization; and for the other 9/35 I read the complete diffs and determined there was no change.  So 35/35 had no change detectable in the build log.

   One of these packages was `palemoon`, a web browser, with naturally a fairly complex build.

   Also naturally I rebuilt the whole toolchain at the tip of the PR, and everything seems to work fine.  I didn't inspect the build logs for this part.

 * **Works when enabled**: I sampled 25 packages from the simpler packages in the tree (direct callers of stdenv.mkDerivation, <= 30 lines long.)
    * 25/25 build successfully with structured attrs.
    * For 22/25, the build log shows no detectable difference.  (Of these 16 had empty diff after normalization; the other 6 were short and easy to read.)
    * 3/25 were more interesting:
      * For one package (`gbsplay`), the build logs expose a bug in the package expression!  I'll send the fix as its own small PR (#85044).  After fixing the bug, enabling structured attrs has no effect, as hoped.
      * For one package (`artha`), the log shows an extra "Nothing to be done" line from `make`.  Harmless in itself, but I plan to investigate in case this is a subtle sign of some bug.
      * For one package (`closurecompiler`), when structured attrs is enabled the calculation of `SOURCE_DATE_EPOCH` gets thrown off by the `.attrs.sh` file.  I plan to debug this and fix.

      I should emphasize that the effects on these 3/25 only appeared when structured attrs was actually enabled.  At the tip of the PR, with `__structuredAttrs` remaining false, I built these packages as part of the "clean as is" testing above, and confirmed the build logs remained unchanged (after normalization.)

</details>

In short:

 * As is, these changes left the build unaffected for 100% of packages I tried, including some complex ones.

 * On taking the further step of actually enabling structured attrs, the build remained unaffected for about 90% of a sample of relatively-simple packages.


