### PR TITLE
python: Fix creating RPMs from Python packages

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.7/fix-hardcoded-path-checking-for-rpmbuild.patch
+++ b/pkgs/development/interpreters/python/cpython/3.7/fix-hardcoded-path-checking-for-rpmbuild.patch
@@ -1,0 +1,30 @@
+From a612c481f6116955d420db5ae1fe4c1eb93eb2f2 Mon Sep 17 00:00:00 2001
+From: Marcin Niemira <marcin.niemira@gmail.com>
+Date: Sun, 9 Jun 2019 07:05:06 +1000
+Subject: [PATCH] bpo-11122: fix hardcoded path checking for rpmbuild in
+ bdist_rpm.py (GH-10594) (cherry picked from commit
+ 45a14942c969ed508b35abd5e116cb18f84ce5b4)
+
+Co-authored-by: Marcin Niemira <marcin.niemira@gmail.com>
+---
+ Lib/distutils/command/bdist_rpm.py                           | 5 +----
+ .../next/Library/2018-11-12-19-08-50.bpo-11122.Gj7BQn.rst    | 1 +
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Library/2018-11-12-19-08-50.bpo-11122.Gj7BQn.rst
+
+diff --git a/Lib/distutils/command/bdist_rpm.py b/Lib/distutils/command/bdist_rpm.py
+index 20ca7ac6dcffa..74381cc69a6ce 100644
+--- a/Lib/distutils/command/bdist_rpm.py
++++ b/Lib/distutils/command/bdist_rpm.py
+@@ -309,10 +309,7 @@ def run(self):
+ 
+         # build package
+         log.info("building RPMs")
+-        rpm_cmd = ['rpm']
+-        if os.path.exists('/usr/bin/rpmbuild') or \
+-           os.path.exists('/bin/rpmbuild'):
+-            rpm_cmd = ['rpmbuild']
++        rpm_cmd = ['rpmbuild']
+ 
+         if self.source_only: # what kind of RPMs?
+             rpm_cmd.append('-bs')

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -103,6 +103,10 @@ in with passthru; stdenv.mkDerivation {
   ] ++ optionals isPy35 [
     # Backports support for LD_LIBRARY_PATH from 3.6
     ./3.5/ld_library_path.patch
+  ] ++ optionals (isPy35 || isPy36 || isPy37) [
+    # Backport a fix for discovering `rpmbuild` command when doing `python setup.py bdist_rpm` to 3.5, 3.6, 3.7.
+    # See: https://bugs.python.org/issue11122
+    ./3.7/fix-hardcoded-path-checking-for-rpmbuild.patch
   ] ++ optionals (isPy37 || isPy38) [
     # Fix darwin build https://bugs.python.org/issue34027
     ./3.7/darwin-libutil.patch


### PR DESCRIPTION
###### Motivation for this change
This should enable (manual) building of RPMs from python projects using
the `python setup.py bdist_rpm` command on systems where `rpmbuild` is not located in
`/usr/bin/rpmbuild`. (e.g. NixOS)
The discovery of the rpmbuild command was fixed upstream in Python 3.8,
so this commit backports the relevant patch to our currently supported
Python 3 versions.

Fixes: #85204

###### Things done
I have only tested that the patches apply but didn't run a full build since it is a mass rebuild. Sorry for that.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
