### PR TITLE
_3mux: init at 0.2.0

### DIFF
--- a/pkgs/tools/misc/3mux/default.nix
+++ b/pkgs/tools/misc/3mux/default.nix
@@ -1,22 +1,24 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "3mux";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "aaronjanse";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1iz839w636vv7208wyrmb9r77wv9m0q1j8km06kmi87m0hcbh807";
+    sha256 = "02ry066psvlqdyhimci7nskw4sfb70dw5z7ag7s7rz36gmx1vnmr";
   };
 
-  modSha256 = "10lnzh22qzls1b4i9dbknbxw5v92bcs7sarqipvvk5fymadr3k2p";
+  modSha256 = "1ag9lx8xcp2z9lrg404914zin45n8f4s08365yk71q5vyiwxjj3i";
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Terminal multiplexer inspired by i3";
     homepage = "https://github.com/aaronjanse/3mux";
     license = licenses.mit;
     maintainers = with maintainers; [ aaronjanse filalex77 ];
+    # TODO: fix modules build on darwin
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/tools/misc/3mux/default.nix
+++ b/pkgs/tools/misc/3mux/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "3mux";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "aaronjanse";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1iz839w636vv7208wyrmb9r77wv9m0q1j8km06kmi87m0hcbh807";
+  };
+
+  modSha256 = "10lnzh22qzls1b4i9dbknbxw5v92bcs7sarqipvvk5fymadr3k2p";
+
+  meta = with lib; {
+    description = "Terminal multiplexer inspired by i3";
+    homepage = "https://github.com/aaronjanse/3mux";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aaronjanse filalex77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -504,6 +504,8 @@ in
 
   _3llo = callPackage ../tools/misc/3llo { };
 
+  _3mux = callPackage ../tools/misc/3mux { };
+
   _1password = callPackage ../applications/misc/1password { };
 
   _6tunnel = callPackage ../tools/networking/6tunnel { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/aaronjanse/3mux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
