### PR TITLE
sn0int: init at 0.18.2

### DIFF
--- a/pkgs/tools/security/sn0int/default.nix
+++ b/pkgs/tools/security/sn0int/default.nix
@@ -1,0 +1,32 @@
+{ lib, fetchFromGitHub, rustPlatform,
+  libsodium, libseccomp, sqlite, pkgconfig }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sn0int";
+  version = "0.18.2";
+
+  src = fetchFromGitHub {
+    owner = "kpcyrd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0b21b0ryq03zrhqailg2iajirn30l358aj3k44lfnravr4h9zwkj";
+  };
+
+  cargoSha256 = "1pvn0sc325b5fh29m2l6cack4qfssa4lp3zhyb1qzkb3fmw3lgcy";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ libsodium libseccomp sqlite ];
+
+  # One of the dependencies (chrootable-https) tries to read "/etc/resolv.conf"
+  # in "checkPhase", hence fails in sandbox of "nix".
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Semi-automatic OSINT framework and package manager";
+    homepage = "https://github.com/kpcyrd/sn0int";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ xrelkd ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6625,6 +6625,8 @@ in
 
   smugline = python3Packages.smugline;
 
+  sn0int = callPackage ../tools/security/sn0int { };
+
   snabb = callPackage ../tools/networking/snabb { } ;
 
   snapcast = callPackage ../applications/audio/snapcast { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`sn0int` is  a semi-automatic OSINT framework and package manager 
- https://github.com/kpcyrd/sn0int

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
