### PR TITLE
keepassxc: 2.5.2 -> 2.5.4

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -33,13 +33,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "keepassxc";
-  version = "2.5.2";
+  version = "2.5.4";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     rev = version;
-    sha256 = "0z5bd17qaq7zpv96gw6qwv6rb4xx7xjq86ss6wm5zskcrraf7r7n";
+    sha256 = "1xih9q1pxszalc0l29fmjxwn1vrrrrbnhc8gmi8brw5sclhbs6bh";
   };
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang [

--- a/pkgs/applications/misc/keepassx/darwin.patch
+++ b/pkgs/applications/misc/keepassx/darwin.patch
@@ -1,16 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 74b1a7ff..0a713a32 100644
+index dc26818..4e836bc 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -307,6 +307,7 @@ if(MINGW)
+@@ -334,6 +334,7 @@ if(MINGW)
      set(PLUGIN_INSTALL_DIR ".")
      set(DATA_INSTALL_DIR "share")
  elseif(APPLE AND WITH_APP_BUNDLE)
-+	set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/Applications")
-     set(CMAKE_INSTALL_MANDIR "${PROGNAME}.app/Contents/Resources/man")
-     set(CLI_INSTALL_DIR "${PROGNAME}.app/Contents/MacOS")
-     set(PROXY_INSTALL_DIR "${PROGNAME}.app/Contents/MacOS")
-@@ -369,12 +370,6 @@ set(CMAKE_AUTORCC ON)
++    set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/Applications")
+     set(BUNDLE_INSTALL_DIR "${PROGNAME}.app/Contents")
+     set(CMAKE_INSTALL_MANDIR "${BUNDLE_INSTALL_DIR}/Resources/man")
+     set(CLI_INSTALL_DIR "${BUNDLE_INSTALL_DIR}/MacOS")
+@@ -397,12 +398,6 @@ set(CMAKE_AUTORCC ON)
  
  if(APPLE)
      set(CMAKE_MACOSX_RPATH TRUE)
@@ -27,7 +27,7 @@ diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 index f142f368..0742512d 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -351,11 +351,6 @@ if(APPLE AND WITH_APP_BUNDLE)
+@@ -380,11 +380,6 @@ if(APPLE AND WITH_APP_BUNDLE)
      set(CPACK_PACKAGE_FILE_NAME "${PROGNAME}-${KEEPASSXC_VERSION}")
      include(CPack)
  


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/2scgphi8y73z532qqabvh07l8cyaq10k-keepassxc-2.5.2	  414785648
/nix/store/9xg4lms4mjrscny27zwdafi3fskkvsxq-keepassxc-2.5.4	  414844008
```
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
