### PR TITLE
echidna: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -661,6 +661,12 @@
     githubId = 3965744;
     name = "Arthur Lee";
   };
+  arturcygan = {
+    email = "arczicygan@gmail.com";
+    github = "arcz";
+    githubId = 4679721;
+    name = "Artur Cygan";
+  };
   artuuge = {
     email = "artuuge@gmail.com";
     github = "artuuge";

--- a/pkgs/tools/security/echidna/default.nix
+++ b/pkgs/tools/security/echidna/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, pkgs }:
+let
+  src = pkgs.fetchFromGitHub {
+    owner  = "crytic";
+    repo   = "echidna";
+    rev    = "09155a7e845b6430bb2c0beb7a01cf602ceb554a";
+    sha256 = "13gpnj77849m1b24w02c2wl7xyyndw3kq3w5xprvap1bdzjlsmps";
+  };
+  drv = import "${src}" {};
+in drv // {
+  meta = with stdenv.lib; {
+    description = "Ethereum smart contract fuzzer";
+    homepage = "https://github.com/crytic/echidna";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ arturcygan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -892,6 +892,8 @@ in
 
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 
+  echidna = callPackage ../tools/security/echidna { };
+
   sedutil = callPackage ../tools/security/sedutil { };
 
   elvish = callPackage ../shells/elvish { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Echidna is a mature smart contract fuzzer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
