### PR TITLE
lektor: make available as application

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -982,6 +982,8 @@ in
 
   lastpass-cli = callPackage ../tools/security/lastpass-cli { };
 
+  lektor = with python3Packages; toPythonApplication lektor;
+
   lesspass-cli = callPackage ../tools/security/lesspass-cli { };
 
   pacparser = callPackage ../tools/networking/pacparser { };


### PR DESCRIPTION
resolves NixOS/nixpkgs#55820

###### Motivation for this change

because Lektor isn't only a library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
   - without #85472 fails with `ModuleNotFoundError: No module named 'pkg_resources'`
   - with #85472 mostly works (JavaScript files for the Admin mode are missing, though.)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>28 package marked as broken and skipped:</summary>

  - digitalbitbox
  - iterm2
  - linuxPackages_4_4.evdi
  - linuxPackages_hardkernel_4_14.bcc
  - linuxPackages_hardkernel_4_14.bpftrace
  - linuxPackages_hardkernel_4_14.can-isotp
  - linuxPackages_hardkernel_4_14.chipsec
  - linuxPackages_hardkernel_4_14.digimend
  - linuxPackages_hardkernel_4_14.evdi
  - linuxPackages_hardkernel_4_14.mba6x_bl
  - linuxPackages_hardkernel_4_14.nvidia_x11
  - linuxPackages_hardkernel_4_14.nvidia_x11_legacy390
  - linuxPackages_hardkernel_4_14.nvidiabl
  - linuxPackages_hardkernel_4_14.prl-tools
  - linuxPackages_hardkernel_4_14.r8168
  - muslCross
  - nix-linter
  - octave-jit
  - octoprint
  - php73Extensions.zmq
  - php74Extensions.couchbase
  - php74Extensions.pthreads
  - python27Packages.flitBuildHook
  - python27Packages.libmodulemd
  - python37Packages.nixpart
  - python37Packages.notify
  - python37Packages.pyblock
  - python38Packages.libselinux
</details>
<details>
  <summary>1 package built:</summary>

  - lektor
</details>

(I guess the "skipped" packages are wrongly listed due to Mic92/nixpkgs-review#96.)