### PR TITLE
plexamp: init

### DIFF
--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -1,0 +1,39 @@
+{ lib, fetchurl, appimageTools, pkgs }:
+
+let
+  pname = "plexamp";
+  version = "3.0.3";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}.AppImage";
+    sha256 = "1rh608kcpdx04p2w2nl94b9p96i37sij5shjhgvak041s64wbpg5";
+    name="${pname}-${version}.AppImage";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  multiPkgs = null; # no 32bit needed
+  extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
+
+  extraInstallCommands = ''
+    ln -s $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/plexamp.desktop $out/share/applications/plexamp.desktop
+    install -m 444 -D ${appimageContents}/plexamp.png \
+      $out/plexamp.png
+    substituteInPlace $out/share/applications/plexamp.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with lib; {
+    description = "A beautiful Plex music player for audiophiles, curators, and hipsters.";
+    homepage = "https://plexamp.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ killercup ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -24,7 +24,7 @@ in appimageTools.wrapType2 {
     ln -s $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/plexamp.desktop $out/share/applications/plexamp.desktop
     install -m 444 -D ${appimageContents}/plexamp.png \
-      $out/plexamp.png
+      $out/share/icons/hicolor/512x512/apps/plexamp.png
     substituteInPlace $out/share/applications/plexamp.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'
   '';

--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -2,12 +2,12 @@
 
 let
   pname = "plexamp";
-  version = "3.0.3";
+  version = "3.1.1";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}.AppImage";
-    sha256 = "1rh608kcpdx04p2w2nl94b9p96i37sij5shjhgvak041s64wbpg5";
+    sha256 = "11hgcysa1x9yqvha6ri4vl1zk8gf8vhcpnh3j38wg9ncd7nz5k2v";
     name="${pname}-${version}.AppImage";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21301,6 +21301,8 @@ in
 
   pistol = callPackage ../tools/misc/pistol { };
 
+  plexamp = callPackage ../applications/audio/plexamp { };
+
   plex-media-player = libsForQt512.callPackage ../applications/video/plex-media-player { };
 
   plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };


### PR DESCRIPTION
###### Motivation for this change
Brand new rewrite of the standalone Plex music player ([announcment](https://medium.com/plexlabs/plexamp-v3-9af3b10063b4)).
Requires a subscription right now.

~~The app image extraction works and the app starts, but I've not been able to log in. The sign in page opens in Web (even though my default browser is Firefox), which is not able to load any page for some reason. Just wanted to throw this out there for others to test and maybe fix my stupid mistake :)~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
