### PR TITLE
WIP: sky: 2.1.7369 -> 2.1.7520

### DIFF
--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -4,7 +4,7 @@
 , curl, sqlite, openssl
 , libuuid, openh264, libv4l, libxkbfile, libXv, zlib, libXmu
 , libXtst, libXdamage, pam, libXfixes, libXrender, libjpeg_original
-, ffmpeg
+, ffmpeg_4
 }:
  let
    # Sky is linked to the libjpeg 8 version and checks for the version number in the code.
@@ -16,20 +16,20 @@
   });
 in
 stdenv.mkDerivation rec {
-  version_major = "2.1.7369";
+  version_major = "2.1.7520";
   version_minor = "1";
   version = version_major + "." + version_minor;
   pname = "sky";
   unpackCmd = "ar x $curSrc; tar -xf data.tar.xz";
   src = fetchurl {
-    url = "https://tel.red/repos/ubuntu/pool/non-free/sky_${version_major + "-" + version_minor}ubuntu+xenial_amd64.deb";
-    sha256 = "0b3j90km3rp5bgaklxw881g0gcy09mqzbhjdfrq4s2np026ql3d9";
+    url = "https://tel.red/repos/ubuntu/pool/non-free/sky_${version_major + "-" + version_minor}ubuntu+eoan_amd64.deb";
+    sha256 = "1pjybzks05vf9s49affwis5w80szizwvxmkgmgyfj7v707r1z5ia";
   };
   buildInputs = [ 
     file
     qt5.qtbase
     SDL
-    ffmpeg
+    ffmpeg_4
     sqlite
     openssl
     openh264

--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -49,9 +49,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     ls -al ./
-    mkdir -p "$out/bin" "$out/lib" "$out/share"
+    mkdir -p "$out/bin" "$out/share"
     cp -a lib/sky/* $out/bin/
-    cp -aR lib/sky/lib64/* "$out/lib/"
     cp -a lib/sky/man.sh "$out/bin"
     chmod +x $out/bin/sky
     cp -a share/* "$out/share"

--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -4,7 +4,7 @@
 , curl, sqlite, openssl
 , libuuid, openh264, libv4l, libxkbfile, libXv, zlib, libXmu
 , libXtst, libXdamage, pam, libXfixes, libXrender, libjpeg_original
-, ffmpeg_4
+, ffmpeg_4, autoPatchelfHook
 }:
  let
    # Sky is linked to the libjpeg 8 version and checks for the version number in the code.
@@ -41,6 +41,10 @@ stdenv.mkDerivation rec {
     libXfixes libXrender
     libjpeg_original_fix
   ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    qt5.wrapQtAppsHook
+  ];
   dontBuild = true;
 
   installPhase = ''
@@ -56,18 +60,6 @@ stdenv.mkDerivation rec {
 
 
   postFixup = ''
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp-client.so.2.0.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp-server.so.2.0.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp-shadow.so.2.0.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp.so.2.0.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libopenh264.so.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/librdtk.so.1.1.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libSDL-1.3.so.0.0.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libsipw.so.1.0.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libwinpr.so.1.1.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libxfreerdp-client.so.2.0.0
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/sky
-    patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}:${stdenv.lib.makeLibraryPath buildInputs} --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/sky_sender
     sed -i "s#/usr/bin/sky#$out/bin/sky#g" $out/share/applications/sky.desktop
     sed -i "s#/usr/lib/sky#$out/bin/#g" $out/share/applications/sky.desktop
   '';


### PR DESCRIPTION
update sky (Skype for Business client)

##### WIP

Current state of this PR:

- :heavy_check_mark: compiles (with `NIXPKGS_ALLOW_UNFREE=1`)
- :heavy_check_mark: runs
- :x: starts itself in an endless loop :scream:

###### Motivation for this change

The previously fetched version of the `.deb` file isn't being offered anymore by RedTel, or at least it's not available at that URL, and it's also not listed at any of these:
- https://www.tel.red/linux/old/
- https://www.tel.red/beta
- https://www.tel.red/repos/ubuntu/pool/non-free/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
