### PR TITLE
[RFC] Declarative wrappers

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -45,6 +45,7 @@ in pythonPackages.buildPythonApplication rec {
     substituteInPlace setup.cfg --replace "‘" "'"
   '';
 
+  dontWrapPythonPrograms = (qt5.wrapQtAppsHook == null);
   # In order to spare double wrapping, we use:
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")

--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -21,7 +21,15 @@ in pythonPackages.buildPythonApplication rec {
     sha256 = "0xalg4dvaqb396h4s6gzxnplgv1lcvsczmmrlhyrj0kfj10amhsj";
   };
 
-  nativeBuildInputs = [ gettext qt5.wrapQtAppsHook qt5.qtbase ]
+  nativeBuildInputs = [ gettext qt5.wrapQtAppsHook ];
+
+  propagatedBuildInputs = with pythonPackages; [
+    qt5.qtbase
+    pyqt5
+    mutagen
+    chromaprint
+    discid
+  ]
     ++ stdenv.lib.optionals (pyqt5.multimediaEnabled) [
       qt5.qtmultimedia.bin
       gst_all_1.gstreamer
@@ -31,13 +39,6 @@ in pythonPackages.buildPythonApplication rec {
       gst_all_1.gst-plugins-good
     ]
   ;
-
-  propagatedBuildInputs = with pythonPackages; [
-    pyqt5
-    mutagen
-    chromaprint
-    discid
-  ];
 
   prePatch = ''
     # Pesky unicode punctuation.

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -130,8 +130,10 @@ let
       ) pkgs
     ;
     allPkgs = (lib.lists.flatten pkgList) ++ extraPkgsByOverride ++ extraPkgs;
+    # Useful for debugging, not evaluated if not used.
     allPkgs_ = builtins.trace "allPkgs is: ${builtins.toJSON allPkgs}" allPkgs;
     allInputs = lib.lists.unique (lib.lists.flatten (getAllInputs allPkgs []));
+    # Useful for debugging, not evaluated if not used.
     allInputs_ = builtins.trace "allInputs is: ${builtins.toJSON allInputs}" allInputs;
     # filter out of all the inputs the packages with the propagateEnv attribute
     envPkgs = builtins.filter (
@@ -141,6 +143,7 @@ let
       else
         false
     ) allInputs;
+    # Useful for debugging, not evaluated if not used.
     envPkgs_ = builtins.trace "envPkgs is: ${builtins.toJSON envPkgs}" envPkgs;
     # Given a package, it's outputs and an envStr such as found in the values
     # of passthru's `propagateEnv`, it replaces all occurences of %<outname>%
@@ -170,7 +173,6 @@ let
     # argument's value - if it was requested to `link` directories of certain
     # env vars or paths, that's taken care of later, at `linkInfo`. The
     # encyclopedia's `linkPaths` set is used if needed.
-    # envInfo = map (
     envInfo = lib.attrsets.foldAttrs (n: a: lib.lists.unique ([n] ++ a)) [] (map (
       pkg:
       # for every package in envPkgs, do the following for every env key and value
@@ -207,7 +209,7 @@ let
             real_value
       ) pkg.propagateEnv)
     ) envPkgs);
-    # ) envPkgs;
+    # Useful for debugging, not evaluated if not used.
     envInfo_ = builtins.trace "envInfo is ${(builtins.toJSON envInfo)}" envInfo;
     makeWrapperArgs = lib.lists.flatten (lib.attrsets.mapAttrsToList (
       key:
@@ -266,6 +268,7 @@ let
     )
       envInfo
     );
+    # Useful for debugging, not evaluated if not used.
     linkCmds_ = builtins.trace "linkCmds is ${builtins.toJSON linkCmds}" linkCmds;
   in
   symlinkJoin {

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -131,6 +131,7 @@ let
   symlinkJoin {
     name = "runtime-env";
     paths = pkgList;
+    passthru.unwrapped = pkgList;
 
     buildInputs = [ makeWrapper ];
     postBuild = ''

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -36,7 +36,7 @@ let
     # list of packages and creates a list of all buildInputs they all depend
     # on. The 2nd argument pkgsFound is used internally and it's expected to be
     # [] at the first call.
-    getAllInputs = 
+    getAllInputs =
       pkgs:
       pkgsFound:
       map (
@@ -83,7 +83,7 @@ let
           envStr;
         }
     ;
-    envInfo = map (
+    envInfo = lib.attrsets.foldAttrs (n: a: [n] ++ a) [] (map (
       pkg:
       # for every package in envPkgs, do the following for every env key and value
       (lib.attrsets.mapAttrs (
@@ -97,10 +97,8 @@ let
           envStr = value;
         }
       ) pkg.propagateEnv)
-    ) envPkgs;
+    ) envPkgs);
     # envInfo_ = builtins.trace "envInfo is ${(builtins.toJSON envInfo)}" envInfo;
-    envInfoFolded = lib.attrsets.foldAttrs (n: a: [n] ++ a) [] envInfo;
-    # envInfoFolded_ = builtins.trace "envInfoFolded is ${(builtins.toJSON envInfoFolded)}" envInfoFolded;
     # Where we add stuff according to encyclopedia.wrapOut
     envInfoWithLocal = lib.attrsets.mapAttrs (
       name:
@@ -109,7 +107,7 @@ let
         values ++ (lib.lists.flatten encyclopedia.wrapOut.${name})
       else
         values
-    ) envInfoFolded;
+    ) envInfo;
     # envInfoWithLocal_ = builtins.trace "envInfoWithLocal is ${(builtins.toJSON envInfoWithLocal)}" envInfoWithLocal;
     makeWrapperArgs = lib.attrsets.mapAttrsToList (
       key:

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -4,6 +4,7 @@
 , extraPkgsByOverride ? []
 }:
 
+# A single pkg or a list of pkgs mainly packaged
 pkgList:
 
 let
@@ -25,7 +26,7 @@ let
       wrapOut = {
         XDG_DATA_DIRS = "$out/share";
       };
-      # If you want an environment variable have a single value and that's it,
+      # If you want an environment variable to have a single value and that's it,
       # put it here:
       singleValue = [
         "GDK_PIXBUF_MODULE_FILE"
@@ -52,7 +53,7 @@ let
       ) pkgs;
     allPkgs = (lib.lists.flatten pkgList) ++ extraPkgsByOverride ++ extraPkgs;
     allInputs = lib.lists.unique (lib.lists.flatten (getAllInputs allPkgs []));
-    # allInputs_ = builtins.trace "${builtins.toJSON allInputs}" allInputs;
+    # allInputs_ = builtins.trace "allInputs is: ${builtins.toJSON allInputs}" allInputs;
     # filter out of all the inputs the packages with the propagateEnv attribute
     envPkgs = builtins.filter (
       pkg:
@@ -84,8 +85,11 @@ let
     ;
     envInfo = map (
       pkg:
+      # for every package in envPkgs, do the following for every env key and value
       (lib.attrsets.mapAttrs (
+        # env var name
         name:
+        # env var value
         value:
         replaceAllOutputs {
           inherit pkg;

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -47,7 +47,7 @@ let
       ) pkgs;
     allPkgs = (lib.lists.flatten pkgList) ++ extraPkgsByOverride ++ extraPkgs;
     allInputs = lib.lists.unique (lib.lists.flatten (getAllInputs allPkgs []));
-    allInputs_ = builtins.trace "${builtins.toJSON allInputs}" allInputs;
+    # allInputs_ = builtins.trace "${builtins.toJSON allInputs}" allInputs;
     # filter out of all the inputs the packages with the propagateEnv attribute
     envPkgs = builtins.filter (
       pkg:
@@ -89,9 +89,9 @@ let
         }
       ) pkg.propagateEnv)
     ) envPkgs;
-    envInfo_ = builtins.trace "envInfo is ${(builtins.toJSON envInfo)}" envInfo;
+    # envInfo_ = builtins.trace "envInfo is ${(builtins.toJSON envInfo)}" envInfo;
     envInfoFolded = lib.attrsets.foldAttrs (n: a: [n] ++ a) [] envInfo;
-    envInfoFolded_ = builtins.trace "envInfoFolded is ${(builtins.toJSON envInfoFolded)}" envInfoFolded;
+    # envInfoFolded_ = builtins.trace "envInfoFolded is ${(builtins.toJSON envInfoFolded)}" envInfoFolded;
     # Where we add stuff according to encyclopedia.wrapOut
     envInfoWithLocal = lib.attrsets.mapAttrs (
       name:
@@ -101,7 +101,7 @@ let
       else
         values
     ) envInfoFolded;
-    envInfoWithLocal_ = builtins.trace "envInfoWithLocal is ${(builtins.toJSON envInfoWithLocal)}" envInfoWithLocal;
+    # envInfoWithLocal_ = builtins.trace "envInfoWithLocal is ${(builtins.toJSON envInfoWithLocal)}" envInfoWithLocal;
     makeWrapperArgs = lib.attrsets.mapAttrsToList (
       key:
       value:
@@ -112,7 +112,7 @@ let
         "--prefix ${key} ${sep} ${builtins.concatStringsSep sep value}"
       )
     ) envInfoWithLocal;
