### PR TITLE
[20.03] python3Packages.cirq: fix test failures (ZHF)

### DIFF
--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -37,13 +37,16 @@ buildPythonPackage rec {
 
   # Cirq 0.6 requires networkx==2.3 only for optional qiskit dependency/test, disable this to avoid networkx version conflicts. https://github.com/quantumlib/Cirq/issues/2368
   # Cirq locks protobuf==3.8.0, but tested working with default pythonPackages.protobuf (3.7). This avoids overrides/pythonPackages.protobuf conflicts
-  prePatch = ''
+  postPatch = ''
     substituteInPlace requirements.txt --replace "networkx==2.3" "networkx" \
       --replace "protobuf==3.8.0" "protobuf"
 
     # Fix sympy 1.5 test failures. Should be fixed in v0.7
     substituteInPlace cirq/optimizers/eject_phased_paulis_test.py --replace "phase_exponent=0.125 + x / 8" "phase_exponent=0.125 + x * 0.125"
     substituteInPlace cirq/contrib/quirk/cells/parse_test.py --replace "parse_formula('5t') == 5 * t" "parse_formula('5t') == 5.0 * t"
+
+    # Fix pandas >= 1.0 error, #2886
+    substituteInPlace cirq/experiments/t1_decay_experiment.py --replace "del tab.columns.name" 'tab.rename_axis(None, axis="columns", inplace=True)'
   '';
 
   propagatedBuildInputs = [
@@ -75,6 +78,9 @@ buildPythonPackage rec {
   pytestFlagsArray = [
     "--ignore=dev_tools"  # Only needed when developing new code, which is out-of-scope
     "--ignore=cirq/google/op_serializer_test.py"  # investigating in https://github.com/quantumlib/Cirq/issues/2727
+  ];
+  disabledTests = [
+    "test_convert_to_ion_gates" # fails due to rounding error, 0.75 != 0.750...2
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Backport of #85412 

ZHF: #80379

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
