### PR TITLE
macvim: 8.2.319 -> 8.2.539

### DIFF
--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -22,14 +22,6 @@ let
     mkdir -p $out/bin
     ln -s /usr/bin/xcrun /usr/bin/xcodebuild /usr/bin/tiffutil /usr/bin/qlmanage $out/bin
   '';
-  # I'm not really sure how configure finds Nix Libsystem, but we get link errors when using
-  # Xcode 11.4 if we're compiling against Xcode's SDK but using Nix Libsystem. We can't just pass
-  # Libsystem's includes though as that causes other issues, particularly with availability macros.
-  # This is a horrible hack but let's just pass the header that's causing problems.
-  fakeLibsystemInclude = runCommand "macvim-libsystem-include-shim" {} ''
-    mkdir -p $out/include/sys/_types
-    ln -s ${darwin.Libsystem}/include/sys/_types/_fd_def.h $out/include/sys/_types
-  '';
 in
 
 stdenv.mkDerivation {
@@ -74,7 +66,6 @@ stdenv.mkDerivation {
       "--with-tlib=ncurses"
       "--with-compiledby=Nix"
       "--disable-sparkle"
-      "LDFLAGS=-headerpad_max_install_names"
   ];
 
   makeFlags = ''PREFIX=$(out) CPPFLAGS="-Wno-error"'';
@@ -89,19 +80,12 @@ stdenv.mkDerivation {
 
   # This is unfortunate, but we need to use the same compiler as Xcode,
   # but Xcode doesn't provide a way to configure the compiler.
-  #
-  # If you're willing to modify the system files, you can do this:
-  #   http://hamelot.co.uk/programming/add-gcc-compiler-to-xcode-6/
-  #
-  # But we don't have that option.
   preConfigure = ''
     CC=/usr/bin/clang
 
     DEV_DIR=$(/usr/bin/xcode-select -print-path)/Platforms/MacOSX.platform/Developer
     configureFlagsArray+=(
       "--with-developer-dir=$DEV_DIR"
-      # Also pass `-g -O` because configure would add those if we weren't setting CFLAGS.
-      "CFLAGS=-g -O -isystem ${fakeLibsystemInclude}/include"
     )
   ''
   # For some reason having LD defined causes PSMTabBarControl to fail at link-time as it
@@ -111,8 +95,34 @@ stdenv.mkDerivation {
   ''
   ;
 
+  # Because we're building with system clang, this means we're building against Xcode's SDK and
+  # linking against system libraries. The configure script is picking up Nix Libsystem (via ruby)
+  # so we need to patch that out or we'll get linker issues. The MacVim binary built by Xcode links
+  # against the system anyway so it doesn't really matter that the Vim binary will too. If we
+  # decide that matters, we can always patch it back to the Nix libsystem post-build.
+  # It also picks up libiconv, libunwind, and objc4 from Nix. These seem relatively harmless but
+  # let's strip them out too.
+  #
+  # Note: If we do add a post-build install_name_tool patch, we need to add the
+  # "LDFLAGS=-headerpad_max_install_names" flag to configureFlags and either patch it into the
+  # Xcode project or pass it as a flag to xcodebuild as well.
   postConfigure = ''
-    substituteInPlace src/auto/config.mk --replace "PERL_CFLAGS	=" "PERL_CFLAGS	= -I${darwin.libutil}/include"
+    substituteInPlace src/auto/config.mk \
+      --replace "PERL_CFLAGS	=" "PERL_CFLAGS	= -I${darwin.libutil}/include" \
+      --replace " -L${stdenv.cc.libc}/lib" "" \
+      --replace " -L${darwin.libobjc}/lib" "" \
+      --replace " -L${darwin.libunwind}/lib" "" \
+      --replace " -L${darwin.libiconv}/lib" ""
+
+    # All the libraries we stripped have -osx- in their name as of this time.
+    # Assert now that this pattern no longer appears in config.mk.
+    ( # scope variable
+      while IFS="" read -r line; do
+        if [[ "$line" == LDFLAGS*-osx-* ]]; then
+          echo "WARNING: src/auto/config.mk contains reference to Nix osx library" >&2
+        fi
+      done <src/auto/config.mk
+    )
 
     substituteInPlace src/MacVim/vimrc --subst-var-by CSCOPE ${cscope}/bin/cscope
   '';

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -35,13 +35,13 @@ in
 stdenv.mkDerivation {
   pname = "macvim";
 
-  version = "8.2.319";
+  version = "8.2.539";
 
   src = fetchFromGitHub {
     owner = "macvim-dev";
     repo = "macvim";
-    rev = "snapshot-162";
-    sha256 = "1mg55jlrz533wlqrx028fyv86rfhdzvm5kdi8xlf67flc5hh9vrp";
+    rev = "snapshot-163";
+    sha256 = "0ibc6h7zmk81dygkxd8a2rcq72zbqmr9kh64xhsm9h0p70505cdk";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/editors/vim/macvim.patch
+++ b/pkgs/applications/editors/vim/macvim.patch
@@ -1,8 +1,8 @@
 diff --git a/src/MacVim/MacVim.xcodeproj/project.pbxproj b/src/MacVim/MacVim.xcodeproj/project.pbxproj
-index e519018de..556a4127d 100644
+index 2bf5687..103b6e4 100644
 --- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
 +++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
-@@ -1007,6 +1007,7 @@
+@@ -1087,6 +1081,7 @@
  				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
  				MACOSX_DEPLOYMENT_TARGET = "";
  				ONLY_ACTIVE_ARCH = YES;
@@ -10,7 +10,7 @@ index e519018de..556a4127d 100644
  				PRODUCT_BUNDLE_IDENTIFIER = org.vim.MacVim;
  				PRODUCT_NAME = MacVim;
  				VERSIONING_SYSTEM = "apple-generic";
-@@ -1039,6 +1040,7 @@
+@@ -1119,6 +1114,7 @@
  				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
  				MACOSX_DEPLOYMENT_TARGET = "";
  				ONLY_ACTIVE_ARCH = YES;
@@ -19,7 +19,7 @@ index e519018de..556a4127d 100644
  				PRODUCT_NAME = MacVim;
  				VERSIONING_SYSTEM = "apple-generic";
 diff --git a/src/MacVim/vimrc b/src/MacVim/vimrc
-index 23a06bf37..dfb10fe94 100644
+index 23a06bf..dfb10fe 100644
 --- a/src/MacVim/vimrc
 +++ b/src/MacVim/vimrc
 @@ -14,35 +14,5 @@ set backspace+=indent,eol,start
@@ -61,10 +61,10 @@ index 23a06bf37..dfb10fe94 100644
 +" Default cscopeprg to the Nix-installed path
 +set cscopeprg=@CSCOPE@
 diff --git a/src/Makefile b/src/Makefile
-index 32810d0a7..13a05f349 100644
+index 24c6934..d0f094e 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -1385,7 +1385,7 @@ MACVIMGUI_SRC	= gui.c gui_beval.c MacVim/gui_macvim.m MacVim/MMBackend.m \
+@@ -1407,7 +1407,7 @@ MACVIMGUI_SRC	= gui.c gui_beval.c MacVim/gui_macvim.m MacVim/MMBackend.m \
  		  MacVim/MacVim.m
  MACVIMGUI_OBJ	= objects/gui.o objects/gui_beval.o \
  		  objects/gui_macvim.o objects/MMBackend.o objects/MacVim.o
@@ -74,10 +74,10 @@ index 32810d0a7..13a05f349 100644
  MACVIMGUI_LIBS_DIR =
  MACVIMGUI_LIBS1	= -framework Cocoa -framework Carbon
 diff --git a/src/auto/configure b/src/auto/configure
-index 9e6a82f4a..3c6d1a89b 100755
+index 730d6d5..0259112 100755
 --- a/src/auto/configure
 +++ b/src/auto/configure
-@@ -5829,10 +5829,7 @@ $as_echo "not found" >&6; }
+@@ -5859,10 +5859,7 @@ $as_echo "not found" >&6; }
  
      for path in "${vi_cv_path_mzscheme_pfx}/lib" "${SCHEME_LIB}"; do
        if test "X$path" != "X"; then
@@ -89,7 +89,7 @@ index 9e6a82f4a..3c6d1a89b 100755
  	  MZSCHEME_LIBS="${path}/libmzscheme3m.a"
  	  MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
  	elif test -f "${path}/libracket3m.a"; then
-@@ -6217,23 +6214,6 @@ $as_echo ">>> too old; need Perl version 5.003_01 or later <<<" >&6; }
+@@ -6247,23 +6244,6 @@ $as_echo ">>> too old; need Perl version 5.003_01 or later <<<" >&6; }
    fi
  
    if test "x$MACOS_X" = "xyes"; then
@@ -113,7 +113,7 @@ index 9e6a82f4a..3c6d1a89b 100755
                  PERL_LIBS=`echo "$PERL_LIBS" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
      PERL_CFLAGS=`echo "$PERL_CFLAGS" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
    fi
-@@ -6456,13 +6436,7 @@ __:
+@@ -6486,13 +6466,7 @@ __:
  eof
  	    	    eval "`cd ${PYTHON_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
  	    rm -f -- "${tmp_mkf}"
@@ -128,7 +128,7 @@ index 9e6a82f4a..3c6d1a89b 100755
  	      vi_cv_path_python_plibs="-L${PYTHON_CONFDIR} -lpython${vi_cv_var_python_version}"
  	      	      	      	      if test -n "${python_LINKFORSHARED}" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
  	        python_link_symbol=`echo ${python_LINKFORSHARED} | sed 's/\([^ \t][^ \t]*[ \t][ \t]*[^ \t][^ \t]*\)[ \t].*/\1/'`
-@@ -6477,7 +6451,6 @@ eof
+@@ -6507,7 +6481,6 @@ eof
  	      fi
  	      vi_cv_path_python_plibs="${vi_cv_path_python_plibs} ${python_BASEMODLIBS} ${python_LIBS} ${python_SYSLIBS} ${python_LINKFORSHARED}"
  	      	      vi_cv_path_python_plibs=`echo $vi_cv_path_python_plibs | sed s/-ltermcap//`
@@ -136,7 +136,7 @@ index 9e6a82f4a..3c6d1a89b 100755
  
  fi
  
-@@ -6556,13 +6529,6 @@ rm -f core conftest.err conftest.$ac_objext \
+@@ -6586,13 +6559,6 @@ rm -f core conftest.err conftest.$ac_objext \
  $as_echo "no" >&6; }
  	fi
  
