### PR TITLE
futhark: stop wrapping the executable

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -572,23 +572,9 @@ self: super: builtins.intersectAttrs super {
   # The test-suite requires a running PostgreSQL server.
   Frames-beam = dontCheck super.Frames-beam;
 
-  # * Compile manpages (which are in RST and are compiled with Sphinx).
-  #
-  # * Wrap so that binary can find GCC and OpenCL headers (dubious if
-  #   a good idea).
+  # Compile manpages (which are in RST and are compiled with Sphinx).
   futhark = with pkgs;
-    let maybeWrap =
-          if pkgs.stdenv.isDarwin then ""
-          else
-            let path = stdenv.lib.makeBinPath [ gcc ];
-            in ''
-            wrapProgram $out/bin/futhark \
-              --prefix PATH : "${path}" \
-              --set NIX_CC_WRAPPER_x86_64_unknown_linux_gnu_TARGET_HOST 1 \
-              --set NIX_CFLAGS_COMPILE "-I${opencl-headers}/include" \
-              --set NIX_CFLAGS_LINK "-L${ocl-icd}/lib"
-            '';
-    in overrideCabal (addBuildTools super.futhark [makeWrapper python37Packages.sphinx])
+    overrideCabal (addBuildTools super.futhark [makeWrapper python37Packages.sphinx])
       (_drv: {
         postBuild = (_drv.postBuild or "") + ''
         make -C docs man
@@ -597,8 +583,7 @@ self: super: builtins.intersectAttrs super {
         postInstall = (_drv.postInstall or "") + ''
         mkdir -p $out/share/man/man1
         mv docs/_build/man/*.1 $out/share/man/man1/
-        ''
-        + maybeWrap;
+        '';
       });
 
   git-annex = with pkgs;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

While I'm sympathetic to the idea, wrapping `futhark` to make OpenCL available is not a good idea, for two reasons:

1. Futhark's main use case is not to generate an executable, but rather to generate C code that is then compiled by the user and linked with other application code.

2. Futhark has many more backends than just C+OpenCL.  It also has C+CUDA, Python+OpenCL, and C#+OpenCL.  These are not addressed by the wrapper, and addressing them would require a huge number of dependencies, including one that is non-free.

Since any nontrivial use of Futhark with Nix will anyway require the user to make some other compilers and libraries available in their environment, this wrapping is not useful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
