### PR TITLE
corerad: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -2,20 +2,20 @@
 
 buildGoModule rec {
   pname = "corerad";
-  version = "0.2.2";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "mdlayher";
     repo = "corerad";
     rev = "v${version}";
-    sha256 = "0nxrksv98mxs5spykhzpydwjzii5cc6gk8az7irs3fdi4jx6pq1w";
+    sha256 = "1594qrwrz4bc3iipm4aqb8l1zyi04pwmiz0vdlfn12qn1p7lad5p";
   };
 
-  modSha256 = "0vbbpndqwwz1mc59j7liaayxaj53cs8s3javgj3pvhkn4vp65p7c";
+  modSha256 = "1cfhxkvwzf7sn227y6h5h19f27a9ngmpnyqdlfba5km8axqn29vm";
 
   buildFlagsArray = ''
     -ldflags=
-    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1583280117
+    -X github.com/mdlayher/corerad/internal/build.linkTimestamp=1586881022
     -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New beta release of CoreRAD.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Built and tested on NixOS:

```
[matt@routnerr-2:~/src/nixpkgs]$ nix-build -A corerad
these derivations will be built: 
  /nix/store/3051m551fmdhyfcziqd0idp5qn6z2gnh-corerad-0.2.3.drv
building '/nix/store/3051m551fmdhyfcziqd0idp5qn6z2gnh-corerad-0.2.3.drv'...
unpacking sources                                                                        
unpacking source archive /nix/store/sh1pnvwd3n4ani5kiy39n8aaaiih7rxw-source
[...]

[matt@routnerr-2:~/src/nixpkgs]$ ./result/bin/corerad -h
CoreRAD v0.2.3 BETA (2020-04-14)                                                         
flags:                                                                                   
  -c string                                                                              
        path to configuration file (default "corerad.toml")
  -init                                                                                  
        write out a default configuration file to "corerad.toml" and exit  
```

New timestamp magic number obtained from git log:

```
✔ ~/src/github.com/mdlayher/corerad [master|✔] 
12:50 $ git log -1 --format=%ct v0.2.3
1586881022
```

/cc @jonringer @danderson 