### PR TITLE
wifite2: 2.2.5 -> 2.5.2

### DIFF
--- a/pkgs/tools/networking/wifite2/default.nix
+++ b/pkgs/tools/networking/wifite2/default.nix
@@ -1,15 +1,28 @@
-{ stdenv, lib, fetchFromGitHub, python3, aircrack-ng, wireshark-cli, reaverwps-t6x, cowpatty, hashcat, hcxtools, which }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, python3, wirelesstools
+, aircrack-ng, wireshark-cli, reaverwps-t6x, cowpatty, hashcat, hcxtools
+, hcxdumptool, pyrit, which }:
 
 python3.pkgs.buildPythonApplication rec {
-  version = "2.2.5";
+  version = "2.5.2";
   pname = "wifite2";
 
   src = fetchFromGitHub {
-    owner = "derv82";
+    owner = "kimocoder";
     repo = "wifite2";
     rev = version;
-    sha256 = "1hfy90wf2bjg0z8rbs8cfhhvz78pzg2c6nj0zksal42mb6b5cjdp";
+    sha256 = "0hsb59d86szn27s3hynpzkp49rmw4g692vrl67nal7rfcdvpp8hb";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/pkg-security-team/wifite/raw/debian/${version}-1/debian/patches/Disable-aircrack-failing-test.patch";
+      sha256 = "04qql8w27c1lqk59ghkr1n6r08jwdrb1dcam5k88szkk2bxv8yx1";
+    })
+    (fetchpatch {
+      url = "https://salsa.debian.org/pkg-security-team/wifite/raw/debian/${version}-1/debian/patches/Disable-two-failing-tests.patch";
+      sha256 = "1sixcqz1kbkhxf38yq55pwycm54adjx22bq46dfnl44mg69nx356";
+    })
+  ];
 
   propagatedBuildInputs = [
     aircrack-ng
@@ -18,6 +31,9 @@ python3.pkgs.buildPythonApplication rec {
     cowpatty
     hashcat
     hcxtools
+    hcxdumptool
+    wirelesstools
+    pyrit
     which
   ];
 
@@ -27,8 +43,8 @@ python3.pkgs.buildPythonApplication rec {
     mv ${sitePackagesDir}/wifite/__main__.py ${sitePackagesDir}/wifite/wifite.py
   '';
 
-  # which is not found
-  doCheck = false;
+  checkInputs = propagatedBuildInputs;
+  checkPhase = "python -m unittest discover tests -v";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/derv82/wifite2";

--- a/pkgs/tools/networking/wifite2/default.nix
+++ b/pkgs/tools/networking/wifite2/default.nix
@@ -51,6 +51,6 @@ python3.pkgs.buildPythonApplication rec {
     description = "Rewrite of the popular wireless network auditor, wifite";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ lassulus ];
+    maintainers = with maintainers; [ lassulus danielfullmer ];
   };
 }


### PR DESCRIPTION
The kimocoder repo is more recently updated, and is the one used by
Debian Linux as well:
See the "Homepage" link on https://packages.debian.org/sid/net/wifite

Additionally, I've enabled the tests, which has the added benefit of failing if the necessary tools are not available.

CC @Lassulus 

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
