### PR TITLE
nixos/rss2email: globally install rss2email

### DIFF
--- a/nixos/modules/services/mail/rss2email.nix
+++ b/nixos/modules/services/mail/rss2email.nix
@@ -91,6 +91,8 @@ in {
       };
     };
 
+    environment.systemPackages = with pkgs; [ rss2email ];
+
     services.rss2email.config.to = cfg.to;
 
     systemd.tmpfiles.rules = [


### PR DESCRIPTION
For man pages.