### PR TITLE
ferm: 2.5.0 -> 2.5.1

### DIFF
--- a/pkgs/tools/networking/ferm/default.nix
+++ b/pkgs/tools/networking/ferm/default.nix
@@ -3,23 +3,27 @@
 let
   inherit (stdenv.lib.versions) majorMinor;
 in stdenv.mkDerivation rec {
-  version = "2.5";
+  version = "2.5.1";
   pname = "ferm";
 
   src = fetchurl {
     url = "http://ferm.foo-projects.org/download/${majorMinor version}/ferm-${version}.tar.xz";
-    sha256 = "0lxqcpirphihpvdqrh5kq0621aqq0h2vdy9q2v85gqdhd52js20p";
+    sha256 = "0awl9s243sxgayr2fcmfks8xydhrmb9gy8bd9sfq738dgq7vybjb";
   };
 
-  buildInputs = [ perl ipset ebtables iptables makeWrapper ];
-  preConfigure = ''
-    substituteInPlace config.mk --replace "PERL = /usr/bin/perl" "PERL = ${perl}/bin/perl"
-    substituteInPlace config.mk --replace "PREFIX = /usr" "PREFIX = $out"
-  '';
+  # perl is used at build time to gather the ferm version.
+  nativeBuildInputs = [ makeWrapper perl ];
+  buildInputs = [ perl ];
+
+  makeFlags = [
+    "PERL=perl"
+    "PREFIX=${placeholder "out"}"
+  ];
+
   postInstall = ''
     rm -r $out/lib/systemd
     for i in "$out/sbin/"*; do
-      wrapProgram "$i" --prefix PATH : "${iptables}/bin:${ipset}/bin:${ebtables}/bin"
+      wrapProgram "$i" --prefix PATH : "${stdenv.lib.makeBinPath [ iptables ipset ebtables ]}"
     done
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
