### PR TITLE
ocamlPackages.ctypes: 0.17.1 → 0.16.0

### DIFF
--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -6,11 +6,11 @@ else
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-ctypes-${version}";
-  version = "0.17.1";
+  version = "0.16.0";
 
   src = fetchzip {
     url = "https://github.com/ocamllabs/ocaml-ctypes/archive/${version}.tar.gz";
-    sha256 = "16brmdnz7wi2z25qqhd5s5blyq4app6jbv6g9pa4vyg6h0nzbcys";
+    sha256 = "0qh2gfx5682wkk2nm1ybspzz9c2xvlnnf6iv08a89kbwa1hvdqrg";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Fix `owl` (broken by #84876).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
