### PR TITLE
ptags: init at 0.3.2

### DIFF
--- a/pkgs/development/tools/misc/ptags/default.nix
+++ b/pkgs/development/tools/misc/ptags/default.nix
@@ -1,0 +1,32 @@
+{ fetchFromGitHub
+, cargo
+, lib
+, rustPlatform
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ptags";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "dalance";
+    repo = "ptags";
+    rev = "v${version}";
+    sha256 = "1xr1szh4dfrcmi6s6dj791k1ix2zbv75rqkqbyb1lmh5548kywkg";
+  };
+
+  cargoSha256 = "1rsnb4kzfb577xw7jk0939n42sv94vvspvbz783bmpy9vl53i38k";
+
+  # Sanity check.
+  checkPhase = ''
+    $releaseDir/ptags --help > /dev/null
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A parallel universal-ctags wrapper for git repository";
+    homepage = "https://github.com/dalance/ptags";
+    maintainers = with maintainers; [ pamplemousse ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -185,6 +185,8 @@ in
 
   protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};
 
+  ptags = callPackage ../development/tools/misc/ptags { };
+
   demoit = callPackage ../servers/demoit { };
 
   deviceTree = callPackage ../os-specific/linux/device-tree {};


### PR DESCRIPTION
###### Motivation for this change

Make [ptags](https://github.com/dalance/ptags/) available via nix.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
