### PR TITLE
exa: include patch to group dir symlinks with regular dirs

### DIFF
--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -19,6 +19,13 @@ buildRustPackage rec {
 
   patches = [
     (fetchpatch {
+      # https://github.com/ogham/exa/pull/516
+      name = "include-symlinks-to-dirs-when-grouping-dirs";
+      url = "https://github.com/ogham/exa/pull/516/commits/69a7e53ee3ef664d575a4047af3c2a7cca2095ee.patch";
+      sha256 = "0553n1vh1dmlq60b86zi6azmfdad7p940gwcc3d3aav37v1bbqgj";
+    })
+
+    (fetchpatch {
       # https://github.com/ogham/exa/pull/584
       name = "fix-panic-on-broken-symlink-in-git-repository.patch";
       url = "https://github.com/ogham/exa/pull/584/commits/a7a8e99cf3a15992afb2383435da0231917ffb54.patch";


### PR DESCRIPTION
###### Motivation for this change
`exa` patched to group symlinks to dirs with regular dirs when passing `--group-directories-first`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