-    makeWrapperArgs_ = builtins.trace "makeWrapperArgs is ${(builtins.toJSON makeWrapperArgs)}" makeWrapperArgs;
+    # makeWrapperArgs_ = builtins.trace "makeWrapperArgs is ${(builtins.toJSON makeWrapperArgs)}" makeWrapperArgs;
   in
   symlinkJoin {
     name = "runtime-env";
@@ -121,7 +121,7 @@ let
     buildInputs = [ makeWrapper ];
     postBuild = ''
       for i in $out/bin/*; do
-        wrapProgram "$i" ${(builtins.concatStringsSep " " makeWrapperArgs_)}
+        wrapProgram "$i" ${(builtins.concatStringsSep " " makeWrapperArgs)}
       done
     '';
   };

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -2,6 +2,7 @@
 , symlinkJoin
 , makeWrapper
 , lndir
+, pkgs
 , extraPkgsByOverride ? []
 }:
 
@@ -21,11 +22,13 @@ let
       XDG_DATA_DIRS = "link";
       # Tells the builder to simply link all the files of a package that
       # propagets this env var. Note that this may affect closure size of the
-      # result as every pkg's `out` is chosen unconditionally. Useful for
+      # result as every pkg's all outputs are used unconditionally. Useful for
       # python / other languages wrappings
       GI_TYPELIB_PATH = "linkPkg";
     },
     */
+    # TODO: Decide what to do when `linkPkg` is used here and the file
+    # nix-support/propagated-build-inputs has different values per package
     linkByEnv ? {},
   }:
   let
@@ -49,6 +52,8 @@ let
       linkPaths = {
         XDG_DATA_DIRS = "$out/share";
         GI_TYPELIB_PATH = "$out/lib/girepository-1.0";
+        QT_PLUGIN_PATH = "$out/${pkgs.qt5.qtbase.qtPluginPrefix}";
+        QML2_IMPORT_PATH = "$out/${pkgs.qt5.qtbase.qtQmlPrefix}";
       };
       # If you want an environment variable to have a single value and that's it,
       # put it here:
@@ -139,8 +144,7 @@ let
                 {
                   linkType = "pkg";
                   linkTo = "$out";
-                  # "out" is not always the default
-                  linkFrom = pkg.out;
+                  linkFrom = pkg;
                 }
             else
               abort "neowrap.nix: I was requested to symlink paths of propagated environment for env var `${name}` but I don't know where to put these files as they are not in my encyclopedia"

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -72,7 +72,7 @@ let
           inherit pkg;
           outputs = lib.lists.subtractLists [outname] outputs;
           envStr = builtins.replaceStrings
-            [ "%${outname}%" ]
+            [ "@${outname}@" ]
             [ "${pkg.${outname}}" ]
           envStr;
         }

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -35,6 +35,16 @@ let
     # TODO: Decide what to do when `linkPkg` is used here and the file
     # nix-support/propagated-build-inputs has different values per package
     linkByEnv ? {},
+    # If we want the wrapping to also include an environmental variable in
+    # out, we list here for every env var what path to add to the wrapper's
+    # values.
+    /*** example value ***
+    wrapOut ? {
+      XDG_DATA_DIRS = "$out/share";
+      PYTHONPATH = "$out/${pkgs.python3.sitePackages}";
+    },
+    */
+    wrapOut ? {},
   }:
   let
     # Where we keep general knowledge about known to be used environmental variables
@@ -43,12 +53,6 @@ let
       # default is ":"
       separators = {
         # XDG_DATA_DIRS = ":";
-      };
-      # If we want the wrapping to also include an environmental variable in
-      # out, we list here for every env var what path to add to the wrapper's
-      # values.
-      wrapOut = {
-        XDG_DATA_DIRS = "$out/share";
       };
       # If the `link` argument was supplied, we use the keys provided here as a
       # dictionary that defines where to symlink the files that the caller
@@ -230,15 +234,15 @@ let
       )
     )
       # Before calculating makeWrapperArgs, we need to add values to env vars
-      # according to encyclopedia.wrapOut:
+      # according to the `wrapOut` argument:
       (lib.attrsets.mapAttrs (
         name:
         values:
-        if builtins.hasAttr name encyclopedia.wrapOut && builtins.isList values then
-          if builtins.elem encyclopedia.wrapOut.${name} values then
+        if builtins.hasAttr name wrapOut && builtins.isList values then
+          if builtins.elem wrapOut.${name} values then
             values
           else
-            values ++ [encyclopedia.wrapOut.${name}]
+            values ++ [wrapOut.${name}]
         else
           values
       ) envInfo)

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -36,18 +36,18 @@ let
       map (
         pkg:
         if (builtins.typeOf pkg) == "set" then
-          if builtins.hasAttr "buildInputs" pkg then
-            # builtins.trace "pkg is of type ${(builtins.typeOf pkg)} and it's ${(builtins.toJSON pkg)}" (getAllInputs pkg.buildInputs pkgsFound ++ [ pkg ])
-            (getAllInputs pkg.buildInputs pkgsFound ++ [ pkg ])
+          if builtins.hasAttr "buildInputs" pkg || builtins.hasAttr "propagatedBuildInputs" pkg then
+            # builtins.trace "pkg is of type ${builtins.typeOf pkg} and it's ${builtins.toJSON pkg}, with inputs: ${builtins.toJSON (pkg.buildInputs ++ pkg.propagatedBuildInputs)}" (getAllInputs (pkg.buildInputs ++ pkg.propagatedBuildInputs) (pkgsFound ++ [ pkg ]))
+            (getAllInputs (pkg.buildInputs ++ pkg.propagatedBuildInputs) (pkgsFound ++ [ pkg ]))
           else
             pkgsFound ++ [ pkg ]
         else
-          # builtins.trace "pkg is not a set but a ${(builtins.typeOf pkg)} at ${(builtins.toJSON pkg)}, current pkgsFound is ${(builtins.toJSON pkgsFound)}" pkgsFound
+          # builtins.trace "pkg is not a set but a ${builtins.typeOf pkg} at ${builtins.toJSON pkg}, current pkgsFound is ${builtins.toJSON pkgsFound}" pkgsFound
           pkgsFound
       ) pkgs;
-    # allInputs = builtins.trace "allinputs is ${builtins.toJSON (getAllInputs pkgList [])}" (getAllInputs pkgList []);
     allPkgs = (lib.lists.flatten pkgList) ++ extraPkgsByOverride ++ extraPkgs;
-    allInputs = lib.lists.flatten (getAllInputs allPkgs []);
+    allInputs = lib.lists.unique (lib.lists.flatten (getAllInputs allPkgs []));
+    allInputs_ = builtins.trace "${builtins.toJSON allInputs}" allInputs;
     # filter out of all the inputs the packages with the propagateEnv attribute
     envPkgs = builtins.filter (
       pkg:
@@ -89,9 +89,9 @@ let
         }
       ) pkg.propagateEnv)
     ) envPkgs;
-    # envInfo_ = builtins.trace "envInfo is ${(builtins.toJSON envInfo)}" envInfo;
+    envInfo_ = builtins.trace "envInfo is ${(builtins.toJSON envInfo)}" envInfo;
     envInfoFolded = lib.attrsets.foldAttrs (n: a: [n] ++ a) [] envInfo;
-    # envInfoFolded_ = builtins.trace "envInfoFolded is ${(builtins.toJSON envInfoFolded)}" envInfoFolded;
+    envInfoFolded_ = builtins.trace "envInfoFolded is ${(builtins.toJSON envInfoFolded)}" envInfoFolded;
     # Where we add stuff according to encyclopedia.wrapOut
     envInfoWithLocal = lib.attrsets.mapAttrs (
       name:
@@ -101,7 +101,7 @@ let
       else
         values
     ) envInfoFolded;
-    # envInfoWithLocal_ = builtins.trace "envInfoWithLocal is ${(builtins.toJSON envInfoWithLocal)}" envInfoWithLocal;
+    envInfoWithLocal_ = builtins.trace "envInfoWithLocal is ${(builtins.toJSON envInfoWithLocal)}" envInfoWithLocal;
     makeWrapperArgs = lib.attrsets.mapAttrsToList (
       key:
       value:
@@ -112,7 +112,7 @@ let
         "--prefix ${key} ${sep} ${builtins.concatStringsSep sep value}"
       )
     ) envInfoWithLocal;
