### PR TITLE
Add myself (turion) to the maintainers list for several packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7816,6 +7816,12 @@
     githubId = 563054;
     name = "Thomas Tuegel";
   };
+  turion = {
+    email = "programming@manuelbaerenz.de";
+    github = "turion";
+    githubId = 303489;
+    name = "Manuel Bärenz";
+  };
   tv = {
     email = "tv@krebsco.de";
     github = "4z3";

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -33,7 +33,7 @@ mkDerivation rec {
     description = "Music notation and composition software";
     homepage = "https://musescore.org/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ vandenoever ];
+    maintainers = with maintainers; [ vandenoever turion ];
     platforms = platforms.linux;
     repositories.git = "https://github.com/musescore/MuseScore";
   };

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -54,7 +54,7 @@ in
       homepage = "https://github.com/VSCodium/vscodium";
       downloadPage = "https://github.com/VSCodium/vscodium/releases";
       license = licenses.mit;
-      maintainers = with maintainers; [ synthetica ];
+      maintainers = with maintainers; [ synthetica turion ];
       platforms = [ "x86_64-linux" "x86_64-darwin" ];
     };
   }

--- a/pkgs/applications/kde/konsole.nix
+++ b/pkgs/applications/kde/konsole.nix
@@ -11,7 +11,7 @@ mkDerivation {
   name = "konsole";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
-    maintainers = [ lib.maintainers.ttuegel ];
+    maintainers = with lib.maintainers; [ ttuegel turion ];
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [

--- a/pkgs/applications/kde/okular.nix
+++ b/pkgs/applications/kde/okular.nix
@@ -21,7 +21,7 @@ mkDerivation {
   meta = with lib; {
     homepage = "http://www.kde.org";
     license = with licenses; [ gpl2 lgpl21 fdl12 bsd3 ];
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = with maintainers; [ ttuegel turion ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
     longDescription = "A community fork of KeePassX, which is itself a port of KeePass Password Safe. The goal is to extend and improve KeePassX with new features and bugfixes to provide a feature-rich, fully cross-platform and modern open-source password manager. Accessible via native cross-platform GUI, CLI, and browser integration with the KeePassXC Browser Extension (https://github.com/keepassxreboot/keepassxc-browser).";
     homepage = "https://keepassxc.org/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ jonafato ];
+    maintainers = with maintainers; [ jonafato turion ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/misc/krusader/default.nix
+++ b/pkgs/applications/misc/krusader/default.nix
@@ -20,7 +20,7 @@ in mkDerivation rec {
     description = "Norton/Total Commander clone for KDE";
     license = licenses.gpl2;
     homepage = "http://www.krusader.org";
-    maintainers = with maintainers; [ sander ];
+    maintainers = with maintainers; [ sander turion ];
   };
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];


### PR DESCRIPTION
Following nh2's advice, I want to be more involved in nixpkgs,
and I'll start to review changes to programs that are important to me,
and that didn't have a long list of maintainers yet.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note: I got the feeling that `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` didn't do anything sensible. See the command line output:
```
$ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
Von https://github.com/NixOS/nixpkgs
 + b57929a4fa1...d4d6d26588d master     -> refs/nixpkgs-review/0  (Aktualisierung erzwungen)
$ git worktree add /home/turion/.cache/nixpkgs-review/rev-f253da42f8fe2bf2d955849d9b4fff54e1a0f0d1-dirty/nixpkgs d4d6d26588de50957d8723b219007b0b35f346d5
Bereite Arbeitsverzeichnis vor (losgelöster HEAD d4d6d26588d)
Aktualisiere Dateien: 100% (21510/21510), Fertig.
HEAD ist jetzt bei d4d6d26588d Merge pull request #85458 from rnhmjoj/mitmproxy
$ nix-env -f /home/turion/.cache/nixpkgs-review/rev-f253da42f8fe2bf2d955849d9b4fff54e1a0f0d1-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```