### PR TITLE
1password: 0.7.0 -> 0.9.4

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -1,42 +1,45 @@
-{ stdenv, fetchzip }:
+{ stdenv, fetchzip, autoPatchelfHook, fetchurl, xar, cpio }:
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.7.0";
+  version = "0.9.4";
   src =
     if stdenv.hostPlatform.system == "i686-linux" then
       fetchzip {
         url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_386_v${version}.zip";
-        sha256 = "1lhp0ws543855rvpvh84rjvyi471259lg618cciqj8j6k04ls1g0";
+        sha256 = "0hgvcm42035fs2qhhvycppcrqgya98rmkk347j3hyj1m6kqxi99c";
         stripRoot = false;
       }
     else if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchzip {
         url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_amd64_v${version}.zip";
-        sha256 = "1sjv5qrc80fk9yz0cn2yj0cdm47ab3ch8n9hzj9hv9d64gjv4w8n";
+        sha256 = "1fvl078kgpvzjr3jfp8zbajzsiwrcm33b7lqksxgcy30paqw6737";
         stripRoot = false;
       }
     else if stdenv.hostPlatform.system == "x86_64-darwin" then
-      fetchzip {
-        url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_darwin_amd64_v${version}.zip";
-        sha256 = "1hnixmq7mrc6ky79k3s61vv89v4qhkm31kyni3rscibfrab0r8ir";
-        stripRoot = false;
+      fetchurl {
+        url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_darwin_amd64_v${version}.pkg";
+        sha256 = "0fzbfxsgf0s93kg647zla9n9k5adnfb57dcwwnibs6lq5k63h8mj";
       }
     else throw "Architecture not supported";
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ xar cpio ];
+
+  unpackPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    xar -xf $src
+    zcat Payload | cpio -i
+  '';
 
   installPhase = ''
     install -D op $out/bin/op
   '';
-  postFixup = stdenv.lib.optionalString stdenv.isLinux ''
-    patchelf \
-      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      $out/bin/op
-  '';
+
+  nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ autoPatchelfHook ];
 
   meta = with stdenv.lib; {
     description  = "1Password command-line tool";
-    homepage     = https://support.1password.com/command-line/;
-    downloadPage = https://app-updates.agilebits.com/product_history/CLI;
+    homepage     = "https://support.1password.com/command-line/";
+    downloadPage = "https://app-updates.agilebits.com/product_history/CLI";
     maintainers  = with maintainers; [ joelburget marsam ];
     license      = licenses.unfree;
     platforms    = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];


### PR DESCRIPTION
#### Things done 
Update 1password to [version 0.9.4](https://app-updates.agilebits.com/product_history/CLI).
The Darwin version comes as a `.pkg` file instead of a zip as previously, I wasn't quite sure how to deal with this, so i used [this](https://github.com/NixOS/nixpkgs/blob/2059bf9e39bef62e9386291e1041371bdd8036ab/pkgs/development/python-modules/gurobipy/darwin.nix#L14) as a reference. Seems to work well as `file` recognizes it as an `Mach-O 64-bit x86_64 executable`. I unfortunately do not have a Mac or i686-linux machine to test, but the x86_64-linux version works perfectly. Also switched to `autoPatchelfHook` for the Linux version. Apologies if something is not right, I'm quite a beginner at this.

Would really appreciate it if someone with a Darwin machine could test.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
