### PR TITLE
ocamlPackages.cow: 2.2.0 -> 2.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/cow/default.nix
+++ b/pkgs/development/ocaml-modules/cow/default.nix
@@ -1,30 +1,29 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib
-, ocamlbuild, topkg
+{ lib, fetchurl, buildDunePackage, alcotest
 , uri, xmlm, omd, ezjsonm }:
 
-stdenv.mkDerivation rec {
-  version = "2.2.0";
-  pname = "ocaml-cow";
+buildDunePackage rec {
+  minimumOCamlVersion = "4.02.3";
 
-  src = fetchFromGitHub {
-    owner  = "mirage";
-    repo   = "ocaml-cow";
-    rev    = "v${version}";
-    sha256 = "0snhabg7rfrrcq2ksr3qghiawd61cw3y4kp6rl7vs87j4cnk3kr2";
+  version = "2.4.0";
+  pname = "cow";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-cow/releases/download/v${version}/cow-v${version}.tbz";
+    sha256 = "1x77lwpskda4zyikwxh500xjn90pgdwz6jm7ca7f36pyav4vl6zx";
   };
 
-  buildInputs = [ ocaml ocamlbuild findlib topkg ];
   propagatedBuildInputs = [ xmlm uri ezjsonm omd ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
 
-  inherit (topkg) buildPhase installPhase;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Caml on the Web";
     longDescription = ''
-      Caml on the Web (COW) is a set of parsers and syntax extensions to let you manipulate HTML, CSS, XML, JSON and Markdown directly from OCaml code.
+      Writing web-applications requires a lot of skills: HTML, XML, JSON and
+      Markdown, to name but a few! This library provides OCaml combinators
+      for these web formats.
     '';
     license = licenses.isc;
     maintainers = [ maintainers.sternenseemann ];
-    inherit (ocaml.meta) platforms;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `cow`. Contains switch to `dune` which makes the package cleaner. Also fixed the package `name`, attribute was correct.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
