### PR TITLE
tensorflow-bin_2: fix tensorboard dependency

### DIFF
--- a/pkgs/development/python-modules/tensorflow/2/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/2/bin.nix
@@ -159,6 +159,14 @@ in buildPythonPackage {
       done
     '';
 
+  # Upstream has a pip hack that results in bin/tensorboard being in both tensorflow
+  # and the propagated input tensorflow-tensorboard, which causes environment collisions.
+  # Another possibility would be to have tensorboard only in the buildInputs
+  # See https://github.com/NixOS/nixpkgs/pull/44381 for more information.
+  postInstall = ''
+    rm $out/bin/tensorboard
+  '';
+
   pythonImportsCheck = [
     "tensorflow"
     "tensorflow.keras"

--- a/pkgs/development/python-modules/tensorflow/2/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/2/bin.nix
@@ -19,7 +19,7 @@
 , opt-einsum
 , backports_weakref
 , tensorflow-estimator_2
-, tensorflow-tensorboard
+, tensorflow-tensorboard_2
 , cudaSupport ? false
 , cudatoolkit ? null
 , cudnn ? null
@@ -77,7 +77,7 @@ in buildPythonPackage {
     google-pasta
     wrapt
     tensorflow-estimator_2
-    tensorflow-tensorboard
+    tensorflow-tensorboard_2
     keras-applications
     keras-preprocessing
   ] ++ lib.optional (!isPy3k) mock


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #85090.  Tensorboard-bin_2 had the wrong tensorboard as an input, and did not include handling of the tensorboard pip hack (#44381).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
