### PR TITLE
stig: use pytestCheckHook framework

### DIFF
--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -1,9 +1,9 @@
 { lib
 , fetchFromGitHub
-, python3
+, python3Packages
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "stig";
   # This project has a different concept for pre release / alpha,
   # Read the project's README for details: https://github.com/rndusr/stig#stig
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
       --replace "urwidtrees>=1.0.3dev0" "urwidtrees"
   '';
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     urwid
     urwidtrees
     aiohttp
@@ -38,16 +38,22 @@ python3.pkgs.buildPythonApplication rec {
     setproctitle
   ];
 
-  checkInputs = with python3.pkgs; [
+  checkInputs = with python3Packages; [
     asynctest
-    pytest
+    pytestCheckHook
   ];
 
-  # test_string__month_day_hour_minute_second fails on darwin
-  checkPhase = ''
-    LC_ALL=en_US.utf8 pytest tests \
-      --deselect=tests/client_test/ttypes_test.py::TestTimestamp::test_string__month_day_hour_minute_second
+  dontUseSetuptoolsCheck = true;
+
+  preCheck = ''
+    export LC_ALL=C
   '';
+
+  pytestFlagsArray = [
+    "tests"
+    # test_string__month_day_hour_minute_second fails on darwin
+    "--deselect=tests/client_test/ttypes_test.py::TestTimestamp::test_string__month_day_hour_minute_second"
+  ];
 
   meta = with lib; {
     description = "TUI and CLI for the BitTorrent client Transmission";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Current package for ˋstigˋ overrides ˋcheckPhaseˋ hence setting ˋdoInstallCheck = falseˋ is ignored.

###### Things done
Use the ˋpytestCheckHookˋ framework.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
