### PR TITLE
hydrogen-unstable: init at 1.0.0-beta2

### DIFF
--- a/pkgs/applications/audio/hydrogen/unstable.nix
+++ b/pkgs/applications/audio/hydrogen/unstable.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, wrapQtAppsHook
+, alsaLib, ladspa-sdk, lash, libarchive, libjack2, liblo, libpulseaudio, libsndfile, lrdf
+, qtbase, qttools, qtxmlpatterns
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hydrogen";
+  version = "1.0.0-beta2";
+
+  src = fetchFromGitHub {
+    owner = "hydrogen-music";
+    repo = pname;
+    rev = version;
+    sha256 = "1s3jrdyjpm92flw9mkkxchnj0wz8nn1y1kifii8ws252iiqjya4a";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
+  buildInputs = [
+    alsaLib ladspa-sdk lash libarchive libjack2 liblo libpulseaudio libsndfile lrdf
+    qtbase qttools qtxmlpatterns
+  ];
+
+  cmakeFlags = [
+    "-DWANT_DEBUG=OFF"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Advanced drum machine";
+    homepage = "http://www.hydrogen-music.org";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ goibhniu orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19841,6 +19841,7 @@ in
   hugo = callPackage ../applications/misc/hugo { };
 
   hydrogen = callPackage ../applications/audio/hydrogen { };
+  hydrogen-unstable = qt5.callPackage ../applications/audio/hydrogen/unstable.nix { };
 
   hydroxide = callPackage ../applications/networking/hydroxide { };
 


### PR DESCRIPTION
###### Motivation for this change

hydrogen has infrequent releases (the last stable was in 2016).

This version switches from Qt 4 to Qt 5 (#33248).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
