### PR TITLE
zrythm: init at 0.8.252

### DIFF
--- a/pkgs/applications/audio/zrythm/default.nix
+++ b/pkgs/applications/audio/zrythm/default.nix
@@ -1,0 +1,123 @@
+{ stdenv
+, fetchFromGitHub
+, SDL2
+, alsaLib
+, audec
+, bash
+, bash-completion
+, carla
+, chromaprint
+, ffmpeg
+, fftw
+, fftwFloat
+, git
+, gtk3
+, gtksourceview3
+, guile
+, help2man
+, libcyaml
+, libgtop
+, libjack2
+, libsamplerate
+, libsndfile
+, libxml2
+, libyaml
+, lilv
+, meson
+, ninja
+, pandoc
+, pcre
+, pkg-config
+, python3
+, rtaudio
+, rtmidi
+, rubberband
+, serd
+, sord
+, sratom
+, texi2html
+, wrapGAppsHook
+, xdg_utils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zrythm";
+  version = "0.8.252";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0m7i8f5y3lvkbflys0iblkl6ksw6kn2b64k6gy10yd549n8adx69";
+  };
+
+  nativeBuildInputs = [
+    audec
+    git
+    gtk3
+    help2man
+    libxml2
+    meson
+    ninja
+    pandoc
+    pkg-config
+    python3
+    python3.pkgs.sphinx
+    texi2html
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    SDL2
+    alsaLib
+    bash-completion
+    carla
+    chromaprint
+    ffmpeg
+    fftw
+    fftwFloat
+    gtksourceview3
+    guile
+    libcyaml
+    libgtop
+    libjack2
+    libsamplerate
+    libsndfile
+    libyaml
+    lilv
+    pcre
+    rtaudio
+    rtmidi
+    rubberband
+    serd
+    sord
+    sratom
+    xdg_utils
+  ];
+
+  mesonFlags = [
+    "-Denable_ffmpeg=true"
+    "-Denable_rtmidi=true"
+    "-Denable_rtaudio=true"
+    "-Denable_sdl=true"
+    "-Dmanpage=true"
+    "-Duser_manual=true"
+  ];
+
+  postPatch = ''
+    chmod +x resources/gen_gtk_resources_xml_wrap.sh # patchShebangs only works on executable files
+    patchShebangs resources/gen_gtk_resources_xml_wrap.sh
+  '';
+
+  preInstall = ''
+    patchShebangs meson_post_install_wrap.sh # gets created during build.
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.zrythm.org";
+    description = "highly automated and intuitive digital audio workstation";
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+    license = licenses.agpl3Plus;
+  };
+}

--- a/pkgs/applications/audio/zrythm/default.nix
+++ b/pkgs/applications/audio/zrythm/default.nix
@@ -42,13 +42,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zrythm";
-  version = "0.8.252";
+  version = "1.0.0-alpha.15.0.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0m7i8f5y3lvkbflys0iblkl6ksw6kn2b64k6gy10yd549n8adx69";
+    sha256 = "0ps5rvpb21ndi4ja487j478r80ha68id75xp30ck2wvcv8i18z9l";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/audec/default.nix
+++ b/pkgs/development/libraries/audec/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchgit, libsndfile, libsamplerate, meson, ninja, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "audec";
+  version = "0.2";
+
+  src = fetchgit {
+    url = "https://git.zrythm.org/git/libaudec";
+    rev = "v${version}";
+    sha256 = "0lfydvs92b0hr72z71ci3yi356rjzi162pgms8dphgg18bz8dazv";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+
+  buildInputs = [
+    libsndfile
+    libsamplerate
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Library for reading and resampling audio files";
+    homepage = "https://git.zrythm.org/cgit/libaudec";
+    license = licenses.agpl3Plus;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libcyaml/default.nix
+++ b/pkgs/development/libraries/libcyaml/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, libyaml }:
+
+stdenv.mkDerivation rec {
+  pname = "libcyaml";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "tlsa";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0h5ydyqdl8kzh526np3jsi0pm7ks16nh1hjkdsjcd6pacw7y6i6z";
+  };
+
+  buildInputs = [
+    libyaml
+  ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = with stdenv.lib; {
+    description = "C library for reading and writing YAML";
+    homepage = "https://github.com/tlsa/libcyaml";
+    license = licenses.isc;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4584,6 +4584,8 @@ in
 
   libcryptui = callPackage ../development/libraries/libcryptui { };
 
+  libcyaml = callPackage ../development/libraries/libcyaml  { };
+
   libsmi = callPackage ../development/libraries/libsmi { };
 
   libgen-cli = callPackage ../tools/misc/libgen-cli { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11091,6 +11091,8 @@ in
 
   aubio = callPackage ../development/libraries/aubio { };
 
+  audec = callPackage ../development/libraries/audec  { };
+
   audiofile = callPackage ../development/libraries/audiofile {
     inherit (darwin.apple_sdk.frameworks) AudioUnit CoreServices;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23007,6 +23007,8 @@ in
 
   zotero = callPackage ../applications/office/zotero { };
 
+  zrythm = callPackage ../applications/audio/zrythm { };
+
   zscroll = callPackage ../applications/misc/zscroll {};
 
   zynaddsubfx = callPackage ../applications/audio/zynaddsubfx { };


### PR DESCRIPTION
###### Problem description:
When I try to install this with: ``nix-env -f $NIXPKGS -iA zrythm`` I get:
```
resources/meson.build:30:0: ERROR: Could not execute command "/usr/bin/env sh /tmp/nix-build-zrythm-0.8.252.drv-0/source/build/resources/gen_gtk_resources_xml_wrap.sh /tmp/nix-build-zrythm-0.8.252.drv-0/source/resources /tmp/nix-build-zrythm-0.8.252.drv-0/source/build/resources/zrythm.gresources.xml".
```
When I do: 
```
nix-shell $NIXPKGS -A zrythm
mkdir zr
cd zr
unpackPhase
genericBuild
```
it builds.

I can then successfully run it with ``/nix/store/nkyh59931zydxb80j3j5i1whcva6ijbl-zrythm-0.8.252/bin/zrythm_launch``

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
