### PR TITLE
globalarrays: 5.7 -> 5.7.1

### DIFF
--- a/pkgs/development/libraries/globalarrays/default.nix
+++ b/pkgs/development/libraries/globalarrays/default.nix
@@ -3,7 +3,7 @@
 } :
 
 let
-  version = "5.7";
+  version = "5.7.2";
 
 in stdenv.mkDerivation {
   pname = "globalarrays";
@@ -13,20 +13,8 @@ in stdenv.mkDerivation {
     owner = "GlobalArrays";
     repo = "ga";
     rev = "v${version}";
-    sha256 = "07i2idaas7pq3in5mdqq5ndvxln5q87nyfgk3vzw85r72c4fq5jh";
+    sha256 = "0c1y9a5jpdw9nafzfmvjcln1xc2gklskaly0r1alm18ng9zng33i";
   };
-
-  # upstream patches for openmpi-4 compatibility
-  patches = [ (fetchpatch {
-    name = "MPI_Type_struct-was-deprecated-in-MPI-2";
-    url = "https://github.com/GlobalArrays/ga/commit/36e6458993b1df745f43b7db86dc17087758e0d2.patch";
-    sha256 = "058qi8x0ananqx980p03yxpyn41cnmm0ifwsl50qp6sc0bnbnclh";
-  })
-  (fetchpatch {
-    name = "MPI_Errhandler_set-was-deprecated-in-MPI-2";
-    url = "https://github.com/GlobalArrays/ga/commit/f1ea5203d2672c1a1d0275a012fb7c2fb3d033d8.patch";
-    sha256 = "06n7ds9alk5xa6hd7waw3wrg88yx2azhdkn3cjs2k189iw8a7fqk";
-  })];
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ openmpi openblas gfortran openssh ];


### PR DESCRIPTION
###### Motivation for this change
Bugfix update, removed obsolete MPI patches.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
