### PR TITLE
g2o: unstable-2019-04-07 -> 20200410

### DIFF
--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ eigen suitesparse libGLU qt5.qtbase libsForQt5.libqglviewer ];
 
+  # Silence noisy warning
+  CXXFLAGS = "-Wno-deprecated-copy";
+
   cmakeFlags = [
     # Detection script is broken
     "-DQGLVIEWER_INCLUDE_DIR=${libsForQt5.libqglviewer}/include/QGLViewer"

--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -1,15 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, cmake, eigen, suitesparse, libGLU, qt5
-, libsForQt5, makeWrapper }:
+{ lib, stdenv, mkDerivation, fetchFromGitHub, cmake, eigen, suitesparse, libGLU
+, qtbase, libqglviewer, makeWrapper }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "g2o";
-  version = "unstable-2019-04-07";
+  version = "20200410";
 
   src = fetchFromGitHub {
     owner = "RainerKuemmerle";
     repo = pname;
-    rev = "9b41a4ea5ade8e1250b9c1b279f3a9c098811b5a";
-    sha256 = "1rgrz6zxiinrik3lgwgvsmlww1m2fnpjmvcx1mf62xi1s2ma5w2i";
+    rev = "${version}_git";
+    sha256 = "11rgj2g9mmwajlr69pjkjvxjyn88afa0r4bchjyvmxswjccizlg2";
   };
 
   # Removes a reference to gcc that is only used in a debug message
@@ -18,14 +18,14 @@ stdenv.mkDerivation rec {
   separateDebugInfo = true;
 
   nativeBuildInputs = [ cmake makeWrapper ];
-  buildInputs = [ eigen suitesparse libGLU qt5.qtbase libsForQt5.libqglviewer ];
+  buildInputs = [ eigen suitesparse libGLU qtbase libqglviewer ];
 
   # Silence noisy warning
   CXXFLAGS = "-Wno-deprecated-copy";
 
   cmakeFlags = [
     # Detection script is broken
-    "-DQGLVIEWER_INCLUDE_DIR=${libsForQt5.libqglviewer}/include/QGLViewer"
+    "-DQGLVIEWER_INCLUDE_DIR=${libqglviewer}/include/QGLViewer"
     "-DG2O_BUILD_EXAMPLES=OFF"
   ] ++ lib.optionals stdenv.isx86_64 ([ "-DDO_SSE_AUTODETECT=OFF" ] ++ {
     default        = [ "-DDISABLE_SSE3=ON" "-DDISABLE_SSE4_1=ON" "-DDISABLE_SSE4_2=ON" "-DDISABLE_SSE4_A=ON" ];
@@ -38,16 +38,11 @@ stdenv.mkDerivation rec {
     skylake-avx512 = [                                                                 "-DDISABLE_SSE4_A=ON" ];
   }.${stdenv.hostPlatform.platform.gcc.arch or "default"});
 
-  postInstall = ''
-    wrapProgram $out/bin/g2o_viewer \
-      --prefix QT_PLUGIN_PATH : "${qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}"
-  '';
-
-  meta = {
+  meta = with lib; {
     description = "A General Framework for Graph Optimization";
     homepage = "https://github.com/RainerKuemmerle/g2o";
-    license = with lib.licenses; [ bsd3 lgpl3 gpl3 ];
-    maintainers = with lib.maintainers; [ lopsided98 ];
-    platforms = lib.platforms.all;
+    license = with licenses; [ bsd3 lgpl3 gpl3 ];
+    maintainers = with maintainers; [ lopsided98 ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1809,7 +1809,7 @@ in
 
   fzy = callPackage ../tools/misc/fzy { };
 
-  g2o = callPackage ../development/libraries/g2o { };
+  g2o = libsForQt5.callPackage ../development/libraries/g2o { };
 
   gbsplay = callPackage ../applications/audio/gbsplay { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates g2o to the latest release and fixes the "Log limit exceeded" error on Hydra. At least the first commit in this PR should probably be backported to 20.03 for ZHF.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
