### PR TITLE
treewide: per RFC45, remove more unquoted URLs

### DIFF
--- a/doc/builders/images/appimagetools.xml
+++ b/doc/builders/images/appimagetools.xml
@@ -63,7 +63,7 @@ type2.AppImage: ELF 64-bit LSB executable, x86-64, version 1 (SYSV) (Lepton 3.x)
 appimageTools.wrapType2 { # or wrapType1
   name = "patchwork"; <co xml:id='ex-appimageTools-wrapping-1' />
   src = fetchurl { <co xml:id='ex-appimageTools-wrapping-2' />
-    url = https://github.com/ssbc/patchwork/releases/download/v3.11.4/Patchwork-3.11.4-linux-x86_64.AppImage;
+    url = "https://github.com/ssbc/patchwork/releases/download/v3.11.4/Patchwork-3.11.4-linux-x86_64.AppImage";
     sha256 =  "1blsprpkvm0ws9b96gb36f0rbf8f5jgmw4x6dsb1kswr4ysf591s";
   };
   extraPkgs = pkgs: with pkgs; [ ]; <co xml:id='ex-appimageTools-wrapping-3' />

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -412,7 +412,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A pythonic wrapper around FFTW, the FFT library, presenting a unified interface for all the supported transforms";
-    homepage = http://hgomersall.github.com/pyFFTW;
+    homepage = "http://hgomersall.github.com/pyFFTW";
     license = with licenses; [ bsd2 bsd3 ];
     maintainers = with maintainers; [ fridh ];
   };

