### PR TITLE
modules/systemd: don't install home.conf example

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -894,7 +894,10 @@ in
       "sysctl.d/50-coredump.conf".source = "${systemd}/example/sysctl.d/50-coredump.conf";
       "sysctl.d/50-default.conf".source = "${systemd}/example/sysctl.d/50-default.conf";
 
-      "tmpfiles.d/home.conf".source = "${systemd}/example/tmpfiles.d/home.conf";
+      # home.conf creates /srv (which we don't want), and /home, which
+      # is handled by NixOS anyway.
+      # "tmpfiles.d/home.conf".source = "${systemd}/example/tmpfiles.d/home.conf";
+
       "tmpfiles.d/journal-nocow.conf".source = "${systemd}/example/tmpfiles.d/journal-nocow.conf";
       "tmpfiles.d/portables.conf".source = "${systemd}/example/tmpfiles.d/portables.conf";
       "tmpfiles.d/static-nodes-permissions.conf".source = "${systemd}/example/tmpfiles.d/static-nodes-permissions.conf";


### PR DESCRIPTION
We don't want /srv on NixOS, and /home is already created by
users-groups.nix.

Furthermore, systemd tmpfiles are set up post-activation, and so
it’s extremely difficult for a user to override them.  They can't
even set their own rules in systemd.tmpfiles, because "home.conf"
comes before "nixos.conf" lexicographically, and so systemd always
picks the "home.conf" ones.