### PR TITLE
iodine: improve test in view of #58806

### DIFF
--- a/nixos/tests/iodine.nix
+++ b/nixos/tests/iodine.nix
@@ -1,6 +1,7 @@
 import ./make-test-python.nix (
   { pkgs, ... }: let
     domain = "whatever.example.com";
+    password = "false;foo;exit;withspecialcharacters";
   in
     {
       name = "iodine";
@@ -21,7 +22,7 @@ import ./make-test-python.nix (
               services.iodine.server = {
                 enable = true;
                 ip = "10.53.53.1/24";
-                passwordFile = "${builtins.toFile "password" "foo"}";
+                passwordFile = "${builtins.toFile "password" password}";
                 inherit domain;
               };
 
@@ -41,7 +42,7 @@ import ./make-test-python.nix (
               server = domain;
             };
             systemd.tmpfiles.rules = [
-              "f /root/pw 0666 root root - foo"
+              "f /root/pw 0666 root root - ${password}"
             ];
             environment.systemPackages = [
               pkgs.nagiosPluginsOfficial


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Some time ago, our iodine package did not support shell metacharacters in passwords. This was fixed in #58806. This pull requests improves the iodine test we have to ensure that metacharacters actually are supported.

I was not actually able to test the new test as I'm lacking machines with KVM support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
