### PR TITLE
crystal: use llvm 10 exclusively

### DIFF
--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -1,6 +1,9 @@
-{ stdenv, lib, crystal, linkFarm, fetchFromGitHub }:
-{ # Generate shards.nix with `nix-shell -p crystal2nix --run crystal2nix` in the projects root
-  shardsFile ? null
+{ stdenv, lib, crystal, shards, git, pkgconfig, which, linkFarm, fetchFromGitHub }:
+{
+  # Some projects do not include a lock file, so you can pass one
+  lockFile ? null
+  # Generate shards.nix with `nix-shell -p crystal2nix --run crystal2nix` in the projects root
+, shardsFile ? null
   # Specify binaries to build in the form { foo.src = "src/foo.cr"; }
   # The default `crystal build` options can be overridden with { foo.options = [ "--no-debug" ]; }
 , crystalBinaries ? {}
@@ -9,45 +12,102 @@
 let
   mkDerivationArgs = builtins.removeAttrs args [ "shardsFile" "crystalBinaries" ];
 
-  crystalLib = linkFarm "crystal-lib" (lib.mapAttrsToList (name: value: {
-    inherit name;
-    path = fetchFromGitHub value;
-  }) (import shardsFile));
+  crystalLib = linkFarm "crystal-lib" (
+    lib.mapAttrsToList (
+      name: value: {
+        inherit name;
+        path = fetchFromGitHub value;
+      }
+    ) (import shardsFile)
+  );
 
-  defaultOptions = [ "--release" "--progress" "--no-debug" "--verbose" ];
+  # we previously had --no-debug here but that is not recommended by upstream
+  defaultOptions = [ "--release" "--progress" "--verbose" ];
 
-in stdenv.mkDerivation (mkDerivationArgs // {
+  buildDirectly = shardsFile == null || crystalBinaries != {};
+in
+stdenv.mkDerivation (
+  mkDerivationArgs // {
 
-  configurePhase = args.configurePhase or ''
-    runHook preConfigure
-    ${lib.optionalString (shardsFile != null) "ln -s ${crystalLib} lib"}
-    runHook postConfigure
-  '';
+    configurePhase = args.configurePhase or ''
+      runHook preConfigure
 
-  buildInputs = args.buildInputs or [] ++ [ crystal ];
+      ${lib.optionalString (lockFile != null) "ln -s ${lockFile} ./shard.lock"}
+      ${lib.optionalString (shardsFile != null) "ln -s ${crystalLib} lib"}
 
-  buildPhase = args.buildPhase or ''
-    runHook preBuild
-    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (bin: attrs: ''
-      crystal ${lib.escapeShellArgs ([
-        "build"
-        "-o" bin
-        (attrs.src or (throw "No source file for crystal binary ${bin} provided"))
-      ] ++ attrs.options or defaultOptions)}
-    '') crystalBinaries)}
-    runHook postBuild
-  '';
+      runHook postConfigure
+    '';
 
-  installPhase = args.installPhase or ''
-    runHook preInstall
-    mkdir -p "$out/bin"
-    ${lib.concatMapStringsSep "\n" (bin: ''
-      mv ${lib.escapeShellArgs [ bin "${placeholder "out"}/bin/${bin}" ]}
-    '') (lib.attrNames crystalBinaries)}
-    runHook postInstall
-  '';
+    CRFLAGS = lib.concatStringsSep " " defaultOptions;
 
-  meta = args.meta or {} // {
-    platforms = args.meta.platforms or crystal.meta.platforms;
-  };
-})
+    buildInputs = args.buildInputs or [] ++ [ crystal shards ];
+
+    nativeBuildInputs = args.nativeBuildInputs or [] ++ [ git pkgconfig which ];
+
+    buildPhase = args.buildPhase or (
+      ''
+        runHook preBuild
+
+        if [ -e Makefile ]; then
+          echo " ** building with make"
+
+          make ''${buildTargets:-build} $buildFlags
+        else
+      '' + (
+        if buildDirectly then ''
+          echo " ** building with crystal"
+
+          ${lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (
+            bin: attrs: ''
+              crystal ${lib.escapeShellArgs (
+              [
+                "build"
+                "-o"
+                bin
+                (attrs.src or (throw "No source file for crystal binary ${bin} provided"))
+              ] ++ attrs.options or defaultOptions
+            )}
+            ''
+          ) crystalBinaries
+        )}
+        '' else ''
+          echo " ** building with shards"
+          shards build --local --production ${lib.concatStringsSep " " defaultOptions}
+        ''
+      ) + ''
+        fi
+
+        runHook postBuild
+      ''
+    );
+
+    installPhase = args.installPhase or (
+      ''
+        runHook preInstall
+
+        if [ -e Makefile ]; then
+          make ''${installTargets:-install} $installFlags
+        else
+      '' + (
+        if buildDirectly then
+          lib.concatMapStringsSep "\n" (
+            bin: ''
+              install -Dm555 ${lib.escapeShellArgs [ bin "${placeholder "out"}/bin/${bin}" ]}
+            ''
+          ) (lib.attrNames crystalBinaries)
+        else ''
+          shards install
+        ''
+      ) + ''
+        fi
+
+        runHook postInstall
+      ''
+    );
+
+    meta = args.meta or {} // {
+      platforms = args.meta.platforms or crystal.meta.platforms;
+    };
+  }
+)

