### PR TITLE
joplin-desktop: 1.0.179 -> 1.0.200

### DIFF
--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -40,9 +40,9 @@ in appimageTools.wrapType2 rec {
       applications directly or from your own text editor. The notes are in
       Markdown format.
     '';
-    homepage = "https://joplin.cozic.net/";
+    homepage = "https://joplinapp.org";
     license = licenses.mit;
-    maintainers = with maintainers; [ rafaelgg raquelgb ];
+    maintainers = with maintainers; [ hugoreeves rafaelgg raquelgb ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "joplin-desktop";
-  version = "1.0.179";
+  version = "1.0.200";
   desktopItem = makeDesktopItem {
      name = "Joplin";
      exec = "joplin-desktop";
@@ -13,7 +13,7 @@ in appimageTools.wrapType2 rec {
   name = "${pname}-${version}";
   src = fetchurl {
     url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}.AppImage";
-    sha256 = "0v7d5wzwiznl755pl6jfg33g6jxr1cbm9j13jpbmfi497hj8w82k";
+    sha256 = "14gwv8i6dprvl96mifadq0zj77a82rww8xd5bmzm8ql6sidi2216";
   };
 
 


### PR DESCRIPTION
Builds successfully on NixOS

###### Motivation for this change

Joplin desktop was last updated in February and is multiple versions behind. The joplin-desktop repository is changing very quickly and an update is needed, in particular one thing that has improved in more recent versions is the end to end encryption.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS **N/A**
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@rafaelgg @raquelgb 