@@ -150,7 +150,7 @@ index 9e6a82f4a..3c6d1a89b 100755
  			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if compile and link flags for Python are sane" >&5
  $as_echo_n "checking if compile and link flags for Python are sane... " >&6; }
  	cflags_save=$CFLAGS
-@@ -7456,11 +7422,7 @@ $as_echo "$tclver - OK" >&6; };
+@@ -7486,11 +7452,7 @@ $as_echo "$tclver - OK" >&6; };
  
        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for location of Tcl include" >&5
  $as_echo_n "checking for location of Tcl include... " >&6; }
@@ -162,7 +162,7 @@ index 9e6a82f4a..3c6d1a89b 100755
        TCL_INC=
        for try in $tclinc; do
  	if test -f "$try/tcl.h"; then
-@@ -7478,12 +7440,8 @@ $as_echo "<not found>" >&6; }
+@@ -7508,12 +7470,8 @@ $as_echo "<not found>" >&6; }
        if test -z "$SKIP_TCL"; then
  	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for location of tclConfig.sh script" >&5
  $as_echo_n "checking for location of tclConfig.sh script... " >&6; }
@@ -175,7 +175,7 @@ index 9e6a82f4a..3c6d1a89b 100755
  	for try in $tclcnf; do
  	  if test -f "$try/tclConfig.sh"; then
  	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $try/tclConfig.sh" >&5
