### PR TITLE
nixos/release-small: drop latestKernel.login

### DIFF
--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -101,7 +101,6 @@ in rec {
         "nixos.tests.installer.separateBoot.x86_64-linux"
         "nixos.tests.installer.simple.x86_64-linux"
         "nixos.tests.ipv6.x86_64-linux"
-        "nixos.tests.latestKernel.login.x86_64-linux"
         "nixos.tests.login.x86_64-linux"
         "nixos.tests.misc.x86_64-linux"
         "nixos.tests.nat.firewall-conntrack.x86_64-linux"


### PR DESCRIPTION
This partially reverts e133e396df9f5a466f2de592dd0b429dee62c959 and addresses https://github.com/NixOS/nixpkgs/pull/84522#issuecomment-616201439.

It seems to be reasonable to only test LTS kernel in -small channel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
