### PR TITLE
terraform-compliance: init at v1.2.11

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-compliance/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-compliance/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, GitPython
+, buildPythonApplication
+, emoji
+, fetchFromGitHub
+, filetype
+, ipython
+, junit-xml
+, lxml
+, mock
+, netaddr
+, pytestCheckHook
+, python3Packages
+, radish-bdd
+, semver
+}:
+
+buildPythonApplication rec {
+  pname = "terraform-compliance";
+  version = "1.2.11";
+
+  # No tests in Pypi package
+  src = fetchFromGitHub {
+    owner = "eerkunt";
+    repo = pname;
+    rev = version;
+    sha256 = "161mszmxqp3wypnda48ama2mmq8yjilkxahwc1mxjwzy1n19sn7v";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    "test_which_success"
+    "test_readable_plan_file_is_not_json"
+  ];
+
+  propagatedBuildInputs = [
+    GitPython
+    emoji
+    filetype
+    ipython
+    junit-xml
+    lxml
+    mock
+    netaddr
+    radish-bdd
+    semver
+  ];
+
+  meta = with lib; {
+    description = "BDD test framework for terraform";
+    homepage = https://github.com/eerkunt/terraform-compliance;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/development/python-modules/colorful/default.nix
+++ b/pkgs/development/python-modules/colorful/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "colorful";
+  version = "0.5.4";
+
+  # No tests in the Pypi package.
+  src = fetchFromGitHub {
+    owner = "timofurrer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1fcz5v8b318a3dsdha4c874jsf3wmcw3f25bv2csixclyzacli98";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Terminal string styling done right, in Python.";
+    homepage = "http://github.com/timofurrer/colorful";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/development/python-modules/pysingleton/default.nix
+++ b/pkgs/development/python-modules/pysingleton/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "pysingleton";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5776e7a4ba0bab26709da604f4e648c5814385fef34010723db3da0d41b0dbcc";
+  };
+
+  pythonImportsCheck = [ "singleton" ];
+
+  # No tests in the Pypi package.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Provides a decorator to create thread-safe singleton classes";
+    homepage = "https://github.com/timofurrer/pysingleton";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/development/python-modules/radish-bdd/default.nix
+++ b/pkgs/development/python-modules/radish-bdd/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, click
+, colorful
+, docopt
+, fetchFromGitHub
+, freezegun
+, humanize
+, lark-parser
+, parse-type
+, pysingleton
+, pytestCheckHook
+, pyyaml
+, tag-expressions
+, lxml
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "radish-bdd";
+  version = "0.13.2";
+
+  # Pypi package does not have necessary test fixtures.
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "radish";
+    rev = "v${version}";
+    sha256 = "1k7l0j8w221pa6k990x4rfm7km4asx5zy4zpzvh029lb9nw2pp8b";
+  };
+
+  propagatedBuildInputs = [
+    lark-parser
+    click
+    colorful
+    tag-expressions
+    parse-type
+    humanize
+    pyyaml
+    docopt
+    pysingleton
+  ];
+
+  checkInputs = [ freezegun lxml pytestCheckHook pytest-mock ];
+  disabledTests = [ "test_main_cli_calls" ];
+
+  meta = with lib; {
+    description = "Behaviour-Driven-Development tool for python";
+    homepage = "http://radish-bdd.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/development/python-modules/tag-expressions/default.nix
+++ b/pkgs/development/python-modules/tag-expressions/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "tag-expressions";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1c0a49c3c0357976822b03c43db8d4a1c5548e16fb07ac939c10bbd5183f529d";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Package to parse logical tag expressions";
+    homepage = "http://github.com/timofurrer/tag-expressions";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26623,6 +26623,8 @@ in
     callPackage ../applications/networking/cluster/terraform-providers {}
   );
 
+  terraform-compliance = python3Packages.callPackage ../applications/networking/cluster/terraform-compliance {};
+
   terraform-docs = callPackage ../applications/networking/cluster/terraform-docs {};
 
   terraform-inventory = callPackage ../applications/networking/cluster/terraform-inventory {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1500,6 +1500,8 @@ in {
 
   pyvoro = callPackage ../development/python-modules/pyvoro { };
 
+  radish-bdd = callPackage ../development/python-modules/radish-bdd { };
+
   relatorio = callPackage ../development/python-modules/relatorio { };
 
   reproject = callPackage ../development/python-modules/reproject { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2536,6 +2536,8 @@ in {
 
   PyLD = callPackage ../development/python-modules/PyLD { };
 
+  pysingleton = callPackage ../development/python-modules/pysingleton { };
+
   python-jose = callPackage ../development/python-modules/python-jose {};
 
   python-json-logger = callPackage ../development/python-modules/python-json-logger { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1639,6 +1639,8 @@ in {
     hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; };
   };
 
+  tag-expressions = callPackage ../development/python-modules/tag-expressions { };
+
   tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
 
   tesserocr = callPackage ../development/python-modules/tesserocr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2084,6 +2084,8 @@ in {
 
   colorclass = callPackage ../development/python-modules/colorclass {};
 
+  colorful = callPackage ../development/python-modules/colorful {};
+
   colorlog = callPackage ../development/python-modules/colorlog { };
 
   colorspacious = callPackage ../development/python-modules/colorspacious { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
