### PR TITLE
fetchurl: don’t run ‘postFetch’ on hashed-mirrors

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -47,13 +47,18 @@ tryDownload() {
 
 
 finish() {
+    local skipPostFetch="$1"
+
     set +o noglob
 
     if [[ $executable == "1" ]]; then
       chmod +x $downloadedFile
     fi
 
-    runHook postFetch
+    if [ -z "$skipPostFetch" ]; then
+        runHook postFetch
+    fi
+
     exit 0
 }
 
@@ -69,7 +74,13 @@ tryHashedMirrors() {
             --fail --silent --show-error --head "$url" \
             --write-out "%{http_code}" --output /dev/null > code 2> log; then
             tryDownload "$url"
-            if test -n "$success"; then finish; fi
+
+            # We skip postFetch here, because hashed-mirrors are
+            # already content addressed. So if $outputHash is in the
+            # hashed-mirror, changes from ‘postFetch’ would already be
+            # made. So, running postFetch will end up applying the
+            # change /again/, which we don’t want.
+            if test -n "$success"; then finish skipPostFetch; fi
         else
             # Be quiet about 404 errors, which we interpret as the file
             # not being present on this particular mirror.


### PR DESCRIPTION
hashed-mirrors are content addressed. So if $outputHash is in the
hashed-mirror, changes from ‘postFetch’ would already be made. So,
running postFetch will end up applying the change /again/, which we
don’t want.

/cc @Ericson2314 @bhipple

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
