### PR TITLE
nix-prefetch: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch/default.nix
@@ -47,7 +47,7 @@ in stdenv.mkDerivation rec {
   dontConfigure = true;
 
   buildPhase = ''
-    a2x -a revdate=$(date --date=@$(cat $src/.timestamp) +%d/%m/%Y) \
+    a2x -a revdate=$(date --utc --date=@$(cat $src/.timestamp) +%d/%m/%Y) \
       -f manpage doc/nix-prefetch.1.asciidoc
   '';
 

--- a/pkgs/tools/package-management/nix-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, asciidoc, docbook_xml_dtd_45, git
-, docbook_xsl, libxml2, libxslt, coreutils, gawk, gnugrep, gnused, jq, nix
-, installShellFiles }:
+{ stdenv, fetchFromGitHub, installShellFiles, makeWrapper, asciidoc
+, docbook_xml_dtd_45, git, docbook_xsl, libxml2, libxslt, coreutils, gawk
+, gnugrep, gnused, jq, nix }:
 
-let binPath = lib.makeBinPath [ coreutils gawk git gnugrep gnused jq nix ];
+let
+  binPath = stdenv.lib.makeBinPath [ coreutils gawk git gnugrep gnused jq nix ];
 
 in stdenv.mkDerivation rec {
   pname = "nix-prefetch";
@@ -12,7 +13,11 @@ in stdenv.mkDerivation rec {
     owner = "msteen";
     repo = "nix-prefetch";
     rev = version;
-    sha256 = "0sf910b1m8q6429pyxlvmmgylha9f2a1s3sq3vgqdnb1dparl34r";
+    sha256 = "15h6f743nn6sdq8l771sjxh92cyzqznkcs7szrc7nm066xvx8rd4";
+    # the stat call has to be in a subshell or we get the current date
+    extraPostFetch = ''
+      echo $(stat -c %Y $out) > $out/.timestamp
+    '';
   };
 
   postPatch = ''
@@ -42,7 +47,8 @@ in stdenv.mkDerivation rec {
   dontConfigure = true;
 
   buildPhase = ''
-    a2x -f manpage doc/nix-prefetch.1.asciidoc
+    a2x -a revdate=$(date --date=@$(cat $src/.timestamp) +%d/%m/%Y) \
+      -f manpage doc/nix-prefetch.1.asciidoc
   '';
 
   installPhase = ''

--- a/pkgs/tools/package-management/nix-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch/default.nix
@@ -1,67 +1,68 @@
-{ stdenv, fetchFromGitHub, makeWrapper
-, asciidoc, docbook_xml_dtd_45, docbook_xsl, libxml2, libxslt
-, coreutils, gawk, gnugrep, gnused, jq, nix }:
+{ stdenv, lib, fetchFromGitHub, makeWrapper, asciidoc, docbook_xml_dtd_45, git
+, docbook_xsl, libxml2, libxslt, coreutils, gawk, gnugrep, gnused, jq, nix
+, installShellFiles }:
 
-stdenv.mkDerivation rec {
+let binPath = lib.makeBinPath [ coreutils gawk git gnugrep gnused jq nix ];
+
+in stdenv.mkDerivation rec {
   pname = "nix-prefetch";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "msteen";
     repo = "nix-prefetch";
     rev = version;
-    sha256 = "0b9gdi7xzmfq0j258x724xsll8gi31m0m4pzfjkqinlm6zwr3sgm";
+    sha256 = "0sf910b1m8q6429pyxlvmmgylha9f2a1s3sq3vgqdnb1dparl34r";
   };
 
+  postPatch = ''
+    lib=$out/lib/${pname}
+
+    substituteInPlace doc/nix-prefetch.1.asciidoc \
+      --subst-var-by version $version
+
+    substituteInPlace src/main.sh \
+      --subst-var-by lib $lib \
+      --subst-var-by version $version
+
+    substituteInPlace src/tests.sh \
+      --subst-var-by bin $out/bin
+  '';
+
   nativeBuildInputs = [
+    asciidoc
+    docbook_xml_dtd_45
+    docbook_xsl
+    installShellFiles
+    libxml2
+    libxslt
     makeWrapper
-    asciidoc docbook_xml_dtd_45 docbook_xsl libxml2 libxslt
   ];
 
-  configurePhase = ''
-    . configure.sh
-  '';
+  dontConfigure = true;
 
   buildPhase = ''
     a2x -f manpage doc/nix-prefetch.1.asciidoc
   '';
 
   installPhase = ''
-    lib=$out/lib/${pname}
-    mkdir -p $lib
-    substitute src/main.sh $lib/main.sh \
-      --subst-var-by lib $lib \
-      --subst-var-by version '${version}'
-    chmod +x $lib/main.sh
-    patchShebangs $lib/main.sh
-    cp lib/*.nix $lib/
-
-    mkdir -p $out/bin
+    install -Dm555 -t $lib src/*.sh
+    install -Dm444 -t $lib lib/*
     makeWrapper $lib/main.sh $out/bin/${pname} \
-      --prefix PATH : '${stdenv.lib.makeBinPath [ coreutils gawk gnugrep gnused jq nix ]}'
+      --prefix PATH : ${binPath}
 
-    substitute src/tests.sh $lib/tests.sh \
-      --subst-var-by bin $out/bin
-    chmod +x $lib/tests.sh
-    patchShebangs $lib/tests.sh
+    installManPage doc/nix-prefetch.?
 
-    mkdir -p $out/share/man/man1
-    substitute doc/nix-prefetch.1 $out/share/man/man1/nix-prefetch.1 \
-      --subst-var-by version '${version}' \
-      --replace '01/01/1970' "$date"
-
-    install -D contrib/nix-prefetch-completion.bash $out/share/bash-completion/completions/nix-prefetch
-    install -D contrib/nix-prefetch-completion.zsh $out/share/zsh/site-functions/_nix_prefetch
+    installShellCompletion --name ${pname} contrib/nix-prefetch-completion.{bash,zsh}
 
     mkdir -p $out/share/doc/${pname}/contrib
-    cp -r contrib/hello_rs $out/share/doc/${pname}/contrib/
+    cp -r contrib/hello_rs $out/share/doc/${pname}/contrib
   '';
 
   meta = with stdenv.lib; {
     description = "Prefetch any fetcher function call, e.g. package sources";
-    homepage = "https://github.com/msteen/nix-prefetch";
     license = licenses.mit;
     maintainers = with maintainers; [ msteen ];
-    platforms = platforms.all;
+    inherit (src.meta) homepage;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Regular update and did some cleanups to make things a little neater. We
patch in the patch phase, install in the install phase and so on.

Also use some of the helpers we have available for shell completion and
man pages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).