### PR TITLE
gbsplay: fix configure flags

### DIFF
--- a/pkgs/applications/audio/gbsplay/default.nix
+++ b/pkgs/applications/audio/gbsplay/default.nix
@@ -11,13 +11,13 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ libpulseaudio ];
-  
-  configureFlagsArray =
+
+  configureFlags =
    [ "--without-test" "--without-contrib" "--disable-devdsp"
      "--enable-pulse" "--disable-alsa" "--disable-midi"
      "--disable-nas" "--disable-dsound" "--disable-i18n" ];
 
-  makeFlagsArray = [ "tests=" ];
+  makeFlags = [ "tests=" ];
 
   meta = with stdenv.lib; {
     description = "gameboy sound player";


### PR DESCRIPTION
###### Motivation for this change

This caused none of these flags to have any effect.  That's because the configure command looked like this:

    ./configure --prefix=/nix/store/svhl0fjdj1jl2sqcppy5vnzpfi4gj3d3-gbsplay-2016-12-17 \
        --without-test\ --without-contrib\ --disable-devdsp\ --enable-pulse\ --disable-alsa\ --disable-midi\ --disable-nas\ --disable-dsound\ --disable-i18n

with one giant flag '--without-test --without-contrib...', containing internal spaces.

This can be seen in `nix log nixpkgs.gbsplay`, in this line:

    configure flags: --prefix=/nix/store/svhl0fjdj1jl2sqcppy5vnzpfi4gj3d3-gbsplay-2016-12-17 --without-test\ --without-contrib\ --disable-devdsp\ --enable-pulse\ --disable-alsa\ --disable-midi\ --disable-nas\ --disable-dsound\ --disable-i18n

and then in the fact that features like "devdsp" and "midi" are listed as enabled in later output, and source files like plugout_midi.c are included in the build.

I don't have a real opinion on whether it's better to have these flags or not, but it's clear the author's intention was to pass them.  So, fix the attr name so they get passed.

(Found this in the course of testing #85042: enabling structured attrs for this package has the same effect as this fix.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  (They successfully execute and print usage messages.)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
