### PR TITLE
mednafen: Add alsaLib to get ALSA audio output

### DIFF
--- a/pkgs/misc/emulators/mednafen/default.nix
+++ b/pkgs/misc/emulators/mednafen/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, freeglut, libGLU, libGL, libcdio, libjack2
-, libsamplerate, libsndfile, libX11, SDL2, SDL2_net, zlib }:
+, libsamplerate, libsndfile, libX11, SDL2, SDL2_net, zlib, alsaLib }:
 
 stdenv.mkDerivation rec {
   pname = "mednafen";
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     libGLU libGL
     libcdio
     libjack2
+    alsaLib
     libsamplerate
     libsndfile
     libX11


### PR DESCRIPTION
###### Motivation for this change

Sound in mednafen won't work on a standard Linux installation (including nixos with `hardware.pulseautio.enable = true`).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
