### PR TITLE
haskellPackages.postgrest: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8286,7 +8286,6 @@ broken-packages:
   - postgresql-simple-typed
   - postgresql-typed
   - postgresql-typed-lifted
-  - postgrest
   - postgrest-ws
   - postie
   - postmark


### PR DESCRIPTION
###### Motivation for this change

With hasql-pool unbroken (#85206), the postgrest package that depends on it is also no longer broken. 

Like with hasql-pool, the postgrest test suite depends on running a database server. `dontCheck` had already been set a while back with https://github.com/NixOS/nixpkgs/commit/e5ff2421efeb759c49c6523c747125f14e634238.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ none ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ no changes ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
