### PR TITLE
guix: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1085,6 +1085,12 @@
     githubId = 3465841;
     name = "Boris Sukholitko";
   };
+  bqv = {
+    email = "nixpkgs@fron.io";
+    github = "bqv";
+    githubId = 822863;
+    name = "Tony Olagbaiye";
+  };
   bradediger = {
     email = "brad@bradediger.com";
     github = "bradediger";

--- a/pkgs/development/guile-modules/bytestructures/default.nix
+++ b/pkgs/development/guile-modules/bytestructures/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, guile
+, autoreconfHook, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "scheme-bytestructures";
+  version = "1.0.7";
+
+  src = fetchFromGitHub {
+    owner = "TaylanUB";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0q0habjiy3h9cigb7q1br9kz6z212dn2ab31f6dgd3rrmsfn5rvb";
+  };
+
+  postConfigure = ''
+    sed -i '/moddir\s*=/s%=.*%=''${out}/share/guile/site%' Makefile;
+    sed -i '/godir\s*=/s%=.*%=''${out}/share/guile/ccache%' Makefile;
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ guile ];
+
+  meta = with stdenv.lib; {
+    description = "Structured access to bytevector contents";
+    homepage = "https://github.com/TaylanUB/scheme-bytestructures";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bqv ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/guile-modules/guile-gcrypt/default.nix
+++ b/pkgs/development/guile-modules/guile-gcrypt/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, guile, libgcrypt
+, autoreconfHook, pkgconfig, texinfo
+}:
+
+stdenv.mkDerivation rec {
+  pname = "guile-gcrypt";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://notabug.org/cwebber/${pname}/archive/v${version}.tar.gz";
+    sha256 = "1qj1yw0kman984x584jjjxnjdhm0pwgp09iyn3b5rqajx7svpqcd";
+  };
+
+  postConfigure = ''
+    sed -i '/moddir\s*=/s%=.*%=''${out}/share/guile/site%' Makefile;
+    sed -i '/godir\s*=/s%=.*%=''${out}/share/guile/ccache%' Makefile;
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig texinfo ];
+  buildInputs = [ guile ];
+  propagatedBuildInputs = [ libgcrypt ];
+
+  meta = with stdenv.lib; {
+    description = "Bindings to Libgcrypt for GNU Guile";
+    homepage = "https://notabug.org/cwebber/guile-gcrypt";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bqv ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/guile-modules/guile-git/default.nix
+++ b/pkgs/development/guile-modules/guile-git/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitLab, guile, libgit2, scheme-bytestructures
+, autoreconfHook, pkg-config, texinfo
+}:
+
+stdenv.mkDerivation rec {
+  pname = "guile-git";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    owner = "guile-git";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1s77s70gzfj6h7bglq431kw8l4iknhsfpc0mnvcp4lkhwdcgyn1n";
+  };
+
+  postConfigure = ''
+    sed -i '/moddir\s*=/s%=.*%=''${out}/share/guile/site%' Makefile;
+    sed -i '/godir\s*=/s%=.*%=''${out}/share/guile/ccache%' Makefile;
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config texinfo ];
+  buildInputs = [ guile ];
+  propagatedBuildInputs = [ libgit2 scheme-bytestructures ];
+
+  meta = with stdenv.lib; {
+    description = "Bindings to Libgit2 for GNU Guile";
+    homepage = "https://gitlab.com/guile-git/guile-git";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bqv ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/guile-modules/guile-json/default.nix
+++ b/pkgs/development/guile-modules/guile-json/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, guile, texinfo, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "guile-json";
+  version = "3.3.0";
+
+  src = fetchurl {
+    url = "mirror://savannah/guile-json/${pname}-${version}.tar.gz";
+    sha256 = "0gbqiii8yl5vg5d2gf8j6pd1wwy9c37sxpdvv94rqnnp11rkbdyf";
+  };
+
+  postConfigure = ''
+    sed -i '/moddir\s*=/s%=.*%=''${out}/share/guile/site%' Makefile;
+    sed -i '/objdir\s*=/s%=.*%=''${out}/share/guile/ccache%' Makefile;
+    sed -i '/moddir\s*=/s%=.*%=''${out}/share/guile/site/json%' json/Makefile;
+    sed -i '/objdir\s*=/s%=.*%=''${out}/share/guile/ccache/json%' json/Makefile;
+  '';
+
+  nativeBuildInputs = [ pkg-config texinfo ];
+  buildInputs = [ guile ];
+
+  meta = with stdenv.lib; {
+    description = "JSON Bindings for GNU Guile";
+    homepage = "https://savannah.nongnu.org/projects/guile-json";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ bqv ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/guile-modules/guile-sqlite3/default.nix
+++ b/pkgs/development/guile-modules/guile-sqlite3/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, guile, sqlite
+, autoreconfHook, pkg-config, texinfo
+}:
+
+stdenv.mkDerivation rec {
+  pname = "guile-sqlite3";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://notabug.org/guile-sqlite3/${pname}/archive/v${version}.tar.gz";
+    sha256 = "1s9gmj72vszn999c82vnq0vic7ly4wcg8lz1qcfmhgk9pihcs0bm";
+  };
+
+  postConfigure = ''
+    sed -i '/moddir\s*=/s%=.*%=''${out}/share/guile/site%' Makefile;
+    sed -i '/godir\s*=/s%=.*%=''${out}/share/guile/ccache%' Makefile;
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config texinfo ];
+  buildInputs = [ guile ];
+  propagatedBuildInputs = [ sqlite ];
+
+  meta = with stdenv.lib; {
+    description = "Bindings to Sqlite3 for GNU Guile";
+    homepage = "https://notabug.org/guile-gcrypt/guile-gcrypt";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bqv ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/guile-modules/guile-ssh/default.nix
+++ b/pkgs/development/guile-modules/guile-ssh/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, guile, libssh
+, autoreconfHook, pkg-config, texinfo, which
+}:
+
+stdenv.mkDerivation rec {
+  pname = "guile-ssh";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "artyom-poptsov";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "054hd9rzfhb48gc1hw3rphhp0cnnd4bs5qmidy5ygsyvy9ravlad";
+  };
+
+  configureFlags = [ "--with-guilesitedir=\${out}/share/guile/site" ];
+
+  postFixup = ''
+    for f in $out/share/guile/site/ssh/**.scm; do \
+      substituteInPlace $f \
+        --replace "libguile-ssh" "$out/lib/libguile-ssh"; \
+    done
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config texinfo which ];
+  buildInputs = [ guile ];
+  propagatedBuildInputs = [ libssh ];
+
+  meta = with stdenv.lib; {
+    description = "Bindings to Libssh for GNU Guile";
+    homepage = "https://github.com/artyom-poptsov/guile-ssh";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bqv ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/tools/package-management/guix/default.nix
+++ b/pkgs/tools/package-management/guix/default.nix
@@ -1,0 +1,80 @@
+{ stdenv, pkgs, lib, fetchurl, pkg-config, makeWrapper, zlib, bzip2, guile
+, guile-gcrypt, guile-git, guile-json, guile-sqlite3, guile-ssh, gnutls, scheme-bytestructures
+, storeDir ? null, stateDir ? null }:
+
+let
+  guile-gnutls = (gnutls.override {
+    inherit guile;
+    guileBindings = true;
+  }).overrideAttrs (attrs: {
+    configureFlags = [
+      "--with-guile-site-dir=\${out}/share/guile/site"
+      "--with-guile-site-ccache-dir=\${out}/share/guile/ccache"
+      "--with-guile-extension-dir=\${out}/lib/guile/extensions"
+    ];
+  });
+in stdenv.mkDerivation rec {
+  pname = "guix";
+  version = "1.1.0";
+
+  src = fetchurl {
+    url = "mirror://gnu/guix/${pname}-${version}.tar.gz";
+    sha256 = "03v48cq94678pi7bkdjfwksrq40lr6q38s38jxh7qjdcyipi0naw";
+  };
+
+  postConfigure = ''
+    sed -i '/guilemoduledir\s*=/s%=.*%=''${out}/share/guile/site%' Makefile;
+    sed -i '/guileobjectdir\s*=/s%=.*%=''${out}/share/guile/ccache%' Makefile;
+  '';
+
+  modules = [
+    guile-gcrypt guile-git guile-json guile-sqlite3 guile-ssh guile-gnutls.out scheme-bytestructures
+  ];
+
+  nativeBuildInputs = [ pkg-config makeWrapper ];
+  buildInputs = [ zlib bzip2 ] ++ modules;
+  propagatedBuildInputs = [ guile ];
+
+  GUILE_LOAD_PATH = let
+    guilePath = [
+      "\${out}/share/guile/site"
+      "${guile-gnutls.out}/lib/guile/extensions"
+    ] ++ (lib.concatMap (module: [
+      "${module}/share/guile/site"
+    ]) modules);
+  in "${lib.concatStringsSep ":" guilePath}";
+  GUILE_LOAD_COMPILED_PATH = let
+    guilePath = [
+      "\${out}/share/guile/ccache"
+      "${guile-gnutls.out}/lib/guile/extensions"
+    ] ++ (lib.concatMap (module: [
+      "${module}/share/guile/ccache"
+    ]) modules);
+  in "${lib.concatStringsSep ":" guilePath}";
+
+  configureFlags = []
+    ++ lib.optional (storeDir != null) "--with-store-dir=${storeDir}"
+    ++ lib.optional (stateDir != null) "--localstatedir=${stateDir}";
+
+  postInstall = ''
+    wrapProgram $out/bin/guix \
+      --prefix GUILE_LOAD_PATH : "${GUILE_LOAD_PATH}" \
+      --prefix GUILE_LOAD_COMPILED_PATH : "${GUILE_LOAD_COMPILED_PATH}"
+
+    wrapProgram $out/bin/guix-daemon \
+      --prefix GUILE_LOAD_PATH : "${GUILE_LOAD_PATH}" \
+      --prefix GUILE_LOAD_COMPILED_PATH : "${GUILE_LOAD_COMPILED_PATH}"
+  '';
+
+  passthru = {
+    inherit guile;
+  };
+
+  meta = with lib; {
+    description = "A transactional package manager for an advanced distribution of the GNU system";
+    homepage = "https://guix.gnu.org/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bqv ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9696,6 +9696,8 @@ in
 
   guile-fibers = callPackage ../development/guile-modules/guile-fibers { };
 
+  guile-gcrypt = callPackage ../development/guile-modules/guile-gcrypt { };
+
   guile-gnome = callPackage ../development/guile-modules/guile-gnome {
     gconf = gnome2.GConf;
     guile = guile_2_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9729,6 +9729,8 @@ in
     guile = guile_2_0;
   };
 
+  guix = callPackage ../tools/package-management/guix { };
+
   inav = callPackage ../development/misc/stm32/inav {
     gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
     binutils-arm-embedded = pkgsCross.arm-embedded.buildPackages.binutils;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9721,6 +9721,8 @@ in
 
   guile-sdl2 = callPackage ../development/guile-modules/guile-sdl2 { };
 
+  guile-sqlite3 = callPackage ../development/guile-modules/guile-sqlite3 { };
+
   guile-xcb = callPackage ../development/guile-modules/guile-xcb {
     guile = guile_2_0;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9707,6 +9707,8 @@ in
     inherit (gnome2) gnome_vfs libglade libgnome libgnomecanvas libgnomeui;
   };
 
+  guile-json = callPackage ../development/guile-modules/guile-json { };
+
   guile-lib = callPackage ../development/guile-modules/guile-lib { };
 
   guile-ncurses = callPackage ../development/guile-modules/guile-ncurses { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9698,6 +9698,8 @@ in
 
   guile-gcrypt = callPackage ../development/guile-modules/guile-gcrypt { };
 
+  scheme-bytestructures = callPackage ../development/guile-modules/bytestructures { };
+
   guile-gnome = callPackage ../development/guile-modules/guile-gnome {
     gconf = gnome2.GConf;
     guile = guile_2_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9723,6 +9723,8 @@ in
 
   guile-sqlite3 = callPackage ../development/guile-modules/guile-sqlite3 { };
 
+  guile-ssh = callPackage ../development/guile-modules/guile-ssh { };
+
   guile-xcb = callPackage ../development/guile-modules/guile-xcb {
     guile = guile_2_0;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9699,6 +9699,7 @@ in
   guile-gcrypt = callPackage ../development/guile-modules/guile-gcrypt { };
 
   scheme-bytestructures = callPackage ../development/guile-modules/bytestructures { };
+  guile-git = callPackage ../development/guile-modules/guile-git { };
 
   guile-gnome = callPackage ../development/guile-modules/guile-gnome {
     gconf = gnome2.GConf;


### PR DESCRIPTION
###### Motivation for this change
Add Guix (migrated from #84004 because I'm a moron)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
