### PR TITLE
zig: upgrade to 0.6.0

### DIFF
--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, llvmPackages, libxml2, zlib }:
+{ stdenv, fetchFromGitHub, cmake, llvmPackages, libxml2, zlib, substituteAll }:
 
 llvmPackages.stdenv.mkDerivation rec {
   version = "0.6.0";
@@ -20,12 +20,12 @@ llvmPackages.stdenv.mkDerivation rec {
     zlib
   ];
 
-  patches = [ ./llvm10_polly.patch ];
-
-  postPatch = ''
-    export llvm_extras=-Wl,${llvmPackages.llvm}/lib/LLVMPolly.so
-    substituteAllInPlace CMakeLists.txt
-  '';
+  patches = [
+    (substituteAll {
+        src = ./llvm10_polly.patch;
+        llvm_extras = "-Wl,${llvmPackages.llvm}/lib/LLVMPolly.so";
+    })
+  ];
 
   preBuild = ''
     export HOME=$TMPDIR;

--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -41,7 +41,7 @@ llvmPackages.stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description =
-      "Programming languaged designed for robustness, optimality, and clarity";
+      "General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software";
     homepage = "https://ziglang.org/";
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -1,25 +1,47 @@
 { stdenv, fetchFromGitHub, cmake, llvmPackages, libxml2, zlib }:
 
-stdenv.mkDerivation rec {
-  version = "0.5.0";
+llvmPackages.stdenv.mkDerivation rec {
+  version = "0.6.0";
   pname = "zig";
 
   src = fetchFromGitHub {
     owner = "ziglang";
     repo = pname;
     rev = version;
-    sha256 = "0xyl0riakh6kwb3yvxihb451kqs4ai4q0aygqygnlb2rlr1dn1zb";
+    sha256 = "13dwm2zpscn4n0p5x8ggs9n7mwmq9cgip383i3qqphg7m3pkls8z";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ llvmPackages.clang-unwrapped llvmPackages.llvm libxml2 zlib ];
+  buildInputs = [
+    llvmPackages.clang-unwrapped
+    llvmPackages.llvm
+    llvmPackages.lld
+    libxml2
+    zlib
+  ];
+
+  patches = [ ./llvm10_polly.patch ];
+
+  postPatch = ''
+    export llvm_extras=-Wl,${llvmPackages.llvm}/lib/LLVMPolly.so
+    substituteAllInPlace CMakeLists.txt
+  '';
 
   preBuild = ''
     export HOME=$TMPDIR;
   '';
 
+  checkPhase = ''
+    runHook preCheck
+    ./zig test $src/test/stage1/behavior.zig
+    runHook postCheck
+  '';
+
+  doCheck = true;
+
   meta = with stdenv.lib; {
-    description = "Programming languaged designed for robustness, optimality, and clarity";
+    description =
+      "Programming languaged designed for robustness, optimality, and clarity";
     homepage = "https://ziglang.org/";
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/development/compilers/zig/llvm10_polly.patch
+++ b/pkgs/development/compilers/zig/llvm10_polly.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 97608cddf..e451c0711 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -369,4 +369,5 @@ target_link_libraries(zig_cpp LINK_PUBLIC
+     ${CLANG_LIBRARIES}
+     ${LLD_LIBRARIES}
+     ${LLVM_LIBRARIES}
++    @llvm_extras@
+ )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15012,7 +15012,7 @@ in
   zmqpp = callPackage ../development/libraries/zmqpp { };
 
   zig = callPackage ../development/compilers/zig {
-    llvmPackages = llvmPackages_9;
+    llvmPackages = llvmPackages_10;
   };
 
   zimlib = callPackage ../development/libraries/zimlib { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

See [Zig 0.6.0 release notes](https://ziglang.org/download/0.6.0/release-notes.html)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
