### PR TITLE
mblaze: install msuck and mblow

### DIFF
--- a/pkgs/applications/networking/mailreaders/mblaze/default.nix
+++ b/pkgs/applications/networking/mailreaders/mblaze/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchFromGitHub, fetchpatch, libiconv }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, libiconv, ruby ? null }:
 
 stdenv.mkDerivation rec {
   pname = "mblaze";
   version = "0.5.1";
 
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ libiconv ];
+  buildInputs = [ ruby ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   src = fetchFromGitHub {
     owner = "chneukirchen";
@@ -24,9 +24,11 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     install -Dm644 -t $out/share/zsh/site-functions contrib/_mblaze
+  '' + lib.optionalString (ruby != null) ''
+    install -Dt $out/bin contrib/msuck contrib/mblow
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/chneukirchen/mblaze";
     description = "Unix utilities to deal with Maildir";
     license = licenses.cc0;


### PR DESCRIPTION
There are lots of other scripts in contrib that we should probably
also install, but I didn't feel like taking the time to review them
all and figure out what dependencies they would need.

It would have been a shame to add a mandatory dependency on Ruby (and
all that entails) to a package that otherwise has basically no
dependencies, so I've made the Ruby dependency optional.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
