### PR TITLE
inkscape: 0.92.5 -> 1.0

### DIFF
--- a/pkgs/applications/graphics/inkscape/0.x.nix
+++ b/pkgs/applications/graphics/inkscape/0.x.nix
@@ -1,0 +1,133 @@
+{ stdenv
+, boehmgc
+, boost
+, cairo
+, cmake
+, fetchpatch
+, fetchurl
+, gettext
+, glib
+, glibmm
+, gsl
+, gtkmm2
+, gtkspell2
+, imagemagick
+, lcms
+, libcdr
+, libexif
+, libpng
+, librevenge
+, librsvg
+, libsigcxx
+, libvisio
+, libwpg
+, libXft
+, libxml2
+, libxslt
+, makeWrapper
+, perlPackages
+, pkg-config
+, poppler
+, popt
+, potrace
+, python3
+, wrapGAppsHook
+, zlib
+}:
+let
+  python3Env = python3.withPackages
+    (ps: with ps; [
+      numpy
+      lxml
+      scour
+    ]);
+in
+stdenv.mkDerivation rec {
+  pname = "inkscape_0";
+  version = "0.92.5";
+
+  src = fetchurl {
+    url = "https://media.inkscape.org/dl/resources/file/inkscape-${version}.tar.bz2";
+    sha256 = "ge5/aeK9ZKlzQ9g5Wkp6eQWyG4YVZu1eXZF5F41Rmgs=";
+  };
+
+  # Inkscape hits the ARGMAX when linking on macOS. It appears to be
+  # CMake’s ARGMAX check doesn’t offer enough padding for NIX_LDFLAGS.
+  # Setting strictDeps it avoids duplicating some dependencies so it
+  # will leave us under ARGMAX.
+  strictDeps = true;
+
+  postPatch = ''
+    patchShebangs share/extensions
+    patchShebangs fix-roff-punct
+
+    # Python is used at run-time to execute scripts, e.g., those from
+    # the "Effects" menu.
+    substituteInPlace src/extension/implementation/script.cpp \
+      --replace '"python-interpreter", "python"' '"python-interpreter", "${python3Env}/bin/python"'
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    makeWrapper
+    python3Env
+    wrapGAppsHook
+  ] ++ (with perlPackages; [
+    perl
+    XMLParser
+  ]);
+
+  buildInputs = [
+    boehmgc
+    boost
+    gettext
+    glib
+    glibmm
+    gsl
+    gtkmm2
+    imagemagick
+    lcms
+    libcdr
+    libexif
+    libpng
+    librevenge
+    librsvg # for loading icons
+    libsigcxx
+    libvisio
+    libwpg
+    libXft
+    libxml2
+    libxslt
+    perlPackages.perl
+    poppler
+    popt
+    potrace
+    python3Env
+    zlib
+  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
+    gtkspell2
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    cairo
+  ];
+
+  # Make sure PyXML modules can be found at run-time.
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change $out/lib/libinkscape_base.dylib $out/lib/inkscape/libinkscape_base.dylib $out/bin/inkscape
+    install_name_tool -change $out/lib/libinkscape_base.dylib $out/lib/inkscape/libinkscape_base.dylib $out/bin/inkview
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Legacy version of vector graphics editor";
+    homepage = "https://www.inkscape.org";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.all;
+    longDescription = ''
+      Inkscape is a feature-rich vector graphics editor that edits
+      files in the W3C SVG (Scalable Vector Graphics) file format.
+
+      If you want to import .eps files install ps2edit.
+    '';
+  };
+}

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -3,14 +3,18 @@
 , boost
 , cairo
 , cmake
-, fetchpatch
+, double-conversion
 , fetchurl
 , gettext
+, gdl
 , glib
+, glib-networking
 , glibmm
 , gsl
-, gtkmm2
-, gtkspell2
+, gtk-mac-integration
+, gtkmm3
+, gtkspell3
+, gdk-pixbuf
 , imagemagick
 , lcms
 , libcdr
@@ -19,18 +23,20 @@
 , librevenge
 , librsvg
 , libsigcxx
+, libsoup
 , libvisio
 , libwpg
 , libXft
 , libxml2
 , libxslt
-, makeWrapper
+, ninja
 , perlPackages
 , pkg-config
 , poppler
 , popt
 , potrace
 , python3
