### PR TITLE
mscgen: fix build

### DIFF
--- a/pkgs/tools/graphics/mscgen/default.nix
+++ b/pkgs/tools/graphics/mscgen/default.nix
@@ -1,4 +1,16 @@
-{ stdenv, fetchurl, flex, bison, gd, libpng, libjpeg, freetype, zlib, libwebp, runtimeShell }:
+{ stdenv
+, bison
+, fetchurl
+, flex
+, freetype
+, gd
+, libjpeg
+, libpng
+, libwebp
+, pkg-config
+, runtimeShell
+, zlib
+}:
 
 let
   version = "0.20";
@@ -12,7 +24,7 @@ stdenv.mkDerivation {
     sha256 = "3c3481ae0599e1c2d30b7ed54ab45249127533ab2f20e768a0ae58d8551ddc23";
   };
 
-  buildInputs = [ flex bison gd libjpeg libpng freetype zlib libwebp ];
+  buildInputs = [ bison flex freetype gd libjpeg libpng libwebp pkg-config zlib ];
 
   doCheck = true;
   preCheck = ''

--- a/pkgs/tools/graphics/mscgen/default.nix
+++ b/pkgs/tools/graphics/mscgen/default.nix
@@ -2,7 +2,6 @@
 , bison
 , fetchurl
 , flex
-, freetype
 , gd
 , libjpeg
 , libpng
@@ -24,12 +23,15 @@ stdenv.mkDerivation {
     sha256 = "3c3481ae0599e1c2d30b7ed54ab45249127533ab2f20e768a0ae58d8551ddc23";
   };
 
-  buildInputs = [ bison flex freetype gd libjpeg libpng libwebp pkg-config zlib ];
+  nativeBuildInputs = [ bison flex pkg-config ];
+  buildInputs = [ gd libjpeg libpng libwebp zlib ];
 
   doCheck = true;
   preCheck = ''
     sed -i -e "s|#!/bin/bash|#!${runtimeShell}|" test/renderercheck.sh
   '';
+
+  outputs = [ "out" "man" ];
 
   meta = {
     homepage = "http://www.mcternan.me.uk/mscgen/";


### PR DESCRIPTION
###### Motivation for this change

Found `nix-env -iA "nixpkgs.mscgen"` build was broken because of missing `pkg-config` dependency. Added it.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
