### PR TITLE
freerdp: re-enable tests except for one failing test

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -1,34 +1,41 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig
-, alsaLib, ffmpeg, glib, openssl, pcre, zlib
-, libX11, libXcursor, libXdamage, libXext, libXi, libXinerama, libXrandr, libXrender, libXv, libXtst
-, libxkbcommon, libxkbfile
-, wayland
-, gstreamer, gst-plugins-base, gst-plugins-good, libunwind, orc
-, libxslt
-, libusb1
-, libpulseaudio ? null
-, cups ? null
-, pcsclite ? null
-, systemd ? null
-, buildServer ? true
-, nocaps ? false
-}:
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, alsaLib, ffmpeg, glib, openssl
+, pcre, zlib, libX11, libXcursor, libXdamage, libXext, libXi, libXinerama
+, libXrandr, libXrender, libXv, libXtst, libxkbcommon, libxkbfile, wayland
+, gstreamer, gst-plugins-base, gst-plugins-good, libunwind, orc, libxslt
+, libusb1, libpulseaudio ? null, cups ? null, pcsclite ? null, systemd ? null
+, buildServer ? true, nocaps ? false }:
 
-stdenv.mkDerivation rec {
+let
+  cmFlag = flag: if flag then "ON" else "OFF";
+  disabledTests = [
+    # this one is probably due to our sandbox
+    {
+      dir = "libfreerdp/crypto/test";
+      file = "Test_x509_cert_info.c";
+    }
+  ];
+
+in stdenv.mkDerivation rec {
   pname = "freerdp";
   version = "2.0.0";
 
   src = fetchFromGitHub {
-    owner  = "FreeRDP";
-    repo   = "FreeRDP";
-    rev    = version;
+    owner = "FreeRDP";
+    repo = "FreeRDP";
+    rev = version;
     sha256 = "0d2559v0z1jnq6jlrvsgdf8p6gd27m8kwdnxckl1x0ygaxs50bqc";
   };
 
-  # outputs = [ "bin" "out" "dev" ];
-
-  prePatch = ''
+  postPatch = ''
     export HOME=$TMP
+
+    # failing test(s)
+    ${lib.concatMapStringsSep "\n" (e: ''
+      substituteInPlace ${e.dir}/CMakeLists.txt \
+        --replace ${e.file} ""
+      rm ${e.dir}/${e.file}
+    '') disabledTests}
+
     substituteInPlace "libfreerdp/freerdp.pc.in" \
       --replace "Requires:" "Requires: @WINPR_PKG_CONFIG_FILENAME@"
   '' + lib.optionalString (pcsclite != null) ''
@@ -39,32 +46,54 @@ stdenv.mkDerivation rec {
       --replace "RDP_SCANCODE_CAPSLOCK" "RDP_SCANCODE_LCONTROL"
   '';
 
-  buildInputs = with lib; [
-    alsaLib cups ffmpeg glib openssl pcre pcsclite libpulseaudio zlib
-    gstreamer gst-plugins-base gst-plugins-good libunwind orc
-    libX11 libXcursor libXdamage libXext libXi libXinerama libXrandr libXrender libXv libXtst
-    libxkbcommon libxkbfile
-    wayland libusb1
-    libxslt
-  ] ++ optional stdenv.isLinux systemd;
+  buildInputs = with lib;
+    [
+      alsaLib
+      cups
+      ffmpeg
+      glib
+      gst-plugins-base
+      gst-plugins-good
+      gstreamer
+      libX11
+      libXcursor
+      libXdamage
+      libXext
+      libXi
+      libXinerama
+      libXrandr
+      libXrender
+      libXtst
+      libXv
+      libpulseaudio
+      libunwind
+      libusb1
+      libxkbcommon
+      libxkbfile
+      libxslt
+      openssl
+      orc
+      pcre
+      pcsclite
+      wayland
+      zlib
+    ] ++ optional stdenv.isLinux systemd;
 
-  nativeBuildInputs = [
-    cmake pkgconfig
-  ];
+  nativeBuildInputs = [ cmake pkgconfig ];
 
-  enableParallelBuilding = true;
+  doCheck = true;
 
-  doCheck = false;
-
-  cmakeFlags = with lib; [
-    "-DCMAKE_INSTALL_LIBDIR=lib"
-    "-DWITH_CUNIT=OFF"
-    "-DWITH_OSS=OFF"
-  ] ++ optional (libpulseaudio != null)       "-DWITH_PULSE=ON"
-    ++ optional (cups != null)                "-DWITH_CUPS=ON"
-    ++ optional (pcsclite != null)            "-DWITH_PCSC=ON"
-    ++ optional buildServer                   "-DWITH_SERVER=ON"
-    ++ optional (stdenv.isx86_64)             "-DWITH_SSE2=ON";
+  cmakeFlags = [ "-DCMAKE_INSTALL_LIBDIR=lib" ]
+    ++ lib.mapAttrsToList (k: v: "-D${k}=${if v then "ON" else "OFF"}") {
+      BUILD_TESTING = doCheck;
+      WITH_CUNIT = doCheck;
+      WITH_CUPS = (cups != null);
+      WITH_OSS = false;
+      WITH_PCSC = (pcsclite != null);
+      WITH_PULSE = (libpulseaudio != null);
+      WITH_SERVER = buildServer;
+      WITH_SSE2 = stdenv.isx86_64;
+    };
 
   meta = with lib; {
     description = "A Remote Desktop Protocol Client";
@@ -72,7 +101,7 @@ stdenv.mkDerivation rec {
       FreeRDP is a client-side implementation of the Remote Desktop Protocol (RDP)
       following the Microsoft Open Specifications.
     '';
-    homepage = "http://www.freerdp.com/";
+    homepage = "https://www.freerdp.com/";
     license = licenses.asl20;
     maintainers = with maintainers; [ peterhoeg lheckemann ];
     platforms = platforms.unix;


### PR DESCRIPTION
Closes #85020

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).