### PR TITLE
drill: init at 0.5.0

### DIFF
--- a/pkgs/tools/networking/drill/default.nix
+++ b/pkgs/tools/networking/drill/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "drill";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "fcsonline";
+    repo = pname;
+    rev = version;
+    sha256 = "0aqd709fg0ha0lzri2p4pgraxvif7z8zcm8rx7sk6s2n605sc4gn";
+  };
+
+  cargoSha256 = "1c8vmyf388kbbs56h8b62nxgxvgy9yj9cnmvax6ycnslkcwmvld0";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  meta = with stdenv.lib; {
+    description = "HTTP load testing application inspired by Ansible syntax";
+    homepage = "https://github.com/fcsonline/drill";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ filalex77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2958,6 +2958,8 @@ in
 
   driftnet = callPackage ../tools/networking/driftnet {};
 
+  drill = callPackage ../tools/networking/drill { };
+
   drone = callPackage ../development/tools/continuous-integration/drone { };
 
   drone-cli = callPackage ../development/tools/continuous-integration/drone-cli { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/fcsonline/drill/releases/tag/0.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
