### PR TITLE
nixos/httpd: modernize module standards

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -261,6 +261,25 @@ environment.systemPackages = [
 </programlisting>
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The httpd web server previously started its main process as root
+     privileged, then ran worker processes as a less privileged identity user.
+     This was changed to start all of httpd as a less privileged user (defined by
+     <xref linkend="opt-services.httpd.user"/> and
+     <xref linkend="opt-services.httpd.group"/>). As a consequence, all files that
+     are needed for httpd to run (included configuration fragments, SSL
+     certificates and keys, etc.) must now be readable by this less privileged
+     user/group.
+    </para>
+    <para>
+     The default value for <xref linkend="opt-services.httpd.mpm"/>
+     has been changed from <literal>prefork</literal> to <literal>event</literal>. Along with
+     this change the default value for
+     <link linkend="opt-services.httpd.virtualHosts">services.httpd.virtualHosts.&lt;name&gt;.http2</link>
+     has been set to <literal>true</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -657,7 +657,7 @@ in
     services.httpd.phpOptions =
       ''
         ; Needed for PHP's mail() function.
-        sendmail_path = sendmail -t -i
+        sendmail_path = ${pkgs.system-sendmail}/bin/sendmail -t -i
 
         ; Don't advertise PHP
         expose_php = off
@@ -708,9 +708,7 @@ in
         wants = concatLists (map (hostOpts: [ "acme-${hostOpts.hostName}.service" "acme-selfsigned-${hostOpts.hostName}.service" ]) vhostsACME);
         after = [ "network.target" "fs.target" ] ++ map (hostOpts: "acme-selfsigned-${hostOpts.hostName}.service") vhostsACME;
 
-        path =
-          [ pkg pkgs.coreutils pkgs.gnugrep ]
-          ++ optional cfg.enablePHP pkgs.system-sendmail; # Needed for PHP's mail() function.
+        path = [ pkg pkgs.coreutils pkgs.gnugrep ];
 
         environment =
           optionalAttrs cfg.enablePHP { PHPRC = phpIni; }

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -453,7 +453,13 @@ in
         type = types.str;
         default = "wwwrun";
         description = ''
-          User account under which httpd runs.
+          User account under which httpd children processes run.
+
+          If you require the main httpd process to run as
+          <literal>root</literal> add the following configuration:
+          <programlisting>
+          systemd.services.httpd.serviceConfig.User = lib.mkForce "root";
+          </programlisting>
         '';
       };
 
@@ -461,7 +467,7 @@ in
         type = types.str;
         default = "wwwrun";
         description = ''
-          Group under which httpd runs.
+          Group under which httpd children processes run.
         '';
       };
 
@@ -724,7 +730,7 @@ in
           ExecStart = "@${pkg}/bin/httpd httpd -f ${httpdConf}";
           ExecStop = "${pkg}/bin/httpd -f ${httpdConf} -k graceful-stop";
           ExecReload = "${pkg}/bin/httpd -f ${httpdConf} -k graceful";
-          User = "root";
+          User = cfg.user;
           Group = cfg.group;
           Type = "forking";
           PIDFile = "${runtimeDir}/httpd.pid";
@@ -732,6 +738,7 @@ in
           RestartSec = "5s";
           RuntimeDirectory = "httpd httpd/runtime";
           RuntimeDirectoryMode = "0750";
+          AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         };
       };
 

--- a/nixos/modules/services/web-servers/apache-httpd/vhost-options.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/vhost-options.nix
@@ -137,7 +137,7 @@ in
 
     http2 = mkOption {
       type = types.bool;
-      default = false;
+      default = true;
       description = ''
         Whether to enable HTTP 2. HTTP/2 is supported in all multi-processing modules that come with httpd. <emphasis>However, if you use the prefork mpm, there will
         be severe restrictions.</emphasis> Refer to <link xlink:href="https://httpd.apache.org/docs/2.4/howto/http2.html#mpm-config"/> for details.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
- security
- performance
- promote modern standards

Under what scenario **might** the new defaults in this PR not be right for you?
- if you use `services.httpd.enablePHP` - you should read upstream `httpd` documentation and carefully decide if you want to have `services.httpd.mpm` set to `event` and `services.httpd.virtualHosts.<name?>.httpd2` set to `true`
- if you use `services.httpd.enablePerl` - again, carefully read upstream `httpd` documentation and carefully decide if you want to have `services.httpd.mpm` set to `event` and `services.httpd.virtualHosts.<name?>.httpd2` set to `true`
- if you use `services.httpd.virtualHosts.<name?>.enableUserDir` and your permissions aren't loose enough you might want the `httpd` master process to run as `root`
- if you use either `services.httpd.enablePHP` or `services.httpd.enablePerl` you should take special care with your ssl certificates as the same user executing your `perl` and `php` scripts will have at least read access to your ssl certificates

To put the above points into context... it is 2020 and you **probably** shouldn't be using `enablePHP`, `enablePerl`, `enableUserDir`, or setting `services.httpd.mpm` to `prefork` unless you are supporting legacy code which can't or won't be updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc  @FPtje @immae @redvers