### PR TITLE
next-gtk-webkit: init at 1.5.0

### DIFF
--- a/pkgs/applications/networking/browsers/next/default.nix
+++ b/pkgs/applications/networking/browsers/next/default.nix
@@ -2,16 +2,11 @@
 , fetchFromGitHub
 , lispPackages
 , sbcl
-, callPackage
+
+# This is the wrapped webkitgtk platform port that we hardcode into the Lisp Core.
+# See https://github.com/atlas-engineer/next/tree/master/ports#next-platform-ports
+, next-gtk-webkit
 }:
-
-let
-
-  # This is the wrapped webkitgtk platform port that we hardcode into the Lisp Core.
-  # See https://github.com/atlas-engineer/next/tree/master/ports#next-platform-ports
-  next-gtk-webkit = callPackage ./next-gtk-webkit.nix {};
-
-in
 
 stdenv.mkDerivation rec {
   pname = "next";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4753,6 +4753,7 @@ in
   netsniff-ng = callPackage ../tools/networking/netsniff-ng { };
 
   next = callPackage ../applications/networking/browsers/next { };
+  next-gtk-webkit = callPackage ../applications/networking/browsers/next/next-gtk-webkit.nix { };
 
   nfpm = callPackage ../tools/package-management/nfpm { };
 


### PR DESCRIPTION
###### Motivation for this change
Break off next-gtk-webkit into it's own package, so builds happen and it can be overriden nicely.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
