### PR TITLE
pythonPackages.secretstorage: drop old dependency

### DIFF
--- a/pkgs/development/python-modules/secretstorage/default.nix
+++ b/pkgs/development/python-modules/secretstorage/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonPackage, pythonOlder, cryptography, jeepney, pygobject3 }:
+{ lib, fetchPypi, buildPythonPackage, pythonOlder, cryptography, jeepney }:
 
 buildPythonPackage rec {
   pname = "secretstorage";
@@ -15,7 +15,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cryptography
     jeepney
-    pygobject3
   ];
 
   # Needs a D-Bus Sesison


### PR DESCRIPTION
###### Motivation for this change
pygobject was an optional dependency at some point but it has been removed and is no longer needed. See https://github.com/NixOS/nixpkgs/issues/80740#issuecomment-615910926.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox
(http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [ ] Tested compilation of all pkgs that depend on this change
- [ ] Tested execution of all binary files
- [x] Determined the impact on package closure size (saves ~500MB!)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
