### PR TITLE
haskellPackages.hasql-pool: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1501,4 +1501,7 @@ self: super: {
   # Fixed at head, but hasn't cut a release in awhile.
   darcs = doJailbreak super.darcs;
 
+  # Test suite requires running a database server. Testing is done upstream.
+  hasql-pool = dontCheck super.hasql-pool;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5621,7 +5621,6 @@ broken-packages:
   - hasql-migration
   - hasql-notifications
   - hasql-optparse-applicative
-  - hasql-pool
   - hasql-postgres
   - hasql-postgres-options
   - hasql-simple


### PR DESCRIPTION
###### Motivation for this change

hasql-pool was marked as broken because of failing tests. The test suite requires running a database server, which is done upstream.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ x ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ currently none, as it was marked as broken ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ none, as it's a library ] Tested execution of all binary files (usually in `./result/bin/`)
- [ no change ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ no change ] Ensured that relevant documentation is up to date
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
