### PR TITLE
treewide: use https for nixos.org and hydra.nixos.org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 <!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
 
-- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
+- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
 - Built on platform(s)
    - [ ] NixOS
    - [ ] macOS

--- a/doc/contributing/quick-start.xml
+++ b/doc/contributing/quick-start.xml
@@ -111,7 +111,7 @@
     </para>
     <para>
      The exact syntax and semantics of the Nix expression language, including the built-in function, are described in the Nix manual in the <link
-    xlink:href="http://hydra.nixos.org/job/nix/trunk/tarball/latest/download-by-type/doc/manual/#chap-writing-nix-expressions">chapter on writing Nix expressions</link>.
+    xlink:href="https://hydra.nixos.org/job/nix/trunk/tarball/latest/download-by-type/doc/manual/#chap-writing-nix-expressions">chapter on writing Nix expressions</link>.
     </para>
    </listitem>
    <listitem>

--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -167,7 +167,7 @@ parameters that the SDK composition function (the function shown in the
 previous section) supports.
 
 This build function is particularly useful when it is desired to use
-[Hydra](http://nixos.org/hydra): the Nix-based continuous integration solution
+[Hydra](https://nixos.org/hydra): the Nix-based continuous integration solution
 to build Android apps. An Android APK gets exposed as a build product and can be
 installed on any Android device with a web browser by navigating to the build
 result page.

--- a/doc/languages-frameworks/ios.section.md
+++ b/doc/languages-frameworks/ios.section.md
@@ -18,7 +18,7 @@ The primary objective of this project is to use the Nix expression language to
 specify how iOS apps can be built from source code, and to automatically spawn
 iOS simulator instances for testing.
 
-This component also makes it possible to use [Hydra](http://nixos.org/hydra),
+This component also makes it possible to use [Hydra](https://nixos.org/hydra),
 the Nix-based continuous integration server to regularly build iOS apps and to
 do wireless ad-hoc installations of enterprise IPAs on iOS devices through
 Hydra.

--- a/doc/preface.chapter.md
+++ b/doc/preface.chapter.md
@@ -42,7 +42,7 @@ distributed as soon as all tests for that channel pass, e.g.
 [this table](https://hydra.nixos.org/job/nixpkgs/trunk/unstable#tabs-constituents)
 shows the status of tests for the `nixpkgs` channel.
 
-The tests are conducted by a cluster called [Hydra](http://nixos.org/hydra/),
+The tests are conducted by a cluster called [Hydra](https://nixos.org/hydra/),
 which also builds binary packages from the Nix expressions in Nixpkgs for
 `x86_64-linux`, `i686-linux` and `x86_64-darwin`.
 The binaries are made available via a [binary cache](https://cache.nixos.org).

--- a/doc/release-notes.xml
+++ b/doc/release-notes.xml
@@ -286,7 +286,7 @@ export NIX_MIRRORS_sourceforge=http://osdn.dl.sourceforge.net/sourceforge/</prog
   <note>
    <para>
     This release of Nixpkgs requires <link
-xlink:href='http://nixos.org/releases/nix/nix-0.10/'>Nix 0.10</link> or higher.
+xlink:href='https://nixos.org/releases/nix/nix-0.10/'>Nix 0.10</link> or higher.
    </para>
   </note>
 
@@ -436,7 +436,7 @@ stdenv.mkDerivation {
    <listitem>
     <para>
      Distribution files have been moved to <link
-  xlink:href="http://nixos.org/" />.
+  xlink:href="https://nixos.org/" />.
     </para>
    </listitem>
    <listitem>

--- a/maintainers/scripts/hydra-eval-failures.py
+++ b/maintainers/scripts/hydra-eval-failures.py
@@ -79,7 +79,7 @@ def cli(jobset):
     and print a summary of failed builds
     """
 
-    url = "http://hydra.nixos.org/jobset/{}".format(jobset)
+    url = "https://hydra.nixos.org/jobset/{}".format(jobset)
 
     # get the last evaluation
     click.echo(click.style(

--- a/nixos/README
+++ b/nixos/README
@@ -2,4 +2,4 @@
 
 NixOS is a Linux distribution based on the purely functional package
 management system Nix.  More information can be found at
-http://nixos.org/nixos and in the manual in doc/manual.
+https://nixos.org/nixos and in the manual in doc/manual.

--- a/nixos/doc/manual/configuration/adding-custom-packages.xml
+++ b/nixos/doc/manual/configuration/adding-custom-packages.xml
@@ -11,7 +11,7 @@
   the package to your clone, and (optionally) submit a patch or pull request to
   have it accepted into the main Nixpkgs repository. This is described in
   detail in the <link
-xlink:href="http://nixos.org/nixpkgs/manual">Nixpkgs
+xlink:href="https://nixos.org/nixpkgs/manual">Nixpkgs
   manual</link>. In short, you clone Nixpkgs:
 <screen>
 <prompt>$ </prompt>git clone https://github.com/NixOS/nixpkgs

--- a/nixos/doc/manual/configuration/config-syntax.xml
+++ b/nixos/doc/manual/configuration/config-syntax.xml
@@ -14,7 +14,7 @@
   when managing complex systems. The syntax and semantics of the Nix language
   are fully described in the
   <link
-xlink:href="http://nixos.org/nix/manual/#chap-writing-nix-expressions">Nix
+xlink:href="https://nixos.org/nix/manual/#chap-writing-nix-expressions">Nix
   manual</link>, but here we give a short overview of the most important
   constructs useful in NixOS configuration files.
  </para>

--- a/nixos/doc/manual/configuration/summary.xml
+++ b/nixos/doc/manual/configuration/summary.xml
@@ -10,7 +10,7 @@
   expression language. It’s not complete. In particular, there are many other
   built-in functions. See the
   <link
-xlink:href="http://nixos.org/nix/manual/#chap-writing-nix-expressions">Nix
+xlink:href="https://nixos.org/nix/manual/#chap-writing-nix-expressions">Nix
   manual</link> for the rest.
  </para>
 

--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -57,7 +57,7 @@
     <listitem>
      <para>
       <link xlink:href="https://github.com/NixOS/nixos-org-configurations/pull/18">
-      Make sure a channel is created at http://nixos.org/channels/. </link>
+      Make sure a channel is created at https://nixos.org/channels/. </link>
      </para>
     </listitem>
     <listitem>

--- a/nixos/doc/manual/development/replace-modules.xml
+++ b/nixos/doc/manual/development/replace-modules.xml
@@ -37,7 +37,7 @@
 
   imports =
     [ # Use postgresql service from nixos-unstable channel.
-      # sudo nix-channel --add http://nixos.org/channels/nixos-unstable nixos-unstable
+      # sudo nix-channel --add https://nixos.org/channels/nixos-unstable nixos-unstable
       &lt;nixos-unstable/nixos/modules/services/databases/postgresql.nix&gt;
     ];
 

--- a/nixos/doc/manual/installation/obtaining.xml
+++ b/nixos/doc/manual/installation/obtaining.xml
@@ -7,7 +7,7 @@
  <para>
   NixOS ISO images can be downloaded from the
   <link
-xlink:href="http://nixos.org/nixos/download.html">NixOS download
+xlink:href="https://nixos.org/nixos/download.html">NixOS download
   page</link>. There are a number of installation options. If you happen to
   have an optical drive and a spare CD, burning the image to CD and booting
   from that is probably the easiest option. Most people will need to prepare a
@@ -26,7 +26,7 @@ xlink:href="https://nixos.wiki/wiki/NixOS_Installation_Guide#Making_the_installa
     <para>
      Using virtual appliances in Open Virtualization Format (OVF) that can be
      imported into VirtualBox. These are available from the
-     <link xlink:href="http://nixos.org/nixos/download.html">NixOS download
+     <link xlink:href="https://nixos.org/nixos/download.html">NixOS download
      page</link>.
     </para>
    </listitem>

--- a/nixos/doc/manual/release-notes/rl-1404.xml
+++ b/nixos/doc/manual/release-notes/rl-1404.xml
@@ -49,7 +49,7 @@
     <para>
      Nix has been updated to 1.7
      (<link
-  xlink:href="http://nixos.org/nix/manual/#ssec-relnotes-1.7">details</link>).
+  xlink:href="https://nixos.org/nix/manual/#ssec-relnotes-1.7">details</link>).
     </para>
    </listitem>
    <listitem>

--- a/nixos/doc/manual/release-notes/rl-1509.xml
+++ b/nixos/doc/manual/release-notes/rl-1509.xml
@@ -22,7 +22,7 @@
     in excess of 8,000 Haskell packages. Detailed instructions on how to use
     that infrastructure can be found in the
     <link
-    xlink:href="http://nixos.org/nixpkgs/manual/#users-guide-to-the-haskell-infrastructure">User's
+    xlink:href="https://nixos.org/nixpkgs/manual/#users-guide-to-the-haskell-infrastructure">User's
     Guide to the Haskell Infrastructure</link>. Users migrating from an earlier
     release may find helpful information below, in the list of
     backwards-incompatible changes. Furthermore, we distribute 51(!) additional
@@ -555,7 +555,7 @@ nix-env -f &quot;&lt;nixpkgs&gt;&quot; -iA haskellPackages.pandoc
      the compiler now is the <literal>haskellPackages.ghcWithPackages</literal>
      function. The
      <link
-    xlink:href="http://nixos.org/nixpkgs/manual/#users-guide-to-the-haskell-infrastructure">User's
+    xlink:href="https://nixos.org/nixpkgs/manual/#users-guide-to-the-haskell-infrastructure">User's
      Guide to the Haskell Infrastructure</link> provides more information about
      this subject.
     </para>

--- a/nixos/doc/manual/release-notes/rl-1603.xml
+++ b/nixos/doc/manual/release-notes/rl-1603.xml
@@ -54,7 +54,7 @@
     xlink:href="https://reproducible-builds.org/specs/source-date-epoch/">SOURCE_DATE_EPOCH</envar>
     to a deterministic value, and Nix has
     <link
-    xlink:href="http://nixos.org/nix/manual/#ssec-relnotes-1.11">gained
+    xlink:href="https://nixos.org/nix/manual/#ssec-relnotes-1.11">gained
     an option</link> to repeat a build a number of times to test determinism.
     An ongoing project, the goal of exact reproducibility is to allow binaries
     to be verified independently (e.g., a user might only trust binaries that

--- a/nixos/modules/programs/venus.nix
+++ b/nixos/modules/programs/venus.nix
@@ -75,7 +75,7 @@ in
       };
 
       link = mkOption {
-        default = "http://planet.nixos.org";
+        default = "https://planet.nixos.org";
         type = types.str;
         description = ''
           Link to the main page.

--- a/nixos/modules/services/editors/emacs.xml
+++ b/nixos/modules/services/editors/emacs.xml
@@ -294,7 +294,7 @@ https://nixos.org/nixpkgs/manual/#sec-modify-via-packageOverrides
     If you are not on NixOS or want to install this particular Emacs only for
     yourself, you can do so by adding it to your
     <filename>~/.config/nixpkgs/config.nix</filename> (see
-    <link xlink:href="http://nixos.org/nixpkgs/manual/#sec-modify-via-packageOverrides">Nixpkgs
+    <link xlink:href="https://nixos.org/nixpkgs/manual/#sec-modify-via-packageOverrides">Nixpkgs
     manual</link>):
     <example xml:id="module-services-emacs-config-nix">
      <title>Custom Emacs in <filename>~/.config/nixpkgs/config.nix</filename></title>

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -283,7 +283,7 @@ in
       trustedBinaryCaches = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        example = [ "http://hydra.nixos.org/" ];
+        example = [ "https://hydra.nixos.org/" ];
         description = ''
           List of binary cache URLs that non-root users can use (in
           addition to those specified using

--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -37,7 +37,7 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
     </head>
     <body onload="javascript:document.title='startup done'">
       <img src="file://${pkgs.fetchurl {
-        url = "http://nixos.org/logo/nixos-hex.svg";
+        url = "https://nixos.org/logo/nixos-hex.svg";
         sha256 = "07ymq6nw8kc22m7kzxjxldhiq8gzmc7f45kq2bvhbdm0w5s112s4";
       }}" />
     </body>

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -108,7 +108,7 @@ in {
     inherit image;
     sshPublicKey = snakeOilPublicKey;
 
-    # ### http://nixos.org/channels/nixos-unstable nixos
+    # ### https://nixos.org/channels/nixos-unstable nixos
     userData = ''
       { pkgs, ... }:
 

--- a/nixos/tests/udisks2.nix
+++ b/nixos/tests/udisks2.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 let
 
   stick = pkgs.fetchurl {
-    url = "http://nixos.org/~eelco/nix/udisks-test.img.xz";
+    url = "https://nixos.org/~eelco/nix/udisks-test.img.xz";
     sha256 = "0was1xgjkjad91nipzclaz5biv3m4b2nk029ga6nk7iklwi19l8b";
   };
 

--- a/pkgs/applications/networking/cluster/chronos/default.nix
+++ b/pkgs/applications/networking/cluster/chronos/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     description = "Fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules";
     maintainers = with maintainers; [ offline ];
     platforms   = platforms.unix;
-    broken = true; # doesn't build http://hydra.nixos.org/build/25768319
+    broken = true; # doesn't build https://hydra.nixos.org/build/25768319
   };
 }

--- a/pkgs/applications/networking/instant-messengers/vacuum/default.nix
+++ b/pkgs/applications/networking/instant-messengers/vacuum/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   ];
 
   # hack: needed to fix build issues in
-  # http://hydra.nixos.org/build/38322959/nixlog/1
+  # https://hydra.nixos.org/build/38322959/nixlog/1
   # should be an upstream issue but it's easy to fix
   NIX_LDFLAGS = "-lz";
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -65,7 +65,7 @@ in
 , # Shell code to build a netrc file for BASIC auth
   netrcPhase ? null
 
-, # Impure env vars (http://nixos.org/nix/manual/#sec-advanced-attributes)
+, # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
   # needed for netrcPhase
   netrcImpureEnvVars ? []
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -371,7 +371,7 @@ self: super: {
   static-resources = dontCheck super.static-resources;
   strive = dontCheck super.strive;                      # fails its own hlint test with tons of warnings
   svndump = dontCheck super.svndump;
-  tar = dontCheck super.tar; #http://hydra.nixos.org/build/25088435/nixlog/2 (fails only on 32-bit)
+  tar = dontCheck super.tar; #https://hydra.nixos.org/build/25088435/nixlog/2 (fails only on 32-bit)
   th-printf = dontCheck super.th-printf;
   thumbnail-plus = dontCheck super.thumbnail-plus;
   tickle = dontCheck super.tickle;

--- a/pkgs/development/interpreters/picoc/default.nix
+++ b/pkgs/development/interpreters/picoc/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   # Tests are currently broken on i686 see
-  # http://hydra.nixos.org/build/24003763/nixlog/1
+  # https://hydra.nixos.org/build/24003763/nixlog/1
   doCheck = if stdenv.isi686 then false else true;
   checkTarget = "test";
 

--- a/pkgs/development/libraries/check/default.nix
+++ b/pkgs/development/libraries/check/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "02zkfiyklckmivrfvdsrlzvzphkdsgjrz3igncw05dv5pshhq3xx";
   };
 
-  # Test can randomly fail: http://hydra.nixos.org/build/7243912
+  # Test can randomly fail: https://hydra.nixos.org/build/7243912
   doCheck = false;
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin CoreServices;

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -25,7 +25,7 @@ let self = stdenv.mkDerivation rec {
     (stdenv.lib.enableFeature cxx "cxx")
     # Build a "fat binary", with routines for several sub-architectures
     # (x86), except on Solaris where some tests crash with "Memory fault".
-    # See <http://hydra.nixos.org/build/2760931>, for instance.
+    # See <https://hydra.nixos.org/build/2760931>, for instance.
     #
     # no darwin because gmp uses ASM that clang doesn't like
     (stdenv.lib.enableFeature (!stdenv.isSunOS && stdenv.hostPlatform.isx86) "fat")

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -27,7 +27,7 @@ let self = stdenv.mkDerivation rec {
     (stdenv.lib.enableFeature cxx "cxx")
     # Build a "fat binary", with routines for several sub-architectures
     # (x86), except on Solaris where some tests crash with "Memory fault".
-    # See <http://hydra.nixos.org/build/2760931>, for instance.
+    # See <https://hydra.nixos.org/build/2760931>, for instance.
     #
     # no darwin because gmp uses ASM that clang doesn't like
     (stdenv.lib.enableFeature (!stdenv.isSunOS && stdenv.hostPlatform.isx86) "fat")

--- a/pkgs/development/libraries/gnutls-kdh/generic.nix
+++ b/pkgs/development/libraries/gnutls-kdh/generic.nix
@@ -11,7 +11,7 @@
 assert guileBindings -> guile != null;
 let
   # XXX: Gnulib's `test-select' fails on FreeBSD:
-  # http://hydra.nixos.org/build/2962084/nixlog/1/raw .
+  # https://hydra.nixos.org/build/2962084/nixlog/1/raw .
   doCheck = !stdenv.isFreeBSD && !stdenv.isDarwin && lib.versionAtLeast version "3.4";
 in
 stdenv.mkDerivation {

--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -11,7 +11,7 @@ let
   version = "3.6.12";
 
   # XXX: Gnulib's `test-select' fails on FreeBSD:
-  # http://hydra.nixos.org/build/2962084/nixlog/1/raw .
+  # https://hydra.nixos.org/build/2962084/nixlog/1/raw .
   doCheck = !stdenv.isFreeBSD && !stdenv.isDarwin && lib.versionAtLeast version "3.4"
       && stdenv.buildPlatform == stdenv.hostPlatform;
 

--- a/pkgs/development/libraries/libgpg-error/default.nix
+++ b/pkgs/development/libraries/libgpg-error/default.nix
@@ -60,7 +60,7 @@ in stdenv.mkDerivation (rec {
     # For some reason, /bin/sh on OpenIndiana leads to this at the end of the
     # `config.status' run:
     #   ./config.status[1401]: shift: (null): bad number
-    # (See <http://hydra.nixos.org/build/2931046/nixlog/1/raw>.)
+    # (See <https://hydra.nixos.org/build/2931046/nixlog/1/raw>.)
     # Thus, re-run it with Bash.
       "${stdenv.shell} config.status";
 

--- a/pkgs/development/python-modules/eggdeps/default.nix
+++ b/pkgs/development/python-modules/eggdeps/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ zope_interface zope_testing ];
 
-  # tests fail, see http://hydra.nixos.org/build/4316603/log/raw
+  # tests fail, see https://hydra.nixos.org/build/4316603/log/raw
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -102,7 +102,7 @@ buildPythonPackage rec {
     })
   ];
 
-  # Seems to fail unpredictably on Darwin. See http://hydra.nixos.org/build/49877419/nixlog/1
+  # Seems to fail unpredictably on Darwin. See https://hydra.nixos.org/build/49877419/nixlog/1
   # for one example, but I've also seen ContextTests.test_set_verify_callback_exception fail.
   doCheck = !stdenv.isDarwin;
 

--- a/pkgs/games/dwarf-fortress/df_permission
+++ b/pkgs/games/dwarf-fortress/df_permission
@@ -12,7 +12,7 @@ Tarn
 On Fri, Oct 29, 2010 at 6:56 AM,  <roconnor@theorem.ca> wrote:
 > I'd like to distribute a *slightly* modified version of Dwarf Fortress which
 > is needed to run it under the NixOS distribution of Linux (see
-> <http://nixos.org/>
+> <https://nixos.org/>
 >
 > Modification: The interpreter location /lib/ld-linux.so.2 in
 > lib/Dwarf_Fortress is replaced with the location of ld-linux.so.2 under the

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -177,7 +177,7 @@ in rec {
   nixStable = callPackage common (rec {
     name = "nix-2.3.4";
     src = fetchurl {
-      url = "http://nixos.org/releases/nix/${name}/${name}.tar.xz";
+      url = "https://nixos.org/releases/nix/${name}/${name}.tar.xz";
       sha256 = "1c626a0de0acc69830b1891ec4d3c96aabe673b2a9fd04cef84f2304d05ad00d";
     };
 

--- a/pkgs/tools/package-management/nixops/nixops-v1_6_1.nix
+++ b/pkgs/tools/package-management/nixops/nixops-v1_6_1.nix
@@ -3,7 +3,7 @@
 callPackage ./generic.nix (rec {
   version = "1.6.1";
   src = fetchurl {
-    url = "http://nixos.org/releases/nixops/nixops-${version}/nixops-${version}.tar.bz2";
+    url = "https://nixos.org/releases/nixops/nixops-${version}/nixops-${version}.tar.bz2";
     sha256 = "0lfx5fhyg3z6725ydsk0ibg5qqzp5s0x9nbdww02k8s307axiah3";
   };
   nixopsAzurePackages = with python2Packages; [

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -1,6 +1,6 @@
 /* TeX Live user docs
   - source: ../../../../../doc/languages-frameworks/texlive.xml
-  - current html: http://nixos.org/nixpkgs/manual/#sec-language-texlive
+  - current html: https://nixos.org/nixpkgs/manual/#sec-language-texlive
 */
 { stdenv, lib, fetchurl, runCommand, writeText, buildEnv
 , callPackage, ghostscriptX, harfbuzz, poppler_min

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25922,7 +25922,7 @@ in
 
   texFunctions = callPackage ../tools/typesetting/tex/nix pkgs;
 
-  # TeX Live; see http://nixos.org/nixpkgs/manual/#sec-language-texlive
+  # TeX Live; see https://nixos.org/nixpkgs/manual/#sec-language-texlive
   texlive = recurseIntoAttrs
     (callPackage ../tools/typesetting/tex/texlive { });
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Let's use https for nixos.org and hydra.nixos.org.

tarballs.nixos.org is omitted from the change because urls from there are always hashed and checked

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