-    # makeWrapperArgs_ = builtins.trace "makeWrapperArgs is ${(builtins.toJSON makeWrapperArgs)}" makeWrapperArgs;
+    makeWrapperArgs_ = builtins.trace "makeWrapperArgs is ${(builtins.toJSON makeWrapperArgs)}" makeWrapperArgs;
   in
   symlinkJoin {
     name = "runtime-env";
@@ -121,7 +121,7 @@ let
     buildInputs = [ makeWrapper ];
     postBuild = ''
       for i in $out/bin/*; do
-        wrapProgram "$i" ${(builtins.concatStringsSep " " makeWrapperArgs)}
+        wrapProgram "$i" ${(builtins.concatStringsSep " " makeWrapperArgs_)}
       done
     '';
   };

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -2,12 +2,14 @@
 , symlinkJoin
 , jq
 , makeWrapper
+, extraPkgsByOverride ? []
 }:
 
 pkgList:
 
 let
   wrapper = {
+    extraPkgs ? [],
     extraMakeWrapperArgs ? ""
   }:
   let
@@ -36,7 +38,8 @@ let
           pkgsFound
       ) pkgs;
     # allInputs = builtins.trace "allinputs is ${builtins.toJSON (getAllInputs pkgList [])}" (getAllInputs pkgList []);
-    allInputs = lib.lists.flatten (getAllInputs pkgList []);
+    allPkgs = (lib.lists.flatten pkgList) ++ extraPkgsByOverride ++ extraPkgs;
+    allInputs = lib.lists.flatten (getAllInputs allPkgs []);
     # filter out of all the inputs the packages with the propagateEnv attribute
     envPkgs = builtins.filter (
       pkg:

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -36,6 +36,20 @@ let
       pkg:
       (builtins.hasAttr "propagateEnv" pkg)
     ) allInputs;
+    envInfo = map (
+      pkg:
+      (lib.attrsets.mapAttrs (
+        name:
+        value:
+        # TODO: make this work with other outputs as well
+        builtins.replaceStrings
+        [ "%out%" ]
+        [ "${pkg.out}" ]
+        value
+      ) pkg.propagateEnv)
+    ) envPkgs;
+    envInfo_ = builtins.trace "envInfo is ${(builtins.toJSON envInfo)}" envInfo;
+    # envInfoFolded = lib.attrsets.foldAttrs (n: a: [n] ++ a) [] envInfo;
   in
   buildEnv {
     name = "runtime-env";
@@ -43,7 +57,7 @@ let
 
     buildInputs = [ jq ];
     postBuild = ''
-      printf '%s\n' ${builtins.concatStringsSep " " envPkgs}
+      printf '%s\n' ${builtins.concatStringsSep " " envInfo_}
       exit 1
     '';
   };

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -13,10 +13,18 @@ let
     extraMakeWrapperArgs ? ""
   }:
   let
-    # Where we keep information about every environmental variable and the
-    # separator between it's values, the default value used is `:`
-    encyclopedia_of_separators = {
-      # XDG_DATA_DIRS = ":";
+    # Where we keep general knowledge about known to be used environmental variables
+    encyclopedia = {
+      # Here we write the separator string between values of every env var, the
+      # default is ":"
+      separators = {
+        # XDG_DATA_DIRS = ":";
+      };
+      # If we want the wrapping to also include an environmental variable in
+      # out, we list here for every env var what path to add to the wrapper's args
+      wrapOut = {
+        XDG_DATA_DIRS = "$out/share";
+      };
     };
     # recursive function that goes deep through the dependency graph of a given
     # list of packages and creates a list of all buildInputs they all depend
@@ -89,8 +97,8 @@ let
       key:
       value:
       (let 
-        sep = encyclopedia_of_separators.${key} or ":";
-      in 
+        sep = encyclopedia.separators.${key} or ":"; # default separator used for most wrappings
+      in
         "--prefix ${key} ${sep} ${builtins.concatStringsSep sep value}"
       )
     ) envInfoFolded;

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -1,6 +1,5 @@
 { lib
 , symlinkJoin
-, jq
 , makeWrapper
 , extraPkgsByOverride ? []
 }:
@@ -113,16 +112,16 @@ let
         "--prefix ${key} ${sep} ${builtins.concatStringsSep sep value}"
       )
     ) envInfoWithLocal;
-    makeWrapperArgs_ = builtins.trace "makeWrapperArgs is ${(builtins.toJSON makeWrapperArgs)}" makeWrapperArgs;
+    # makeWrapperArgs_ = builtins.trace "makeWrapperArgs is ${(builtins.toJSON makeWrapperArgs)}" makeWrapperArgs;
   in
   symlinkJoin {
     name = "runtime-env";
     paths = pkgList;
 
-    buildInputs = [ jq makeWrapper ];
+    buildInputs = [ makeWrapper ];
     postBuild = ''
       for i in $out/bin/*; do
-        wrapProgram "$i" ${(builtins.concatStringsSep " " makeWrapperArgs_)}
+        wrapProgram "$i" ${(builtins.concatStringsSep " " makeWrapperArgs)}
       done
     '';
   };

--- a/pkgs/build-support/neowrap.nix
+++ b/pkgs/build-support/neowrap.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildEnv
+, jq
+}:
+
+pkgList:
+
+let
+  wrapper = {
+    extraMakeWrapperArgs ? ""
+  }:
+  let
+    # recursive function that goes deep through the dependency graph of a given
+    # list of packages and creates a list of all buildInputs they all depend
+    # on. The 2nd argument pkgsFound is used internally and it's expected to be
+    # [] at the first call.
+    getAllInputs = 
+      pkgs:
+      pkgsFound:
+      map (
+        pkg:
+        if (builtins.typeOf pkg) == "set" then
+          if builtins.hasAttr "buildInputs" pkg then
+            # builtins.trace "pkg is of type ${(builtins.typeOf pkg)} and it's ${(builtins.toJSON pkg)}" (getAllInputs pkg.buildInputs pkgsFound ++ [ pkg ])
+            (getAllInputs pkg.buildInputs pkgsFound ++ [ pkg ])
+          else
+            pkgsFound ++ [ pkg ]
+        else
+          # builtins.trace "pkg is not a set but a ${(builtins.typeOf pkg)} at ${(builtins.toJSON pkg)}, current pkgsFound is ${(builtins.toJSON pkgsFound)}" pkgsFound
+          pkgsFound
+      ) pkgs;
+    # allInputs = builtins.trace "allinputs is ${builtins.toJSON (getAllInputs pkgList [])}" (getAllInputs pkgList []);
+    allInputs = lib.lists.flatten (getAllInputs pkgList []);
+    # filter out of all the inputs the packages with the propagateEnv attribute
+    envPkgs = builtins.filter (
+      pkg:
+      (builtins.hasAttr "propagateEnv" pkg)
+    ) allInputs;
+  in
+  buildEnv {
+    name = "runtime-env";
+    paths = pkgList;
+
+    buildInputs = [ jq ];
+    postBuild = ''
+      printf '%s\n' ${builtins.concatStringsSep " " envPkgs}
+      exit 1
+    '';
+  };
+in
+  lib.makeOverridable wrapper

--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+      GI_TYPELIB_PATH = "@out@/lib/girepository-1.0";
     };
   };
 

--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -38,6 +38,9 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript {
       packageName = pname;
     };
+    propagateEnv = {
+      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+    };
   };
 
   meta = {

--- a/pkgs/development/libraries/dconf/default.nix
+++ b/pkgs/development/libraries/dconf/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GIO_EXTRA_MODULES = "%lib%/lib/gio/modules";
+      GIO_EXTRA_MODULES = "@lib@/lib/gio/modules";
     };
   };
 

--- a/pkgs/development/libraries/dconf/default.nix
+++ b/pkgs/development/libraries/dconf/default.nix
@@ -35,6 +35,9 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript {
       packageName = pname;
     };
+    propagateEnv = {
+      GIO_EXTRA_MODULES = "%out%/lib/gio/modules";
+    };
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/dconf/default.nix
+++ b/pkgs/development/libraries/dconf/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GIO_EXTRA_MODULES = "%out%/lib/gio/modules";
+      GIO_EXTRA_MODULES = "%lib%/lib/gio/modules";
     };
   };
 

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -100,7 +100,7 @@ in stdenv.mkDerivation rec {
     moduleDir = "lib/gdk-pixbuf-2.0/2.10.0/loaders";
     cacheFile = "lib/gdk-pixbuf-2.0/2.10.0/loaders.cache";
     propagateEnv = {
-      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+      GI_TYPELIB_PATH = "@out@/lib/girepository-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -98,6 +98,7 @@ in stdenv.mkDerivation rec {
 
     # gdk_pixbuf_moduledir variable from gdk-pixbuf-2.0.pc
     moduleDir = "lib/gdk-pixbuf-2.0/2.10.0/loaders";
+    cacheFile = "lib/gdk-pixbuf-2.0/2.10.0/loaders.cache";
     propagateEnv = {
       GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
     };

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -98,6 +98,9 @@ in stdenv.mkDerivation rec {
 
     # gdk_pixbuf_moduledir variable from gdk-pixbuf-2.0.pc
     moduleDir = "lib/gdk-pixbuf-2.0/2.10.0/loaders";
+    propagateEnv = {
+      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+    };
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+      GI_TYPELIB_PATH = "@out@/lib/girepository-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -72,6 +72,9 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript {
       packageName = pname;
     };
+    propagateEnv = {
+      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+    };
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
+++ b/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome3.updateScript { packageName = "gsettings-desktop-schemas"; };
     propagateEnv = {
-      XDG_DATA_DIRS = "%out%/share/gsettings-schemas/${pname}-${version}";
-      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+      XDG_DATA_DIRS = "@out@/share/gsettings-schemas/${pname}-${version}";
+      GI_TYPELIB_PATH = "@out@/lib/girepository-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
+++ b/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome3.updateScript { packageName = "gsettings-desktop-schemas"; };
+    propagateEnv = {
+      XDG_DATA_DIRS = "%out%/share/gsettings-schemas/${pname}-${version}";
+    };
   };
 
   # meson installs the schemas to share/glib-2.0/schemas

--- a/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
+++ b/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript { packageName = "gsettings-desktop-schemas"; };
     propagateEnv = {
       XDG_DATA_DIRS = "%out%/share/gsettings-schemas/${pname}-${version}";
+      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -278,6 +278,12 @@ in stdenv.mkDerivation rec {
   # that trip up clang with format security enabled.
   hardeningDisable = [ "format" ];
 
+  passthru = {
+    propagateEnv = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+    };
+  };
+
   doCheck = false; # fails 20 out of 58 tests, expensive
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -280,7 +280,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     propagateEnv = {
-      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "@out@/lib/gstreamer-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -136,7 +136,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     propagateEnv = {
-      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "@out@/lib/gstreamer-1.0";
     };
     # Downstream `gst-*` packages depending on `gst-plugins-base`
     # have meson build options like 'gl' etc. that depend

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -135,6 +135,9 @@ stdenv.mkDerivation rec {
   doCheck = false; # fails, wants DRI access for OpenGL
 
   passthru = {
+    propagateEnv = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+    };
     # Downstream `gst-*` packages depending on `gst-plugins-base`
     # have meson build options like 'gl' etc. that depend
     # on these features being built in `-base`.

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -100,6 +100,12 @@ stdenv.mkDerivation rec {
     moveToOutput "share/bash-completion" "$dev"
   '';
 
+  passthru = {
+    propagateEnv = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+    };
+  };
+
   setupHook = ./setup-hook.sh;
 
   meta = with lib ;{

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     propagateEnv = {
-      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "@out@/lib/gstreamer-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     propagateEnv = {
-      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "@out@/lib/gstreamer-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -55,6 +55,12 @@ stdenv.mkDerivation rec {
     sed -i -r -e 's/p(bad|good) = .*/p\1 = pbase/' tests/check/meson.build
   '';
 
+  passthru = {
+    propagateEnv = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+    };
+  };
+
   meta = with stdenv.lib; {
     description = "Library for creation of audio/video non-linear editors";
     homepage = "https://gstreamer.freedesktop.org";

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -136,6 +136,12 @@ stdenv.mkDerivation rec {
   # fails 1 tests with "Unexpected critical/warning: g_object_set_is_valid_property: object class 'GstRtpStorage' has no property named ''"
   doCheck = false;
 
+  passthru = {
+    propagateEnv = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+    };
+  };
+
   meta = with stdenv.lib; {
     description = "GStreamer Good Plugins";
     homepage = "https://gstreamer.freedesktop.org";

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -138,7 +138,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     propagateEnv = {
-      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "@out@/lib/gstreamer-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     propagateEnv = {
-      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "@out@/lib/gstreamer-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -37,6 +37,12 @@ stdenv.mkDerivation rec {
     libav
   ];
 
+  passthru = {
+    propagateEnv = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+    };
+  };
+
   meta = with lib; {
     description = "FFmpeg/libav plugin for GStreamer";
     homepage = "https://gstreamer.freedesktop.org";

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     propagateEnv = {
-      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "@out@/lib/gstreamer-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -55,6 +55,12 @@ stdenv.mkDerivation rec {
     DiskArbitration
   ]);
 
+  passthru = {
+    propagateEnv = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+    };
+  };
+
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
     "-Dsidplay=disabled" # sidplay / sidplay/player.h isn't packaged in nixpkgs as of writing

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     propagateEnv = {
-      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "@out@/lib/gstreamer-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -62,6 +62,12 @@ stdenv.mkDerivation rec {
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
   ];
 
