### PR TITLE
trivial-builders: Sanitize derivation name

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -4,7 +4,8 @@ let
 
   runCommand' = runLocal: stdenv: name: env: buildCommand:
     stdenv.mkDerivation ({
-      inherit name buildCommand;
+      name = lib.strings.sanitizeDerivationName name;
+      inherit buildCommand;
       passAsFile = [ "buildCommand" ];
     }
     // (lib.optionalAttrs runLocal {


### PR DESCRIPTION
###### Motivation for this change
This then supports using functions like writeShellScriptBin with script names
that would be invalid as derivation names, which was desired by a user on IRC.

Assuming `sanitizeDerivationName` as introduced in https://github.com/NixOS/nixpkgs/pull/83241 is correct (which I'm pretty sure it is, comes with covering tests), this change will be fully backwards compatible without any rebuilds.

An alternative would be to use `sanitizeDerivationName` in `mkDerivation` directly, but that might influence performance a bit too much for not much of a benefit. This is much more useful for these trivial builders, which especially don't support changing the derivation name on its own.

###### Things done

- [x] Made sure a simple `writeShellScriptBin "{^_^}"` newly works after this commit