### PR TITLE
ghidra: 9.1 -> 9.1.2

### DIFF
--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -16,11 +16,11 @@
 
 in stdenv.mkDerivation {
 
-  name = "ghidra-9.1";
+  name = "ghidra-9.1.2";
 
   src = fetchurl {
-    url = "https://ghidra-sre.org/ghidra_9.1_PUBLIC_20191023.zip";
-    sha256 = "0pl7s59008gvgwz4mxp7rz3xr3vaa12a6s5zvx2yr9jxx3gk1l99";
+    url = "https://ghidra-sre.org/ghidra_9.1.2_PUBLIC_20200212.zip";
+    sha256 = "0qdcxhnvbbj2w071s377x0kh9gbqpdvpgclh15jrfzgx397gmqzb";
   };
 
   nativeBuildInputs = [
@@ -42,7 +42,7 @@ in stdenv.mkDerivation {
     mkdir -p "${pkg_path}" "$out/share/applications"
     cp -a * "${pkg_path}"
     ln -s ${desktopItem}/share/applications/* $out/share/applications
-    
+
     icotool -x "${pkg_path}/support/ghidra.ico"
     rm ghidra_4_40x40x32.png
     for f in ghidra_*.png; do

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -25,9 +25,10 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [
     makeWrapper
-    autoPatchelfHook
     unzip
-  ];
+  ] ++
+    # leave macOS binaries unpatched since autoPatchelfHook doesn't work there
+    (if stdenv.isDarwin then [] else [ autoPatchelfHook ]);
 
   buildInputs = [
     stdenv.cc.cc.lib


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
