### PR TITLE
audiality2, koboredux: init

### DIFF
--- a/pkgs/development/libraries/audiality2/default.nix
+++ b/pkgs/development/libraries/audiality2/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+# The two audio backends:
+, SDL2
+, jack2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "audiality2";
+  version = "1.9.4";
+
+  src = fetchFromGitHub {
+    owner = "olofson";
+    repo = "audiality2";
+    rev = "v${version}";
+    sha256 = "0ipqna7a9mxqm0fl9ggwhbc7i9yxz3jfyi0w3dymjp40v7jw1n20";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    jack2
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A realtime scripted modular audio engine for video games and musical applications";
+    homepage = "http://audiality.org";
+    license = licenses.zlib;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/games/koboredux/default.nix
+++ b/pkgs/games/koboredux/default.nix
@@ -1,0 +1,87 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, requireFile
+, cmake
+, pkg-config
+, SDL2
+, SDL2_image
+, audiality2
+, useProprietaryAssets ? true
+}:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  pname = "koboredux";
+  version = "0.7.5.1";
+
+  src =
+    [(fetchFromGitHub {
+      owner = "olofson";
+      repo = "koboredux";
+      rev = "v${version}";
+      sha256 = "09h9r65z8bar2z89s09j6px0gdq355kjf38rmd85xb2aqwnm6xig";
+    })]
+    ++
+    (optional useProprietaryAssets (requireFile {
+      name = "koboredux-${version}-Linux.tar.bz2";
+      sha256 = "11bmicx9i11m4c3dp19jsql0zy4rjf5a28x4hd2wl8h3bf8cdgav";
+      message = ''
+        Please purchase the game on https://olofson.itch.io/kobo-redux
+        and download the Linux build.
+
+        Once you have downloaded the file, please use the following command
+        and re-run the installation:
+
+        nix-prefetch-url file://\$PWD/koboredux-${version}-Linux.tar.bz2
+
+        Alternatively, install the "koboredux-free" package, which replaces the
+        proprietary assets with a placeholder theme.
+      '';
+    }));
+
+  sourceRoot = "source"; # needed when we have the assets source
+
+  # Fix clang build
+  patches = [(fetchpatch {
+    url = "https://github.com/olofson/koboredux/commit/cf92b8a61d002ccaa9fbcda7a96dab08a681dee4.patch";
+    sha256 = "0dwhvis7ghf3mgzjd2rwn8hk3ndlgfwwcqaq581yc5rwd73v6vw4";
+  })];
+
+  postPatch = optionalString useProprietaryAssets ''
+    cp -r ../koboredux-${version}-Linux/sfx/redux data/sfx/
+    cp -r ../koboredux-${version}-Linux/gfx/redux data/gfx/
+    cp -r ../koboredux-${version}-Linux/gfx/redux_fullscreen data/gfx/
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    audiality2
+  ];
+
+  meta = {
+    description = "A frantic 80's style 2D shooter, similar to XKobo and Kobo Deluxe" +
+      optionalString (!useProprietaryAssets) " (built without proprietary assets)";
+    longDescription = ''
+      Kobo Redux is a frantic 80's style 2D shooter, inspired by the look and
+      feel of 90's arcade cabinets. The gameplay is fast and unforgiving,
+      although with less of the frustrating quirkiness of the actual games
+      of the 80's. A true challenge in the spirit of the arcade era!
+    '' + optionalString (!useProprietaryAssets) ''
+
+      This version replaces the official proprietary assets with placeholders.
+      For the full experience, consider installing "koboredux" instead.
+    '';
+    homepage = "https://olofson.itch.io/kobo-redux";
+    license = with licenses; if useProprietaryAssets then unfree else gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24246,6 +24246,12 @@ in
 
   kobodeluxe = callPackage ../games/kobodeluxe { };
 
+  koboredux = callPackage ../games/koboredux { };
+
+  koboredux-free = callPackage ../games/koboredux {
+    useProprietaryAssets = false;
+  };
+
   leela-zero = libsForQt5.callPackage ../games/leela-zero { };
 
   lgogdownloader = callPackage ../games/lgogdownloader { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11488,6 +11488,8 @@ in
 
   aubio = callPackage ../development/libraries/aubio { };
 
+  audiality2 = callPackage ../development/libraries/audiality2 { };
+
   audiofile = callPackage ../development/libraries/audiofile {
     inherit (darwin.apple_sdk.frameworks) AudioUnit CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change

Great game similar to the already packaged kobodeluxe. I think packaging also the proprietary part is fair, since in doing so we encourage a sensible foss business model. If you are a nixpkgs committer and want to test the proprietary assets, you can contact me and I'll send you a key.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).