### PR TITLE
libwacom: 1.1 -> 1.3

### DIFF
--- a/pkgs/development/libraries/libwacom/default.nix
+++ b/pkgs/development/libraries/libwacom/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, meson, ninja, glib, pkgconfig, udev, libgudev }:
+{ stdenv, fetchFromGitHub, meson, ninja, glib, pkgconfig, udev, libgudev, doxygen }:
 
 stdenv.mkDerivation rec {
   pname = "libwacom";
-  version = "1.1";
+  version = "1.3";
 
   outputs = [ "out" "dev" ];
 
@@ -10,12 +10,12 @@ stdenv.mkDerivation rec {
     owner = "linuxwacom";
     repo = "libwacom";
     rev = "libwacom-${version}";
-    sha256 = "037vnyfg7nim6h3f4m04w6a9pr6hi04df14qpys580kf5xnf87nz";
+    sha256 = "12g8jb67wj6sgg9ar2w8kkw1m1431rn9nd0j64qkrd3vy9g4l0hk";
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
+  nativeBuildInputs = [ pkgconfig meson ninja doxygen ];
 
-  mesonFlags = [ "-Dtests=false" ];
+  mesonFlags = [ "-Dtests=disabled" ];
 
   buildInputs = [ glib udev libgudev ];
 

--- a/pkgs/development/libraries/libwacom/default.nix
+++ b/pkgs/development/libraries/libwacom/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     homepage = "https://linuxwacom.github.io/";
     description = "Libraries, configuration, and diagnostic tools for Wacom tablets running under Linux";
+    maintainers = teams.freedesktop.members;
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updating libwacom from 1.1 to 1.3, for updated tablet definitions.  Added doxygen and cmake to get compilation to work.

I am opening this PR in advance of actually seeing if it breaks anything, because *many* pkgs depend on this.  This also seems to have no maintainer set, and I'm a bit uncomfortable adding myself as a maintainer for such a core package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
