### PR TITLE
treewide: mark broken packages for 20.03

### DIFF
--- a/pkgs/applications/audio/friture/default.nix
+++ b/pkgs/applications/audio/friture/default.nix
@@ -41,5 +41,6 @@ in py.buildPythonApplication rec {
     license = licenses.gpl3;
     platforms = platforms.linux; # fails on Darwin
     maintainers = [ maintainers.laikq ];
+    broken = true;
   };
 }

--- a/pkgs/applications/audio/mopidy/mopify.nix
+++ b/pkgs/applications/audio/mopidy/mopify.nix
@@ -19,5 +19,6 @@ pythonPackages.buildPythonApplication rec {
     description = "A mopidy webclient based on the Spotify webbased interface";
     license = licenses.gpl3;
     maintainers = [ maintainers.Gonzih ];
+    broken = true;
   };
 }

--- a/pkgs/applications/audio/mopidy/musicbox-webclient.nix
+++ b/pkgs/applications/audio/mopidy/musicbox-webclient.nix
@@ -19,5 +19,6 @@ pythonPackages.buildPythonApplication rec {
     description = "Mopidy extension for playing music from SoundCloud";
     license = licenses.mit;
     maintainers = [ maintainers.spwhitt ];
+    broken = true;
   };
 }

--- a/pkgs/applications/audio/mopidy/soundcloud.nix
+++ b/pkgs/applications/audio/mopidy/soundcloud.nix
@@ -19,5 +19,6 @@ pythonPackages.buildPythonApplication rec {
     description = "Mopidy extension for playing music from SoundCloud";
     license = licenses.mit;
     maintainers = [ maintainers.spwhitt ];
+    broken = true;
   };
 }

--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -19,5 +19,6 @@ pythonPackages.buildPythonApplication rec {
     description = "Mopidy extension for playing music from YouTube";
     license = licenses.asl20;
     maintainers = [ maintainers.spwhitt ];
+    broken = true;
   };
 }

--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
       it is published under the GNU General Public License.
     '';
     license = stdenv.lib.licenses.gpl2;
+    broken = true;
   };
 
   src =

--- a/pkgs/applications/blockchains/ethabi.nix
+++ b/pkgs/applications/blockchains/ethabi.nix
@@ -23,5 +23,6 @@ buildRustPackage rec {
     maintainers = [ maintainers.dbrock ];
     license = licenses.gpl3;
     inherit version;
+    broken = true;
   };
 }

--- a/pkgs/applications/editors/nvi/default.nix
+++ b/pkgs/applications/editors/nvi/default.nix
@@ -51,5 +51,6 @@ stdenv.mkDerivation {
     homepage = http://www.bostic.com/vi/;
     description = "The Berkeley Vi Editor";
     license = stdenv.lib.licenses.free;
+    broken = true;
   };
 }

--- a/pkgs/applications/graphics/k3d/default.nix
+++ b/pkgs/applications/graphics/k3d/default.nix
@@ -47,5 +47,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ maintainers.raskin ];
     license = licenses.gpl2;
+    broken = true;
   };
 }

--- a/pkgs/applications/kde/kdepim-addons.nix
+++ b/pkgs/applications/kde/kdepim-addons.nix
@@ -13,6 +13,7 @@ mkDerivation {
   meta = {
     license = with lib.licenses; [ gpl2Plus lgpl21Plus ];
     maintainers = kdepimTeam;
+    broken = true;
   };
   nativeBuildInputs = [ extra-cmake-modules shared-mime-info ];
   buildInputs = [

--- a/pkgs/applications/kde/kitinerary.nix
+++ b/pkgs/applications/kde/kitinerary.nix
@@ -9,6 +9,7 @@ mkDerivation {
   meta = {
     license = with lib.licenses; [ lgpl21 ];
     maintainers = [ lib.maintainers.bkchr ];
+    broken = true;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [

--- a/pkgs/applications/misc/ape/default.nix
+++ b/pkgs/applications/misc/ape/default.nix
@@ -41,5 +41,6 @@ stdenv.mkDerivation rec {
     license = license;
     platforms = platforms.unix;
     maintainers = with maintainers; [ yrashk ];
+    broken = true;
   };
 }

--- a/pkgs/applications/misc/hovercraft/default.nix
+++ b/pkgs/applications/misc/hovercraft/default.nix
@@ -31,5 +31,6 @@ buildPythonApplication rec {
     homepage = https://github.com/regebro/hovercraft;
     license = licenses.mit;
     maintainers = with maintainers; [ goibhniu makefu ];
+    broken = true;
   };
 }

--- a/pkgs/applications/misc/navit/default.nix
+++ b/pkgs/applications/misc/navit/default.nix
@@ -86,5 +86,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.genesis ];
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -66,5 +66,6 @@ in buildPythonApplication rec {
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ srghma ];
     platforms = lib.platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -54,5 +54,6 @@ mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ doronbehar ];
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/misc/topydo/default.nix
+++ b/pkgs/applications/misc/topydo/default.nix
@@ -30,5 +30,6 @@ buildPythonApplication rec {
     description = "A cli todo application compatible with the todo.txt format";
     homepage = "https://github.com/bram85/topydo";
     license = licenses.gpl3;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/cluster/kubeval/default.nix
+++ b/pkgs/applications/networking/cluster/kubeval/default.nix
@@ -44,5 +44,6 @@ buildGoModule rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ nicknovitski ];
     platforms = platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/cluster/marathon/default.nix
+++ b/pkgs/applications/networking/cluster/marathon/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ kamilchm kevincox pradeepchhetri ];
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -258,5 +258,6 @@ in stdenv.mkDerivation rec {
     description = "A cluster manager that provides efficient resource isolation and sharing across distributed applications, or frameworks";
     maintainers = with maintainers; [ cstrahan kevincox offline ];
     platforms   = platforms.unix;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/amsn/default.nix
+++ b/pkgs/applications/networking/instant-messengers/amsn/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation {
     homepage = http://amsn-project.net;
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
@@ -56,5 +56,6 @@ in
       platforms = platforms.linux;
       maintainers = [ maintainers.raskin ];
       license = licenses.gpl3Plus;
+      broken = true;
     };
   }

--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -44,5 +44,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ hrdinka ];
     platforms = platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ erictapen ];
     license = licenses.gpl3;
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/modem-manager-gui/default.nix
+++ b/pkgs/applications/networking/modem-manager-gui/default.nix
@@ -59,5 +59,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ ahuzik ];
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/mumble/overlay.nix
+++ b/pkgs/applications/networking/mumble/overlay.nix
@@ -24,5 +24,6 @@ in stdenv.mkDerivation {
 
   meta = {
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -52,5 +52,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/rndusr/stig";
     license = licenses.gpl3;
     maintainers = with maintainers; [ doronbehar ];
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/super-productivity/default.nix
+++ b/pkgs/applications/networking/super-productivity/default.nix
@@ -102,5 +102,6 @@ in stdenv.mkDerivation {
     license = licenses.mit;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ offline ];
+    broken = true;
   };
 }

--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -77,5 +77,6 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.aszlig ];
     platforms = lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/science/logic/avy/default.nix
+++ b/pkgs/applications/science/logic/avy/default.nix
@@ -49,5 +49,6 @@ stdenv.mkDerivation {
     # See pkgs/applications/science/logic/glucose/default.nix
     # (The error is different due to glucose-fenv.patch, but the same)
     badPlatforms = [ "aarch64-linux" ];
+    broken = true;
   };
 }

--- a/pkgs/applications/science/logic/leo2/default.nix
+++ b/pkgs/applications/science/logic/leo2/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.bsd3;
     homepage = http://www.leoprover.org/;
+    broken = true;
   };
 }

