### PR TITLE
buildGoPackage: use $out instead of $bin

### DIFF
--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -192,18 +192,6 @@ deis = buildGoPackage rec {
   </para>
 
   <para>
-   <varname>buildGoPackage</varname> produces <xref linkend='chap-multiple-output' xrefstyle="select: title" /> where <varname>bin</varname> includes program binaries. You can test build a Go binary as follows:
-<screen>
-<prompt>$ </prompt>nix-build -A deis.bin
-</screen>
-   or build all outputs with:
-<screen>
-<prompt>$ </prompt>nix-build -A deis.all
-</screen>
-   <varname>bin</varname> output will be installed by default with <varname>nix-env -i</varname> or <varname>systemPackages</varname>.
-  </para>
-
-  <para>
    You may use Go packages installed into the active Nix profiles by adding the following to your ~/.bashrc:
 <screen>
 for p in $NIX_PROFILES; do

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -312,6 +312,11 @@ environment.systemPackages = [
      the <literal>notmuch.emacs</literal> output.
     </para>
    </listitem>
+   <listitem>
+   <para>
+     The default output of <literal>buildGoPackage</literal> is now <literal>$out</literal> instead of <literal>$bin</literal>.
+   </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/programs/singularity.nix
+++ b/nixos/modules/programs/singularity.nix
@@ -5,8 +5,8 @@ let
   cfg = config.programs.singularity;
   singularity = pkgs.singularity.overrideAttrs (attrs : {
     installPhase = attrs.installPhase + ''
-      mv $bin/libexec/singularity/bin/starter-suid $bin/libexec/singularity/bin/starter-suid.orig
-      ln -s /run/wrappers/bin/singularity-suid $bin/libexec/singularity/bin/starter-suid
+      mv $out/libexec/singularity/bin/starter-suid $out/libexec/singularity/bin/starter-suid.orig
+      ln -s /run/wrappers/bin/singularity-suid $out/libexec/singularity/bin/starter-suid
     '';
   });
 in {

--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -127,7 +127,7 @@ in
       serviceConfig = {
         StateDirectory = "gitlab-runner";
         ExecReload= "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-        ExecStart = ''${cfg.package.bin}/bin/gitlab-runner run \
+        ExecStart = ''${cfg.package}/bin/gitlab-runner run \
           --working-directory ${cfg.workDir} \
           --config /etc/gitlab-runner/config.toml \
           --service gitlab-runner \

--- a/nixos/modules/services/misc/confd.nix
+++ b/nixos/modules/services/misc/confd.nix
@@ -75,7 +75,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       serviceConfig = {
-        ExecStart = "${cfg.package.bin}/bin/confd";
+        ExecStart = "${cfg.package}/bin/confd";
       };
     };
 

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -178,7 +178,7 @@ in {
 
       serviceConfig = {
         Type = "notify";
-        ExecStart = "${pkgs.etcd.bin}/bin/etcd";
+        ExecStart = "${pkgs.etcd}/bin/etcd";
         User = "etcd";
         LimitNOFILE = 40000;
       };

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -335,7 +335,7 @@ in
       description = "gitea";
       after = [ "network.target" ] ++ lib.optional usePostgresql "postgresql.service" ++ lib.optional useMysql "mysql.service";
       wantedBy = [ "multi-user.target" ];
-      path = [ gitea.bin pkgs.gitAndTools.git ];
+      path = [ gitea pkgs.gitAndTools.git ];
 
       preStart = let
         runConfig = "${cfg.stateDir}/custom/conf/app.ini";
@@ -347,11 +347,11 @@ in
           cp -f ${configFile} ${runConfig}
 
           if [ ! -e ${secretKey} ]; then
-              ${gitea.bin}/bin/gitea generate secret SECRET_KEY > ${secretKey}
+              ${gitea}/bin/gitea generate secret SECRET_KEY > ${secretKey}
           fi
 
           if [ ! -e ${jwtSecret} ]; then
-              ${gitea.bin}/bin/gitea generate secret LFS_JWT_SECRET > ${jwtSecret}
+              ${gitea}/bin/gitea generate secret LFS_JWT_SECRET > ${jwtSecret}
           fi
 
           KEY="$(head -n1 ${secretKey})"
@@ -374,7 +374,7 @@ in
         HOOKS=$(find ${cfg.repositoryRoot} -mindepth 4 -maxdepth 6 -type f -wholename "*git/hooks/*")
         if [ "$HOOKS" ]
         then
-          sed -ri 's,/nix/store/[a-z0-9.-]+/bin/gitea,${gitea.bin}/bin/gitea,g' $HOOKS
+          sed -ri 's,/nix/store/[a-z0-9.-]+/bin/gitea,${gitea}/bin/gitea,g' $HOOKS
           sed -ri 's,/nix/store/[a-z0-9.-]+/bin/env,${pkgs.coreutils}/bin/env,g' $HOOKS
           sed -ri 's,/nix/store/[a-z0-9.-]+/bin/bash,${pkgs.bash}/bin/bash,g' $HOOKS
           sed -ri 's,/nix/store/[a-z0-9.-]+/bin/perl,${pkgs.perl}/bin/perl,g' $HOOKS
@@ -383,7 +383,7 @@ in
         # update command option in authorized_keys
         if [ -r ${cfg.stateDir}/.ssh/authorized_keys ]
         then
-          sed -ri 's,/nix/store/[a-z0-9.-]+/bin/gitea,${gitea.bin}/bin/gitea,g' ${cfg.stateDir}/.ssh/authorized_keys
+          sed -ri 's,/nix/store/[a-z0-9.-]+/bin/gitea,${gitea}/bin/gitea,g' ${cfg.stateDir}/.ssh/authorized_keys
         fi
       '';
 
@@ -392,7 +392,7 @@ in
         User = cfg.user;
         Group = "gitea";
         WorkingDirectory = cfg.stateDir;
-        ExecStart = "${gitea.bin}/bin/gitea web";
+        ExecStart = "${gitea}/bin/gitea web";
         Restart = "always";
 
         # Filesystem
@@ -450,7 +450,7 @@ in
        description = "gitea dump";
        after = [ "gitea.service" ];
        wantedBy = [ "default.target" ];
-       path = [ gitea.bin ];
+       path = [ gitea ];
 
        environment = {
          USER = cfg.user;
@@ -461,7 +461,7 @@ in
        serviceConfig = {
          Type = "oneshot";
          User = cfg.user;
-         ExecStart = "${gitea.bin}/bin/gitea dump";
+         ExecStart = "${gitea}/bin/gitea dump";
          WorkingDirectory = cfg.stateDir;
        };
     };

--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -200,7 +200,7 @@ in
       description = "Gogs (Go Git Service)";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.gogs.bin ];
+      path = [ pkgs.gogs ];
 
       preStart = let
         runConfig = "${cfg.stateDir}/custom/conf/app.ini";
@@ -230,7 +230,7 @@ in
         HOOKS=$(find ${cfg.repositoryRoot} -mindepth 4 -maxdepth 4 -type f -wholename "*git/hooks/*")
         if [ "$HOOKS" ]
         then
-          sed -ri 's,/nix/store/[a-z0-9.-]+/bin/gogs,${pkgs.gogs.bin}/bin/gogs,g' $HOOKS
+          sed -ri 's,/nix/store/[a-z0-9.-]+/bin/gogs,${pkgs.gogs}/bin/gogs,g' $HOOKS
           sed -ri 's,/nix/store/[a-z0-9.-]+/bin/env,${pkgs.coreutils}/bin/env,g' $HOOKS
           sed -ri 's,/nix/store/[a-z0-9.-]+/bin/bash,${pkgs.bash}/bin/bash,g' $HOOKS
           sed -ri 's,/nix/store/[a-z0-9.-]+/bin/perl,${pkgs.perl}/bin/perl,g' $HOOKS
@@ -242,7 +242,7 @@ in
         User = cfg.user;
         Group = cfg.group;
         WorkingDirectory = cfg.stateDir;
-        ExecStart = "${pkgs.gogs.bin}/bin/gogs web";
+        ExecStart = "${pkgs.gogs}/bin/gogs web";
         Restart = "always";
       };
 

--- a/nixos/modules/services/misc/leaps.nix
+++ b/nixos/modules/services/misc/leaps.nix
@@ -55,7 +55,7 @@ in
         Restart = "on-failure";
         WorkingDirectory = stateDir;
         PrivateTmp = true;
-        ExecStart = "${pkgs.leaps.bin}/bin/leaps -path ${toString cfg.path} -address ${cfg.address}:${toString cfg.port}";
+        ExecStart = "${pkgs.leaps}/bin/leaps -path ${toString cfg.path} -address ${cfg.address}:${toString cfg.port}";
       };
     };
   };

