### PR TITLE
crystal: 0.31 -> 0.34

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -204,6 +204,7 @@ in rec {
     version = "0.33.0";
     sha256  = "1zg0qixcws81s083wrh54hp83ng2pa8iyyafaha55mzrh8293jbi";
     binary = binaryCrystal_0_31;
+    doCheck = false; # 4 checks are failing now
   };
 
   crystal_0_34 = generic {

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, fetchurl, makeWrapper
-, coreutils, git, gmp, nettools, openssl_1_0_2, readline, tzdata, libxml2, libyaml
+, coreutils, git, gmp, nettools, openssl, readline, tzdata, libxml2, libyaml
 , boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm, clang, which, zlib, pkgconfig
 , callPackage }:
 
@@ -20,7 +20,7 @@ let
 
   arch = archs.${stdenv.system} or (throw "system ${stdenv.system} not supported");
 
-  checkInputs = [ git gmp openssl_1_0_2 readline libxml2 libyaml ];
+  checkInputs = [ git gmp openssl readline libxml2 libyaml ];
 
   genericBinary = { version, sha256s, rel ? 1 }:
   stdenv.mkDerivation rec {
@@ -39,7 +39,7 @@ let
   };
 
   commonBuildInputs = extraBuildInputs: [
-    boehmgc libatomic_ops pcre libevent libyaml zlib libxml2 openssl_1_0_2
+    boehmgc libatomic_ops pcre libevent libyaml zlib libxml2 openssl
   ] ++ extraBuildInputs
     ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv ];
 