+, substituteAll
 , wrapGAppsHook
 , zlib
 }:
@@ -44,11 +50,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "inkscape";
-  version = "0.92.5";
+  version = "1.0";
 
   src = fetchurl {
-    url = "https://media.inkscape.org/dl/resources/file/${pname}-${version}.tar.bz2";
-    sha256 = "02wsa66ifycibmgfsrhmhqdv41brg955lffq8drsjr5xw9lpzvl1";
+    url = "https://media.inkscape.org/dl/resources/file/${pname}-${version}.tar.xz";
+    sha256 = "1fwl7yjkykqb86555k4fm24inhc40mrvxqwgl2v2vi9alv8j7hc9";
   };
 
   # Inkscape hits the ARGMAX when linking on macOS. It appears to be
@@ -57,21 +63,28 @@ stdenv.mkDerivation rec {
   # will leave us under ARGMAX.
   strictDeps = true;
 
+  patches = [
+    (substituteAll {
+      src = ./fix-python-paths.patch;
+      # Python is used at run-time to execute scripts,
+      # e.g., those from the "Effects" menu.
+      python3 = "${python3Env}/bin/python";
+    })
+  ];
+
   postPatch = ''
     patchShebangs share/extensions
-    patchShebangs fix-roff-punct
-
-    # Python is used at run-time to execute scripts, e.g., those from
-    # the "Effects" menu.
-    substituteInPlace src/extension/implementation/script.cpp \
-      --replace '"python-interpreter", "python"' '"python-interpreter", "${python3Env}/bin/python"'
+    patchShebangs share/templates
+    patchShebangs man/fix-roff-punct
   '';
 
   nativeBuildInputs = [
     pkg-config
     cmake
-    makeWrapper
+    ninja
     python3Env
+    glib # for setup hook
+    gdk-pixbuf # for setup hook
     wrapGAppsHook
   ] ++ (with perlPackages; [
     perl
@@ -81,11 +94,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boehmgc
     boost
+    double-conversion
+    gdl
     gettext
     glib
+    glib-networking
     glibmm
     gsl
-    gtkmm2
+    gtkmm3
     imagemagick
     lcms
     libcdr
@@ -94,6 +110,7 @@ stdenv.mkDerivation rec {
     librevenge
     librsvg # for loading icons
     libsigcxx
+    libsoup
     libvisio
     libwpg
     libXft
@@ -106,9 +123,10 @@ stdenv.mkDerivation rec {
     python3Env
     zlib
   ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
-    gtkspell2
+    gtkspell3
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     cairo
+    gtk-mac-integration
   ];
 
   # Make sure PyXML modules can be found at run-time.

--- a/pkgs/applications/graphics/inkscape/fix-python-paths.patch
+++ b/pkgs/applications/graphics/inkscape/fix-python-paths.patch
@@ -1,0 +1,15 @@
+--- a/src/extension/implementation/script.cpp
++++ b/src/extension/implementation/script.cpp
+@@ -77,10 +77,10 @@ const std::map<std::string, Script::inte
+         { "python",  {"python-interpreter",  {"pythonw"           }}},
+ #elif defined __APPLE__
+         { "perl",    {"perl-interpreter",    {"perl"              }}},
+-        { "python",  {"python-interpreter",  {"python3"           }}},
++        { "python",  {"python-interpreter",  {"@python3@"         }}},
+ #else
+         { "perl",    {"perl-interpreter",    {"perl"              }}},
+-        { "python",  {"python-interpreter",  {"python3", "python" }}},
++        { "python",  {"python-interpreter",  {"@python3@"         }}},
+ #endif
+         { "python2", {"python2-interpreter", {"python2", "python" }}},
+         { "ruby",    {"ruby-interpreter",    {"ruby"    }}},

--- a/pkgs/data/fonts/emojione/default.nix
+++ b/pkgs/data/fonts/emojione/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, inkscape, imagemagick, potrace, svgo, scfbuild }:
+{ stdenv, fetchFromGitHub, inkscape_0, imagemagick, potrace, svgo, scfbuild }:
 
 stdenv.mkDerivation rec {
   pname = "emojione";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     export HOME="$NIX_BUILD_ROOT"
   '';
 
-  nativeBuildInputs = [ inkscape imagemagick potrace svgo scfbuild ];
+  nativeBuildInputs = [ inkscape_0 imagemagick potrace svgo scfbuild ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, inkscape, imagemagick, potrace, svgo, scfbuild }:
+{ stdenv, fetchFromGitHub, inkscape_0, imagemagick, potrace, svgo, scfbuild }:
 
 stdenv.mkDerivation rec {
   pname = "twemoji-color-font";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "00pbgqpkq21wl8fs0q1xp49xb10m48b9sz8cdc58flkd2vqfssw2";
   };
 
-  nativeBuildInputs = [ inkscape imagemagick potrace svgo scfbuild ];
+  nativeBuildInputs = [ inkscape_0 imagemagick potrace svgo scfbuild ];
   # silence inkscape errors about non-writable home
   preBuild = "export HOME=\"$NIX_BUILD_ROOT\"";
   makeFlags = [ "SCFBUILD=${scfbuild}/bin/scfbuild" ];

--- a/pkgs/data/icons/bibata-cursors/default.nix
+++ b/pkgs/data/icons/bibata-cursors/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen, python3 }:
+{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape_0, xcursorgen, python3 }:
 
 let
   py = python3.withPackages(ps: [ ps.pillow ]);
@@ -25,7 +25,7 @@ in stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs  = [
     gnome-themes-extra
-    inkscape
+    inkscape_0
     xcursorgen
     py
   ];

--- a/pkgs/data/icons/bibata-cursors/extra.nix
+++ b/pkgs/data/icons/bibata-cursors/extra.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen, python3 }:
+{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape_0, xcursorgen, python3 }:
 
 let
   py = python3.withPackages(ps: [ ps.pillow ]);
@@ -25,7 +25,7 @@ in stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs  = [
     gnome-themes-extra
-    inkscape
+    inkscape_0
     xcursorgen
     py
   ];

--- a/pkgs/data/icons/bibata-cursors/translucent.nix
+++ b/pkgs/data/icons/bibata-cursors/translucent.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen }:
+{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape_0, xcursorgen }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "bibata-cursors-translucent";
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs  = [
     gnome-themes-extra
-    inkscape
+    inkscape_0
     xcursorgen
   ];
 

--- a/pkgs/data/icons/capitaine-cursors/default.nix
+++ b/pkgs/data/icons/capitaine-cursors/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, inkscape, xcursorgen, bc }:
+, inkscape_0, xcursorgen, bc }:
 
 stdenv.mkDerivation rec {
   pname = "capitaine-cursors";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs  =[
-    inkscape
+    inkscape_0
     xcursorgen
     bc
   ];

--- a/pkgs/data/icons/numix-cursor-theme/default.nix
+++ b/pkgs/data/icons/numix-cursor-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, inkscape, xcursorgen }:
+{ stdenv, fetchFromGitHub, inkscape_0, xcursorgen }:
 
 stdenv.mkDerivation rec {
   version = "1.1";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0p8h48wsy3z5dz9vdnp01fpn6q8ky0h74l5qgixlip557bsa1spi";
   };
 