-@@ -7673,10 +7631,6 @@ $as_echo "$rubyhdrdir" >&6; }
+@@ -7703,10 +7661,6 @@ $as_echo "$rubyhdrdir" >&6; }
  	if test -f "$rubylibdir/$librubya"; then
  	  librubyarg="$librubyarg"
  	  RUBY_LIBS="$RUBY_LIBS -L$rubylibdir"
@@ -187,10 +187,10 @@ index 9e6a82f4a..3c6d1a89b 100755
  
  	if test "X$librubyarg" != "X"; then
 diff --git a/src/vim.h b/src/vim.h
-index f158aab..a714da9 100644
+index 87d1c92..8a7d5a5 100644
 --- a/src/vim.h
 +++ b/src/vim.h
-@@ -243,17 +243,6 @@
+@@ -250,17 +250,6 @@
  # define SUN_SYSTEM
  #endif
  
@@ -209,7 +209,7 @@ index f158aab..a714da9 100644
  # include "os_amiga.h"
  #endif
 diff --git a/src/vimtutor b/src/vimtutor
-index 1e8769b25..47078b0e7 100755
+index 1e8769b..47078b0 100755
 --- a/src/vimtutor
 +++ b/src/vimtutor
 @@ -16,7 +16,7 @@ seq="vim vim81 vim80 vim8 vim74 vim73 vim72 vim71 vim70 vim7 vim6 vi"

