### PR TITLE
mailspring: init at 1.7.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7782,6 +7782,12 @@
     githubId = 1486805;
     name = "Toon Nolten";
   };
+  toschmidt = {
+    email = "tobias.schmidt@in.tum.de";
+    github = "toschmidt";
+    githubId = 27586264;
+    name = "Tobias Schmidt";
+  };
   travisbhartwell = {
     email = "nafai@travishartwell.net";
     github = "travisbhartwell";

--- a/pkgs/applications/networking/mailreaders/mailspring/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailspring/default.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, fetchurl
+, autoPatchelfHook
+, alsaLib
+, coreutils
+, db
+, dpkg
+, glib
+, gtk3
+, libkrb5
+, libsecret
+, nss
+, openssl
+, udev
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mailspring";
+  version = "1.7.8";
+
+  src = fetchurl {
+    url = "https://github.com/Foundry376/Mailspring/releases/download/${version}/mailspring-${version}-amd64.deb";
+    sha256 = "207fbf813b6da018a5b848e5dc1194b5996daab39adbd873b2cecb0565c105ce";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    alsaLib
+    db
+    glib
+    gtk3
+    libkrb5
+    libsecret
+    nss
+    xorg.libxkbfile
+    xorg.libXScrnSaver
+    xorg.libXtst
+  ];
+
+  runtimeDependencies = [
+    coreutils
+    openssl
+    udev.lib
+  ];
+
+  unpackPhase = ''
+    dpkg -x $src .
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib}
+    cp -ar ./usr/share $out
+
+    substituteInPlace $out/share/mailspring/resources/app.asar.unpacked/mailsync \
+      --replace realpath ${coreutils}/bin/realpath \
+      --replace dirname ${coreutils}/bin/dirname
+
+    ln -s $out/share/mailspring/mailspring $out/bin/mailspring
+    ln -s ${openssl.out}/lib/libcrypto.so $out/lib/libcrypto.so.1.0.0
+  '';
+
+  postFixup = /* sh */ ''
+    substituteInPlace $out/share/applications/mailspring.desktop \
+      --replace /usr/bin $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A beautiful, fast and maintained fork of Nylas Mail by one of the original authors";
+    longDescription = ''
+      Mailspring is an open-source mail client forked from Nylas Mail and built with Electron.
+      Mailspring's sync engine runs locally, but its source is not open.
+    '';
+    license = licenses.unfree;
+    maintainers = with maintainers; [ toschmidt ];
+    homepage = "https://getmailspring.com";
+    downloadPage = "https://github.com/Foundry376/Mailspring";
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20677,6 +20677,8 @@ in
 
   normalize = callPackage ../applications/audio/normalize { };
 
+  mailspring = callPackage ../applications/networking/mailreaders/mailspring {};
+
   mm = callPackage ../applications/networking/instant-messengers/mm { };
 
   mm-common = callPackage ../development/libraries/mm-common { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Packaged the mail client [Mailspring](https://github.com/Foundry376/Mailspring) at version 1.7.5

> Mailspring is a new version of Nylas Mail maintained by one of the original authors. It's faster, leaner, and shipping today!

Currently two pull requests for mailspring at version 1.6.3 exist: #69384 and #69027 

Syncing mails does not work in #69384 and #69027 uses buildFHSUserEnv although only one file needs patching.

This PR is based on the work done by rummik in #69384 and solves both problems for the latest version of mailspring.

The application needs `gnome-keyring` for storing passwords.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
cc @