### PR TITLE
fetchFromGitHub: add possibility to fetch release assets

### DIFF
--- a/pkgs/build-support/fetchgithub/release.nix
+++ b/pkgs/build-support/fetchgithub/release.nix
@@ -1,0 +1,19 @@
+{ lib, fetchurl }:
+
+{ owner, repo, tag, asset
+, name ? "source"
+, githubBase ? "github.com"
+, ... }@args:
+
+# don't do fetchFromGitHub's job
+assert (asset != "${tag}.zip" && asset != "${tag}.tar.gz");
+
+let
+  baseUrl = "https://${githubBase}/${owner}/${repo}";
+  passthruAttrs = removeAttrs args [ "owner" "repo" "tag" "githubBase" "asset" ];
+  fetchArgs = {
+    inherit name;
+    url = "${baseUrl}/releases/download/${tag}/${asset}";
+    meta.homepage = baseUrl;
+  } // passthruAttrs;
+in fetchurl fetchArgs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -389,6 +389,8 @@ in
   fetchNuGet = callPackage ../build-support/fetchnuget { };
   buildDotnetPackage = callPackage ../build-support/build-dotnet-package { };
 
+  fetchGitHubRelease = callPackage ../build-support/fetchgithub/release.nix {};
+
   fetchgx = callPackage ../build-support/fetchgx { };
 
   resolveMirrorURLs = {url}: fetchurl {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Sometimes it is desireable to download files that are uploaded as assets to accompany a release. This is for example often the case in `ocamlPackages`, since package authors often generate release tarballs containing the source code, but preprocessed to adjust certain values like version numbers. Instead of using `fetchurl` all the time, we could now use `fetchGitHubRelease`.

Instead of ...

```nix
src = fetchurl {
  url = "https://github.com/hannesm/duration/releases/download/${version}/duration-${version}.tbz";
  sha256 = "0m9r0ayhpl98g9vdxrbjdcllns274jilic5v8xj1x7dphw21p95h";
};
```

... we'd have ...

```nix
src = fetchGitHubRelease {
  owner = "hannesm";
  repo = pname;
  tag = version;
  sha256 = "07dbirgrypxjg743k4fqw63vzk489ps4m5dncnzfvxjb93xmi9n5";
  asset = "${pname}-${version}.tbz";
};
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
