### PR TITLE
zenith: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/tools/system/zenith/cargo-lock.patch
+++ b/pkgs/tools/system/zenith/cargo-lock.patch
@@ -1,5 +1,5 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index 3f4eec6..2f565c6 100644
+index 3f4eec6..64b1a6a 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -1297,7 +1297,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
@@ -7,7 +7,7 @@ index 3f4eec6..2f565c6 100644
  [[package]]
  name = "zenith"
 -version = "0.8.0"
-+version = "0.8.1"
++version = "0.8.2"
  dependencies = [
   "battery",
   "bincode",

--- a/pkgs/tools/system/zenith/default.nix
+++ b/pkgs/tools/system/zenith/default.nix
@@ -2,17 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "zenith";
-  version = "0.8.1";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "bvaisvil";
     repo = pname;
     rev = version;
-    sha256 = "12wbx4zhf1rf13g3mw8vcn8aqk9vcza61vi42y6c1pb2km73qw1h";
+    sha256 = "1s1l4nq4bsvi54i603faann8cp1409qa2ka7id0m38b3li8z2984";
   };
 
   cargoPatches = [ ./cargo-lock.patch ];
-  cargoSha256 = "1nyci2vjwsyfscsd520d1r5vyazb33hv4mrsysy6amss4jdf2dlq";
+  cargoSha256 = "0h6k7yf4hpfxnad46iv8gp3v3zc4x4p9yab40gr8xv8r1syf9f6g";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/h0181nkivr54fal5czspwj2cifapgcsz-zenith-0.8.1	  34.8M
/nix/store/8g2ddb86m5w1piz3630d3j9ddchrn666-zenith-0.8.2	  34.8M