--- a/doc/languages-frameworks/ruby.xml
+++ b/doc/languages-frameworks/ruby.xml
@@ -32,7 +32,7 @@ bundlerEnv rec {
 
   meta = with lib; {
     description = "A monitoring framework that aims to be simple, malleable, and scalable";
-    homepage    = http://sensuapp.org/;
+    homepage    = "http://sensuapp.org/";
     license     = with licenses; mit;
     maintainers = with maintainers; [ theuni ];
     platforms   = platforms.unix;
@@ -69,7 +69,7 @@ bundlerApp {
 
   meta = with lib; {
     description = "Tool and libraries for maintaining Ruby gems.";
-    homepage    = https://github.com/nyarly/corundum;
+    homepage    = "https://github.com/nyarly/corundum";
     license     = licenses.mit;
     maintainers = [ maintainers.nyarly ];
     platforms   = platforms.unix;

--- a/doc/old/cross.txt
+++ b/doc/old/cross.txt
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
   name = "binutils-2.16.1-arm";
   builder = ./builder.sh;
   src = fetchurl {
-    url = http://ftp.nluug.nl/gnu/binutils/binutils-2.16.1.tar.bz2;
+    url = "http://ftp.nluug.nl/gnu/binutils/binutils-2.16.1.tar.bz2";
     sha256 = "1ian3kwh2vg6hr3ymrv48s04gijs539vzrq62xr76bxbhbwnz2np";
   };
   inherit noSysDirs;
@@ -84,7 +84,7 @@ stdenv.mkDerivation {
   name = "linux-headers-2.6.13.1-arm";
   builder = ./builder.sh;
   src = fetchurl {
-    url = http://www.kernel.org/pub/linux/kernel/v2.6/linux-2.6.13.1.tar.bz2;
+    url = "http://www.kernel.org/pub/linux/kernel/v2.6/linux-2.6.13.1.tar.bz2";
     sha256 = "12qxmc827fjhaz53kjy7vyrzsaqcg78amiqsb3qm20z26w705lma";
   };
 }

--- a/doc/release-notes.xml
+++ b/doc/release-notes.xml
@@ -190,7 +190,7 @@ preConfigure = "configureFlagsArray=(\"CFLAGS=-O0 -g\")";</programlisting>
       The function <function>fetchurl</function> now has support for two different kinds of mirroring of files. First, it has support for <emphasis>content-addressable mirrors</emphasis>. For example, given the <function>fetchurl</function> call
 <programlisting>
 fetchurl {
-  url = http://releases.mozilla.org/<replaceable>...</replaceable>/firefox-2.0.0.6-source.tar.bz2;
+  url = "http://releases.mozilla.org/<replaceable>...</replaceable>/firefox-2.0.0.6-source.tar.bz2";
   sha1 = "eb72f55e4a8bf08e8c6ef227c0ade3d068ba1082";
 }</programlisting>
       <function>fetchurl</function> will first try to download this file from <link

--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -14,7 +14,7 @@
 stdenv.mkDerivation {
   name = "libfoo-1.2.3";
   src = fetchurl {
-    url = http://example.org/libfoo-1.2.3.tar.bz2;
+    url = "http://example.org/libfoo-1.2.3.tar.bz2";
     sha256 = "0x2g1jqygyr5wiwg4ma1nd7w4ydpy82z9gkcv8vh2v8dn3y58v5m";
   };
 }</programlisting>

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -596,7 +596,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
   psfl = spdx {
     spdxId = "Python-2.0";
     fullName = "Python Software Foundation License version 2";
-    #url = http://docs.python.org/license.html;
+    #url = "http://docs.python.org/license.html";
   };
 
   publicDomain = {

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -132,7 +132,7 @@ in
         example = literalExample ''
           {
             dkuk-redmine_alex_skin = builtins.fetchurl {
-              url = https://bitbucket.org/dkuk/redmine_alex_skin/get/1842ef675ef3.zip;
+              url = "https://bitbucket.org/dkuk/redmine_alex_skin/get/1842ef675ef3.zip";
               sha256 = "0hrin9lzyi50k4w2bd2b30vrf1i4fi1c0gyas5801wn8i7kpm9yl";
             };
           }
@@ -146,7 +146,7 @@ in
         example = literalExample ''
           {
             redmine_env_auth = builtins.fetchurl {
-              url = https://github.com/Intera/redmine_env_auth/archive/0.6.zip;
+              url = "https://github.com/Intera/redmine_env_auth/archive/0.6.zip";
               sha256 = "0yyr1yjd8gvvh832wdc8m3xfnhhxzk2pk3gm2psg5w9jdvd6skak";
             };
           }

--- a/nixos/modules/services/security/bitwarden_rs/default.nix
+++ b/nixos/modules/services/security/bitwarden_rs/default.nix
@@ -58,7 +58,7 @@ in {
       default = {};
       example = literalExample ''
         {
-          domain = https://bw.domain.tld:8443;
+          domain = "https://bw.domain.tld:8443";
           signupsAllowed = true;
           rocketPort = 8222;
           rocketLog = "critical";

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -105,7 +105,7 @@ let
               name = "embed-pdf-viewer-plugin";
               # Download the theme from the wordpress site
               src = pkgs.fetchurl {
-                url = https://downloads.wordpress.org/plugin/embed-pdf-viewer.2.0.3.zip;
+                url = "https://downloads.wordpress.org/plugin/embed-pdf-viewer.2.0.3.zip";
                 sha256 = "1rhba5h5fjlhy8p05zf0p14c9iagfh96y91r36ni0rmk6y891lyd";
               };
               # We need unzip to build this package
@@ -132,7 +132,7 @@ let
               name = "responsive-theme";
               # Download the theme from the wordpress site
               src = pkgs.fetchurl {
-                url = https://downloads.wordpress.org/theme/responsive.3.14.zip;
+                url = "https://downloads.wordpress.org/theme/responsive.3.14.zip";
                 sha256 = "0rjwm811f4aa4q43r77zxlpklyb85q08f9c8ns2akcarrvj5ydx3";
               };
               # We need unzip to build this package

--- a/pkgs/applications/audio/polyphone/default.nix
+++ b/pkgs/applications/audio/polyphone/default.nix
@@ -41,7 +41,7 @@ mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A soundfont editor for creating musical instruments";
-    homepage = https://www.polyphone-soundfonts.com/;
+    homepage = "https://www.polyphone-soundfonts.com/";
     license = licenses.gpl3;
     maintainers = [ maintainers.maxdamantus ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/termpdf.py/default.nix
+++ b/pkgs/applications/misc/termpdf.py/default.nix
@@ -44,7 +44,7 @@ buildPythonApplication {
       A graphical pdf (and epub, cbz, ...) reader that works
       inside the kitty terminal.
     '';
-    homepage = https://github.com/dsanson/termpdf.py;
+    homepage = "https://github.com/dsanson/termpdf.py";
     maintainers = with maintainers; [ teto ];
     license = licenses.mit;
   };

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -150,7 +150,7 @@ let
                                                                           ];
 
   graal-mxcache = jvmci8-mxcache ++ [
-    # rec { sha1 = "5001adab652fc4eb35e30cdefbb0765442f8b7db"; name = "LLVM_ORG_LIBCXX_SRC_${sha1}/llvm-org-libcxx-src.tar.gz";                          url = https://lafo.ssw.uni-linz.ac.at/pub/llvm-org/compiler-rt-llvmorg-8.0.0-4-gd563e33a79-bgae3b177eaa-linux-amd64.tar.gz; }
+    # rec { sha1 = "5001adab652fc4eb35e30cdefbb0765442f8b7db"; name = "LLVM_ORG_LIBCXX_SRC_${sha1}/llvm-org-libcxx-src.tar.gz";                          url = "https://lafo.ssw.uni-linz.ac.at/pub/llvm-org/compiler-rt-llvmorg-8.0.0-4-gd563e33a79-bgae3b177eaa-linux-amd64.tar.gz"; }
     rec { sha1 = "5001adab652fc4eb35e30cdefbb0765442f8b7db"; name = "LLVM_ORG_COMPILER_RT_LINUX_${sha1}/llvm-org-compiler-rt-linux.tar.gz";            url = "https://lafo.ssw.uni-linz.ac.at/pub/llvm-org/compiler-rt-llvmorg-8.0.0-4-gd563e33a79-bgae3b177eaa-linux-amd64.tar.gz"; }
     rec { sha1 = "a990b2dba1c706f5c43c56fedfe70bad9a695852"; name = "LLVM_WRAPPER_${sha1}/llvm-wrapper.jar";                                           url = "mirror://maven/org/bytedeco/javacpp-presets/llvm/6.0.1-1.4.2/llvm-6.0.1-1.4.2.jar"; }
     rec { sha1 = "decbd95d46092fa9afaf2523b5b23d07ad7ad6bc"; name = "LLVM_WRAPPER_${sha1}/llvm-wrapper.sources.jar";                                   url = "mirror://maven/org/bytedeco/javacpp-presets/llvm/6.0.1-1.4.2/llvm-6.0.1-1.4.2-sources.jar"; }

--- a/pkgs/development/haskell-modules/configuration-tensorflow.nix
+++ b/pkgs/development/haskell-modules/configuration-tensorflow.nix
@@ -55,12 +55,12 @@ in
   haskell-src-exts_1_19_1 = appendPatches (doJailbreak super.haskell-src-exts_1_19_1) [
     # Adapt to the Semigroup–Monoid Proposal (enables building on GHC >= 8.4)
     (pkgs.fetchpatch {
-        url = https://github.com/haskell-suite/haskell-src-exts/commit/258e072fe9e37f94360b7488b58ea2832843bbb8.patch;
+        url = "https://github.com/haskell-suite/haskell-src-exts/commit/258e072fe9e37f94360b7488b58ea2832843bbb8.patch";
         sha256 = "0ja6ai41v9plinlhjwja282m6ahn6mw4xi79np0jxqk83cg0z1ff";
     })
     # Adapt to MonadFail proposal (enables building on GHC >= 8.8)
     (pkgs.fetchpatch {
-        url = https://gist.githubusercontent.com/mikesperber/0f2addaf3fbe97ffb4a5234d8711ba41/raw/e09e20998283c7195e82d546ba9266d290eb000d/gistfile1.txt;
+        url = "https://gist.githubusercontent.com/mikesperber/0f2addaf3fbe97ffb4a5234d8711ba41/raw/e09e20998283c7195e82d546ba9266d290eb000d/gistfile1.txt";
         sha256 = "18clvli7vpqsqlf2f3qidn71738j9zdlpana6wha3x0dxwan5ly0";
     }) ];
 

--- a/pkgs/development/libraries/biblesync/default.nix
+++ b/pkgs/development/libraries/biblesync/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libuuid ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.crosswire.org/wiki/BibleSync;
+    homepage = "http://www.crosswire.org/wiki/BibleSync";
     description = "A multicast protocol to Bible software shared conavigation";
     longDescription = ''
       BibleSync is a multicast protocol to support Bible software shared

--- a/pkgs/development/node-packages/node-packages-v10.nix
+++ b/pkgs/development/node-packages/node-packages-v10.nix
@@ -15293,7 +15293,7 @@ let
       version = "1.0.1";
       src = fetchurl {
         name = "emitter-1.0.1.tar.gz";
-        url = https://codeload.github.com/component/emitter/tar.gz/1.0.1;
+        url = "https://codeload.github.com/component/emitter/tar.gz/1.0.1";
         sha256 = "0eae744826723877457f7a7ac7f31d68a5a060673b3a883f6a8e325bf48f313d";
       };
     };
@@ -19632,7 +19632,7 @@ let
       version = "2.0.1";
       src = fetchurl {
         name = "global-2.0.1.tar.gz";
-        url = https://codeload.github.com/component/global/tar.gz/v2.0.1;
+        url = "https://codeload.github.com/component/global/tar.gz/v2.0.1";
         sha256 = "42be02b7148745447f6ba21137c972ca82d2cad92d30d63bd4fc310623901785";
       };
     };
@@ -31657,7 +31657,7 @@ let
       version = "0.9.15";
       src = fetchurl {
         name = "oauth-0.9.15.tar.gz";
-        url = https://codeload.github.com/ciaranj/node-oauth/legacy.tar.gz/master;
+        url = "https://codeload.github.com/ciaranj/node-oauth/legacy.tar.gz/master";
         sha256 = "9341c28772841acde618c778e85e381976f425824b816100792f697e68aec947";
       };
     };
@@ -48868,7 +48868,7 @@ let
       version = "1.5.0";
       src = fetchurl {
         name = "xmlhttprequest-1.5.0.tar.gz";
-        url = https://codeload.github.com/LearnBoost/node-XMLHttpRequest/tar.gz/0f36d0b5ebc03d85f860d42a64ae9791e1daa433;
+        url = "https://codeload.github.com/LearnBoost/node-XMLHttpRequest/tar.gz/0f36d0b5ebc03d85f860d42a64ae9791e1daa433";
         sha256 = "28dd0394d85befe8be4e9cd9f6803102780c62cbb09298cb174b52ff9777624f";
       };
     };
@@ -49891,7 +49891,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "CLI tool for Angular";
-      homepage = https://github.com/angular/angular-cli;
+      homepage = "https://github.com/angular/angular-cli";
       license = "MIT";
     };
     production = true;
@@ -49935,7 +49935,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "The command line interface for Antora.";
-      homepage = https://antora.org/;
+      homepage = "https://antora.org/";
       license = "MPL-2.0";
     };
     production = true;
@@ -50264,7 +50264,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "The default site generator pipeline for producing and publishing static documentation sites with Antora.";
-      homepage = https://antora.org/;
+      homepage = "https://antora.org/";
       license = "MPL-2.0";
     };
     production = true;
@@ -50427,7 +50427,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "A secure and free password manager for all of your devices.";
-      homepage = https://bitwarden.com/;
+      homepage = "https://bitwarden.com/";
       license = "GPL-3.0";
     };
     production = true;
