### PR TITLE
Fix: ulauncher paths finding

### DIFF
--- a/pkgs/applications/misc/ulauncher/0001-Adjust-get_data_path-for-NixOS.patch
+++ b/pkgs/applications/misc/ulauncher/0001-Adjust-get_data_path-for-NixOS.patch
@@ -16,7 +16,7 @@ diff --git a/ulauncher/config.py b/ulauncher/config.py
 index f21014e..cc636e1 100644
 --- a/ulauncher/config.py
 +++ b/ulauncher/config.py
-@@ -50,15 +50,24 @@ def get_data_path():
+@@ -50,15 +50,13 @@ def get_data_path():
      is specified at installation time.
      """
  
@@ -29,27 +29,15 @@ index f21014e..cc636e1 100644
 -        raise ProjectPathNotFoundError(abs_data_path)
 -
 -    return abs_data_path
-+    paths = list(
-+        filter(
-+            os.path.exists,
-+            [
-+                os.path.join(dir, "ulauncher")
-+                for dir in xdg_data_dirs
-+                # Get path that isn't in the /nix/store so they don't get hardcoded into configs
-+                if not dir.startswith("/nix/store/")
-+                # Exclude .local/share/ulauncher which isn't what we want
-+                if not dir.startswith(xdg_data_home)
-+            ],
-+        )
-+    )
-+
-+    try:
-+        return paths[0]
-+    except:
-+        raise ProjectPathNotFoundError()
++    for xdir in xdg_data_dirs:
++        xdir = os.path.join(xdir, "ulauncher")
++        if (os.path.exists(xdir) and
++            xdir.startswith("/nix/store/") and
++            not xdir.startswith(xdg_data_home)):
++            return xdir
++    raise ProjectPathNotFoundError()
  
  
  def is_wayland():
 -- 
 2.25.1
-


### PR DESCRIPTION
Fix path finding

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix for the following exception:
```
2020-04-16 03:29:53,349 | ERROR | ulauncher: except_hook() | Uncaught exception
Traceback (most recent call last):
  File "/nix/store/p8qyv86nhfbf7pgn9ccdfjy4wzkqxs8h-ulauncher-5.6.1/lib/python3.7/site-packages/ulauncher/config.py", line 68, in get_data_path
    return paths[0]
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/nix/store/p8qyv86nhfbf7pgn9ccdfjy4wzkqxs8h-ulauncher-5.6.1/bin/..ulauncher-wrapped-wrapped", line 29, in <module>
    main()
  File "/nix/store/p8qyv86nhfbf7pgn9ccdfjy4wzkqxs8h-ulauncher-5.6.1/lib/python3.7/site-packages/ulauncher/main.py", line 128, in main
    window = UlauncherWindow.get_instance()
  File "/nix/store/p8qyv86nhfbf7pgn9ccdfjy4wzkqxs8h-ulauncher-5.6.1/lib/python3.7/site-packages/ulauncher/utils/decorator/singleton.py", line 19, in wrapper
    instance = fn(*args, **kwargs)
  File "/nix/store/p8qyv86nhfbf7pgn9ccdfjy4wzkqxs8h-ulauncher-5.6.1/lib/python3.7/site-packages/ulauncher/ui/windows/UlauncherWindow.py", line 55, in get_instance
    return cls()
  File "/nix/store/p8qyv86nhfbf7pgn9ccdfjy4wzkqxs8h-ulauncher-5.6.1/lib/python3.7/site-packages/ulauncher/ui/windows/UlauncherWindow.py", line 63, in __new__
    builder = Builder.new_from_file('UlauncherWindow')
  File "/nix/store/p8qyv86nhfbf7pgn9ccdfjy4wzkqxs8h-ulauncher-5.6.1/lib/python3.7/site-packages/ulauncher/ui/windows/Builder.py", line 47, in new_from_file
    ui_filename = get_data_file('ui', '%s.ui' % (builder_file_name,))
  File "/nix/store/p8qyv86nhfbf7pgn9ccdfjy4wzkqxs8h-ulauncher-5.6.1/lib/python3.7/site-packages/ulauncher/config.py", line 42, in get_data_file
    return os.path.join(get_data_path(), *path_segments)
  File "/nix/store/p8qyv86nhfbf7pgn9ccdfjy4wzkqxs8h-ulauncher-5.6.1/lib/python3.7/site-packages/ulauncher/config.py", line 70, in get_data_path
    raise ProjectPathNotFoundError()
ulauncher.config.ProjectPathNotFoundError
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
