### PR TITLE
uniutils: init @ 2.27

### DIFF
--- a/pkgs/tools/text/ascii2binary/default.nix
+++ b/pkgs/tools/text/ascii2binary/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "ascii2binary";
+  version = "2.14";
+
+  src = fetchurl {
+    # The "normal" url gives a 404.
+    # url = "https://billposer.org/Software/Downloads/${pname}-${version}.tar.bz2";
+    # Use Debian's mirror instead:
+    url = "mirror://debian/pool/main/a/${pname}/${pname}_${version}.orig.tar.gz";
+    sha256 = "1a9md30a60mrr6jri172m88ni5ygj1i8ghdzfgjksl6w5cmk7p5d";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Convert between ASCII, hexadecimal and binary representations";
+    homepage = "https://www.billposer.org/software.html";
+    maintainers = with maintainers; [ synthetica ];
+  };
+}

--- a/pkgs/tools/text/uniutils/default.nix
+++ b/pkgs/tools/text/uniutils/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchurl, makeWrapper, ascii2binary, unicode-character-database }:
+
+stdenv.mkDerivation rec {
+  pname = "uniutils";
+  version = "2.27";
+
+  src = fetchurl {
+    # The "normal" url gives a 404.
+    # url = "https://billposer.org/Software/Downloads/${pname}-${version}.tar.bz2"
+    # Use Debian's mirror instead:
+    url = "mirror://debian/pool/main/u/${pname}/${pname}_${version}.orig.tar.gz";
+    sha256 = "15hmlsfwicdsqniqap0gz7dbv7a7bl9pkxhh0pkalrrsb8hsjqn6";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  # Patching logic adapted from the AUR package:
+  # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=uniutils
+  postPatch = ''
+    UNICODE="${unicode-character-database}/share/unicode/"
+
+    # update the UCD
+    gawk -f ./genunames.awk \
+      $UNICODE/UnicodeData.txt > unames.c
+
+    # update the blocks
+    sed -i -e '
+      /#include "unirange.h"/ a #include "blocks.c"
+      /struct cr Range_Table/,/^};/ d
+    ' unirange.c
+    gawk -F'[;.].? *' '
+      BEGIN { print "struct cr Range_Table[] = {" }
+      END { print "};" }
+      /^[0-9A-F]/ { print "{0x"$1",0x"$2",\""$3"\"}," }
+    ' $UNICODE/Blocks.txt > blocks.c
+  '';
+
+  configurePhase = ''
+    ./configure --prefix=$out
+  '';
+
+  buildPhase = ''
+    make
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/utf8lookup" \
+      --prefix PATH ":" ${ascii2binary}/bin:$out/bin
+  '';
+
+  testPhase = ''
+    cd $src
+    make test
+  '';
+
+  outputs = [ "out" "man" ];
+
+  meta = with stdenv.lib; {
+    description = "A set of programs for manipulating and analyzing Unicode text";
+    homepage = "https://www.billposer.org/software.html";
+    maintainers = with maintainers; [ synthetica ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -703,6 +703,8 @@ in
 
   ascii = callPackage ../tools/text/ascii { };
 
+  ascii2binary = callPackage ../tools/text/ascii2binary { };
+
   asciinema = callPackage ../tools/misc/asciinema {};
 
   asciiquarium = callPackage ../applications/misc/asciiquarium {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3560,6 +3560,8 @@ in
 
   uni2ascii = callPackage ../tools/text/uni2ascii { };
 
+  uniutils = callPackage ../tools/text/uniutils { };
+
   galculator = callPackage ../applications/misc/galculator {
     gtk = gtk3;
   };


### PR DESCRIPTION
Present in 9 repo's at the time of writing:
https://repology.org/project/uniutils/versions

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
