### PR TITLE
megatools: 1.10.2 -> 1.10.3

### DIFF
--- a/pkgs/tools/networking/megatools/default.nix
+++ b/pkgs/tools/networking/megatools/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchgit, autoreconfHook, pkgconfig, glib, fuse, curl, glib-networking
+{ stdenv, fetchgit, autoreconfHook, pkg-config, glib, fuse, curl, glib-networking
 , asciidoc, libxml2, docbook_xsl, docbook_xml_dtd_45, libxslt, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "megatools";
-  version = "1.10.2";
+  version = "1.10.3";
 
   src = fetchgit {
     url = "https://megous.com/git/megatools";
-    rev = version;
-    sha256 = "001hw8j36ld03wwaphq3xdaazf2dpl36h84k8xmk524x8vlia8lk";
+    rev = "5581d06e447b84d0101d36dc96ab72920eec1017";
+    sha256 = "1fh456kjsmdvpmvklkpi06h720yvhahd4rxa6cm5x818pl44p1r4";
   };
 
   nativeBuildInputs = [
-    autoreconfHook pkgconfig wrapGAppsHook asciidoc libxml2
+    autoreconfHook pkg-config wrapGAppsHook asciidoc libxml2
     docbook_xsl docbook_xml_dtd_45 libxslt
   ];
   buildInputs = [ glib glib-networking curl ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
> https://megatools.megous.com/builds/NEWS
```
megatools 1.10.3 - 2020-04-15
=============================

This is a bugfix release.

Fixes:
- Add support for new format of mega.nz links (by Alberto Garcia)
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).