### PR TITLE
hydra: 2020-04-07 -> 2020-04-16

### DIFF
--- a/nixos/tests/hydra/db-migration.nix
+++ b/nixos/tests/hydra/db-migration.nix
@@ -1,8 +1,14 @@
-{ system ? builtins.currentSystem, ... }:
+{ system ? builtins.currentSystem
+, pkgs ? import ../../.. { inherit system; }
+, ...
+}:
 
 let inherit (import ./common.nix { inherit system; }) baseConfig; in
 
-{ mig = import ../make-test-python.nix ({ pkgs, lib, ... }: {
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+with pkgs.lib;
+
+{ mig = makeTest {
     name = "hydra-db-migration";
     meta = with pkgs.stdenv.lib.maintainers; {
       maintainers = [ ma27 ];
@@ -82,5 +88,5 @@ let inherit (import ./common.nix { inherit system; }) baseConfig; in
 
       original.shutdown()
     '';
-  });
+  };
 }

--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -5,6 +5,7 @@
 , docbook_xsl, openssh, gnused, coreutils, findutils, gzip, lzma, gnutar
 , rpm, dpkg, cdrkit, pixz, lib, boost, autoreconfHook, src ? null, version ? null
 , migration ? false, patches ? []
+, tests ? {}
 }:
 
 with stdenv;
@@ -124,7 +125,7 @@ in stdenv.mkDerivation rec {
 
   dontStrip = true;
 
-  passthru = { inherit perlDeps migration; };
+  passthru = { inherit perlDeps migration tests; };
 
   meta = with stdenv.lib; {
     description = "Nix-based continuous build system";

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, nixStable, callPackage, nixFlakes, fetchpatch }:
+{ fetchFromGitHub, nixStable, callPackage, nixFlakes, fetchpatch, nixosTests }:
 
 {
   # Package for phase-1 of the db migration for Hydra.
@@ -13,6 +13,11 @@
     };
     nix = nixStable;
     migration = true;
+
+    tests = {
+      db-migration = nixosTests.hydra-db-migration.mig;
+      basic = nixosTests.hydra.hydra-migration;
+    };
   };
 
   # Hydra from latest master branch. Contains breaking changes,
@@ -27,5 +32,9 @@
       sha256 = "1vs3lyfyafsl7wbpmycv7c3n9n2rkrswp65msb6q1iskgpvr96d5";
     };
     nix = nixFlakes;
+    tests = {
+      db-migration = nixosTests.hydra-db-migration.mig;
+      basic = nixosTests.hydra.hydra-unstable;
+    };
   };
 }

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -19,20 +19,13 @@
   # so when having an older version, `pkgs.hydra-migration` should be deployed first.
 
   hydra-unstable = callPackage ./common.nix {
-    version = "2020-04-07";
+    version = "2020-04-16";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "4cabb37ebdeade1435ad8ebf1913cdd603b9c452";
-      sha256 = "1ccy639x6yyrqqqqli7vlqm6pcvcq5dx1w3ckba77rl8pd5h31f7";
+      rev = "87837f1d82904bf48e11b5641258b6be2f663c3b";
+      sha256 = "1vs3lyfyafsl7wbpmycv7c3n9n2rkrswp65msb6q1iskgpvr96d5";
     };
-    patches = [
-      # https://github.com/NixOS/hydra/pull/732
-      (fetchpatch {
-        url = "https://github.com/NixOS/hydra/commit/2f9d422172235297759f2b224fe0636cad07b6fb.patch";
-        sha256 = "0152nsqqc5d85qdygmwrsk88i9y6nk1b639fj2n042pjvr0kpz6k";
-      })
-    ];
     nix = nixFlakes;
   };
 }


### PR DESCRIPTION

###### Motivation for this change

* Updates [`hydra`](http://nixos.org/hydra) to latest rev available.
* Removes custom patches for buildings since all downstream patches were either merged or fixed by another issue.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
