### PR TITLE
linux: Enable `CONFIG_NET_DROP_MONITOR` by default

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -178,6 +178,10 @@ let
       NF_TABLES_BRIDGE            = mkMerge [ (whenBetween "4.19" "5.3" yes)
                                               (whenAtLeast "5.3" module) ];
 
+      # needed for `dropwatch`
+      # Builtin-only since https://github.com/torvalds/linux/commit/f4b6bcc7002f0e3a3428bac33cf1945abff95450
+      NET_DROP_MONITOR = yes;
+
       # needed for ss
       INET_DIAG         = yes;
       INET_TCP_DIAG     = module;


### PR DESCRIPTION
###### Motivation for this change

Needed for subscribing to dropped packets (e.g. via `dropwatch`).

On by default in:

* Ubuntu since 2017: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1660634
* OpenSUSE since 2015: https://lists.opensuse.org/opensuse-kernel/2015-07/msg00040.html
* Fedora as claimed by https://lists.debian.org/debian-kernel/2010/04/msg01031.html
* Arch since before anybody even conceived the great-grandparents of the person who came up with the idea ;-) ([kernel config](https://git.archlinux.org/svntogit/packages.git/tree/trunk/config?h=packages/linux&id=08a7fa88eaa91ef8b0e1f71b496d4097c3702e8d#n1784))

Requested for:

* Debian (but no reply): https://lists.debian.org/debian-kernel/2010/04/msg01031.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - tested on 20.03
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
