### PR TITLE
meson: 0.53.2 → 0.54.0

### DIFF
--- a/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
+++ b/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
@@ -1,25 +1,19 @@
 --- a/mesonbuild/coredata.py
 +++ b/mesonbuild/coredata.py
-@@ -375,18 +375,13 @@
-         '''
-         if option.endswith('dir') and os.path.isabs(value) and \
+@@ -483,7 +483,6 @@ class CoreData:
+             return value
+         if option.endswith('dir') and value.is_absolute() and \
             option not in builtin_dir_noprefix_options:
 -            # Value must be a subdir of the prefix
              # commonpath will always return a path in the native format, so we
              # must use pathlib.PurePath to do the same conversion before
              # comparing.
--            if os.path.commonpath([value, prefix]) != str(PurePath(prefix)):
--                m = 'The value of the {!r} option is {!r} which must be a ' \
--                    'subdir of the prefix {!r}.\nNote that if you pass a ' \
--                    'relative path, it is assumed to be a subdir of prefix.'
--                raise MesonException(m.format(option, value, prefix))
--            # Convert path to be relative to prefix
--            skip = len(prefix) + 1
--            value = value[skip:]
-+            if os.path.commonpath([value, prefix]) == str(PurePath(prefix)):
-+                # Convert path to be relative to prefix
-+                skip = len(prefix) + 1
-+                value = value[skip:]
-         return value
- 
-     def init_builtins(self):
+@@ -495,7 +494,7 @@ class CoreData:
+             try:
+                 value = value.relative_to(prefix)
+             except ValueError:
+-                raise MesonException(msg.format(option, value, prefix))
++                pass
+             if '..' in str(value):
+                 raise MesonException(msg.format(option, value, prefix))
+         return value.as_posix()

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -19,11 +19,11 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "meson";
-  version = "0.53.2";
+  version = "0.54.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "Po+DDzMYQ5fC6wtlHsUCrbY97LKJeL3ISzVY1xKEwh8=";
+    sha256 = "3eVybXeBEqy9Sme7NjOrLuddM9HoeaYoOntKRMM2PCc=";
   };
 
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change


https://mesonbuild.com/Release-notes-for-0-54-0.html



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Successfully built:
- [x] systemd
- [x] fwupd
- [x] gnome3.gnome-shell
- [x] gnome-builder