--- a/nixos/modules/services/misc/ssm-agent.nix
+++ b/nixos/modules/services/misc/ssm-agent.nix
@@ -35,7 +35,7 @@ in {
 
       path = [ fake-lsb-release ];
       serviceConfig = {
-        ExecStart = "${cfg.package.bin}/bin/agent";
+        ExecStart = "${cfg.package}/bin/agent";
         KillMode = "process";
         Restart = "on-failure";
         RestartSec = "15min";
@@ -43,4 +43,3 @@ in {
     };
   };
 }
-

--- a/nixos/modules/services/monitoring/bosun.nix
+++ b/nixos/modules/services/monitoring/bosun.nix
@@ -148,7 +148,7 @@ in {
         User = cfg.user;
         Group = cfg.group;
         ExecStart = ''
-          ${cfg.package.bin}/bin/bosun -c ${configFile}
+          ${cfg.package}/bin/bosun -c ${configFile}
         '';
       };
     };

--- a/nixos/modules/services/monitoring/grafana-reporter.nix
+++ b/nixos/modules/services/monitoring/grafana-reporter.nix
@@ -59,7 +59,7 @@ in {
           "-templates ${cfg.templateDir}"
         ];
       in {
-        ExecStart = "${pkgs.grafana_reporter.bin}/bin/grafana-reporter ${args}";
+        ExecStart = "${pkgs.grafana_reporter}/bin/grafana-reporter ${args}";
       };
     };
   };

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -535,7 +535,7 @@ in {
         ${optionalString cfg.provision.enable ''
           export GF_PATHS_PROVISIONING=${provisionConfDir};
         ''}
-        exec ${cfg.package.bin}/bin/grafana-server -homepath ${cfg.dataDir}
+        exec ${cfg.package}/bin/grafana-server -homepath ${cfg.dataDir}
       '';
       serviceConfig = {
         WorkingDirectory = cfg.dataDir;

--- a/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
@@ -58,7 +58,7 @@ in
     in {
     serviceConfig = {
       ExecStart = ''
-        ${pkgs.prometheus-snmp-exporter.bin}/bin/snmp_exporter \
+        ${pkgs.prometheus-snmp-exporter}/bin/snmp_exporter \
           --config.file=${escapeShellArg configFile} \
           --log.format=${escapeShellArg cfg.logFormat} \
           --log.level=${cfg.logLevel} \

--- a/nixos/modules/services/monitoring/scollector.nix
+++ b/nixos/modules/services/monitoring/scollector.nix
@@ -118,7 +118,7 @@ in {
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
-        ExecStart = "${cfg.package.bin}/bin/scollector -conf=${conf} ${lib.concatStringsSep " " cfg.extraOpts}";
+        ExecStart = "${cfg.package}/bin/scollector -conf=${conf} ${lib.concatStringsSep " " cfg.extraOpts}";
       };
     };
 

--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -179,15 +179,15 @@ in
             (filterAttrs (n: _: hasPrefix "consul.d/" n) config.environment.etc);
 
         serviceConfig = {
-          ExecStart = "@${cfg.package.bin}/bin/consul consul agent -config-dir /etc/consul.d"
+          ExecStart = "@${cfg.package}/bin/consul consul agent -config-dir /etc/consul.d"
             + concatMapStrings (n: " -config-file ${n}") configFiles;
-          ExecReload = "${cfg.package.bin}/bin/consul reload";
+          ExecReload = "${cfg.package}/bin/consul reload";
           PermissionsStartOnly = true;
           User = if cfg.dropPrivileges then "consul" else null;
           Restart = "on-failure";
           TimeoutStartSec = "infinity";
         } // (optionalAttrs (cfg.leaveOnStop) {
-          ExecStop = "${cfg.package.bin}/bin/consul leave";
+          ExecStop = "${cfg.package}/bin/consul leave";
         });
 
         path = with pkgs; [ iproute gnugrep gawk consul ];
@@ -238,7 +238,7 @@ in
 
         serviceConfig = {
           ExecStart = ''
-            ${cfg.alerts.package.bin}/bin/consul-alerts start \
+            ${cfg.alerts.package}/bin/consul-alerts start \
               --alert-addr=${cfg.alerts.listenAddr} \
               --consul-addr=${cfg.alerts.consulAddr} \
               ${optionalString cfg.alerts.watchChecks "--watch-checks"} \

--- a/nixos/modules/services/networking/flannel.nix
+++ b/nixos/modules/services/networking/flannel.nix
@@ -19,8 +19,8 @@ in {
     package = mkOption {
       description = "Package to use for flannel";
       type = types.package;
-      default = pkgs.flannel.bin;
-      defaultText = "pkgs.flannel.bin";
+      default = pkgs.flannel;
+      defaultText = "pkgs.flannel";
     };
 
     publicIp = mkOption {
@@ -167,7 +167,7 @@ in {
         touch /run/flannel/docker
       '' + optionalString (cfg.storageBackend == "etcd") ''
         echo "setting network configuration"
-        until ${pkgs.etcdctl.bin}/bin/etcdctl set /coreos.com/network/config '${builtins.toJSON networkConfig}'
+        until ${pkgs.etcdctl}/bin/etcdctl set /coreos.com/network/config '${builtins.toJSON networkConfig}'
         do
           echo "setting network configuration, retry"
           sleep 1

--- a/nixos/modules/services/networking/skydns.nix
+++ b/nixos/modules/services/networking/skydns.nix
@@ -83,7 +83,7 @@ in {
         SKYDNS_NAMESERVERS = concatStringsSep "," cfg.nameservers;
       };
       serviceConfig = {
-        ExecStart = "${cfg.package.bin}/bin/skydns";
+        ExecStart = "${cfg.package}/bin/skydns";
       };
     };
 

--- a/nixos/modules/services/security/hologram-agent.nix
+++ b/nixos/modules/services/security/hologram-agent.nix
@@ -43,12 +43,12 @@ in {
       description = "Provide EC2 instance credentials to machines outside of EC2";
       after       = [ "network.target" ];
       wantedBy    = [ "multi-user.target" ];
-      requires    = [ "network-link-dummy0.service" "network-addresses-dummy0.service" ]; 
+      requires    = [ "network-link-dummy0.service" "network-addresses-dummy0.service" ];
       preStart = ''
         /run/current-system/sw/bin/rm -fv /run/hologram.sock
       '';
       serviceConfig = {
-        ExecStart = "${pkgs.hologram.bin}/bin/hologram-agent -debug -conf ${cfgFile} -port ${cfg.httpPort}";
+        ExecStart = "${pkgs.hologram}/bin/hologram-agent -debug -conf ${cfgFile} -port ${cfg.httpPort}";
       };
     };
 

--- a/nixos/modules/services/security/hologram-server.nix
+++ b/nixos/modules/services/security/hologram-server.nix
@@ -123,7 +123,7 @@ in {
       wantedBy    = [ "multi-user.target" ];
 
       serviceConfig = {
-        ExecStart = "${pkgs.hologram.bin}/bin/hologram-server --debug --conf ${cfgFile}";
+        ExecStart = "${pkgs.hologram}/bin/hologram-server --debug --conf ${cfgFile}";
       };
     };
   };

--- a/nixos/modules/services/security/oauth2_proxy.nix
+++ b/nixos/modules/services/security/oauth2_proxy.nix
@@ -577,7 +577,7 @@ in
       serviceConfig = {
         User = "oauth2_proxy";
         Restart = "always";
-        ExecStart = "${cfg.package.bin}/bin/oauth2_proxy ${configString}";
+        ExecStart = "${cfg.package}/bin/oauth2_proxy ${configString}";
         EnvironmentFile = mkIf (cfg.keyFile != null) cfg.keyFile;
       };
     };

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -224,7 +224,7 @@ in
         serviceConfig = {
           User = "nobody";
           Group = "nogroup";
-          ExecStart = "${pkgs.matterircd.bin}/bin/matterircd ${concatStringsSep " " cfg.matterircd.parameters}";
+          ExecStart = "${pkgs.matterircd}/bin/matterircd ${concatStringsSep " " cfg.matterircd.parameters}";
           WorkingDirectory = "/tmp";
           PrivateTmp = true;
           Restart = "always";

--- a/nixos/modules/virtualisation/ecs-agent.nix
+++ b/nixos/modules/virtualisation/ecs-agent.nix
@@ -38,9 +38,8 @@ in {
         if [ ! -z "$ECS_DATADIR" ]; then
           mkdir -p "$ECS_DATADIR"
         fi
-        ${cfg.package.bin}/bin/agent
+        ${cfg.package}/bin/agent
       '';
     };
   };
 }
-

--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -108,7 +108,7 @@ in
       '';
 
       serviceConfig = {
-        ExecStart = "@${cfg.package.bin}/bin/lxd lxd --group lxd";
+        ExecStart = "@${cfg.package}/bin/lxd lxd --group lxd";
         Type = "simple";
         KillMode = "process"; # when stopping, leave the containers alone
         LimitMEMLOCK = "infinity";

--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -6,13 +6,11 @@ let
 
   # Provides a fake "docker" binary mapping to podman
   dockerCompat = pkgs.runCommandNoCC "${pkgs.podman.pname}-docker-compat-${pkgs.podman.version}" {
-    outputs = [ "out" "bin" "man" ];
+    outputs = [ "out" "man" ];
     inherit (pkgs.podman) meta;
   } ''
-    mkdir $out
-
-    mkdir -p $bin/bin
-    ln -s ${pkgs.podman.bin}/bin/podman $bin/bin/docker
+    mkdir -p $out/bin
+    ln -s ${pkgs.podman}/bin/podman $out/bin/docker
 
     mkdir -p $man/share/man/man1
     for f in ${pkgs.podman.man}/share/man/man1/*; do

--- a/pkgs/applications/blockchains/dcrwallet.nix
+++ b/pkgs/applications/blockchains/dcrwallet.nix
@@ -29,8 +29,8 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    mkdir -pv $bin/bin
-    cp -v dcrwallet $bin/bin
+    mkdir -pv $out/bin
+    cp -v dcrwallet $out/bin
   '';
 
 

--- a/pkgs/applications/blockchains/quorum.nix
+++ b/pkgs/applications/blockchains/quorum.nix
@@ -21,8 +21,8 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    mkdir -pv $bin/bin
-    cp -v build/bin/geth build/bin/bootnode build/bin/swarm $bin/bin
+    mkdir -pv $out/bin
+    cp -v build/bin/geth build/bin/bootnode build/bin/swarm $out/bin
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/overmind/default.nix
+++ b/pkgs/applications/misc/overmind/default.nix
@@ -8,7 +8,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
-    wrapProgram "$bin/bin/overmind" --prefix PATH : "${lib.makeBinPath [ tmux which ]}"
+    wrapProgram "$out/bin/overmind" --prefix PATH : "${lib.makeBinPath [ tmux which ]}"
   '';
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -126,8 +126,8 @@ let
     installPhase = ''
       pushd go/src/${goPackagePath}
 
-      mkdir -p "$bin/bin"
-      install -m 0755 -t "$bin/bin" ./bin/*
+      mkdir -p "$out/bin"
+      install -m 0755 -t "$out/bin" ./bin/*
 
       popd
     '';
@@ -181,8 +181,8 @@ let
     installPhase = ''
       pushd go/src/${goPackagePath}
 
-      mkdir -p "$bin/bin"
-      install -m 0755 -t "$bin/bin" ./dist/artifacts/k3s
+      mkdir -p "$out/bin"
+      install -m 0755 -t "$out/bin" ./dist/artifacts/k3s
 
       popd
     '';

--- a/pkgs/applications/networking/cluster/kompose/default.nix
+++ b/pkgs/applications/networking/cluster/kompose/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ installShellFiles ];
   postInstall = ''
     for shell in bash zsh; do
-      $bin/bin/kompose completion $shell > kompose.$shell
+      $out/bin/kompose completion $shell > kompose.$shell
       installShellCompletion kompose.$shell
     done
   '';

--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -34,7 +34,7 @@ let
 
         postInstall = ''
           for shell in bash zsh; do
-            $bin/bin/kops completion $shell > kops.$shell
+            $out/bin/kops completion $shell > kops.$shell
             installShellCompletion kops.$shell
           done
         '';

--- a/pkgs/applications/networking/cluster/minishift/default.nix
+++ b/pkgs/applications/networking/cluster/minishift/default.nix
@@ -48,7 +48,7 @@ in buildGoPackage rec {
   '';
 
   postInstall = ''
-    wrapProgram "$bin/bin/minishift" \
+    wrapProgram "$out/bin/minishift" \
       --prefix PATH ':' '${lib.makeBinPath [ docker-machine-kvm openshift ]}'
   '';
 

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -72,8 +72,8 @@ in buildGoPackage rec {
   '';
 
   installPhase = ''
-    mkdir -p $bin/bin
-    cp -a "_output/local/bin/$(go env GOOS)/$(go env GOARCH)/"* "$bin/bin/"
+    mkdir -p $out/bin
+    cp -a "_output/local/bin/$(go env GOOS)/$(go env GOARCH)/"* "$out/bin/"
     installShellCompletion --bash contrib/completions/bash/*
     installShellCompletion --zsh contrib/completions/zsh/*
   '';

--- a/pkgs/applications/networking/cluster/stern/default.nix
+++ b/pkgs/applications/networking/cluster/stern/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall =
-    let stern = if isCrossBuild then buildPackages.stern else "$bin"; in
+    let stern = if isCrossBuild then buildPackages.stern else "$out"; in
     ''
       for shell in bash zsh; do
         ${stern}/bin/stern --completion $shell > stern.$shell

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -26,7 +26,7 @@ let
 
       postInstall = ''
         # remove all plugins, they are part of the main binary now
-        for i in $bin/bin/*; do
+        for i in $out/bin/*; do
           if [[ $(basename $i) != terraform ]]; then
             rm "$i"
           fi
@@ -88,7 +88,7 @@ let
 
             buildCommand = ''
               mkdir -p $out/bin/
-              makeWrapper "${terraform.bin}/bin/terraform" "$out/bin/terraform" \
+              makeWrapper "${terraform}/bin/terraform" "$out/bin/terraform" \
                 --set NIX_TERRAFORM_PLUGIN_DIR "${
                   buildEnv {
                     name = "tf-plugin-env";

--- a/pkgs/applications/networking/cluster/terragrunt/default.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/default.nix
@@ -23,7 +23,7 @@ buildGoPackage rec {
   '';
 
   postInstall = ''
-    wrapProgram $bin/bin/terragrunt \
+    wrapProgram $out/bin/terragrunt \
       --set TERRAGRUNT_TFPATH ${lib.getBin terraform.full}/bin/terraform
   '';
 

--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -15,7 +15,7 @@ buildGoPackage rec {
 
   subPackages = [ "." ];
 
-  outputs = [ "bin" "out" "man" ];
+  outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -23,7 +23,7 @@ buildGoPackage rec {
     let
       rcloneBin =
         if stdenv.buildPlatform == stdenv.hostPlatform
-        then "$bin"
+        then "$out"
         else stdenv.lib.getBin buildPackages.rclone;
     in
       ''

--- a/pkgs/applications/version-management/git-and-tools/grv/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/grv/default.nix
@@ -36,7 +36,7 @@ buildGoPackage {
 
   installPhase = ''
     runHook preInstall
-    install -D grv $bin/bin/grv
+    install -D grv $out/bin/grv
     runHook postInstall
   '';
 

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -44,7 +44,7 @@ buildGoPackage rec {
     )
   '';
 
-  outputs = [ "bin" "out" "data" ];
+  outputs = [ "out" "data" ];
 
   postInstall = ''
     mkdir $data
@@ -52,7 +52,7 @@ buildGoPackage rec {
     mkdir -p $out
     cp -R ./go/src/${goPackagePath}/options/locale $out/locale
 
-    wrapProgram $bin/bin/gitea \
+    wrapProgram $out/bin/gitea \
       --prefix PATH : ${makeBinPath [ bash git gzip openssh ]}
   '';
 

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -65,7 +65,7 @@ in buildGoPackage rec {
        "'/run/gitlab/shell-config.yml'"
   '';
 
-  outputs = [ "bin" "out" "ruby" ];
+  outputs = [ "out" "ruby" ];
 
   meta = with stdenv.lib; {
     homepage = "https://gitlab.com/gitlab-org/gitaly";

--- a/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
@@ -18,8 +18,8 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   postInstall = ''
-    cp -r "$NIX_BUILD_TOP/go/src/$goPackagePath"/bin/* $bin/bin
-    cp -r "$NIX_BUILD_TOP/go/src/$goPackagePath"/{support,VERSION} $bin/
+    cp -r "$NIX_BUILD_TOP/go/src/$goPackagePath"/bin/* $out/bin
+    cp -r "$NIX_BUILD_TOP/go/src/$goPackagePath"/{support,VERSION} $out/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/gogs/default.nix
+++ b/pkgs/applications/version-management/gogs/default.nix
@@ -34,13 +34,13 @@ buildGoPackage rec {
     (  optional sqliteSupport "sqlite"
     ++ optional pamSupport "pam");
 
-  outputs = [ "bin" "out" "data" ];
+  outputs = [ "out" "data" ];
 
   postInstall = ''
     mkdir $data
     cp -R $src/{public,templates} $data
 
-    wrapProgram $bin/bin/gogs \
+    wrapProgram $out/bin/gogs \
       --prefix PATH : ${makeBinPath [ bash git gzip openssh ]}
   '';
 

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -14,7 +14,7 @@ buildGoPackage rec {
   };
 
   goPackagePath = "github.com/containerd/containerd";
-  outputs = [ "bin" "out" "man" ];
+  outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ go-md2man utillinux ];
 
@@ -33,7 +33,7 @@ buildGoPackage rec {
 
   installPhase = ''
     for b in bin/*; do
-      install -Dm555 $b $bin/$b
+      install -Dm555 $b $out/$b
     done
 
     make man

--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -32,7 +32,6 @@ in buildGoPackage rec {
     sha256 = "1cy2lqasfn5n20vlm3ckb6myci8ya6qv08dw8fq7z4ycnm39r1a6";
   };
 
-  outputs = [ "bin" "out" ];
   nativeBuildInputs = [ git pkgconfig which ];
   buildInputs = [ btrfs-progs gpgme libapparmor libassuan libgpgerror
                  libseccomp libselinux lvm2 ]
@@ -47,9 +46,9 @@ in buildGoPackage rec {
       bin/pinns
   '';
   installPhase = ''
-    install -Dm755 bin/crio $bin/bin/crio${flavor}
-    install -Dm755 bin/crio-status $bin/bin/crio-status${flavor}
-    install -Dm755 bin/pinns $bin/bin/pinns${flavor}
+    install -Dm755 bin/crio $out/bin/crio${flavor}
+    install -Dm755 bin/crio-status $out/bin/crio-status${flavor}
+    install -Dm755 bin/pinns $out/bin/pinns${flavor}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/virtualization/docker-slim/default.nix
+++ b/pkgs/applications/virtualization/docker-slim/default.nix
@@ -33,7 +33,7 @@ buildGoPackage rec {
   # docker-slim tries to create its state dir next to the binary (inside the nix
   # store), so we set it to use the working directory at the time of invocation
   postInstall = ''
-    wrapProgram "$bin/bin/docker-slim" --add-flags '--state-path "$(pwd)"'
+    wrapProgram "$out/bin/docker-slim" --add-flags '--state-path "$(pwd)"'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/virtualization/docker/proxy.nix
+++ b/pkgs/applications/virtualization/docker/proxy.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
   goDeps = null;
 
   installPhase = ''
-    install -m755 -D ./go/bin/proxy $bin/bin/docker-proxy
+    install -m755 -D ./go/bin/proxy $out/bin/docker-proxy
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -25,7 +25,7 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/containers/libpod";
 
-  outputs = [ "bin" "out" "man" ];
+  outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ pkg-config go-md2man installShellFiles ];
 
@@ -40,7 +40,7 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    install -Dm555 bin/podman $bin/bin/podman
+    install -Dm555 bin/podman $out/bin/podman
     installShellCompletion --bash completions/bash/podman
     installShellCompletion --zsh completions/zsh/_podman
     MANDIR=$man/share/man make install.man

--- a/pkgs/applications/virtualization/runc/default.nix
+++ b/pkgs/applications/virtualization/runc/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
   };
 
   goPackagePath = "github.com/opencontainers/runc";
-  outputs = [ "bin" "out" "man" ];
+  outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ go-md2man installShellFiles pkg-config which ];
   buildInputs = [ libseccomp libapparmor apparmor-parser ];
@@ -38,7 +38,7 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    install -Dm755 runc $bin/bin/runc
+    install -Dm755 runc $out/bin/runc
     installManPage man/*/*
   '';
 

--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -42,7 +42,7 @@ buildGoPackage rec {
     patchShebangs .
     sed -i 's|defaultPath := "[^"]*"|defaultPath := "${stdenv.lib.makeBinPath propagatedBuildInputs}"|' cmd/internal/cli/actions.go
 
-    ./mconfig -V ${version} -p $bin --localstatedir=/var
+    ./mconfig -V ${version} -p $out --localstatedir=/var
 
     # Don't install SUID binaries
     sed -i 's/-m 4755/-m 755/g' builddir/Makefile
@@ -54,16 +54,16 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    make -C builddir install LOCALSTATEDIR=$bin/var
-    chmod 755 $bin/libexec/singularity/bin/starter-suid
-    wrapProgram $bin/bin/singularity --prefix PATH : ${stdenv.lib.makeBinPath propagatedBuildInputs}
+    make -C builddir install LOCALSTATEDIR=$out/var
+    chmod 755 $out/libexec/singularity/bin/starter-suid
+    wrapProgram $out/bin/singularity --prefix PATH : ${stdenv.lib.makeBinPath propagatedBuildInputs}
   '';
 
   postFixup = ''
-    find $bin/ -type f -executable -exec remove-references-to -t ${go} '{}' + || true
+    find $out/libexec/ -type f -executable -exec remove-references-to -t ${go} '{}' + || true
 
     # These etc scripts shouldn't have their paths patched
-    cp etc/actions/* $bin/etc/singularity/actions/
+    cp etc/actions/* $out/etc/singularity/actions/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/deepin/dde-api/default.nix
+++ b/pkgs/desktops/deepin/dde-api/default.nix
@@ -37,8 +37,6 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  outputs = [ "out" ];
-
   nativeBuildInputs = [
     pkgconfig
     deepin-gettext-tools # build
@@ -109,7 +107,7 @@ buildGoPackage rec {
   installPhase = ''
     make install PREFIX="$out" SYSTEMD_LIB_DIR="$out/lib" -C go/src/${goPackagePath}
     mv $out/share/gocode $out/share/go
-    remove-references-to -t ${go} $out/bin/* $out/lib/deepin-api/*
+    remove-references-to -t ${go} $out/lib/deepin-api/*
   '';
 
   postFixup = ''

--- a/pkgs/desktops/deepin/dde-daemon/default.nix
+++ b/pkgs/desktops/deepin/dde-daemon/default.nix
@@ -29,8 +29,6 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  outputs = [ "out" ];
-
   nativeBuildInputs = [
     pkgconfig
     dbus-factory

--- a/pkgs/desktops/deepin/startdde/default.nix
+++ b/pkgs/desktops/deepin/startdde/default.nix
@@ -22,8 +22,6 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  outputs = [ "out" ];
-
   nativeBuildInputs = [
     pkgconfig
     dbus-factory
@@ -114,7 +112,7 @@ buildGoPackage rec {
   installPhase = ''
     make install PREFIX="$out" -C go/src/${goPackagePath}
     rm -rf $out/share/lightdm  # this is uselesss for NixOS
-    remove-references-to -t ${go} $out/bin/* $out/sbin/*
+    remove-references-to -t ${go} $out/sbin/*
   '';
 
   postFixup = ''

--- a/pkgs/development/go-packages/generic/default.nix
+++ b/pkgs/development/go-packages/generic/default.nix
@@ -203,15 +203,15 @@ let
     installPhase = args.installPhase or ''
       runHook preInstall
 
-      mkdir -p $bin
+      mkdir -p $out
       dir="$NIX_BUILD_TOP/go/bin"
-      [ -e "$dir" ] && cp -r $dir $bin
+      [ -e "$dir" ] && cp -r $dir $out
 
       runHook postInstall
     '';
 
     preFixup = preFixup + ''
-      find $bin/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
+      find $out/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
     '';
 
     strictDeps = true;
@@ -234,9 +234,6 @@ let
       lib.optionalAttrs (goPackageAliases != []) { inherit goPackageAliases; };
 
     enableParallelBuilding = enableParallelBuilding;
-
-    # I prefer to call this dev but propagatedBuildInputs expects $out to exist
-    outputs = args.outputs or [ "bin" "out" ];
 
     meta = {
       # Add default meta information

--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
     sha256 = "187cvb3i5cwm7cwxmzpl2ca7900yb6v6b6cybyz5mnd5ccy5ff1q";
   };
 
-  outputs = [ "bin" "man" "out" ];
+  outputs = [ "out" "man" ];
 
   goPackagePath = "github.com/containers/buildah";
   excludedPackages = [ "tests" ];
@@ -35,7 +35,7 @@ buildGoPackage rec {
   buildPhase = ''
     pushd go/src/${goPackagePath}
     make GIT_COMMIT="unknown"
-    install -Dm755 buildah $bin/bin/buildah
+    install -Dm755 buildah $out/bin/buildah
     installShellCompletion --bash contrib/completions/bash/buildah
   '';
 

--- a/pkgs/development/tools/cloudfoundry-cli/default.nix
+++ b/pkgs/development/tools/cloudfoundry-cli/default.nix
@@ -34,7 +34,7 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    install -Dm555 out/cf "$bin/bin/cf"
+    install -Dm555 out/cf "$out/bin/cf"
     installShellCompletion --bash "$src/ci/installers/completion/cf"
   '';
 

--- a/pkgs/development/tools/container-linux-config-transpiler/default.nix
+++ b/pkgs/development/tools/container-linux-config-transpiler/default.nix
@@ -20,8 +20,8 @@ buildGoPackage rec {
   '';
 
   postInstall = ''
-    mv $bin/bin/{internal,ct}
-    rm $bin/bin/tools
+    mv $out/bin/{internal,ct}
+    rm $out/bin/tools
   '';
 
   meta = {

--- a/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
@@ -24,10 +24,10 @@ buildGoPackage rec {
 
   postInstall = ''
     # Fix binary name
-    mv $bin/bin/{agent,buildkite-agent}
+    mv $out/bin/{agent,buildkite-agent}
 
     # These are runtime dependencies
-    wrapProgram $bin/bin/buildkite-agent \
+    wrapProgram $out/bin/buildkite-agent \
       --prefix PATH : '${stdenv.lib.makeBinPath [ openssh git coreutils gnused gnugrep ]}'
   '';
 

--- a/pkgs/development/tools/continuous-integration/buildkite-agent/generic.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/generic.nix
@@ -15,17 +15,17 @@ buildGoPackage {
   postInstall = ''
     ${stdenv.lib.optionalString hasBootstrapScript ''
     # Install bootstrap.sh
-    mkdir -p $bin/libexec/buildkite-agent
-    cp $NIX_BUILD_TOP/go/src/${goPackagePath}/templates/bootstrap.sh $bin/libexec/buildkite-agent
-    sed -e "s|#!/bin/bash|#!${bash}/bin/bash|g" -i $bin/libexec/buildkite-agent/bootstrap.sh
+    mkdir -p $out/libexec/buildkite-agent
+    cp $NIX_BUILD_TOP/go/src/${goPackagePath}/templates/bootstrap.sh $out/libexec/buildkite-agent
+    sed -e "s|#!/bin/bash|#!${bash}/bin/bash|g" -i $out/libexec/buildkite-agent/bootstrap.sh
     ''}
 
     # Fix binary name
-    mv $bin/bin/{agent,buildkite-agent}
+    mv $out/bin/{agent,buildkite-agent}
 
     # These are runtime dependencies
-    wrapProgram $bin/bin/buildkite-agent \
-      ${stdenv.lib.optionalString hasBootstrapScript "--set BUILDKITE_BOOTSTRAP_SCRIPT_PATH $bin/libexec/buildkite-agent/bootstrap.sh"} \
+    wrapProgram $out/bin/buildkite-agent \
+      ${stdenv.lib.optionalString hasBootstrapScript "--set BUILDKITE_BOOTSTRAP_SCRIPT_PATH $out/libexec/buildkite-agent/bootstrap.sh"} \
       --prefix PATH : '${stdenv.lib.makeBinPath [ openssh git coreutils gnused gnugrep ]}'
   '';
 

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -35,10 +35,10 @@ buildGoPackage rec {
   patches = [ ./fix-shell-path.patch ];
 
   postInstall = ''
-    touch $bin/bin/hello
-    install -d $bin/bin/helper-images
-    ln -sf ${docker_x86_64} $bin/bin/helper-images/prebuilt-x86_64.tar.xz
-    ln -sf ${docker_arm} $bin/bin/helper-images/prebuilt-arm.tar.xz
+    touch $out/bin/hello
+    install -d $out/bin/helper-images
+    ln -sf ${docker_x86_64} $out/bin/helper-images/prebuilt-x86_64.tar.xz
+    ln -sf ${docker_arm} $out/bin/helper-images/prebuilt-arm.tar.xz
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/deis/default.nix
+++ b/pkgs/development/tools/deis/default.nix
@@ -9,8 +9,8 @@ buildGoPackage rec {
   subPackages = [ "client" ];
 
   postInstall = ''
-    if [ -f "$bin/bin/client" ]; then
-      mv "$bin/bin/client" "$bin/bin/deis"
+    if [ -f "$out/bin/client" ]; then
+      mv "$out/bin/client" "$out/bin/deis"
     fi
   '';
 

--- a/pkgs/development/tools/dep2nix/default.nix
+++ b/pkgs/development/tools/dep2nix/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   ];
 
   postFixup = ''
-    wrapProgram $bin/bin/dep2nix \
+    wrapProgram $out/bin/dep2nix \
       --prefix PATH : ${nix-prefetch-scripts}/bin
   '';
 

--- a/pkgs/development/tools/doctl/default.nix
+++ b/pkgs/development/tools/doctl/default.nix
@@ -21,7 +21,7 @@ buildGoPackage rec {
   postInstall = ''
     export HOME=$(mktemp -d) # attempts to write to /homeless-shelter
     for shell in bash fish zsh; do
-      $bin/bin/doctl completion $shell > doctl.$shell
+      $out/bin/doctl completion $shell > doctl.$shell
       installShellCompletion doctl.$shell
     done
   '';

--- a/pkgs/development/tools/fac/default.nix
+++ b/pkgs/development/tools/fac/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
-    wrapProgram $bin/bin/fac \
+    wrapProgram $out/bin/fac \
       --prefix PATH : ${git}/bin
 
     # Install man page, not installed by default

--- a/pkgs/development/tools/go2nix/default.nix
+++ b/pkgs/development/tools/go2nix/default.nix
@@ -17,14 +17,14 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  outputs = [ "bin" "out" "man" ];
+  outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ go-bindata gotools makeWrapper ];
 
   preBuild = ''go generate ./...'';
 
   postInstall = ''
-    wrapProgram $bin/bin/go2nix \
+    wrapProgram $out/bin/go2nix \
       --prefix PATH : ${nix-prefetch-git}/bin \
       --prefix PATH : ${git}/bin
 

--- a/pkgs/development/tools/gocode-gomod/default.nix
+++ b/pkgs/development/tools/gocode-gomod/default.nix
@@ -25,7 +25,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   postInstall = ''
-    mv $bin/bin/gocode $bin/bin/gocode-gomod
+    mv $out/bin/gocode $out/bin/gocode-gomod
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/kind/default.nix
+++ b/pkgs/development/tools/kind/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ installShellFiles ];
   postInstall = ''
     for shell in bash zsh; do
-      $bin/bin/kind completion $shell > kind.$shell
+      $out/bin/kind completion $shell > kind.$shell
       installShellCompletion kind.$shell
     done
   '';

--- a/pkgs/development/tools/misc/hound/default.nix
+++ b/pkgs/development/tools/misc/hound/default.nix
@@ -27,7 +27,7 @@ buildGoPackage rec {
   postInstall = with stdenv; let
     binPath = lib.makeBinPath [ mercurial git ];
   in ''
-    wrapProgram $bin/bin/houndd --prefix PATH : ${binPath}
+    wrapProgram $out/bin/houndd --prefix PATH : ${binPath}
   '';
 
   meta = {

--- a/pkgs/development/tools/out-of-tree/default.nix
+++ b/pkgs/development/tools/out-of-tree/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   postFixup = ''
-    wrapProgram $bin/bin/out-of-tree \
+    wrapProgram $out/bin/out-of-tree \
       --prefix PATH : "${stdenv.lib.makeBinPath [ qemu docker which ]}"
   '';
 

--- a/pkgs/development/tools/skaffold/default.nix
+++ b/pkgs/development/tools/skaffold/default.nix
@@ -26,7 +26,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ installShellFiles ];
   postInstall = ''
     for shell in bash zsh; do
-      $bin/bin/skaffold completion $shell > skaffold.$shell
+      $out/bin/skaffold completion $shell > skaffold.$shell
       installShellCompletion skaffold.$shell
     done
   '';

--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -34,7 +34,7 @@ buildGoPackage {
   inherit version;
   inherit src goPackagePath;
 
-  outputs = [ "bin" "man" "out" ];
+  outputs = [ "out" "man" ];
 
   excludedPackages = [ "integration" ];
 

--- a/pkgs/development/tools/toxiproxy/default.nix
+++ b/pkgs/development/tools/toxiproxy/default.nix
@@ -15,8 +15,8 @@ buildGoPackage rec {
   buildFlagsArray = "-ldflags=-X github.com/Shopify/toxiproxy.Version=v${version}";
 
   postInstall = ''
-    mv $bin/bin/cli $bin/bin/toxiproxy-cli
-    mv $bin/bin/cmd $bin/bin/toxiproxy-cmd
+    mv $out/bin/cli $out/bin/toxiproxy-cli
+    mv $out/bin/cmd $out/bin/toxiproxy-cmd
   '';
 
   meta = {

--- a/pkgs/development/tools/vgo2nix/default.nix
+++ b/pkgs/development/tools/vgo2nix/default.nix
@@ -28,7 +28,7 @@ buildGoPackage {
   postInstall = with stdenv; let
     binPath = lib.makeBinPath [ nix-prefetch-git go ];
   in ''
-    wrapProgram $bin/bin/vgo2nix --prefix PATH : ${binPath}
+    wrapProgram $out/bin/vgo2nix --prefix PATH : ${binPath}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/wally-cli/default.nix
+++ b/pkgs/development/tools/wally-cli/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   };
 
   postInstall = ''
-    mv $bin/bin/cli $bin/bin/wally
+    mv $out/bin/cli $out/bin/wally
   '';
 
   goDeps = ./deps.nix;

--- a/pkgs/games/boohu/default.nix
+++ b/pkgs/games/boohu/default.nix
@@ -14,7 +14,7 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  postInstall = "mv $bin/bin/boohu.git $bin/bin/boohu";
+  postInstall = "mv $out/bin/boohu.git $out/bin/boohu";
 
   meta = with stdenv.lib; {
     description = "A new coffee-break roguelike game";

--- a/pkgs/games/harmonist/default.nix
+++ b/pkgs/games/harmonist/default.nix
@@ -14,7 +14,7 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  postInstall = "mv $bin/bin/harmonist.git $bin/bin/harmonist";
+  postInstall = "mv $out/bin/harmonist.git $out/bin/harmonist";
 
   meta = with stdenv.lib; {
     description = "A stealth coffee-break roguelike game";

--- a/pkgs/misc/logging/beats/6.x.nix
+++ b/pkgs/misc/logging/beats/6.x.nix
@@ -47,7 +47,7 @@ in {
     '';
     buildInputs = [ systemd.dev ];
     postFixup = let libPath = stdenv.lib.makeLibraryPath [ systemd.lib ]; in ''
-      patchelf --set-rpath ${libPath} "$bin/bin/journalbeat"
+      patchelf --set-rpath ${libPath} "$out/bin/journalbeat"
     '';
   };
 }

--- a/pkgs/misc/logging/beats/7.x.nix
+++ b/pkgs/misc/logging/beats/7.x.nix
@@ -46,7 +46,7 @@ in {
     '';
     buildInputs = [ systemd.dev ];
     postFixup = let libPath = stdenv.lib.makeLibraryPath [ systemd.lib ]; in ''
-      patchelf --set-rpath ${libPath} "$bin/bin/journalbeat"
+      patchelf --set-rpath ${libPath} "$out/bin/journalbeat"
     '';
   };
 }

--- a/pkgs/servers/dex/default.nix
+++ b/pkgs/servers/dex/default.nix
@@ -22,8 +22,8 @@ buildGoPackage rec {
   ];
 
   postInstall = ''
-    mkdir -p $bin/share
-    cp -r $src/web $bin/share/web
+    mkdir -p $out/share
+    cp -r $src/web $out/share/web
   '';
 
   meta = with lib; {

--- a/pkgs/servers/etcd/default.nix
+++ b/pkgs/servers/etcd/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    install -Dm755 bin/* bin/functional/cmd/* -t $bin/bin
+    install -Dm755 bin/* bin/functional/cmd/* -t $out/bin
   '';
 
   passthru.tests = with nixosTests; {

--- a/pkgs/servers/meguca/default.nix
+++ b/pkgs/servers/meguca/default.nix
@@ -35,9 +35,9 @@ buildGoPackage {
   '';
 
   installPhase = ''
-    mkdir -p $bin/bin $bin/share/meguca
-    cp meguca $bin/bin
-    cp -r www $bin/share/meguca
+    mkdir -p $out/bin $out/share/meguca
+    cp meguca $out/bin
+    cp -r www $out/share/meguca
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/miniflux/default.nix
+++ b/pkgs/servers/miniflux/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   '';
 
   postInstall = ''
-    mv $bin/bin/miniflux.app $bin/bin/miniflux
+    mv $out/bin/miniflux.app $out/bin/miniflux
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/monitoring/grafana-reporter/default.nix
+++ b/pkgs/servers/monitoring/grafana-reporter/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   };
 
   postInstall = ''
-    wrapProgram $bin/bin/grafana-reporter \
+    wrapProgram $out/bin/grafana-reporter \
       --prefix PATH : ${makeBinPath [ tetex ]}
   '';
 

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -29,10 +29,10 @@ buildGoPackage rec {
 
   postInstall = ''
     tar -xvf $srcStatic
-    mkdir -p $bin/share/grafana
-    mv grafana-*/{public,conf,tools} $bin/share/grafana/
+    mkdir -p $out/share/grafana
+    mv grafana-*/{public,conf,tools} $out/share/grafana/
   '' + lib.optionalString phantomJsSupport ''
-    ln -sf ${phantomjs2}/bin/phantomjs $bin/share/grafana/tools/phantomjs/phantomjs
+    ln -sf ${phantomjs2}/bin/phantomjs $out/share/grafana/tools/phantomjs/phantomjs
   '';
 
   meta = with lib; {

--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -24,7 +24,7 @@ buildGoPackage rec {
   buildInputs = stdenv.lib.optionals stdenv.isLinux [ systemd.dev ];
 
   preFixup = stdenv.lib.optionalString stdenv.isLinux ''
-    wrapProgram $bin/bin/promtail \
+    wrapProgram $out/bin/promtail \
       --prefix LD_LIBRARY_PATH : "${systemd.lib}/lib"
   '';
 

--- a/pkgs/servers/monitoring/prometheus/alertmanager.nix
+++ b/pkgs/servers/monitoring/prometheus/alertmanager.nix
@@ -27,7 +27,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
-    $bin/bin/amtool --completion-script-bash > amtool.bash
+    $out/bin/amtool --completion-script-bash > amtool.bash
     installShellCompletion amtool.bash
   '';
 

--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -54,9 +54,9 @@ in buildGoPackage rec {
   '';
 
   preInstall = ''
-    mkdir -p "$bin/share/doc/prometheus" "$bin/etc/prometheus"
-    cp -a $src/documentation/* $bin/share/doc/prometheus
-    cp -a $src/console_libraries $src/consoles $bin/etc/prometheus
+    mkdir -p "$out/share/doc/prometheus" "$out/etc/prometheus"
+    cp -a $src/documentation/* $out/share/doc/prometheus
+    cp -a $src/console_libraries $src/consoles $out/etc/prometheus
   '';
 
   doCheck = true;

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
@@ -43,7 +43,7 @@ buildGoPackage rec {
   ];
 
   postInstall = optionalString withSystemdSupport ''
-    wrapProgram $bin/bin/postfix_exporter \
+    wrapProgram $out/bin/postfix_exporter \
       --prefix LD_LIBRARY_PATH : "${systemd.lib}/lib"
   '';
 

--- a/pkgs/servers/monitoring/prometheus/pushgateway.nix
+++ b/pkgs/servers/monitoring/prometheus/pushgateway.nix
@@ -29,7 +29,7 @@ buildGoPackage rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    export PATH=$PATH:$bin/bin
+    export PATH=$PATH:$out/bin
 
     pushgateway --help
 

--- a/pkgs/servers/monitoring/uchiwa/default.nix
+++ b/pkgs/servers/monitoring/uchiwa/default.nix
@@ -16,7 +16,7 @@ let
     goPackagePath = "github.com/${owner}/${repo}";
     inherit src;
     postInstall = ''
-      mkdir $out
+      mkdir -p $out
       cp go/src/github.com/sensu/uchiwa/public/index.html $out/
     '';
   };
@@ -37,7 +37,7 @@ in stdenv.mkDerivation {
 
   buildCommand = ''
     mkdir -p $out/bin $out/public
-    makeWrapper ${backend.bin}/bin/uchiwa $out/bin/uchiwa \
+    makeWrapper ${backend}/bin/uchiwa $out/bin/uchiwa \
       --add-flags "-p $out/public"
     ln -s ${backend.out}/index.html $out/public/index.html
     ln -s ${frontend.out}/bower_components $out/public/bower_components

--- a/pkgs/servers/nginx-sso/default.nix
+++ b/pkgs/servers/nginx-sso/default.nix
@@ -15,8 +15,8 @@ buildGoPackage rec {
   };
 
   postInstall = ''
-    mkdir -p $bin/share
-    cp -R $src/frontend $bin/share
+    mkdir -p $out/share
+    cp -R $src/frontend $out/share
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -42,7 +42,7 @@ buildGoPackage rec {
   installPhase = ''
     runHook preInstall
 
-    install -D cockroachoss $bin/bin/cockroach
+    install -D cockroachoss $out/bin/cockroach
     installShellCompletion cockroach.bash
 
     mkdir -p $man/share/man
@@ -51,11 +51,7 @@ buildGoPackage rec {
     runHook postInstall
   '';
 
-  # Unfortunately we have to keep an empty reference to $out, because it seems
-  # buildGoPackages only nukes references to the go compiler under $bin, effectively
-  # making all binary output under $bin mandatory. Ideally, we would just use
-  # $out and $man and remove $bin since there's no point in an empty path. :(
-  outputs = [ "bin" "man" "out" ];
+  outputs = [ "out" "man" ];
 
   meta = with stdenv.lib; {
     homepage    = "https://www.cockroachlabs.com";

--- a/pkgs/tools/admin/docker-credential-helpers/default.nix
+++ b/pkgs/tools/admin/docker-credential-helpers/default.nix
@@ -32,11 +32,11 @@ buildGoPackage rec {
   installPhase =
     if stdenv.isDarwin
     then ''
-      install -Dm755 -t $bin/bin bin/docker-credential-osxkeychain
+      install -Dm755 -t $out/bin bin/docker-credential-osxkeychain
     ''
     else ''
-      install -Dm755 -t $bin/bin bin/docker-credential-pass
-      install -Dm755 -t $bin/bin bin/docker-credential-secretservice
+      install -Dm755 -t $out/bin bin/docker-credential-pass
+      install -Dm755 -t $out/bin bin/docker-credential-secretservice
     '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -31,9 +31,9 @@ buildGoPackage rec {
 
   postInstall = ''
     # test binaries, code generation
-    rm $bin/bin/{deps,macaroon-identity,generate}
+    rm $out/bin/{deps,macaroon-identity,generate}
 
-    wrapProgram $bin/bin/lxd --prefix PATH : ${stdenv.lib.makeBinPath [
+    wrapProgram $out/bin/lxd --prefix PATH : ${stdenv.lib.makeBinPath [
       acl rsync gnutar xz btrfs-progs gzip dnsmasq squashfsTools iproute iptables ebtables bash criu
       (writeShellScriptBin "apparmor_parser" ''
         exec '${apparmor-parser}/bin/apparmor_parser' -I '${apparmor-profiles}/etc/apparmor.d' "$@"

--- a/pkgs/tools/backup/diskrsync/default.nix
+++ b/pkgs/tools/backup/diskrsync/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
   buildInputs = [ makeWrapper ];
 
   preFixup = ''
-    wrapProgram "$bin/bin/diskrsync" --argv0 diskrsync --prefix PATH : ${openssh}/bin
+    wrapProgram "$out/bin/diskrsync" --argv0 diskrsync --prefix PATH : ${openssh}/bin
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/backup/duplicacy/default.nix
+++ b/pkgs/tools/backup/duplicacy/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    install -D duplicacy_main $bin/bin/duplicacy
+    install -D duplicacy_main $out/bin/duplicacy
   '';
 
   meta = with lib; {

--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   passthru.tests.restic = nixosTests.restic;
 
   postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
-    $bin/bin/restic generate \
+    $out/bin/restic generate \
       --bash-completion restic.bash \
       --zsh-completion restic.zsh \
       --man .

--- a/pkgs/tools/backup/restic/rest-server.nix
+++ b/pkgs/tools/backup/restic/rest-server.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    install -Dt $bin/bin rest-server
+    install -Dt $out/bin rest-server
   '';
 
   meta = with lib; {

--- a/pkgs/tools/filesystems/gcsfuse/default.nix
+++ b/pkgs/tools/filesystems/gcsfuse/default.nix
@@ -16,8 +16,8 @@ buildGoPackage rec {
   subPackages = [ "." "tools/mount_gcsfuse" ];
 
   postInstall = ''
-    ln -s $bin/bin/mount_gcsfuse $bin/bin/mount.gcsfuse
-    ln -s $bin/bin/mount_gcsfuse $bin/bin/mount.fuse.gcsfuse
+    ln -s $out/bin/mount_gcsfuse $out/bin/mount.gcsfuse
+    ln -s $out/bin/mount_gcsfuse $out/bin/mount.fuse.gcsfuse
   '';
 
   meta = with lib;{

--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -33,7 +33,7 @@ buildGoPackage {
 
   postInstall = ''
     installShellCompletion --bash ${aptlyCompletionSrc}/aptly
-    wrapProgram "$bin/bin/aptly" \
+    wrapProgram "$out/bin/aptly" \
       --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg bzip2 xz graphviz ]}"
   '';
 

--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -23,9 +23,9 @@ buildGoPackage rec {
 
   installPhase = ''
     mkdir -p $out
-    make install DESTDIR=$bin
-    mkdir -p $bin/share/fish/vendor_conf.d
-    echo "eval ($bin/bin/direnv hook fish)" > $bin/share/fish/vendor_conf.d/direnv.fish
+    make install DESTDIR=$out
+    mkdir -p $out/share/fish/vendor_conf.d
+    echo "eval ($out/bin/direnv hook fish)" > $out/share/fish/vendor_conf.d/direnv.fish
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/mongodb-tools/default.nix
+++ b/pkgs/tools/misc/mongodb-tools/default.nix
@@ -45,7 +45,7 @@ in buildGoPackage {
     runHook preBuild
 
     ${stdenv.lib.concatMapStrings (t: ''
-      go build -o "$bin/bin/${t}" -tags ssl -ldflags "-s -w" $goPackagePath/${t}/main
+      go build -o "$out/bin/${t}" -tags ssl -ldflags "-s -w" $goPackagePath/${t}/main
     '') tools}
 
     runHook postBuild

--- a/pkgs/tools/misc/phraseapp-client/default.nix
+++ b/pkgs/tools/misc/phraseapp-client/default.nix
@@ -15,7 +15,7 @@ buildGoPackage rec {
   };
 
   postInstall = ''
-    ln -s $bin/bin/phraseapp-client $bin/bin/phraseapp
+    ln -s $out/bin/phraseapp-client $out/bin/phraseapp
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/tewisay/default.nix
+++ b/pkgs/tools/misc/tewisay/default.nix
@@ -18,12 +18,12 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   postInstall = ''
-    install -D -t $bin/share/tewisay/cows go/src/${goPackagePath}/cows/*.cow
+    install -D -t $out/share/tewisay/cows go/src/${goPackagePath}/cows/*.cow
   '';
 
   preFixup = ''
-    wrapProgram $bin/bin/tewisay \
-      --prefix COWPATH : $bin/share/tewisay/cows
+    wrapProgram $out/bin/tewisay \
+      --prefix COWPATH : $out/share/tewisay/cows
   '';
 
   meta = {

--- a/pkgs/tools/networking/assh/default.nix
+++ b/pkgs/tools/networking/assh/default.nix
@@ -10,7 +10,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
-    wrapProgram "$bin/bin/assh" \
+    wrapProgram "$out/bin/assh" \
       --prefix PATH : ${openssh}/bin
   '';
 

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -47,8 +47,8 @@ in buildGoPackage rec {
 
   # DataDog use paths relative to the agent binary, so fix these.
   postPatch = ''
-    sed -e "s|PyChecksPath =.*|PyChecksPath = \"$bin/${python.sitePackages}\"|" \
-        -e "s|distPath =.*|distPath = \"$bin/share/datadog-agent\"|" \
+    sed -e "s|PyChecksPath =.*|PyChecksPath = \"$out/${python.sitePackages}\"|" \
+        -e "s|distPath =.*|distPath = \"$out/share/datadog-agent\"|" \
         -i cmd/agent/common/common_nix.go
     sed -e "s|/bin/hostname|${lib.getBin hostname}/bin/hostname|" \
         -i pkg/util/hostname_nix.go
@@ -57,14 +57,14 @@ in buildGoPackage rec {
   # Install the config files and python modules from the "dist" dir
   # into standard paths.
   postInstall = ''
-    mkdir -p $bin/${python.sitePackages} $bin/share/datadog-agent
-    cp -R $src/cmd/agent/dist/conf.d $bin/share/datadog-agent
-    cp -R $src/cmd/agent/dist/{checks,utils,config.py} $bin/${python.sitePackages}
+    mkdir -p $out/${python.sitePackages} $out/share/datadog-agent
+    cp -R $src/cmd/agent/dist/conf.d $out/share/datadog-agent
+    cp -R $src/cmd/agent/dist/{checks,utils,config.py} $out/${python.sitePackages}
 
-    cp -R $src/pkg/status/dist/templates $bin/share/datadog-agent
+    cp -R $src/pkg/status/dist/templates $out/share/datadog-agent
 
-    wrapProgram "$bin/bin/agent" \
-      --set PYTHONPATH "$bin/${python.sitePackages}" \
+    wrapProgram "$out/bin/agent" \
+      --set PYTHONPATH "$out/${python.sitePackages}" \
       --prefix LD_LIBRARY_PATH : ${systemd.lib}/lib
   '';
 

--- a/pkgs/tools/networking/guardian-agent/default.nix
+++ b/pkgs/tools/networking/guardian-agent/default.nix
@@ -23,14 +23,14 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   postInstall = ''
-    mkdir -p $bin/bin $out/share/doc/${pname}
-    cp -v ./go/src/github.com/StanfordSNR/${pname}/scripts/* $bin/bin/
+    mkdir -p $out/bin $out/share/doc/${pname}
+    cp -v ./go/src/github.com/StanfordSNR/${pname}/scripts/* $out/bin/
     cp -vr ./go/src/github.com/StanfordSNR/${pname}/{AUTHORS,doc,LICENSE,README.md} $out/share/doc/guardian-agent
   '';
 
   postFixup = ''
-		wrapProgram $bin/bin/sga-guard \
-			--prefix PATH : "$bin/bin" \
+		wrapProgram $out/bin/sga-guard \
+			--prefix PATH : "$out/bin" \
 			--prefix PATH : "${autossh}/bin"
   '';
 

--- a/pkgs/tools/package-management/morph/default.nix
+++ b/pkgs/tools/package-management/morph/default.nix
@@ -29,10 +29,10 @@ buildGoPackage rec {
   postInstall = ''
     mkdir -p $lib
     cp -v $src/data/*.nix $lib
-    wrapProgram $bin/bin/morph --prefix PATH : ${lib.makeBinPath [ openssh ]};
+    wrapProgram $out/bin/morph --prefix PATH : ${lib.makeBinPath [ openssh ]};
   '';
 
-  outputs = [ "out" "bin" "lib" ];
+  outputs = [ "out" "lib" ];
 
   meta = with lib; {
     description = "Morph is a NixOS host manager written in Golang.";

--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -23,13 +23,13 @@ buildGoPackage rec {
 
   postInstall = ''
     for shell in bash fish zsh; do
-      $bin/bin/gopass completion $shell > gopass.$shell
+      $out/bin/gopass completion $shell > gopass.$shell
       installShellCompletion gopass.$shell
     done
   '';
 
   postFixup = ''
-    wrapProgram $bin/bin/gopass \
+    wrapProgram $out/bin/gopass \
       --prefix PATH : "${wrapperPath}"
   '';
 

--- a/pkgs/tools/security/notary/default.nix
+++ b/pkgs/tools/security/notary/default.nix
@@ -26,7 +26,7 @@ buildGoPackage rec {
 
   installPhase = ''
     runHook preInstall
-    install -D bin/notary $bin/bin/notary
+    install -D bin/notary $out/bin/notary
     runHook postInstall
   '';
 

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -23,7 +23,7 @@ buildGoPackage rec {
   ];
 
   postInstall = ''
-    echo "complete -C $bin/bin/vault vault" > vault.bash
+    echo "complete -C $out/bin/vault vault" > vault.bash
     installShellCompletion vault.bash
   '';
 

--- a/pkgs/tools/security/verifpal/default.nix
+++ b/pkgs/tools/security/verifpal/default.nix
@@ -28,8 +28,8 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    mkdir -p $bin/bin
-    cp go/src/$goPackagePath/build/bin/linux/verifpal $bin/bin/
+    mkdir -p $out/bin
+    cp go/src/$goPackagePath/build/bin/linux/verifpal $out/bin/
   '';
 
   meta = {

--- a/pkgs/tools/system/localtime/default.nix
+++ b/pkgs/tools/system/localtime/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
-    "BINDIR=${placeholder "bin"}/bin"
+    "BINDIR=${placeholder "out"}/bin"
   ];
 
   buildPhase = ''

--- a/pkgs/tools/virtualization/cri-tools/default.nix
+++ b/pkgs/tools/virtualization/cri-tools/default.nix
@@ -14,7 +14,7 @@ buildGoPackage rec {
 
   buildPhase = ''
     pushd go/src/${goPackagePath}
-    make all install BINDIR=$bin/bin
+    make all install BINDIR=$out/bin
   '';
 
   meta = with lib; {

--- a/pkgs/tools/virtualization/distrobuilder/default.nix
+++ b/pkgs/tools/virtualization/distrobuilder/default.nix
@@ -23,7 +23,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   postInstall = ''
-    wrapProgram $bin/bin/distrobuilder --prefix PATH ":" ${binPath}
+    wrapProgram $out/bin/distrobuilder --prefix PATH ":" ${binPath}
   '';
   nativeBuildInputs = [ pkgconfig makeWrapper ];
 


### PR DESCRIPTION
cc @kalbasit @Mic92

This changes `buildGoPackage` to use to `$out` instead of `$bin` which matches the behaviour of `buildGoModule` (and `buildRustPackage`).

https://github.com/NixOS/nixpkgs/blob/a2d9f5843336b00398542448321a497309907d05/pkgs/servers/sql/cockroachdb/default.nix#L53-L57

