### PR TITLE
ili2c: 5.0.0 -> 5.0.8

### DIFF
--- a/pkgs/tools/misc/ili2c/default.nix
+++ b/pkgs/tools/misc/ili2c/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "ili2c";
-  version = "5.0.0";
+  version = "5.0.8";
 
   nativeBuildInputs = [ ant jdk makeWrapper ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "claeis";
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "0xps2343d5gdr2aj8j3l4cjq4k9zbxxlhnp8sjlhxh1wdczxlwx6";
+    sha256 = "1yhsyh940kb33y2n6xl7zhf0f6q0nrxbyg6c4g5n2imllpn54sgi";
   };
 
   buildPhase = "ant jar";


### PR DESCRIPTION
###### Motivation for this change

newest upstream version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>

  - ilixi
</details>
<details>
  <summary>1 package built:</summary>

  - ili2c
</details>