### PR TITLE
nixos/programs.npm: Fix rebuild of nixos system

### DIFF
--- a/nixos/modules/programs/npm.nix
+++ b/nixos/modules/programs/npm.nix
@@ -15,7 +15,7 @@ in
 
       package = mkOption {
         type = types.package;
-        description = "The npm package version / flavor to use";
+        description = "The nodejs package version / flavor to use";
         default = pkgs.nodejs;
         example = literalExample "pkgs.nodePackages_13_x";
       };

--- a/nixos/modules/programs/npm.nix
+++ b/nixos/modules/programs/npm.nix
@@ -14,10 +14,10 @@ in
       enable = mkEnableOption "<command>npm</command> global config";
 
       package = mkOption {
-        type = types.path or null;
+        type = types.package;
         description = "The npm package version / flavor to use";
-        default = if hasAttr "npm" pkgs.nodePackages then pkgs.nodePackages.npm else null;
-        example = literalExample "pkgs.nodePackages_13_x.npm";
+        default = pkgs.nodejs;
+        example = literalExample "pkgs.nodePackages_13_x";
       };
 
       npmrc = mkOption {

--- a/nixos/modules/programs/npm.nix
+++ b/nixos/modules/programs/npm.nix
@@ -14,9 +14,9 @@ in
       enable = mkEnableOption "<command>npm</command> global config";
 
       package = mkOption {
-        type = types.path;
+        type = types.path or null;
         description = "The npm package version / flavor to use";
-        default = pkgs.nodePackages.npm;
+        default = if hasAttr "npm" pkgs.nodePackages then pkgs.nodePackages.npm else null;
         example = literalExample "pkgs.nodePackages_13_x.npm";
       };
 


### PR DESCRIPTION
###### Motivation for this change
PR https://github.com/NixOS/nixpkgs/pull/84599 introduced an option 
that breaks rebuilding nixos in case that user has set nodePackages to a different
version than nodePackages_10_x. The package attribute npm is not part of any other
nodePackages version than version 10.

This commit makes sure nixos may be build by users who set their nodePackages to a different
version and do not want to have programs npm enabled.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