-  nativeBuildInputs = [ inkscape xcursorgen ];
+  nativeBuildInputs = [ inkscape_0 xcursorgen ];
 
   buildPhase = ''
     patchShebangs .

--- a/pkgs/data/themes/adapta/default.nix
+++ b/pkgs/data/themes/adapta/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, parallel, sassc, inkscape, libxml2, glib, gdk-pixbuf, librsvg, gtk-engine-murrine, gnome3 }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, parallel, sassc, inkscape_0, libxml2, glib, gdk-pixbuf, librsvg, gtk-engine-murrine, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "adapta-gtk-theme";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     parallel
     sassc
-    inkscape
+    inkscape_0
     libxml2
     glib.dev
     gnome3.gnome-shell

--- a/pkgs/data/themes/arc/default.nix
+++ b/pkgs/data/themes/arc/default.nix
@@ -7,7 +7,7 @@
 , gnome3
 , gtk-engine-murrine
 , optipng
-, inkscape
+, inkscape_0
 }:
 
 stdenv.mkDerivation rec {
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     sassc
     optipng
-    inkscape
+    inkscape_0
     gtk3
   ];
 

--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchurl, glib, gtk-engine-murrine, gtk_engines, inkscape, optipng, sassc, which }:
+{ stdenv, fetchFromGitHub, fetchurl, glib, gtk-engine-murrine, gtk_engines, inkscape_0, optipng, sassc, which }:
 
 stdenv.mkDerivation rec {
   pname = "mojave-gtk-theme";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "source";
 
-  nativeBuildInputs = [ glib inkscape optipng sassc which ];
+  nativeBuildInputs = [ glib inkscape_0 optipng sassc which ];
 
   buildInputs = [ gtk_engines ];
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
              src/assets/xfwm4/render-assets.sh
     do
       substituteInPlace $f \
-        --replace /usr/bin/inkscape ${inkscape}/bin/inkscape \
+        --replace /usr/bin/inkscape ${inkscape_0}/bin/inkscape \
         --replace /usr/bin/optipng ${optipng}/bin/optipng
     done
 

--- a/pkgs/data/themes/numix-solarized/default.nix
+++ b/pkgs/data/themes/numix-solarized/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, python3, sass, glib, gdk-pixbuf, libxml2,
-  inkscape, optipng, gtk-engine-murrine
+  inkscape_0, optipng, gtk-engine-murrine
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "1kda0lyqi3cxh163fbj8yyi6jj6pf0y980k4s0cmyi3hkh4cqyd5";
   };
 
