### PR TITLE
lektor: fix "ImportError: No module named pkg_resources"

### DIFF
--- a/pkgs/development/python-modules/lektor/default.nix
+++ b/pkgs/development/python-modules/lektor/default.nix
@@ -19,6 +19,7 @@
 , pytest-click
 , isPy27
 , functools32
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -34,7 +35,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     click watchdog exifread requests mistune inifile Babel jinja2
-    flask pyopenssl ndg-httpsclient
+    flask pyopenssl ndg-httpsclient setuptools
   ] ++ lib.optionals isPy27 [ functools32 ];
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change

Without this change, the `lektor` command fails with
```
Traceback (most recent call last):
  File "/nix/store/5m4zpcdvvg87yyhizqh0jg9b1q53qm9r-python3.7-lektor-3.1.3/bin/.lektor-wrapped", line 7, in <module>
    from lektor.cli import main
  File "/nix/store/3i5djvb74iwng1mmmcm059i3sdn0py0b-python3-3.7.5-env/lib/python3.7/site-packages/lektor/cli.py", line 8, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 package built:</summary>

  - python27Packages.lektor
  - python37Packages.lektor
  - python38Packages.lektor
</details>