### PR TITLE
ocamlPackages.alcotest: 0.8.5 → 1.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/alcotest/default.nix
+++ b/pkgs/development/ocaml-modules/alcotest/default.nix
@@ -1,45 +1,22 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, topkg, dune
-, cmdliner, astring, fmt, result, uuidm
+{ lib, buildDunePackage, fetchurl
+, astring, cmdliner, fmt, uuidm, re, stdlib-shims
 }:
 
-let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
-    version = "0.8.5";
-    sha256 = "1mhckvdcxkikbzgvy24kjz4265l15b86a6swz7m3ynbgvqdcfzqn";
-    nativeBuildInputs = [ dune ];
-    propagatedBuildInputs = [ uuidm ];
-    buildPhase = "dune build -p alcotest";
-    inherit (dune) installPhase;
-  } else {
-    version = "0.7.2";
-    sha256 = "1qgsz2zz5ky6s5pf3j3shc4fjc36rqnjflk8x0wl1fcpvvkr52md";
-    buildInputs = [ topkg ];
-    nativeBuildInputs = [ ocamlbuild ];
-    inherit (topkg) buildPhase installPhase;
-  };
-in
+buildDunePackage rec {
+  pname = "alcotest";
+  version = "1.0.1";
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-alcotest-${version}";
-  inherit (param) version buildPhase installPhase;
-
-  src = fetchzip {
-    url = "https://github.com/mirage/alcotest/archive/${version}.tar.gz";
-    inherit (param) sha256;
+  src = fetchurl {
+    url = "https://github.com/mirage/alcotest/releases/download/${version}/alcotest-${version}.tbz";
+    sha256 = "1xlklxb83gamqbg8j5dzm5jk4mvcwkspxajh93p6vpw9ia1li1qc";
   };
 
-  nativeBuildInputs = [ ocaml findlib ] ++ (param.nativeBuildInputs or []);
-  buildInputs = [ findlib ] ++ (param.buildInputs or []);
+  propagatedBuildInputs = [ astring cmdliner fmt uuidm re stdlib-shims ];
 
-  propagatedBuildInputs = [ cmdliner astring fmt result ]
-  ++ (param.propagatedBuildInputs or []);
-
-  createFindlibDestdir = true;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/mirage/alcotest";
     description = "A lightweight and colourful test framework";
-    license = stdenv.lib.licenses.isc;
+    license = licenses.isc;
     maintainers = [ maintainers.ericbmerritt ];
   };
 }

--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, alcotest, result, bigstringaf }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, alcotest, result, bigstringaf }:
 
 buildDunePackage rec {
   pname = "angstrom";
@@ -13,14 +13,14 @@ buildDunePackage rec {
     sha256 = "0w0wavqzdy2hrh7cjyl9w72ad4vndhwhknwvyacvkwkja5wys5b2";
   };
 
-  buildInputs = [ alcotest ];
+  checkInputs = [ alcotest ];
   propagatedBuildInputs = [ bigstringaf result ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
 
   meta = {
     homepage = "https://github.com/inhabitedtype/angstrom";
     description = "OCaml parser combinators built for speed and memory efficiency";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sternenseemann ];
   };
 }

--- a/pkgs/development/ocaml-modules/base64/default.nix
+++ b/pkgs/development/ocaml-modules/base64/default.nix
@@ -1,8 +1,8 @@
-{ lib, fetchzip, buildDunePackage, alcotest, bos }:
+{ lib, fetchpatch, fetchzip, buildDunePackage, alcotest, bos }:
 
 let version = "3.2.0"; in
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "base64";
   inherit version;
 
@@ -13,9 +13,16 @@ buildDunePackage {
 
   minimumOCamlVersion = "4.03";
 
-  buildInputs = [ alcotest bos ];
+  buildInputs = [ bos ];
+
+  # Fix test-suite for alcotest ≥ 1.0
+  patches = [(fetchpatch {
+    url = "https://github.com/mirage/ocaml-base64/commit/8d334d02aa52875158fae3e2fb8fe0a5596598d0.patch";
+    sha256 = "0lvqdp98qavpzis1wgwh3ijajq79hq47898gsrk37fpyjbrdzf5q";
+  })];
 
   doCheck = true;
+  checkInputs = [ alcotest ];
 
   meta = {
     homepage = "https://github.com/mirage/ocaml-base64";

--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage, alcotest, bigarray-compat }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, alcotest, bigarray-compat }:
 
 buildDunePackage rec {
   pname = "bigstringaf";
@@ -13,9 +13,9 @@ buildDunePackage rec {
     sha256 = "04b088vrqzmxsyan9f9nr8721bxip4b930cgvb5zkbbmrw3ylmwc";
   };
 
-  buildInputs = [ alcotest ];
+  checkInputs = [ alcotest ];
   propagatedBuildInputs = [ bigarray-compat ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
 
   meta = {
     description = "Bigstring intrinsics and fast blits based on memcpy/memmove";

--- a/pkgs/development/ocaml-modules/digestif/default.nix
+++ b/pkgs/development/ocaml-modules/digestif/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchurl, fetchpatch, buildDunePackage
 , bigarray-compat, eqaf, stdlib-shims
 , alcotest
 }:
@@ -11,6 +11,12 @@ buildDunePackage rec {
     url = "https://github.com/mirage/digestif/releases/download/v${version}/digestif-v${version}.tbz";
     sha256 = "09g4zngqiw97cljv8ds4m063wcxz3y7c7vzaprsbpjzi0ja5jdcy";
   };
+
+  # Fix tests with alcotest ≥ 1
+  patches = [ (fetchpatch {
+    url = "https://github.com/mirage/digestif/commit/b65d996c692d75da0a81323253429e07d14b72b6.patch";
+    sha256 = "0sf7qglcp19dhs65pwrrc7d9v57icf18jsrhpmvwskx8b4dchfiv";
+  })];
 
   buildInputs = lib.optional doCheck alcotest;
   propagatedBuildInputs = [ bigarray-compat eqaf stdlib-shims ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
