### PR TITLE
nixos/httpd: fix broken PHP extensions

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -338,6 +338,7 @@ let
     }
     ''
       cat ${php}/etc/php.ini > $out
+      cat ${php}/lib/custom-php.ini > $out
       echo "$options" >> $out
     '';
 

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -12,7 +12,7 @@ let
 
   httpdConf = cfg.configFile;
 
-  php = cfg.phpPackage.override { apacheHttpd = pkg.dev; /* otherwise it only gets .out */ };
+  php = cfg.phpPackage.override { apacheHttpd = pkg; };
 
   phpMajorVersion = lib.versions.major (lib.getVersion php);
 

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -117,6 +117,7 @@ in rec {
         (onFullSupported "nixos.tests.openssh")
         (onFullSupported "nixos.tests.pantheon")
         (onFullSupported "nixos.tests.php.fpm")
+        (onFullSupported "nixos.tests.php.httpd")
         (onFullSupported "nixos.tests.php.pcre")
         (onFullSupported "nixos.tests.plasma5")
         (onFullSupported "nixos.tests.predictable-interface-names.predictableNetworkd")

--- a/nixos/tests/php/default.nix
+++ b/nixos/tests/php/default.nix
@@ -3,5 +3,6 @@
   pkgs ? import ../../.. { inherit system config; }
 }: {
   fpm = import ./fpm.nix { inherit system pkgs; };
+  httpd = import ./httpd.nix { inherit system pkgs; };
   pcre = import ./pcre.nix { inherit system pkgs; };
 }

--- a/nixos/tests/php/fpm.nix
+++ b/nixos/tests/php/fpm.nix
@@ -43,13 +43,11 @@ import ../make-test-python.nix ({pkgs, ...}: {
     machine.wait_for_unit("phpfpm-foobar.service")
 
     # Check so we get an evaluated PHP back
-    assert "PHP Version ${pkgs.php.version}" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+    response = machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+    assert "PHP Version ${pkgs.php.version}" in response, "PHP version not detected"
 
     # Check so we have database and some other extensions loaded
-    assert "json" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
-    assert "opcache" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
-    assert "pdo_mysql" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
-    assert "pdo_pgsql" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
-    assert "pdo_sqlite" in machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+    for ext in ["json", "opcache", "pdo_mysql", "pdo_pgsql", "pdo_sqlite"]:
+        assert ext in response, f"Missing {ext} extension"
   '';
 })

--- a/nixos/tests/php/httpd.nix
+++ b/nixos/tests/php/httpd.nix
@@ -1,0 +1,31 @@
+import ../make-test-python.nix ({pkgs, ...}: {
+  name = "php-httpd-test";
+  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ etu ];
+
+  machine = { config, lib, pkgs, ... }: {
+    services.httpd = {
+      enable = true;
+      adminAddr = "admin@phpfpm";
+      virtualHosts."phpfpm" = let
+        testdir = pkgs.writeTextDir "web/index.php" "<?php phpinfo();";
+      in {
+        documentRoot = "${testdir}/web";
+        locations."/" = {
+          index = "index.php index.html";
+        };
+      };
+      enablePHP = true;
+    };
+  };
+  testScript = { ... }: ''
+    machine.wait_for_unit("httpd.service")
+
+    # Check so we get an evaluated PHP back
+    response = machine.succeed("curl -vvv -s http://127.0.0.1:80/")
+    assert "PHP Version ${pkgs.php.version}" in response, "PHP version not detected"
+
+    # Check so we have database and some other extensions loaded
+    for ext in ["json", "opcache", "pdo_mysql", "pdo_pgsql", "pdo_sqlite"]:
+        assert ext in response, f"Missing {ext} extension"
+  '';
+})

--- a/nixos/tests/php/pcre.nix
+++ b/nixos/tests/php/pcre.nix
@@ -30,8 +30,8 @@ in import ../make-test-python.nix ({ ...}: {
     ''
       machine.wait_for_unit("httpd.service")
       # Ensure php evaluation by matching on the var_dump syntax
-      assert 'string(${toString (builtins.stringLength testString)}) "${testString}"' in machine.succeed(
-          "curl -vvv -s http://127.0.0.1:80/index.php"
-      )
+      response = machine.succeed("curl -vvv -s http://127.0.0.1:80/index.php")
+      expected = 'string(${toString (builtins.stringLength testString)}) "${testString}"'
+      assert expected in response, "Does not appear to be able to use subgroups."
     '';
 })


### PR DESCRIPTION
###### Motivation for this change
Fix PHP extensions not being loaded by the httpd’s PHP module.

Fixes: #85401

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
