### PR TITLE
spago: 0.14.0 -> 0.15.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -655,22 +655,19 @@ self: super: builtins.intersectAttrs super {
 
   spago =
     let
-      # Spago needs a patch for MonadFail changes.
-      # https://github.com/purescript/spago/pull/584
-      # This can probably be removed when a version after spago-0.14.0 is released.
+      # Spago needs a small patch to work with the latest versions of rio.
+      # https://github.com/purescript/spago/pull/616
+      # This can probably be removed when a version after spago-0.15.1 is released.
       spagoWithPatches = appendPatch super.spago (pkgs.fetchpatch {
-        url = "https://github.com/purescript/spago/pull/584/commits/898a8e48665e5a73ea03525ce2c973455ab9ac52.patch";
-        sha256 = "05gs1hjlcf60cr6728rhgwwgxp3ildly14v4l2lrh6ma2fljhyjy";
+        url = "https://github.com/purescript/spago/pull/616/commits/95b5fa0f1d3bfb07972d1ef5004b8bee8a070667.patch";
+        sha256 = "0v3890lwhddfrq9mhbq92962pkxra8kwbin97wg3s0b02dk65ysc";
       });
 
       # Spago basically compiles with LTS-14, but it requires a newer version
       # of directory.  This is to work around a bug only present on windows, so
       # we can safely jailbreak spago and use the older directory package from
       # LTS-14.
-      spagoWithOverrides = doJailbreak (spagoWithPatches.override {
-        # spago requires dhall-1.29.0.
-        dhall = self.dhall_1_29_0;
-      });
+      spagoWithOverrides = doJailbreak spagoWithPatches;
 
       # This defines the version of the purescript-docs-search release we are using.
       # This is defined in the src/Spago/Prelude.hs file in the spago source.

--- a/pkgs/development/tools/purescript/spago/spago.nix
+++ b/pkgs/development/tools/purescript/spago/spago.nix
@@ -7,15 +7,15 @@
 , prettyprinter, process, QuickCheck, retry, rio, rio-orphans, safe
 , semver-range, stdenv, stm, tar, template-haskell, temporary, text
 , time, transformers, turtle, unliftio, unordered-containers
-, vector, versions, zlib
+, vector, versions, with-utf8, zlib
 }:
 mkDerivation {
   pname = "spago";
-  version = "0.14.0";
+  version = "0.15.1";
   src = fetchgit {
     url = "https://github.com/purescript/spago.git";
-    sha256 = "12i1430prqspy73nwfxc17zf51yprhrxxcnhw4rks6jhkgwxf4a4";
-    rev = "7a99343e4876a465600eaa64b0697a9f0b2a49a9";
+    sha256 = "09ypbm03ap8xfhq803ra3cc01dxcavckn7nis6hi80dk2xxlhc3d";
+    rev = "d5d206ff0f5c686f8b609fb4bc2e866959cc0144";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -25,17 +25,13 @@ mkDerivation {
     bytestring Cabal containers dhall directory either exceptions
     file-embed filepath foldl fsnotify github Glob http-client
     http-conduit lens-family-core megaparsec mtl network-uri
-    open-browser prettyprinter process retry rio rio-orphans safe
-    semver-range stm tar template-haskell temporary text time
-    transformers turtle unliftio unordered-containers vector versions
-    zlib
+    open-browser optparse-applicative prettyprinter process retry rio
+    rio-orphans safe semver-range stm tar template-haskell temporary
+    text time transformers turtle unliftio unordered-containers vector
+    versions with-utf8 zlib
   ];
   libraryToolDepends = [ hpack ];
-  executableHaskellDepends = [
-    aeson-pretty async-pool base bytestring containers dhall filepath
-    github lens-family-core megaparsec optparse-applicative process
-    retry stm temporary text time turtle vector
-  ];
+  executableHaskellDepends = [ base text turtle with-utf8 ];
   testHaskellDepends = [
     base containers directory extra hspec hspec-megaparsec megaparsec
     process QuickCheck temporary text turtle versions


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `spago` to the latest release: https://github.com/purescript/spago/releases/tag/0.15.1
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
