### PR TITLE
kodelife: fix non-x86 hashes

### DIFF
--- a/pkgs/applications/graphics/kodelife/default.nix
+++ b/pkgs/applications/graphics/kodelife/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontStrip = true;
   dontPatchELF = true;
+  preferLocalBuild = true;
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/graphics/kodelife/default.nix
+++ b/pkgs/applications/graphics/kodelife/default.nix
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
   src = fetchzip {
     url = "https://hexler.net/pub/${pname}/${pname}-${version}-${suffix}.zip";
     sha256 = {
-      aarch64-linux = "1lcpj1mgkvksq1d08ibh59y0dmdh7zm77wi5ziqhg3p5g9nxyasd";
-      armv7l-linux  = "0sljy06302x567jqw5lagbyhpc3j140jk4wccacxjrbb6hcx3l42";
-      x86_64-darwin = "1b058s9kny026q395nj99v8hggxkgv43nnjkmx1a2siajw0db94c";
+      aarch64-linux = "0z2fqlf156348ha3zhv16kvqdx68fbwbzch2gzjm9x1na9n5k1ra";
+      armv7l-linux  = "1ppwgrmgl1j2ws9mhrscvvkamd69a6xw7x35df6d30cyj97r0mzy";
+      x86_64-darwin = "0f8vn6m3xzsiyxm2ka5wkbp63wvzrix6g1xrbpvcm3v2llmychkl";
       x86_64-linux  = "035c1nlw0nim057sz3axpkcgkafqbm6gpr8hwr097vlrqll6w3dv";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
follow up to #84417

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
