### PR TITLE
Cmake paths patch 1/? (boost, aws-sdk-cpp)

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/cmake-dirs.patch
+++ b/pkgs/development/libraries/aws-sdk-cpp/cmake-dirs.patch
@@ -1,0 +1,75 @@
+diff --git a/cmake/AWSSDKConfig.cmake b/cmake/AWSSDKConfig.cmake
+index e87252123e..5457bd5910 100644
+--- a/cmake/AWSSDKConfig.cmake
++++ b/cmake/AWSSDKConfig.cmake
+@@ -82,6 +82,7 @@ if (AWSSDK_ROOT_DIR)
+             )
+ else()
+     find_file(AWSSDK_CORE_HEADER_FILE Aws.h
++        "/${AWSSDK_INSTALL_INCLUDEDIR}/aws/core"
+         "/usr/${AWSSDK_INSTALL_INCLUDEDIR}/aws/core"
+         "/usr/local/${AWSSDK_INSTALL_INCLUDEDIR}/aws/core"
+         "C:/Progra~1/AWSSDK/${AWSSDK_INSTALL_INCLUDEDIR}/aws/core"
+@@ -97,14 +98,18 @@ if (NOT AWSSDK_CORE_HEADER_FILE)
+     message(FATAL_ERROR "AWS SDK for C++ is missing, please install it first")
+ endif()
+ 
+-# based on core header file path, inspects the actual AWSSDK_ROOT_DIR
+-get_filename_component(AWSSDK_ROOT_DIR "${AWSSDK_CORE_HEADER_FILE}" PATH)
+-get_filename_component(AWSSDK_ROOT_DIR "${AWSSDK_ROOT_DIR}" PATH)
+-get_filename_component(AWSSDK_ROOT_DIR "${AWSSDK_ROOT_DIR}" PATH)
+-get_filename_component(AWSSDK_ROOT_DIR "${AWSSDK_ROOT_DIR}" PATH)
+-
+-if (NOT AWSSDK_ROOT_DIR)
+-    message(FATAL_ERROR "AWSSDK_ROOT_DIR is not set or can't be calculated from the path of core header file")
++if (IS_ABSOLUTE ${AWSSDK_INSTALL_LIBDIR})
++    set(AWSSDK_ROOT_DIR "")
++else()
++    # based on core header file path, inspects the actual AWSSDK_ROOT_DIR
++    get_filename_component(AWSSDK_ROOT_DIR "${AWSSDK_CORE_HEADER_FILE}" PATH)
++    get_filename_component(AWSSDK_ROOT_DIR "${AWSSDK_ROOT_DIR}" PATH)
++    get_filename_component(AWSSDK_ROOT_DIR "${AWSSDK_ROOT_DIR}" PATH)
++    get_filename_component(AWSSDK_ROOT_DIR "${AWSSDK_ROOT_DIR}" PATH)
++
++    if (NOT AWSSDK_ROOT_DIR)
++	message(FATAL_ERROR "AWSSDK_ROOT_DIR is not set or can't be calculated from the path of core header file")
++    endif()
+ endif()
+ 
+ 
+diff --git a/cmake/utilities.cmake b/cmake/utilities.cmake
+index 283a14a138..646aea1da3 100644
+--- a/cmake/utilities.cmake
++++ b/cmake/utilities.cmake
+@@ -43,7 +43,8 @@ macro(setup_install)
+                 EXPORT "${PROJECT_NAME}-targets"
+                 ARCHIVE DESTINATION ${ARCHIVE_DIRECTORY}
+                 LIBRARY DESTINATION ${LIBRARY_DIRECTORY}
+-                RUNTIME DESTINATION ${BINARY_DIRECTORY} )
++                RUNTIME DESTINATION ${BINARY_DIRECTORY}
++                INCLUDES DESTINATION ${INCLUDE_DIRECTORY} )
+ 
+         if (BUILD_SHARED_LIBS)
+             install(
+@@ -57,7 +58,8 @@ macro(setup_install)
+             install (TARGETS ${PROJECT_NAME}
+                      ARCHIVE DESTINATION ${ARCHIVE_DIRECTORY}/${SDK_INSTALL_BINARY_PREFIX}/${PLATFORM_INSTALL_QUALIFIER}/\${CMAKE_INSTALL_CONFIG_NAME}
+                      LIBRARY DESTINATION ${LIBRARY_DIRECTORY}/${SDK_INSTALL_BINARY_PREFIX}/${PLATFORM_INSTALL_QUALIFIER}/\${CMAKE_INSTALL_CONFIG_NAME}
+-                     RUNTIME DESTINATION ${BINARY_DIRECTORY}/${SDK_INSTALL_BINARY_PREFIX}/${PLATFORM_INSTALL_QUALIFIER}/\${CMAKE_INSTALL_CONFIG_NAME})
++                     RUNTIME DESTINATION ${BINARY_DIRECTORY}/${SDK_INSTALL_BINARY_PREFIX}/${PLATFORM_INSTALL_QUALIFIER}/\${CMAKE_INSTALL_CONFIG_NAME}
++                     INCLUDES DESTINATION ${INCLUDE_DIRECTORY}/${SDK_INSTALL_BINARY_PREFIX}/${PLATFORM_INSTALL_QUALIFIER}/\${CMAKE_INSTALL_CONFIG_NAME})
+         endif()
+     endif()
+ endmacro()
+diff --git a/toolchains/pkg-config.pc.in b/toolchains/pkg-config.pc.in
+index 9b519d2772..a61069225c 100644
+--- a/toolchains/pkg-config.pc.in
++++ b/toolchains/pkg-config.pc.in
+@@ -1,5 +1,5 @@
+-includedir=@CMAKE_INSTALL_PREFIX@/@INCLUDE_DIRECTORY@
+-libdir=@CMAKE_INSTALL_PREFIX@/@LIBRARY_DIRECTORY@
++includedir=@INCLUDE_DIRECTORY@
++libdir=@LIBRARY_DIRECTORY@
+ 
+ Name: @PROJECT_NAME@
+ Description: @PROJECT_DESCRIPTION@

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -50,6 +50,12 @@ stdenv.mkDerivation rec {
       rm aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
     '';
 
+  postFixupHooks = [
+    # This bodge is necessary so that the file that the generated -config.cmake file
+    # points to an existing directory.
+    ''mkdir -p $out/include''
+  ];
+
   __darwinAllowLocalNetworking = true;
 
   patches = [
@@ -57,6 +63,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/aws/aws-sdk-cpp/commit/42991ab549087c81cb630e5d3d2413e8a9cf8a97.patch";
       sha256 = "0myq5cm3lvl5r56hg0sc0zyn1clbkd9ys0wr95ghw6bhwpvfv8gr";
     })
