### PR TITLE
kdegraphics-thumbnailers: Add patch for thumbnail.so hang.

### DIFF
--- a/pkgs/applications/kde/kdegraphics-thumbnailers.nix
+++ b/pkgs/applications/kde/kdegraphics-thumbnailers.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib,
+  mkDerivation, lib, fetchpatch,
   extra-cmake-modules, karchive, kio, libkexiv2, libkdcraw
 }:
 
@@ -9,6 +9,14 @@ mkDerivation {
     license = [ lib.licenses.lgpl21 ];
     maintainers = [ lib.maintainers.ttuegel ];
   };
+  patches = [
+    # Fix a bug with thumbnail.so processes hanging:
+    # https://bugs.kde.org/show_bug.cgi?id=404652
+    (fetchpatch {
+      url = "https://phabricator.kde.org/file/data/tnk4b6roouixzifi6vre/PHID-FILE-qkkedevt7svx7lv56ea5/D26635.diff";
+      sha256 = "0fq85zhymmrq8vl0y6vgh87qf4c6fhcq704p4kpkaq7y0isxj4h1";
+    })
+  ];
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ karchive kio libkexiv2 libkdcraw ];
 }


### PR DESCRIPTION
Fixes a bug in the KDE PDF thumbnail generator which causes thumbnail.so processes to hang and accumulate as well as a long delay during shutdown/reboot as systemd tries to terminate the processes and eventually gives up. Reproduction is probably easy, have a folder with a PDF and browse it with Dolphin. The patch here is the same as was accepted upstream.

https://bugs.kde.org/show_bug.cgi?id=404652
https://phabricator.kde.org/D26635

This is a pretty annoying bug so I think that a patch is appropriate as is backporting to 19.09. Tested on release-19.09 but it surely works in master because of the same kdegraphics-thumbnailers version. 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