+  passthru = {
+    propagateEnv = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
+    };
+  };
+
   meta = with stdenv.lib; {
     description = "Set of VAAPI GStreamer Plug-ins";
     homepage = "https://gstreamer.freedesktop.org";

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -190,8 +190,8 @@ stdenv.mkDerivation rec {
       attrPath = "gtk3";
     };
     propagateEnv = {
-      XDG_DATA_DIRS = "%out%/share/gsettings-schemas/${pname}-${version}";
-      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+      XDG_DATA_DIRS = "@out@/share/gsettings-schemas/${pname}-${version}";
+      GI_TYPELIB_PATH = "@out@/lib/girepository-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -191,6 +191,7 @@ stdenv.mkDerivation rec {
     };
     propagateEnv = {
       XDG_DATA_DIRS = "%out%/share/gsettings-schemas/${pname}-${version}";
+      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
     };
   };
 

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -189,6 +189,9 @@ stdenv.mkDerivation rec {
       packageName = "gtk+";
       attrPath = "gtk3";
     };
+    propagateEnv = {
+      XDG_DATA_DIRS = "%out%/share/gsettings-schemas/${pname}-${version}";
+    };
   };
 
   meta = {

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GIO_EXTRA_MODULES = "%out%/lib/gio/modules"
+      GIO_EXTRA_MODULES = "%out%/lib/gio/modules";
     };
   };
 

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GIO_EXTRA_MODULES = "%out%/lib/gio/modules";
+      GIO_EXTRA_MODULES = "@out@/lib/gio/modules";
     };
   };
 

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -120,6 +120,9 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript {
       packageName = pname;
     };
+    propagateEnv = {
+      GIO_EXTRA_MODULES = "%out%/lib/gio/modules"
+    };
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -77,8 +77,8 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GDK_PIXBUF_MODULE_FILE = "%out%/${gdk-pixbuf.cacheFile}";
-      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+      GDK_PIXBUF_MODULE_FILE = "@out@/${gdk-pixbuf.cacheFile}";
+      GI_TYPELIB_PATH = "@out@/lib/girepository-1.0";
     };
   };
 

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -76,6 +76,10 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript {
       packageName = pname;
     };
+    propagateEnv = {
+      GDK_PIXBUF_MODULE_FILE = "%out%/lib/${gdk-pixbuf.moduleDir}/loaders.cache";
+      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+    };
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GDK_PIXBUF_MODULE_FILE = "%out%/${gdk-pixbuf.moduleDir}/loaders.cache";
+      GDK_PIXBUF_MODULE_FILE = "%out%/${gdk-pixbuf.cacheFile}";
       GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
     };
   };

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GDK_PIXBUF_MODULE_FILE = "%out%/lib/${gdk-pixbuf.moduleDir}/loaders.cache";
+      GDK_PIXBUF_MODULE_FILE = "%out%/${gdk-pixbuf.moduleDir}/loaders.cache";
       GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
     };
   };

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -55,7 +55,7 @@ in stdenv.mkDerivation rec {
       packageName = pname;
     };
     propagateEnv = {
-      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+      GI_TYPELIB_PATH = "@out@/lib/girepository-1.0";
     };
   };
 

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -54,6 +54,9 @@ in stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript {
       packageName = pname;
     };
