### PR TITLE
afl: fix afl-clang-fast++ by making it a copy of afl-clang-fast, not a symlink

### DIFF
--- a/pkgs/tools/security/afl/default.nix
+++ b/pkgs/tools/security/afl/default.nix
@@ -47,6 +47,11 @@ let
       # has totally different semantics in that case(?) - and also set a
       # proper AFL_CC and AFL_CXX so we don't pick up the wrong one out
       # of $PATH.
+      # first though we need to replace the afl-clang-fast++ symlink with
+      # a real copy to prevent wrapProgram skipping the symlink and confusing
+      # nix's cc wrapper
+      rm $out/bin/afl-clang-fast++
+      cp $out/bin/afl-clang-fast $out/bin/afl-clang-fast++
       for x in $out/bin/afl-clang-fast $out/bin/afl-clang-fast++; do
         wrapProgram $x \
           --prefix AFL_PATH : "$out/lib/afl" \


### PR DESCRIPTION
###### Motivation for this change
`wrapProgram` seems to perform some sort of `realpath` check and ends up wrapping the symlink's target directly, skipping `afl-clang-fast++` entirely. Unfortunately, nix's cc wrapper relies on inspecting `argv[0]` as part of its cpp-mode detection, and will switch back to c mode if it can't find a `++`.

Ultimately it would be nice to have the option to disable this `realpath` check of `wrapProgram`, but for now the penalty is just a small addition to the on-disk size of the package.

cc @thoughtpolice 

Anyone interested in this package might also consider approving #76645 which I've just updated similarly. `aflplusplus` is better and more maintainable (has tests!).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
