### PR TITLE
PHP maintainer team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -179,6 +179,7 @@
 
 # PHP
 /doc/languages-frameworks/php.section.md @etu
+/nixos/tests/php                         @etu
+/pkgs/build-support/build-pecl.nix       @etu
 /pkgs/development/interpreters/php       @etu
 /pkgs/top-level/php-packages.nix         @etu
-/pkgs/build-support/build-pecl.nix       @etu

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -31,6 +31,17 @@ with lib.maintainers; {
     scope = "Maintain GNOME desktop environment and platform.";
   };
 
+  php = {
+    members = [
+      aanderse
+      etu
+      globin
+      ma27
+      talyz
+    ];
+    scope = "Maintain PHP related packages and extensions.";
+  };
+
   podman = {
     members = [
       adisbladis

--- a/nixos/tests/php/fpm.nix
+++ b/nixos/tests/php/fpm.nix
@@ -1,6 +1,6 @@
-import ../make-test-python.nix ({pkgs, ...}: {
+import ../make-test-python.nix ({pkgs, lib, ...}: {
   name = "php-fpm-nginx-test";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ etu ];
+  meta.maintainers = lib.teams.php.members;
 
   machine = { config, lib, pkgs, ... }: {
     services.nginx = {

--- a/nixos/tests/php/httpd.nix
+++ b/nixos/tests/php/httpd.nix
@@ -1,6 +1,6 @@
-import ../make-test-python.nix ({pkgs, ...}: {
+import ../make-test-python.nix ({pkgs, lib, ...}: {
   name = "php-httpd-test";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ etu ];
+  meta.maintainers = lib.teams.php.members;
 
   machine = { config, lib, pkgs, ... }: {
     services.httpd = {

--- a/nixos/tests/php/pcre.nix
+++ b/nixos/tests/php/pcre.nix
@@ -1,7 +1,9 @@
 let
   testString = "can-use-subgroups";
-in import ../make-test-python.nix ({ ...}: {
+in import ../make-test-python.nix ({lib, ...}: {
   name = "php-httpd-pcre-jit-test";
+  meta.maintainers = lib.teams.php.members;
+
   machine = { lib, pkgs, ... }: {
     time.timeZone = "UTC";
     services.httpd = {

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -138,9 +138,9 @@ let
 
     meta = with stdenv.lib; {
       description = "An HTML-embedded scripting language";
-      homepage = "https://www.php.net/";
+      homepage = "https://www.php.net";
       license = licenses.php301;
-      maintainers = with maintainers; [ globin etu ma27 ];
+      maintainers = teams.php.members;
       platforms = platforms.all;
       outputsToInstall = [ "out" "dev" ];
     };
@@ -194,6 +194,7 @@ let
             passthru = {
               inherit buildEnv withExtensions enabledExtensions;
               inherit (php-packages) packages extensions;
+              inherit (php) meta;
             };
             paths = [ php ];
             postBuild = ''

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -51,7 +51,7 @@ in
         description = "An application for building and managing Phars";
         license = licenses.mit;
         homepage = "https://box-project.github.io/box2/";
-        maintainers = with maintainers; [ jtojnar ];
+        maintainers = with maintainers; [ jtojnar ] ++ teams.php.members;
       };
     };
 
@@ -80,7 +80,7 @@ in
         description = "Dependency Manager for PHP";
         license = licenses.mit;
         homepage = "https://getcomposer.org/";
-        maintainers = with maintainers; [ globin offline ];
+        maintainers = with maintainers; [ offline ] ++ teams.php.members;
       };
     };
 
@@ -107,7 +107,7 @@ in
         description = "A tool to automatically fix PHP coding standards issues";
         license = licenses.mit;
         homepage = "http://cs.sensiolabs.org/";
-        maintainers = with maintainers; [ jtojnar ];
+        maintainers = with maintainers; [ jtojnar ] ++ teams.php.members;
       };
     };
 
@@ -144,7 +144,7 @@ in
         description = "This tool check syntax of PHP files faster than serial check with fancier output";
         license = licenses.bsd2;
         homepage = "https://github.com/JakubOnderka/PHP-Parallel-Lint";
-        maintainers = with maintainers; [ jtojnar ];
+        maintainers = with maintainers; [ jtojnar ] ++ teams.php.members;
       };
     };
 
@@ -171,7 +171,7 @@ in
         description = "PHP coding standard beautifier and fixer";
         license = licenses.bsd3;
         homepage = "https://squizlabs.github.io/PHP_CodeSniffer/";
-        maintainers = with maintainers; [ cmcdragonkai etu ];
+        maintainers = with maintainers; [ cmcdragonkai ] ++ teams.php.members;
       };
     };
 
@@ -198,7 +198,7 @@ in
         description = "PHP coding standard tool";
         license = licenses.bsd3;
         homepage = "https://squizlabs.github.io/PHP_CodeSniffer/";
-        maintainers = with maintainers; [ javaguirre etu ];
+        maintainers = with maintainers; [ javaguirre ] ++ teams.php.members;
       };
     };
 
@@ -224,15 +224,15 @@ in
       meta = with pkgs.lib; {
         description = "PHP Static Analysis Tool";
         longDescription = ''
-        PHPStan focuses on finding errors in your code without actually running
-        it. It catches whole classes of bugs even before you write tests for the
-        code. It moves PHP closer to compiled languages in the sense that the
-        correctness of each line of the code can be checked before you run the
-        actual line.
-      '';
+          PHPStan focuses on finding errors in your code without actually
+          running it. It catches whole classes of bugs even before you write
+          tests for the code. It moves PHP closer to compiled languages in the
+          sense that the correctness of each line of the code can be checked
+          before you run the actual line.
+        '';
         license = licenses.mit;
         homepage = "https://github.com/phpstan/phpstan";
-        maintainers = with maintainers; [ etu ];
+        maintainers = teams.php.members;
       };
     };
 
@@ -259,6 +259,7 @@ in
         description = "A static analysis tool for finding errors in PHP applications";
         license = licenses.mit;
         homepage = "https://github.com/vimeo/psalm";
+        maintainers = teams.php.members;
       };
     };
 
@@ -285,7 +286,7 @@ in
         description = "PsySH is a runtime developer console, interactive debugger and REPL for PHP.";
         license = licenses.mit;
         homepage = "https://psysh.org/";
-        maintainers = with maintainers; [ caugner ];
+        maintainers = with maintainers; [ caugner ] ++ teams.php.members;
       };
     };
   };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -308,6 +308,8 @@ in
       checkFlagsArray = ["REPORT_EXIT_STATUS=1" "NO_INTERACTION=1"];
       makeFlags = [ "phpincludedir=$(dev)/include" ];
       outputs = [ "out" "dev" ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     apcu_bc = buildPecl {
@@ -320,6 +322,8 @@ in
         php.extensions.apcu
         pcre'
       ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     ast = buildPecl {
@@ -327,6 +331,8 @@ in
       pname = "ast";
 
       sha256 = "16c5isldm4csjbcvz1qk2mmrhgvh24sxsp6w6f5a37xpa3vciawp";
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     couchbase = buildPecl rec {
@@ -374,6 +380,7 @@ in
         '')
       ];
 
+      meta.maintainers = lib.teams.php.members;
       meta.broken = isPhp74; # Build error
     };
 
@@ -406,6 +413,7 @@ in
         '';
         license = licenses.php301;
         homepage = "https://bitbucket.org/osmanov/pecl-event/";
+        maintainers = teams.php.members;
       };
     };
 
