### PR TITLE
sourcehut: 2020.04.16

### DIFF
--- a/pkgs/applications/version-management/sourcehut/builds.nix
+++ b/pkgs/applications/version-management/sourcehut/builds.nix
@@ -4,7 +4,7 @@
 , srht, redis, celery, pyyaml, markdown }:
 
 let
-  version = "0.52.5";
+  version = "0.56.13";
 
   buildWorker = src: buildGoModule {
     inherit src version;
@@ -20,7 +20,7 @@ in buildPythonPackage rec {
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/builds.sr.ht";
     rev = version;
-    sha256 = "142aycnary6yfi0y1i3zgpyndi0756fingavcz2dnqi36pkajaaj";
+    sha256 = "uFoS9xaVXsZZf4neZQcUyTqKo2RshOQeifD27kaKSVE=";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/builds.nix
+++ b/pkgs/applications/version-management/sourcehut/builds.nix
@@ -11,7 +11,7 @@ let
     pname = "builds-sr-ht-worker";
     goPackagePath = "git.sr.ht/~sircmpwn/builds.sr.ht/worker";
 
-    modSha256 = "1dwp87zsbh4a48q0pacssy329kchrd4sa47c5a1k8smbqn078424";
+    modSha256 = "10is7siscids9qz6jh9m1i17749dafqqkg4b3sslmxaxyn16yj97";
   };
 in buildPythonPackage rec {
   inherit version;

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, fetchNodeModules, buildPythonPackage
 , pgpy, flask, bleach, misaka, humanize, markdown, psycopg2, pygments, requests
-, sqlalchemy, cryptography, beautifulsoup4, sqlalchemy-utils, celery, alembic
-, importlib-metadata
+, sqlalchemy, cryptography, beautifulsoup4, sqlalchemy-utils, prometheus_client
+, celery, alembic, importlib-metadata
 , sassc, nodejs
 , writeText }:
 
@@ -44,6 +44,7 @@ buildPythonPackage rec {
     cryptography
     beautifulsoup4
     sqlalchemy-utils
+    prometheus_client
 
     # Unofficial runtime dependencies?
     celery

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, fetchNodeModules, buildPythonPackage
-, pgpy, flask, bleach, misaka, humanize, markdown, psycopg2, pygments, requests
-, sqlalchemy, cryptography, beautifulsoup4, sqlalchemy-utils, prometheus_client
+, pgpy, flask, bleach, misaka, humanize, html5lib, markdown, psycopg2, pygments
+, requests, sqlalchemy, cryptography, beautifulsoup4, sqlalchemy-utils, prometheus_client
 , celery, alembic, importlib-metadata
 , sassc, nodejs
 , writeText }:
@@ -36,6 +36,7 @@ buildPythonPackage rec {
     bleach
     misaka
     humanize
+    html5lib
     markdown
     psycopg2
     pygments

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "srht";
-  version = "0.57.2";
+  version = "0.59.13";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/core.sr.ht";
     rev = version;
-    sha256 = "11rfpb0wf1xzrhcnpahaghmi5626snzph0vsbxlmmqx75wf0p6mf";
+    sha256 = "5jc6MtG/cBry05Sq51UAFzSBvKKkdNTA67UIDvJt9uU=";
   };
 
   node_modules = fetchNodeModules {

--- a/pkgs/applications/version-management/sourcehut/dispatch.nix
+++ b/pkgs/applications/version-management/sourcehut/dispatch.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "dispatchsrht";
-  version = "0.13.3";
+  version = "0.14.1";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/dispatch.sr.ht";
     rev = version;
-    sha256 = "08asayfwpzafscpli5grx1p0y1ryz7pqkznf5bd9j8ir2iyhbc10";
+    sha256 = "eJ+oHs9m74Q8V6fUBLOA1ksUiwdaR1/Bxlf3jcexdkA=";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, buildPythonPackage
 , python
 , buildGoModule
-, srht, pygit2, scmsrht }:
+, srht, minio, pygit2, scmsrht }:
 
 let
   version = "0.50.3";
@@ -55,6 +55,7 @@ in buildPythonPackage rec {
 
   propagatedBuildInputs = [
     srht
+    minio
     pygit2
     scmsrht
   ];

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -4,7 +4,7 @@
 , srht, pygit2, scmsrht }:
 
 let
