### PR TITLE
mpc-qt: 18.08 -> 2019-06-09

### DIFF
--- a/pkgs/applications/video/mpc-qt/default.nix
+++ b/pkgs/applications/video/mpc-qt/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, qtx11extras, qttools, mpv }:
+{ stdenv, mkDerivation, fetchFromGitLab, pkgconfig, qmake, qtx11extras, qttools, mpv }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "mpc-qt";
-  version = "18.08";
+  version = "2019-06-09";
 
-  src = fetchFromGitHub {
-    owner = "cmdrkotori";
+  src = fetchFromGitLab {
+    owner = "mpc-qt";
     repo = "mpc-qt";
-    rev = "v${version}";
-    sha256 = "1rxlkg3vsrapazdlb1i6c5a1vvf2114bsqwzcm3n2wc5c93yqsna";
+    rev = "2abe6e7fc643068d50522468fe75d614861555ad";
+    sha256 = "1cis8dl9pm91mpnp696zvwsfp96gkwr8jgs45anbwd7ldw78w4x5";
   };
 
   nativeBuildInputs = [ pkgconfig qmake qttools ];
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Media Player Classic Qute Theater";
-    homepage = "https://github.com/cmdrkotori/mpc-qt";
+    homepage = "https://gitlab.com/mpc-qt/mpc-qt";
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ romildo ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- update to the latest commit in git repository
- use mkDerivation for qt applications
- original repo disappeared from github; use the one from gitlab

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).