--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -1,9 +1,6 @@
-{ stdenv, lib, crystal, shards, git, pkgconfig, which, linkFarm, fetchFromGitHub }:
-{
-  # Some projects do not include a lock file, so you can pass one
-  lockFile ? null
-  # Generate shards.nix with `nix-shell -p crystal2nix --run crystal2nix` in the projects root
-, shardsFile ? null
+{ stdenv, lib, crystal, linkFarm, fetchFromGitHub }:
+{ # Generate shards.nix with `nix-shell -p crystal2nix --run crystal2nix` in the projects root
+  shardsFile ? null
   # Specify binaries to build in the form { foo.src = "src/foo.cr"; }
   # The default `crystal build` options can be overridden with { foo.options = [ "--no-debug" ]; }
 , crystalBinaries ? {}
@@ -12,102 +9,45 @@
 let
   mkDerivationArgs = builtins.removeAttrs args [ "shardsFile" "crystalBinaries" ];
 
-  crystalLib = linkFarm "crystal-lib" (
-    lib.mapAttrsToList (
-      name: value: {
-        inherit name;
-        path = fetchFromGitHub value;
-      }
-    ) (import shardsFile)
-  );
+  crystalLib = linkFarm "crystal-lib" (lib.mapAttrsToList (name: value: {
+    inherit name;
+    path = fetchFromGitHub value;
+  }) (import shardsFile));
 
-  # we previously had --no-debug here but that is not recommended by upstream
-  defaultOptions = [ "--release" "--progress" "--verbose" ];
+  defaultOptions = [ "--release" "--progress" "--no-debug" "--verbose" ];
 
-  buildDirectly = shardsFile == null || crystalBinaries != {};
-in
-stdenv.mkDerivation (
-  mkDerivationArgs // {
+in stdenv.mkDerivation (mkDerivationArgs // {
 
-    configurePhase = args.configurePhase or ''
-      runHook preConfigure
+  configurePhase = args.configurePhase or ''
+    runHook preConfigure
+    ${lib.optionalString (shardsFile != null) "ln -s ${crystalLib} lib"}
+    runHook postConfigure
+  '';
 
-      ${lib.optionalString (lockFile != null) "ln -s ${lockFile} ./shard.lock"}
-      ${lib.optionalString (shardsFile != null) "ln -s ${crystalLib} lib"}
+  buildInputs = args.buildInputs or [] ++ [ crystal ];
 
-      runHook postConfigure
-    '';
+  buildPhase = args.buildPhase or ''
+    runHook preBuild
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (bin: attrs: ''
+      crystal ${lib.escapeShellArgs ([
+        "build"
+        "-o" bin
+        (attrs.src or (throw "No source file for crystal binary ${bin} provided"))
+      ] ++ attrs.options or defaultOptions)}
+    '') crystalBinaries)}
+    runHook postBuild
+  '';
 
-    CRFLAGS = lib.concatStringsSep " " defaultOptions;
+  installPhase = args.installPhase or ''
+    runHook preInstall
+    mkdir -p "$out/bin"
+    ${lib.concatMapStringsSep "\n" (bin: ''
+      mv ${lib.escapeShellArgs [ bin "${placeholder "out"}/bin/${bin}" ]}
+    '') (lib.attrNames crystalBinaries)}
+    runHook postInstall
+  '';
 
-    buildInputs = args.buildInputs or [] ++ [ crystal shards ];
-
-    nativeBuildInputs = args.nativeBuildInputs or [] ++ [ git pkgconfig which ];
-
-    buildPhase = args.buildPhase or (
-      ''
-        runHook preBuild
-
-        if [ -e Makefile ]; then
-          echo " ** building with make"
-
-          make ''${buildTargets:-build} $buildFlags
-        else
-      '' + (
-        if buildDirectly then ''
-          echo " ** building with crystal"
-
-          ${lib.concatStringsSep "\n" (
-          lib.mapAttrsToList (
-            bin: attrs: ''
-              crystal ${lib.escapeShellArgs (
-              [
-                "build"
-                "-o"
-                bin
-                (attrs.src or (throw "No source file for crystal binary ${bin} provided"))
-              ] ++ attrs.options or defaultOptions
-            )}
-            ''
-          ) crystalBinaries
-        )}
-        '' else ''
-          echo " ** building with shards"
-          shards build --local --production ${lib.concatStringsSep " " defaultOptions}
-        ''
-      ) + ''
-        fi
-
-        runHook postBuild
-      ''
-    );
-
-    installPhase = args.installPhase or (
-      ''
-        runHook preInstall
-
-        if [ -e Makefile ]; then
-          make ''${installTargets:-install} $installFlags
-        else
-      '' + (
-        if buildDirectly then
-          lib.concatMapStringsSep "\n" (
-            bin: ''
-              install -Dm555 ${lib.escapeShellArgs [ bin "${placeholder "out"}/bin/${bin}" ]}
-            ''
-          ) (lib.attrNames crystalBinaries)
-        else ''
-          shards install
-        ''
-      ) + ''
-        fi
-
-        runHook postInstall
-      ''
-    );
-
-    meta = args.meta or {} // {
-      platforms = args.meta.platforms or crystal.meta.platforms;
-    };
-  }
-)
+  meta = args.meta or {} // {
+    platforms = args.meta.platforms or crystal.meta.platforms;
+  };
+})

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -108,6 +108,8 @@ let
       "all" "docs"
     ];
 
