### PR TITLE
nixos/services/samba: install samba when nixos module is enabled

### DIFF
--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -248,7 +248,7 @@ in
         };
 
         security.pam.services.samba = {};
-
+        environment.systemPackages = [ config.services.samba.package ];
       })
     ];
 


### PR DESCRIPTION
###### Motivation for this change
It’s confusing that when I set `services.samba.enabled = true;` in `configuration.nix` I can’t use samba because `smbpasswd` is not (straightforwardly) accessible.

This fix was suggested in https://github.com/NixOS/nixpkgs/issues/22435.