### PR TITLE
edk2: Support build on macOS

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -17,9 +17,13 @@ let
     throw "Unsupported architecture";
 
   version = lib.getVersion edk2;
+  buildType = if stdenv.isDarwin then
+    "CLANGPDB"
+  else
+    "GCC5";
 in
 
-edk2.mkDerivation projectDscPath {
+edk2.mkDerivation projectDscPath buildType {
   name = "OVMF-${version}";
 
   outputs = [ "out" "fd" ];
@@ -57,6 +61,6 @@ edk2.mkDerivation projectDscPath {
     description = "Sample UEFI firmware for QEMU and KVM";
     homepage = https://github.com/tianocore/tianocore.github.io/wiki/OVMF;
     license = stdenv.lib.licenses.bsd2;
-    platforms = ["x86_64-linux" "i686-linux" "aarch64-linux"];
+    platforms = ["x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin"];
   };
 }

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -17,13 +17,9 @@ let
     throw "Unsupported architecture";
 
   version = lib.getVersion edk2;
-  buildType = if stdenv.isDarwin then
-    "CLANGPDB"
-  else
-    "GCC5";
 in
 
-edk2.mkDerivation projectDscPath buildType {
+edk2.mkDerivation projectDscPath {
   name = "OVMF-${version}";
 
   outputs = [ "out" "fd" ];

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -55,7 +55,7 @@ edk2.mkDerivation projectDscPath {
 
   meta = {
     description = "Sample UEFI firmware for QEMU and KVM";
-    homepage = https://github.com/tianocore/tianocore.github.io/wiki/OVMF;
+    homepage = "https://github.com/tianocore/tianocore.github.io/wiki/OVMF";
     license = stdenv.lib.licenses.bsd2;
     platforms = ["x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin"];
   };

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,4 +1,17 @@
-{ stdenv, fetchgit, fetchpatch, libuuid, python3, iasl, bc }:
+{
+    stdenv,
+    clangStdenv,
+    fetchgit,
+    fetchpatch,
+    libuuid,
+    python3,
+    iasl,
+    bc,
+    clang_9,
+    llvmPackages_9,
+    overrideCC,
+    lib,
+}:
 
 let
   pythonEnv = python3.withPackages (ps: [ps.tkinter]);
@@ -12,7 +25,12 @@ else if stdenv.isAarch64 then
 else
   throw "Unsupported architecture";
 
-edk2 = stdenv.mkDerivation {
+buildStdenv = if stdenv.isDarwin then
+  overrideCC clangStdenv [ clang_9 llvmPackages_9.llvm llvmPackages_9.lld ]
+else
+  stdenv;
+
+edk2 = buildStdenv.mkDerivation {
   pname = "edk2";
   version = "201911";
 
@@ -25,8 +43,10 @@ edk2 = stdenv.mkDerivation {
 
   buildInputs = [ libuuid pythonEnv ];
 
-  makeFlags = [ "-C BaseTools" ];
-  NIX_CFLAGS_COMPILE = "-Wno-return-type -Wno-error=stringop-truncation";
+  makeFlags = [ "-C BaseTools" ]
+    ++ lib.optional (stdenv.isDarwin) [ "BUILD_CC=clang BUILD_CXX=clang++ BUILD_AS=clang" ];
+
+  NIX_CFLAGS_COMPILE = "-Wno-return-type" + lib.optionalString (!stdenv.isDarwin) " -Wno-error=stringop-truncation";
 
   hardeningDisable = [ "format" "fortify" ];
 
@@ -38,15 +58,15 @@ edk2 = stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Intel EFI development kit";
     homepage = https://sourceforge.net/projects/edk2/;
     license = licenses.bsd2;
-    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 
   passthru = {
-    mkDerivation = projectDscPath: attrs: stdenv.mkDerivation ({
+    mkDerivation = projectDscPath: buildType: attrs: buildStdenv.mkDerivation ({
       inherit (edk2) src;
 
       buildInputs = [ bc pythonEnv ] ++ attrs.buildInputs or [];
@@ -65,7 +85,7 @@ edk2 = stdenv.mkDerivation {
 
       buildPhase = ''
         runHook preBuild
-        build -a ${targetArch} -b RELEASE -t GCC5 -p ${projectDscPath} -n $NIX_BUILD_CORES $buildFlags
+        build -a ${targetArch} -b RELEASE -t ${buildType} -p ${projectDscPath} -n $NIX_BUILD_CORES $buildFlags
         runHook postBuild
       '';
 

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -65,7 +65,7 @@ edk2 = buildStdenv.mkDerivation {
 
   meta = with lib; {
     description = "Intel EFI development kit";
-    homepage = https://sourceforge.net/projects/edk2/;
+    homepage = "https://sourceforge.net/projects/edk2/";
     license = licenses.bsd2;
     platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" ];
   };

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,16 +1,16 @@
 {
-    stdenv,
-    clangStdenv,
-    fetchgit,
-    fetchpatch,
-    libuuid,
-    python3,
-    iasl,
-    bc,
-    clang_9,
-    llvmPackages_9,
-    overrideCC,
-    lib,
+  stdenv,
+  clangStdenv,
+  fetchgit,
+  fetchpatch,
+  libuuid,
+  python3,
+  iasl,
+  bc,
+  clang_9,
+  llvmPackages_9,
+  overrideCC,
+  lib,
 }:
 
 let


### PR DESCRIPTION
###### Motivation for this change

Booting qemu tests with OVMF firmware on macOS requires the firmware files provided by these packages. With this change, the package builds out of the box. My first attempt was to use clang everywhere, but unfortunately, there are some [assumptions](https://github.com/tianocore/edk2/blob/master/BaseTools/Source/C/Makefiles/header.makefile#L70) in the edk2 build system that caused the clang build on Linux to fail.

*Note*: There seems to be an issue with temporary directories (AF_UNIX path name too long) on macOS, I had to run `TMPDIR=/tmp nix-build default.nix -A OVMF` .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
