### PR TITLE
picom: add withDebug option

### DIFF
--- a/pkgs/applications/window-managers/picom/default.nix
+++ b/pkgs/applications/window-managers/picom/default.nix
@@ -1,38 +1,75 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config, uthash, asciidoc, docbook_xml_dtd_45
-, docbook_xsl, libxslt, libxml2, makeWrapper, meson, ninja
-, xorgproto, libxcb ,xcbutilrenderutil, xcbutilimage, pixman, libev
-, dbus, libconfig, libdrm, libGL, pcre, libX11
-, libXinerama, libXext, xwininfo, libxdg_basedir }:
+{ asciidoc
+, dbus
+, docbook_xml_dtd_45
+, docbook_xsl
+, fetchFromGitHub
+, lib
+, libconfig
+, libdrm
+, libev
+, libGL
+, libX11
+, libxcb
+, libxdg_basedir
+, libXext
+, libXinerama
+, libxml2
+, libxslt
+, makeWrapper
+, meson
+, ninja
+, pcre
+, pixman
+, pkg-config
+, stdenv
+, uthash
+, xcbutilimage
+, xcbutilrenderutil
+, xorgproto
+, xwininfo
+}:
 
 stdenv.mkDerivation rec {
   pname = "picom";
   version = "8.2";
 
   src = fetchFromGitHub {
-    owner  = "yshui";
-    repo   = "picom";
-    rev    = "v${version}";
+    owner = "yshui";
+    repo = "picom";
+    rev = "v${version}";
     sha256 = "0gjksayz2xpmgglvw17ppsan2imrd1fijs579kbf27xwp503xgfl";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
-    meson ninja
-    pkg-config
-    uthash
     asciidoc
     docbook_xml_dtd_45
     docbook_xsl
     makeWrapper
+    meson
+    ninja
+    pkg-config
+    uthash
   ];
 
   buildInputs = [
-    dbus libX11 libXext
-    xorgproto
-    libXinerama libdrm pcre libxml2 libxslt libconfig libGL
-    libxcb xcbutilrenderutil xcbutilimage
-    pixman libev
+    dbus
+    libconfig
+    libdrm
+    libev
+    libGL
+    libX11
+    libxcb
     libxdg_basedir
+    libXext
+    libXinerama
+    libxml2
+    libxslt
+    pcre
+    pixman
+    xcbutilimage
+    xcbutilrenderutil
+    xorgproto
   ];
 
   mesonBuildType = "release";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This makes it easy to build picom in such a way that it supports debugging. Just install `picom.override {debug=true;}`. (The first commit applies `nixpkgs-fmt`.)

I asked on IRC if it's ok to add this kind of `debug ? false` options to packages if someone just bothers to do it and I was told by one person that it sounds reasonable. I can see this kind of convention in a few packages but there seems to be inconsistency whether to use `debug`, `withDebug` or `enableDebug` as the option name. I'm more than happy to pick any of those if there's some consensus.

cc maintainers @ertes @Enzime @Twey 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
