### PR TITLE
pythonPackages.pulsectl: init at 20.4.3

### DIFF
--- a/pkgs/development/python-modules/pulsectl/default.nix
+++ b/pkgs/development/python-modules/pulsectl/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, libpulseaudio, glibc, substituteAll, stdenv, pulseaudio, python }:
+
+buildPythonPackage rec {
+  pname = "pulsectl";
+  version = "20.4.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1m5fz740r4rk2i8qsnblsn16hai7givqxbx21swhpflan1yzvzzm";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./library-paths.patch;
+      libpulse = "${libpulseaudio.out}/lib/libpulse${stdenv.hostPlatform.extensions.sharedLibrary}";
+      librt = "${glibc.out}/lib/librt${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  checkInputs = [ pulseaudio ];
+  checkPhase = ''
+    ${python.interpreter} -m unittest pulsectl.tests.all
+  '';
+
+  meta = with lib; {
+    description = "Python high-level interface and ctypes-based bindings for PulseAudio (libpulse)";
+    homepage = "https://pypi.python.org/pypi/pulsectl/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/pulsectl/library-paths.patch
+++ b/pkgs/development/python-modules/pulsectl/library-paths.patch
@@ -1,0 +1,22 @@
+diff --git a/pulsectl/_pulsectl.py b/pulsectl/_pulsectl.py
+index 4422ddf..3fb2f39 100644
+--- a/pulsectl/_pulsectl.py
++++ b/pulsectl/_pulsectl.py
+@@ -31,7 +31,7 @@ else:
+ 		if not hasattr(mono_time, 'ts'):
+ 			class timespec(Structure):
+ 				_fields_ = [('tv_sec', c_long), ('tv_nsec', c_long)]
+-			librt = CDLL('librt.so.1', use_errno=True)
++			librt = CDLL('@librt@', use_errno=True)
+ 			mono_time.get = librt.clock_gettime
+ 			mono_time.get.argtypes = [c_int, POINTER(timespec)]
+ 			mono_time.ts = timespec
+@@ -625,7 +625,7 @@ class LibPulse(object):
+ 
+ 
+ 	def __init__(self):
+-		p = CDLL(ctypes.util.find_library('libpulse') or 'libpulse.so.0')
++		p = CDLL('@libpulse@')
+ 
+ 		self.funcs = dict()
+ 		for k, spec in self.func_defs.items():

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1063,6 +1063,8 @@ in {
 
   proglog = callPackage ../development/python-modules/proglog { };
 
+  pulsectl = callPackage ../development/python-modules/pulsectl { };
+
   pure-python-adb-homeassistant = callPackage ../development/python-modules/pure-python-adb-homeassistant { };
 
   purl = callPackage ../development/python-modules/purl { };


### PR DESCRIPTION
###### Motivation for this change

I require this for a script that interacts with pulesaudio.

> Python (3.x and 2.x) high-level interface and ctypes-based bindings for PulseAudio (libpulse), mostly focused on mixer-like controls and introspection-related operations (as opposed to e.g. submitting sound samples to play, player-like client).

https://github.com/mk-fg/python-pulse-control

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