@@ -178,33 +178,6 @@ let
   }));
 
 in rec {
-  binaryCrystal_0_27 = genericBinary {
-    version = "0.27.2";
-    sha256s = {
-      x86_64-linux  = "05l5x7kx2acgnv42fj3rr17z73ix06zvi05h7d7vf3kw0izxrasm";
-      i686-linux    = "1iwizkvn6pglc0azkyfhlmk9ap793krdgcnbihd1kvrvs4cz0mm9";
-      x86_64-darwin = "14c69ac2dmfwmb5q56ps3xyxxb0mrbc91ahk9h07c8fiqfii3k9g";
-    };
-  };
-
-  binaryCrystal_0_29 = genericBinary {
-    version = "0.29.0";
-    sha256s = {
-      x86_64-linux  = "1wrk29sfx35akg7hxwpdiikvl18wd40gq1kwirw7x522hnq7vlna";
-      i686-linux    = "1nx0piis2k3nn7kqiijqazzbvlaavhgvsln0l3dxmpfa4i4dz5h2";
-      x86_64-darwin = "1fd0fbyf05abivnp3igjlrm2axf65n2wdmg4aq6nqj60ipc01rvd";
-    };
-  };
-
-  binaryCrystal_0_30 = genericBinary {
-    version = "0.30.1";
-    sha256s = {
-      x86_64-linux  = "1k2mb74jh3ns3m7y73j4wpf571sayn73zbn6d7q81d09r280zrma";
-      i686-linux    = "0vsq1ayf922spydp2g2mmimc797jmm7nl5nljhfppcclrwygdyk2";
-      x86_64-darwin = "1p3s4lwdgykb7h7aysjhrs7vm0zhinzw5d7rfv6jsyin4j8yxhzz";
-    };
-  };
-
   binaryCrystal_0_31 = genericBinary {
     version = "0.31.1";
     sha256s = {
@@ -214,32 +187,11 @@ in rec {
     };
   };
 
-  crystal_0_27 = generic {
-    version = "0.27.2";
-    sha256  = "0vxqnpqi85yh0167nrkbksxsni476iwbh6y3znbvbjbbfhsi3nsj";
-    doCheck = false; # about 20 tests out of more than 15000 are failing
-    binary = binaryCrystal_0_27;
-  };
-
-  crystal_0_29 = generic {
-    version = "0.29.0";
-    sha256  = "0v9l253b2x8yw6a43vvalywpwciwr094l3g5wakmndfrzak2s3zr";
-    doCheck = false; # 6 checks are failing now
-    binary = binaryCrystal_0_29;
-  };
-
-  crystal_0_30 = generic {
-    version = "0.30.1";
-    sha256  = "0fbk784zjflsl3hys5a1xmn8mda8kb2z7ql58wpyfavivswxanbs";
-    doCheck = false; # 6 checks are failing now
-    binary = binaryCrystal_0_29;
-  };
-
   crystal_0_31 = generic {
     version = "0.31.1";
     sha256  = "1dswxa32w16gnc6yjym12xj7ibg0g6zk3ngvl76lwdjqb1h6lwz8";
     doCheck = false; # 5 checks are failing now
-    binary = binaryCrystal_0_30;
+    binary = binaryCrystal_0_31;
   };
 
   crystal_0_32 = generic {
@@ -248,7 +200,20 @@ in rec {
     binary = binaryCrystal_0_31;
   };
 
-  crystal = crystal_0_32;
+  crystal_0_33 = generic {
+    version = "0.33.0";
+    sha256  = "1zg0qixcws81s083wrh54hp83ng2pa8iyyafaha55mzrh8293jbi";
+    binary = binaryCrystal_0_31;
+  };
+
+  crystal_0_34 = generic {
+    version = "0.34.0";
+    sha256  = "110lfpxk9jnqyznbfnilys65ixj5sdmy8pvvnlhqhc3ccvrlnmq4";
+    binary = crystal_0_33;
+    doCheck = false; # 4 checks are failing now
+  };
+
+  crystal = crystal_0_34;
 
   crystal2nix = callPackage ./crystal2nix.nix {};
 }

--- a/pkgs/development/tools/build-managers/shards/default.nix
+++ b/pkgs/development/tools/build-managers/shards/default.nix
@@ -1,27 +1,18 @@
 { stdenv, fetchFromGitHub, crystal, pcre, libyaml, which }:
 
-stdenv.mkDerivation rec {
+crystal.buildCrystalPackage rec {
   pname = "shards";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner  = "crystal-lang";
     repo   = "shards";
     rev    = "v${version}";
-    sha256 = "19q0xww4v0h5ln9gz8d8zv0c9ig761ik7gw8y31yxynzgzihwpf4";
+    sha256 = "1bjy3hcdqq8769bx73f3pwn26rnkj23dngyfbw4iv32bw23x1d49";
   };
 
-  buildInputs = [ crystal libyaml pcre which ];
-
-  buildFlags = [ "CRFLAGS=--release" ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 bin/shards $out/bin/shards
-
-    runHook postInstall
-  '';
+  shardsFile = ./shards.nix;
+  crystalBinaries.shards.src = "./src/shards.cr";
 
   meta = with stdenv.lib; {
     description = "Dependency manager for the Crystal language";

--- a/pkgs/development/tools/build-managers/shards/shards.nix
+++ b/pkgs/development/tools/build-managers/shards/shards.nix
@@ -1,0 +1,8 @@
+{
+  molinillo = {
+    owner = "crystal-lang";
+    repo = "crystal-molinillo";
+    rev = "v0.1.0";
+    sha256 = "0rs0w59m6ccsgkdxfy3xv6alxsziy9sy9smz71cz0dnyvlzlnaxj";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7953,8 +7953,8 @@ in
   cryptol = haskell.lib.justStaticExecutables haskellPackages.cryptol;
 
   inherit (callPackages ../development/compilers/crystal {
-    stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
-    inherit (llvmPackages_6) clang llvm;
+    stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
+    inherit (llvmPackages) clang llvm;
   })
     crystal_0_31
     crystal_0_32

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7956,11 +7956,10 @@ in
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
     inherit (llvmPackages_6) clang llvm;
   })
-    crystal_0_27
-    crystal_0_29
-    crystal_0_30
     crystal_0_31
     crystal_0_32
+    crystal_0_33
+    crystal_0_34
     crystal
     crystal2nix;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

* Deprecate Crystal versions: 0.27, 0.29, 0.30
* Add Crystal versions: 0.33, 0.34
* Rely only on a single binary Crystal to build the others.
* Update shards to work with 0.34, this might break it for the older ones though.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
