### PR TITLE
pasystray: add patch to fix crash when running under wayland

### DIFF
--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -14,6 +14,11 @@ stdenv.mkDerivation rec {
     sha256 = "0xx1bm9kimgq11a359ikabdndqg5q54pn1d1dyyjnrj0s41168fk";
   };
 
+  patches = [
+    # https://github.com/christophgysin/pasystray/issues/90#issuecomment-306190701
+    ./fix-wayland.patch
+  ];
+
   nativeBuildInputs = [ pkgconfig autoreconfHook wrapGAppsHook ];
   buildInputs = [
     gnome3.adwaita-icon-theme

--- a/pkgs/tools/audio/pasystray/fix-wayland.patch
+++ b/pkgs/tools/audio/pasystray/fix-wayland.patch
@@ -1,0 +1,34 @@
+--- a/src/x11-property.c
++++ b/src/x11-property.c
+@@ -43,11 +43,15 @@ static Window window;
+ void x11_property_init()
+ {
+     display = gdk_x11_get_default_xdisplay();
++    if (!GDK_IS_X11_DISPLAY(display)) return;
++    Screen* scr = ScreenOfDisplay(display, 0);
++
+     window = RootWindow(display, 0);
+ }
+ 
+ void x11_property_set(const char* key, const char* value)
+ {
++    if (!GDK_IS_X11_DISPLAY(display)) return;
+     g_debug("[x11-property] setting '%s' to '%s'", key, value);
+ 
+     Atom atom = XInternAtom(display, key, False);
+@@ -57,6 +61,7 @@ void x11_property_set(const char* key, c
+ 
+ void x11_property_del(const char* key)
+ {
++    if (!GDK_IS_X11_DISPLAY(display)) return;
+     g_debug("[x11-property] deleting '%s'", key);
+ 
+     Atom atom = XInternAtom(display, key, False);
+@@ -65,6 +70,7 @@ void x11_property_del(const char* key)
+ 
+ char* x11_property_get(const char* key)
+ {
++    if (!GDK_IS_X11_DISPLAY(display)) return NULL;
+     Atom property = XInternAtom(display, key, False);
+     Atom actual_type;
+     int actual_format;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix pasystray, so it works on wayland. For tray icon to show, you need `waybar` or similar, as it does not work with `swaybar` yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
