### PR TITLE
nixos/networking: fix setting MAC Address and MTU in networkd, fix tests

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -237,6 +237,38 @@ let
             '';
           };
 
+        createNetworkLink = i:
+        let
+          deviceDependency = if (config.boot.isContainer || i.name == "lo")
+            then []
+            else [ (subsystemDevice i.name) ];
+        in
+        nameValuePair "network-link-${i.name}"
+        { description = "Link configuration of ${i.name}";
+          wantedBy = [ "network-interfaces.target" ];
+          before = [ "network-interfaces.target" ];
+          bindsTo = deviceDependency;
+          after = [ "network-pre.target" ] ++ deviceDependency;
+          path = [ pkgs.iproute ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          script =
+            ''
+              echo "Configuring link..."
+            '' + optionalString (i.macAddress != null) ''
+              echo "setting MAC address to ${i.macAddress}..."
+              ip link set "${i.name}" address "${i.macAddress}"
+            '' + optionalString (i.mtu != null) ''
+              echo "setting MTU to ${toString i.mtu}..."
+              ip link set "${i.name}" mtu "${toString i.mtu}"
+            '' + ''
+              echo -n "bringing up interface... "
+              ip link set "${i.name}" up && echo "done" || (echo "failed"; exit 1)
+            '';
+        };
+
         createTunDevice = i: nameValuePair "${i.name}-netdev"
           { description = "Virtual Network Interface ${i.name}";
             bindsTo = [ "dev-net-tun.device" ];
@@ -508,6 +540,7 @@ let
           });
 
       in listToAttrs (
+           map createNetworkLink interfaces ++
            map configureAddrs interfaces ++
            map createTunDevice (filter (i: i.virtual) interfaces))
          // mapAttrs' createBridgeDevice cfg.bridges

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -94,7 +94,12 @@ in
           address = forEach (interfaceIps i)
             (ip: "${ip.address}/${toString ip.prefixLength}");
           networkConfig.IPv6PrivacyExtensions = "kernel";
-        } ];
+          linkConfig = optionalAttrs (i.macAddress != null) {
+            MACAddress = i.macAddress;
+          } // optionalAttrs (i.mtu != null) {
+            MTUBytes = toString i.mtu;
+          };
+        }];
       })))
       (mkMerge (flip mapAttrsToList cfg.bridges (name: bridge: {
         netdevs."40-${name}" = {

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1145,38 +1145,7 @@ in
           ${cfg.localCommands}
         '';
       };
-    } // (listToAttrs (forEach interfaces (i:
-      let
-        deviceDependency = if (config.boot.isContainer || i.name == "lo")
-          then []
-          else [ (subsystemDevice i.name) ];
-      in
-      nameValuePair "network-link-${i.name}"
-      { description = "Link configuration of ${i.name}";
-        wantedBy = [ "network-interfaces.target" ];
-        before = [ "network-interfaces.target" ];
-        bindsTo = deviceDependency;
-        after = [ "network-pre.target" ] ++ deviceDependency;
-        path = [ pkgs.iproute ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-        };
-        script =
-          ''
-            echo "Configuring link..."
-          '' + optionalString (i.macAddress != null) ''
-            echo "setting MAC address to ${i.macAddress}..."
-            ip link set "${i.name}" address "${i.macAddress}"
-          '' + optionalString (i.mtu != null) ''
-            echo "setting MTU to ${toString i.mtu}..."
-            ip link set "${i.name}" mtu "${toString i.mtu}"
-          '' + ''
-            echo -n "bringing up interface... "
-            ip link set "${i.name}" up && echo "done" || (echo "failed"; exit 1)
-          '';
-      })));
-
+    };
     services.mstpd = mkIf needsMstpd { enable = true; };
 
     virtualisation.vswitch = mkIf (cfg.vswitches != { }) { enable = true; };

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1031,6 +1031,11 @@ in
         message = ''
           Temporary addresses are only needed when IPv6 is enabled.
         '';