@@ -52016,7 +52016,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Command line interface for rapid Vue.js development";
-      homepage = https://cli.vuejs.org/;
+      homepage = "https://cli.vuejs.org/";
       license = "MIT";
     };
     production = true;
@@ -52378,7 +52378,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Creating Electron app packages";
-      homepage = https://github.com/electron/asar;
+      homepage = "https://github.com/electron/asar";
       license = "MIT";
     };
     production = true;
@@ -52536,7 +52536,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "The browser package manager";
-      homepage = http://bower.io/;
+      homepage = "http://bower.io/";
       license = "MIT";
     };
     production = true;
@@ -52666,7 +52666,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Generate nix expressions to fetch bower dependencies";
-      homepage = https://github.com/rvl/bower2nix;
+      homepage = "https://github.com/rvl/bower2nix";
       license = "GPL-3.0";
     };
     production = true;
@@ -53275,7 +53275,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "A well-tested CSS minifier";
-      homepage = https://github.com/jakubpawlowicz/clean-css;
+      homepage = "https://github.com/jakubpawlowicz/clean-css";
       license = "MIT";
     };
     production = true;
@@ -56498,7 +56498,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Unfancy JavaScript";
-      homepage = http://coffeescript.org/;
+      homepage = "http://coffeescript.org/";
       license = "MIT";
     };
     production = true;
