### PR TITLE
g933-utils: init at unstable-2019-08-04

### DIFF
--- a/pkgs/tools/misc/g933-utils/default.nix
+++ b/pkgs/tools/misc/g933-utils/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, rustPlatform, udev, pkgconfig }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "g933-utils";
+  version = "unstable-2019-08-04";
+
+  src = fetchFromGitHub {
+    owner = "ashkitten";
+    repo = "g933-utils";
+    rev = "b80cfd59fc41ae5d577c147311376dd7f7882493";
+    sha256 = "06napzpk3nayzixb4l4fzdiwpgmcrsbc5j9m4qip1yn6dfkin3p0";
+  };
+
+  cargoSha256 = "16xgk4rc36d6lylh2dzv63ryq9s7fli3h2qva1m1p6f0gpasnk7w";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ udev ];
+
+  meta = with stdenv.lib; {
+    description = "An application to configure Logitech wireless G933/G533 headsets";
+    homepage = "https://github.com/ashkitten/g933-utils";
+    license = licenses.mit;
+    maintainers = with maintainers; [ seqizz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20086,6 +20086,8 @@ in
 
   fte = callPackage ../applications/editors/fte { };
 
+  g933-utils = callPackage ../tools/misc/g933-utils { };
+
   game-music-emu = callPackage ../applications/audio/game-music-emu { };
 
   gavrasm = callPackage ../development/compilers/gavrasm { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A tool written via Rust, helps getting/setting configuration and info from Logitech headsets.

Although some questions are present, since this is my first rust app packaging (sorry & thanks):

- There are no release numbers upstream, I just used 0.13 as `README` has 13 versions. I know it's bad but what do we do in these cases?
- Repository has some simple udev rules, including them sounds shaky since it sets a "logitech" group. Adding `logitech-udev-rules` package as a dependency could be enough or is this even needed?
- Is the selected category correct?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
