### PR TITLE
[20.03] node-problem-detector: init at 0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3997,6 +3997,12 @@
     githubId = 32152;
     name = "Luka Blaskovic";
   };
+  lbpdt = {
+    email = "nix@pdtpartners.com";
+    github = "lbpdt";
+    githubId = 45168934;
+    name = "Louis Blin";
+  };
   ldelelis = {
     email = "ldelelis@est.frba.utn.edu.ar";
     github = "ldelelis";

--- a/pkgs/applications/networking/cluster/node-problem-detector/default.nix
+++ b/pkgs/applications/networking/cluster/node-problem-detector/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, buildGoModule, fetchFromGitHub, systemd }:
+
+buildGoModule rec {
+  pname = "node-problem-detector";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "kubernetes";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "02avknglmkr9k933a64hkw0rjfxvyh4sc3x70p41b8q2g6vzv2gs";
+  };
+
+  # Project upstream recommends building through vendoring
+  overrideModAttrs = (_: {
+    buildCommand = ''
+      echo "Skipping go.mod, using vendoring instead." && touch $out
+    '';
+  });
+
+  modSha256 = "0ip26j2h11n1kgkz36rl4akv694yz65hr72q4kv4b3lxcbi65b3p";
+
+  # Optionally, a log counter binary can be created to parse journald logs.
+  # The binary is dynamically linked against systemd libraries, making it a
+  # Linux-only feature. See 'ENABLE_JOURNALD' upstream:
+  # https://github.com/kubernetes/node-problem-detector/blob/master/Makefile
+  subPackages = [ "cmd/nodeproblemdetector" ] ++
+    stdenv.lib.optionals stdenv.isLinux [ "cmd/logcounter" ];
+
+  preBuild = ''
+    export CGO_ENABLED=${if stdenv.isLinux then "1" else "0"}
+  '';
+
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ systemd ];
+
+  buildFlags = "-mod vendor" +
+    stdenv.lib.optionalString stdenv.isLinux " -tags journald";
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-X k8s.io/${pname}/pkg/version.version=v${version}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Various problem detectors running on the Kubernetes nodes";
+    homepage = "https://github.com/kubernetes/node-problem-detector";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lbpdt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20476,6 +20476,8 @@ in
     geoip = geoipWithDatabase;
   };
 
+  node-problem-detector = callPackage ../applications/networking/cluster/node-problem-detector { };
+
   notion = callPackage ../applications/window-managers/notion { };
 
   open-policy-agent = callPackage ../development/tools/open-policy-agent { };


### PR DESCRIPTION
(cherry picked from commit 511cb624b79e859cbf7f463e3e55112ad0bdcf24)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
