### PR TITLE
ledger-autosync: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/applications/office/ledger-autosync/default.nix
+++ b/pkgs/applications/office/ledger-autosync/default.nix
@@ -2,14 +2,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ledger-autosync";
-  version = "1.0.1";
+  version = "1.0.2";
 
 # no tests included in PyPI tarball
   src = fetchFromGitHub {
     owner = "egh";
     repo = "ledger-autosync";
     rev = "v${version}";
-    sha256 = "1h5mjngdd3rmzwmy026xmas0491kxxi1vxkd5m1xii7y6j50z14q";
+    sha256 = "0sh32jcf8iznnbg1kqlrswbzfmn4h3gkw32q20xwxzz4935pz1qk";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