@@ -57893,7 +57893,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Create React Native apps with no build configuration.";
-      homepage = https://github.com/expo/create-react-native-app;
+      homepage = "https://github.com/expo/create-react-native-app";
       license = "BSD-3-Clause";
     };
     production = true;
@@ -57915,7 +57915,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "CSSLint";
-      homepage = http://csslint.net/;
+      homepage = "http://csslint.net/";
       license = "MIT";
     };
     production = true;
@@ -58570,7 +58570,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Dat is the package manager for data. Easily share and version control data.";
-      homepage = https://datproject.org/;
+      homepage = "https://datproject.org/";
       license = "BSD-3-Clause";
     };
     production = true;
@@ -58591,7 +58591,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "A DHCP server written in JavaScript";
-      homepage = https://github.com/infusion/node-dhcp;
+      homepage = "https://github.com/infusion/node-dhcp";
       license = "MIT OR GPL-2.0";
     };
     production = true;
@@ -58736,7 +58736,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "A blockchain-based DNS + HTTPS server that fixes HTTPS security, and more!";
-      homepage = https://github.com/okTurtles/dnschain;
+      homepage = "https://github.com/okTurtles/dnschain";
       license = "MPL-2.0";
     };
     production = true;
@@ -59269,7 +59269,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "EmojiOne is a complete set of emojis designed for the web. It includes libraries to easily convert unicode characters to shortnames (:smile:) and shortnames to our custom emoji images. PNG formats provided for the emoji images.";
-      homepage = https://www.emojione.com/;
+      homepage = "https://www.emojione.com/";
     };
     production = true;
     bypassCache = true;
@@ -59445,7 +59445,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "An AST-based pattern checker for JavaScript.";
-      homepage = https://eslint.org/;
+      homepage = "https://eslint.org/";
       license = "MIT";
     };
     production = true;
@@ -59627,7 +59627,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Makes eslint the fastest linter on the planet";
-      homepage = https://github.com/mantoni/eslint_d.js;
+      homepage = "https://github.com/mantoni/eslint_d.js";
       license = "MIT";
     };
     production = true;
@@ -60652,7 +60652,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "git hosting on secure-scuttlebutt (ssb)";
-      homepage = https://git-ssb.celehner.com/%25n92DiQh7ietE%2BR%2BX%2FI403LQoyf2DtR3WQfCkDKlheQU%3D.sha256;
+      homepage = "https://git-ssb.celehner.com/%25n92DiQh7ietE%2BR%2BX%2FI403LQoyf2DtR3WQfCkDKlheQU%3D.sha256";
       license = "Fair";
     };
     production = true;
@@ -62504,7 +62504,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "The streaming build system.";
-      homepage = https://gulpjs.com/;
+      homepage = "https://gulpjs.com/";
       license = "MIT";
     };
     production = true;
@@ -62849,7 +62849,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Command line interface for gulp";
-      homepage = http://gulpjs.com/;
+      homepage = "http://gulpjs.com/";
       license = "MIT";
     };
     production = true;
@@ -62880,7 +62880,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Highly configurable, well-tested, JavaScript-based HTML minifier.";
-      homepage = https://kangax.github.io/html-minifier/;
+      homepage = "https://kangax.github.io/html-minifier/";
       license = "MIT";
     };
     production = true;
