### PR TITLE
racket: use --enable-useprefix configure flag.

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -82,7 +82,10 @@ stdenv.mkDerivation rec {
   '';
 
   shared = if stdenv.isDarwin then "dylib" else "shared";
-  configureFlags = [ "--enable-${shared}"  "--enable-lt=${libtool}/bin/libtool" ]
+  configureFlags = [ "--enable-${shared}"  "--enable-lt=${libtool}/bin/libtool"
+                     # The following flag is a temporary workaround for an upstream bug:
+                     #   https://github.com/racket/racket/issues/3046
+                     "--enable-useprefix" ]
                    ++ stdenv.lib.optional disableDocs [ "--disable-docs" ]
                    ++ stdenv.lib.optional stdenv.isDarwin [ "--enable-xonx" ];
 


### PR DESCRIPTION
This PR has a workaround for a regression in upstream Racket packaging, the upstream bug tracking this is here:

  https://github.com/racket/racket/issues/3046

Some relevant discussion of this issue can be found here:

  https://discourse.nixos.org/t/racket-does-not-find-documentation-after-update/6712/6

###### Motivation for this change

The upstream regression causes install locations in the package to be inconsistent with expectations (e.g., docs).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
