### PR TITLE
kapitonov-plugins-pack: init at 1.2.1

### DIFF
--- a/pkgs/applications/audio/kapitonov-plugins-pack/default.nix
+++ b/pkgs/applications/audio/kapitonov-plugins-pack/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, faust, meson, ninja, pkg-config
+, boost, cairo, fftw, gnome3, ladspa-sdk, libxcb, lv2, xcbutilwm
+, zita-convolver, zita-resampler
+ }:
+
+stdenv.mkDerivation rec {
+  pname = "kapitonov-plugins-pack";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "olegkapitonov";
+    repo = pname;
+    rev = version;
+    sha256 = "1mxi7b1vrzg25x85lqk8c77iziqrqyz18mqkfjlz09sxp5wfs9w4";
+  };
+
+  nativeBuildInputs = [
+    faust
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    cairo
+    fftw
+    ladspa-sdk
+    libxcb
+    lv2
+    xcbutilwm
+    zita-convolver
+    zita-resampler
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Set of LADSPA and LV2 plugins for guitar sound processing";
+    homepage = https://github.com/olegkapitonov/Kapitonov-Plugins-Pack;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21002,6 +21002,8 @@ in
 
   kanshi = callPackage ../tools/misc/kanshi { };
 
+  kapitonov-plugins-pack = callPackage ../applications/audio/kapitonov-plugins-pack { };
+
   kdeApplications =
     let
       mkApplications = import ../applications/kde;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
