### PR TITLE
python3Packages.dotnetcore2: 2.1.11 -> 2.1.13

### DIFF
--- a/pkgs/development/python-modules/dotnetcore2/default.nix
+++ b/pkgs/development/python-modules/dotnetcore2/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "dotnetcore2";
-  version = "2.1.11";
+  version = "2.1.13";
   format = "wheel";
   disabled = isPy27;
 
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     inherit pname version format;
     python = "py3";
     platform = "manylinux1_x86_64";
-    sha256 = "0qhp94bjz4icz2f0fnhgck875chiqzy4lvsp6lwhj5jd0zsv2bb3";
+    sha256 = "1fbg3pn7g0a6pg0gb5vaapcc3cdp6wfnliim57fn3cnzmx5d8p6i";
   };
 
   nativeBuildInputs = [ unzip ];
@@ -35,13 +35,9 @@ buildPythonPackage rec {
     )
   ];
 
-  # unfortunately the noraml pip install fails because the manylinux1 format check fails with NixOS
-  installPhase = ''
-    mkdir -p $out/${python.sitePackages}/${pname}
-    # copy metadata
-    cp -r dotnetcore2-2* $out/${python.sitePackages}
-    # copy non-dotnetcore related files
-    cp -r dotnetcore2/{__init__.py,runtime.py} $out/${python.sitePackages}/${pname}
+  # prevent exposing a broken dotnet executable
+  postInstall = ''
+    rm -r $out/${python.sitePackages}/${pname}/bin
   '';
 
   # no tests, ensure it's one useful function works


### PR DESCRIPTION
###### Motivation for this change
routine update

instead of installing just the *.py s, remove the extraneous entry point.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