+    propagateEnv = {
+      GI_TYPELIB_PATH = "%out%/lib/girepository-1.0";
+    };
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -163,8 +163,8 @@ stdenv.mkDerivation rec {
   qtDocPrefix = "share/doc/qt-${qtCompatVersion}";
   passthru = {
     propagateEnv = {
-      QT_PLUGIN_PATH = "%bin%/${qtPluginPrefix}";
-      # QML2_IMPORT_PATH = "%bin%/${qtQmlPrefix}";
+      QT_PLUGIN_PATH = "@bin@/${qtPluginPrefix}";
+      # QML2_IMPORT_PATH = "@bin@/${qtQmlPrefix}";
     };
   };
 

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -35,7 +35,7 @@ let
     if compareVersion "5.12.4" < 0 then ".qmake.cache" else ".qmake.stash";
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
 
   name = "qtbase-${version}";
   inherit qtCompatVersion src version;
@@ -161,6 +161,12 @@ stdenv.mkDerivation {
   qtPluginPrefix = "lib/qt-${qtCompatVersion}/plugins";
   qtQmlPrefix = "lib/qt-${qtCompatVersion}/qml";
   qtDocPrefix = "share/doc/qt-${qtCompatVersion}";
+  passthru = {
+    propagateEnv = {
+      QT_PLUGIN_PATH = "%bin%/${qtPluginPrefix}";
+      # QML2_PLUGIN_PATH = "%bin%/${qtQmlPrefix}";
+    };
+  };
 
   setOutputFlags = false;
   preConfigure = ''

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -164,7 +164,7 @@ stdenv.mkDerivation rec {
   passthru = {
     propagateEnv = {
       QT_PLUGIN_PATH = "%bin%/${qtPluginPrefix}";
-      # QML2_PLUGIN_PATH = "%bin%/${qtQmlPrefix}";
+      # QML2_IMPORT_PATH = "%bin%/${qtQmlPrefix}";
     };
   };
 

--- a/pkgs/development/libraries/qt-5/modules/qtcharts.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtcharts.nix
@@ -6,8 +6,8 @@ qtModule {
   outputs = [ "out" "dev" "bin" ];
   passthru = {
     propagateEnv = {
-      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QT_PLUGIN_PATH = "@bin@/${qtbase.qtPluginPrefix}";
+      QML2_IMPORT_PATH = "@bin@/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtcharts.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtcharts.nix
@@ -7,7 +7,7 @@ qtModule {
   passthru = {
     propagateEnv = {
       QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtcharts.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtcharts.nix
@@ -4,4 +4,10 @@ qtModule {
   name = "qtcharts";
   qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
+  passthru = {
+    propagateEnv = {
+      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
+      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+    };
+  };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -23,4 +23,10 @@ qtModule {
     "bin/qmlscene"
     "bin/qmltestrunner"
   ];
+  passthru = {
+    propagateEnv = {
+      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
+      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+    };
+  };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -26,7 +26,7 @@ qtModule {
   passthru = {
     propagateEnv = {
       QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -25,8 +25,8 @@ qtModule {
   ];
   passthru = {
     propagateEnv = {
-      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QT_PLUGIN_PATH = "@bin@/${qtbase.qtPluginPrefix}";
+      QML2_IMPORT_PATH = "@bin@/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -15,8 +15,8 @@ qtModule {
   NIX_LDFLAGS = optionalString (stdenv.isDarwin) "-lobjc";
   passthru = {
     propagateEnv = {
-      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QT_PLUGIN_PATH = "@bin@/${qtbase.qtPluginPrefix}";
+      QML2_IMPORT_PATH = "@bin@/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -16,7 +16,7 @@ qtModule {
   passthru = {
     propagateEnv = {
       QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -13,4 +13,10 @@ qtModule {
   outputs = [ "bin" "dev" "out" ];
   qmakeFlags = [ "GST_VERSION=1.0" ];
   NIX_LDFLAGS = optionalString (stdenv.isDarwin) "-lobjc";
+  passthru = {
+    propagateEnv = {
+      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
+      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+    };
+  };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
@@ -7,7 +7,7 @@ qtModule {
   passthru = {
     propagateEnv = {
       # QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
@@ -4,4 +4,10 @@ qtModule {
   name = "qtquickcontrols2";
   qtInputs = [ qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
+  passthru = {
+    propagateEnv = {
+      # QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
+      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+    };
+  };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
@@ -6,8 +6,8 @@ qtModule {
   outputs = [ "out" "dev" "bin" ];
   passthru = {
     propagateEnv = {
-      # QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      # QT_PLUGIN_PATH = "@bin@/${qtbase.qtPluginPrefix}";
+      QML2_IMPORT_PATH = "@bin@/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
@@ -1,4 +1,4 @@
-{ qtModule, qtdeclarative }:
+{ qtModule, qtdeclarative, qtbase }:
 
 qtModule {
   name = "qtquickcontrols2";

--- a/pkgs/development/libraries/qt-5/modules/qtsvg.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtsvg.nix
@@ -4,4 +4,10 @@ qtModule {
   name = "qtsvg";
   qtInputs = [ qtbase ];
   outputs = [ "out" "dev" "bin" ];
+  passthru = {
+    propagateEnv = {
+      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
+      # QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+    };
+  };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtsvg.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtsvg.nix
@@ -6,8 +6,8 @@ qtModule {
   outputs = [ "out" "dev" "bin" ];
   passthru = {
     propagateEnv = {
-      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      # QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QT_PLUGIN_PATH = "@bin@/${qtbase.qtPluginPrefix}";
+      # QML2_IMPORT_PATH = "@bin@/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtsvg.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtsvg.nix
@@ -7,7 +7,7 @@ qtModule {
   passthru = {
     propagateEnv = {
       QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      # QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      # QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -9,7 +9,7 @@ qtModule {
   passthru = {
     propagateEnv = {
       QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -6,4 +6,10 @@ qtModule {
   buildInputs = [ wayland ];
   nativeBuildInputs = [ pkgconfig ];
   outputs = [ "out" "dev" "bin" ];
+  passthru = {
+    propagateEnv = {
+      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
+      QML2_PLUGIN_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+    };
+  };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -8,8 +8,8 @@ qtModule {
   outputs = [ "out" "dev" "bin" ];
   passthru = {
     propagateEnv = {
-      QT_PLUGIN_PATH = "%bin%/${qtbase.qtPluginPrefix}";
-      QML2_IMPORT_PATH = "%bin%/${qtbase.qtQmlPrefix}";
+      QT_PLUGIN_PATH = "@bin@/${qtbase.qtPluginPrefix}";
+      QML2_IMPORT_PATH = "@bin@/${qtbase.qtQmlPrefix}";
     };
   };
 }

--- a/pkgs/development/python-modules/Babel/default.nix
+++ b/pkgs/development/python-modules/Babel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, fetchpatch, pytz, pytest, freezegun, glibcLocales }:
+{ stdenv, python, lib, buildPythonPackage, fetchPypi, fetchpatch, pytz, pytest, freezegun, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "Babel";
@@ -29,6 +29,11 @@ buildPythonPackage rec {
       sha256 = "09yny8614knr8ngrrddmqzkxk70am135rccv2ncc6dji4xbqbfln";
     })
   ];
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   propagatedBuildInputs = [ pytz ];
 

--- a/pkgs/development/python-modules/Babel/default.nix
+++ b/pkgs/development/python-modules/Babel/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   ];
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/alabaster/default.nix
+++ b/pkgs/development/python-modules/alabaster/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   doCheck = false;
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/alabaster/default.nix
+++ b/pkgs/development/python-modules/alabaster/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , pygments }:
 
 buildPythonPackage rec {
@@ -14,6 +14,11 @@ buildPythonPackage rec {
 
   # No tests included
   doCheck = false;
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/bitprophet/alabaster";

--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchPypi
 , buildPythonPackage
+, python
 }:
 
 buildPythonPackage rec {
@@ -10,6 +11,11 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f";
+  };
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
   };
 
   meta = {

--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   };
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/chardet/default.nix
+++ b/pkgs/development/python-modules/chardet/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   };
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/chardet/default.nix
+++ b/pkgs/development/python-modules/chardet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, fetchpatch
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, python
 , pytest, pytestrunner, hypothesis }:
 
 buildPythonPackage rec {
@@ -8,6 +8,11 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "1bpalpia6r5x1kknbk11p1fzph56fmmnp405ds8icksd3knr5aw4";
+  };
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
   };
 
   patches = [

--- a/pkgs/development/python-modules/cycler/default.nix
+++ b/pkgs/development/python-modules/cycler/default.nix
@@ -27,6 +27,12 @@ buildPythonPackage rec {
   # https://github.com/matplotlib/cycler/issues/31
   doCheck = false;
 
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
+
   meta = {
     description = "Composable style cycles";
     homepage = "https://github.com/matplotlib/cycler";

--- a/pkgs/development/python-modules/cycler/default.nix
+++ b/pkgs/development/python-modules/cycler/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/dateutil/default.nix
+++ b/pkgs/development/python-modules/dateutil/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/dateutil/default.nix
+++ b/pkgs/development/python-modules/dateutil/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, six, setuptools_scm, pytest }:
+{ stdenv, buildPythonPackage, fetchPypi, six, setuptools_scm, pytest, python }:
 buildPythonPackage rec {
   pname = "python-dateutil";
   version = "2.8.1";
@@ -17,6 +17,11 @@ buildPythonPackage rec {
 
   # Requires fixing
   doCheck = false;
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "Powerful extensions to the standard datetime module";

--- a/pkgs/development/python-modules/dbus/default.nix
+++ b/pkgs/development/python-modules/dbus/default.nix
@@ -19,6 +19,12 @@ buildPythonPackage rec {
 
   disabled = isPyPy;
 
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ dbus dbus-glib ]
     # My guess why it's sometimes trying to -lncurses.

--- a/pkgs/development/python-modules/dbus/default.nix
+++ b/pkgs/development/python-modules/dbus/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/discid/default.nix
+++ b/pkgs/development/python-modules/discid/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/discid/default.nix
+++ b/pkgs/development/python-modules/discid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, libdiscid, buildPythonPackage, fetchPypi }:
+{ stdenv, libdiscid, buildPythonPackage, fetchPypi, python }:
 
 buildPythonPackage rec {
   pname = "discid";
@@ -7,6 +7,11 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "1fc6kvnqwaz9lrs2qgsp8wh0nabf49010r0r53wnsmpmafy315nd";
+  };
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
   };
 
   patchPhase =

--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -21,6 +21,11 @@ buildPythonPackage rec {
   checkPhase = lib.optionalString (isPy3k && stdenv.isDarwin) ''LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8" '' + ''
     ${python.interpreter} test/alltests.py
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   # Create symlinks lacking a ".py" suffix, many programs depend on these names
   postFixup = ''

--- a/pkgs/development/python-modules/html5lib/default.nix
+++ b/pkgs/development/python-modules/html5lib/default.nix
@@ -7,6 +7,7 @@
 , mock
 , six
 , webencodings
+, python
 }:
 
 buildPythonPackage rec {
@@ -29,6 +30,11 @@ buildPythonPackage rec {
     rm html5lib/tests/test_stream.py
     py.test
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = {
     homepage = "https://github.com/html5lib/html5lib-python";

--- a/pkgs/development/python-modules/html5lib/default.nix
+++ b/pkgs/development/python-modules/html5lib/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/idna/default.nix
+++ b/pkgs/development/python-modules/idna/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
 }:
 
 buildPythonPackage rec {
@@ -10,6 +11,11 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407";
+  };
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
   };
 
   meta = {

--- a/pkgs/development/python-modules/idna/default.nix
+++ b/pkgs/development/python-modules/idna/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   };
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/imagesize/default.nix
+++ b/pkgs/development/python-modules/imagesize/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   };
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/imagesize/default.nix
+++ b/pkgs/development/python-modules/imagesize/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, python
 }:
 
 buildPythonPackage rec {
@@ -10,6 +11,11 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5";
+  };
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -3,6 +3,7 @@
 , isPy3k
 , fetchPypi
 , pytest
+, python
 , markupsafe }:
 
 buildPythonPackage rec {
@@ -24,6 +25,11 @@ buildPythonPackage rec {
   checkPhase = ''
     pytest -v tests
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = "http://jinja.pocoo.org/";

--- a/pkgs/development/python-modules/kiwisolver/default.nix
+++ b/pkgs/development/python-modules/kiwisolver/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   doCheck = false;
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/kiwisolver/default.nix
+++ b/pkgs/development/python-modules/kiwisolver/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , stdenv
 , libcxx
+, python
 }:
 
 buildPythonPackage rec {
@@ -18,6 +19,11 @@ buildPythonPackage rec {
   
   # Does not include tests
   doCheck = false;
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = {
     description = "A fast implementation of the Cassowary constraint solver";

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
 
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -34,9 +34,7 @@ buildPythonPackage rec {
 
   XDG_RUNTIME_DIR = "/tmp";
 
-  nativeBuildInputs = [ pkgconfig ];
-
-  buildInputs = [ python which sphinx stdenv ]
+  nativeBuildInputs = [ pkgconfig python which sphinx stdenv ]
     ++ stdenv.lib.optional enableGhostscript ghostscript
     ++ stdenv.lib.optional stdenv.isDarwin [ Cocoa ];
 
@@ -47,6 +45,12 @@ buildPythonPackage rec {
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobject-introspection pygobject3 ]
     ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ]
     ++ stdenv.lib.optionals enableQt [ pyqt5 ];
+
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   patches =
     [ ./basedirlist.patch ];

--- a/pkgs/development/python-modules/mock/default.nix
+++ b/pkgs/development/python-modules/mock/default.nix
@@ -28,6 +28,11 @@ buildPythonPackage rec {
   checkPhase = ''
     ${python.interpreter} -m unittest discover
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = with lib; {
     description = "Mock objects for Python";

--- a/pkgs/development/python-modules/mock/default.nix
+++ b/pkgs/development/python-modules/mock/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/mutagen/default.nix
+++ b/pkgs/development/python-modules/mutagen/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   LC_ALL = "en_US.UTF-8";
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/mutagen/default.nix
+++ b/pkgs/development/python-modules/mutagen/default.nix
@@ -8,6 +8,7 @@
 , pytest
 , setuptools
 , pkgs
+, python
 }:
 
 buildPythonPackage rec {
@@ -25,6 +26,12 @@ buildPythonPackage rec {
     pkgs.glibcLocales pycodestyle pyflakes pytest hypothesis
   ];
   LC_ALL = "en_US.UTF-8";
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
+
 
   meta = with lib; {
     description = "Python multimedia tagging library";

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -71,7 +71,7 @@ in buildPythonPackage rec {
     blas = blas;
     inherit blasImplementation cfg;
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -70,6 +70,9 @@ in buildPythonPackage rec {
   passthru = {
     blas = blas;
     inherit blasImplementation cfg;
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
   };
 
   # Disable test

--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, meson, ninja, buildPythonPackage, pytest, pkgconfig, cairo, xlibsWrapper, isPy33, isPy3k }:
+{ lib, fetchFromGitHub, meson, ninja, buildPythonPackage, pytest, python, pkgconfig, cairo, xlibsWrapper, isPy33, isPy3k }:
 
 buildPythonPackage rec {
   pname = "pycairo";
@@ -25,6 +25,12 @@ buildPythonPackage rec {
     cairo
     xlibsWrapper
   ];
+
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   checkInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonPackage, pkgconfig, glib, gobject-introspection,
+{ stdenv, fetchurl, buildPythonPackage, pkgconfig, glib, gobject-introspection, python,
 pycairo, cairo, which, ncurses, meson, ninja, isPy3k, gnome3 }:
 
 buildPythonPackage rec {
@@ -27,6 +27,9 @@ buildPythonPackage rec {
     updateScript = gnome3.updateScript {
       packageName = pname;
       attrPath = "python3.pkgs.${pname}3";
+    };
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
       attrPath = "python3.pkgs.${pname}3";
     };
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/pyparsing/default.nix
+++ b/pkgs/development/python-modules/pyparsing/default.nix
@@ -1,7 +1,7 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
-
+, python
 # pythonPackages
 , coverage
 }:
@@ -23,6 +23,11 @@ buildPythonPackage rec {
     coverage run --branch simple_unit_tests.py
     coverage run --branch unitTests.py
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/pyparsing/pyparsing";

--- a/pkgs/development/python-modules/pyparsing/default.nix
+++ b/pkgs/development/python-modules/pyparsing/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -88,7 +88,7 @@ in buildPythonPackage rec {
   configurePhase = ''
     runHook preConfigure
 
-    export PYTHONPATH=$PYTHONPATH:$out/${python.sitePackages}
+    export NIX_PYTHONPATH=$NIX_PYTHONPATH:$out/${python.sitePackages}
 
     ${python.executable} configure.py  -w \
       --confirm-license \
@@ -106,7 +106,7 @@ in buildPythonPackage rec {
   postInstall = ''
     ln -s ${sip}/${python.sitePackages}/PyQt5/sip.* $out/${python.sitePackages}/PyQt5/
     for i in $out/bin/*; do
-      wrapProgram $i --prefix PYTHONPATH : "$PYTHONPATH"
+      wrapProgram $i --prefix NIX_PYTHONPATH : "$NIX_PYTHONPATH"
     done
 
     # Let's make it a namespace package
@@ -137,7 +137,7 @@ in buildPythonPackage rec {
 
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -135,6 +135,12 @@ in buildPythonPackage rec {
     ${python.interpreter} -c "${imports}"
   '';
 
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
+
   doCheck = true;
 
   enableParallelBuilding = true;

--- a/pkgs/development/python-modules/pytz/default.nix
+++ b/pkgs/development/python-modules/pytz/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/pytz/default.nix
+++ b/pkgs/development/python-modules/pytz/default.nix
@@ -12,6 +12,11 @@ buildPythonPackage rec {
   checkPhase = ''
     ${python.interpreter} -m unittest discover -s pytz/tests
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = with lib; {
     description = "World timezone definitions, modern and historical";

--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   };
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, buildPythonPackage
+{ stdenv, fetchPypi, buildPythonPackage, python
 , urllib3, idna, chardet, certifi
 , pytest }:
 
@@ -9,6 +9,11 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4";
+  };
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
   };
 
   nativeBuildInputs = [ pytest ];

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -55,6 +55,11 @@ in buildPythonPackage rec {
   preBuild = lib.strings.optionalString (!stdenv.hostPlatform.isWindows) ''
     export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   pipInstallFlags = [ "--ignore-installed" ];
 

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -57,7 +57,7 @@ in buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/simplejson/default.nix
+++ b/pkgs/development/python-modules/simplejson/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/simplejson/default.nix
+++ b/pkgs/development/python-modules/simplejson/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , stdenv
 , pytest
+, python
 }:
 
 buildPythonPackage rec {
@@ -24,6 +25,11 @@ buildPythonPackage rec {
   checkPhase = ''
     PYTHONWARNINGS="ignore" pytest simplejson/tests
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = {
     description = "A simple, fast, extensible JSON encoder/decoder for Python";

--- a/pkgs/development/python-modules/six/default.nix
+++ b/pkgs/development/python-modules/six/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/six/default.nix
+++ b/pkgs/development/python-modules/six/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
 , pytest
 }:
 
@@ -18,6 +19,11 @@ buildPythonPackage rec {
   checkPhase = ''
     py.test test_six.py
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   # To prevent infinite recursion with pytest
   doCheck = false;

--- a/pkgs/development/python-modules/snowballstemmer/default.nix
+++ b/pkgs/development/python-modules/snowballstemmer/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/snowballstemmer/default.nix
+++ b/pkgs/development/python-modules/snowballstemmer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, PyStemmer, fetchPypi }:
+{ stdenv, python, buildPythonPackage, PyStemmer, fetchPypi }:
 
 buildPythonPackage rec {
   pname = "snowballstemmer";
@@ -11,6 +11,12 @@ buildPythonPackage rec {
 
   # No tests included
   doCheck = false;
+
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   propagatedBuildInputs = [ PyStemmer ];
 

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   LC_ALL = "en_US.UTF-8";
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -39,6 +39,11 @@ buildPythonPackage rec {
     sha256 = "19a28nsb0w4bs6k8rdfyk6vzrcwdpvhs2wq77rgpmww59yvndrz6";
   };
   LC_ALL = "en_US.UTF-8";
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   checkInputs = [ pytest ];
   buildInputs = [ simplejson mock glibcLocales html5lib ] ++ lib.optional (pythonOlder "3.4") enum34;

--- a/pkgs/development/python-modules/tkinter/default.nix
+++ b/pkgs/development/python-modules/tkinter/default.nix
@@ -23,6 +23,11 @@ buildPythonPackage {
     new_rpath=$(sed "s#${py}#${python}#g" <<< "$old_rpath" )
     patchelf --set-rpath $new_rpath $out/${py.sitePackages}/_tkinter*
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${py.sitePackages}";
+    };
+  };
 
   meta = py.meta;
 

--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -37,6 +37,11 @@ buildPythonPackage rec {
   checkPhase = ''
     ${python.interpreter} -m unittest discover *_test.py
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   src = fetchPypi {
     inherit pname sha256 version;

--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , pytest, mock, tornado, pyopenssl, cryptography
 , idna, certifi, ipaddress, pysocks }:
 
@@ -9,6 +9,11 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc";
+  };
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
   };
 
   NOSE_EXCLUDE = stdenv.lib.concatStringsSep "," [

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   };
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/whoosh/default.nix
+++ b/pkgs/development/python-modules/whoosh/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   '';
   passthru = {
     propagateEnv = {
-      PYTHONPATH = "@out@/${python.sitePackages}";
+      NIX_PYTHONPATH = "@out@/${python.sitePackages}";
     };
   };
 

--- a/pkgs/development/python-modules/whoosh/default.nix
+++ b/pkgs/development/python-modules/whoosh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest, python }:
 
 buildPythonPackage rec {
   pname = "Whoosh";
@@ -19,6 +19,11 @@ buildPythonPackage rec {
     # FIXME: test_minimize_dfa fails on python 3.6
     py.test -k "not test_timelimit and not test_minimize_dfa"
   '';
+  passthru = {
+    propagateEnv = {
+      PYTHONPATH = "@out@/${python.sitePackages}";
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "Fast, pure-Python full text indexing, search, and spell

--- a/pkgs/tools/X11/arandr/default.nix
+++ b/pkgs/tools/X11/arandr/default.nix
@@ -23,6 +23,8 @@ in buildPythonApplication rec {
   # no tests
   doCheck = false;
 
+  dontWrapPythonPrograms = (wrapGAppsHook == null);
+
   # hook for gobject-introspection doesn't like strictDeps
   # https://github.com/NixOS/nixpkgs/issues/56943
   strictDeps = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21223,9 +21223,6 @@ in
       qt5 = qt5 // {
         wrapQtAppsHook = null;
       };
-    }).overrideAttrs(oldAttrs: {
-      preFixup = "";
-      dontWrapPythonPrograms = true;
     })
   ) { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21194,9 +21194,9 @@ in
 
   pianobooster = qt5.callPackage ../applications/audio/pianobooster { };
 
-  picard = callPackage ../applications/audio/picard { };
+  picard-oldy-wrapped = callPackage ../applications/audio/picard { };
 
-  picard-newly-unwrapped = (picard.override {
+  picard-newly-unwrapped = (picard-oldy-wrapped.override {
     qt5 = qt5 // {
       wrapQtAppsHook = null;
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -667,7 +667,7 @@ in
     }) {
       wrapOut = {
         XDG_DATA_DIRS = "$out/share";
-        PYTHONPATH = "$out/${python3.sitePackages}";
+        NIX_PYTHONPATH = "$out/${python3.sitePackages}";
       };
     }
   ;
@@ -21233,7 +21233,7 @@ in
     }) {
       wrapOut = {
         XDG_DATA_DIRS = "$out/share";
-        PYTHONPATH = "$out/${python3.sitePackages}";
+        NIX_PYTHONPATH = "$out/${python3.sitePackages}";
       };
     }
   ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -661,9 +661,16 @@ in
 
   arandr-oldy-wrapped = callPackage ../tools/X11/arandr { };
 
-  arandr-newly-wrapped = wrapGApps (arandr-oldy-wrapped.override {
-    wrapGAppsHook = null;
-  }) { };
+  arandr-newly-wrapped = wrapGApps (
+    arandr-oldy-wrapped.override {
+      wrapGAppsHook = null;
+    }) {
+      wrapOut = {
+        XDG_DATA_DIRS = "$out/share";
+        PYTHONPATH = "$out/${python3.sitePackages}";
+      };
+    }
+  ;
 
   inherit (callPackages ../servers/nosql/arangodb {
     stdenv = gcc8Stdenv;
@@ -21219,12 +21226,17 @@ in
   picard-oldy-wrapped = callPackage ../applications/audio/picard { };
 
   picard-newly-wrapped = wrapGeneric (
-    (picard-oldy-wrapped.override {
+    picard-oldy-wrapped.override {
       qt5 = qt5 // {
         wrapQtAppsHook = null;
       };
-    })
-  ) { };
+    }) {
+      wrapOut = {
+        XDG_DATA_DIRS = "$out/share";
+        PYTHONPATH = "$out/${python3.sitePackages}";
+      };
+    }
+  ;
 
   picocom = callPackage ../tools/misc/picocom {
     inherit (darwin.apple_sdk.frameworks) IOKit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -659,10 +659,11 @@ in
 
   archivemount = callPackage ../tools/filesystems/archivemount { };
 
-  arandr = callPackage ../tools/X11/arandr { };
+  arandr-oldy-wrapped = callPackage ../tools/X11/arandr { };
 
-  arandr-newly-unwrapped = arandr.override { wrapGAppsHook = null; };
-  arandr-newly-wrapped = wrapGApps arandr-newly-unwrapped { };
+  arandr-newly-wrapped = wrapGApps (arandr-oldy-wrapped.override {
+    wrapGAppsHook = null;
+  }) { };
 
   inherit (callPackages ../servers/nosql/arangodb {
     stdenv = gcc8Stdenv;
@@ -22286,7 +22287,7 @@ in
 
   wrapNeovim = callPackage ../applications/editors/neovim/wrapper.nix { };
 
-  wrapGeneric = callPackage ../build-support/neowrap.nix {};
+  wrapGeneric = callPackage ../build-support/neowrap.nix { lndir = xorg.lndir; };
   wrapGApps = wrapGeneric.override {
     extraPkgsByOverride = [
       dconf

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21197,14 +21197,15 @@ in
 
   picard-oldy-wrapped = callPackage ../applications/audio/picard { };
 
-  picard-newly-unwrapped = (picard-oldy-wrapped.override {
+  picard-newly-wrapped = wrapGeneric (
+    (picard-oldy-wrapped.override {
     qt5 = qt5 // {
       wrapQtAppsHook = null;
     };
-  }).overrideAttrs(oldAttrs: {
-    preFixup = "";
-  });
-  picard-newly-wrapped = wrapGeneric picard-newly-unwrapped {};
+    }).overrideAttrs(oldAttrs: {
+      preFixup = "";
+    })
+  ) { };
 
   picocom = callPackage ../tools/misc/picocom {
     inherit (darwin.apple_sdk.frameworks) IOKit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21195,15 +21195,37 @@ in
 
   pianobooster = qt5.callPackage ../applications/audio/pianobooster { };
 
+  test-new-py-env = wrapGeneric python3 {
+    linkByEnv = {
+      PYTHONPATH = "linkPkg";
+    };
+    extraPkgs = with python3.pkgs; [
+      # Not how when you use matplot with and without qt, the environment
+      # calculated in `result/bin/python` has QT_PLUGIN_PATH and other env
+      # vars.
+
+      # matplotlib
+      (matplotlib.override {
+        enableQt = true;
+      })
+    ];
+  };
+  test-old-py-env = python3.withPackages(ps: with ps; [
+    (matplotlib.override {
+      enableQt = true;
+    })
+  ]);
+
   picard-oldy-wrapped = callPackage ../applications/audio/picard { };
 
   picard-newly-wrapped = wrapGeneric (
     (picard-oldy-wrapped.override {
-    qt5 = qt5 // {
-      wrapQtAppsHook = null;
-    };
+      qt5 = qt5 // {
+        wrapQtAppsHook = null;
+      };
     }).overrideAttrs(oldAttrs: {
       preFixup = "";
+      dontWrapPythonPrograms = true;
     })
   ) { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21207,7 +21207,7 @@ in
       PYTHONPATH = "linkPkg";
     };
     extraPkgs = with python3.pkgs; [
-      # Not how when you use matplot with and without qt, the environment
+      # Note how when you use matplot with and without qt, the environment
       # calculated in `result/bin/python` has QT_PLUGIN_PATH and other env
       # vars.
 
@@ -21234,6 +21234,9 @@ in
       wrapOut = {
         XDG_DATA_DIRS = "$out/share";
         NIX_PYTHONPATH = "$out/${python3.sitePackages}";
+      };
+      linkByEnv = {
+        NIX_PYTHONPATH = "linkPkg";
       };
     }
   ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19751,7 +19751,7 @@ in
 
   gvisor-containerd-shim = callPackage ../applications/virtualization/gvisor/containerd-shim.nix { };
 
-  guvcview = callPackage ../os-specific/linux/guvcview { };
+  guvcview = wrapGApps (callPackage ../os-specific/linux/guvcview { }) {  };
 
   gxmessage = callPackage ../applications/misc/gxmessage { };
 
@@ -21195,6 +21195,15 @@ in
   pianobooster = qt5.callPackage ../applications/audio/pianobooster { };
 
   picard = callPackage ../applications/audio/picard { };
+
+  picard-newly-unwrapped = (picard.override {
+    qt5 = qt5 // {
+      wrapQtAppsHook = null;
+    };
+  }).overrideAttrs(oldAttrs: {
+    preFixup = "";
+  });
+  picard-newly-wrapped = wrapGeneric picard-newly-unwrapped {};
 
   picocom = callPackage ../tools/misc/picocom {
     inherit (darwin.apple_sdk.frameworks) IOKit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -147,6 +147,10 @@ in
 
   buildFHSUserEnv = callPackage ../build-support/build-fhs-userenv { };
 
+  wrapWithRuntimeDeps = callPackage ../build-support/neowrap.nix { }; # not actually a package
+
+  somthing-else = wrapWithRuntimeDeps mutt { };
+
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
   castget = callPackage ../applications/networking/feedreaders/castget { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22282,7 +22282,7 @@ in
     extraPkgsByOverride = [
       dconf
       librsvg
-      pango
+      gdk-pixbuf
       atk
     ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -662,7 +662,7 @@ in
   arandr = callPackage ../tools/X11/arandr { };
 
   arandr-newly-unwrapped = arandr.override { wrapGAppsHook = null; };
-  arandr-newly-wrapped = wrapGeneric [ arandr-newly-unwrapped ] { };
+  arandr-newly-wrapped = wrapGApps arandr-newly-unwrapped { };
 
   inherit (callPackages ../servers/nosql/arangodb {
     stdenv = gcc8Stdenv;
@@ -22277,7 +22277,15 @@ in
 
   wrapNeovim = callPackage ../applications/editors/neovim/wrapper.nix { };
 
-  wrapGeneric = callPackage ../build-support/neowrap.nix { }; # not actually a package
+  wrapGeneric = callPackage ../build-support/neowrap.nix {};
+  wrapGApps = wrapGeneric.override {
+    extraPkgsByOverride = [
+      dconf
+      librsvg
+      pango
+      atk
+    ];
+  };
 
   neovim-unwrapped = callPackage ../applications/editors/neovim {
     lua =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -147,10 +147,6 @@ in
 
   buildFHSUserEnv = callPackage ../build-support/build-fhs-userenv { };
 
-  wrapWithRuntimeDeps = callPackage ../build-support/neowrap.nix { }; # not actually a package
-
-  somthing-else = wrapWithRuntimeDeps mutt { };
-
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
   castget = callPackage ../applications/networking/feedreaders/castget { };
@@ -664,6 +660,9 @@ in
   archivemount = callPackage ../tools/filesystems/archivemount { };
 
   arandr = callPackage ../tools/X11/arandr { };
+
+  arandr-newly-unwrapped = arandr.override { wrapGAppsHook = null; };
+  arandr-newly-wrapped = wrapWithEnv [ arandr-newly-unwrapped ] { };
 
   inherit (callPackages ../servers/nosql/arangodb {
     stdenv = gcc8Stdenv;
@@ -22277,6 +22276,8 @@ in
   vimpc = callPackage ../applications/audio/vimpc { };
 
   wrapNeovim = callPackage ../applications/editors/neovim/wrapper.nix { };
+
+  wrapWithEnv = callPackage ../build-support/neowrap.nix { }; # not actually a package
 
   neovim-unwrapped = callPackage ../applications/editors/neovim {
     lua =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -662,7 +662,7 @@ in
   arandr = callPackage ../tools/X11/arandr { };
 
   arandr-newly-unwrapped = arandr.override { wrapGAppsHook = null; };
-  arandr-newly-wrapped = wrapWithEnv [ arandr-newly-unwrapped ] { };
+  arandr-newly-wrapped = wrapGeneric [ arandr-newly-unwrapped ] { };
 
   inherit (callPackages ../servers/nosql/arangodb {
     stdenv = gcc8Stdenv;
@@ -22277,7 +22277,7 @@ in
 
   wrapNeovim = callPackage ../applications/editors/neovim/wrapper.nix { };
 
-  wrapWithEnv = callPackage ../build-support/neowrap.nix { }; # not actually a package
+  wrapGeneric = callPackage ../build-support/neowrap.nix { }; # not actually a package
 
   neovim-unwrapped = callPackage ../applications/editors/neovim {
     lua =


### PR DESCRIPTION
###### Motivation for this change

Create a new wrapper to rule them all! :smiling_imp:

Now Seriously: This has been talked over since like for ever and now I'd like to present to you a Pure Nix function that creates a wrapper environment for any derivation you'll give it, using `symlinkJoin`. It does so by recursively searching for a derivation's inputs' for derivations with an attribute such as:

```nix
  passthru = {
    propagateEnv = {
      GST_PLUGIN_SYSTEM_PATH_1_0 = "%out%/lib/gstreamer-1.0";
    };
  };
```

This recursive search means, that you don't have to take care of orchestrating `wrapGAppsHook` and `wrapQtAppsHook` or others with stuff like this:

```nix
  preFixup = ''
    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
  ''
```

I tested in this new function in wrapping [picard](https://github.com/NixOS/nixpkgs/blob/e3510bc553d86efd75d708f25702ddc8694c9dc4/pkgs/applications/audio/picard/default.nix), [gucview](https://github.com/NixOS/nixpkgs/blob/e3510bc553d86efd75d708f25702ddc8694c9dc4/pkgs/os-specific/linux/guvcview/default.nix) (which is currently not wrapped but there's an open PR that wraps it the old way https://github.com/NixOS/nixpkgs/pull/84449) and [arandr](https://github.com/NixOS/nixpkgs/blob/6283f15bb9b65af64571a78b039115807dcc2958/pkgs/tools/X11/arandr/default.nix). 

Here's an example of the environments (new lines inserted to help readability) created for guvcview with the old way and the new way:

#### OLD

```sh
GIO_EXTRA_MODULES=
'/nix/store/z7gzw2bb3ypvf1wq1fjjn5r45idfgg0g-dconf-0.34.0-lib/lib/gio/modules'${GIO_EXTRA_MODULES:+':'}$GIO_EXTRA_MODULES
GIO_EXTRA_MODULES=
'/nix/store/z7gzw2bb3ypvf1wq1fjjn5r45idfgg0g-dconf-0.34.0-lib/lib/gio/modules'${GIO_EXTRA_MODULES:+':'}$GIO_EXTRA_MODULES
GDK_PIXBUF_MODULE_FILE=
'/nix/store/18l8ly5235r94s2rr122i3cfichccxqn-librsvg-2.46.4/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache'
XDG_DATA_DIRS=
'/nix/store/nwksqszw0dakmizrrlql9pamcf39vnxg-gtk+3-3.24.14/share/gsettings-schemas/gtk+3-3.24.14
/nix/store/slmsmbyfgf1rqj9rp6s1y33cqaz8q203-gsettings-desktop-schemas-3.34.0/share/gsettings-schemas/gsettings-desktop-schemas-3.34.0
/nix/store/nwksqszw0dakmizrrlql9pamcf39vnxg-gtk+3-3.24.14/share/gsettings-schemas/gtk+3-3.24.14
/nix/store/slmsmbyfgf1rqj9rp6s1y33cqaz8q203-gsettings-desktop-schemas-3.34.0/share/gsettings-schemas/gsettings-desktop-schemas-3.34.0'${XDG_DATA_DIRS
+'
'}$XDG_DATA_DIRS
XDG_DATA_DIRS=
'/nix/store/92p57svcsqgwa5fgb8z9qg7m7r66nx7a-guvcview-2.0.6/share'${XDG_DATA_DIRS:+':'}$XDG_DATA_DIRS
```

#### NEW

```sh
GDK_PIXBUF_MODULE_FILE=
${GDK_PIXBUF_MODULE_FILE-'/nix/store/a7dwk7qamr2j7220rsfvn8w386b8a3lc-librsvg-2.48.0/lib/gdk-pixbuf-2.0/2.10.0
loaders.cache'}
GIO_EXTRA_MODULES=
'/nix/store/0byixyx6l833y9a7ah8ygbh4d4nfgcin-dconf-0.36.0-lib/lib/gio/modules'${GIO_EXTRA_MODULES:+':'}$GIO_EXTRA_MODULES
GI_TYPELIB_PATH='/nix/store/2chzii7gwmlcii9x73l0v3bl7lf2awvb-gtk+3-3.24.14/lib/girepository-1.0
/nix/store/ly22x5s6v91i840xkkj82dhblkfgl79v-atk-2.35.1/lib/girepository-1.0
/nix/store/kah2hha1zcbv0xvyq7fdx26gxd03002x-gdk-pixbuf-2.40.0/lib/girepository-1.0
/nix/store/xjg7kpw38mfaab2fsarll2d39nk06ha5-gsettings-desktop-schemas-3.36.0/lib/girepository-1.0
/nix/store/r4vrzisk85nfkmmafvvi348czb8l4p86-gobject-introspection-1.64.0/lib/girepository-1.0
/nix/store/y9sn0hll1m90zdi8bwa5126lmdkdp8i9-pango-1.44.7/lib/girepository-1.0
/nix/store/a7dwk7qamr2j7220rsfvn8w386b8a3lc-librsvg-2.48.0/lib/girepository-1.0
/nix/store/kah2hha1zcbv0xvyq7fdx26gxd03002x-gdk-pixbuf-2.40.0/lib/girepository-1.0
/nix/store/ly22x5s6v91i840xkkj82dhblkfgl79v-atk-2.35.1/lib/girepository-1.0
'${GI_TYPELIB_PATH:+':'}$GI_TYPELIB_PATH
XDG_DATA_DIRS=
'/nix/store/2chzii7gwmlcii9x73l0v3bl7lf2awvb-gtk+3-3.24.14/share/gsettings-schemas/gtk+3-3.24.14
/nix/store/xjg7kpw38mfaab2fsarll2d39nk06ha5-gsettings-desktop-schemas-3.36.0/share/gsettings-schemas/gsettings-desktop-schemas-3.36.0
/nix/store/y2fj89hq03nxdpc7bv7k9dpbc3f082ah-runtime-env/share
'${XDG_DATA_DIRS:+':'}$XDG_DATA_DIRS
```

As you can see, there are duplicates entries in the old wrapper which increases the chances of hitting obsurd issues such as what https://github.com/NixOS/nixpkgs/pull/84689 fixed.

## What ~~didn't~~ works?

(EDIT) Everything I tested.

## How would a user override a derivation wrapped this way?

Say `all-packages.nix` has:

```nix
  my-awesome-pkg = wrapGeneric (callPackage ../applications/my-awesome-pkg { }) { };
```

Assuming the user knows `my-awesome-pkg` is wrapped with `wrapGeneric`, he would need to use an overlay like this:

```nix
self: super:

{
  my-awesome-pkg = super.wrapGeneric (
    super.my-awesome-pkg.unwrapped.overrideAttrs(oldAttrs: {
      preFixup = ''
        overriding preFixup from an overlay!!
      '';
    })
  ) {};
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
