### PR TITLE
zziplib: 0.13.69 → 0.13.71

### DIFF
--- a/pkgs/development/libraries/zziplib/default.nix
+++ b/pkgs/development/libraries/zziplib/default.nix
@@ -1,47 +1,74 @@
-{ docbook_xml_dtd_412, fetchurl, stdenv, perl, python2, zip, xmlto, zlib, fetchpatch }:
+{ stdenv
+, cmake
+, pkg-config
+, ninja
+, fetchFromGitHub
+, fetchpatch
+, zip
+, unzip
+, python3
+, xmlto
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "zziplib";
-  version = "0.13.69";
+  version = "0.13.71";
 
-  src = fetchurl {
-    url = "https://github.com/gdraheim/zziplib/archive/v${version}.tar.gz";
-    sha256 = "0i052a7shww0fzsxrdp3rd7g4mbzx7324a8ysbc0br7frpblcql4";
+  src = fetchFromGitHub {
+    owner = "gdraheim";
+    repo = "zziplib";
+    rev = "v${version}";
+    sha256 = "P+7D57sc2oIABhk3k96aRILpGnsND5SLXHh2lqr9O4E=";
   };
 
   patches = [
+    # Fix ninja parsing
     (fetchpatch {
-      name = "CVE-2018-17828.patch";
-      url = "https://github.com/gdraheim/zziplib/commit/f609ae8971f3c0ce6.diff";
-      sha256 = "0jhiz4fgr93wzh6q03avn95b2nsf6402jaki6hxirxyhs5v9ahry";
+      url = "https://github.com/gdraheim/zziplib/commit/75e22f3c365b62acbad8d8645d5404242800dfba.patch";
+      sha256 = "IB0am3K0x4+Ug1CKvowTtkS8JD6zHJJ247A7guJOw80=";
     })
 
+    # Install man pages
     (fetchpatch {
-      name = "CVE-2018-16548-part1.patch";
-      url = "https://github.com/gdraheim/zziplib/commit/9411bde3e4a70a81ff3ffd256b71927b2d90dcbb.patch";
-      sha256 = "0cy8i182zbvcqzs5z2j13d5sl7hbh59pkgw4xkyg5yz739q4fp9b";
+      url = "https://github.com/gdraheim/zziplib/commit/5583ccc7a247ee27556ede344e93d3ac1dc72e9b.patch";
+      sha256 = "wVExEZN8Ml1/3GicB0ZYsLVS3KJ8BSz8i4Gu46naz1Y=";
+      excludes = [ "GNUmakefile" ];
     })
+
+    # Fix man page formatting
     (fetchpatch {
-      name = "CVE-2018-16548-part2.patch";
-      url = "https://github.com/gdraheim/zziplib/commit/d2e5d5c53212e54a97ad64b793a4389193fec687.patch";
-      sha256 = "153wd4vab8xqj9avcpx8g2zw9qsp9nkaqi7yc65pz3r7xfcxwdla";
-    })
-    (fetchpatch {
-      name = "CVE-2018-16548-part3.patch";
-      url = "https://github.com/gdraheim/zziplib/commit/0e1dadb05c1473b9df2d7b8f298dab801778ef99.patch";
-      sha256 = "0fs6dns8l7dz5a900397g8b7x62z72b0pbpdmwk1hnx6vb7z5rz5";
+      url = "https://github.com/gdraheim/zziplib/commit/22ed64f13dc239f86664c60496261f544bce1088.patch";
+      sha256 = "ScFVWLc4LQPqkcHn9HK/VkLula4b5HzuYl0b5vi4Ikc=";
     })
   ];
-  postPatch = ''
-    sed -i -e s,--export-dynamic,, configure
-  '';
 
-  buildInputs = [ docbook_xml_dtd_412 perl python2 zip xmlto zlib ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ninja # make fails, unable to find test2.zip
+    zip
+    python3
+    xmlto
+  ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  checkInputs = [
+    unzip
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
+  ];
 
   # tests are broken (https://github.com/gdraheim/zziplib/issues/20),
   # and test/zziptests.py requires network access
   # (https://github.com/gdraheim/zziplib/issues/24)
   doCheck = false;
+  checkTarget = "check";
 
   meta = with stdenv.lib; {
     description = "Library to extract data from files archived in a zip file";
@@ -60,6 +87,6 @@ stdenv.mkDerivation rec {
     homepage = "http://zziplib.sourceforge.net/";
 
     maintainers = [ ];
-    platforms = python2.meta.platforms;
+    platforms = python3.meta.platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Another step in getting rid of Python 2 (continued from https://github.com/NixOS/nixpkgs/pull/76488)

https://github.com/gdraheim/zziplib/releases/tag/v0.13.70
https://github.com/gdraheim/zziplib/releases/tag/v0.13.71

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
