### PR TITLE
transifex-client: 0.13.6 -> 0.13.9

### DIFF
--- a/pkgs/tools/text/transifex-client/default.nix
+++ b/pkgs/tools/text/transifex-client/default.nix
@@ -3,7 +3,7 @@
 
 buildPythonApplication rec {
   pname = "transifex-client";
-  version = "0.13.6";
+  version = "0.13.9";
 
   propagatedBuildInputs = [
     urllib3 requests python-slugify six setuptools
@@ -11,13 +11,13 @@ buildPythonApplication rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0y6pprlmkmi7wfqr3k70sb913qa70p3i90q5mravrai7cr32y1w8";
+    sha256 = "0lgd77vrddvyn8afkxr7a7hblmp4k5sr0i9i1032xdih2bipdd9f";
   };
 
   prePatch = ''
     substituteInPlace requirements.txt --replace "urllib3<1.24" "urllib3>=1.24" \
       --replace "six==1.11.0" "six>=1.11.0" \
-      --replace "python-slugify==1.2.6" "python-slugify>=1.2.6"
+      --replace "python-slugify<2.0.0" "python-slugify>2.0.0"
   '';
 
   # Requires external resources


### PR DESCRIPTION
###### Motivation for this change
I've tested to use `tx pull` on a local project, so it seems to work fine even though the updated patching.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