-  nativeBuildInputs = [ python3 sass glib gdk-pixbuf libxml2 inkscape optipng ];
+  nativeBuildInputs = [ python3 sass glib gdk-pixbuf libxml2 inkscape_0 optipng ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
     substituteInPlace Makefile --replace '$(DESTDIR)'/usr $out
     substituteInPlace scripts/render-assets.sh \
-      --replace /usr/bin/inkscape ${inkscape}/bin/inkscape \
+      --replace /usr/bin/inkscape ${inkscape_0}/bin/inkscape \
       --replace /usr/bin/optipng ${optipng}/bin/optipng
   '';
 

--- a/pkgs/data/themes/plata/default.nix
+++ b/pkgs/data/themes/plata/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitLab, autoreconfHook, pkgconfig, parallel
-, sassc, inkscape, libxml2, glib, gdk-pixbuf, librsvg, gtk-engine-murrine
+, sassc, inkscape_0, libxml2, glib, gdk-pixbuf, librsvg, gtk-engine-murrine
 , cinnamonSupport ? true
 , gnomeFlashbackSupport ? true
 , gnomeShellSupport ? true
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     parallel
     sassc
-    inkscape
+    inkscape_0
     libxml2
     glib.dev
   ]

--- a/pkgs/data/themes/pop-gtk/default.nix
+++ b/pkgs/data/themes/pop-gtk/default.nix
@@ -4,7 +4,7 @@
 , ninja
 , sassc
 , gtk3
-, inkscape
+, inkscape_0
 , optipng
 , gtk-engine-murrine
 , gdk-pixbuf
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     ninja
     sassc
     gtk3
-    inkscape
+    inkscape_0
     optipng
     python3
   ];
@@ -48,9 +48,9 @@ stdenv.mkDerivation rec {
     for file in $(find -name render-\*.sh); do
       substituteInPlace "$file" \
         --replace 'INKSCAPE="/usr/bin/inkscape"' \
-                  'INKSCAPE="inkscape"' \
+                  'INKSCAPE="${inkscape_0}/bin/inkscape"' \
         --replace 'OPTIPNG="/usr/bin/optipng"' \
-                  'OPTIPNG="optipng"'
+                  'OPTIPNG="${optipng}/bin/optipng"'
     done
   '';
 

--- a/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
@@ -23,7 +23,7 @@
 , docbook_xsl
 , docbook_xml_dtd_42
 , gobject-introspection
-, inkscape
+, inkscape_0
 , poppler_utils
 , desktop-file-utils
 , wrapGAppsHook
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     python3
 
     # building getting started
-    inkscape
+    inkscape_0
     poppler_utils
   ];
 