-  version = "0.43.3";
+  version = "0.50.3";
 
   buildShell = src: buildGoModule {
     inherit src version;
@@ -44,7 +44,7 @@ in buildPythonPackage rec {
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/git.sr.ht";
     rev = version;
-    sha256 = "1f9wfyri85bq4zi9xkbfcfb69q4abh0hz7p3lghj460hh9zxc57w";
+    sha256 = "dmcTee3hp6ZkwwunG4ouEVmCxQ1a9LfQ7oWpHxnKumc=";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/hg.nix
+++ b/pkgs/applications/version-management/sourcehut/hg.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "hgsrht";
-  version = "0.21.1";
+  version = "0.26.0";
 
   src = fetchhg {
     url = "https://hg.sr.ht/~sircmpwn/hg.sr.ht";
     rev = version;
-    sha256 = "19r8zcy4xf9imqifqw3b7ylxd46i025ncns69kn5xp11damilz66";
+    sha256 = "kX0KZSEzYQ/hxL2vKh+mpaRuG16qbBKN2Xwp+e9pTxs=";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/lists.nix
+++ b/pkgs/applications/version-management/sourcehut/lists.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "listssrht";
-  version = "0.40.3";
+  version = "0.41.8";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/lists.sr.ht";
     rev = version;
-    sha256 = "1s736i5wm04pqa5k7455bdjdi7vjgvq32q1v6mdsp1w7jhgy1ags";
+    sha256 = "Gmt6ttupyhZhpyH/IASEt8SZGrlQmEEtV5bE11yIiXQ=";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/man.nix
+++ b/pkgs/applications/version-management/sourcehut/man.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "mansrht";
-  version = "0.14.1";
+  version = "0.14.7";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/man.sr.ht";
     rev = version;
-    sha256 = "13yar0sa24jyiq0l4p4bgq6p5crj148f26sxwyi37g76jqba4rfi";
+    sha256 = "CKXWVXr2P1D6Nz9/S5rOkuOi9piy66RreQv2RQ0KSfs=";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/meta.nix
+++ b/pkgs/applications/version-management/sourcehut/meta.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, buildPythonPackage
 , python
 , pgpy, srht, redis, bcrypt, qrcode, stripe, zxcvbn, alembic, pystache
-, sshpubkeys, weasyprint, prometheus_client }:
+, sshpubkeys, weasyprint }:
 
 buildPythonPackage rec {
   pname = "metasrht";
@@ -27,7 +27,6 @@ buildPythonPackage rec {
     pystache
     sshpubkeys
     weasyprint
-    prometheus_client
   ];
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/meta.nix
+++ b/pkgs/applications/version-management/sourcehut/meta.nix
@@ -5,12 +5,12 @@
 
 buildPythonPackage rec {
   pname = "metasrht";
-  version = "0.41.10";
+  version = "0.42.13";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/meta.sr.ht";
     rev = version;
-    sha256 = "1srzrajgwq85kjryxykj708m2c98r6a84x4k4a5grwznqw3mwm6p";
+    sha256 = "p7WgnfOsX09YxJJclHwdIky/jYkTOxibbYmXwcmE2S4=";
   };
 
   nativeBuildInputs = srht.nativeBuildInputs;

--- a/pkgs/applications/version-management/sourcehut/paste.nix
+++ b/pkgs/applications/version-management/sourcehut/paste.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "pastesrht";
-  version = "0.9.2";
+  version = "0.10.3";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/paste.sr.ht";
     rev = version;
-    sha256 = "0hiv607a7446dba524kblmpswlcz0z4i1jr49ng7g90nhpsk8dy4";
+    sha256 = "i1M4L5NG152zkIEFj2vDHa9lr5aE1ioToDVPpkIqemk=";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "scmsrht";
-  version = "0.18.1";
+  version = "0.19.11";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/scm.sr.ht";
     rev = version;
-    sha256 = "1f0h8vbbqx34v1rgzqjkgbf0z7jhnp8hdlzmrxwhs74kj6zjb134";
+    sha256 = "a0JIZcO/3op409t+jq4/fImuppuGqfGxBPgBh67DGHM=";
   };
 
   nativeBuildInputs = srht.nativeBuildInputs;

--- a/pkgs/applications/version-management/sourcehut/todo.nix
+++ b/pkgs/applications/version-management/sourcehut/todo.nix
@@ -5,12 +5,12 @@
 
 buildPythonPackage rec {
   pname = "todosrht";
-  version = "0.55.3";
+  version = "0.57.14";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/todo.sr.ht";
     rev = version;
-    sha256 = "1j82yxdnag0q6rp0rpiq3ccn5maa1k58j2f1ilcsxf1gr13pycf5";
+    sha256 = "nlTf7KV6vjqqVEXZ6OOZ5dAj1iHTDPYj4DnAD2hGp5c=";
   };
 
   patches = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
version bumps -> version bumps
fix build -> fixing hashes of internal modules
include * -> dependencies that are required that aren't checked in the build from upstream
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
