### PR TITLE
ocamlPackages.bap: 1.6.0 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/libbap/default.nix
+++ b/pkgs/development/libraries/libbap/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation {
   pname = "libbap";
-  version = "master-2019-04-05";
+  version = "master-2019-11-15";
 
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
     repo = "bap-bindings";
-    rev = "1a89db62f1239a15d310b400f74e151c0a64f37f";
-    sha256 = "0mln9adjgxzhjmjayq06ahgiay4vj5kmnzdxqz3nsik9h3npycd6";
+    rev = "1a30dd3e1df18c432a83a7038b555662d6982ae3";
+    sha256 = "140gmak2kymh3r0fagb6ms66lmvwhhqj8pcd3qxc1p4ar330fwrh";
   };
 
   nativeBuildInputs = [ autoreconfHook which ];

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -12,12 +12,12 @@ else
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-bap-${version}";
-  version = "1.6.0";
+  version = "2.0.0";
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
     repo = "bap";
     rev = "v${version}";
-    sha256 = "0ryf2xb37pj2f9mc3p5prqgqrylph9qgq7q9jnbx8b03nzzpa6h6";
+    sha256 = "0lb9xkfp67wjjqr75p6krivmjra7l5673236v9ny4gp0xi0755bk";
   };
 
   sigs = fetchurl {
@@ -53,7 +53,9 @@ stdenv.mkDerivation rec {
     ln -s $sigs $out/share/bap/sigs.zip
   '';
 
-  disableIda = "--disable-ida --disable-fsi-benchmark";
+  disableIda = "--disable-ida";
+
+  patches = [ ./dont-add-curses.patch ];
 
   configureFlags = [ "--enable-everything ${disableIda}" "--with-llvm-config=${llvm}/bin/llvm-config" ];
 

--- a/pkgs/development/ocaml-modules/bap/dont-add-curses.patch
+++ b/pkgs/development/ocaml-modules/bap/dont-add-curses.patch
@@ -1,0 +1,32 @@
+From e6f6d1529d1725e8c1ed3c96eecc4aea43417aea Mon Sep 17 00:00:00 2001
+From: Matthew Maurer <matthew.r.maurer@gmail.com>
+Date: Sun, 19 Apr 2020 15:50:01 -0700
+Subject: [PATCH] Remove attempt to work around libcurses dependency issues.
+
+BAP doesn't actually link against libcurses, LLVM does. By adding
+-lcurses to this file, we accidentally broke linking on any systems
+where LLVM got linked against libncurses (not libcurses) without a
+libcurses compatibility shim.
+
+Overall, we should get -l flags from llvm-config, not attempt to
+shoehorn them in later, as this is fragile.
+---
+ oasis/llvm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/oasis/llvm b/oasis/llvm
+index 966c407..fba3fb4 100644
+--- a/oasis/llvm
++++ b/oasis/llvm
+@@ -31,7 +31,7 @@ Library bap_llvm
+                  Bap_llvm_ogre_samples,
+                  Bap_llvm_ogre_types
+   CCOpt:         $cc_optimization
+-  CCLib:         $llvm_lib $cxxlibs $llvm_ldflags -lcurses
++  CCLib:         $llvm_lib $cxxlibs $llvm_ldflags
+   CSources:      llvm_disasm.h,
+                  llvm_disasm.c,
+                  llvm_stubs.c,
+-- 
+2.22.0
+


### PR DESCRIPTION
Also roll libbap forwards, as it does not build against the new bap.

###### Motivation for this change
Update packages to new version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
