### PR TITLE
python3Packages.simpleaudio: init at 1.0.4

### DIFF
--- a/pkgs/development/python-modules/simpleaudio/default.nix
+++ b/pkgs/development/python-modules/simpleaudio/default.nix
@@ -1,0 +1,24 @@
+{ alsaLib, buildPythonPackage, fetchFromGitHub, isPy27, lib }:
+
+buildPythonPackage rec {
+  pname = "simpleaudio";
+  version = "1.0.4";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "hamiltron";
+    repo = "py-simple-audio";
+    rev = version;
+    sha256 = "12nypzb1m14yip4zrbzin5jc5awyp1d5md5y40g5anj4phb4hx1i";
+  };
+
+  buildInputs = [ alsaLib ];
+
+  meta = with lib; {
+    homepage = "https://github.com/hamiltron/py-simple-audio";
+    description =
+      "A simple audio playback Python extension - cross-platform, asynchronous, dependency-free";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lucus16 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1461,6 +1461,8 @@ in {
 
   shellingham = callPackage ../development/python-modules/shellingham {};
 
+  simpleaudio = callPackage ../development/python-modules/simpleaudio { };
+
   simpleeval = callPackage ../development/python-modules/simpleeval { };
 
   simple-salesforce = callPackage ../development/python-modules/simple-salesforce { };


### PR DESCRIPTION
###### Motivation for this change

The `simpleaudio` package has no other python library dependencies and is cross platform which makes it ideal for collaboration with people on other platforms.

###### Things done

`python2Packages.simpleaudio` fails to build, it's Python 3 only. Do I need to add something to indicate this?

- [x] Tested library works as expected in a simple python project.
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
