### PR TITLE
pypandoc: unstable-2018-06-18 -> 1.5

### DIFF
--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -3,21 +3,21 @@
 
 buildPythonPackage rec {
   pname = "pypandoc";
-  version = "unstable-2018-06-18";
+  version = "1.5";
 
   src = fetchFromGitHub {
     owner = "bebraw";
     repo = pname;
-    rev = "87912f0f17e0a71c1160008df708c876d32e5819";
-    sha256 = "0l6knkxxhmni4lx8hyvbb71svnhza08ivyklqlk5fw637gznc0hx";
+    rev = version;
+    sha256 = "1lpslfns6zxx7b0xr13bzg921lwrj5am8za0b2dviywk6iiib0ld";
   };
 
   postPatch = ''
     # set pandoc path statically
     sed -i '/^__pandoc_path = None$/c__pandoc_path = "${pandoc}/bin/pandoc"' pypandoc/__init__.py
 
-    # Fix tests: requires network access
-    substituteInPlace tests.py --replace "pypandoc.convert(url, 'html')" "'GPL2 license'"
+    # Skip test that requires network access
+    sed -i '/test_basic_conversion_from_http_url/i\\    @unittest.skip\("no network access during checkPhase"\)' tests.py
   '';
 
   preCheck = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to latest release of `pypandoc` which finally also contains the bug fixes we switched to unstable for.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @bennofs 