### PR TITLE
chromedriver: 78.0.3904.70 -> 81.0.4044.69

### DIFF
--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -6,12 +6,12 @@ let
   allSpecs = {
     x86_64-linux = {
       system = "linux64";
-      sha256 = "155yilj9w8a6jbkx1axhhkizwdc12krl4xixn10j7n94bvny4w2y";
+      sha256 = "1mqsangjindfqgvjxgmpgfrcd8a2lqmwl587l0ip0p5wwz8yq5wi";
     };
 
     x86_64-darwin = {
       system = "mac64";
-      sha256 = "0dzy9ihhbhx4byr2kalwfbn6jbk1hinacdqi25lvhaprdbrh2igh";
+      sha256 = "18ydf2bk5aiin3yffb9z8215idz65nkhgxq0mmlvwb8gwsdvnwi1";
     };
   };
 
@@ -28,7 +28,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "chromedriver";
-  version = "78.0.3904.70";
+  version = "81.0.4044.69";
 
   src = fetchurl {
     url = "https://chromedriver.storage.googleapis.com/${version}/chromedriver_${spec.system}.zip";


### PR DESCRIPTION
backport of NixOS/nixpkgs#85302

###### Motivation for this change

Bring in sync with chromium version, so that chromedriver and chromium can be used together. See https://chromedriver.chromium.org/downloads/version-selection

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix run -f . nixpkgs-review -c nixpkgs-review wip -b release-20.03`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>

  - self
</details>
<details>
  <summary>3 package built:</summary>

  - chromedriver
  - selendroid
  - selenium-server-standalone
</details>