@@ -418,6 +426,8 @@ in
       configureFlags = [ "--enable-igbinary" ];
       makeFlags = [ "phpincludedir=$(dev)/include" ];
       outputs = [ "out" "dev" ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     imagick = buildPecl {
@@ -429,6 +439,8 @@ in
       configureFlags = [ "--with-imagick=${pkgs.imagemagick.dev}" ];
       nativeBuildInputs = [ pkgs.pkgconfig ];
       buildInputs = [ pcre' ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     mailparse = buildPecl {
@@ -440,6 +452,8 @@ in
       postConfigure = ''
         echo "#define HAVE_MBSTRING 1" >> config.h
       '';
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     maxminddb = buildPecl rec {
@@ -459,7 +473,7 @@ in
       meta = with pkgs.lib; {
         description = "C extension that is a drop-in replacement for MaxMind\\Db\\Reader";
         license = with licenses; [ asl20 ];
-        maintainers = with maintainers; [ ajs124 das_j ];
+        maintainers = with maintainers; [ ajs124 das_j ] ++ teams.php.members;
       };
     };
 
@@ -486,6 +500,8 @@ in
 
       nativeBuildInputs = [ pkgs.pkgconfig ];
       buildInputs = with pkgs; [ cyrus_sasl zlib ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     mongodb = buildPecl {
@@ -503,6 +519,8 @@ in
         zlib
         pcre'
       ] ++ lib.optional (pkgs.stdenv.isDarwin) pkgs.darwin.apple_sdk.frameworks.Security;
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     oci8 = buildPecl {
@@ -516,6 +534,8 @@ in
       postPatch = ''
         sed -i -e 's|OCISDKMANINC=`.*$|OCISDKMANINC="${pkgs.oracle-instantclient.dev}/include"|' config.m4
       '';
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     pcov = buildPecl {
@@ -525,6 +545,8 @@ in
       sha256 = "1psfwscrc025z8mziq69pcx60k4fbkqa5g2ia8lplb94mmarj0v1";
 
       buildInputs = [ pcre' ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     pcs = buildPecl {
@@ -533,6 +555,7 @@ in
 
       sha256 = "0d4p1gpl8gkzdiv860qzxfz250ryf0wmjgyc8qcaaqgkdyh5jy5p";
 
+      meta.maintainers = lib.teams.php.members;
       meta.broken = isPhp74; # Build error
     };
 
@@ -548,8 +571,10 @@ in
       internalDeps = [ php.extensions.pdo ];
 
       postPatch = ''
-      sed -i -e 's|OCISDKMANINC=`.*$|OCISDKMANINC="${pkgs.oracle-instantclient.dev}/include"|' config.m4
-    '';
+        sed -i -e 's|OCISDKMANINC=`.*$|OCISDKMANINC="${pkgs.oracle-instantclient.dev}/include"|' config.m4
+      '';
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     pdo_sqlsrv = buildPecl {
@@ -561,6 +586,8 @@ in
       internalDeps = [ php.extensions.pdo ];
 
       buildInputs = [ pkgs.unixODBC ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     php_excel = buildPecl rec {
@@ -576,6 +603,8 @@ in
       };
 
       configureFlags = [ "--with-excel" "--with-libxl-incdir=${pkgs.libxl}/include_c" "--with-libxl-libdir=${pkgs.libxl}/lib" ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     pinba = let
@@ -601,6 +630,7 @@ in
           statistics server for PHP using MySQL as a read-only interface.
         '';
         homepage = "http://pinba.org/";
+        maintainers = teams.php.members;
       };
     };
 
@@ -618,6 +648,7 @@ in
         '';
         license = licenses.bsd3;
         homepage = "https://developers.google.com/protocol-buffers/";
+        maintainers = teams.php.members;
       };
     };
 
@@ -653,6 +684,8 @@ in
         session
       ] ++ lib.optionals (lib.versionOlder php.version "7.4") [
         hash ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     sqlsrv = buildPecl {
@@ -662,6 +695,8 @@ in
       sha256 = "1kv4krk1w4hri99b0sdgwgy9c4y0yh217wx2y3irhkfi46kdrjnw";
 
       buildInputs = [ pkgs.unixODBC ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     v8 = buildPecl {
@@ -672,6 +707,8 @@ in
 
       buildInputs = [ pkgs.v8_6_x ];
       configureFlags = [ "--with-v8=${pkgs.v8_6_x}" ];
+
+      meta.maintainers = lib.teams.php.members;
       meta.broken = true;
     };
 
@@ -683,6 +720,8 @@ in
 
       buildInputs = [ pkgs.v8_6_x ];
       configureFlags = [ "--with-v8js=${pkgs.v8_6_x}" ];
+
+      meta.maintainers = lib.teams.php.members;
       meta.broken = true;
     };
 
@@ -696,6 +735,8 @@ in
       checkTarget = "test";
 
       zendExtension = true;
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     yaml = buildPecl {
@@ -709,6 +750,8 @@ in
       ];
 
       nativeBuildInputs = [ pkgs.pkgconfig ];
+
+      meta.maintainers = lib.teams.php.members;
     };
 
     zmq = buildPecl {
@@ -723,6 +766,7 @@ in
 
       nativeBuildInputs = [ pkgs.pkgconfig ];
 
+      meta.maintainers = lib.teams.php.members;
       meta.broken = isPhp73;
     };
   } // (let
@@ -782,6 +826,8 @@ in
                               --prune-empty-dirs \
                               . $dev/include/
       '';
+
+      meta.maintainers = lib.teams.php.members;
     });
 
     # This list contains build instructions for different modules that one may


### PR DESCRIPTION
###### Motivation for this change
Since we now have support for maintainer teams I thought that we should have one for PHP. It's a big ecosystem used by many after all.

So I took the liberty to add a bunch of people and I will request a review from these people, and I won't merge them as part of the maintainer team unless they approve this PR.

These people are added to the maintainer team: @aanderse @globin @Ma27 @talyz 

If you **don't** want to be on the maintainer team, please leave a note and I'll update the PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
