### PR TITLE
netris: init at 0.52

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5824,6 +5824,16 @@
     githubId = 131844;
     name = "Igor Pashev";
   };
+  patryk27 = {
+    email = "wychowaniec.patryk@gmail.com";
+    github = "Patryk27";
+    githubId = 3395477;
+    name = "Patryk Wychowaniec";
+    keys = [{
+      longkeyid = "rsa4096/0xF62547D075E09767";
+      fingerprint = "196A BFEC 6A1D D1EC 7594  F8D1 F625 47D0 75E0 9767";
+    }];
+  };
   patternspandemic = {
     email = "patternspandemic@live.com";
     github = "patternspandemic";

--- a/pkgs/games/netris/default.nix
+++ b/pkgs/games/netris/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation {
+  pname = "netris";
+  version = "0.52";
+
+  src = fetchFromGitHub {
+    owner = "naclander";
+    repo = "netris";
+    rev = "6773c9b2d39a70481a5d6eb5368e9ced6229ad2b";
+    sha256 = "0gmxbpn50pnffidwjchkzph9rh2jm4wfq7hj8msp5vhdq5h0z9hm";
+  };
+
+  buildInputs = [
+    ncurses
+  ];
+
+  configureScript = "./Configure";
+  dontAddPrefix = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./netris $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A free networked version of T*tris";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ patryk27 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23590,7 +23590,7 @@ in
     lua = lua5_1;
   };
 
-  n2048 = callPackage ../games/n2048 {};
+  n2048 = callPackage ../games/n2048 { };
 
   naev = callPackage ../games/naev { };
 
@@ -23602,6 +23602,8 @@ in
   };
 
   nethack-x11 = callPackage ../games/nethack { x11Mode = true; };
+  
+  netris = callPackage ../games/netris { };
 
   neverball = callPackage ../games/neverball { };
 


### PR DESCRIPTION
###### Motivation for this change

I _love_ `netris` and seems like no one before had a time to add it - it's a very simple game, available also in e.g. Ubuntu (https://packages.ubuntu.com/xenial/games/netris).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
