### PR TITLE
linode-cli: remove deprecated perl version, init python version at 2.14.1

### DIFF
--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -1,42 +1,70 @@
-{ stdenv, fetchFromGitHub, perlPackages, makeWrapper}:
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, fetchpatch
+, fetchurl
+, terminaltables
+, colorclass
+, requests
+, pyyaml
+, setuptools
+}:
 
-perlPackages.buildPerlPackage rec {
+let
+
+  spec = fetchurl {
+    url = "https://developers.linode.com/api/docs/v4/openapi.yaml";
+    sha256 = "1l2fahdcmv7sp1qkwr5nv2vls8fypvlybwylqfzhyjmn7jqkw4hq";
+  };
+
+in
+
+buildPythonApplication rec {
   pname = "linode-cli";
-  version = "1.4.7";
+  version = "2.14.1";
 
   src = fetchFromGitHub {
     owner = "linode";
-    repo = "cli";
-    rev = "v${version}";
-    sha256 = "1wiz067wgxi4z4rz4n9p7dlvx5z4hkl2nxpfvhikl6dri4m2nkkp";
+    repo = pname;
+    rev = version;
+    sha256 = "1hpdmbzs182iag471yvq3kwd1san04a58sczzbmw6vjv2kswn1c2";
   };
 
-  buildInputs = [ makeWrapper ];
-  propagatedBuildInputs = with perlPackages; [
-    JSON
-    LWP
-    MozillaCA
-    TryTiny
-    WebServiceLinode
+  patches = [
+    # make enum34 depend on python version
+    ( fetchpatch {
+        url = "https://github.com/linode/linode-cli/pull/184/commits/4cf55759c5da33fbc49b9ba664698875d67d4f76.patch";
+        sha256 = "04n9a6yh0abyyymvfzajhav6qxwvzjl2vs8jnqp3yqrma7kl0slj";
+    })
   ];
 
-  # Wrap perl scripts so they can find libraries
-  postInstall = ''
-    for n in "$out/bin"/*; do
-      wrapProgram "$n" --prefix PERL5LIB : "$PERL5LIB"
-    done
+  # remove need for git history
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "version=get_version()," "version='${version}',"
   '';
 
-  # Has no tests
+  propagatedBuildInputs = [
+    terminaltables
+    colorclass
+    requests
+    pyyaml
+    setuptools
+  ];
+
+  postConfigure = ''
+    python3 -m linodecli bake ${spec} --skip-config
+    cp data-3 linodecli/
+  '';
+
+  # requires linode access token for unit tests, and running executable
   doCheck = false;
 
-  # Has no "doc" or "devdoc" outputs
-  outputs = [ "out" ];
-
-  meta = with stdenv.lib; {
-    description = "Command-line interface to the Linode platform";
-    homepage = "https://github.com/linode/cli";
-    license = with licenses; [ artistic2 gpl2 ];
-    maintainers = with maintainers; [ nixy ];
+  meta = with lib; {
+    homepage = "https://github.com/linode/linode-cli";
+    description = "The Linode Command Line Interface";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ryantm ];
   };
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26295,7 +26295,7 @@ in
 
   xib2nib = callPackage ../development/tools/xib2nib {};
 
-  linode-cli = callPackage ../tools/virtualization/linode-cli { };
+  linode-cli = python3Packages.callPackage ../tools/virtualization/linode-cli {};
 
   hss = callPackage ../tools/networking/hss {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is the new official CLI for accessing the Linode APIs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