+      })) ++ (forEach interfaces (i: {
+        assertion = (i.virtual && i.virtualType == "tun") -> i.macAddress == null;
+        message = ''
+          Setting a MAC Address for tun device ${i.name} isn't supported.
+        '';
       })) ++ [
         {
           assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -471,7 +471,7 @@ let
 
         with subtest("Wait for networking to come up"):
             machine.start()
-            machine.wait_for_unit("network-online.target")
+            machine.wait_for_unit("network.target")
 
         with subtest("Test interfaces set up"):
             list = machine.succeed("ip tuntap list | sort").strip()
@@ -486,7 +486,8 @@ let
             """.format(
                 list, targetList
             )
-
+      '' # network-addresses-* only exist in scripted networking
+      + optionalString (!networkd) ''
         with subtest("Test interfaces clean up"):
             machine.succeed("systemctl stop network-addresses-tap0")
             machine.sleep(10)

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -602,17 +602,17 @@ let
       };
 
       testScript = ''
-        targetIPv4Table = """
-        10.0.0.0/16 proto static scope link mtu 1500 
-        192.168.1.0/24 proto kernel scope link src 192.168.1.2 
-        192.168.2.0/24 via 192.168.1.1 proto static 
-        """.strip()
+        targetIPv4Table = [
+            "10.0.0.0/16 proto static scope link mtu 1500",
+            "192.168.1.0/24 proto kernel scope link src 192.168.1.2",
+            "192.168.2.0/24 via 192.168.1.1 proto static",
+        ]
 
-        targetIPv6Table = """
-        2001:1470:fffd:2097::/64 proto kernel metric 256 pref medium
-        2001:1470:fffd:2098::/64 via fdfd:b3f0::1 proto static metric 1024 pref medium
-        fdfd:b3f0::/48 proto static metric 1024 pref medium
-        """.strip()
+        targetIPv6Table = [
+            "2001:1470:fffd:2097::/64 proto kernel metric 256 pref medium",
+            "2001:1470:fffd:2098::/64 via fdfd:b3f0::1 proto static metric 1024 pref medium",
+            "fdfd:b3f0::/48 proto static metric 1024 pref medium",
+        ]
 
         machine.start()
         machine.wait_for_unit("network.target")
@@ -620,9 +620,9 @@ let
         with subtest("test routing tables"):
             ipv4Table = machine.succeed("ip -4 route list dev eth0 | head -n3").strip()
             ipv6Table = machine.succeed("ip -6 route list dev eth0 | head -n3").strip()
-            assert (
-                ipv4Table == targetIPv4Table
-            ), """
+            assert [
+                l.strip() for l in ipv4Table.splitlines()
+            ] == targetIPv4Table, """
               The IPv4 routing table does not match the expected one:
                 Result:
                   {}
@@ -631,9 +631,9 @@ let
               """.format(
                 ipv4Table, targetIPv4Table
             )
-            assert (
-                ipv6Table == targetIPv6Table
-            ), """
+            assert [
+                l.strip() for l in ipv6Table.splitlines()
+            ] == targetIPv6Table, """
               The IPv6 routing table does not match the expected one:
                 Result:
                   {}


### PR DESCRIPTION
###### Motivation for this change
This cleans up code setting MTU and MAC Address. We only use `network-link-${interfaceName}` in scripted networking, and use the native networkd methods to set it in case of networkd.

This also improves the reliability of the networking tests, and fixes `nixosTests.networking.networkd.virtual`.

@rnhmjoj We can just backport a501abd5499d8f82f0991a7b78bcbc4169b0537f into 20.03 to fix the test there as well.

Ran all tests in `nixosTests.networking.networkd` and `nixosTests.networking.scripted` in master, and 20.03 with a501abd5499d8f82f0991a7b78bcbc4169b0537f cherry-picked, they succeed now :tada: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
