### PR TITLE
gpgme: Fix build with python on macOS

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, fetchpatch, libgpgerror, gnupg, pkgconfig, glib, pth, libassuan
+{ stdenv, fetchurl, fetchpatch
+, autoreconfHook, libgpgerror, gnupg, pkgconfig, glib, pth, libassuan
 , file, which, ncurses
 , texinfo
 , buildPackages
@@ -33,7 +34,14 @@ stdenv.mkDerivation rec {
       url = "http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=patch;h=c4cf527ea227edb468a84bf9b8ce996807bd6992";
       sha256 = "pKL1tvUw7PB2w4FHSt2up4SvpFiprBH6TLdgKxYFC3g=";
     })
-  ];
+    # https://lists.gnupg.org/pipermail/gnupg-devel/2020-April/034591.html
+    (fetchpatch {
+      name = "0001-Fix-python-tests-on-non-Linux.patch";
+      url = "https://lists.gnupg.org/pipermail/gnupg-devel/attachments/20200415/f7be62d1/attachment.obj";
+      sha256 = "00d4sxq63601lzdp2ha1i8fvybh7dzih4531jh8bx07fab3sw65g";
+    })
+    # Disable python tests on Darwin as they use gpg (see configureFlags below)
+  ] ++ lib.optional stdenv.isDarwin ./disable-python-tests.patch;
 
   outputs = [ "out" "dev" "info" ];
   outputBin = "dev"; # gpgme-config; not so sure about gpgme-tool
@@ -42,23 +50,10 @@ stdenv.mkDerivation rec {
     [ libgpgerror glib libassuan pth ]
     ++ lib.optional (qtbase != null) qtbase;
 
-  nativeBuildInputs = [ file pkgconfig gnupg texinfo ]
+  nativeBuildInputs = [ pkgconfig gnupg texinfo autoreconfHook ]
   ++ lib.optionals pythonSupport [ python swig2 which ncurses ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-
-  postPatch =''
-    substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file
-  ''
-  # Apply only on Darwin to save rebuilds on Linux
-     + lib.optionalString stdenv.isDarwin ''
-    sed -i "s/LD_LIBRARY_PATH/@shlibpath_var@/" lang/python/tests/Makefile.in
-    sed -i "s/ac_subst_vars='/ac_subst_vars='shlibpath_var\n/" configure
-  ''
-  # Disable python tests on Darwin as they use gpg (see configureFlags below)
-     + lib.optionalString stdenv.isDarwin ''
-    sed -i "s/SUBDIRS = \. tests/SUBDIRS = ./" lang/python/Makefile.in
-  '';
 
   configureFlags = [
     "--enable-fixed-path=${gnupg}/bin"

--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -49,6 +49,15 @@ stdenv.mkDerivation rec {
 
   postPatch =''
     substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file
+  ''
+  # Apply only on Darwin to save rebuilds on Linux
+     + lib.optionalString stdenv.isDarwin ''
+    sed -i "s/LD_LIBRARY_PATH/@shlibpath_var@/" lang/python/tests/Makefile.in
+    sed -i "s/ac_subst_vars='/ac_subst_vars='shlibpath_var\n/" configure
+  ''
+  # Disable python tests on Darwin as they use gpg (see configureFlags below)
+     + lib.optionalString stdenv.isDarwin ''
+    sed -i "s/SUBDIRS = \. tests/SUBDIRS = ./" lang/python/Makefile.in
   '';
 
   configureFlags = [

--- a/pkgs/development/libraries/gpgme/disable-python-tests.patch
+++ b/pkgs/development/libraries/gpgme/disable-python-tests.patch
@@ -1,0 +1,12 @@
+diff -Naur --strip-trailing-cr gpgme-1.13.1.org/lang/python/Makefile.am gpgme-1.13.1/lang/python/Makefile.am
+--- gpgme-1.13.1.org/lang/python/Makefile.am	2019-06-04 07:27:49.000000000 +0100
++++ gpgme-1.13.1/lang/python/Makefile.am	2020-04-15 14:27:34.810172944 +0100
+@@ -23,7 +23,7 @@
+ 	gpgme.i \
+ 	helpers.c helpers.h private.h
+ 
+-SUBDIRS = . tests examples doc src
++SUBDIRS = . examples doc src
+ 
+ .PHONY: prepare
+ prepare: copystamp


### PR DESCRIPTION
* Replace LD_LIBRARY_PATH with OS-specific name (e.g. DYLD_LIBRARY_PATH
  on macOS).
* Disable Python tests on macOS, because they use gpg, which fails due
  to a very long socket path (https://github.com/NixOS/nix/pull/1085).

The former should be fixed upstream ([patch](https://lists.gnupg.org/pipermail/gnupg-devel/2020-April/034591.html)). The latter is a Nix-specific issue,
but it can be worked-around upstream by making Python tests respect
--disable-gpg-test.

Fixes #70996.
Related NixOS/nix#1085.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).