### PR TITLE
j: 807 -> 901

### DIFF
--- a/pkgs/development/interpreters/j/default.nix
+++ b/pkgs/development/interpreters/j/default.nix
@@ -2,13 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "j";
-  version = "807";
-  jtype = "release";
+  version = "901";
+  jtype = "release-e";
   src = fetchFromGitHub {
     owner = "jsoftware";
     repo = "jsource";
     rev = "j${version}-${jtype}";
-    sha256 = "1qciw2yg9x996zglvj2461qby038x89xcmfb3qyrh3myn8m1nq2n";
+    sha256 = "13ky37rrl6mc66fckrdnrw64gmvq1qlv6skzd513lab4d0wigshw";
+    name = "jsource";
   };
 
   buildInputs = [ readline libedit bc ];
@@ -26,57 +27,33 @@ stdenv.mkDerivation rec {
     export HOME=$TMPDIR
     export JLIB=$SOURCE_DIR/jlibrary
 
-    export jbld=$HOME/bld
-    export jplatform=${platform}
-    export jmake=$SOURCE_DIR/make
-    export jgit=$SOURCE_DIR
-    export JBIN=$jbld/j${bits}/bin
-    mkdir -p $JBIN
-
     echo $OUT_DIR
 
-    cd make
+    cd make2
 
     patchShebangs .
-    sed -i jvars.sh -e "
-      s@~/git/jsource@$SOURCE_DIR@;
-      s@~/jbld@$HOME@;
-      "
-
     sed -i $JLIB/bin/profile.ijs -e "s@'/usr/share/j/.*'@'$out/share/j'@;"
 
-    # For future versions, watch
-    # https://github.com/jsoftware/jsource/pull/4
-    cp ./jvars.sh $HOME
+    ./build_all.sh
 
-    echo '
-      #define jversion   "${version}"
-      #define jplatform  "${platform}"
-      #define jtype      "${jtype}"         // release,beta,...
-      #define jlicense   "GPL3"
-      #define jbuilder   "nixpkgs"  // website or email
-      ' > ../jsrc/jversion.h
-
-    ./build_jconsole.sh j${bits}
-    ./build_libj.sh j${bits}
+    cp $SOURCE_DIR/bin/${platform}/j${bits}*/* "$JLIB/bin"
   '';
 
   checkPhase = ''
-    echo 'i. 5' | $JBIN/jconsole | fgrep "0 1 2 3 4"
+
+    echo 'i. 5' | $JLIB/bin/jconsole | fgrep "0 1 2 3 4"
 
     # Now run the real tests
     cd $SOURCE_DIR/test
     for f in *.ijs
     do
       echo $f
-      $JBIN/jconsole < $f > /dev/null || echo FAIL && echo PASS
+      $JLIB/bin/jconsole < $f > /dev/null || echo FAIL && echo PASS
     done
   '';
 
   installPhase = ''
     mkdir -p "$out"
-    cp -r $JBIN "$out/bin"
-    rm $out/bin/*.txt # Remove logs from the bin folder
 
     mkdir -p "$out/share/j"
     cp -r $JLIB/{addons,system} "$out/share/j"


### PR DESCRIPTION
Upgrade j to 901.
Uses the newer build scripts in the make2 directory in the jsource repo.

###### Motivation for this change
Update j to the latest stable release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
