### PR TITLE
gopass: Add passAlias parameter to derivation

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -48,7 +48,7 @@ buildGoModule rec {
     description     = "The slightly more awesome Standard Unix Password Manager for Teams. Written in Go.";
     homepage        = "https://www.gopass.pw/";
     license         = licenses.mit;
-    maintainers     = with maintainers; [ andir ];
+    maintainers     = with maintainers; [ andir rvolosatovs ];
     platforms       = platforms.unix;
 
     longDescription = ''

--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, buildGoModule, fetchFromGitHub, git, gnupg, xclip, wl-clipboard, installShellFiles, makeWrapper }:
+{ stdenv, makeWrapper
+, buildGoModule, fetchFromGitHub, installShellFiles
+, git
+, gnupg
+, xclip
+, wl-clipboard
+, passAlias ? false
+}:
 
 buildGoModule rec {
   pname = "gopass";
@@ -28,6 +35,8 @@ buildGoModule rec {
       $out/bin/gopass completion $shell > gopass.$shell
       installShellCompletion gopass.$shell
     done
+  '' + stdenv.lib.optionalString passAlias ''
+    ln -s $bin/bin/gopass $bin/bin/pass
   '';
 
   postFixup = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add a `passAlias` to `gopass` derivation, similarly to how there's `viAlias` parameter supported by vim/neovim derivations.
Apart from convenience this is also necessary for e.g. making `docker-credential-helpers` work without patching the latter - the package uses `pass` executable from `PATH` https://github.com/docker/docker-credential-helpers/blob/f78081d1f7fef6ad74ad6b79368de6348386e591/pass/pass_linux.go#L67. By setting `passAlias` to `true` (e.g. via overlays like so: https://github.com/rvolosatovs/infrastructure/blob/94971f34db9df79b6666e626fa52840eb1fee840/nixpkgs/overlays.nix#L315-L317), secure Docker authentication via `gopass` "just works"™

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
