### PR TITLE
lightworks: fix meta

### DIFF
--- a/pkgs/applications/video/lightworks/default.nix
+++ b/pkgs/applications/video/lightworks/default.nix
@@ -65,14 +65,6 @@ let
     '';
 
     dontPatchELF = true;
-
-    meta = {
-      description = "Professional Non-Linear Video Editor";
-      homepage = "https://www.lwks.com/";
-      license = stdenv.lib.licenses.unfree;
-      maintainers = [ stdenv.lib.maintainers.antonxy ];
-      platforms = [ "x86_64-linux" ];
-    };
   };
 
 # Lightworks expects some files in /usr/share/lightworks
@@ -84,4 +76,12 @@ in buildFHSUserEnv {
   ];
 
   runScript = "lightworks";
+
+  meta = {
+    description = "Professional Non-Linear Video Editor";
+    homepage = "https://www.lwks.com/";
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.antonxy ];
+    platforms = [ "x86_64-linux" ];
+  };
 }


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The meta attrs must be in the final derivation, as otherwise `nix edit nixpkgs.lightworks` or `nix search lightworks` don't work.


###### Things done

I moved the `meta` attrs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
