### PR TITLE
buildRustCrate: support proc-macro in default prelude

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -16,6 +16,9 @@
       ++ [crateFeatures]
       ++ extraRustcOpts
       ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--target ${rust.toRustTarget stdenv.hostPlatform} -C linker=${stdenv.hostPlatform.config}-gcc"
+      # since rustc 1.42 the "proc_macro" crate is part of the default crate prelude
+      # https://github.com/rust-lang/cargo/commit/4d64eb99a4#diff-7f98585dbf9d30aa100c8318e2c77e79R1021-R1022
+      ++ lib.optional (lib.elem "proc-macro" crateType) "--extern proc_macro"
     ;
     rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
 

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -412,6 +412,18 @@ let
               "test ignore_main ... ok"
             ];
           };
+      procMacroInPrelude = {
+        procMacro = true;
+        edition = "2018";
+        src = symlinkJoin {
+          name = "proc-macro-in-prelude";
+          paths = [
+            (mkFile "src/lib.rs" ''
+              use proc_macro::TokenTree;
+            '')
+          ];
+        };
+      };
     };
     brotliCrates = (callPackage ./brotli-crates.nix {});
     tests = lib.mapAttrs (key: value: mkTest (value // lib.optionalAttrs (!value?crateName) { crateName = key; })) cases;


### PR DESCRIPTION
###### Motivation for this change

With rust 1.42.0 "proc_macro" is supposed to be part of the standard prelude. For reasons that are beyond my understanding this language level change isn't part of the compiler but rather a change in cargo.

This PR updates our behavior to be compatible with what rust/cargo "proper" are doing.

cc @alyssais @nagisa 