### PR TITLE
Add ACME maintainers team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -17,6 +17,18 @@
 
 { lib }:
 with lib.maintainers; {
+  acme = {
+    members = [
+      aanderse
+      andrew-d
+      arianvp
+      emily
+      flokli
+      m1cr0man
+    ];
+    scope = "Maintain ACME-related packages and modules.";
+  };
+
   freedesktop = {
     members = [ jtojnar worldofpeace ];
     scope = "Maintain Freedesktop.org packages for graphical desktop.";

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -458,7 +458,7 @@ in
   ];
 
   meta = {
-    maintainers = with lib.maintainers; [ abbradar fpletz globin m1cr0man ];
+    maintainers = lib.teams.acme.members;
     doc = ./acme.xml;
   };
 }

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -12,8 +12,9 @@ let
     fi
   '';
 
-in import ./make-test-python.nix {
+in import ./make-test-python.nix ({ lib, ... }: {
   name = "acme";
+  meta.maintainers = lib.teams.acme.members;
 
   nodes = rec {
     acme = { nodes, lib, ... }: {
@@ -207,4 +208,4 @@ in import ./make-test-python.nix {
               "curl --cacert /tmp/ca.crt https://c.example.test/ | grep -qF 'hello world'"
           )
     '';
-}
+})

--- a/pkgs/tools/admin/lego/default.nix
+++ b/pkgs/tools/admin/lego/default.nix
@@ -22,6 +22,6 @@ buildGoModule rec {
     description = "Let's Encrypt client and ACME library written in Go";
     license = licenses.mit;
     homepage = "https://go-acme.github.io/lego/";
-    maintainers = with maintainers; [ andrew-d ];
+    maintainers = teams.acme.members;
   };
 }

--- a/pkgs/tools/admin/pebble/default.nix
+++ b/pkgs/tools/admin/pebble/default.nix
@@ -21,6 +21,6 @@ in buildGoPackage {
     homepage = "https://github.com/letsencrypt/pebble";
     description = "A miniature version of Boulder, Pebble is a small RFC 8555 ACME test server not suited for a production CA";
     license = [ lib.licenses.mpl20 ];
-    maintainers = with lib.maintainers; [ emily ];
+    maintainers = lib.teams.acme.members;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a maintainers team for ACME, per https://github.com/NixOS/nixpkgs/pull/83474#issuecomment-614703535.

To avoid having a huge team that gets pinged on every PR, I kept it to people who have recently made substantial/multiple changes to the ACME modules, erring on the side of leaving people out, but without any intent to make a value judgement on their contributions. If you're in the list but don't want to actively review ACME PRs, or are missing but want to be added, please let me know!

cc (on the list, but might not want to be) @aanderse @andrew-d @arianvp @flokli @m1cr0man
cc (not on the list, but might want to be) @abbradar @fpletz @globin @Mic92 @mweinelt (...insert yourself here?)
cc (not in `lib.maintainers`) @immae

cc @grahamc; would it be possible to have an @NixOS/acme-maintainers team generated from this for ccs? I'm not sure if ofborg supports automatically pinging maintainers of a test/module, and having automatically generated *-maintainers GitHub teams seems like something that would be useful in general.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).