@@ -63250,7 +63250,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "High precision scientific calculator with support for physical units";
-      homepage = https://github.com/sharkdp/insect;
+      homepage = "https://github.com/sharkdp/insect";
       license = "MIT";
     };
     production = true;
@@ -63571,7 +63571,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "A tool for creating and developing Ionic Framework mobile apps.";
-      homepage = https://ionicframework.com/;
+      homepage = "https://ionicframework.com/";
       license = "MIT";
     };
     production = true;
@@ -64112,7 +64112,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Implementation of the Language Server Protocol for JavaScript and TypeScript";
-      homepage = https://github.com/sourcegraph/javascript-typescript-langserver;
+      homepage = "https://github.com/sourcegraph/javascript-typescript-langserver";
       license = "Apache-2.0";
     };
     production = true;
@@ -64962,7 +64962,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "beautifier.io for node";
-      homepage = https://beautifier.io/;
+      homepage = "https://beautifier.io/";
       license = "MIT";
     };
     production = true;
@@ -64985,7 +64985,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "YAML 1.2 parser and serializer";
-      homepage = https://github.com/nodeca/js-yaml;
+      homepage = "https://github.com/nodeca/js-yaml";
       license = "MIT";
     };
     production = true;
@@ -65081,7 +65081,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Static analysis tool for JavaScript";
-      homepage = http://jshint.com/;
+      homepage = "http://jshint.com/";
       license = "(MIT AND JSON)";
     };
     production = true;
@@ -65124,7 +65124,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "JSON diff";
-      homepage = https://github.com/andreyvit/json-diff;
+      homepage = "https://github.com/andreyvit/json-diff";
     };
     production = true;
     bypassCache = true;
@@ -65179,7 +65179,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Various utilities for JSON References (http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03).";
-      homepage = https://github.com/whitlockjc/json-refs;
+      homepage = "https://github.com/whitlockjc/json-refs";
       license = "MIT";
     };
     production = true;
@@ -65460,7 +65460,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Get a full fake REST API with zero coding in less than 30 seconds";
-      homepage = https://github.com/typicode/json-server;
+      homepage = "https://github.com/typicode/json-server";
       license = "MIT";
     };
     production = true;
@@ -65487,7 +65487,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Validate JSON";
-      homepage = http://zaach.github.com/jsonlint/;
+      homepage = "http://zaach.github.com/jsonlint/";
     };
     production = true;
     bypassCache = true;
@@ -65687,7 +65687,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Spectacular Test Runner for JavaScript.";
-      homepage = http://karma-runner.github.io/;
+      homepage = "http://karma-runner.github.io/";
       license = "MIT";
     };
     production = true;
@@ -65781,7 +65781,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Merges multiple lcov results into one";
-      homepage = https://github.com/mweibel/lcov-result-merger;
+      homepage = "https://github.com/mweibel/lcov-result-merger";
       license = "MIT";
     };
     production = true;
@@ -67083,7 +67083,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Leaner CSS";
-      homepage = http://lesscss.org/;
+      homepage = "http://lesscss.org/";
       license = "Apache-2.0";
     };
     production = true;
@@ -67108,7 +67108,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "clean-css plugin for less.js";
-      homepage = http://lesscss.org/;
+      homepage = "http://lesscss.org/";
     };
     production = true;
     bypassCache = true;
@@ -67949,7 +67949,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Live Markdown previews for your favourite editor.";
-      homepage = https://github.com/shime/livedown;
+      homepage = "https://github.com/shime/livedown";
       license = "MIT";
     };
     production = true;
@@ -69107,7 +69107,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Madoko is a fast scholarly Markdown processor written in Koka";
-      homepage = http://madoko.codeplex.com/;
+      homepage = "http://madoko.codeplex.com/";
     };
     production = true;
     bypassCache = true;
@@ -69247,7 +69247,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Meeting room kiosk app for displaying meeting room schedules and booking rooms in your organization. Built against Google Apps, but other sources can be defined.";
-      homepage = https://bitbucket.org/aahmed/meat;
+      homepage = "https://bitbucket.org/aahmed/meat";
     };
     production = true;
     bypassCache = true;
@@ -70105,7 +70105,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "simple, flexible, fun test framework";
-      homepage = https://mochajs.org/;
+      homepage = "https://mochajs.org/";
       license = "MIT";
     };
     production = true;
@@ -70229,7 +70229,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Neovim client API and neovim remote plugin provider";
-      homepage = https://github.com/neovim/node-client;
+      homepage = "https://github.com/neovim/node-client";
       license = "MIT";
     };
     production = true;
@@ -70388,7 +70388,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Build tool and bindings loader for node-gyp that supports prebuilds";
-      homepage = https://github.com/prebuild/node-gyp-build;
+      homepage = "https://github.com/prebuild/node-gyp-build";
       license = "MIT";
     };
     production = true;
@@ -70684,7 +70684,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Web Inspector based nodeJS debugger";
-      homepage = http://github.com/node-inspector/node-inspector;
+      homepage = "http://github.com/node-inspector/node-inspector";
     };
     production = true;
     bypassCache = true;
