### PR TITLE
age: 1.0.0-beta2 -> git-2020-03-25

### DIFF
--- a/pkgs/tools/security/age/default.nix
+++ b/pkgs/tools/security/age/default.nix
@@ -2,9 +2,9 @@
 
 buildGoModule rec {
   pname = "age";
-  version = "1.0.0-beta2";
+  version = "unstable-2020-03-25";
   goPackagePath = "github.com/FiloSottile/age";
-  modSha256 = "0kwdwhkxgqjd8h1p7pm4h4xidp2vk840h1j4qya4qz8bjf9vskl9";
+  modSha256 = "00yhn1894ni8bvkqm1vr0rqkky52pkhvdzbi2sqx3czlgb5ibw3h";
 
   subPackages = [
     "cmd/age"
@@ -14,8 +14,8 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "FiloSottile";
     repo = "age";
-    rev = "v${version}";
-    sha256 = "1n1ww8yjw0mg00dvnfmggww9kwp1hls0a85iv6vx9k89mzv8mdrq";
+    rev = "f0f8092d60bb96737fa096c29ec6d8adb5810390";
+    sha256 = "079kfc8d1pr39hr4qnx48kviyzwg4p8m4pz0bdkypns4aq8ppbfk";
   };
 
   meta = with lib; {


### PR DESCRIPTION
There has been no new official release of age, but some important fixes and changes have been done since the last release in December: https://github.com/FiloSottile/age/compare/v1.0.0-beta2...f0f8092d60bb96737fa096c29ec6d8adb5810390

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
