### PR TITLE
python.pkgs.zimports: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/zimports/default.nix
+++ b/pkgs/development/python-modules/zimports/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, isPy3k
+, fetchFromGitHub
+, buildPythonPackage
+, flake8-import-order
+, pyflakes
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "zimports";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "sqlalchemyorg";
+    repo = "zimports";
+    rev = version;
+    sha256 = "0a5axflkk0wv0rdnrh8l2rgj8gh2pfkg5lrvr8x4yxxiifawrafc";
+  };
+
+  disabled = !isPy3k;
+
+  propagatedBuildInputs = [
+    pyflakes
+    flake8-import-order
+  ];
+
+  checkInputs = [
+    mock
+  ];
+
+  meta = with lib; {
+    description = "Python import rewriter";
+    homepage = "https://github.com/sqlalchemyorg/zimports";
+    license = licenses.mit;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6010,6 +6010,8 @@ in {
 
   zerorpc = callPackage ../development/python-modules/zerorpc { };
 
+  zimports = callPackage ../development/python-modules/zimports { };
+
   zipstream = callPackage ../development/python-modules/zipstream { };
 
   zodb = callPackage ../development/python-modules/zodb {};


### PR DESCRIPTION
###### Motivation for this change

The author gives a pretty good overview of why one would want to use
zimports over other import organizers:

https://github.com/sqlalchemyorg/zimports/tree/0.2.0#zzzeek-why-are-you-writing-one-of-these-there-are-a-dozen-pep8-import-fixers


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
