### PR TITLE
Fix/howdoi

### DIFF
--- a/pkgs/development/python-modules/howdoi/default.nix
+++ b/pkgs/development/python-modules/howdoi/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , buildPythonPackage
 , fetchPypi
 , six
@@ -19,8 +18,7 @@ buildPythonPackage rec {
     sha256 = "3b322668606d29d8a841c3b28c0574851f512b55c33a7ceb982b6a98d82fa3e3";
   };
 
-  propagatedBuildInputs = [ six requests-cache pygments pyquery ]
-    ++ lib.optionals stdenv.isDarwin [ cachelib appdirs ];
+  propagatedBuildInputs = [ six requests-cache pygments pyquery cachelib appdirs ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/howdoi/default.nix
+++ b/pkgs/development/python-modules/howdoi/default.nix
@@ -1,10 +1,13 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , six
 , requests-cache
 , pygments
 , pyquery
+, cachelib
+, appdirs
 }:
 
 buildPythonPackage rec {
@@ -16,7 +19,8 @@ buildPythonPackage rec {
     sha256 = "3b322668606d29d8a841c3b28c0574851f512b55c33a7ceb982b6a98d82fa3e3";
   };
 
-  propagatedBuildInputs = [ six requests-cache pygments pyquery ];
+  propagatedBuildInputs = [ six requests-cache pygments pyquery ]
+    ++ lib.optionals stdenv.isDarwin [ cachelib appdirs ];
 
   preCheck = ''
     export HOME=$(mktemp -d)


### PR DESCRIPTION
###### Motivation for this change

Wanted `howdoi` utility available in `nix-env`, but
`nix-env -iA "nixpkgs.python37Packages.howdoi"` was broken on both Darwin and Ubuntu due to missing dependencies on `cachelib` and `appdirs`.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
