### PR TITLE
home-assistant: 0.108.2 -> 0.108.7

### DIFF
--- a/pkgs/development/python-modules/snitun/default.nix
+++ b/pkgs/development/python-modules/snitun/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, buildPythonPackage, python, fetchFromGitHub, attrs, cryptography, async-timeout, pytest-aiohttp, pytest }:
+{ lib, stdenv, buildPythonPackage, python, fetchFromGitHub
+, attrs, cryptography, async-timeout, pytest-aiohttp, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "snitun";
@@ -13,12 +15,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ attrs cryptography async-timeout ];
 
-  checkInputs = [ pytest pytest-aiohttp ];
+  checkInputs = [ pytestCheckHook pytest-aiohttp ];
 
-  checkPhase = ''
-    # https://github.com/NabuCasa/snitun/issues/61
-    pytest ${lib.optionalString stdenv.isDarwin "-k 'not test_multiplexer_data_channel_abort_full'"} tests/
-  '';
+  disabledTests = lib.optionals stdenv.isDarwin [
+    "test_multiplexer_data_channel_abort_full" # https://github.com/NabuCasa/snitun/issues/61
+    # port binding conflicts
+    "test_snitun_single_runner_timeout"
+    "test_snitun_single_runner_throttling"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/nabucasa/snitun";

--- a/pkgs/servers/home-assistant/0001-setup.py-relax-dependencies.patch
+++ b/pkgs/servers/home-assistant/0001-setup.py-relax-dependencies.patch
@@ -1,4 +1,4 @@
-From 80f39643bb4d25f8ffcbd92804844961b303f4d0 Mon Sep 17 00:00:00 2001
+From 679364e1cd95dc7179dbd3114ec35b282fbcb0af Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Thu, 9 Apr 2020 07:20:46 +0100
 Subject: [PATCH] setup.py: relax dependencies
@@ -8,11 +8,11 @@ Content-Transfer-Encoding: 8bit
 
 Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
 ---
- setup.py | 10 +++++-----
- 1 file changed, 5 insertions(+), 5 deletions(-)
+ setup.py | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/setup.py b/setup.py
-index f53af0ee1..ff4227487 100755
+index e0daacd98b..7166f1f228 100755
 --- a/setup.py
 +++ b/setup.py
 @@ -32,10 +32,10 @@ PROJECT_URLS = {
@@ -28,7 +28,12 @@ index f53af0ee1..ff4227487 100755
      "bcrypt==3.1.7",
      "certifi>=2019.11.28",
      "ciso8601==2.1.3",
-@@ -47,9 +47,9 @@ REQUIRES = [
+@@ -43,13 +43,13 @@ REQUIRES = [
+     "jinja2>=2.11.1",
+     "PyJWT==1.7.1",
+     # PyJWT has loose dependency. We want the latest one.
+-    "cryptography==2.8",
++    "cryptography>=2.8",
      "pip>=8.0.3",
      "python-slugify==4.0.0",
      "pytz>=2019.03",
@@ -42,5 +47,5 @@ index f53af0ee1..ff4227487 100755
      "voluptuous-serialize==2.3.0",
  ]
 -- 
-2.25.1
+2.26.1
 

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.108.2";
+  version = "0.108.7";
   components = {
     "abode" = ps: with ps; [ ]; # missing inputs: abodepy
     "acer_projector" = ps: with ps; [ pyserial];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -67,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.108.2";
+  hassVersion = "0.108.7";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -86,7 +86,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "0v4i1ak7pkpycas0mzdmxgc42xgfymwx2b0a2a4h13c4z46pbs2l";
+    sha256 = "0nk1615ms6nlmhgmsgsknc6m7b19baan8m4kr4s97njngiardxm7";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20200407.2";
+  version = "20200418.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0krwn67bkybjb69daik6dki5hm36xs4nbfwqkh0q7ami1xr1f56d";
+    sha256 = "12px8znc6nw5ndg4f28lvfpqsnzi00b5qgpdj9jwny0fss4aglnb";
   };
 
   # no Python tests implemented


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
