### PR TITLE
Sylk: 2.5.0 -> 2.6.1

### DIFF
--- a/pkgs/applications/networking/Sylk/default.nix
+++ b/pkgs/applications/networking/Sylk/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "Sylk";
-  version = "2.5.0";
+  version = "2.6.1";
 in
 
 appimageTools.wrapType2 rec {
@@ -10,7 +10,7 @@ appimageTools.wrapType2 rec {
 
   src = fetchurl {
     url = "http://download.ag-projects.com/Sylk/Sylk-${version}-x86_64.AppImage";
-    sha256 = "1jhs25zzdac3r2wz886vlpb0bz77p52mdlrbsbv28h6is79pbd69";
+    hash = "sha256:0417qk925k7p3fiq1zha9al86jrz6mqspda7mi3h9blpbyvlcy7w";
   };
 
   profile = ''


### PR DESCRIPTION
###### Motivation for this change

Simple version bump.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
