### PR TITLE
libgit2: unbundle pcre

### DIFF
--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, python3
-, zlib, libssh2, openssl, http-parser
+, zlib, libssh2, openssl, pcre, http-parser
 , libiconv, Security
 }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake python3 pkgconfig ];
 
-  buildInputs = [ zlib libssh2 openssl http-parser ]
+  buildInputs = [ zlib libssh2 openssl pcre http-parser ]
     ++ stdenv.lib.optional stdenv.isDarwin Security;
 
   propagatedBuildInputs = stdenv.lib.optional (!stdenv.isLinux) libiconv;


### PR DESCRIPTION
###### Motivation for this change

libgit2 has bundled pcre (not pcre2) in
https://github.com/libgit2/libgit2/pull/4935

Before this change configure printed "regex, using bundled PCRE",
after this change it prints "regex, using system PCRE".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
