### PR TITLE
tremc: init at 0.9.1

### DIFF
--- a/pkgs/applications/networking/p2p/tremc/default.nix
+++ b/pkgs/applications/networking/p2p/tremc/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, python3Packages
+, x11Support ? !stdenv.isDarwin
+, xclip ? null
+, pbcopy ? null
+, useGeoIP ? false # Require /var/lib/geoip-databases/GeoIP.dat
+}:
+let
+  wrapperPath = with stdenv.lib; makeBinPath (
+    optional x11Support xclip ++
+    optional stdenv.isDarwin pbcopy
+  );
+in
+python3Packages.buildPythonPackage rec {
+  version = "0.9.1";
+  pname = "tremc";
+
+  src = fetchFromGitHub {
+    owner = "tremc";
+    repo = pname;
+    rev = "0.9.1";
+    sha256 = "1yhwvlcyv1s830p5a7q5x3mkb3mbvr5cn5nh7y62l5b6iyyynlvm";
+  };
+
+  buildInputs = with python3Packages; [
+    python
+    wrapPython
+  ];
+
+  pythonPath = with python3Packages; [
+    ipy
+    pyperclip
+  ] ++
+  stdenv.lib.optional useGeoIP GeoIP;
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  makeWrapperArgs = ["--prefix PATH : ${wrapperPath}"];
+
+  installPhase = ''
+    make DESTDIR=$out install
+    wrapPythonPrograms
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Curses interface for transmission";
+    homepage = "https://github.com/tremc/tremc";
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22170,6 +22170,8 @@ in
 
   treesheets = callPackage ../applications/office/treesheets { wxGTK = wxGTK31; };
 
+  tremc = callPackage ../applications/networking/p2p/tremc { };
+
   tribler = callPackage ../applications/networking/p2p/tribler { };
 
   trojita = libsForQt5.callPackage ../applications/networking/mailreaders/trojita {


### PR DESCRIPTION
###### Motivation for this change
[transmission-remote-cli](https://github.com/fagga/transmission-remote-cli) is no longer maintained but points to two alternatves: [stig](https://github.com/rndusr/stig) and [tremc](https://github.com/tremc/tremc).

###### Things done
Package tremc.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
