### PR TITLE
nixos/nat: substitute iptables for compat under nftables

### DIFF
--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -254,7 +254,7 @@ in
         }
       ];
 
-      environment.systemPackages = [ pkgs.iptables ];
+      environment.systemPackages = [ config.networking.firewall.package ];
 
       boot = {
         kernelModules = [ "nf_nat_ftp" ];
@@ -273,7 +273,7 @@ in
         description = "Network Address Translation";
         wantedBy = [ "network.target" ];
         after = [ "network-pre.target" "systemd-modules-load.service" ];
-        path = [ pkgs.iptables ];
+        path = [ config.networking.firewall.package ];
         unitConfig.ConditionCapability = "CAP_NET_ADMIN";
 
         serviceConfig = {

--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -103,6 +103,7 @@ in
     }];
     boot.blacklistedKernelModules = [ "ip_tables" ];
     environment.systemPackages = [ pkgs.nftables ];
+    networking.firewall.package = mkDefault pkgs.iptables-nftables-compat;
     systemd.services.nftables = {
       description = "nftables firewall";
       before = [ "network-pre.target" ];


### PR DESCRIPTION
(Migrated from #84949 due to a wonderful demonstration of PEBKAC)

###### Motivation for this change
Currently, NAT will not work if you have nftables enabled (and therefore default firewall disabled (and therefore ip_tables unloaded/blacklisted)). This allows those using nftables to enable nat and have it work with minimal code change, thanks to the good work of those who created iptables-nftables-compat.

Debugging why my containers had no network access was a pain, this change fixed my issue, I'm using it right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
