### PR TITLE
WIP: cc-wrapper: -nostdlib doessn't mean not C++

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -60,8 +60,6 @@ while (( "$n" < "$nParams" )); do
         dontLink=1
     elif [[ "$p" = -x && "$p2" = c++* && "$isCpp" = 0 ]]; then
         isCpp=1
-    elif [ "$p" = -nostdlib ]; then
-        isCpp=-1
     elif [ "$p" = -nostdinc ]; then
         cppInclude=0
     elif [ "$p" = -nostdinc++ ]; then


### PR DESCRIPTION
###### Motivation for this change

This was introduced in 87607af7a1bf35682f8ad206307ed46e8ead260a, which
made the wrapper aware of `-x <lang>` flags. I am not sure why this new
case was added, especially with the `-l` that looks like a mistake.

FWIW, https://github.com/briansmith/nostdlib is an example of writing C++
with -nosdlib.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
