### PR TITLE
system-syzygy: Fix invalid desktopFile arguments

### DIFF
--- a/pkgs/games/system-syzygy/default.nix
+++ b/pkgs/games/system-syzygy/default.nix
@@ -3,7 +3,7 @@
 let
   desktopFile = makeDesktopItem {
     name = "system-syzygy";
-    exec = "%out%/bin/syzygy";
+    exec = "@out@/bin/syzygy";
     comment = "A puzzle game";
     desktopName = "System Syzygy";
     categories = "Game;";


### PR DESCRIPTION
###### Motivation for this change

Fixes this build failure:

```
Running desktop-file validation
/nix/store/vadj03624kv6h963c7fjwdz1hg403aa9-system-syzygy.desktop/share/applications/system-syzygy.desktop: error: value "%out%/bin/syzygy" for key "Exec" in group "Desktop Entry" contains an invalid field code "%o"
/nix/store/vadj03624kv6h963c7fjwdz1hg403aa9-system-syzygy.desktop/share/applications/system-syzygy.desktop: error: value "%out%/bin/syzygy" for key "Exec" in group "Desktop Entry" contains an invalid field code "%/"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
