### PR TITLE
android-studio: Fix the license (unfree)

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -187,7 +187,14 @@ in runCommand
       homepage = if channel == "stable"
         then "https://developer.android.com/studio/index.html"
         else "https://developer.android.com/studio/preview/index.html";
-      license = licenses.asl20;
+      license = with licenses; [ asl20 unfree ]; # The code is under Apache-2.0, but:
+      # If one selects Help -> Licenses in Android Studio, the dialog shows the following:
+      # "Android Studio includes proprietary code subject to separate license,
+      # including JetBrains CLion(R) (www.jetbrains.com/clion) and IntelliJ(R)
+      # IDEA Community Edition (www.jetbrains.com/idea)."
+      # Also: For actual development the Android SDK is required and the Google
+      # binaries are also distributed as proprietary software (unlike the
+      # source-code itself).
       platforms = [ "x86_64-linux" ];
       maintainers = with maintainers; [ primeos ];
     };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I just noticed that Android Studio states that it contains proprietary code so this obviously requires an update to the licensing situation.

Screenshot:
![help-licenses](https://user-images.githubusercontent.com/7537109/79072942-fea70300-7ce3-11ea-8968-f5bf81bdec79.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
