### PR TITLE
nixosTests.flannel: port to python, unbreak

### DIFF
--- a/nixos/tests/flannel.nix
+++ b/nixos/tests/flannel.nix
@@ -1,20 +1,24 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ lib, ...} : {
   name = "flannel";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with lib.maintainers; {
     maintainers = [ offline ];
   };
 
   nodes = let
-    flannelConfig = {
+    flannelConfig = { pkgs, ... } : {
       services.flannel = {
         enable = true;
+        backend = {
+          Type = "udp";
+          Port = 8285;
+        };
         network = "10.1.0.0/16";
         iface = "eth1";
         etcd.endpoints = ["http://etcd:2379"];
       };
 
-      networking.firewall.allowedUDPPorts = [ 8472 ];
+      networking.firewall.allowedUDPPorts = [ 8285 ];
     };
   in {
     etcd = { ... }: {
@@ -32,25 +36,22 @@ import ./make-test.nix ({ pkgs, ...} : {
       networking.firewall.allowedTCPPorts = [ 2379 ];
     };
 
-    node1 = { ... }: {
-      require = [flannelConfig];
-    };
-
-    node2 = { ... }: {
-      require = [flannelConfig];
-    };
+    node1 = flannelConfig;
+    node2 = flannelConfig;
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $node1->waitForUnit("flannel.service");
-    $node2->waitForUnit("flannel.service");
+    node1.wait_for_unit("flannel.service")
+    node2.wait_for_unit("flannel.service")
 
-    my $ip1 = $node1->succeed("ip -4 addr show flannel.1 | grep -oP '(?<=inet).*(?=/)'");
-    my $ip2 = $node2->succeed("ip -4 addr show flannel.1 | grep -oP '(?<=inet).*(?=/)'");
+    node1.wait_until_succeeds("ip l show dev flannel0")
+    ip1 = node1.succeed("ip -4 addr show flannel0 | grep -oP '(?<=inet).*(?=/)'")
+    node2.wait_until_succeeds("ip l show dev flannel0")
+    ip2 = node2.succeed("ip -4 addr show flannel0 | grep -oP '(?<=inet).*(?=/)'")
 
-    $node1->waitUntilSucceeds("ping -c 1 $ip2");
-    $node2->waitUntilSucceeds("ping -c 1 $ip1");
+    node1.wait_until_succeeds(f"ping -c 1 {ip2}")
+    node2.wait_until_succeeds(f"ping -c 1 {ip1}")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
The flannel test was broken and still written in Perl.

For reasons yet unknown, the vxlan backend doesn't work (at least inside
the qemu networking), so this is moved to the udp backend.

Note changing the backend apparently also changes the interface name,
it's now `flannel0`, not `flannel.1`

fixes #74941
Python VM Test Migration: #72828

@johanot do you have an idea why it's broken inside qemu's networking?

https://github.com/NixOS/nixpkgs/pull/55649 suggests it once worked, so I'm curious.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