+    ./cmake-dirs.patch
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/boost/cmake-paths.patch
+++ b/pkgs/development/libraries/boost/cmake-paths.patch
@@ -1,0 +1,21 @@
+diff --git a/tools/boost_install/boost-install.jam b/tools/boost_install/boost-install.jam
+index ad19f7b55..ec6bf57ff 100644
+--- a/tools/boost_install/boost-install.jam
++++ b/tools/boost_install/boost-install.jam
+@@ -587,6 +587,7 @@ rule generate-cmake-config- ( target : sources * : properties * )
+         "# Compute the include and library directories relative to this file."
+         ""
+         "get_filename_component(_BOOST_CMAKEDIR \"${CMAKE_CURRENT_LIST_DIR}/../\" ABSOLUTE)"
++        "get_filename_component(_BOOST_REAL_CMAKEDIR \"${CMAKE_CURRENT_LIST_DIR}/../\" ABSOLUTE)"
+         : true ;
+ 
+     if [ path.is-rooted $(cmakedir) ]
+@@ -607,6 +608,8 @@ rule generate-cmake-config- ( target : sources * : properties * )
+             "  unset(_BOOST_CMAKEDIR_ORIGINAL)"
+             "endif()"
+             ""
++	    "# Assume that the installer actually did know where the libs were to be installed"
++            "get_filename_component(_BOOST_CMAKEDIR \"$(cmakedir-native)\" REALPATH)"
+             : true ;
+     }
+ 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -112,7 +112,8 @@ stdenv.mkDerivation {
   ++ optional stdenv.isDarwin (
     if version == "1.55.0"
     then ./darwin-1.55-no-system-python.patch
-    else ./darwin-no-system-python.patch);
+    else ./darwin-no-system-python.patch)
+  ++ optional (versionAtLeast version "1.70") ./cmake-paths.patch;
 
   meta = {
     homepage = "http://boost.org/";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Many packages generate CMake configuration files that try to figure out the paths to include and library directories from the location of the CMake file; this breaks in NixOS derivations with a `dev` output because the CMake package gets installed to `$out/lib/cmake`, but then gets moved into the `dev` output by the `_multioutDevs` fixup hook.

This needs to be fixed on a case-by-case basis, because this usually involves custom logic. So far, I've fixed boost (>= 1.70; before that, it didn't install cmake files as far as I can tell) and aws-sdk-cpp.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (I hoped Hydra would do that for me)
- [ ] Tested execution of all binary files (usually in `./result/bin/`) (no binaries, only libraries, and they should be unaffected)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
     (within 10KiB for both)
- [x] Ensured that relevant documentation is up to date (I couldn't find any)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