--- a/pkgs/applications/science/misc/colmap/default.nix
+++ b/pkgs/applications/science/misc/colmap/default.nix
@@ -40,5 +40,6 @@ mkDerivation rec {
     license = licenses.bsd2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ lebastr ];
+    broken = true;
   };
 }

--- a/pkgs/applications/science/misc/sasview/default.nix
+++ b/pkgs/applications/science/misc/sasview/default.nix
@@ -71,5 +71,6 @@ python.pkgs.buildPythonApplication rec {
     description = "Fitting and data analysis for small angle scattering data";
     maintainers = with maintainers; [ rprospero ];
     license = licenses.bsd3;
+    broken = true;
   };
 }

--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -69,5 +69,6 @@ mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ pxc ];
+    broken = true;
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-annex-metadata-gui/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-metadata-gui/default.nix
@@ -23,5 +23,6 @@ buildPythonApplication rec {
     maintainers = with maintainers; [ dotlambda ];
     license = licenses.gpl3Plus;
     platforms = with platforms; linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -57,5 +57,6 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     license = with licenses; gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     license = with licenses; gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -47,5 +47,6 @@ stdenv.mkDerivation rec {
     license = with licenses; gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/window-managers/jwm/default.nix
+++ b/pkgs/applications/window-managers/jwm/default.nix
@@ -6,7 +6,7 @@
 stdenv.mkDerivation rec {
   pname = "jwm";
   version = "1685";
-  
+
   src = fetchFromGitHub {
     owner = "joewing";
     repo = "jwm";
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     platforms   = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.romildo ];
+    broken = true;
   };
 }

--- a/pkgs/desktops/surf-display/default.nix
+++ b/pkgs/desktops/surf-display/default.nix
@@ -53,5 +53,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ etu ];
     license = licenses.gpl2;
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/development/compilers/avian/default.nix
+++ b/pkgs/development/compilers/avian/default.nix
@@ -39,5 +39,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.isc;
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.earldouglas ];
+    broken = true;
   };
 }

--- a/pkgs/development/compilers/mercury/default.nix
+++ b/pkgs/development/compilers/mercury/default.nix
@@ -58,5 +58,6 @@ stdenv.mkDerivation rec {
     license     = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     maintainers = [ ];
+    broken = true;
   };
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -906,7 +906,8 @@ self: super: {
   cryptohash-md5 = doJailbreak super.cryptohash-md5;
   text-short = doJailbreak super.text-short;
   gitHUD = dontCheck super.gitHUD;
-  githud = dontCheck super.githud;
+  # broken 20.03
+  githud = markBroken super.githud;
 
   # https://github.com/aisamanra/config-ini/issues/12
   config-ini = dontCheck super.config-ini;
@@ -1419,5 +1420,29 @@ self: super: {
   amqp-utils = super.amqp-utils.override {
     amqp = dontCheck super.amqp_0_19_1;
   };
+
+  # 20.03 broken packages
+
+  envy-extensible = markBroken super.envy-extensible;
+  exceptionfree-readfile = markBroken super.exceptionfree-readfile;
+  fcf-containers = markBroken super.fcf-containers;
+  first-class-instances = markBroken super.first-class-instances;
+  flp = markBroken super.flp;
+  hal = markBroken super.hal;
+  hcad = markBroken super.hcad;
+  hedis-envy = markBroken super.hedis-envy;
+  hhwloc = markBroken super.hhwloc;
+  layered-state = markBroken super.layered-state;
+  network-uri-static = markBroken super.network-uri-static;
+  pandoc-plot = markBroken super.pandoc-plot;
+  patch = markBroken super.patch;
+  prologue = markBroken super.prologue;
+  provenience = markBroken super.provenience;
+  refractor = markBroken super.refractor;
+  shwifty = markBroken super.shwifty;
+  smallcheck-kind-generics = markBroken super.smallcheck-kind-generics;
+  traversal-template = markBroken super.traversal-template;
+  vector-text = markBroken super.vector-text;
+  zbar = markBroken super.zbar;
 
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/interpreters/clojurescript/lumo/default.nix
+++ b/pkgs/development/interpreters/clojurescript/lumo/default.nix
@@ -122,7 +122,7 @@ let # packageJSON=./package.json;
     classp    = cljdeps.makeClasspaths {
                   extraClasspaths=["src/js" "src/cljs/bundled" "src/cljs/snapshot"];
                 };
-    
+
 
     getJarPath = jarName: (lib.findFirst (p: p.name == jarName) null cljdeps.packages).path.jar;
 
@@ -147,7 +147,7 @@ in stdenv.mkDerivation {
     # configure clojure-cli
     mkdir ./.cpcache
     export CLJ_CONFIG=`pwd`
-    export CLJ_CACHE=`pwd`/.cpcache 
+    export CLJ_CACHE=`pwd`/.cpcache
 
     # require more namespaces for cljs-bundle
     sed -i "s!ns lumo.core! \
@@ -155,7 +155,7 @@ in stdenv.mkDerivation {
                (:require ${requireDeps}) \
                (:require-macros [clojure.template :as temp] \
                                 [cljs.test :as test])!g" \
-              ./src/cljs/snapshot/lumo/core.cljs          
+              ./src/cljs/snapshot/lumo/core.cljs
 
     # Step 1: compile clojurescript with :none and :simple
     ${clojure}/bin/clojure -Scp ${classp} -e "${compileClojurescript true}"
@@ -204,7 +204,7 @@ in stdenv.mkDerivation {
     # Step 3: generate munged cache jsons
     ${clojure}/bin/clojure -Scp ${classp} -e "${cacheToJsons}"
     rm  ./target/cljs/core\$macros\.cljc\.cache\.json
-    
+
 
     # Step 4: Bunde javascript
     NODE_ENV=production node scripts/bundle.js
@@ -251,6 +251,7 @@ in stdenv.mkDerivation {
     license = stdenv.lib.licenses.epl10;
     maintainers = [ stdenv.lib.maintainers.hlolli ];
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }
 

--- a/pkgs/development/libraries/bwidget/default.nix
+++ b/pkgs/development/libraries/bwidget/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     description = "High-level widget set for Tcl/Tk";
     license = stdenv.lib.licenses.tcltk;
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/galario/default.nix
+++ b/pkgs/development/libraries/galario/default.nix
@@ -74,5 +74,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl3;
     maintainers = [ maintainers.smaret ];
     platforms = platforms.all;
+    broken = pythonPackages.isPy38;
   };
 }

--- a/pkgs/development/libraries/gcc/libstdc++/5.nix
+++ b/pkgs/development/libraries/gcc/libstdc++/5.nix
@@ -113,5 +113,6 @@ stdenv.mkDerivation rec {
     description = "GNU Compiler Collection, version ${version} -- C++ standard library";
     platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar ];
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/libgaminggear/default.nix
+++ b/pkgs/development/libraries/libgaminggear/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     homepage = https://sourceforge.net/projects/libgaminggear/;
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2Plus;
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/nsss/default.nix
+++ b/pkgs/development/libraries/nsss/default.nix
@@ -30,4 +30,6 @@ buildPackage {
     mv examples $doc/share/doc/nsss/examples
   '';
 
+  meta.broken = true;
+
 }

--- a/pkgs/development/libraries/qtutilities/default.nix
+++ b/pkgs/development/libraries/qtutilities/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ doronbehar ];
     platforms   = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/soil/default.nix
+++ b/pkgs/development/libraries/soil/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation {
     homepage  = https://www.lonesock.net/soil.html;
     license   = stdenv.lib.licenses.publicDomain;
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/swiften/default.nix
+++ b/pkgs/development/libraries/swiften/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl2Plus;
     platforms   = platforms.linux;
     maintainers = [ maintainers.twey ];
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/utmps/default.nix
+++ b/pkgs/development/libraries/utmps/default.nix
@@ -28,5 +28,6 @@ buildPackage {
     mv doc $doc/share/doc/utmps/html
     mv examples $doc/share/doc/utmps/examples
   '';
+  meta.broken = true;
 }
 

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -990,6 +990,7 @@ luaexpat = buildLuarocksPackage {
     license = {
       fullName = "MIT/X11";
     };
+    broken = true;
   };
 };
 luaffi = buildLuarocksPackage {

--- a/pkgs/development/misc/google-clasp/default.nix
+++ b/pkgs/development/misc/google-clasp/default.nix
@@ -15,5 +15,6 @@ in
     license = stdenv.lib.licenses.asl20;
     maintainers = [ stdenv.lib.maintainers.michojel ];
     priority = 100;
+    broken = true;
   };
 }

