### PR TITLE
[release-20.03] muse: 3.1pre1 -> 3.1.0

### DIFF
--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -1,25 +1,33 @@
-{ stdenv
-, fetchFromGitHub
-, libjack2
-, wrapQtAppsHook
-, qtsvg
-, qttools
-, cmake
-, libsndfile
-, libsamplerate
-, ladspaH
-, fluidsynth
-, alsaLib
-, rtaudio
-, lash
-, dssi
-, liblo
-, pkgconfig
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, qttools, wrapQtAppsHook
+, alsaLib, dssi, fluidsynth, ladspaH, lash, libinstpatch, libjack2, liblo
+, libsamplerate, libsndfile, lilv, librdf, lv2, qtsvg, rtaudio, rubberband, sord
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "muse-sequencer";
-  version = "3.1pre1";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "muse-sequencer";
+    repo = "muse";
+    rev = "muse_${builtins.replaceStrings ["."] ["_"] version}";
+    sha256 = "08k25652w88xf2i79lw305x1phpk7idrww9jkqwcs8q6wzgmz8aq";
+  };
+
+  sourceRoot = "source/muse3";
+
+  prePatch = ''
+    chmod u+w $NIX_BUILD_TOP
+  '';
+
+  patches = [ ./fix-parallel-building.patch ];
+
+  nativeBuildInputs = [ cmake pkgconfig qttools wrapQtAppsHook ];
+
+  buildInputs = [
+    alsaLib dssi fluidsynth ladspaH lash libinstpatch libjack2 liblo
+    libsamplerate libsndfile lilv librdf lv2 qtsvg rtaudio rubberband sord
+  ];
 
   meta = with stdenv.lib; {
     homepage = "https://www.muse-sequencer.org/";
@@ -32,39 +40,7 @@ stdenv.mkDerivation {
       MusE aims to be a complete multitrack virtual studio for Linux,
       it is published under the GNU General Public License.
     '';
-    license = stdenv.lib.licenses.gpl2;
-    broken = true;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ orivej ];
   };
-
-  src =
-    fetchFromGitHub {
-      owner = "muse-sequencer";
-      repo = "muse";
-      rev = "2167ae053c16a633d8377acdb1debaac10932838";
-      sha256 = "0rsdx8lvcbz5bapnjvypw8h8bq587s9z8cf2znqrk6ah38s6fsrf";
-    };
-
-
-  nativeBuildInputs = [
-    pkgconfig
-    wrapQtAppsHook
-    qttools
-    cmake
-  ];
-
-  buildInputs = [
-    libjack2
-    qtsvg
-    libsndfile
-    libsamplerate
-    ladspaH
-    fluidsynth
-    alsaLib
-    rtaudio
-    lash
-    dssi
-    liblo
-  ];
-
-  sourceRoot = "source/muse3";
 }

--- a/pkgs/applications/audio/muse/fix-parallel-building.patch
+++ b/pkgs/applications/audio/muse/fix-parallel-building.patch
@@ -1,0 +1,78 @@
+To confirm these dependencies, run in a fresh build tree:
+
+
+ninja muse/components/CMakeFiles/components.dir/confmport.o
+
+In file included from ../muse/components/confmport.cpp:48:
+../muse/mplugins/midifilterimpl.h:28:10: fatal error:
+ui_midifilter.h: No such file or directory
+
+
+ninja muse/waveedit/CMakeFiles/waveedit.dir/wavecanvas.o
+
+In file included from ../muse/waveedit/wavecanvas.cpp:72:
+../muse/components/copy_on_write.h:26:10: fatal error:
+ui_copy_on_write_base.h: No such file or directory
+
+
+ninja muse/instruments/CMakeFiles/instruments.dir/editinstrument.o
+
+In file included from ../muse/instruments/editinstrument.cpp:58:
+../muse/components/editevent.h:26:10: fatal error:
+ui_editnotedialogbase.h: No such file or directory
+
+
+ninja muse/liste/CMakeFiles/liste.dir/listedit.o
+
+In file included from ../muse/liste/listedit.cpp:37:
+../muse/components/editevent.h:26:10: fatal error:
+ui_editnotedialogbase.h: No such file or directory
+
+
+ninja muse/mixer/CMakeFiles/mixer.dir/rack.o
+
+In file included from ../muse/mixer/rack.cpp:49:
+../muse/components/plugindialog.h:4:10: fatal error:
+ui_plugindialogbase.h: No such file or directory
+
+
+--- a/muse/components/CMakeLists.txt
++++ b/muse/components/CMakeLists.txt
+@@ -343,4 +343,5 @@ set_target_properties( components
+ target_link_libraries ( components
+       ${QT_LIBRARIES}
++      mplugins
+       widgets
+       xml_module
+--- a/muse/waveedit/CMakeLists.txt
++++ b/muse/waveedit/CMakeLists.txt
+@@ -79,4 +79,5 @@ set_target_properties( waveedit
+ target_link_libraries( waveedit
+       ${QT_LIBRARIES}
++      components
+       widgets
+       )
+--- a/muse/instruments/CMakeLists.txt
++++ b/muse/instruments/CMakeLists.txt
+@@ -78,4 +78,5 @@ set_target_properties( instruments
+ target_link_libraries ( instruments
+       ${QT_LIBRARIES}
++      components
+       icons
+       widgets
+--- a/muse/liste/CMakeLists.txt
++++ b/muse/liste/CMakeLists.txt
+@@ -65,4 +65,5 @@ set_target_properties( liste
+ target_link_libraries ( liste
+       ${QT_LIBRARIES}
++      components
+       awl
+       widgets
+--- a/muse/mixer/CMakeLists.txt
++++ b/muse/mixer/CMakeLists.txt
+@@ -87,4 +87,5 @@ set_target_properties ( mixer
+ target_link_libraries ( mixer
+       ${QT_LIBRARIES}
++      components
+       widgets
+       )

--- a/pkgs/development/libraries/audio/libinstpatch/default.nix
+++ b/pkgs/development/libraries/audio/libinstpatch/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, pkg-config, glib, libsndfile }:
+
+stdenv.mkDerivation rec {
+  pname = "libinstpatch";
+  version = "1.1.4";
+
+  src = fetchFromGitHub {
+    owner = "swami";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1v7mv43xxwrzi3agrc60agcw46jaidr8ql9kkm1w4jxkf4c6z6dz";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  propagatedBuildInputs = [ glib libsndfile ]; # Both are needed for includes.
+
+  cmakeFlags = [
+    "-DLIB_SUFFIX=" # Install in $out/lib.
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.swamiproject.org/";
+    description = "MIDI instrument patch files support library";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12803,6 +12803,8 @@ in
 
   libinput-gestures = callPackage ../tools/inputmethods/libinput-gestures {};
 
+  libinstpatch = callPackage ../development/libraries/audio/libinstpatch { };
+
   libisofs = callPackage ../development/libraries/libisofs { };
 
   libisoburn = callPackage ../development/libraries/libisoburn { };


### PR DESCRIPTION
###### Motivation for this change

Backport muse fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).