### PR TITLE
ocamlPackages.asn1-combinators: 0.2.0 -> 0.2.2

### DIFF
--- a/pkgs/development/ocaml-modules/asn1-combinators/default.nix
+++ b/pkgs/development/ocaml-modules/asn1-combinators/default.nix
@@ -1,45 +1,27 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild
-, cstruct, zarith, ounit, result, topkg, ptime
+{ lib, buildDunePackage, fetchurl
+, cstruct, zarith, bigarray-compat, stdlib-shims, ptime, alcotest
 }:
 
-let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
-    version = "0.2.0";
-    sha256 = "0yfq4hnyzx6hy05m60007cfpq88wxwa8wqzib19lnk2qrgy772mx";
-    propagatedBuildInputs = [ ptime ];
-  } else {
-    version = "0.1.3";
-    sha256 = "0hpn049i46sdnv2i6m7r6m6ch0jz8argybh71wykbvcqdby08zxj";
-    propagatedBuildInputs = [ ];
-  };
-in
+buildDunePackage rec {
+  minimumOCamlVersion = "4.05";
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-asn1-combinators-${version}";
-  inherit (param) version;
+  pname = "asn1-combinators";
+  version = "0.2.2";
 
-  src = fetchFromGitHub {
-    owner  = "mirleft";
-    repo   = "ocaml-asn1-combinators";
-    rev    = "v${version}";
-    inherit (param) sha256;
+  src = fetchurl {
+    url = "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v${version}/asn1-combinators-v${version}.tbz";
+    sha256 = "0c9n3nki3drjwn7yv2pg7nzyzsi409laq70830wh147hvvwxbsy9";
   };
 
-  buildInputs = [ findlib ounit topkg ];
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  propagatedBuildInputs = [ result cstruct zarith ] ++ param.propagatedBuildInputs;
-
-  buildPhase = "${topkg.run} build --tests true";
-
-  inherit (topkg) installPhase;
+  propagatedBuildInputs = [ cstruct zarith bigarray-compat stdlib-shims ptime ];
 
   doCheck = true;
-  checkPhase = "${topkg.run} test";
+  checkInputs = [ alcotest ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/mirleft/ocaml-asn1-combinators";
     description = "Combinators for expressing ASN.1 grammars in OCaml";
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = licenses.isc;
+    maintainers = with maintainers; [ vbgl ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Update, gets rid of `ounit` dependency. Also removed the old package version for older OCaml versions, as it doesn't seem to be necessary (anymore)?

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).