### PR TITLE
electrum-personal-server: init at 0.2.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -602,6 +602,7 @@
   ./services/networking/dnsdist.nix
   ./services/networking/dnsmasq.nix
   ./services/networking/ejabberd.nix
+  ./services/networking/electrum-personal-server.nix
   ./services/networking/epmd.nix
   ./services/networking/eternal-terminal.nix
   ./services/networking/fakeroute.nix

--- a/nixos/modules/services/networking/electrum-personal-server.nix
+++ b/nixos/modules/services/networking/electrum-personal-server.nix
@@ -1,0 +1,58 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let cfg = config.services.electrum-personal-server;
+in {
+  options = {
+
+    services.electrum-personal-server = {
+      enable = mkEnableOption "Enable the Electrum Personal Server as a systemd user service. Requires services.bitcoind";
+
+      configFile = mkOption {
+        type = types.str;
+        default = "\$HOME/.config/electrum-personal-server/config.ini";
+        example = "\$HOME/.config/electrum-personal-server/config.ini";
+        description = "The user-specific configuration file path.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.electrum-personal-server;
+        defaultText = "pkgs.electrum-personal-server";
+        description = "The package providing the Electrum Personal Server.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    assertions = [
+      { assertion = (config.services.bitcoind.enable == true);
+        message = "To use Electrum Personal Server you must enable (and configure) Bitcoin Core with services.bitcoind.enable.";
+      }
+    ];
+
+    systemd.user.services.electrum-personal-server = {
+      description = "Electrum Personal Server";
+      after = [ "bitcoind.service" "graphical-session.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = 60;
+
+        ExecStart = pkgs.writeScript "electrum-personal-server-execstart" ''
+          #!/bin/sh
+          ${cfg.package}/bin/electrum-personal-server ${cfg.configFile}
+        '';
+
+        # If the user doesn't have an Electrum Personal Server configuration,
+        # don't bother running the service.
+        ExecCondition = pkgs.writeScript "electrum-personal-server-execcondition" ''
+          #!/bin/sh
+          stat ${cfg.configFile}
+        '';
+      };
+    };
+  };
+}

--- a/pkgs/applications/misc/electrum-personal-server/default.nix
+++ b/pkgs/applications/misc/electrum-personal-server/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, python3, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "electrum-personal-server";
+  version = "0.2.0";
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "chris-belcher";
+    repo = "electrum-personal-server";
+    rev = "eps-v${version}";
+    sha256 = "0ysb0jhklv8m2bvkzm0w939vjdvwmc7zn53rai7yilvragzaq2w6";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ wheel pytestrunner setuptools ];
+
+  meta = with stdenv.lib; {
+    description = "An lightweight, single-user implementation of the Electrum server protocol";
+    longDescription = ''
+      Electrum Personal Server aims to make using Electrum bitcoin wallet 
+      more secure and more private. It makes it easy to connect your 
+      Electrum wallet to your own full node.
+    '';
+    homepage = "https://github.com/chris-belcher/electrum-personal-server";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ emmanuelrosa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19029,6 +19029,8 @@ in
 
   electrum-ltc = callPackage ../applications/misc/electrum/ltc.nix { };
 
+  electrum-personal-server = callPackage ../applications/misc/electrum-personal-server { };
+
   elementary-planner = callPackage ../applications/office/elementary-planner { };
 
   elinks = callPackage ../applications/networking/browsers/elinks { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This change adds a package and NixOS module for ([Electrum Personal Server]https://github.com/chris-belcher/electrum-personal-server). The module sets up the service as a systemd user service, and thus each user would configure the service. The only configuration provided by the module is the location of the user's configuration file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [*] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [*] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [*] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [*] Ensured that relevant documentation is up to date
- [*] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
