### PR TITLE
colorpicker: init at git-2018-01-14

### DIFF
--- a/pkgs/tools/misc/colorpicker/default.nix
+++ b/pkgs/tools/misc/colorpicker/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, pkg-config, gtk2 }:
+
+stdenv.mkDerivation rec {
+  pname = "colorpicker";
+  version = "git-2018-01-14";
+
+  src = fetchFromGitHub {
+    owner = "Ancurio";
+    repo  = "colorpicker";
+    rev   = "287676947e6e3b5b0cee784aeb1638cf22f0ce17";
+    sha256 = "1kj1dpb79llrfpszraaz6r7ci114zqi5rmqxwsvq2dnnpjxyi29r";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gtk2 ];
+
+  installPhase = ''
+    install -Dt $out/bin colorpicker
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Click on a pixel on your screen and print its color value in RGB";
+    homepage = "https://github.com/Ancurio/colorpicker";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -180,6 +180,8 @@ in
 
   colorz = callPackage ../tools/misc/colorz { };
 
+  colorpicker = callPackage ../tools/misc/colorpicker { };
+
   comedilib = callPackage ../development/libraries/comedilib {  };
 
   cpu-x = callPackage ../applications/misc/cpu-x { };


### PR DESCRIPTION
Click on a pixel on your screen and print its color value in RGB (X11)

This doesn't look that maintained or has a release, but its super useful and works great.