### PR TITLE
wpsoffice: 11.1.0.9080 -> 11.1.0.9505

### DIFF
--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -71,8 +71,8 @@ stdenv.mkDerivation rec{
     cairo
     dbus.lib
     expat
-    ffmpeg_3.out
-    fontconfig.lib
+    ffmpeg_3
+    fontconfig
     freetype
     gdk-pixbuf
     glib
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec{
     libXrender
     libXtst
     libpng12
-    libtool.lib
+    libtool
     libuuid
     libxcb
     libxml2

--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -28,11 +28,11 @@
 
 stdenv.mkDerivation rec{
   pname = "wpsoffice";
-  version = "11.1.0.9080";
+  version = "11.1.0.9505";
 
   src = fetchurl {
-    url = "http://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/9080/wps-office_11.1.0.9080.XA_amd64.deb";
-    sha256 = "1731e9aea22ef4e558ad66b1373d863452b4f570aecf09d448ae28a821333454";
+    url = "http://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/9505/wps-office_11.1.0.9505.XA_amd64.deb";
+    sha256 = "1bvaxwd3npw3kswk7k1p6mcbfg37x0ym4sp6xis6ykz870qivqk5";
   };
   unpackCmd = "dpkg -x $src .";
   sourceRoot = ".";

--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -151,8 +151,7 @@ stdenv.mkDerivation rec{
     done
     for i in $out/share/applications/*;do
       substituteInPlace $i \
-        --replace /usr/bin $out/bin \
-        --replace /opt/kingsoft/wps-office $prefix
+        --replace /usr/bin $out/bin
     done
   '';
 

--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -1,9 +1,30 @@
-{ stdenv, fetchurl
-, libX11, glib, xorg, fontconfig, freetype
-, zlib, libpng12, libICE, libXrender, cups
-, alsaLib, atk, cairo, dbus, expat
-, gdk-pixbuf, gtk2-x11, lzma, pango, zotero
-, sqlite, libuuid, qt5, dpkg }:
+{ stdenv
+, fetchurl
+, alsaLib
+, atk
+, cairo
+, cups
+, dbus
+, dpkg
+, expat
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gtk2-x11
+, libICE
+, libX11
+, libXrender
+, libpng12
+, libuuid
+, lzma
+, pango
+, qt5
+, sqlite
+, xorg
+, zlib
+, zotero
+}:
 
 stdenv.mkDerivation rec{
   pname = "wpsoffice";
@@ -28,40 +49,39 @@ stdenv.mkDerivation rec{
   };
 
   libPath = with xorg; stdenv.lib.makeLibraryPath [
-    libX11
-    libpng12
-    glib
-    libSM
-    libXext
-    fontconfig
-    zlib
-    freetype
-    libICE
-    cups
-    libXrender
-    libxcb
-
     alsaLib
     atk
     cairo
+    cups
     dbus.daemon.lib
     expat
+    fontconfig
     fontconfig.lib
+    freetype
     gdk-pixbuf
+    glib
     gtk2-x11
-    lzma
-    pango
-    zotero
-    sqlite
-    libuuid
+    libICE
+    libSM
+    libX11
+    libXScrnSaver
     libXcomposite
     libXcursor
     libXdamage
+    libXext
     libXfixes
     libXi
     libXrandr
-    libXScrnSaver
+    libXrender
     libXtst
+    libpng12
+    libuuid
+    libxcb
+    lzma
+    pango
+    sqlite
+    zlib
+    zotero
   ];
 
   dontPatchELF = true;

--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec{
   meta = {
     description = "Office program originally named Kingsoft Office";
     homepage = "http://wps-community.org/";
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
     hydraPlatforms = [];
     license = stdenv.lib.licenses.unfreeRedistributable;
     maintainers = [ stdenv.lib.maintainers.mlatus ];

--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , autoPatchelfHook
 , dpkg
+, wrapGAppsHook
 , wrapQtAppsHook
 , alsaLib
 , atk
@@ -52,7 +53,7 @@ stdenv.mkDerivation rec{
     rm opt/kingsoft/wps-office/office6/{libjsetapi.so,libjswppapi.so,libjswpsapi.so}
   '';
 
-  nativeBuildInputs = [ autoPatchelfHook dpkg wrapQtAppsHook ];
+  nativeBuildInputs = [ autoPatchelfHook dpkg wrapGAppsHook wrapQtAppsHook ];
 
   meta = {
     description = "Office program originally named Kingsoft Office";
@@ -152,6 +153,22 @@ stdenv.mkDerivation rec{
       substituteInPlace $i \
         --replace /usr/bin $out/bin \
         --replace /opt/kingsoft/wps-office $prefix
+    done
+  '';
+
+  runtimeLibPath = stdenv.lib.makeLibraryPath [
+    cups.lib
+  ];
+
+  dontWrapQtApps = true;
+  dontWrapGApps = true;
+  postFixup = ''
+    for f in "$out"/bin/*; do
+      echo "Wrapping $f"
+      wrapProgram "$f" \
+        "''${gappsWrapperArgs[@]}" \
+        "''${qtWrapperArgs[@]}" \
+        --suffix LD_LIBRARY_PATH : "$runtimeLibPath"
     done
   '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22533,7 +22533,7 @@ in
 
   worldengine-cli = python3Packages.worldengine;
 
-  wpsoffice = callPackage ../applications/office/wpsoffice {};
+  wpsoffice = libsForQt5.callPackage ../applications/office/wpsoffice {};
 
   wrapFirefox = callPackage ../applications/networking/browsers/firefox/wrapper.nix { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates wpsoffice to the latest version. Switch to `autoPatchelfHook` should make package more standard. This is based on the hard work done by @Ninlives in #82408.

Closes: #82408
Fixes: #63736

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Th0rgal