### PR TITLE
luajit_2_0, luajit_2_1: bump to 2020-03-20, GC64 mode switch

### DIFF
--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -1,9 +1,10 @@
 { self, callPackage, lib }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.0.5";
+  version = "2.0.5-2020-03-20";
+  rev = "e613105";
   isStable = true;
-  sha256 = "0yg9q4q6v028bgh85317ykc9whgxgysp76qzaqgq55y6jy11yjw7";
+  sha256 = "0k843z90s4hi0qhri6ixy8sv21nig8jwbznpqgqg845ji530kqj7";
   extraMeta = { # this isn't precise but it at least stops the useless Hydra build
     platforms = with lib; filter (p: p != "aarch64-linux")
       (platforms.linux ++ platforms.darwin);

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -1,7 +1,8 @@
 { self, callPackage }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.1.0-beta3";
+  version = "2.1.0-2020-03-20";
+  rev = "9143e86";
   isStable = false;
-  sha256 = "1hyrhpkwjqsv54hnnx4cl8vk44h9d6c9w0fz1jfjz00w255y7lhs";
+  sha256 = "1zw1yr0375d6jr5x20zvkvk76hkaqamjynbswpl604w6r6id070b";
 }

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchurl, buildPackages
+{ stdenv, fetchFromGitHub, buildPackages
 , name ? "luajit-${version}"
 , isStable
 , sha256
+, rev
 , version
 , extraMeta ? {}
 , callPackage
@@ -10,6 +11,7 @@
 , enableFFI ? true
 , enableJIT ? true
 , enableJITDebugModule ? enableJIT
+, enableGC64 ? stdenv.hostPlatform.isAarch64
 , enable52Compat ? false
 , enableValgrindSupport ? false
 , valgrind ? null
@@ -28,6 +30,7 @@ let
      optional (!enableFFI) "-DLUAJIT_DISABLE_FFI"
   ++ optional (!enableJIT) "-DLUAJIT_DISABLE_JIT"
   ++ optional enable52Compat "-DLUAJIT_ENABLE_LUA52COMPAT"
+  ++ optional (!enableGC64) "-DLUAJIT_DISABLE_GC64"
   ++ optional useSystemMalloc "-DLUAJIT_USE_SYSMALLOC"
   ++ optional enableValgrindSupport "-DLUAJIT_USE_VALGRIND"
   ++ optional enableGDBJITSupport "-DLUAJIT_USE_GDBJIT"
@@ -37,9 +40,10 @@ let
 in
 stdenv.mkDerivation rec {
   inherit name version;
-  src = fetchurl {
-    url = "http://luajit.org/download/LuaJIT-${version}.tar.gz";
-    inherit sha256;
+  src = fetchFromGitHub {
+    owner  = "LuaJIT";
+    repo   = "LuaJIT";
+    inherit sha256 rev;
   };
 
   luaversion = "5.1";


### PR DESCRIPTION
###### Motivation for this change

Follows "the plan": https://github.com/NixOS/nixpkgs/pull/77800#issuecomment-576295871
>* update luajit_2_1 to latest 2.1 branch and build it with -DLUAJIT_DISABLE_GC64 by default
>* add flag in luajit_2_1 package E.g. gc64 so packages like Minetest can use LJ_GC64 variant easily

LuaJIT didn't release for a long time, there are lots of stability fixes (especially for aarch64) and GC64 mode (no more memory limit on first 2G of process space) is finally usable for production but still disabled by default, it can be turned on by new `enableGC64` flag.

Heavy LuaJIT consumers like OpenResty are using latest git versions for stability and performance. It should be safe to use them for default LuaJIT interpreter.

Should solve #77800

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @vcunat