### PR TITLE
yubioath-desktop: 5.0.2 -> 5.0.3

### DIFF
--- a/pkgs/applications/misc/yubioath-desktop/default.nix
+++ b/pkgs/applications/misc/yubioath-desktop/default.nix
@@ -6,11 +6,11 @@
 
 mkDerivation rec {
   pname = "yubioath-desktop";
-  version = "5.0.2";
+  version = "5.0.3";
 
   src = fetchurl {
     url = "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-${version}.tar.gz";
-    sha256 = "19ingk0ab88a22s04apcw8kx9xygxlbk8kp4xnb8pmf8z3k6l2gf";
+    sha256 = "1g0jd7mmch6a6n8k5pp3w27qd5cijnvzk05lwraf0i96m68h7x1k";
   };
 
   doCheck = false;
@@ -38,13 +38,13 @@ mkDerivation rec {
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.getLib pcsclite}/lib:${yubikey-personalization}/lib"
 
       mkdir -p $out/share/applications
-      cp resources/yubioath-desktop.desktop \
-        $out/share/applications/yubioath-desktop.desktop
+      cp resources/com.yubico.yubioath.desktop \
+        $out/share/applications/com.yubico.yubioath.desktop
       mkdir -p $out/share/yubioath/icons
-      cp resources/icons/*.{icns,ico,png,xpm} $out/share/yubioath/icons
-      substituteInPlace $out/share/applications/yubioath-desktop.desktop \
+      cp resources/icons/*.{icns,ico,png,svg} $out/share/yubioath/icons
+      substituteInPlace $out/share/applications/com.yubico.yubioath.desktop \
         --replace 'Exec=yubioath-desktop' "Exec=$out/bin/yubioath-desktop" \
-        --replace 'Icon=yubioath' "Icon=$out/share/yubioath/icons/yubioath.png"
+        --replace 'Icon=yubioath' "Icon=$out/share/yubioath/icons/com.yubico.yubioath.png"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds support for the Yubikey 5 NFC

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
