### PR TITLE
worldofgoo: 1.41 -> 1.53

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4709,6 +4709,12 @@
     githubId = 502805;
     name = "Max Zerzouri";
   };
+  maxeaubrey = {
+    email = "maxeaubrey@gmail.com";
+    github = "maxeaubrey";
+    githubId = 35892750;
+    name = "Maxine Aubrey";
+  };
   mbakke = {
     email = "mbakke@fastmail.com";
     github = "mbakke";

--- a/pkgs/games/worldofgoo/default.nix
+++ b/pkgs/games/worldofgoo/default.nix
@@ -1,71 +1,64 @@
-{ stdenv, requireFile
-, libX11, libXext, libXau, libxcb, libXdmcp , SDL, SDL_mixer, libvorbis, libGLU, libGL
-, runtimeShell
-, demo ? false }:
+{ stdenv, requireFile, unzip, makeDesktopItem, SDL2, SDL2_mixer, libogg, libvorbis }:
 
-# TODO: add i686 support
+let
+  arch = if stdenv.system == "x86_64-linux"
+    then "x86_64"
+    else "x86";
+
+  desktopItem = makeDesktopItem {
+    desktopName = "World of Goo";
+    genericName = "World of Goo";
+    categories = "Game;";
+    exec = "WorldOfGoo.bin.${arch}";
+    icon = "2dboy-worldofgoo";
+    name = "worldofgoo";
+    type = "Application";
+  };
+
+in
 
 stdenv.mkDerivation rec {
-  name = if demo
-    then "WorldOfGooDemo-1.41"
-    else "WorldofGoo-1.41";
+  pname = "WorldOfGoo";
+  version = "1.53";
 
-  arch = if stdenv.hostPlatform.system == "x86_64-linux" then "supported"
-    else throw "Sorry. World of Goo only is only supported on x86_64 now.";
-
-  goBuyItNow = ''
+  helpMsg = ''
     We cannot download the full version automatically, as you require a license.
-    Once you bought a license, you need to add your downloaded version to the nix store.
-    You can do this by using "nix-prefetch-url file://\$PWD/WorldOfGooSetup.1.41.tar.gz" in the
-    directory where you saved it.
-
-    Or you can install the demo version: 'nix-env -i -A pkgs.worldofgoo_demo'.
+    Once you have bought a license, you need to add your downloaded version to the nix store.
+    You can do this by using "nix-prefetch-url file://\$PWD/${pname}.Linux${version}.sh"
+    in the directory where you saved it.
   '';
 
-  getTheDemo = ''
-    We cannot download the demo version automatically. Please go to
-    http://worldofgoo.com/dl2.php?lk=demo, then add it to your nix store.
-    You can do this by using "nix-prefetch-url file://\$PWD/WorldOfGooDemo.1.41.tar.gz" in the
-    directory where you saved it.
+  src = requireFile {
+    message = helpMsg;
+    name = "WorldOfGoo.Linux.1.53.sh";
+    sha256 = "175e4b0499a765f1564942da4bd65029f8aae1de8231749c56bec672187d53ee";
+  };
+
+  buildInputs = [ unzip ];
+  sourceRoot = pname;
+  phases = [ "unpackPhase installPhase" ];
+
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib stdenv.cc.libc SDL2 SDL2_mixer
+    libogg libvorbis ];
+
+  unpackPhase = ''
+    # The game is distributed as a shell script, with a tar of mojosetup, and a 
+    # zip archive attached to the end. Therefore a simple unzip does the job.
+    # However, to avoid unzip errors, we need to strip those out first.
+    tail -c +421887 ${src} > ${src}.zip
+    unzip -q ${src}.zip -d ${pname}
   '';
-
-  src = if demo
-    then
-      requireFile {
-         message = getTheDemo;
-         name = "WorldOfGooDemo.1.41.tar.gz";
-         sha256 = "0ndcix1ckvcj47sgndncr3hxjcg402cbd8r16rhq4cc43ibbaxri";
-       }
-    else
-      requireFile {
-        message = goBuyItNow;
-        name = "WorldOfGooSetup.1.41.tar.gz";
-        sha256 = "0rj5asx4a2x41ncwdby26762my1lk1gaqar2rl8dijfnpq8qlnk7";
-      };
-
-  phases = "unpackPhase installPhase";
-
-  # XXX: stdenv.lib.makeLibraryPath doesn't pick up /lib64
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc ]
-    + ":" + stdenv.lib.makeLibraryPath [libX11 libXext libXau libxcb libXdmcp SDL SDL_mixer libvorbis libGLU libGL ]
-    + ":" + stdenv.cc.cc + "/lib64";
 
   installPhase = ''
-    mkdir -p $out/libexec/2dboy/WorldOfGoo/
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/share/applications $out/share/icons/hicolor/256x256/apps
 
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath $libPath ./WorldOfGoo.bin64
+    install -t $out/bin -m755 data/${arch}/WorldOfGoo.bin.${arch}
+    cp -R data/noarch/* $out/bin
+    cp data/noarch/game/gooicon.png $out/share/icons/hicolor/256x256/apps/2dboy-worldofgoo.png
+    cp ${desktopItem}/share/applications/worldofgoo.desktop \
+      $out/share/applications/worldofgoo.desktop
 
-    cp -r * $out/libexec/2dboy/WorldOfGoo/
-
-    #makeWrapper doesn't do cd. :(
-
-    cat > $out/bin/WorldofGoo << EOF
-    #!${runtimeShell}
-    cd $out/libexec/2dboy/WorldOfGoo
-    exec ./WorldOfGoo.bin64
-    EOF
-    chmod +x $out/bin/WorldofGoo
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath $libPath $out/bin/WorldOfGoo.bin.${arch}
   '';
 
   meta = with stdenv.lib; {
@@ -77,7 +70,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://worldofgoo.com";
     license = licenses.unfree;
-    maintainers = with maintainers; [ jcumming ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ jcumming maxeaubrey ];
   };
-
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23979,10 +23979,6 @@ in
     lua = lua5_2;
   };
 
-  worldofgoo_demo = worldofgoo.override {
-    demo = true;
-  };
-
   worldofgoo = callPackage ../games/worldofgoo { };
 
   xboard =  callPackage ../games/xboard { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Latest version of the game (update from early 2019). The demo is no longer available for download so I removed support for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
