### PR TITLE
forked-daapd: init at 27.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -449,6 +449,7 @@
   ./services/misc/ethminer.nix
   ./services/misc/exhibitor.nix
   ./services/misc/felix.nix
+  ./services/misc/forked-daapd.nix
   ./services/misc/freeswitch.nix
   ./services/misc/fstrim.nix
   ./services/misc/gammu-smsd.nix

--- a/nixos/modules/services/misc/forked-daapd.nix
+++ b/nixos/modules/services/misc/forked-daapd.nix
@@ -1,0 +1,149 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.forked-daapd;
+
+  configPrimitives = with types; (nullOr (either (either (either bool int) str) path));
+  configPrimitivesWithList = with types; (either configPrimitives (listOf configPrimitives));
+  configTypes = with types; (either configPrimitivesWithList (attrsOf configPrimitivesWithList));
+  toStr = v: if isBool v then boolToString v else toString v;
+
+  boolToYes = b: if b then "yes" else "no";
+  listToStrings = l: builtins.concatStringsSep " " (map (x: "\"${toString x}\",") l);
+
+  linesForAttrs = attrs: concatMap (name: let value = attrs.${name}; in
+  if isAttrs value
+    then [ "${name} {" ] ++ (linesForAttrs value) ++ [ "}" ]
+  else if isList value then [ "${name} = { ${(listToStrings value)} }" ]
+  else [ "${name}=${toStr value}" ]
+  ) (attrNames attrs);
+
+  configFile = pkgs.writeText "forked-daapd.conf" (concatStringsSep "\n" (linesForAttrs cfg.config));
+
+in {
+  options.services.forked-daapd = {
+    enable = mkEnableOption "";
+
+    libraryPaths = mkOption {
+      type = types.listOf types.path;
+      description = "List of directories to index";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "daapd";
+      description = "User account under which forked-daapd runs.";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.forked-daapd;
+      description = "Package to use.";
+    };
+
+    home = mkOption {
+      type = types.path;
+      default = "/var/lib/forked-daapd";
+      description = "The directory where forked-daapd will create files. Make sure it is writable.";
+    };
+
+    virtualHost = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Name of the nginx virtualhost to use and setup. If null, do not setup any virtualhost.";
+    };
+
+    config = mkOption {
+      type = types.attrsOf configTypes;
+      default = {};
+      example = literalExample ''
+        general = {
+          loglevel = debug;
+        }
+      '';
+      description = "forked-daapd configuration file. Refer to the sample configuration";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Open ports in the firewall";
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    services.forked-daapd.config = mkMerge [
+      {
+        general = {
+          uid = cfg.user;
+          logfile = mkDefault "${ cfg.home }/forked-daapd.log";
+          db_path = mkDefault "${ cfg.home }/songs3.db";
+          cache_path = mkDefault "${ cfg.home }/cache.db";
+          websocket_port = mkDefault 3688;
+        };
+        library = {
+          directories = cfg.libraryPaths;
+          port = mkDefault 3689;
+        };
+      }
+      (mkIf cfg.openFirewall {
+        airplay_shared = {
+          control_port = mkDefault 3690;
+          timing_port = mkDefault 3691;
+        };
+      })
+    ];
+
+    systemd.services.forked-daapd = {
+      description = "DAAP/DACP (iTunes), RSP and MPD server, supports AirPlay and Remote";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = ''
+          ${cfg.package}/bin/forked-daapd -f -c ${configFile}
+        '';
+        Restart = "always";
+        User = cfg.user;
+        UMask = "0022";
+      };
+    };
+
+    services.avahi = {
+      enable = true;
+      publish.enable = true;
+      publish.userServices = true;
+      openFirewall = cfg.openFirewall;
+    };
+
+    services.nginx = mkIf (cfg.virtualHost != null) {
+      enable = true;
+      recommendedProxySettings = true;
+      virtualHosts.${cfg.virtualHost} = {
+        locations."/".proxyPass = "http://localhost:${toString cfg.config.library.port}";
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [
+        cfg.config.general.websocket_port
+        cfg.config.library.port
+      ];
+      allowedUDPPorts = [
+        cfg.config.airplay_shared.control_port
+        cfg.config.airplay_shared.timing_port
+      ];
+    };
+
+    users.users.daapd = {
+      description = "forked-daapd service user";
+      name = cfg.user;
+      home = cfg.home;
+      createHome = true;
+      isSystemUser = true;
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -113,6 +113,7 @@ in
   flannel = handleTestOn ["x86_64-linux"] ./flannel.nix {};
   fluentd = handleTest ./fluentd.nix {};
   fontconfig-default-fonts = handleTest ./fontconfig-default-fonts.nix {};
+  forked-daapd = handleTest ./forked-daapd.nix {};
   freeswitch = handleTest ./freeswitch.nix {};
   fsck = handleTest ./fsck.nix {};
   ft2-clone = handleTest ./ft2-clone.nix {};

--- a/nixos/tests/forked-daapd.nix
+++ b/nixos/tests/forked-daapd.nix
@@ -1,0 +1,44 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+let
+  configDir = "/var/lib/forked-daapd";
+  port = 3689;
+in {
+  name = "forked-daapd";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = with maintainers; [ flyfloh ];
+  };
+
+  nodes = {
+    forked_daapd =
+      { pkgs, ... }:
+      {
+        services.forked-daapd = {
+          enable = true;
+          libraryPaths = [ "/media/music" ];
+          home = configDir;
+          openFirewall = true;
+          config = {
+            general = {
+              loglevel = "debug";
+            };
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+    forked_daapd.wait_for_unit("forked-daapd.service")
+    with subtest("Check that the web interface can be reached"):
+        forked_daapd.wait_for_open_port(${toString port})
+        forked_daapd.succeed("curl --fail http://localhost:${toString port}/")
+    with subtest("Print log to ease debugging"):
+        output_log = forked_daapd.succeed("cat ${configDir}/forked-daapd.log")
+        print("\n### forked_daapd.log ###\n")
+        print(output_log + "\n")
+
+    with subtest("Check that no errors were logged"):
+        assert "ERROR" not in output_log
+  '';
+})

--- a/pkgs/servers/forked-daapd/default.nix
+++ b/pkgs/servers/forked-daapd/default.nix
@@ -1,0 +1,87 @@
+{ stdenv,
+  fetchFromGitHub,
+  avahi,
+  antlr3,
+  autoconf,
+  autoreconfHook,
+  curl,
+  ffmpeg,
+  gawk,
+  gettext,
+  gnutls,
+  gperf,
+  json_c,
+  minixml,
+  openssl,
+  libantlr3c,
+  libconfuse,
+  libevent,
+  libgcrypt,
+  libgpgerror,
+  libplist,
+  libsodium,
+  libunistring,
+  libuv,
+  libwebsockets,
+  pkg-config,
+  protobufc,
+  pulseaudio,
+  sqlite,
+  zlib,
+  spotifySupport ? false, libspotify ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "forked-daapd";
+  version = "27.2";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "ejurgensen";
+    rev = version;
+    sha256 = "027ysyc906g1czrpks0qla29ysma9vij88n75v09flajw2d09k6b";
+  };
+
+  nativeBuildInputs = [ antlr3
+                        autoconf
+                        autoreconfHook
+                        ffmpeg
+                        gawk
+                        gettext
+                        gnutls
+                        gperf
+                        json_c
+                        libantlr3c
+                        libconfuse
+                        libevent
+                        libgcrypt
+                        libgpgerror
+                        libplist
+                        libsodium
+                        libunistring
+                        libuv
+                        libwebsockets
+                        minixml
+                        openssl
+                        pkg-config
+                        protobufc
+                        pulseaudio
+                        sqlite
+                        zlib ];
+
+  buildInputs = [ avahi curl ] ++ stdenv.lib.optional spotifySupport libspotify;
+
+  configureFlags = [ "--enable-chromecast"
+                     "--enable-lastfm"
+                     "--with-pulseaudio"
+                   ] ++ stdenv.lib.optional spotifySupport "--enable-spotify";
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://ejurgensen.github.io/forked-daapd";
+    description = "Linux/FreeBSD DAAP (iTunes) and MPD media server with support for AirPlay devices (multiroom), Apple Remote (and compatibles), Chromecast, Spotify and internet radio.";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ flyfloh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -441,6 +441,8 @@ in
 
   fetchgx = callPackage ../build-support/fetchgx { };
 
+  forked-daapd = callPackage ../servers/forked-daapd { };
+
   resolveMirrorURLs = {url}: fetchurl {
     showURLs = true;
     inherit url;


### PR DESCRIPTION
NixOS is missing a package for forked-daapd, which is a DAAP (iTunes) and MPD media server with support for AirPlay devices (multiroom), Apple Remote (and compatibles), Chromecast, Spotify and internet radio.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
