### PR TITLE
[20.03] pythonPackages.{namedlist, ludios_wpull}: mark broken only on Python 3.8

### DIFF
--- a/pkgs/development/python-modules/ludios_wpull/default.nix
+++ b/pkgs/development/python-modules/ludios_wpull/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , isPy3k
+, isPy38
 , chardet
 , dnspython
 , html5-parser
@@ -16,7 +17,7 @@ buildPythonPackage rec {
   pname = "ludios_wpull";
   version = "3.0.7";
 
-  disabled = !isPy3k;
+  disabled = !isPy3k || isPy38;
 
   src = fetchFromGitHub {
     rev = version;
@@ -35,6 +36,5 @@ buildPythonPackage rec {
     homepage = https://github.com/ludios/wpull;
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ ivan ];
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/namedlist/default.nix
+++ b/pkgs/development/python-modules/namedlist/default.nix
@@ -2,11 +2,14 @@
 , buildPythonPackage
 , fetchPypi
 , pytest
+, isPy38
 }:
 
 buildPythonPackage rec {
   pname = "namedlist";
   version = "1.7";
+
+  disabled = isPy38;
 
   src = fetchPypi {
     inherit pname version;
@@ -29,6 +32,5 @@ buildPythonPackage rec {
     homepage = https://bitbucket.org/ericvsmith/namedlist;
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ivan ];
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This undoes some of 5fe104de46afa84f317247f9e62794c15611a66c - these libraries work fine on Python 3.7 and are used by grab-site.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