@@ -71251,7 +71251,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Low-code programming for event-driven applications";
-      homepage = http://nodered.org/;
+      homepage = "http://nodered.org/";
       license = "Apache-2.0";
     };
     production = true;
@@ -71441,7 +71441,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Generate Nix expressions to build NPM packages";
-      homepage = https://github.com/svanderburg/node2nix;
+      homepage = "https://github.com/svanderburg/node2nix";
       license = "MIT";
     };
     production = true;
@@ -71605,7 +71605,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Simple monitor script for use during development of a node.js app.";
-      homepage = http://nodemon.io/;
+      homepage = "http://nodemon.io/";
       license = "MIT";
     };
     production = true;
@@ -71623,7 +71623,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "a package manager for JavaScript";
-      homepage = https://docs.npmjs.com/;
+      homepage = "https://docs.npmjs.com/";
       license = "Artistic-2.0";
     };
     production = true;
@@ -71919,7 +71919,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Find newer versions of dependencies than what your package.json or bower.json allows";
-      homepage = https://github.com/tjunnone/npm-check-updates;
+      homepage = "https://github.com/tjunnone/npm-check-updates";
       license = "Apache-2.0";
     };
     production = true;
@@ -72093,7 +72093,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Generate nix expressions to build npm packages";
-      homepage = https://github.com/NixOS/npm2nix;
+      homepage = "https://github.com/NixOS/npm2nix";
     };
     production = true;
     bypassCache = true;
@@ -72134,7 +72134,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "OCaml language server";
-      homepage = https://github.com/freebroccolo/ocaml-language-server;
+      homepage = "https://github.com/freebroccolo/ocaml-language-server";
       license = "Apache-2.0";
     };
     production = true;
@@ -73695,7 +73695,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Streaming torrent client for Node.js";
-      homepage = https://github.com/mafintosh/peerflix;
+      homepage = "https://github.com/mafintosh/peerflix";
       license = "MIT";
     };
     production = true;
@@ -74084,7 +74084,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Fast, disk space efficient package manager";
-      homepage = https://pnpm.js.org/;
+      homepage = "https://pnpm.js.org/";
       license = "MIT";
     };
     production = true;
@@ -74261,7 +74261,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Prettier is an opinionated code formatter";
-      homepage = https://prettier.io/;
+      homepage = "https://prettier.io/";
       license = "MIT";
     };
     production = true;
@@ -74648,7 +74648,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "A build system for PureScript projects";
-      homepage = https://github.com/purescript-contrib/pulp;
+      homepage = "https://github.com/purescript-contrib/pulp";
       license = "LGPL-3.0+";
     };
     production = true;
@@ -74820,7 +74820,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "A set of complementary tools to React, including the JSX transformer.";
-      homepage = https://facebook.github.io/react;
+      homepage = "https://facebook.github.io/react";
       license = "BSD-3-Clause";
     };
     production = true;
@@ -74838,7 +74838,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "The HTML Presentation Framework";
-      homepage = http://revealjs.com/;
+      homepage = "http://revealjs.com/";
       license = "MIT";
     };
     production = true;
@@ -76486,7 +76486,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Serverless Framework - Build web, mobile and IoT applications with serverless architectures using AWS Lambda, Azure Functions, Google CloudFunctions & more";
-      homepage = https://serverless.com/framework/docs/;
+      homepage = "https://serverless.com/framework/docs/";
       license = "MIT";
     };
     production = true;
@@ -78588,7 +78588,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "network protocol layer for secure-scuttlebutt";
-      homepage = https://github.com/ssbc/ssb-server;
+      homepage = "https://github.com/ssbc/ssb-server";
       license = "MIT";
     };
     production = true;
@@ -78606,7 +78606,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Send metric data from statsd to Stackdriver";
-      homepage = https://www.stackdriver.com/;
+      homepage = "https://www.stackdriver.com/";
       license = "MIT";
     };
     production = true;
@@ -79525,7 +79525,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Nodejs-based tool for optimizing SVG vector graphics files";
-      homepage = https://github.com/svg/svgo;
+      homepage = "https://github.com/svg/svgo";
       license = "MIT";
     };
     production = true;
@@ -80560,7 +80560,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "The pluggable linting tool for text and markdown.";
-      homepage = https://github.com/textlint/textlint/;
+      homepage = "https://github.com/textlint/textlint/";
       license = "MIT";
     };
     production = true;
@@ -80582,7 +80582,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Latex plugin for [textlint](https://github.com/textlint/textlint &#34;textlint&#34;).";
-      homepage = https://github.com/elzup/textlint-plugin-latex;
+      homepage = "https://github.com/elzup/textlint-plugin-latex";
       license = "MIT";
     };
     production = true;
@@ -80621,7 +80621,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "textlint rule check that abbreviations within parentheses.";
-      homepage = https://github.com/azu/textlint-rule-abbr-within-parentheses;
+      homepage = "https://github.com/azu/textlint-rule-abbr-within-parentheses";
       license = "MIT";
     };
     production = true;
