### PR TITLE
kicad: add option to override footprint, symbol and 3d model locations

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -197,13 +197,13 @@ stdenv.mkDerivation rec {
     "--prefix XDG_DATA_DIRS : ${cups}/share"
     "--prefix GIO_EXTRA_MODULES : ${gnome3.dconf}/lib/gio/modules"
 
-    "--set KISYSMOD ${footprints}/share/kicad/modules"
-    "--set KICAD_SYMBOL_DIR ${symbols}/share/kicad/library"
-    "--set KICAD_TEMPLATE_DIR ${templates}/share/kicad/template"
+    "--set-default KISYSMOD ${footprints}/share/kicad/modules"
+    "--set-default KICAD_SYMBOL_DIR ${symbols}/share/kicad/library"
+    "--set-default KICAD_TEMPLATE_DIR ${templates}/share/kicad/template"
     "--prefix KICAD_TEMPLATE_DIR : ${symbols}/share/kicad/template"
     "--prefix KICAD_TEMPLATE_DIR : ${footprints}/share/kicad/template"
   ]
-  ++ optionals (with3d) [ "--set KISYS3DMOD ${packages3d}/share/kicad/modules/packages3d" ]
+  ++ optionals (with3d) [ "--set-default KISYS3DMOD ${packages3d}/share/kicad/modules/packages3d" ]
   ++ optionals (withNgspice) [ "--prefix LD_LIBRARY_PATH : ${libngspice}/lib" ]
 
   # infinisil's workaround for #39493


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This PR makes it easy to supply custom library locations, which is useful when working on the libraries or using a git version.

I'm not really sure what the standard nixpkgs practice is here. I like this solution because it makes it really easy to work on the various libraries or use a git version. As I see it, the two main alternatives to this are:

1. Do it in an overlay.
2. Do it manually with the "Manage Symbol Libraries..." and "Manage Footprint Libraries...", etc. GUI menu options.

I don't like option 1 because correctly doing this with an overlay does not seem trivial, although maybe someone better at Nix will show me why it's easy. I'm also not a fan of option 2 because the GUI options don't allow you to specify a path that Kicad looks in for the libraries. Rather, you have to specify each library/footprint file individually which is a lot of unnecessary work when doing a lot of work on the kicad libraries. Option 2 also doesn't help when you want to use the git master version of a library.

What are people's thoughts on this?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
