### PR TITLE
castor: init at 0.8.14

### DIFF
--- a/pkgs/applications/networking/browsers/castor/default.nix
+++ b/pkgs/applications/networking/browsers/castor/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, fetchurl
+, rustPlatform
+, pkg-config
+, wrapGAppsHook
+, openssl
+, gtk3
+, gdk-pixbuf
+, pango
+, atk
+, cairo
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "castor";
+  version = "0.8.14";
+
+  src = fetchurl {
+    url = "https://git.sr.ht/~julienxx/castor/archive/${version}.tar.gz";
+    sha256 = "1ykpmbimhfy3ys2hvv0mn8xiwxzdl43gpny1nc58i0gzv07ar8sc";
+  };
+
+  cargoSha256 = "04w49wka1vkb295lk6fzd6c5rwhzrqkp26hd5d94rx7bhcjmmb9w";
+  verifyCargoDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    openssl
+    gtk3
+    gdk-pixbuf
+    pango
+    atk
+    cairo
+  ];
+
+  postInstall = "make PREFIX=$out copy-data";
+
+  # Sometimes tests fail when run in parallel
+  checkFlags = [ "--test-threads=1" ];
+
+  meta = with stdenv.lib; {
+    description = "A graphical client for plain-text protocols written in Rust with GTK. It currently supports the Gemini, Gopher and Finger protocols";
+    homepage = "https://sr.ht/~julienxx/Castor";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18696,6 +18696,8 @@ in
 
   carla = qt5.callPackage ../applications/audio/carla { };
 
+  castor = callPackage ../applications/networking/browsers/castor { };
+
   catimg = callPackage ../tools/misc/catimg { };
 
   catt = python3Packages.callPackage ../applications/video/catt { };


### PR DESCRIPTION
###### Motivation for this change

We didn't have a gemini client yet :)

I'm not sure whether I should change the name to `castor-browser`, since there's already a different `castor` packaged by some distros: https://repology.org/project/castor

~~I'm also not sure if this needs some gtk wrapping stuff~~ wrapped

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
