### PR TITLE
ocamlPackages: jackline: switch to mirage-crypto and update dependencies

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -1,22 +1,23 @@
 { stdenv, fetchFromGitHub, ocamlPackages }:
 
-assert stdenv.lib.versionAtLeast ocamlPackages.ocaml.version "4.02.2";
+assert stdenv.lib.versionAtLeast ocamlPackages.ocaml.version "4.07";
 
 stdenv.mkDerivation {
   pname = "jackline";
-  version = "2019-08-08";
+  version = "unstable-2020-03-22";
 
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "jackline";
-    rev    = "b934594010a563ded9c0f436e3fab8f1cae29856";
-    sha256 = "076h03jd970xlii90ax6kvgyq67g81gs30yvdzps366n7zzy3yfc";
+    rev    = "52f84525c74c43e8d03fb1e6ff025ccb2699e4aa";
+    sha256 = "0wir573ah1w16xzdn9rfwk3569zq4ff5frp0ywq70va4gdlb679c";
   };
 
   buildInputs = with ocamlPackages; [
-                  ocaml ocamlbuild findlib topkg ppx_sexp_conv
-                  erm_xmpp tls nocrypto x509 ocaml_lwt otr astring
-                  ptime notty sexplib hex uutf
+                  ocaml ocamlbuild findlib topkg ppx_sexp_conv ppx_deriving
+                  erm_xmpp tls mirage-crypto mirage-crypto-pk x509 domain-name
+                  ocaml_lwt otr astring ptime mtime notty sexplib hex uutf
+                  dns-client base64
                 ];
 
   buildPhase = "${ocamlPackages.topkg.run} build --pinned true";
@@ -25,7 +26,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/hannesm/jackline";
-    description = "Terminal-based XMPP client in OCaml";
+    description = "minimalistic secure XMPP client in OCaml";
     license = licenses.bsd2;
     maintainers = with maintainers; [ sternenseemann ];
   };

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -10,6 +10,5 @@ buildDunePackage {
 
 	minimumOCamlVersion = "4.03";
 
-	buildInputs = [ sexplib ppx_tools_versioned ];
-	propagatedBuildInputs = [ cstruct ];
+	propagatedBuildInputs = [ cstruct ppx_tools_versioned sexplib ];
 }

