### PR TITLE
deezloader-remix: init at 4.3.0

### DIFF
--- a/pkgs/tools/audio/deezloader-remix/default.nix
+++ b/pkgs/tools/audio/deezloader-remix/default.nix
@@ -1,0 +1,30 @@
+{ appimageTools, fetchurl, lib, gsettings-desktop-schemas, gtk3 }:
+
+let
+  pname = "deezloader-remix";
+  version = "4.3.0";
+in
+appimageTools.wrapType2 rec {
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "https://www.dropbox.com/s/nmznos9sxg72nlf/Deezloader_Remix_4.3.0-x86_64.appimage?dl=0";
+    sha256 = "17v3gbliymzsmzjvwhz3z6bz86fpxcfzvnzafnlbrg8ikds3kamc";
+  };
+
+  profile = ''
+    export LC_ALL=C.UTF-8
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+
+  multiPkgs = null; # no 32bit needed
+  extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [ p.at-spi2-atk p.at-spi2-core ];
+  extraInstallCommands = "mv $out/bin/{${name},${pname}}";
+
+  meta = with lib; {
+    description = "Download songs, playlists and albums directly from Deezer's Server";
+    homepage = "https://notabug.org/RemixDevs/DeezloaderRemix";
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ luc65r ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2850,6 +2850,8 @@ in
 
   deer = callPackage ../shells/zsh/zsh-deer { };
 
+  deezloader-remix = callPackage ../tools/audio/deezloader-remix { };
+
   detox = callPackage ../tools/misc/detox { };
 
   devilspie2 = callPackage ../applications/misc/devilspie2 {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Make Deezloader Remix available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
