### PR TITLE
gtk-mac-integration: 2.0.8 -> 2.1.3

### DIFF
--- a/pkgs/development/libraries/gtk-mac-integration/default.nix
+++ b/pkgs/development/libraries/gtk-mac-integration/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig, glib, gtk-doc, gtk, gobject-introspection }:
+{ stdenv, fetchFromGitLab, autoreconfHook, pkgconfig, glib, gtk-doc, gtk, gobject-introspection }:
 
-stdenv.mkDerivation {
-  name = "gtk-mac-integration-2.0.8";
+stdenv.mkDerivation rec {
+  pname = "gtk-mac-integration";
+  version = "2.1.3";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
     owner = "GNOME";
-    repo = "gtk-mac-integration";
-    rev = "79e708870cdeea24ecdb036c77b4630104ae1776";
-    sha256 = "1fbhnvj0rqc3089ypvgnpkp6ad2rr37v5qk38008dgamb9h7f3qs";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "1w0agv4r0daklv5d2f3l0c10krravjq8bj9hsdsrpka48dbnqmap";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig gtk-doc gobject-introspection ];
@@ -18,14 +20,11 @@ stdenv.mkDerivation {
     gtkdocize
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Provides integration for GTK applications into the Mac desktop";
-
     license = licenses.lgpl21;
-
     homepage = "https://wiki.gnome.org/Projects/GTK/OSX/Integration";
-
-    maintainers = [ maintainers.matthewbauer ];
+    maintainers = with maintainers; [ matthewbauer ];
     platforms = platforms.darwin;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