--- a/pkgs/development/ocaml-modules/otr/default.nix
+++ b/pkgs/development/ocaml-modules/otr/default.nix
@@ -1,21 +1,25 @@
-{ lib, fetchFromGitHub, buildDunePackage
-, cstruct, sexplib0, rresult, nocrypto, astring
+{ lib, fetchurl, buildDunePackage
+, cstruct, sexplib0, rresult, mirage-crypto, mirage-crypto-pk, astring, base64
+, mirage-crypto-rng
 }:
 
 buildDunePackage rec {
   pname = "otr";
-  version = "0.3.6";
+  version = "0.3.8";
 
-  src = fetchFromGitHub {
-    owner  = "hannesm";
-    repo   = "ocaml-otr";
-    rev    = version;
-    sha256 = "0iz6p85a0jxng9aq9blqsky173zaqfr6wlc5j48ad55lgwzlbih5";
+  src = fetchurl {
+    url = "https://github.com/hannesm/ocaml-otr/releases/download/v${version}/otr-v${version}.tbz";
+    sha256 = "18hn9l8wznqnlh2jf1hpnp36f1cx80ncwiiivsbj34llhgp3893d";
   };
 
-  propagatedBuildInputs = [ cstruct sexplib0 rresult nocrypto astring ];
+  useDune2 = true;
+
+  propagatedBuildInputs = [ cstruct sexplib0 mirage-crypto mirage-crypto-pk
+                            astring rresult base64 ];
 
   doCheck = true;
+  checkInputs = [ mirage-crypto-rng ];
+
   meta = with lib; {
     homepage = "https://github.com/hannesm/ocaml-otr";
     description = "Off-the-record messaging protocol, purely in OCaml";

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -1,38 +1,26 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, topkg
-, ppx_sexp_conv, result, x509, nocrypto, cstruct-sexp, ppx_cstruct, cstruct-unix, ounit
-, lwt     ? null}:
+{ stdenv, fetchurl, buildDunePackage, ppx_sexp_conv, ppx_cstruct, cstruct
+, cstruct-sexp, sexplib, mirage-crypto, mirage-crypto-pk, mirage-crypto-rng
+, x509, domain-name, fmt, cstruct-unix, ounit2, ocaml_lwt, ptime }:
 
-with stdenv.lib;
+buildDunePackage rec {
+  minimumOCamlVersion = "4.07";
 
-let withLwt = lwt != null; in
+  version = "0.11.1";
+  pname = "tls";
 
-if !versionAtLeast ocaml.version "4.04"
-then throw "tls is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  version = "0.10.4";
-  name = "ocaml${ocaml.version}-tls-${version}";
-
-  src = fetchFromGitHub {
-    owner  = "mirleft";
-    repo   = "ocaml-tls";
-    rev    = version;
-    sha256 = "02wv4lia583imn3sfci4nqv6ac5nzig5j3yfdnlqa0q8bp9rfc6g";
+  src = fetchurl {
+    url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-v${version}.tbz";
+    sha256 = "0ms13fbaxgmpbviazlfa4hb7nmi7s22nklc7ns926b0rr1aq1069";
   };
 
-  nativeBuildInputs = [ ocaml ocamlbuild findlib ];
-  buildInputs = [ findlib topkg ppx_sexp_conv ppx_cstruct ]
-  ++ optionals doCheck [ ounit cstruct-unix ];
-  propagatedBuildInputs = [ cstruct-sexp nocrypto result x509 ] ++
-                          optional withLwt lwt;
+  useDune2 = true;
 
-  buildPhase = "${topkg.run} build --tests ${boolToString doCheck} --with-mirage false --with-lwt ${boolToString withLwt}";
+  doCheck = true;
+  buildInputs = [ cstruct-unix ounit2 ];
 
-  doCheck = versionAtLeast ocaml.version "4.06";
-  checkPhase = "${topkg.run} test";
-
-  inherit (topkg) installPhase;
+  propagatedBuildInputs = [ ppx_sexp_conv ppx_cstruct cstruct cstruct-sexp
+                            sexplib mirage-crypto mirage-crypto-pk mirage-crypto-rng
+                            x509 domain-name fmt ocaml_lwt ptime ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mirleft/ocaml-tls";

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -1,21 +1,26 @@
-{ lib, fetchurl, buildDunePackage, ocaml
+{ lib, fetchurl, buildDunePackage
 , alcotest, cstruct-unix
-, asn1-combinators, domain-name, fmt, gmap, nocrypto, rresult
+, asn1-combinators, domain-name, fmt, gmap, rresult, mirage-crypto, mirage-crypto-pk
+, logs, base64
 }:
 
 buildDunePackage rec {
+  minimumOCamlVersion = "4.07";
+
   pname = "x509";
-  version = "0.7.1";
+  version = "0.11.0";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-x509/releases/download/v${version}/x509-v${version}.tbz";
-    sha256 = "0hnklgdm1fwwqi0nfvpdbp7ddqvrh9h8697mr99bxqdfhg6sxh1w";
+    sha256 = "0gcs3vpmixxxx2q4b2iphb1xw1jffya1wkp0p1xbmsfcghzrj20m";
   };
 
-  buildInputs = lib.optionals doCheck [ alcotest cstruct-unix ];
-  propagatedBuildInputs = [ asn1-combinators domain-name fmt gmap nocrypto rresult ];
+  useDune2 = true;
 
-  doCheck = lib.versionAtLeast ocaml.version "4.06";
+  buildInputs = [ alcotest cstruct-unix ];
+  propagatedBuildInputs = [ asn1-combinators domain-name fmt gmap mirage-crypto mirage-crypto-pk rresult  logs base64 ];
+
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/mirleft/ocaml-x509";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -765,9 +765,7 @@ let
 
     textutils_p4 = callPackage ../development/ocaml-modules/textutils { };
 
-    tls = callPackage ../development/ocaml-modules/tls {
-      lwt = ocaml_lwt;
-    };
+    tls = callPackage ../development/ocaml-modules/tls { };
 
     type_conv_108_08_00 = callPackage ../development/ocaml-modules/type_conv/108.08.00.nix { };
     type_conv_109_60_01 = callPackage ../development/ocaml-modules/type_conv/109.60.01.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Jackline and a few of the packages it depends on recently switched to mirage-crypto (a fork of nocrypto integrated with RNG code and using dune), so I figured I add the packages and update the packages that switched. This also lead to quite a long list of packages that had to be added.

For the mirage packages I mostly left out the subpackages that were intended for usage in Xen Unikernel, because we haven't yet packaged the related packages for `ocamlPackages` yet (i. e. mirage-runtime …). Let me know if I accidentally went something out erroneously.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @vbgl