### PR TITLE
linux: bump stable versions (5.6.4 -> 5.6.5 & 5.5.17 -> 5.5.18)

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -14,6 +14,11 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.32.a/linux-hardened-5.4.32.a.patch",
         "version_suffix": "NixOS-a"
     },
+    "5.5.18": {
+        "sha256": "0v7vla784sf1fk6d8qa5x8hkyhjb1jkw4lxxcgvvlqbmxl8md8ld",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.5.18.a/linux-hardened-5.5.18.a.patch",
+        "version_suffix": "a"
+    },
     "5.6.5": {
         "sha256": "19cdpygm5zx3szxl456lfjg5sffqcmn18470wv7prm8rf6liqdj3",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.6.5.a/linux-hardened-5.6.5.a.patch",

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -10,9 +10,9 @@
         "version_suffix": "NixOS-a"
     },
     "5.4.33": {
-        "sha256": "154iz7i9l0hihjrmfk6rjh7hhqwyhsdjr2c74m3dhadrlm5hwy89",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.32.a/linux-hardened-5.4.32.a.patch",
-        "version_suffix": "NixOS-a"
+        "sha256": "1hjfvhyvz5kyvx25809brhsvfv9mjv9q1mw6ydb71gfwhw6q8d8b",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.33.a/linux-hardened-5.4.33.a.patch",
+        "version_suffix": "a"
     },
     "5.5.18": {
         "sha256": "0v7vla784sf1fk6d8qa5x8hkyhjb1jkw4lxxcgvvlqbmxl8md8ld",

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -13,10 +13,5 @@
         "sha256": "154iz7i9l0hihjrmfk6rjh7hhqwyhsdjr2c74m3dhadrlm5hwy89",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.32.a/linux-hardened-5.4.32.a.patch",
         "version_suffix": "NixOS-a"
-    },
-    "5.5.17": {
-        "sha256": "1lms090kkk4vlvfssqsm7r3j88hlf8smrnpcgq24v9rq9pbr0fyw",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.5.17.a/linux-hardened-5.5.17.a.patch",
-        "version_suffix": "a"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -13,5 +13,10 @@
         "sha256": "154iz7i9l0hihjrmfk6rjh7hhqwyhsdjr2c74m3dhadrlm5hwy89",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.32.a/linux-hardened-5.4.32.a.patch",
         "version_suffix": "NixOS-a"
+    },
+    "5.6.5": {
+        "sha256": "19cdpygm5zx3szxl456lfjg5sffqcmn18470wv7prm8rf6liqdj3",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.6.5.a/linux-hardened-5.6.5.a.patch",
+        "version_suffix": "a"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -18,10 +18,5 @@
         "sha256": "1lms090kkk4vlvfssqsm7r3j88hlf8smrnpcgq24v9rq9pbr0fyw",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.5.17.a/linux-hardened-5.5.17.a.patch",
         "version_suffix": "a"
-    },
-    "5.6.4": {
-        "sha256": "05wkzh7927n71x4cl69mclc44grqpnx6i65hli470q1rg1qrk26n",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.6.4.a/linux-hardened-5.6.4.a.patch",
-        "version_suffix": "a"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -5,9 +5,9 @@
         "version_suffix": "a"
     },
     "4.19.116": {
-        "sha256": "1f54g0xw708kxha07nsb979h5vwxjrkbwa5h04zny2kq702x1h13",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.115.a/linux-hardened-4.19.115.a.patch",
-        "version_suffix": "NixOS-a"
+        "sha256": "00y4i905gzs9w9kckrn1frh2vw32fsndz03g2psl1gk17snc3q7c",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.116.a/linux-hardened-4.19.116.a.patch",
+        "version_suffix": "a"
     },
     "5.4.33": {
         "sha256": "1hjfvhyvz5kyvx25809brhsvfv9mjv9q1mw6ydb71gfwhw6q8d8b",

--- a/pkgs/os-specific/linux/kernel/linux-5.5.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.5.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.5.17";
+  version = "5.5.18";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "06aqhlysa7zdj6c69hyii3hfqlfa9751ivga38rbqw1lr2gbbnj0";
+    sha256 = "01iiiq4dsyyc5y6b52wax9as6dzhdi172vd1423sc1yp4rrk8178";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.6.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.6.4";
+  version = "5.6.5";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "14cxbc9xi4s3xwx4yb1yd4z0kidsk3d443skf5sgmdhcalg79wax";
+    sha256 = "1rjjkcmzsj9azggh960qnk2x44ns475b8nbd4nxazrz1rgdx76zp";
   };
 } // (args.argsOverride or {}))


### PR DESCRIPTION
###### Motivation for this change

Bumps stable versions `5.6.4` -> `5.6.5` and `5.5.17` -> `5.5.18`.
`5.6.5` built and booted successfully on my machine.

Ran `pkgs/os-specific/linux/kernel/update.sh` which brought in the commits with the patches. Please tell me if I did something wrong :+1: 

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
