### PR TITLE
laminar: init at 0.8

### DIFF
--- a/pkgs/development/tools/continuous-integration/laminar/default.nix
+++ b/pkgs/development/tools/continuous-integration/laminar/default.nix
@@ -1,0 +1,80 @@
+{ stdenv
+, lib
+, fetchurl
+, cmake
+, capnproto
+, sqlite
+, boost
+, zlib
+, rapidjson
+, pandoc
+, enableSystemd ? false
+, customConfig ? null
+}:
+let
+  js.vue = fetchurl {
+    url = "https://cdnjs.cloudflare.com/ajax/libs/vue/2.3.4/vue.min.js";
+    sha256 = "01zklp5cyik65dfn64m8h2y2dxzgbyzgmbf99y7fwgnf0155r7pq";
+  };
+  js.vue-router = fetchurl {
+    url =
+      "https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.7.0/vue-router.min.js";
+    sha256 = "07gx7znb30rk1z7w6ca7dlfjp44q12bbq6jghwfm27mf6psa80as";
+  };
+  js.ansi_up = fetchurl {
+    url = "https://raw.githubusercontent.com/drudru/ansi_up/v1.3.0/ansi_up.js";
+    sha256 = "1993dywxqi2ylnxybwk7m0s0bg2bq7kfllpyr0s8ck6chd0p8i6r";
+  };
+  js.Chart = fetchurl {
+    url = "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js";
+    sha256 = "1jh4h12qchsba03dx03mrvs4r8g9qfjn56xm56jqzgqf7r209xq9";
+  };
+  css.bootstrap = fetchurl {
+    url =
+      "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css";
+    sha256 = "11vx860prsx7wsy8b0yrrk04ih8kvrxkk8l16snsc4n286bdkyri";
+  };
+in stdenv.mkDerivation rec {
+  name = "laminar";
+  version = "0.8";
+  src = fetchurl {
+    url = "https://github.com/ohwgiles/laminar/archive/${version}.tar.gz";
+    sha256 = "05g73j3vpib47kr7mackcazf7s6bc3xwz4h6k7sp7yb5ng7gj20g";
+  };
+  patches = [ ./patches/no-network.patch ];
+  nativeBuildInputs = [ cmake pandoc ];
+  buildInputs = [ capnproto sqlite boost zlib rapidjson ];
+  preBuild = ''
+    mkdir -p js css
+    cp  ${js.vue}         js/vue.min.js
+    cp  ${js.vue-router}  js/vue-router.min.js
+    cp  ${js.ansi_up}     js/ansi_up.js
+    cp  ${js.Chart}       js/Chart.min.js
+    cp  ${css.bootstrap}  css/bootstrap.min.css
+  '';
+  postInstall = ''
+    mv $out/usr/share $out
+    mkdir $out/bin
+    mv $out/usr/{bin,sbin}/* $out/bin
+    rmdir $out/usr/{bin,sbin}
+    rmdir $out/usr
+
+    mkdir -p $out/share/doc/laminar
+    pandoc -s ../UserManual.md -o $out/share/doc/laminar/UserManual.html
+  '' + lib.optionalString (customConfig != null) ''
+    cp ${customConfig} /etc/etc/laminar.conf
+  '' + (if enableSystemd then ''
+    sed -i "s,/etc/,$out/etc/," $out/lib/systemd/system/laminar.service
+    sed -i "s,/usr/sbin/,$out/bin/," $out/lib/systemd/system/laminar.service
+  '' else ''
+    rm -r $out/lib # it contains only systemd unit file
+  '');
+
+  meta = with stdenv.lib; {
+    description = "Lightweight and modular continuous integration service";
+    homepage = "https://laminar.ohwg.net";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/tools/continuous-integration/laminar/patches/no-network.patch
+++ b/pkgs/development/tools/continuous-integration/laminar/patches/no-network.patch
@@ -1,0 +1,26 @@
+Build system that downloads stuff from network is bad. Build system that
+does so unconditionally is twice as bad.
+
+Required files are downloaded as separate fixed-output derivations and
+put into correct location before build phase starts.
+
+--- laminar-0.8/CMakeLists.txt
++++ laminar-0.8-new/CMakeLists.txt
+@@ -69,17 +69,6 @@
+     COMMAND sh -c '( echo -n "\\#define INDEX_HTML_UNCOMPRESSED_SIZE " && wc -c < "${CMAKE_SOURCE_DIR}/src/resources/index.html" ) > index_html_size.h'
+     DEPENDS src/resources/index.html)
+ 
+-# Download 3rd-party frontend JS libs...
+-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue/2.3.4/vue.min.js
+-        js/vue.min.js EXPECTED_MD5 ae2fca1cfa0e31377819b1b0ffef704c)
+-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.7.0/vue-router.min.js
+-        js/vue-router.min.js EXPECTED_MD5 5d3e35710dbe02de78c39e3e439b8d4e)
+-file(DOWNLOAD https://raw.githubusercontent.com/drudru/ansi_up/v1.3.0/ansi_up.js
+-        js/ansi_up.js EXPECTED_MD5 158566dc1ff8f2804de972f7e841e2f6)
+-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js
+-        js/Chart.min.js EXPECTED_MD5 f6c8efa65711e0cbbc99ba72997ecd0e)
+-file(DOWNLOAD https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css
+-        css/bootstrap.min.css EXPECTED_MD5 5d5357cb3704e1f43a1f5bfed2aebf42)
+ # ...and compile them
+ generate_compressed_bins(${CMAKE_BINARY_DIR} js/vue-router.min.js js/vue.min.js
+     js/ansi_up.js js/Chart.min.js css/bootstrap.min.css)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10474,6 +10474,8 @@ in
 
   lazygit = callPackage ../development/tools/lazygit { };
 
+  laminar = callPackage ../development/tools/continuous-integration/laminar { };
+
   Literate = callPackage ../development/tools/literate-programming/Literate {};
 
   lcov = callPackage ../development/tools/analysis/lcov { };


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).