### PR TITLE
Revert "lib/options: Use escapeNixIdentifier for showOption"

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -191,7 +191,7 @@ rec {
 
      Example:
        (showOption ["foo" "bar" "baz"]) == "foo.bar.baz"
-       (showOption ["foo" "bar.baz" "tux"]) == "foo.\"bar.baz\".tux"
+       (showOption ["foo" "bar.baz" "tux"]) == "foo.bar.baz.tux"
 
      Placeholders will not be quoted as they are not actual values:
        (showOption ["foo" "*" "bar"]) == "foo.*.bar"

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -200,13 +200,14 @@ rec {
      Unlike attributes, options can also start with numbers:
        (showOption ["windowManager" "2bwm" "enable"]) == "windowManager.2bwm.enable"
   */
-  showOption = parts:
-    let
-      escapeOptionPart = part:
-        if part == "*" || builtins.match "<.+>" part != null || builtins.match "[a-zA-Z0-9_][a-zA-Z0-9_'-]+" part != null
-        then part
-        else escapeNixIdentifier part;
-    in concatMapStringsSep "." escapeOptionPart parts;
+  showOption = parts: let
+    escapeOptionPart = part:
+      let
+        escaped = lib.strings.escapeNixString part;
+      in if escaped == "\"${part}\""
+         then part
+         else escaped;
+    in (concatStringsSep ".") (map escapeOptionPart parts);
   showFiles = files: concatStringsSep " and " (map (f: "`${f}'") files);
   unknownModule = "<unknown-file>";
 


### PR DESCRIPTION
###### Motivation for this change

This is used in in the manual generation for option identifiers that can
be linked. This, unike what the example describes, doesn't preserve
quotes which is needed for these identifiers to be valid.

/cc @Infinisil @jtojnar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
