### PR TITLE
mesa-glu: use HTTPS instead of FTP

### DIFF
--- a/pkgs/development/libraries/mesa-glu/default.nix
+++ b/pkgs/development/libraries/mesa-glu/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "9.0.1";
 
   src = fetchurl {
-    url = "ftp://ftp.freedesktop.org/pub/mesa/${pname}/${pname}-${version}.tar.xz";
+    url = "https://mesa.freedesktop.org/archive/${pname}/${pname}-${version}.tar.xz";
     sha256 = "1g2m634p73mixkzv1qz1d0flwm390ydi41bwmchiqvdssqnlqnpv";
   };
 


### PR DESCRIPTION
FTP is often blocked by firewalls and is generally slower and less secure than HTTPS.

No change to `src` hash.  Validated with `nix-build -A mesa_glu.src --check` and by putting a wrong hash and validating it prints back the correct hash.