### PR TITLE
cabal-install-parsers: update Cabal dependency

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1453,9 +1453,12 @@ self: super: {
   # details.
   cryptonite = dontCheck super.cryptonite;
 
-  # The test suite depends on an impure cabal-install installation
-  # in $HOME, which we don't have in our build sandbox.
-  cabal-install-parsers = dontCheck super.cabal-install-parsers;
+  # The test suite depends on an impure cabal-install installation in
+  # $HOME, which we don't have in our build sandbox, and it is keeping
+  # up with the most recent Cabal version.
+  cabal-install-parsers = dontCheck (super.cabal-install-parsers.overrideScope (self: super: {
+    Cabal = self.Cabal_3_2_0_0;
+  }));
 
   # haskell-ci-0.8 needs cabal-install-parsers ==0.1, but we have 0.2.
   haskell-ci = doJailbreak super.haskell-ci;


### PR DESCRIPTION
#### Motivation for this change

This also unbreaks `haskell-ci`.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