+    LLVM_CONFIG = "${llvm}/bin/llvm-config";
+
     FLAGS = [
       "--release"
       "--single-module" # needed for deterministic builds

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, fetchurl, makeWrapper
-, coreutils, git, gmp, nettools, openssl, readline, tzdata, libxml2, libyaml
+, coreutils, git, gmp, hostname, openssl, readline, tzdata, libxml2, libyaml
 , boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm, clang, which, zlib, pkgconfig
 , callPackage }:
 
@@ -62,9 +62,12 @@ let
       substituteInPlace src/crystal/system/unix/time.cr \
         --replace /usr/share/zoneinfo ${tzdata}/share/zoneinfo
 
-      ln -s spec/compiler spec/std
+      ln -sf spec/compiler spec/std
 
-      mkdir /tmp/crystal
+      # Dirty fix for when no sandboxing is enabled
+      rm -rf /tmp/crystal
+      mkdir -p /tmp/crystal
+
       substituteInPlace spec/std/file_spec.cr \
         --replace '/bin/ls' '${coreutils}/bin/ls' \
         --replace '/usr/share' '/tmp/crystal' \
@@ -81,7 +84,7 @@ let
         --replace '{% if flag?(:gnu) %}"listen: "{% else %}"bind: "{% end %}' '"bind: "'
 
       substituteInPlace spec/std/system_spec.cr \
-        --replace '`hostname`' '`${nettools}/bin/hostname`'
+        --replace '`hostname`' '`${hostname}/bin/hostname`'
 
       # See https://github.com/crystal-lang/crystal/pull/8640
       substituteInPlace spec/std/http/cookie_spec.cr \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8077,8 +8077,7 @@ in
   cryptol = haskell.lib.justStaticExecutables haskellPackages.cryptol;
 
   inherit (callPackages ../development/compilers/crystal {
-    stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
-    inherit (llvmPackages) clang llvm;
+    inherit (llvmPackages_10) stdenv clang llvm;
   })
     crystal_0_31
     crystal_0_32


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is trying to fix build failures on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