@@ -80935,7 +80935,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "textlint rule for alex";
-      homepage = https://github.com/textlint-rule/textlint-rule-alex;
+      homepage = "https://github.com/textlint-rule/textlint-rule-alex";
       license = "MIT";
     };
     production = true;
@@ -80960,7 +80960,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "textlint rule to check common misspellings";
-      homepage = https://github.com/io-monad/textlint-rule-common-misspellings;
+      homepage = "https://github.com/io-monad/textlint-rule-common-misspellings";
       license = "GPL-3.0";
     };
     production = true;
@@ -80982,7 +80982,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Textlint rule to check correct usage of diacritics";
-      homepage = https://github.com/sapegin/textlint-rule-diacritics;
+      homepage = "https://github.com/sapegin/textlint-rule-diacritics";
       license = "MIT";
     };
     production = true;
@@ -81019,7 +81019,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "textlint rule that specify the maximum word count of a sentence.";
-      homepage = https://github.com/azu/textlint-rule-en-max-word-count;
+      homepage = "https://github.com/azu/textlint-rule-en-max-word-count";
       license = "MIT";
     };
     production = true;
@@ -81112,7 +81112,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "textlint rule that check no start with duplicated conjunction.";
-      homepage = https://github.com/textlint-rule/textlint-rule-no-start-duplicated-conjunction;
+      homepage = "https://github.com/textlint-rule/textlint-rule-no-start-duplicated-conjunction";
       license = "MIT";
     };
     production = true;
@@ -81153,7 +81153,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "textlint rule that check with or without period in list item.";
-      homepage = https://github.com/textlint-rule/textlint-rule-period-in-list-item;
+      homepage = "https://github.com/textlint-rule/textlint-rule-period-in-list-item";
       license = "MIT";
     };
     production = true;
@@ -81183,7 +81183,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Textlint rule to find filler words, buzzwords and chiches";
-      homepage = https://github.com/sapegin/textlint-rule-stop-words;
+      homepage = "https://github.com/sapegin/textlint-rule-stop-words";
       license = "MIT";
     };
     production = true;
@@ -81213,7 +81213,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "TextLint rule to check correct terms spelling";
-      homepage = https://github.com/sapegin/textlint-rule-terminology;
+      homepage = "https://github.com/sapegin/textlint-rule-terminology";
       license = "MIT";
     };
     production = true;
@@ -81253,7 +81253,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "textlint rule that check unexpanded acronym word.";
-      homepage = https://github.com/textlint-rule/textlint-rule-unexpanded-acronym;
+      homepage = "https://github.com/textlint-rule/textlint-rule-unexpanded-acronym";
       license = "MIT";
     };
     production = true;
@@ -81293,7 +81293,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "textlint rule to check your English style with write good";
-      homepage = https://github.com/textlint-rule/textlint-rule-write-good;
+      homepage = "https://github.com/textlint-rule/textlint-rule-write-good";
       license = "MIT";
     };
     production = true;
@@ -81728,7 +81728,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "The self-hosted Web IRC client";
-      homepage = https://thelounge.chat/;
+      homepage = "https://thelounge.chat/";
       license = "MIT";
     };
     production = true;
@@ -81746,7 +81746,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "JavaScript 3D library";
-      homepage = https://threejs.org/;
+      homepage = "https://threejs.org/";
       license = "MIT";
     };
     production = true;
@@ -82087,7 +82087,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Joyent Triton CLI and client (https://www.joyent.com/triton)";
-      homepage = https://github.com/joyent/node-triton;
+      homepage = "https://github.com/joyent/node-triton";
       license = "MPL-2.0";
     };
     production = true;
@@ -82136,7 +82136,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "TSUN: a repl for TypeScript Upgraded Node";
-      homepage = https://github.com/HerringtonDarkholme/typescript-repl;
+      homepage = "https://github.com/HerringtonDarkholme/typescript-repl";
       license = "MIT";
     };
     production = true;
@@ -82177,7 +82177,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "TypeScript is a language for application scale JavaScript development";
-      homepage = https://www.typescriptlang.org/;
+      homepage = "https://www.typescriptlang.org/";
       license = "Apache-2.0";
     };
     production = true;
@@ -83941,7 +83941,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "vue-language-server";
-      homepage = https://github.com/vuejs/vetur/tree/master/server;
+      homepage = "https://github.com/vuejs/vetur/tree/master/server";
       license = "MIT";
     };
     production = true;
@@ -85040,7 +85040,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "A command line tool to help build, run, and test web extensions";
-      homepage = https://github.com/mozilla/web-ext;
+      homepage = "https://github.com/mozilla/web-ext";
       license = "MPL-2.0";
     };
     production = true;
@@ -85516,7 +85516,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jsx, es7, css, less, ... and your custom stuff.";
-      homepage = https://github.com/webpack/webpack;
+      homepage = "https://github.com/webpack/webpack";
       license = "MIT";
     };
     production = true;
@@ -86581,7 +86581,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Copy files && directories with webpack";
-      homepage = https://github.com/webpack-contrib/copy-webpack-plugin;
+      homepage = "https://github.com/webpack-contrib/copy-webpack-plugin";
       license = "MIT";
     };
     production = true;