--- a/pkgs/desktops/mate/mate-utils/default.nix
+++ b/pkgs/desktops/mate/mate-utils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gettext, itstool, glib, gtk3, libxml2, libgtop, libcanberra-gtk3, inkscape, udisks2, mate, hicolor-icon-theme, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, gettext, itstool, glib, gtk3, libxml2, libgtop, libcanberra-gtk3, inkscape_0, udisks2, mate, hicolor-icon-theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "mate-utils";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     gettext
     itstool
-    inkscape
+    inkscape_0
     wrapGAppsHook
   ];
 

--- a/pkgs/development/libraries/gdl/default.nix
+++ b/pkgs/development/libraries/gdl/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.gnome.org/gdl/";
     maintainers = teams.gnome.members;
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, zlib, boost
 , openal, glm, freetype, libGLU, SDL2, epoxy
-, dejavu_fonts, inkscape, optipng, imagemagick
+, dejavu_fonts, inkscape_0, optipng, imagemagick
 , withCrashReporter ? !stdenv.isDarwin
 ,   qtbase ? null
 ,   wrapQtAppsHook ? null
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
-    cmake inkscape imagemagick optipng
+    cmake inkscape_0 imagemagick optipng
   ] ++ optionals withCrashReporter [ wrapQtAppsHook ];
 
   buildInputs = [

--- a/pkgs/tools/graphics/fim/default.nix
+++ b/pkgs/tools/graphics/fim/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, autoconf, automake, pkgconfig
 , perl, flex, bison, readline, libexif
 , x11Support ? true, SDL
-, svgSupport ? true, inkscape
+, svgSupport ? true, inkscape_0
 , asciiArtSupport ? true, aalib
 , gifSupport ? true, giflib
 , tiffSupport ? true, libtiff
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   buildInputs = with stdenv.lib;
     [ perl flex bison readline libexif ]
     ++ optional x11Support SDL
-    ++ optional svgSupport inkscape
+    ++ optional svgSupport inkscape_0
     ++ optional asciiArtSupport aalib
     ++ optional gifSupport giflib
     ++ optional tiffSupport libtiff

--- a/pkgs/tools/typesetting/tex/dblatex/default.nix
+++ b/pkgs/tools/typesetting/tex/dblatex/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python2, libxslt, texlive
-, enableAllFeatures ? false, imagemagick ? null, transfig ? null, inkscape ? null, fontconfig ? null, ghostscript ? null
+, enableAllFeatures ? false, imagemagick ? null, transfig ? null, inkscape_0 ? null, fontconfig ? null, ghostscript ? null
 
 , tex ? texlive.combine { # satisfy all packages that ./configure mentions
     inherit (texlive) scheme-basic epstopdf anysize appendix changebar
@@ -16,7 +16,7 @@
 assert enableAllFeatures ->
   imagemagick != null &&
   transfig != null &&
-  inkscape != null &&
+  inkscape_0 != null &&
   fontconfig != null &&
   ghostscript != null;
 
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
             -e 's|Popen("pdflatex|Popen("${tex}/bin/pdflatex|g' \
             -e 's|"fc-match"|"${fontconfig.bin}/bin/fc-match"|g' \
             -e 's|"fc-list"|"${fontconfig.bin}/bin/fc-list"|g' \
-            -e 's|cmd = "inkscape|cmd = "${inkscape}/bin/inkscape|g' \
+            -e 's|cmd = "inkscape|cmd = "${inkscape_0}/bin/inkscape|g' \
             -e 's|cmd = "fig2dev|cmd = "${transfig}/bin/fig2dev|g' \
             -e 's|cmd = \["ps2pdf|cmd = ["${ghostscript}/bin/ps2pdf|g' \
             -e 's|cmd = "convert|cmd = "${imagemagick.out}/bin/convert|g' \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20603,6 +20603,10 @@ in
     lcms = lcms2;
   };
 
+  inkscape_0 = callPackage ../applications/graphics/inkscape/0.x.nix {
+    lcms = lcms2;
+  };
+
   inspectrum = libsForQt5.callPackage ../applications/radio/inspectrum { };
 
   ion3 = callPackage ../applications/window-managers/ion-3 {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

Update to Inkscape 1.0 final.

This PR also keeps Inkscape 0.92.5 as `inkscape_0` package, because with 1.0 the CLI interface has been changed completely. Packages using Inkscape 0.x CLI interface were patched to use this instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
