### PR TITLE
containerd: fix --version output

### DIFF
--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -5,6 +5,8 @@ with lib;
 buildGoPackage rec {
   pname = "containerd";
   version = "1.2.13";
+  # git commit for the above version's tag
+  commit = "7ad184331fa3e55e52b890ea95e65ba581ae3429";
 
   src = fetchFromGitHub {
     owner = "containerd";
@@ -20,7 +22,7 @@ buildGoPackage rec {
 
   buildInputs = [ btrfs-progs ];
 
-  buildFlags = [ "VERSION=v${version}" ];
+  buildFlags = [ "VERSION=v${version}" "REVISION=${commit}" ];
 
   BUILDTAGS = []
     ++ optional (btrfs-progs == null) "no_btrfs";
@@ -28,7 +30,7 @@ buildGoPackage rec {
   buildPhase = ''
     cd go/src/${goPackagePath}
     patchShebangs .
-    make binaries
+    make binaries $buildFlags
   '';
 
   installPhase = ''


### PR DESCRIPTION
Before this change, 'containerd --version' with the nix package wouldn't
print useful version information.

In addition, the build output a bunch of (harmless) errors about 'git:
command not found'.

This fixes those problems.

cc @vdemeester 

Here's the difference from this change:
```
# Before
$ nix-build -E 'with import <nixpkgs> {}; callPackage ./default.nix {}'
...
building
patching script interpreter paths in .
...
make: git: Command not found
... (repeated several times)

$ ./result-bin/bin/containerd --version
containerd github.com/containerd/containerd  .m

# After
# No git errors on building it, and...
$ ./result-bin/bin/containerd --version
containerd github.com/containerd/containerd v1.2.13 7ad184331fa3e55e52b890ea95e65ba581ae3429
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
