### PR TITLE
birdtray: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/applications/misc/birdtray/default.nix
+++ b/pkgs/applications/misc/birdtray/default.nix
@@ -7,28 +7,23 @@
   , qtbase
   , qttools
   , qtx11extras
-  , sqlite
 }:
 
 mkDerivation rec {
   pname = "birdtray";
-  version = "1.7.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "gyunaev";
     repo = pname;
-    rev = "RELEASE_${version}";
-    sha256 = "0wj2lq5bz1p0cf6yj43v3ifxschcrh5amwx30wqw2m4bb8syzjw1";
+    rev = version;
+    sha256 = "15d0gz889vf9b2a046m93s5kdi6lw2sqjd5gaxgjkjrs20x5vr18";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
-    qtbase qtx11extras sqlite
+    qtbase qttools qtx11extras
   ];
-
-  installPhase = ''
-    install -Dm755 birdtray $out/bin/birdtray
-  '';
 
   meta = with lib; {
     description = "Mail system tray notification icon for Thunderbird";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bump version and make desktop item installed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - 283.6M -> 294.1M
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
