### PR TITLE
python3Packages.neo: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/neo/default.nix
+++ b/pkgs/development/python-modules/neo/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, numpy
+, quantities
+}:
+
+buildPythonPackage rec {
+  pname = "neo";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n74miad4dadavnzi1hqlyzyk795x7qq2adp71i011534ixs70ik";
+  };
+
+  propagatedBuildInputs = [ numpy quantities ];
+
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    nosetests --exclude=iotest
+  '';
+
+  meta = with lib; {
+    homepage = "https://neuralensemble.org/neo/";
+    description = "Package for representing electrophysiology data in Python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -957,6 +957,8 @@ in {
 
   ndtypes = callPackage ../development/python-modules/ndtypes { };
 
+  neo = callPackage ../development/python-modules/neo { };
+
   nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };
 
   neuron = pkgs.neuron.override {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
