### PR TITLE
salt: 2019.2.0 -> 3000.2

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -1,21 +1,38 @@
-{
-  stdenv, pythonPackages, openssl,
-
+{ lib
+, python3
+, openssl
   # Many Salt modules require various Python modules to be installed,
   # passing them in this array enables Salt to find them.
-  extraInputs ? []
+, extraInputs ? []
 }:
+let
 
-pythonPackages.buildPythonApplication rec {
-  pname = "salt";
-  version = "2019.2.0";
-
-  src = pythonPackages.fetchPypi {
-    inherit pname version;
-    sha256 = "1kgn3lway0zwwysyzpphv05j4xgxk92dk4rv1vybr2527wmvp5an";
+  py = python3.override {
+    packageOverrides = self: super: {
+      # Can be unpinned once https://github.com/saltstack/salt/issues/56007 is resolved
+      msgpack = super.msgpack.overridePythonAttrs (
+        oldAttrs: rec {
+          version = "0.6.2";
+          src = oldAttrs.src.override {
+            inherit version;
+            sha256 = "0c0q3vx0x137567msgs5dnizghnr059qi5kfqigxbz26jf2jyg7a";
+          };
+        }
+      );
+    };
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+in
+py.pkgs.buildPythonApplication rec {
+  pname = "salt";
+  version = "3000.2";
+
+  src = py.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "1n90qqhsvbf4pc4pcbya3rjfkblbccf4np4mxpghjqaa16fl4cqf";
+  };
+
+  propagatedBuildInputs = with py.pkgs; [
     jinja2
     markupsafe
     msgpack
@@ -24,8 +41,6 @@ pythonPackages.buildPythonApplication rec {
     pyzmq
     requests
     tornado_4
-  ] ++ stdenv.lib.optionals (!pythonPackages.isPy3k) [
-    futures
   ] ++ extraInputs;
 
   patches = [ ./fix-libcrypto-loading.patch ];
@@ -40,7 +55,7 @@ pythonPackages.buildPythonApplication rec {
   # as is it rather long.
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://saltstack.com/";
     description = "Portable, distributed, remote execution and configuration management system";
     maintainers = with maintainers; [ aneeshusa ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
salt-minion service failed for me since a while with the following error, so I upgraded salt itself and python from 2 to 3.
The error is gone now and minion and master work as expected.
```
Process Process-1:
Traceback (most recent call last):
  File "/nix/store/mdnyphb6385xrcx2qw2g43bq81x1p67m-python-2.7.17/lib/python2.7/multiprocessing/process.py", line 267, in _bootstrap
    self.run()
  File "/nix/store/mdnyphb6385xrcx2qw2g43bq81x1p67m-python-2.7.17/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/scripts.py", line 157, in minion_process
    minion.start()
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/cli/daemons.py", line 348, in start
    self.minion.tune_in()
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/minion.py", line 1053, in tune_in
    self._bind()
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/minion.py", line 953, in _bind
    self.event = salt.utils.event.get_event('minion', opts=self.opts, io_loop=self.io_loop)
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/utils/event.py", line 146, in get_event
    raise_errors=raise_errors)
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/utils/event.py", line 274, in __init__
    self.connect_pub()
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/utils/event.py", line 386, in connect_pub
    io_loop=self.io_loop
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/transport/ipc.py", line 264, in __new__
    client.__singleton_init__(io_loop=io_loop, socket_path=socket_path)
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/transport/ipc.py", line 666, in __singleton_init__
    socket_path, io_loop=io_loop)
  File "/nix/store/lxxxwhm55201l8w524bhzqxi3ln364qb-salt-2019.2.0/lib/python2.7/site-packages/salt/transport/ipc.py", line 292, in __singleton_init__
    self.unpacker = msgpack.Unpacker(encoding=encoding)
TypeError: __init__() got an unexpected keyword argument 'encoding'
Exception AttributeError: AttributeError("'IPCMessageSubscriber' object has no attribute '_refcount_lock'",) in <bound method IPCMessageSubscriber.__del__ of <salt.transport.ipc.IPCMessageSubscriber object at 0x7a276f80fed0>> ignored
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
