### PR TITLE
openmvg: 1.3 -> 1.5 (unbreak)

### DIFF
--- a/pkgs/applications/science/misc/openmvg/default.nix
+++ b/pkgs/applications/science/misc/openmvg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, cmake
+{ stdenv, fetchFromGitHub, pkgconfig, cmake
 , libjpeg ? null
 , zlib ? null
 , libpng ? null
@@ -8,15 +8,14 @@
 , enableDocs ? false }:
 
 stdenv.mkDerivation rec {
-  version = "1.3";
+  version = "1.6";
   pname = "openmvg";
 
-  src = fetchgit {
-    url = "https://www.github.com/openmvg/openmvg.git";
-
-    # Tag v1.1
-    rev = "refs/tags/v${version}";
-    sha256 = "1cf1gbcl8zvxp4rr6f6vaxwcg0yzc4xban2b5p9zy1m4k1f81zyb";
+  src = fetchFromGitHub {
+    owner = "openmvg";
+    repo = "openmvg";
+    rev = "v${version}";
+    sha256 = "0mrsi0dzgi7cjzn13r9xv7rnc8c9a4h8ip78xy88m9xsyr21wd1h";
     fetchSubmodules = true;
   };
 
@@ -46,6 +45,5 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.mpl20;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ mdaiter ];
-    broken = true; # 2018-04-11
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Unbreak OpenMVG.  Turns out all that was needed was to bump the version.

###### Things done
I successfully did a 3D photogrammetry reconstruction with this change.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
