### PR TITLE
libaio: 0.3.110 -> 0.3.111 & update source url from fedorahosted to pagure

### DIFF
--- a/pkgs/os-specific/linux/libaio/default.nix
+++ b/pkgs/os-specific/linux/libaio/default.nix
@@ -1,18 +1,13 @@
 { stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.110";
+  version = "0.3.111";
   pname = "libaio";
 
   src = fetchurl {
-    url = "https://fedorahosted.org/releases/l/i/libaio/${pname}-${version}.tar.gz";
-    sha256 = "0zjzfkwd1kdvq6zpawhzisv7qbq1ffs343i5fs9p498pcf7046g0";
+    url = "https://pagure.io/libaio/archive/${pname}-${version}/${pname}-${pname}-${version}.tar.gz";
+    sha256 = "1fih2y2js0dl9qshpyb14m0nnxlms2527shgcxg0hnbflv5igg76";
   };
-
-  patches = [ (fetchpatch {
-    url = "https://pagure.io/libaio/c/da47c32b2ff39e52fbed1622c34b86bc88d7c217.patch";
-    sha256 = "1kqpiswjn549s3w3m89bw5qkl7bw5pvq6gp5cdzd926ymlgivj5c";
-  }) ];
 
   postPatch = ''
     patchShebangs harness


### PR DESCRIPTION
###### Motivation for this change
Give this package a working src URL.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
