### PR TITLE
bookworm: unstable-2018-11-19 -> 1.1.2

### DIFF
--- a/pkgs/applications/office/bookworm/default.nix
+++ b/pkgs/applications/office/bookworm/default.nix
@@ -1,15 +1,16 @@
 { stdenv, fetchFromGitHub, pantheon, vala, python3, python2, pkgconfig, libxml2, meson, ninja, gtk3, gnome3, glib, webkitgtk, libgee
-, gobject-introspection, sqlite, poppler, poppler_utils, html2text, curl, gnugrep, coreutils, bash, unzip, unar, wrapGAppsHook }:
+, gobject-introspection, sqlite, poppler, poppler_utils, html2text, curl, gnugrep, coreutils, bash, unzip, unar, wrapGAppsHook
+, appstream, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   pname = "bookworm";
-  version = "unstable-2018-11-19";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "babluboy";
     repo = pname;
-    rev = "4c3061784ff42151cac77d12bf2a28bf831fdfc5";
-    sha256 = "0yrqxa60xlvz249kx966z5krx8i7h17ac0hjgq9p8f0irzy5yp0n";
+    rev = version;
+    sha256 = "0w0rlyahpgx0l6inkbj106agbnr2czil0vdcy1zzv70apnjz488j";
   };
 
   nativeBuildInputs = [
@@ -35,6 +36,8 @@ stdenv.mkDerivation rec {
     python2
     sqlite
     webkitgtk
+    appstream
+    desktop-file-utils
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

upgrading the app

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
