### PR TITLE
git: Allow the update script to target non-latest versions

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/update.sh
+++ b/pkgs/applications/version-management/git-and-tools/git/update.sh
@@ -5,14 +5,15 @@ set -eu -o pipefail
 
 oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion git" | tr -d '"')"
 latestTag="$(git ls-remote --tags --sort="v:refname" git://github.com/git/git.git | grep -v '\{\}' | grep -v '\-rc' | tail -1 | sed 's|^.*/v\(.*\)|\1|')"
+targetVersion="${1:-latestTag}"
 
-if [ ! "${oldVersion}" = "${latestTag}" ]; then
-  update-source-version git "${latestTag}"
+if [ ! "${oldVersion}" = "${targetVersion}" ]; then
+  update-source-version git "${targetVersion}"
   nixpkgs="$(git rev-parse --show-toplevel)"
   default_nix="$nixpkgs/pkgs/applications/version-management/git-and-tools/git/default.nix"
   nix-build -A git
   git add "${default_nix}"
-  git commit -m "git: ${oldVersion} -> ${latestTag}"
+  git commit -m "git: ${oldVersion} -> ${targetVersion}"
 else
   echo "git is already up-to-date"
 fi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This came in handy when I wanted to bump a patch version while avoiding a new minor version. See #85277.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