--- a/pkgs/development/misc/qmk_firmware/default.nix
+++ b/pkgs/development/misc/qmk_firmware/default.nix
@@ -36,4 +36,5 @@ in stdenv.mkDerivation {
     dfu-programmer
     dfu-util
   ];
+  meta.broken = true;
 }

--- a/pkgs/development/python-modules/alerta-server/default.nix
+++ b/pkgs/development/python-modules/alerta-server/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi, pythonOlder, pyyaml
-, python-dateutil, requests, pymongo, raven, bcrypt, flask, pyjwt, flask-cors, psycopg2, pytz, flask-compress, jinja2
+, python-dateutil, requests, pymongo, raven, bcrypt, flask, pyjwt, flask-cors, psycopg2, pytz, flask-compress, jinja2, isPy38
 }:
 
 buildPythonPackage rec {
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     homepage = https://alerta.io;
     description = "Alerta Monitoring System server";
     license = licenses.asl20;
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/apache-airflow/default.nix
+++ b/pkgs/development/python-modules/apache-airflow/default.nix
@@ -53,6 +53,7 @@
 , nose
 , python
 , isPy3k
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -187,5 +188,6 @@ buildPythonPackage rec {
     homepage = http://airflow.apache.org/;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc maintainers.ingenieroariel ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/aria2p/default.nix
+++ b/pkgs/development/python-modules/aria2p/default.nix
@@ -1,6 +1,7 @@
 { stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder
 , aria2, poetry, pytest, pytestcov, pytest_xdist, responses
 , asciimatics, loguru, requests, setuptools, websocket_client
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -15,7 +16,7 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "1inak3y2win58zbzykfzy6xp00f276sqsz69h2nfsd93mpr74wf6";
   };
-  
+
   nativeBuildInputs = [ poetry ];
 
   preBuild = ''
@@ -39,5 +40,6 @@ buildPythonPackage rec {
     description = "Command-line tool and library to interact with an aria2c daemon process with JSON-RPC";
     license = licenses.isc;
     maintainers = with maintainers; [ koral ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/asttokens/default.nix
+++ b/pkgs/development/python-modules/asttokens/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchPypi, buildPythonPackage, fetchpatch, astroid, six, coverage
-, lazy-object-proxy, nose, wrapt
+, lazy-object-proxy, nose, wrapt, isPy38
 }:
 
 buildPythonPackage rec {
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/asynctest/default.nix
+++ b/pkgs/development/python-modules/asynctest/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, python }:
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, python, isPy38 }:
 
 buildPythonPackage rec {
   pname = "asynctest";
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     homepage = https://github.com/Martiusweb/asynctest;
     license = licenses.asl20;
     maintainers = with maintainers; [ dotlambda ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/behave/default.nix
+++ b/pkgs/development/python-modules/behave/default.nix
@@ -2,7 +2,7 @@
 , buildPythonApplication, python, pythonOlder
 , mock, nose, pathpy, pyhamcrest, pytest_4
 , glibcLocales, parse, parse-type, six
-, traceback2
+, traceback2, isPy38
 }:
 
 buildPythonApplication rec {
@@ -48,5 +48,6 @@ buildPythonApplication rec {
     description = "behaviour-driven development, Python style";
     license = licenses.bsd2;
     maintainers = with maintainers; [ alunduil ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/browser-cookie3/default.nix
+++ b/pkgs/development/python-modules/browser-cookie3/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonPackage, isPy3k, keyring, pbkdf2, pyaes}:
+{ lib, fetchPypi, buildPythonPackage, isPy3k, keyring, pbkdf2, pyaes, isPy38 }:
 buildPythonPackage rec {
   pname = "browser-cookie3";
   version = "0.9.1";
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ borisbabic ];
     homepage = https://github.com/borisbabic/browser_cookie3;
     license = licenses.gpl3;
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/canmatrix/default.nix
+++ b/pkgs/development/python-modules/canmatrix/default.nix
@@ -13,6 +13,7 @@
 , XlsxWriter
 , pyyaml
 , pytest
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -54,6 +55,7 @@ buildPythonPackage rec {
     description = "Support and convert several CAN (Controller Area Network) database formats .arxml .dbc .dbf .kcd .sym fibex xls(x)";
     license = licenses.bsd2;
     maintainers = with maintainers; [ sorki ];
+    broken = isPy38;
   };
 }
 

--- a/pkgs/development/python-modules/canopen/default.nix
+++ b/pkgs/development/python-modules/canopen/default.nix
@@ -3,7 +3,9 @@
 , fetchFromGitHub
 , nose
 , can
-, canmatrix }:
+, canmatrix
+, isPy38
+}:
 
 buildPythonPackage {
   pname = "canopen";
@@ -40,5 +42,6 @@ buildPythonPackage {
     description = "CANopen stack implementation";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ sorki ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -20,6 +20,7 @@
 , pydot
 , pyyaml
 , pygraphviz
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -82,5 +83,6 @@ buildPythonPackage rec {
     homepage = "http://github.com/quantumlib/cirq";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/clifford/default.nix
+++ b/pkgs/development/python-modules/clifford/default.nix
@@ -8,6 +8,7 @@
 , h5py
 , nose
 , isPy27
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -46,5 +47,6 @@ buildPythonPackage rec {
     homepage = https://clifford.readthedocs.io;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/csvs-to-sqlite/default.nix
+++ b/pkgs/development/python-modules/csvs-to-sqlite/default.nix
@@ -9,6 +9,7 @@
 , py-lru-cache
 , six
 , pytest
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -44,6 +45,7 @@ buildPythonPackage rec {
     homepage = https://github.com/simonw/csvs-to-sqlite;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 
 }

--- a/pkgs/development/python-modules/cufflinks/default.nix
+++ b/pkgs/development/python-modules/cufflinks/default.nix
@@ -8,6 +8,7 @@
 , pandas
 , six
 , statsmodels
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -55,5 +56,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/santosjorge/cufflinks";
     license = licenses.mit;
     maintainers = with maintainers; [ globin ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/dask-jobqueue/default.nix
+++ b/pkgs/development/python-modules/dask-jobqueue/default.nix
@@ -5,6 +5,7 @@
 , distributed
 , docrep
 , pytest
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -29,5 +30,6 @@ buildPythonPackage rec {
     description = "Deploy Dask on job schedulers like PBS, SLURM, and SGE";
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/datashader/default.nix
+++ b/pkgs/development/python-modules/datashader/default.nix
@@ -25,6 +25,7 @@
 , fastparquet
 , testpath
 , nbconvert
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -81,5 +82,6 @@ buildPythonPackage rec {
     homepage = https://datashader.org;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k, six, unittest2 }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, six, unittest2, isPy38 }:
 
 let
   testPath =
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     homepage = https://github.com/ets-labs/python-dependency-injector;
     license = licenses.bsd3;
     maintainers = with maintainers; [ gerschtli ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/django-versatileimagefield/default.nix
+++ b/pkgs/development/python-modules/django-versatileimagefield/default.nix
@@ -4,6 +4,7 @@
 , django
 , python
 , pillow
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -26,6 +27,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/respondcreate/django-versatileimagefield/";
     license = licenses.mit;
     maintainers = with maintainers; [ mmai ];
+    broken = isPy38;
   };
 }
 

--- a/pkgs/development/python-modules/fire/default.nix
+++ b/pkgs/development/python-modules/fire/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch, six, hypothesis, mock
-, python-Levenshtein, pytest, termcolor, isPy27, enum34 }:
+, python-Levenshtein, pytest, termcolor, isPy27, enum34, isPy38 }:
 
 buildPythonPackage rec {
   pname = "fire";
@@ -42,5 +42,6 @@ buildPythonPackage rec {
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ leenaars ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/fluidasserts/default.nix
+++ b/pkgs/development/python-modules/fluidasserts/default.nix
@@ -172,5 +172,6 @@ buildPythonPackage rec {
     maintainers = with maintainers; [
       kamadorueda
     ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/fritzconnection/default.nix
+++ b/pkgs/development/python-modules/fritzconnection/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, lxml, requests, tkinter }:
+{ stdenv, buildPythonPackage, fetchPypi, lxml, requests, tkinter, isPy38 }:
 
 buildPythonPackage rec {
   pname = "fritzconnection";
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     homepage = https://bitbucket.org/kbr/fritzconnection;
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/furl/default.nix
+++ b/pkgs/development/python-modules/furl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, flake8, six, orderedmultidict }:
+{ stdenv, buildPythonPackage, fetchPypi, flake8, six, orderedmultidict, isPy38 }:
 
 buildPythonPackage rec {
   pname = "furl";
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     homepage = https://github.com/gruns/furl;
     license = licenses.publicDomain;
     maintainers = with maintainers; [ vanzef ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/git-annex-adapter/default.nix
+++ b/pkgs/development/python-modules/git-annex-adapter/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, isPy3k, fetchFromGitHub, substituteAll
-, python, utillinux, pygit2, gitMinimal, git-annex
+, python, utillinux, pygit2, gitMinimal, git-annex, isPy38
 }:
 
 buildPythonPackage rec {
@@ -39,5 +39,6 @@ buildPythonPackage rec {
     description = "Call git-annex commands from Python";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dotlambda ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google-music-proto/default.nix
+++ b/pkgs/development/python-modules/google-music-proto/default.nix
@@ -4,6 +4,7 @@
 , marshmallow
 , pendulum
 , protobuf
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -33,5 +34,6 @@ buildPythonPackage rec {
     description = "Sans-I/O wrapper of Google Music API calls";
     license = licenses.mit;
     maintainers = with maintainers; [ jakewaksbaum ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google-music/default.nix
+++ b/pkgs/development/python-modules/google-music/default.nix
@@ -5,6 +5,7 @@
 , protobuf
 , requests_oauthlib
 , tenacity
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -40,5 +41,6 @@ buildPythonPackage rec {
     description = "A Google Music API wrapper";
     license = licenses.mit;
     maintainers = with maintainers; [ jakewaksbaum ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_automl/default.nix
+++ b/pkgs/development/python-modules/google_cloud_automl/default.nix
@@ -5,6 +5,7 @@
 , google_api_core
 , pytest
 , mock
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -28,5 +29,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_bigquery/default.nix
+++ b/pkgs/development/python-modules/google_cloud_bigquery/default.nix
@@ -9,6 +9,7 @@
 , pytest
 , mock
 , ipython
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -32,5 +33,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_container/default.nix
+++ b/pkgs/development/python-modules/google_cloud_container/default.nix
@@ -4,6 +4,7 @@
 , google_api_core
 , pytest
 , mock
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -27,5 +28,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_datastore/default.nix
+++ b/pkgs/development/python-modules/google_cloud_datastore/default.nix
@@ -5,6 +5,7 @@
 , google_cloud_core
 , pytest
 , mock
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -28,5 +29,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_dns/default.nix
+++ b/pkgs/development/python-modules/google_cloud_dns/default.nix
@@ -5,6 +5,7 @@
 , google_cloud_core
 , pytest
 , mock
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -28,5 +29,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_error_reporting/default.nix
+++ b/pkgs/development/python-modules/google_cloud_error_reporting/default.nix
@@ -4,6 +4,7 @@
 , google_cloud_logging
 , pytest
 , mock
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -27,5 +28,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_logging/default.nix
+++ b/pkgs/development/python-modules/google_cloud_logging/default.nix
@@ -8,6 +8,7 @@
 , webapp2
 , django
 , flask
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -31,5 +32,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_resource_manager/default.nix
+++ b/pkgs/development/python-modules/google_cloud_resource_manager/default.nix
@@ -5,6 +5,7 @@
 , google_api_core
 , pytest
 , mock
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -28,5 +29,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_runtimeconfig/default.nix
+++ b/pkgs/development/python-modules/google_cloud_runtimeconfig/default.nix
@@ -5,6 +5,7 @@
 , google_cloud_core
 , pytest
 , mock
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -28,5 +29,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_spanner/default.nix
+++ b/pkgs/development/python-modules/google_cloud_spanner/default.nix
@@ -7,6 +7,7 @@
 , google_cloud_core
 , pytest
 , mock
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -30,5 +31,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_storage/default.nix
+++ b/pkgs/development/python-modules/google_cloud_storage/default.nix
@@ -7,6 +7,7 @@
 , pytest
 , mock
 , setuptools
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -35,5 +36,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/google_cloud_translate/default.nix
+++ b/pkgs/development/python-modules/google_cloud_translate/default.nix
@@ -6,6 +6,7 @@
 , grpcio
 , pytest
 , mock
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -31,5 +32,6 @@ buildPythonPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/gssapi/default.nix
+++ b/pkgs/development/python-modules/gssapi/default.nix
@@ -14,6 +14,7 @@
 , cython
 , python
 , k5test
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -66,5 +67,6 @@ buildPythonPackage rec {
     homepage = https://pypi.python.org/pypi/gssapi;
     description = "Python GSSAPI Wrapper";
     license = licenses.mit;
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/gumath/default.nix
+++ b/pkgs/development/python-modules/gumath/default.nix
@@ -6,12 +6,13 @@
 , libxnd
 , libgumath
 , isPy27
+, isPy38
 }:
 
 buildPythonPackage {
   pname = "gumath";
   disabled = isPy27;
-  inherit (libgumath) src version meta;
+  inherit (libgumath) src version;
 
   checkInputs = [ numba ];
   propagatedBuildInputs = [ ndtypes xnd ];
@@ -25,4 +26,8 @@ buildPythonPackage {
       --replace 'add_runtime_library_dirs = ["$ORIGIN"]' \
                 'add_runtime_library_dirs = ["${libndtypes}/lib", "${libxnd}/lib", "${libgumath}/lib"]'
   '';
+
+  meta = libgumath.meta // {
+    broken = isPy38;
+  };
 }

--- a/pkgs/development/python-modules/howdoi/default.nix
+++ b/pkgs/development/python-modules/howdoi/default.nix
@@ -5,6 +5,7 @@
 , requests-cache
 , pygments
 , pyquery
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -27,5 +28,6 @@ buildPythonPackage rec {
     homepage = https://pypi.python.org/pypi/howdoi;
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/hug/default.nix
+++ b/pkgs/development/python-modules/hug/default.nix
@@ -6,6 +6,7 @@
 , marshmallow
 , mock
 , numpy
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -34,6 +35,7 @@ buildPythonPackage rec {
     description = "A Python framework that makes developing APIs as simple as possible, but no simpler";
     homepage = https://github.com/timothycrosley/hug;
     license = licenses.mit;
+    broken = isPy38;
   };
 
 }

--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -14,6 +14,7 @@
 , tables
 , pyarrow
 , graphviz
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -53,5 +54,6 @@ buildPythonPackage rec {
     homepage = https://github.com/ibis-project/ibis;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/imbalanced-learn/default.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/default.nix
@@ -4,6 +4,7 @@
 , pytest
 , scikitlearn
 , tensorflow
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -32,5 +33,6 @@ buildPythonPackage rec {
     description = "Library offering a number of re-sampling techniques commonly used in datasets showing strong between-class imbalance";
     homepage = https://github.com/scikit-learn-contrib/imbalanced-learn;
     license = licenses.mit;
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/imgaug/default.nix
+++ b/pkgs/development/python-modules/imgaug/default.nix
@@ -9,6 +9,7 @@
 , shapely
 , six
 , stdenv
+, isPy38
 }:
 
 buildPythonPackage rec {
@@ -24,7 +25,7 @@ buildPythonPackage rec {
     substituteInPlace requirements.txt \
       --replace "opencv-python-headless" ""
     substituteInPlace setup.py \
-      --replace "opencv-python-headless" "" 
+      --replace "opencv-python-headless" ""
     substituteInPlace pytest.ini \
       --replace "--xdoctest --xdoctest-global-exec=\"import imgaug as ia\nfrom imgaug import augmenters as iaa\"" ""
   '';
@@ -51,5 +52,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ cmcdragonkai rakesh4g ];
     platforms = platforms.linux;
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/immutables/default.nix
+++ b/pkgs/development/python-modules/immutables/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder }:
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy38 }:
 
 buildPythonPackage rec {
   pname = "immutables";
@@ -15,5 +15,6 @@ buildPythonPackage rec {
     homepage = https://github.com/MagicStack/immutables;
     license = with lib.licenses; [ asl20 ];
     maintainers = with lib.maintainers; [ catern ];
+    broken = isPy38;
   };
 }

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -18,6 +18,7 @@
 , tornado
 , pytest
 , pythonOlder
+, isPy38
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -66,5 +66,6 @@ buildPythonPackage rec {
     homepage = https://github.com/ContinuumIO/intake;
     license = licenses.bsd2;
     maintainers = [ maintainers.costrouc ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/jug/default.nix
+++ b/pkgs/development/python-modules/jug/default.nix
@@ -1,7 +1,8 @@
 { stdenv, buildPythonPackage, fetchPypi, fetchpatch
 , nose, numpy
 , bottle, pyyaml, redis, six
-, zlib }:
+, zlib, isPy38
+}:
 
 buildPythonPackage rec {
   pname = "Jug";

--- a/pkgs/development/python-modules/jug/default.nix
+++ b/pkgs/development/python-modules/jug/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     homepage = https://jug.readthedocs.io/;
     maintainers = with maintainers; [ luispedro ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/junit-xml/default.nix
+++ b/pkgs/development/python-modules/junit-xml/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     homepage = https://github.com/kyrus/python-junit-xml;
     maintainers = with maintainers; [ multun ];
     license = licenses.mit;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/junit-xml/default.nix
+++ b/pkgs/development/python-modules/junit-xml/default.nix
@@ -4,6 +4,7 @@
 , six
 , pytest
 , pytest-sugar
+, isPy38
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/junos-eznc/default.nix
+++ b/pkgs/development/python-modules/junos-eznc/default.nix
@@ -11,6 +11,7 @@
 , jinja2
 , pyyaml
 , nose
+, isPy38
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/junos-eznc/default.nix
+++ b/pkgs/development/python-modules/junos-eznc/default.nix
@@ -38,5 +38,6 @@ buildPythonPackage rec {
     description = "Junos 'EZ' automation for non-programmers";
     license = licenses.asl20;
     maintainers = with maintainers; [ xnaveira ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/locustio/default.nix
+++ b/pkgs/development/python-modules/locustio/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
   meta = {
     homepage = https://locust.io/;
     description = "A load testing tool";
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/ludios_wpull/default.nix
+++ b/pkgs/development/python-modules/ludios_wpull/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     homepage = https://github.com/ludios/wpull;
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ ivan ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/macropy/default.nix
+++ b/pkgs/development/python-modules/macropy/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage rec {
     description = "Macros in Python: quasiquotes, case classes, LINQ and more";
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/marionette-harness/mozfile.nix
+++ b/pkgs/development/python-modules/marionette-harness/mozfile.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     homepage = https://wiki.mozilla.org/Auto-tools/Projects/Mozbase;
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ raskin ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/markdownsuperscript/default.nix
+++ b/pkgs/development/python-modules/markdownsuperscript/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     description = "An extension to the Python Markdown package enabling superscript text";
     homepage = https://github.com/jambonrose/markdown_superscript_extension;
     license = stdenv.lib.licenses.bsd2;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/mecab-python3/default.nix
+++ b/pkgs/development/python-modules/mecab-python3/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage =  https://github.com/SamuraiT/mecab-python3;
     license = with licenses; [ gpl2 lgpl21 bsd3 ]; # any of the three
     maintainers = with maintainers; [ ixxie ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/mock-open/default.nix
+++ b/pkgs/development/python-modules/mock-open/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     homepage = https://github.com/nivbend/mock-open;
     description = "A better mock for file I/O";
     license = licenses.mit;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/namedlist/default.nix
+++ b/pkgs/development/python-modules/namedlist/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     homepage = https://bitbucket.org/ericvsmith/namedlist;
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ivan ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -109,5 +109,6 @@ buildPythonPackage rec {
     description = "Neuroimaging in Python: Pipelines and Interfaces";
     license = licenses.bsd3;
     maintainers = with maintainers; [ ashgillman ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/nixpkgs/default.nix
+++ b/pkgs/development/python-modules/nixpkgs/default.nix
@@ -17,6 +17,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ pbr ];
+  nativeBuidInputs = [ pythonix ];
   propagatedBuildInputs = [ pythonix ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -75,5 +75,6 @@ buildPythonPackage rec {
     homepage = http://getpelican.com/;
     license = licenses.agpl3;
     maintainers = with maintainers; [ offline prikhi ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/persim/default.nix
+++ b/pkgs/development/python-modules/persim/default.nix
@@ -46,5 +46,6 @@ buildPythonPackage rec {
     homepage = https://persim.scikit-tda.org;
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pg8000/default.nix
+++ b/pkgs/development/python-modules/pg8000/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
     description = "PostgreSQL interface library, for asyncio";
     maintainers = with maintainers; [ domenkozar ];
     platforms = platforms.unix;
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/piep/default.nix
+++ b/pkgs/development/python-modules/piep/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
     homepage = https://github.com/timbertson/piep;
     maintainers = with maintainers; [ timbertson ];
     license = licenses.gpl3;
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/pymc3/default.nix
+++ b/pkgs/development/python-modules/pymc3/default.nix
@@ -59,5 +59,6 @@ buildPythonPackage rec {
     homepage = https://github.com/pymc-devs/pymc3;
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ilya-kolpakov ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pymssql/default.nix
+++ b/pkgs/development/python-modules/pymssql/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
       SQL Server";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ mredaelli ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pyside/default.nix
+++ b/pkgs/development/python-modules/pyside/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "LGPL-licensed Python bindings for the Qt cross-platform application and UI framework";
     license = lib.licenses.lgpl21;
     homepage = http://www.pyside.org;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pyside/shiboken.nix
+++ b/pkgs/development/python-modules/pyside/shiboken.nix
@@ -35,5 +35,6 @@ buildPythonPackage rec {
     homepage = http://www.pyside.org/docs/shiboken/;
     maintainers = [ ];
     platforms = lib.platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pyside/tools.nix
+++ b/pkgs/development/python-modules/pyside/tools.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     homepage = https://wiki.qt.io/PySide;
     maintainers = [ ];
     platforms = platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pyside2-tools/default.nix
+++ b/pkgs/development/python-modules/pyside2-tools/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2;
     homepage = "https://wiki.qt.io/Qt_for_Python";
     maintainers = with maintainers; [ gebner ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -34,5 +34,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21;
     homepage = "https://wiki.qt.io/Qt_for_Python";
     maintainers = with maintainers; [ gebner ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pysnooper/default.nix
+++ b/pkgs/development/python-modules/pysnooper/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     homepage = https://github.com/cool-RR/PySnooper;
     license = licenses.mit;
     maintainers = with maintainers; [ seqizz ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pysonos/default.nix
+++ b/pkgs/development/python-modules/pysonos/default.nix
@@ -38,5 +38,6 @@ buildPythonPackage rec {
     description = "A SoCo fork with fixes for Home Assistant";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ juaningan ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pyspinel/default.nix
+++ b/pkgs/development/python-modules/pyspinel/default.nix
@@ -17,5 +17,6 @@ buildPythonPackage rec {
     description = "Interface to the OpenThread Network Co-Processor (NCP)";
     homepage = "https://github.com/openthread/pyspinel";
     maintainers = with lib.maintainers; [ gebner ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -33,5 +33,6 @@ buildPythonPackage rec {
     homepage = https://pysptk.readthedocs.io/en/latest/;
     license = licenses.mit;
     maintainers = with maintainers; [ hyphon81 ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pystemd/default.nix
+++ b/pkgs/development/python-modules/pystemd/default.nix
@@ -20,5 +20,6 @@ python.pkgs.buildPythonPackage rec {
     homepage = https://github.com/facebookincubator/pystemd/;
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ flokli ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pytest-cram/default.nix
+++ b/pkgs/development/python-modules/pytest-cram/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = https://github.com/tbekolay/pytest-cram;
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jluttine ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/python-docx/default.nix
+++ b/pkgs/development/python-modules/python-docx/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     homepage = https://python-docx.readthedocs.io/en/latest/;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.alexchapman ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/python-jsonrpc-server/default.nix
+++ b/pkgs/development/python-modules/python-jsonrpc-server/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage rec {
     description = "A Python 2 and 3 asynchronous JSON RPC server";
     license = licenses.mit;
     maintainers = [ maintainers.mic92 ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/python-toolbox/default.nix
+++ b/pkgs/development/python-modules/python-toolbox/default.nix
@@ -28,5 +28,6 @@ buildPythonPackage rec {
     homepage = https://github.com/cool-RR/python_toolbox;
     license = licenses.mit;
     maintainers = with maintainers; [ seqizz ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pywbem/default.nix
+++ b/pkgs/development/python-modules/pywbem/default.nix
@@ -53,5 +53,6 @@ buildPythonPackage rec {
     homepage = https://pywbem.github.io;
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ peterhoeg ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pyx/default.nix
+++ b/pkgs/development/python-modules/pyx/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
     description = "Python package for the generation of PostScript, PDF, and SVG files";
     homepage = http://pyx.sourceforge.net/;
     license = with licenses; [ gpl2 ];
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/rethinkdb/default.nix
+++ b/pkgs/development/python-modules/rethinkdb/default.nix
@@ -18,6 +18,7 @@ buildPythonPackage rec {
     description = "Python driver library for the RethinkDB database server";
     homepage = "https://pypi.python.org/pypi/rethinkdb";
     license = licenses.agpl3;
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/ripser/default.nix
+++ b/pkgs/development/python-modules/ripser/default.nix
@@ -44,5 +44,6 @@ buildPythonPackage rec {
     homepage = https://ripser.scikit-tda.org;
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/robotframework-tools/default.nix
+++ b/pkgs/development/python-modules/robotframework-tools/default.nix
@@ -46,5 +46,6 @@ buildPythonPackage rec {
     homepage = https://bitbucket.org/userzimmermann/robotframework-tools;
     license = licenses.gpl3;
     maintainers = [ maintainers.costrouc ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/rpy2/default.nix
+++ b/pkgs/development/python-modules/rpy2/default.nix
@@ -94,5 +94,6 @@ buildPythonPackage rec {
       license = lib.licenses.gpl2Plus;
       platforms = lib.platforms.unix;
       maintainers = with lib.maintainers; [ joelmo ];
+      broken = true;
     };
   }

--- a/pkgs/development/python-modules/ruffus/default.nix
+++ b/pkgs/development/python-modules/ruffus/default.nix
@@ -48,6 +48,7 @@ buildPythonPackage rec {
     homepage = http://www.ruffus.org.uk;
     license = licenses.mit;
     maintainers = [ maintainers.kiwi ];
+    broken = true;
   };
 }
 

--- a/pkgs/development/python-modules/salmon-mail/default.nix
+++ b/pkgs/development/python-modules/salmon-mail/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "Pythonic mail application server";
     license = licenses.gpl3;
     maintainers = with maintainers; [ jluttine ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/scikit-tda/default.nix
+++ b/pkgs/development/python-modules/scikit-tda/default.nix
@@ -60,5 +60,6 @@ buildPythonPackage rec {
     homepage = https://github.com/scikit-tda/scikit-tda;
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -46,5 +46,6 @@ buildPythonPackage rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ drewkett marsam ];
     platforms = platforms.unix;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/secp256k1/default.nix
+++ b/pkgs/development/python-modules/secp256k1/default.nix
@@ -44,5 +44,6 @@ buildPythonPackage rec {
     description = "Python FFI bindings for secp256k1";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ chris-martin ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/shouldbe/default.nix
+++ b/pkgs/development/python-modules/shouldbe/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
     description = "Python Assertion Helpers inspired by Shouldly";
     homepage =  https://pypi.python.org/pypi/shouldbe/;
     license = licenses.mit;
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     homepage = https://github.com/trailofbits/slither;
     license = licenses.agpl3;
     maintainers = [ maintainers.asymmetric ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/snowflake-connector-python/default.nix
+++ b/pkgs/development/python-modules/snowflake-connector-python/default.nix
@@ -61,5 +61,6 @@ buildPythonPackage rec {
     description = "Snowflake Connector for Python";
     homepage = "https://www.snowflake.com/";
     license = licenses.asl20;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/snowflake-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/snowflake-sqlalchemy/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Snowflake SQLAlchemy Dialect";
     homepage = "https://www.snowflake.net/";
     license = licenses.asl20;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/soco/default.nix
+++ b/pkgs/development/python-modules/soco/default.nix
@@ -30,5 +30,6 @@ buildPythonPackage rec {
     homepage = http://python-soco.com/;
     description = "A CLI and library to control Sonos speakers";
     license = lib.licenses.mit;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/sphinx-jinja/default.nix
+++ b/pkgs/development/python-modules/sphinx-jinja/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Sphinx extension to include jinja templates in documentation";
     maintainers = with maintainers; [ nand0p ];
     license = licenses.mit;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -66,5 +66,6 @@ buildPythonPackage rec {
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ gebner ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/stem/default.nix
+++ b/pkgs/development/python-modules/stem/default.nix
@@ -26,5 +26,6 @@ buildPythonPackage rec {
     homepage = https://stem.torproject.org/;
     license = licenses.gpl3;
     maintainers = with maintainers; [ phreedom ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/streamz/default.nix
+++ b/pkgs/development/python-modules/streamz/default.nix
@@ -62,5 +62,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/python-streamz/streamz";
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/svgwrite/default.nix
+++ b/pkgs/development/python-modules/svgwrite/default.nix
@@ -33,6 +33,7 @@ buildPythonPackage rec {
     description = "A Python library to create SVG drawings";
     homepage = https://github.com/mozman/svgwrite;
     license = licenses.mit;
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -55,6 +55,7 @@ buildPythonPackage rec {
     description = "Command line tool and set of Python wrapper classes for interacting with toggl's API";
     license = licenses.mit;
     maintainers = [ maintainers.mmahut ];
+    broken = true;
   };
 }
 

--- a/pkgs/development/python-modules/trackpy/default.nix
+++ b/pkgs/development/python-modules/trackpy/default.nix
@@ -54,5 +54,6 @@ buildPythonPackage rec {
     homepage = https://github.com/soft-matter/trackpy;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/wordfreq/default.nix
+++ b/pkgs/development/python-modules/wordfreq/default.nix
@@ -45,5 +45,6 @@ buildPythonPackage {
     homepage =  https://github.com/LuminosoInsight/wordfreq/;
     license = licenses.mit;
     maintainers = with maintainers; [ ixxie ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/yappi/default.nix
+++ b/pkgs/development/python-modules/yappi/default.nix
@@ -18,5 +18,6 @@ buildPythonPackage rec {
     description = "Python profiler that supports multithreading and measuring CPU time";
     license = licenses.mit;
     maintainers = with maintainers; [ orivej ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/zconfig/default.nix
+++ b/pkgs/development/python-modules/zconfig/default.nix
@@ -25,5 +25,6 @@ buildPythonPackage rec {
     homepage = https://pypi.python.org/pypi/ZConfig;
     license = licenses.zpl20;
     maintainers = [ maintainers.goibhniu ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/zdaemon/default.nix
+++ b/pkgs/development/python-modules/zdaemon/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
     homepage = https://pypi.python.org/pypi/zdaemon;
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/zodb/default.nix
+++ b/pkgs/development/python-modules/zodb/default.nix
@@ -62,5 +62,6 @@ buildPythonPackage rec {
       homepage = https://pypi.python.org/pypi/ZODB;
       license = licenses.zpl21;
       maintainers = with maintainers; [ goibhniu ];
+      broken = true;
     };
 }

--- a/pkgs/development/python-modules/zope_filerepresentation/default.nix
+++ b/pkgs/development/python-modules/zope_filerepresentation/default.nix
@@ -20,6 +20,7 @@ buildPythonPackage rec {
     description = "File-system Representation Interfaces";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/zope_lifecycleevent/default.nix
+++ b/pkgs/development/python-modules/zope_lifecycleevent/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
     description = "Object life-cycle events";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];
+    broken = true;
   };
 
 }

--- a/pkgs/development/tools/analysis/retdec/default.nix
+++ b/pkgs/development/tools/analysis/retdec/default.nix
@@ -232,5 +232,6 @@ in stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ dtzWill timokau ];
     platforms = ["x86_64-linux" "i686-linux"];
+    broken = withPEPatterns;
   };
 }

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -87,5 +87,6 @@ in newPython.pkgs.buildPythonApplication rec {
     license = licenses.mit;
     maintainers = with maintainers; [ HaoZeke ];
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/development/tools/database/litecli/default.nix
+++ b/pkgs/development/tools/database/litecli/default.nix
@@ -41,5 +41,6 @@ python3Packages.buildPythonApplication rec {
     homepage = https://litecli.com;
     license = licenses.bsd3;
     maintainers = with maintainers; [ Scriptkiddi ];
+    broken = true;
   };
 }

--- a/pkgs/development/tools/misc/act/default.nix
+++ b/pkgs/development/tools/misc/act/default.nix
@@ -18,5 +18,6 @@ buildGoModule rec {
     homepage = "https://circleci.com/";
     license = licenses.mit;
     maintainers = with maintainers; [ filalex77 ];
+    broken = true;
   };
 }

--- a/pkgs/development/tools/parinfer-rust/default.nix
+++ b/pkgs/development/tools/parinfer-rust/default.nix
@@ -32,5 +32,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.isc;
     maintainers = with maintainers; [ eraserhd ];
     platforms = platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/development/tools/prospector/default.nix
+++ b/pkgs/development/tools/prospector/default.nix
@@ -70,5 +70,6 @@ buildPythonApplication rec {
     maintainers = with maintainers; [
       kamadorueda
     ];
+    broken = true;
   };
 }

--- a/pkgs/development/tools/setupcfg2nix/default.nix
+++ b/pkgs/development/tools/setupcfg2nix/default.nix
@@ -15,5 +15,6 @@ buildSetupcfg rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.shlevy ];
+    broken = true;
   };
 }

--- a/pkgs/games/atanks/default.nix
+++ b/pkgs/games/atanks/default.nix
@@ -19,5 +19,6 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
     license = licenses.gpl2;
+    broken = true;
   };
 }

--- a/pkgs/games/freeorion/default.nix
+++ b/pkgs/games/freeorion/default.nix
@@ -48,5 +48,6 @@ stdenv.mkDerivation rec {
     license = with licenses; [ gpl2 cc-by-sa-30 ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ tex ];
+    broken = true;
   };
 }

--- a/pkgs/games/lincity/ng.nix
+++ b/pkgs/games/lincity/ng.nix
@@ -51,5 +51,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/games/onscripter-en/default.nix
+++ b/pkgs/games/onscripter-en/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ abbradar ];
+    broken = true;
   };
 }

--- a/pkgs/games/racer/default.nix
+++ b/pkgs/games/racer/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation {
     homepage = http://hippo.nipax.cz/download.en.php;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/games/trigger/default.nix
+++ b/pkgs/games/trigger/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [viric];
     platforms = with stdenv.lib.platforms; linux;
+    broken = true;
   };
 }

--- a/pkgs/misc/emulators/atari800/default.nix
+++ b/pkgs/misc/emulators/atari800/default.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation rec{
     maintainers = [ maintainers.AndersonTorres ];
     license = licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/misc/emulators/hatari/default.nix
+++ b/pkgs/misc/emulators/hatari/default.nix
@@ -19,5 +19,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ ];
+    broken = true;
   };
 }

--- a/pkgs/misc/rkdeveloptool/default.nix
+++ b/pkgs/misc/rkdeveloptool/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation {
     description = "A tool from Rockchip to communicate with Rockusb devices";
     license = licenses.gpl2;
     maintainers = [ maintainers.lopsided98 ];
+    broken = true;
   };
 }

--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     license = licenses.apsl20;
     maintainers = with maintainers; [ matthewbauer ];
+    broken = true;
   };
 
 }

--- a/pkgs/os-specific/linux/roccat-tools/default.nix
+++ b/pkgs/os-specific/linux/roccat-tools/default.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation rec {
     homepage = http://roccat.sourceforge.net/;
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2Plus;
+    broken = true;
   };
 }

--- a/pkgs/servers/monitoring/plugins/esxi.nix
+++ b/pkgs/servers/monitoring/plugins/esxi.nix
@@ -33,5 +33,6 @@ in python2Packages.buildPythonApplication rec {
     homepage = https://www.claudiokuenzler.com/nagios-plugins/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
+    broken = true;
   };
 }

--- a/pkgs/servers/rippled/validator-keys-tool.nix
+++ b/pkgs/servers/rippled/validator-keys-tool.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ offline ];
     license = licenses.isc;
     platforms = [ "x86_64-linux" ];
+    broken = true;
   };
 }

--- a/pkgs/servers/sql/percona/5.6.x.nix
+++ b/pkgs/servers/sql/percona/5.6.x.nix
@@ -57,5 +57,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl2;
     maintainers = with maintainers; [ grahamc ];
+    broken = true;
   };
 }

--- a/pkgs/shells/dgsh/default.nix
+++ b/pkgs/shells/dgsh/default.nix
@@ -41,5 +41,6 @@ stdenv.mkDerivation {
     license = with licenses; asl20;
     maintainers = with maintainers; [ vrthra ];
     platforms = with platforms; all;
+    broken = true;
   };
 }

--- a/pkgs/tools/X11/ncview/default.nix
+++ b/pkgs/tools/X11/ncview/default.nix
@@ -21,5 +21,6 @@ in stdenv.mkDerivation {
     homepage    = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html";
     license = licenses.gpl3;
     maintainers = with maintainers; [ jmettes ];
+    broken = true;
   };
 }

--- a/pkgs/tools/X11/xprintidle-ng/default.nix
+++ b/pkgs/tools/X11/xprintidle-ng/default.nix
@@ -42,5 +42,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/tools/audio/google-music-scripts/default.nix
+++ b/pkgs/tools/audio/google-music-scripts/default.nix
@@ -31,5 +31,6 @@ python3.pkgs.buildPythonApplication rec {
     description = "A CLI utility for interacting with Google Music";
     license = licenses.mit;
     maintainers = with maintainers; [ jakewaksbaum ];
+    broken = true;
   };
 }

--- a/pkgs/tools/backup/partimage/default.nix
+++ b/pkgs/tools/backup/partimage/default.nix
@@ -39,5 +39,6 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.marcweber];
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/tools/compression/lbzip2/default.nix
+++ b/pkgs/tools/compression/lbzip2/default.nix
@@ -14,5 +14,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ abbradar ];
     platforms = platforms.unix;
+    broken = true;
   };
 }

--- a/pkgs/tools/filesystems/lizardfs/default.nix
+++ b/pkgs/tools/filesystems/lizardfs/default.nix
@@ -55,5 +55,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl3;
     maintainers = [ maintainers.rushmorem ];
+    broken = true;
   };
 }

--- a/pkgs/tools/filesystems/orangefs/default.nix
+++ b/pkgs/tools/filesystems/orangefs/default.nix
@@ -57,5 +57,6 @@ stdenv.mkDerivation rec {
     license = with licenses;  [ asl20 bsd3 gpl2 lgpl21 lgpl21Plus openldap ];
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ markuskowa ];
+    broken = true;
   };
 }

--- a/pkgs/tools/misc/bmap-tools/default.nix
+++ b/pkgs/tools/misc/bmap-tools/default.nix
@@ -17,5 +17,6 @@ python2Packages.buildPythonApplication rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/tools/misc/grub/trusted.nix
+++ b/pkgs/tools/misc/grub/trusted.nix
@@ -96,5 +96,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/Sirrix-AG/TrustedGRUB2;
     license = licenses.gpl3Plus;
     platforms = platforms.gnu ++ platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/tools/misc/ntfy/default.nix
+++ b/pkgs/tools/misc/ntfy/default.nix
@@ -33,5 +33,6 @@ pythonPackages.buildPythonApplication rec {
     homepage = http://ntfy.rtfd.org/;
     license = licenses.gpl3;
     maintainers = with maintainers; [ jfrankenau kamilchm ];
+    broken = true;
   };
 }

--- a/pkgs/tools/misc/trac/default.nix
+++ b/pkgs/tools/misc/trac/default.nix
@@ -52,5 +52,6 @@ buildPythonApplication rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ mmahut ];
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/tools/networking/ip2unix/default.nix
+++ b/pkgs/tools/networking/ip2unix/default.nix
@@ -42,5 +42,6 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.lgpl3;
     maintainers = [ stdenv.lib.maintainers.aszlig ];
+    broken = true;
   };
 }

--- a/pkgs/tools/networking/mitmproxy/default.nix
+++ b/pkgs/tools/networking/mitmproxy/default.nix
@@ -79,5 +79,6 @@ buildPythonPackage rec {
     homepage    = https://mitmproxy.org/;
     license     = licenses.mit;
     maintainers = with maintainers; [ fpletz kamilchm ];
+    broken = true;
   };
 }

--- a/pkgs/tools/networking/packetdrill/default.nix
+++ b/pkgs/tools/networking/packetdrill/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ dmjio cleverca22 ];
+    broken = true;
   };
 }

--- a/pkgs/tools/networking/py-wmi-client/default.nix
+++ b/pkgs/tools/networking/py-wmi-client/default.nix
@@ -21,5 +21,6 @@ pythonPackages.buildPythonApplication rec {
     homepage = "https://github.com/dlundgren/py-wmi-client";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
+    broken = true;
   };
 }

--- a/pkgs/tools/package-management/cargo-download/default.nix
+++ b/pkgs/tools/package-management/cargo-download/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchgit, darwin, buildPlatform
 , buildRustCrate, buildRustCrateHelpers, defaultCrateOverrides }:
 
-((import ./Cargo.nix {
+(((import ./Cargo.nix {
   inherit lib buildPlatform buildRustCrate buildRustCrateHelpers fetchgit;
   cratesIO = import ./crates-io.nix { inherit lib buildRustCrate buildRustCrateHelpers; };
 }).cargo_download {}).override {
@@ -11,4 +11,8 @@
         darwin.apple_sdk.frameworks.Security;
     };
   };
-}
+}).overrideAttrs ({ meta ? {}, ... }: {
+  meta = meta // {
+    broken = true;
+  };
+})

--- a/pkgs/tools/security/gencfsm/default.nix
+++ b/pkgs/tools/security/gencfsm/default.nix
@@ -35,5 +35,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.spacefrogg ];
+    broken = true;
   };
 }

--- a/pkgs/tools/security/sequoia/default.nix
+++ b/pkgs/tools/security/sequoia/default.nix
@@ -87,6 +87,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ minijackson doronbehar ];
     platforms = platforms.all;
-    broken = stdenv.targetPlatform.isDarwin;
+    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15574,7 +15574,7 @@ in
   mysql = mariadb; # TODO: move to aliases.nix
 
   mongodb = hiPrio mongodb-3_4;
-  
+
   mongodb-3_4 = callPackage ../servers/nosql/mongodb/v3_4.nix {
     sasl = cyrus_sasl;
     boost = boost160;

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -562,6 +562,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
       license = stdenv.lib.licenses.asl20;
       maintainers = with stdenv.lib.maintainers; [ obadz ];
       platforms = with stdenv.lib.platforms; linux;
+      broken = true;
     };
   };
 
@@ -589,6 +590,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
       license = stdenv.lib.licenses.asl20;
       maintainers = with stdenv.lib.maintainers; [ obadz ];
       platforms = with stdenv.lib.platforms; linux;
+      broken = true;
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1681,7 +1681,7 @@ in {
 
   asn1ate = callPackage ../development/python-modules/asn1ate { };
 
-  atlassian-python-api = callPackage ../development/python-modules/atlassian-python-api { };  
+  atlassian-python-api = callPackage ../development/python-modules/atlassian-python-api { };
 
   atomiclong = callPackage ../development/python-modules/atomiclong { };
 
@@ -3605,9 +3605,13 @@ in {
 
   folium = callPackage ../development/python-modules/folium { };
 
-  fontforge = toPythonModule (pkgs.fontforge.override {
+  fontforge = (toPythonModule (pkgs.fontforge.override {
     withPython = true;
     inherit python;
+  })).overrideAttrs (old: {
+    meta = old.meta // {
+      broken = isPy38;
+    };
   });
 
   fonttools = callPackage ../development/python-modules/fonttools { };
@@ -4371,7 +4375,7 @@ in {
 
   nbconvert = callPackage ../development/python-modules/nbconvert { };
 
-  nbformat = if isPy3k then 
+  nbformat = if isPy3k then
     callPackage ../development/python-modules/nbformat { }
   else callPackage ../development/python-modules/nbformat/2.nix { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes #83805

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
