### PR TITLE
moonplus: init at 0.3.8

### DIFF
--- a/pkgs/development/compilers/moonplus/default.nix
+++ b/pkgs/development/compilers/moonplus/default.nix
@@ -1,0 +1,24 @@
+{ fetchFromGitHub, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "MoonPlus";
+  version = "0.3.8";
+  src = fetchFromGitHub {
+    owner = "pigpigyyy";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12wcw6zvm1a7hphjngy0hr6ywq1y9wpa9ssrryqv0ni4kamylqqr";
+  };
+
+  installPhase = ''
+    install -D bin/release/moonp $out/bin/moonp
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/pigpigyyy/MoonPlus";
+    description = "Moonscript to Lua compiler";
+    license = licenses.mit;
+    maintainers = with maintainers; [ xe ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8890,6 +8890,8 @@ in
 
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
+  moonplus = callPackage ../development/compilers/moonplus { };
+
   msbuild = callPackage ../development/tools/build-managers/msbuild { mono = mono6; };
 
   mosml = callPackage ../development/compilers/mosml { };


### PR DESCRIPTION
###### Motivation for this change

Adding [MoonPlus](https://github.com/pigpigyyy/MoonPlus) for faster MoonScript -> Lua translation

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
This package is 1.4 megabytes uncompressed.
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
