### PR TITLE
rust: bootstrap from source

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6104,6 +6104,12 @@
     githubId = 18549627;
     name = "Proglodyte";
   };
+  progval = {
+    email = "progval+nix@progval.net";
+    github = "ProgVal";
+    githubId = 406946;
+    name = "Valentin Lorentz";
+  };
   protoben = {
     email = "protob3n@gmail.com";
     github = "protoben";

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -17,6 +17,7 @@
 , buildType ? "release"
 , meta ? {}
 , target ? null
+, rustTargetPrefix ? ""
 , cargoVendorDir ? null
 , ... } @ args:
 
@@ -56,7 +57,7 @@ let
   cxxForBuild="${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}c++";
   ccForHost="${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
   cxxForHost="${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++";
-  releaseDir = "target/${rustTarget}/${buildType}";
+  releaseDir = "${rustTargetPrefix}target/${rustTarget}/${buildType}";
 
 in
 

--- a/pkgs/development/compilers/mrustc/bootstrap.nix
+++ b/pkgs/development/compilers/mrustc/bootstrap.nix
@@ -1,0 +1,133 @@
+{ stdenv
+, fetchurl
+, fetchFromGitHub
+, makeWrapper
+, mrustc
+, mrustc-minicargo
+, llvm_7
+, libffi
+, cmake
+, python3
+, zlib
+, libxml2
+, openssl
+, pkgconfig
+, curl
+, which
+, bash
+}:
+
+let
+  mrustcVersion = "0.9";
+  mrustcTag = "v${mrustcVersion}";
+  rustcVersion = "1.29.0";
+in
+
+stdenv.mkDerivation {
+  pname = "mrustc-bootstrap";
+  version = "${mrustcVersion}_${rustcVersion}";
+
+  src = fetchFromGitHub {
+    owner = "thepowersgang";
+    repo = "mrustc";
+    rev = mrustcTag;
+    sha256 = "194ny7vsks5ygiw7d8yxjmp1qwigd71ilchis6xjl6bb2sj97rd2";
+  };
+  rustcSrc = fetchurl {
+    url = "https://static.rust-lang.org/dist/rustc-${rustcVersion}-src.tar.gz";
+    sha256 = "1sb15znckj8pc8q3g7cq03pijnida6cg64yqmgiayxkzskzk9sx4";
+  };
+
+  postUnpack = "tar -xf $rustcSrc -C source/";
+
+  # the rust build system complains that nix alters the checksums
+  dontFixLibtool = true;
+
+  patches = [
+    ./patches/0001-use-shared-mrustc-minicargo.patch
+    ./patches/0002-use-shared-llvm.patch
+    ./patches/0003-dont-build-llvm.patch
+    ./patches/0004-echo-newlines.patch
+    ./patches/0005-remove-time-dependency.patch
+    ./patches/0006-settable-rust-target.patch
+    ./patches/0007-increase-parallelism.patch
+  ];
+
+  postPatch = ''
+    echo "applying patch ./rustc-${rustcVersion}-src.patch"
+    patch -p0 -d rustc-${rustcVersion}-src/ < rustc-${rustcVersion}-src.patch
+  '';
+
+  # rustc unfortunately needs cmake to compile llvm-rt but doesn't
+  # use it for the normal build. This disables cmake in Nix.
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    stdenv which bash makeWrapper
+    # compiling toolchain
+    mrustc mrustc-minicargo
+    # for rustc
+    llvm_7 libffi cmake python3 zlib libxml2
+    # for cargo
+    openssl pkgconfig curl cmake
+  ];
+
+  # Use shared mrustc/minicargo/llvm instead of rebuilding them
+  MRUSTC = "${mrustc}/bin/mrustc";
+  MINICARGO = "${mrustc-minicargo}/bin/minicargo";
+  LLVM_CONFIG = "${llvm_7}/bin/llvm-config";
+
+  RUSTC_TARGET = stdenv.buildPlatform.config;
+
+  buildPhase = ''
+    echo minicargo.mk: libs
+    make -f minicargo.mk PARLEVEL=$NIX_BUILD_CORES LIBS
+
+    echo minicargo.mk: deps
+    mkdir -p output/cargo-build
+    # minicargo has concurrency issues when running these; let's build them
+    # without parallelism
+    for crate in regex regex-0.2.11 curl-sys
+    do
+      echo "building $crate"
+      minicargo rustc-${rustcVersion}-src/src/vendor/$crate --vendor-dir rustc-${rustcVersion}-src/src/vendor --output-dir output/cargo-build -L output/
+    done
+
+    echo minicargo.mk: rustc
+    make -f minicargo.mk PARLEVEL=$NIX_BUILD_CORES output/rustc
+
+    echo minicargo.mk: cargo
+    make -f minicargo.mk PARLEVEL=$NIX_BUILD_CORES output/cargo
+
+    echo run_rustc
+    make -C run_rustc PARLEVEL=$NIX_BUILD_CORES
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    run_rustc/output/prefix/bin/hello_world | grep "hello, world"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/ $out/lib/
+    cp run_rustc/output/prefix/bin/cargo $out/bin/cargo
+    cp run_rustc/output/prefix/bin/rustc_binary $out/bin/rustc
+
+    cp -r run_rustc/output/prefix/lib/* $out/lib/
+    cp $out/lib/rustlib/${stdenv.buildPlatform.config}/lib/*.so $out/lib/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/thepowersgang/mrustc";
+    description = "A minimal build of Rust";
+    longDescription = ''
+      A minimal build of Rust, built from source using mrustc.
+      This is useful for bootstrapping the main Rust compiler without
+      an initial binary toolchain download.
+    '';
+    maintainers = with maintainers; [ progval ];
+    license = with licenses; [ mit asl20 ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/development/compilers/mrustc/default.nix
+++ b/pkgs/development/compilers/mrustc/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, fetchFromGitHub
+, zlib
+}:
+
+let
+  version = "0.9";
+  tag = "v${version}";
+  rev = "15773561e40ca5c8cffe0a618c544b6cfdc5ad7e";
+in
+
+stdenv.mkDerivation {
+  inherit version;
+  pname = "mrustc";
+
+  src = fetchFromGitHub {
+    owner = "thepowersgang";
+    repo = "mrustc";
+    rev = tag;
+    sha256 = "194ny7vsks5ygiw7d8yxjmp1qwigd71ilchis6xjl6bb2sj97rd2";
+  };
+
+  postPatch = ''
+    sed -i 's/\$(shell git show --pretty=%H -s)/${rev}/' Makefile
+    sed -i 's/\$(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)/${tag}/' Makefile
+    sed -i 's/\$(shell git diff-index --quiet HEAD; echo $$?)/0/' Makefile
+  '';
+
+  buildInputs = [ stdenv zlib ];
+  buildPhase = "make -j $NIX_BUILD_CORES";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/mrustc $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Mutabah's Rust Compiler";
+    longDescription = ''
+      In-progress alternative rust compiler, written in C++.
+      Capable of building a fully-working copy of rustc,
+      but not yet suitable for everyday use.
+    '';
+    homepage = "https://github.com/thepowersgang/mrustc";
+    license = licenses.mit;
+    maintainers = [ maintainers.progval ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/compilers/mrustc/minicargo.nix
+++ b/pkgs/development/compilers/mrustc/minicargo.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+, mrustc
+}:
+
+let
+  version = "0.9";
+  tag = "v${version}";
+in
+
+stdenv.mkDerivation {
+  inherit version;
+  pname = "mrustc-minicargo";
+
+  src = fetchFromGitHub {
+    owner = "thepowersgang";
+    repo = "mrustc";
+    rev = tag;
+    sha256 = "194ny7vsks5ygiw7d8yxjmp1qwigd71ilchis6xjl6bb2sj97rd2";
+  };
+
+  buildInputs = [ stdenv makeWrapper ];
+
+  # Not actually required at build time, only at run time
+  propagatedBuildInputs = [ mrustc ];
+
+  buildPhase = "make -f minicargo.mk -j $NIX_BUILD_CORES tools/bin/minicargo";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp tools/bin/minicargo $out/bin
+
+    # without it, minicargo defaults to "<minicargo_path>/../../bin/mrustc" 
+    wrapProgram "$out/bin/minicargo" --set MRUSTC_PATH ${mrustc}/bin/mrustc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A minimalist builder for Rust";
+    longDescription = ''
+      A minimalist builder for Rust, similar to Cargo but written in C++.
+      Designed to work with mrustc to build Rust projects
+      (like the Rust compiler itself).
+    '';
+    homepage = "https://github.com/thepowersgang/mrustc";
+    license = licenses.mit;
+    maintainers = [ maintainers.progval ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/compilers/mrustc/patches/0001-use-shared-mrustc-minicargo.patch
+++ b/pkgs/development/compilers/mrustc/patches/0001-use-shared-mrustc-minicargo.patch
@@ -1,0 +1,21 @@
+--- a/minicargo.mk
++++ b/minicargo.mk
+@@ -25,8 +25,8 @@
+ 
+ OUTDIR := output$(OUTDIR_SUF)/
+ 
+-MRUSTC := bin/mrustc
+-MINICARGO := tools/bin/minicargo
++MRUSTC ?= bin/mrustc
++MINICARGO ?= tools/bin/minicargo
+ RUSTC_OUT_BIN := rustc
+ ifeq ($(RUSTC_VERSION),1.29.0)
+   RUSTC_OUT_BIN := rustc_binary
+@@ -42,7 +42,6 @@
+ LLVM_TARGETS ?= X86;ARM;AArch64#;Mips;PowerPC;SystemZ;JSBackend;MSP430;Sparc;NVPTX
+ OVERRIDE_DIR := script-overrides/$(RUSTC_CHANNEL)-$(RUSTC_VERSION)$(OVERRIDE_SUFFIX)/
+ 
+-.PHONY: bin/mrustc tools/bin/minicargo
+ .PHONY: $(OUTDIR)libstd.rlib $(OUTDIR)libtest.rlib $(OUTDIR)libpanic_unwind.rlib $(OUTDIR)libproc_macro.rlib
+ .PHONY: $(OUTDIR)rustc $(OUTDIR)cargo
+ 

--- a/pkgs/development/compilers/mrustc/patches/0002-use-shared-llvm.patch
+++ b/pkgs/development/compilers/mrustc/patches/0002-use-shared-llvm.patch
@@ -1,0 +1,35 @@
+--- a/minicargo.mk
++++ b/minicargo.mk
+@@ -37,7 +37,7 @@
+ 	RUSTCSRC := rustc-$(RUSTC_VERSION)-src/
+ endif
+ 
+-LLVM_CONFIG := $(RUSTCSRC)build/bin/llvm-config
++LLVM_CONFIG ?= $(RUSTCSRC)build/bin/llvm-config
+ RUSTC_TARGET ?= x86_64-unknown-linux-gnu
+ LLVM_TARGETS ?= X86;ARM;AArch64#;Mips;PowerPC;SystemZ;JSBackend;MSP430;Sparc;NVPTX
+ OVERRIDE_DIR := script-overrides/$(RUSTC_CHANNEL)-$(RUSTC_VERSION)$(OVERRIDE_SUFFIX)/
+
+--- a/run_rustc/Makefile
++++ b/run_rustc/Makefile
+@@ -20,7 +20,7 @@
+ LIBDIR_S := $(PREFIX_S)lib/rustlib/$(RUSTC_TARGET)/lib/
+ BINDIR_S := $(PREFIX_S)bin/
+ 
+-LLVM_CONFIG := $(RUST_SRC)../build/bin/llvm-config
++LLVM_CONFIG ?= $(RUST_SRC)../build/bin/llvm-config
+ LLVM_TARGETS ?= X86;ARM;AArch64#;Mips;PowerPC;SystemZ;JSBackend;MSP430;Sparc;NVPTX
+ 
+ RUSTC_ENV_VARS := CFG_COMPILER_HOST_TRIPLE=$(RUSTC_TARGET)
+--- a/rustc-1.29.0-src/src/librustc_llvm/lib.rs
+--- b/rustc-1.29.0-src/src/librustc_llvm/lib.rs
+@@ -23,6 +23,9 @@
+ #![feature(link_args)]
+ #![feature(static_nobundle)]
+ 
++// https://github.com/rust-lang/rust/issues/34486
++#[link(name = "ffi")] extern {}
++
+ // See librustc_cratesio_shim/Cargo.toml for a comment explaining this.
+ #[allow(unused_extern_crates)]
+ extern crate rustc_cratesio_shim;

--- a/pkgs/development/compilers/mrustc/patches/0003-dont-build-llvm.patch
+++ b/pkgs/development/compilers/mrustc/patches/0003-dont-build-llvm.patch
@@ -1,0 +1,14 @@
+--- a/minicargo.mk
++++ b/minicargo.mk
+@@ -116,11 +116,6 @@
+ LLVM_CMAKE_OPTS += CMAKE_BUILD_TYPE=RelWithDebInfo
+ 
+ 
+-$(LLVM_CONFIG): $(RUSTCSRC)build/Makefile
+-	$Vcd $(RUSTCSRC)build && $(MAKE)
+-$(RUSTCSRC)build/Makefile: $(RUSTCSRC)src/llvm/CMakeLists.txt
+-	@mkdir -p $(RUSTCSRC)build
+-	$Vcd $(RUSTCSRC)build && cmake $(addprefix -D , $(LLVM_CMAKE_OPTS)) ../src/llvm
+ 
+ 
+ #

--- a/pkgs/development/compilers/mrustc/patches/0004-echo-newlines.patch
+++ b/pkgs/development/compilers/mrustc/patches/0004-echo-newlines.patch
@@ -1,0 +1,13 @@
+--- a/run_rustc/Makefile
++++ b/run_rustc/Makefile
+@@ -103,7 +103,9 @@
+ else
+ 	cp $(OUTDIR)build-rustc/release/rustc_binary $(BINDIR)rustc_binary
+ endif
+-	echo '#!/bin/sh\nd=$$(dirname $$0)\nLD_LIBRARY_PATH="$(abspath $(LIBDIR))" $$d/rustc_binary $$@' >$@
++	echo '#!$(shell which bash)' > $@
++	echo 'd=$$(dirname $$0)' >> $@
++	echo 'LD_LIBRARY_PATH="$(abspath $(LIBDIR))" $$d/rustc_binary $$@' >> $@
+ 	chmod +x $@
+ 
+ $(BINDIR)hello_world: $(RUST_SRC)test/run-pass/hello.rs $(LIBDIR)libstd.rlib $(BINDIR)rustc

--- a/pkgs/development/compilers/mrustc/patches/0005-remove-time-dependency.patch
+++ b/pkgs/development/compilers/mrustc/patches/0005-remove-time-dependency.patch
@@ -1,0 +1,25 @@
+--- a/run_rustc/Makefile
++++ b/run_rustc/Makefile
+@@ -111,7 +111,7 @@
+ $(BINDIR)hello_world: $(RUST_SRC)test/run-pass/hello.rs $(LIBDIR)libstd.rlib $(BINDIR)rustc
+ 	@mkdir -p $(dir $@)
+ 	@echo "[RUSTC] -o $@"
+-	$Vtime $(DBG) $(BINDIR)rustc $(RUSTFLAGS_$@) -L $(LIBDIR) -L ../output/libs $< -o $@
++	$V $(DBG) $(BINDIR)rustc $(RUSTFLAGS_$@) -L $(LIBDIR) -L ../output/libs $< -o $@
+ 
+ # 
+ # - Build libstd in a hacky hard-coded way first, to allow build scripts to work
+@@ -119,11 +119,11 @@
+ $(LIBDIR_S)lib%.rlib: $(RUST_SRC)lib%/lib.rs $(BINDIR_S)rustc
+ 	@mkdir -p $(dir $@)
+ 	@echo "[RUSTC] -o $@"
+-	$Vtime $(DBG) $(BINDIR_S)rustc --crate-type rlib --crate-name $* -L $(LIBDIR_S) $< -o $@ $(RUSTFLAGS_$*)
++	$V $(DBG) $(BINDIR_S)rustc --crate-type rlib --crate-name $* -L $(LIBDIR_S) $< -o $@ $(RUSTFLAGS_$*)
+ $(LIBDIR_S)lib%.rlib: $(RUST_SRC)lib%/src/lib.rs $(BINDIR_S)rustc
+ 	@mkdir -p $(dir $@)
+ 	@echo "[RUSTC] -o $@"
+-	$Vtime $(DBG) $(BINDIR_S)rustc --crate-type rlib --crate-name $* -L $(LIBDIR_S) $< -o $@ $(RUSTFLAGS_$*)
++	$V $(DBG) $(BINDIR_S)rustc --crate-type rlib --crate-name $* -L $(LIBDIR_S) $< -o $@ $(RUSTFLAGS_$*)
+ 
+ fcn_extcrate = $(patsubst %,$(LIBDIR_S)lib%.rlib,$(1))
+ 

--- a/pkgs/development/compilers/mrustc/patches/0006-settable-rust-target.patch
+++ b/pkgs/development/compilers/mrustc/patches/0006-settable-rust-target.patch
@@ -1,0 +1,11 @@
+--- a/run_rustc/Makefile3
++++ b/run_rustc/Makefile
+@@ -9,7 +9,7 @@
+ OUTDIR_SUF ?= -$(RUSTC_VERSION)
+ endif
+ 
+-RUSTC_TARGET := x86_64-unknown-linux-gnu
++RUSTC_TARGET ?= x86_64-unknown-linux-gnu
+ 
+ OUTDIR := output$(OUTDIR_SUF)/
+ PREFIX := $(OUTDIR)prefix/

--- a/pkgs/development/compilers/mrustc/patches/0007-increase-parallelism.patch
+++ b/pkgs/development/compilers/mrustc/patches/0007-increase-parallelism.patch
@@ -1,0 +1,28 @@
+--- a/run_rustc/Makefile
++++ b/run_rustc/Makefile
+@@ -79,14 +79,14 @@
+ 	@mkdir -p $(OUTDIR)build-std
+ 	@mkdir -p $(LIBDIR)
+ 	@echo [CARGO] $(RUST_SRC)libstd/Cargo.toml
+-	$VCARGO_TARGET_DIR=$(OUTDIR)build-std RUSTC=$(BINDIR_S)rustc $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)libstd/Cargo.toml  -j 1 --release --features panic-unwind
++	$VCARGO_TARGET_DIR=$(OUTDIR)build-std RUSTC=$(BINDIR_S)rustc $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)libstd/Cargo.toml  -j $(NIX_BUILD_CORES) --release --features panic-unwind
+ 	$Vcp --remove-destination $(OUTDIR)build-std/release/deps/*.rlib $(LIBDIR)
+ 	$Vcp --remove-destination $(OUTDIR)build-std/release/deps/*.so $(LIBDIR)
+ # libtest
+ $(LIBDIR)libtest.rlib: $(BINDIR)rustc_m $(LIBDIR)libstd.rlib $(CARGO_HOME)config
+ 	@mkdir -p $(OUTDIR)build-test
+ 	@echo [CARGO] $(RUST_SRC)libtest/Cargo.toml
+-	$VCARGO_TARGET_DIR=$(OUTDIR)build-test RUSTC=$(BINDIR)rustc_m $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)libtest/Cargo.toml  -j 1 --release
++	$VCARGO_TARGET_DIR=$(OUTDIR)build-test RUSTC=$(BINDIR)rustc_m $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)libtest/Cargo.toml  -j $(NIX_BUILD_CORES) --release
+ 	@mkdir -p $(LIBDIR)
+ 	$Vcp --remove-destination $(OUTDIR)build-test/release/deps/*.rlib $(LIBDIR)
+ 	$Vcp --remove-destination $(OUTDIR)build-test/release/deps/*.so $(LIBDIR)
+@@ -95,7 +95,7 @@
+ $(BINDIR)rustc: $(BINDIR)rustc_m $(BINDIR)cargo $(CARGO_HOME)config $(LIBDIR)libtest.rlib
+ 	@mkdir -p $(PREFIX)tmp
+ 	@echo [CARGO] $(RUST_SRC)rustc/Cargo.toml
+-	$V$(RUSTC_ENV_VARS) TMPDIR=$(abspath $(PREFIX)tmp) CARGO_TARGET_DIR=$(OUTDIR)build-rustc RUSTC=$(BINDIR)rustc_m RUSTC_ERROR_METADATA_DST=$(abspath $(PREFIX)) $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)rustc/Cargo.toml --release -j 1
++	$V$(RUSTC_ENV_VARS) TMPDIR=$(abspath $(PREFIX)tmp) CARGO_TARGET_DIR=$(OUTDIR)build-rustc RUSTC=$(BINDIR)rustc_m RUSTC_ERROR_METADATA_DST=$(abspath $(PREFIX)) $(CARGO_ENV) $(BINDIR)cargo build --manifest-path $(RUST_SRC)rustc/Cargo.toml --release -j $(NIX_BUILD_CORES)
+ 	cp $(OUTDIR)build-rustc/release/deps/*.so $(LIBDIR)
+ 	cp $(OUTDIR)build-rustc/release/deps/*.rlib $(LIBDIR)
+ ifeq ($(RUSTC_VERSION),1.19.0)

--- a/pkgs/development/compilers/rust/0002-serde.patch
+++ b/pkgs/development/compilers/rust/0002-serde.patch
@@ -1,0 +1,26 @@
+From 036c87c82793f1da9f98445e8e27462cc19bbe0a Mon Sep 17 00:00:00 2001
+From: John Ericson <John.Ericson@Obsidian.Systems>
+Date: Sat, 22 Feb 2020 14:38:38 -0500
+Subject: [PATCH] Allow getting `no_std` from the config file
+
+Currently, it is only set correctly in the sanity checking implicit
+default fallback code. Having a config file at all will for force
+`no_std = false`.
+---
+ src/bootstrap/config.rs | 3 +++
+ src/bootstrap/sanity.rs | 4 +---
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+--- a/src/bootstrap/toolstate.rs
++++ b/src/bootstrap/toolstate.rs
+@@ -8,6 +8,9 @@
+ // option. This file may not be copied, modified, or distributed
+ // except according to those terms.
+ 
++
++use serde_json;
++
+ #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+ #[serde(rename_all = "kebab-case")]
+ /// Whether a tool can be compiled, tested or neither
+

--- a/pkgs/development/compilers/rust/0003-proc-macro.patch
+++ b/pkgs/development/compilers/rust/0003-proc-macro.patch
@@ -1,0 +1,19 @@
+--- a/src/vendor/proc-macro2/Cargo.toml
++++ b/src/vendor/proc-macro2/Cargo.toml
+@@ -27,12 +27,14 @@
+ 
+ [lib]
+ doctest = false
++[dependencies]
++proc_macro = { path = "../../libproc_macro", optional = true }
+ [dependencies.unicode-xid]
+ version = "0.1"
+ 
+ [features]
+ default = ["proc-macro"]
+ nightly = ["proc-macro"]
+-proc-macro = []
++proc-macro = ["proc_macro"]
+ [badges.travis-ci]
+ repository = "alexcrichton/proc-macro2"
+

--- a/pkgs/development/compilers/rust/1_29.nix
+++ b/pkgs/development/compilers/rust/1_29.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_7
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.29.0";
+  rustcSha256 = "1sb15znckj8pc8q3g7cq03pijnida6cg64yqmgiayxkzskzk9sx4";
+
+  llvm = llvm_7;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.mrustc-full;
+    cargo = buildPackages.mrustc-full;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_29;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_7" ])
+
+

--- a/pkgs/development/compilers/rust/1_30.nix
+++ b/pkgs/development/compilers/rust/1_30.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_7
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.30.1";
+  rustcSha256 = "0aavdc1lqv0cjzbqwl5n59yd0bqdlhn0zas61ljf38yrvc18k8rn";
+
+  llvm = llvm_7;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.mrustc-bootstrap;
+    cargo = buildPackages.mrustc-bootstrap;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_30;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_7" ])
+

--- a/pkgs/development/compilers/rust/1_31.nix
+++ b/pkgs/development/compilers/rust/1_31.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_7
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.31.1";
+  rustcSha256 = "01pg2619bwjnhjbphryrbkwaz0lw8cfffm4xlz35znzipb04vmcs";
+
+  llvm = llvm_7;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_30.packages.stable.rustc;
+    cargo = buildPackages.rust_1_30.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_31;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_7" ])
+
+

--- a/pkgs/development/compilers/rust/1_32.nix
+++ b/pkgs/development/compilers/rust/1_32.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_7
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.32.0";
+  rustcSha256 = "0ji2l9xv53y27xy72qagggvq47gayr5lcv2jwvmfirx029vlqnac";
+
+  llvm = llvm_7;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_31.packages.stable.rustc;
+    cargo = buildPackages.rust_1_31.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_32;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_7" ])
+
+

--- a/pkgs/development/compilers/rust/1_33.nix
+++ b/pkgs/development/compilers/rust/1_33.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_7
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.33.0";
+  rustcSha256 = "152x91mg7bz4ygligwjb05fgm1blwy2i70s2j03zc9jiwvbsh0as";
+
+  llvm = llvm_7;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_32.packages.stable.rustc;
+    cargo = buildPackages.rust_1_32.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_33;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_7" ])
+
+

--- a/pkgs/development/compilers/rust/1_34.nix
+++ b/pkgs/development/compilers/rust/1_34.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_8
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.34.2";
+  rustcSha256 = "0mig0prkmlnpbba1cmi17vlsl88ikv5pi26zjy2kcr64l62lm6n6";
+
+  llvm = llvm_8;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_33.packages.stable.rustc;
+    cargo = buildPackages.rust_1_33.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_34;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_8" ])
+
+

--- a/pkgs/development/compilers/rust/1_35.nix
+++ b/pkgs/development/compilers/rust/1_35.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_8
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.35.0";
+  rustcSha256 = "0bbizy6b7002v1rdhrxrf5gijclbyizdhkglhp81ib3bf5x66kas";
+
+  llvm = llvm_8;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_34.packages.stable.rustc;
+    cargo = buildPackages.rust_1_34.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_35;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_8" ])
+
+

--- a/pkgs/development/compilers/rust/1_36.nix
+++ b/pkgs/development/compilers/rust/1_36.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_8
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.36.0";
+  rustcSha256 = "06xv2p6zq03lidr0yaf029ii8wnjjqa894nkmrm6s0rx47by9i04";
+
+  llvm = llvm_8;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_35.packages.stable.rustc;
+    cargo = buildPackages.rust_1_35.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_36;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_8" ])
+
+

--- a/pkgs/development/compilers/rust/1_37.nix
+++ b/pkgs/development/compilers/rust/1_37.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_8
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.37.0";
+  rustcSha256 = "1hrqprybhkhs6d9b5pjskfnc5z9v2l2gync7nb39qjb5s0h703hj";
+
+  llvm = llvm_8;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_36.packages.stable.rustc;
+    cargo = buildPackages.rust_1_36.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_37;
+
+  # This specific version of Rust requires compiler-rt (for profiling).
+  # See also:
+  # * https://github.com/NixOS/nixpkgs/commit/b7a828031238b0962cd91131eba50844ef401b93
+  # * https://github.com/NixOS/nixpkgs/commit/adb15c3a63fd96edcf7585394b8ccbeb1ceee336
+  rustcPreConfigure = ''
+    mkdir src/llvm-project/compiler-rt
+    tar xf ${llvmPackages_5.compiler-rt.src} -C src/llvm-project/compiler-rt --strip-components=1
+  '';
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_8" ])
+
+

--- a/pkgs/development/compilers/rust/1_38.nix
+++ b/pkgs/development/compilers/rust/1_38.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_8
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.38.0";
+  rustcSha256 = "101dlpsfkq67p0hbwx4acqq6n90dj4bbprndizpgh1kigk566hk4";
+
+  llvm = llvm_8;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_37.packages.stable.rustc;
+    cargo = buildPackages.rust_1_37.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_38;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_8" ])
+
+

--- a/pkgs/development/compilers/rust/1_39.nix
+++ b/pkgs/development/compilers/rust/1_39.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_8
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.39.0";
+  rustcSha256 = "0mwkc1bnil2cfyf6nglpvbn2y0zfbv44zfhsd5qg4c9rm6vgd8dl";
+
+  llvm = llvm_8;
+
+  # rustc-dev didn't exist yet
+  enableRustcDev = false;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_38.packages.stable.rustc;
+    cargo = buildPackages.rust_1_38.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_39;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_8" ])
+
+

--- a/pkgs/development/compilers/rust/1_40.nix
+++ b/pkgs/development/compilers/rust/1_40.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_8
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.40.0";
+  rustcSha256 = "1ba9llwhqm49w7sz3z0gqscj039m53ky9wxzhaj11z6yg1ah15yx";
+
+  llvm = llvm_8;
+
+  enableRustcDev = true;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_39.packages.stable.rustc;
+    cargo = buildPackages.rust_1_39.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_40;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_8" ])
+
+

--- a/pkgs/development/compilers/rust/1_41.nix
+++ b/pkgs/development/compilers/rust/1_41.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchpatch
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, llvm_8
+, pkgsBuildTarget, pkgsBuildBuild
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.41.1";
+  rustcSha256 = "0jypz2mrzac41sj0zh07yd1z36g2s2rvgsb8g624sk4l14n84ijm";  # FIXME
+
+  llvm = llvm_8;
+
+  enableRustcDev = true;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_40.packages.stable.rustc;
+    cargo = buildPackages.rust_1_40.packages.stable.cargo;
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_41;
+
+  rustcPatches = [
+    # Allow getting no_std from the config file. See:
+    # * https://github.com/NixOS/nixpkgs/commit/0b0e6918331b1e99d2b148e296a9bd0cd0dd5479
+    # * https://github.com/rust-lang/rust/pull/69381
+    (fetchpatch {
+      url = "https://github.com/QuiltOS/rust/commit/f1803452b9e95bfdbc3b8763138b9f92c7d12b46.diff";
+      sha256 = "1mzxaj46bq7ll617wg0mqnbnwr1da3hd4pbap8bjwhs3kfqnr7kk";
+    })
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "llvm_8" ])
+
+

--- a/pkgs/development/compilers/rust/1_42.nix
+++ b/pkgs/development/compilers/rust/1_42.nix
@@ -12,6 +12,7 @@
 , newScope, callPackage
 , CoreFoundation, Security
 , llvmPackages_5
+, llvm_9
 , pkgsBuildTarget, pkgsBuildBuild
 } @ args:
 
@@ -19,19 +20,15 @@ import ./default.nix {
   rustcVersion = "1.42.0";
   rustcSha256 = "0x9lxs82may6c0iln0b908cxyn1cv7h03n5cmbx3j1bas4qzks6j";
 
+  llvm = llvm_9;
+
+  enableRustcDev = true;
+
   # Note: the version MUST be one version prior to the version we're
   # building
-  bootstrapVersion = "1.41.0";
-
-  # fetch hashes by running `print-hashes.sh 1.42.0`
-  bootstrapHashes = {
-    i686-unknown-linux-gnu = "a93a34f9cf3d35de2496352cb615b42b792eb09db3149b3a278efd2c58fa7897";
-    x86_64-unknown-linux-gnu = "343ba8ef7397eab7b3bb2382e5e4cb08835a87bff5c8074382c0b6930a41948b";
-    arm-unknown-linux-gnueabihf = "d0b33fcc97eeb96d716b30573c7e66affdf9077ecdecb30df2498b49f8284047";
-    armv7-unknown-linux-gnueabihf = "3c8e787fb4f4f304a065e78c38010f0b5722d809f9dafb0e904084bf0f54f7be";
-    aarch64-unknown-linux-gnu = "79ddfb5e2563d0ee09a567fbbe121a2aed3c3bc61255b2787f2dd42183a10f27";
-    i686-apple-darwin = "628134b3fbaf5c0e7a25bd9a2b8d25f6e68bb256c8b04a3332ec979f5a1cd339";
-    x86_64-apple-darwin = "b6504003ab70b11f278e0243a43ba9d6bf75e8ad6819b4058a2b6e3991cc8d7a";
+  bootstrapRustPackages = {
+    rustc = buildPackages.rust_1_41.packages.stable.rustc;
+    cargo = buildPackages.rust_1_41.packages.stable.cargo;
   };
 
   selectRustPackage = pkgs: pkgs.rust_1_42;
@@ -41,4 +38,6 @@ import ./default.nix {
   ];
 }
 
-(builtins.removeAttrs args [ "fetchpatch" ])
+(builtins.removeAttrs args [ "fetchpatch" "llvm_9" ])
+
+

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -15,88 +15,88 @@ let
     = "rustc,rust-std-${platform}"
     + (optionalString bootstrapping ",cargo")
     ;
-in
-
-rec {
-  rustc = stdenv.mkDerivation {
-    name = "rustc-${versionType}-${version}";
-
-    inherit version;
-    inherit src;
-
-    meta = with stdenv.lib; {
-      homepage = "http://www.rust-lang.org/";
-      description = "A safe, concurrent, practical language";
-      maintainers = with maintainers; [ qknight ];
-      license = [ licenses.mit licenses.asl20 ];
+in {
+  packages = rec {
+    rustc = stdenv.mkDerivation {
+      name = "rustc-${versionType}-${version}";
+  
+      inherit version;
+      inherit src;
+  
+      meta = with stdenv.lib; {
+        homepage = "http://www.rust-lang.org/";
+        description = "A safe, concurrent, practical language";
+        maintainers = with maintainers; [ qknight ];
+        license = [ licenses.mit licenses.asl20 ];
+      };
+  
+      buildInputs = [ bash ]
+        ++ stdenv.lib.optional stdenv.isDarwin Security;
+  
+      postPatch = ''
+        patchShebangs .
+      '';
+  
+      installPhase = ''
+        ./install.sh --prefix=$out \
+          --components=${installComponents}
+  
+        ${optionalString (stdenv.isLinux && bootstrapping) ''
+          patchelf \
+            --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+            "$out/bin/rustc"
+          patchelf \
+            --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+            "$out/bin/rustdoc"
+          patchelf \
+            --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+            "$out/bin/cargo"
+        ''}
+  
+        # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
+        # (or similar) here. It causes strange effects where rustc loads
+        # the wrong libraries in a bootstrap-build causing failures that
+        # are very hard to track down. For details, see
+        # https://github.com/rust-lang/rust/issues/34722#issuecomment-232164943
+      '';
+  
+      setupHooks = ./setup-hook.sh;
     };
-
-    buildInputs = [ bash ]
-      ++ stdenv.lib.optional stdenv.isDarwin Security;
-
-    postPatch = ''
-      patchShebangs .
-    '';
-
-    installPhase = ''
-      ./install.sh --prefix=$out \
-        --components=${installComponents}
-
-      ${optionalString (stdenv.isLinux && bootstrapping) ''
-        patchelf \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          "$out/bin/rustc"
-        patchelf \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          "$out/bin/rustdoc"
-        patchelf \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          "$out/bin/cargo"
-      ''}
-
-      # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
-      # (or similar) here. It causes strange effects where rustc loads
-      # the wrong libraries in a bootstrap-build causing failures that
-      # are very hard to track down. For details, see
-      # https://github.com/rust-lang/rust/issues/34722#issuecomment-232164943
-    '';
-
-    setupHooks = ./setup-hook.sh;
-  };
-
-  cargo = stdenv.mkDerivation {
-    name = "cargo-${versionType}-${version}";
-
-    inherit version;
-    inherit src;
-
-    meta = with stdenv.lib; {
-      homepage = "http://www.rust-lang.org/";
-      description = "A safe, concurrent, practical language";
-      maintainers = with maintainers; [ qknight ];
-      license = [ licenses.mit licenses.asl20 ];
+  
+    cargo = stdenv.mkDerivation {
+      name = "cargo-${versionType}-${version}";
+  
+      inherit version;
+      inherit src;
+  
+      meta = with stdenv.lib; {
+        homepage = "http://www.rust-lang.org/";
+        description = "A safe, concurrent, practical language";
+        maintainers = with maintainers; [ qknight ];
+        license = [ licenses.mit licenses.asl20 ];
+      };
+  
+      buildInputs = [ makeWrapper bash ]
+        ++ stdenv.lib.optional stdenv.isDarwin Security;
+  
+      postPatch = ''
+        patchShebangs .
+      '';
+  
+      installPhase = ''
+        patchShebangs ./install.sh
+        ./install.sh --prefix=$out \
+          --components=cargo
+  
+        ${optionalString (stdenv.isLinux && bootstrapping) ''
+          patchelf \
+            --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+            "$out/bin/cargo"
+        ''}
+  
+        wrapProgram "$out/bin/cargo" \
+          --suffix PATH : "${rustc}/bin"
+      '';
     };
-
-    buildInputs = [ makeWrapper bash ]
-      ++ stdenv.lib.optional stdenv.isDarwin Security;
-
-    postPatch = ''
-      patchShebangs .
-    '';
-
-    installPhase = ''
-      patchShebangs ./install.sh
-      ./install.sh --prefix=$out \
-        --components=cargo
-
-      ${optionalString (stdenv.isLinux && bootstrapping) ''
-        patchelf \
-          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-          "$out/bin/cargo"
-      ''}
-
-      wrapProgram "$out/bin/cargo" \
-        --suffix PATH : "${rustc}/bin"
-    '';
   };
 }

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -3,12 +3,16 @@
 , CoreFoundation, Security
 }:
 
+let
+  rustTargetPrefix = if (builtins.compareVersions rustc.version "1.32.0") >= 0 then "" else "src/";
+in
 rustPlatform.buildRustPackage {
   name = "cargo-${rustc.version}";
   inherit (rustc) version src;
 
+  inherit rustTargetPrefix;
   # the rust source tarball already has all the dependencies vendored, no need to fetch them again
-  cargoVendorDir = "vendor";
+  cargoVendorDir = "${rustTargetPrefix}vendor";
   preBuild = "pushd src/tools/cargo";
   postBuild = "popd";
 

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -1,10 +1,11 @@
 { rustcVersion
 , rustcSha256
 , enableRustcDev ? true
-, bootstrapVersion
-, bootstrapHashes
+, bootstrapRustPackages
 , selectRustPackage
 , rustcPatches ? []
+, rustcPreConfigure ? null
+, llvm
 }:
 { stdenv, lib
 , buildPackages
@@ -53,18 +54,9 @@
   # cycles / purify builds). In this way, nixpkgs would be in control of all
   # bootstrapping.
   packages = {
-    prebuilt = callPackage ./bootstrap.nix {
-      version = bootstrapVersion;
-      hashes = bootstrapHashes;
-    };
     stable = lib.makeScope newScope (self: let
-      # Like `buildRustPackages`, but may also contain prebuilt binaries to
-      # break cycle. Just like `bootstrapTools` for nixpkgs as a whole,
-      # nothing in the final package set should refer to this.
-      bootstrapRustPackages = self.buildRustPackages.overrideScope' (_: _:
-        lib.optionalAttrs (stdenv.buildPlatform == stdenv.hostPlatform)
-          (selectRustPackage buildPackages).packages.prebuilt);
       bootRustPlatform = makeRustPlatform bootstrapRustPackages;
+
     in {
       # Packages suitable for build-time, e.g. `build.rs`-type stuff.
       buildRustPackages = (selectRustPackage buildPackages).packages.stable;
@@ -75,6 +67,9 @@
         sha256 = rustcSha256;
         inherit enableRustcDev;
 
+        inherit llvm;
+
+        preConfigure = rustcPreConfigure;
         patches = rustcPatches;
 
         # Use boot package set to break cycle

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,6 +1,6 @@
 { stdenv, removeReferencesTo, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget
 , fetchurl, file, python3
-, llvm_9, darwin, cmake, rust, rustPlatform
+, llvm, darwin, cmake, rust, rustPlatform
 , pkgconfig, openssl
 , which, libffi
 , withBundledLLVM ? false
@@ -8,18 +8,19 @@
 , version
 , sha256
 , patches ? []
+, preConfigure ? null
 }:
 
 let
   inherit (stdenv.lib) optionals optional optionalString;
   inherit (darwin.apple_sdk.frameworks) Security;
 
-  llvmSharedForBuild = pkgsBuildBuild.llvm_9.override { enableSharedLibraries = true; };
-  llvmSharedForHost = pkgsBuildHost.llvm_9.override { enableSharedLibraries = true; };
-  llvmSharedForTarget = pkgsBuildTarget.llvm_9.override { enableSharedLibraries = true; };
+  llvmSharedForBuild = llvm.override { enableSharedLibraries = true; };
+  llvmSharedForHost = llvm.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = llvm.override { enableSharedLibraries = true; };
 
   # For use at runtime
-  llvmShared = llvm_9.override { enableSharedLibraries = true; };
+  llvmShared = llvm.override { enableSharedLibraries = true; };
 in stdenv.mkDerivation rec {
   pname = "rustc";
   inherit version;
@@ -93,6 +94,8 @@ in stdenv.mkDerivation rec {
   ] ++ optionals stdenv.isLinux [
     "--enable-profiler" # build libprofiler_builtins
   ];
+
+  inherit preConfigure;
 
   # The bootstrap.py will generated a Makefile that then executes the build.
   # The BOOTSTRAP_ARGS used by this Makefile must include all flags to pass

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8963,6 +8963,10 @@ in
     inherit (darwin) apple_sdk;
   };
 
+  mrustc = callPackage ../development/compilers/mrustc { };
+  mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
+  mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
+
   rust_1_42 = callPackage ../development/compilers/rust/1_42.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8970,9 +8970,57 @@ in
   rust_1_42 = callPackage ../development/compilers/rust/1_42.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
+  rust_1_41 = callPackage ../development/compilers/rust/1_41.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_40 = callPackage ../development/compilers/rust/1_40.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_39 = callPackage ../development/compilers/rust/1_39.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_38 = callPackage ../development/compilers/rust/1_38.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_37 = callPackage ../development/compilers/rust/1_37.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_36 = callPackage ../development/compilers/rust/1_36.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_35 = callPackage ../development/compilers/rust/1_35.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_34 = callPackage ../development/compilers/rust/1_34.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_33 = callPackage ../development/compilers/rust/1_33.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_32 = callPackage ../development/compilers/rust/1_32.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_31 = callPackage ../development/compilers/rust/1_31.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rust_1_30 = callPackage ../development/compilers/rust/1_30.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
   rust = rust_1_42;
 
   rustPackages_1_42 = rust_1_42.packages.stable;
+  rustPackages_1_41 = rust_1_41.packages.stable;
+  rustPackages_1_40 = rust_1_40.packages.stable;
+  rustPackages_1_39 = rust_1_39.packages.stable;
+  rustPackages_1_38 = rust_1_38.packages.stable;
+  rustPackages_1_37 = rust_1_37.packages.stable;
+  rustPackages_1_36 = rust_1_36.packages.stable;
+  rustPackages_1_35 = rust_1_35.packages.stable;
+  rustPackages_1_34 = rust_1_34.packages.stable;
+  rustPackages_1_33 = rust_1_33.packages.stable;
+  rustPackages_1_32 = rust_1_32.packages.stable;
+  rustPackages_1_31 = rust_1_31.packages.stable;
+  rustPackages_1_30 = rust_1_30.packages.stable;
   rustPackages = rustPackages_1_42;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;


### PR DESCRIPTION
###### Motivation for this change

Fully building Rust from source instead of starting with a binary download.
Resolves #72606.

###### Things done

* Added mrustc, a small compiler written in C++
* Compile Rust 1.29 with mrustc (this is the latest version that mrustc can compile)
* Add Rust 1.30.2,  to 1.41.0, as each version 1.n is required to build version 1.(n+1)
* Change the 1.42 derivation to build from the previous 1.41 derivation instead of rustc-binary

###### Discussion

I am not sure this is something you want in Nixpkgs; as it significantly increases the resources needed to build the latest Rust version.
The initial build of Rust 1.29 (by mrustc) requires 2.5GB in /build and 15GB of RAM and takes about 30 minutes on a modern x86 machine. Each subsequent build of Rust (by rustc) takes about 15 minutes.
Most of the build time (especially the first one) is spent in a single compilation unit, which is `src/librustc/lib.rs`, so it is not very parallel.

It also requires LLVM 7 and 8 for older Rust version, in addition to LLVM 9 for the current version. (Although all versions should support LLVM 7, if you want to reduce this.)

###### Tests

I tested building on x86_64 and master. I'm currently building the chain on x86_64 + staging but it's looking good so far (I'll update this text when it's done).
I'm also trying to test on aarch64, but it's taking forever as my test machine only has 4GB of RAM.

###### Checklist

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