--- a/pkgs/applications/editors/vim/macvim.patch
+++ b/pkgs/applications/editors/vim/macvim.patch
@@ -1,23 +1,3 @@
-diff --git a/src/MacVim/MacVim.xcodeproj/project.pbxproj b/src/MacVim/MacVim.xcodeproj/project.pbxproj
-index 2bf5687..103b6e4 100644
---- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
-+++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
-@@ -1087,6 +1081,7 @@
- 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
- 				MACOSX_DEPLOYMENT_TARGET = "";
- 				ONLY_ACTIVE_ARCH = YES;
-+				OTHER_LDFLAGS = "-headerpad_max_install_names";
- 				PRODUCT_BUNDLE_IDENTIFIER = org.vim.MacVim;
- 				PRODUCT_NAME = MacVim;
- 				VERSIONING_SYSTEM = "apple-generic";
-@@ -1119,6 +1114,7 @@
- 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
- 				MACOSX_DEPLOYMENT_TARGET = "";
- 				ONLY_ACTIVE_ARCH = YES;
-+				OTHER_LDFLAGS = "-headerpad_max_install_names";
- 				PRODUCT_BUNDLE_IDENTIFIER = org.vim.MacVim;
- 				PRODUCT_NAME = MacVim;
- 				VERSIONING_SYSTEM = "apple-generic";
 diff --git a/src/MacVim/vimrc b/src/MacVim/vimrc
 index 23a06bf..dfb10fe 100644
 --- a/src/MacVim/vimrc


### PR DESCRIPTION
###### Motivation for this change
https://github.com/macvim-dev/macvim/releases/tag/snapshot-163

This also includes a fix for compatibility with Xcode 11.4. Xcode 11.4 has an updated `sys/_types/_fd_def.h` header that references a new symbol from libSystem. This is a problem because we're using `/usr/bin/clang` to compile the non-Xcode portion, and this
pulls in headers from Xcode's SDK. Somehow it's still linking to the Nix libraries. The end result is we get a linker error where this new symbol can't be found at link time, even though it's a weak import and isn't required at runtime.

Ideally we'd provide a full 10.12 SDK to `/usr/bin/clang`, but we can't do that because even the DevSDK package we use for our 10.12 SDK doesn't contain everything (in particular it's missing nearly all dylibs) so we just get linker errors if we do that.

Instead we'll just strip the LDFLAGS post-configure so it no longer references the Nix versions of OS libraries. This means we're not linking against Nix libSystem anymore, and that fixes the link error. This also prevents this issue from cropping up again in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