@@ -86878,7 +86878,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "WebTorrent, the streaming torrent client. For the command line.";
-      homepage = https://webtorrent.io/;
+      homepage = "https://webtorrent.io/";
       license = "MIT";
     };
     production = true;
@@ -87917,7 +87917,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "CLI tool for running Yeoman generators";
-      homepage = http://yeoman.io/;
+      homepage = "http://yeoman.io/";
       license = "BSD-2-Clause";
     };
     production = true;

--- a/pkgs/development/node-packages/node-packages-v12.nix
+++ b/pkgs/development/node-packages/node-packages-v12.nix
@@ -2475,7 +2475,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Unfancy JavaScript";
-      homepage = http://coffeescript.org/;
+      homepage = "http://coffeescript.org/";
       license = "MIT";
     };
     production = true;
@@ -2953,7 +2953,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Generate Nix expressions to build NPM packages";
-      homepage = https://github.com/svanderburg/node2nix;
+      homepage = "https://github.com/svanderburg/node2nix";
       license = "MIT";
     };
     production = true;
@@ -3090,7 +3090,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Build tool and bindings loader for node-gyp that supports prebuilds";
-      homepage = https://github.com/prebuild/node-gyp-build;
+      homepage = "https://github.com/prebuild/node-gyp-build";
       license = "MIT";
     };
     production = true;

--- a/pkgs/development/node-packages/node-packages-v13.nix
+++ b/pkgs/development/node-packages/node-packages-v13.nix
@@ -1441,7 +1441,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Generate Nix expressions to build NPM packages";
-      homepage = https://github.com/svanderburg/node2nix;
+      homepage = "https://github.com/svanderburg/node2nix";
       license = "MIT";
     };
     production = true;

--- a/pkgs/development/python-modules/requests_download/default.nix
+++ b/pkgs/development/python-modules/requests_download/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   format = "wheel";
 
   #src = pkgs.fetchurl {
-  #  url = https://files.pythonhosted.org/packages/60/af/10f899f0574a81cbc511124c08d7c7dc46c20d4f956a6a3c793ad4330bb4/requests_download-0.1.2-py2.py3-none-any.whl;
+  #  url = "https://files.pythonhosted.org/packages/60/af/10f899f0574a81cbc511124c08d7c7dc46c20d4f956a6a3c793ad4330bb4/requests_download-0.1.2-py2.py3-none-any.whl";
   #  sha256 = "1ballx1hljpdpyvqzqn79m0dc21z2smrnxk2ylb6dbpg5crrskcr";
   #};
 

--- a/pkgs/os-specific/linux/gogoclient/default.nix
+++ b/pkgs/os-specific/linux/gogoclient/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   name = "${baseName}-${version}";
 
   src = fetchurl {
-    #url = http://gogo6.com/downloads/gogoc-1_2-RELEASE.tar.gz;
+    #url = "http://gogo6.com/downloads/gogoc-1_2-RELEASE.tar.gz";
     url = "https://src.fedoraproject.org/repo/pkgs/gogoc/gogoc-1_2-RELEASE.tar.gz/41177ed683cf511cc206c7782c37baa9/gogoc-1_2-RELEASE.tar.gz";
     sha256 = "a0ef45c0bd1fc9964dc8ac059b7d78c12674bf67ef641740554e166fa99a2f49";
   };

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -141,11 +141,11 @@ in rec {
   #    # provided here verbatim for the convenience of anyone wanting to build
   #    # Asterisk from other sources. Include in externals.
   #    "sounds/asterisk-core-sounds-en-gsm-1.5.tar.gz" = fetchurl {
-  #      url = http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-core-sounds-en-gsm-1.5.tar.gz;
+  #      url = "http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-core-sounds-en-gsm-1.5.tar.gz";
   #      sha256 = "01xzbg7xy0c5zg7sixjw5025pvr4z64kfzi9zvx19im0w331h4cd";
   #    };
   #    "sounds/asterisk-moh-opsound-wav-2.03.tar.gz" = fetchurl {
-  #      url = http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-moh-opsound-wav-2.03.tar.gz;
+  #      url = "http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-moh-opsound-wav-2.03.tar.gz";
   #      sha256 = "449fb810d16502c3052fedf02f7e77b36206ac5a145f3dacf4177843a2fcb538";
   #    };
   #    # TODO: Sounds for other languages could be added here

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16811,7 +16811,7 @@ let
       sha256 = "f98a10c625640170cdda408cccc72bdd7f66f8ebe5f59dec1b96185171ef11d0";
     };
     meta = {
-      #homepage = http://web-cpan.berlios.de/modules/Statistics-Descriptive/; # berlios shut down; I found no replacement
+      #homepage = "http://web-cpan.berlios.de/modules/Statistics-Descriptive/"; # berlios shut down; I found no replacement
       description = "Module of basic descriptive statistical functions";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This PR deals with the rest of the unquoted URLs in the tree.

I also included occurrences in comments and documentation just to be consistent.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
