### PR TITLE
rutorrent: init at 3.10-beta

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1006,6 +1006,7 @@
   ./services/web-apps/restya-board.nix
   ./services/web-apps/sogo.nix
   ./services/web-apps/rss-bridge.nix
+  ./services/web-apps/rutorrent.nix
   ./services/web-apps/tt-rss.nix
   ./services/web-apps/trac.nix
   ./services/web-apps/trilium.nix

--- a/nixos/modules/services/torrent/rtorrent.nix
+++ b/nixos/modules/services/torrent/rtorrent.nix
@@ -76,6 +76,14 @@ in {
       '';
     };
 
+    rpcGroup = mkOption {
+      type = types.str;
+      default = "rtorrent";
+      description = ''
+        The group owning the RPC socket.
+      '';
+    };
+
     configText = mkOption {
       type = types.lines;
       default = "";
@@ -176,7 +184,7 @@ in {
 
       # XMLRPC
       scgi_local = (cfg.rpcsock)
-      schedule = scgi_group,0,0,"execute.nothrow=chown,\":rtorrent\",(cfg.rpcsock)"
+      schedule = scgi_group,0,0,"execute.nothrow=chown,\":${cfg.rpcGroup}\",(cfg.rpcsock)"
       schedule = scgi_permission,0,0,"execute.nothrow=chmod,\"g+w,o=\",(cfg.rpcsock)"
     '';
 

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -169,7 +169,7 @@ in {
                   "localhost",
                 );
 
-                $profilePath = '../share';		// Path to user profiles
+                $profilePath = '${cfg.dataDir}/share';		// Path to user profiles
                 $profileMask = 0770;			// Mask for files and directory creation in user profiles.
                 // Both Webserver and rtorrent users must have read-write access to it.
                 // For example, if Webserver and rtorrent users are in the same group then the value may be 0770.

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -6,7 +6,7 @@ let
   cfg = config.services.rutorrent;
 
   pluginDependencies = with pkgs; {
-    _task = [ pgrep ];
+    _task = [ procps ];
     unpack = [ unzip unrar ];
     rss = [ curl ];
     mediainfo = [ mediainfo ];

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -26,7 +26,7 @@ in {
         description = "FQDN for the rutorrent instance.";
       };
 
-      home = mkOption {
+      dataDir = mkOption {
         type = types.str;
         default = "/var/lib/rutorrent";
         description = "Storage path of rutorrent.";
@@ -143,7 +143,7 @@ in {
                 $schedule_rand = 10;			// rand for schedulers start, +0..X seconds
 
                 $do_diagnostic = true;
-                $log_file = '${cfg.home}/logs/errors.log';		// path to log file (comment or leave blank to disable logging)
+                $log_file = '${cfg.dataDir}/logs/errors.log';		// path to log file (comment or leave blank to disable logging)
 
                 $saveUploadedTorrents = true;		// Save uploaded torrents to profile/torrents directory or not
                 $overwriteUploadedTorrents = false;     // Overwrite existing uploaded torrents in profile/torrents directory or make unique name
@@ -184,31 +184,31 @@ in {
             wantedBy = [ "multi-user.target" ];
             before = [ "phpfpm-rutorrent.service" ];
             script = ''
-              ln -sf ${pkgs.rutorrent}/{css,images,js,lang,index.html} ${cfg.home}/
-              mkdir -p ${cfg.home}/{conf,logs,plugins} ${cfg.home}/share/{settings,torrents,users}
-              ln -sf ${pkgs.rutorrent}/conf/{access.ini,plugins.ini} ${cfg.home}/conf/
-              ln -sf ${rutorrentConfig} ${cfg.home}/conf/config.php
+              ln -sf ${pkgs.rutorrent}/{css,images,js,lang,index.html} ${cfg.dataDir}/
+              mkdir -p ${cfg.dataDir}/{conf,logs,plugins} ${cfg.dataDir}/share/{settings,torrents,users}
+              ln -sf ${pkgs.rutorrent}/conf/{access.ini,plugins.ini} ${cfg.dataDir}/conf/
+              ln -sf ${rutorrentConfig} ${cfg.dataDir}/conf/config.php
 
-              cp -r ${pkgs.rutorrent}/php ${cfg.home}/
+              cp -r ${pkgs.rutorrent}/php ${cfg.dataDir}/
 
               ${optionalString (cfg.plugins != [])
-                ''cp -r ${concatMapStringsSep " " (p: "${pkgs.rutorrent}/plugins/${p}") cfg.plugins} ${cfg.home}/plugins/''}
+                ''cp -r ${concatMapStringsSep " " (p: "${pkgs.rutorrent}/plugins/${p}") cfg.plugins} ${cfg.dataDir}/plugins/''}
 
-              chown -R rutorrent:rutorrent ${cfg.home}/{conf,share,logs,plugins}
-              chmod -R 755 ${cfg.home}/{conf,share,logs,plugins}
+              chown -R rutorrent:rutorrent ${cfg.dataDir}/{conf,share,logs,plugins}
+              chmod -R 755 ${cfg.dataDir}/{conf,share,logs,plugins}
             '';
             serviceConfig.Type = "oneshot";
           };
         };
 
-        tmpfiles.rules = [ "d '${cfg.home}' 0775 rutorrent rutorrent -" ];
+        tmpfiles.rules = [ "d '${cfg.dataDir}' 0775 rutorrent rutorrent -" ];
       };
 
       users.groups.rutorrent = {};
 
       users.users = {
         rutorrent = {
-          home = cfg.home;
+          home = cfg.dataDir;
           group = "rutorrent";
           extraGroups = [ config.services.rtorrent.group ];
           description = "rutorrent Daemon user";
@@ -239,7 +239,7 @@ in {
             enable = true;
             virtualHosts = {
               ${cfg.hostName} = {
-                root = cfg.home;
+                root = cfg.dataDir;
                 locations = {
                   "~ [^/]\.php(/|$)" = {
                     extraConfig = ''

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -19,24 +19,24 @@ let
 in {
   options = {
     services.rutorrent = {
-      enable = mkEnableOption "rutorrent";
+      enable = mkEnableOption "ruTorrent";
 
       hostName = mkOption {
         type = types.str;
-        description = "FQDN for the rutorrent instance.";
+        description = "FQDN for the ruTorrent instance.";
       };
 
       dataDir = mkOption {
         type = types.str;
         default = "/var/lib/rutorrent";
-        description = "Storage path of rutorrent.";
+        description = "Storage path of ruTorrent.";
       };
 
       user = mkOption {
         type = types.str;
         default = "rutorrent";
         description = ''
-          User which runs the rutorrent service.
+          User which runs the ruTorrent service.
         '';
       };
 
@@ -44,7 +44,7 @@ in {
         type = types.str;
         default = "rutorrent";
         description = ''
-          Group which runs the rutorrent service.
+          Group which runs the ruTorrent service.
         '';
       };
 
@@ -78,7 +78,7 @@ in {
           "pm.max_requests" = 500;
         };
         description = ''
-          Options for rutorrent's PHP pool. See the documentation on <literal>php-fpm.conf</literal> for details on configuration directives.
+          Options for ruTorrent's PHP pool. See the documentation on <literal>php-fpm.conf</literal> for details on configuration directives.
         '';
       };
 
@@ -227,7 +227,7 @@ in {
           home = cfg.dataDir;
           group = cfg.group;
           extraGroups = [ config.services.rtorrent.group ];
-          description = "rutorrent Daemon user";
+          description = "ruTorrent Daemon user";
           isSystemUser = true;
         };
 

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -1,0 +1,281 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.rutorrent;
+
+  pluginDependencies = with pkgs; {
+    _task = [ pgrep ];
+    unpack = [ unzip unrar ];
+    rss = [ curl ];
+    mediainfo = [ mediainfo ];
+    spectrogram = [ sox ];
+    screenshots = [ ffmpeg ];
+  };
+
+  getPluginDependencies = concatMap (p: attrByPath [ p ] [] pluginDependencies);
+
+in {
+  options = {
+    services.rutorrent = {
+      enable = mkEnableOption "rutorrent";
+
+      hostName = mkOption {
+        type = types.str;
+        description = "FQDN for the rutorrent instance.";
+      };
+
+      home = mkOption {
+        type = types.str;
+        default = "/var/lib/rutorrent";
+        description = "Storage path of rutorrent.";
+      };
+
+      rpcSocket = mkOption {
+        type = types.str;
+        default = config.services.rtorrent.rpcSocket;
+        defaultText = "config.services.rtorrent.rpcSocket";
+        description = ''
+          Path to rtorrent rpc socket.
+        '';
+      };
+
+      plugins = mkOption {
+        type = with types; listOf (either str package);
+        default = [ "httprpc" ];
+        example = literalExample ''[ "httprpc" "data" "diskspace" "edit" "erasedata" "theme" "trafic" ]'';
+        description = ''
+          List of plugins to enable. See the list of <link xlink:href="https://github.com/Novik/ruTorrent/wiki/Plugins#currently-there-are-the-following-plugins">available plugins</link>. Note: the <literal>unpack</literal> plugin needs the nonfree <literal>unrar</literal> package.
+          You need to either enable one of the <literal>rpc</literal> or <literal>httprpc</literal> plugin or enable the <xref linkend="opt-services.rutorrent.nginx.exposeInsecureRPC2mount"/> option.
+        '';
+      };
+
+      poolSettings = mkOption {
+        type = with types; attrsOf (oneOf [ str int bool ]);
+        default = {
+          "pm" = "dynamic";
+          "pm.max_children" = 32;
+          "pm.start_servers" = 2;
+          "pm.min_spare_servers" = 2;
+          "pm.max_spare_servers" = 4;
+          "pm.max_requests" = 500;
+        };
+        description = ''
+          Options for rutorrent's PHP pool. See the documentation on <literal>php-fpm.conf</literal> for details on configuration directives.
+        '';
+      };
+
+      nginx = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to enable nginx virtual host management.
+            Further nginx configuration can be done by adapting <literal>services.nginx.virtualHosts.&lt;name&gt;</literal>.
+            See <xref linkend="opt-services.nginx.virtualHosts"/> for further information.
+          '';
+        };
+
+        exposeInsecureRPC2mount = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            If you do not enable one of the <literal>rpc</literal> or <literal>httprpc</literal> plugins you need to expose an RPC mount through scgi using this option.
+            Warning: This allow to run arbitrary commands, as the rtorrent user, so make sure to use authentification. The simplest way would be to use the <literal>services.nginx.virtualHosts.&lt;name&gt;.basicAuth</literal> option.
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    { assertions = let
+        usedRpcPlugins = intersectLists cfg.plugins [ "httprpc" "rpc" ];
+      in [
+        { assertion = (length usedRpcPlugins < 2);
+          message = "Please specify only one of httprpc or rpc plugins";
+        }
+        { assertion = !(length usedRpcPlugins > 0 && cfg.nginx.exposeInsecureRPC2mount);
+          message = "Please do not use exposeInsecureRPC2mount if you use one of httprpc or rpc plugins";
+        }
+      ];
+
+      warnings = let
+        nginxVhostCfg = config.services.nginx.virtualHosts."${cfg.hostName}";
+      in []
+        ++ (optional (cfg.nginx.exposeInsecureRPC2mount && (nginxVhostCfg.basicAuth == {} || nginxVhostCfg.basicAuthFile == null )) ''
+          You are using exposeInsecureRPC2mount without using basic auth on the virtual host. The exposed rpc mount allow for remote command execution.
+
+          Please make sure it is not accessible from the outside.
+        '');
+
+      systemd = {
+        services = {
+          rtorrent.path = getPluginDependencies cfg.plugins;
+          rutorrent-setup = let
+            rutorrentConfig = pkgs.writeText "rutorrent-config.php" ''
+              <?php
+                // configuration parameters
+
+                // for snoopy client
+                @define('HTTP_USER_AGENT', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36', true);
+                @define('HTTP_TIME_OUT', 30, true);	// in seconds
+                @define('HTTP_USE_GZIP', true, true);
+                $httpIP = null;				// IP string. Or null for any.
+                $httpProxy = array
+                (
+                  'use' 	=> false,
+                  'proto'	=> 'http',		// 'http' or 'https'
+                  'host'	=> 'PROXY_HOST_HERE',
+                  'port'	=> 3128
+                );
+
+                @define('RPC_TIME_OUT', 5, true);	// in seconds
+
+                @define('LOG_RPC_CALLS', false, true);
+                @define('LOG_RPC_FAULTS', true, true);
+
+                // for php
+                @define('PHP_USE_GZIP', false, true);
+                @define('PHP_GZIP_LEVEL', 2, true);
+
+                $schedule_rand = 10;			// rand for schedulers start, +0..X seconds
+
+                $do_diagnostic = true;
+                $log_file = '${cfg.home}/logs/errors.log';		// path to log file (comment or leave blank to disable logging)
+
+                $saveUploadedTorrents = true;		// Save uploaded torrents to profile/torrents directory or not
+                $overwriteUploadedTorrents = false;     // Overwrite existing uploaded torrents in profile/torrents directory or make unique name
+
+                $topDirectory = '/';			// Upper available directory. Absolute path with trail slash.
+                $forbidUserSettings = false;
+
+                $scgi_port = 0;
+                $scgi_host = "unix://${cfg.rpcSocket}";
+
+                $XMLRPCMountPoint = "/RPC2";		// DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
+
+                $pathToExternals = array(
+                  "php" 	=> ''',			// Something like /usr/bin/php. If empty, will be found in PATH.
+                  "curl"	=> ''',			// Something like /usr/bin/curl. If empty, will be found in PATH.
+                  "gzip"	=> ''',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
+                  "id"	=> ''',			// Something like /usr/bin/id. If empty, will be found in PATH.
+                  "stat"	=> ''',			// Something like /usr/bin/stat. If empty, will be found in PATH.
+                );
+
+                $localhosts = array( 			// list of local interfaces
+                  "127.0.0.1",
+                  "localhost",
+                );
+
+                $profilePath = '../share';		// Path to user profiles
+                $profileMask = 0777;			// Mask for files and directory creation in user profiles.
+                // Both Webserver and rtorrent users must have read-write access to it.
+                // For example, if Webserver and rtorrent users are in the same group then the value may be 0770.
+
+                $tempDirectory = null;			// Temp directory. Absolute path with trail slash. If null, then autodetect will be used.
+
+                $canUseXSendFile = false;		// If true then use X-Sendfile feature if it exist
+
+                $locale = "UTF8";
+            '';
+          in {
+            wantedBy = [ "multi-user.target" ];
+            before = [ "phpfpm-rutorrent.service" ];
+            script = ''
+              ln -sf ${pkgs.rutorrent}/{css,images,js,lang,index.html} ${cfg.home}/
+              mkdir -p ${cfg.home}/{conf,logs,plugins} ${cfg.home}/share/{settings,torrents,users}
+              ln -sf ${pkgs.rutorrent}/conf/{access.ini,plugins.ini} ${cfg.home}/conf/
+              ln -sf ${rutorrentConfig} ${cfg.home}/conf/config.php
+
+              cp -r ${pkgs.rutorrent}/php ${cfg.home}/
+
+              ${optionalString (cfg.plugins != [])
+                ''cp -r ${concatMapStringsSep " " (p: "${pkgs.rutorrent}/plugins/${p}") cfg.plugins} ${cfg.home}/plugins/''}
+
+              chown -R rutorrent:rutorrent ${cfg.home}/{conf,share,logs,plugins}
+              chmod -R 755 ${cfg.home}/{conf,share,logs,plugins}
+            '';
+            serviceConfig.Type = "oneshot";
+          };
+        };
+
+        tmpfiles.rules = [ "d '${cfg.home}' 0775 rutorrent rutorrent -" ];
+      };
+
+      users.groups.rutorrent = {};
+
+      users.users = {
+        rutorrent = {
+          home = cfg.home;
+          group = "rutorrent";
+          extraGroups = [ config.services.rtorrent.group ];
+          description = "rutorrent Daemon user";
+          isSystemUser = true;
+        };
+
+        "${config.services.rtorrent.user}" = {
+          extraGroups = [ "rutorrent" ];
+        };
+      };
+    }
+
+    (mkIf cfg.nginx.enable (mkMerge [
+      { services = {
+          phpfpm = {
+            pools.rutorrent = {
+              user = "rutorrent";
+              group = "rtorrent";
+              settings = mapAttrs (name: mkDefault) {
+                "listen.owner" = config.services.nginx.user;
+                "listen.group" = config.services.nginx.group;
+              } // cfg.poolSettings;
+              phpEnv."PATH" = with pkgs; lib.makeBinPath [ php curl procps gzip ];
+            };
+          };
+
+          nginx = {
+            enable = true;
+            virtualHosts = {
+              ${cfg.hostName} = {
+                root = cfg.home;
+                locations = {
+                  "~ [^/]\.php(/|$)" = {
+                    extraConfig = ''
+                      fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+                      if (!-f $document_root$fastcgi_script_name) {
+                        return 404;
+                      }
+
+                      # Mitigate https://httpoxy.org/ vulnerabilities
+                      fastcgi_param HTTP_PROXY "";
+
+                      fastcgi_pass unix:${config.services.phpfpm.pools.rutorrent.socket};
+                      fastcgi_index index.php;
+
+                      include ${pkgs.nginx}/conf/fastcgi.conf;
+                    '';
+                  };
+                };
+              };
+            };
+          };
+        };
+      }
+
+      (mkIf cfg.nginx.exposeInsecureRPC2mount {
+        services.nginx.virtualHosts."${cfg.hostName}".locations."/RPC2" = {
+          extraConfig = ''
+            include ${pkgs.nginx}/conf/scgi_params;
+            scgi_pass unix:${cfg.rpcSocket};
+          '';
+        };
+
+        services.rtorrent.configText = ''
+          schedule = scgi_group,0,0,"execute.nothrow=chown,\":nginx\",(cfg.rpcsock)"
+        '';
+      })
+    ]))
+  ]);
+}

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -287,9 +287,7 @@ in {
           '';
         };
 
-        services.rtorrent.configText = ''
-          schedule = scgi_group,0,0,"execute.nothrow=chown,\":nginx\",(cfg.rpcsock)"
-        '';
+        services.rtorrent.rpcGroup = "nginx";
       })
     ]))
   ]);

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -170,7 +170,7 @@ in {
                 );
 
                 $profilePath = '../share';		// Path to user profiles
-                $profileMask = 0777;			// Mask for files and directory creation in user profiles.
+                $profileMask = 0770;			// Mask for files and directory creation in user profiles.
                 // Both Webserver and rtorrent users must have read-write access to it.
                 // For example, if Webserver and rtorrent users are in the same group then the value may be 0770.
 

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -157,11 +157,11 @@ in {
                 $XMLRPCMountPoint = "/RPC2";		// DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
 
                 $pathToExternals = array(
-                  "php" 	=> ''',			// Something like /usr/bin/php. If empty, will be found in PATH.
-                  "curl"	=> ''',			// Something like /usr/bin/curl. If empty, will be found in PATH.
-                  "gzip"	=> ''',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
-                  "id"	=> ''',			// Something like /usr/bin/id. If empty, will be found in PATH.
-                  "stat"	=> ''',			// Something like /usr/bin/stat. If empty, will be found in PATH.
+                  "php" 	=> "${pkgs.php}/bin/php",			// Something like /usr/bin/php. If empty, will be found in PATH.
+                  "curl"	=> "${pkgs.curl}/bin/curl",			// Something like /usr/bin/curl. If empty, will be found in PATH.
+                  "gzip"	=> "${pkgs.gzip}/bin/gzip",			// Something like /usr/bin/gzip. If empty, will be found in PATH.
+                  "id"	=> "${pkgs.coreutils}/bin/id",			// Something like /usr/bin/id. If empty, will be found in PATH.
+                  "stat"	=> "${pkgs.coreutils}/bin/stat",			// Something like /usr/bin/stat. If empty, will be found in PATH.
                 );
 
                 $localhosts = array( 			// list of local interfaces
@@ -231,7 +231,6 @@ in {
                 "listen.owner" = config.services.nginx.user;
                 "listen.group" = config.services.nginx.group;
               } // cfg.poolSettings;
-              phpEnv."PATH" = with pkgs; lib.makeBinPath [ php curl procps gzip ];
             };
           };
 

--- a/pkgs/applications/networking/p2p/rutorrent/default.nix
+++ b/pkgs/applications/networking/p2p/rutorrent/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "rutorrent";
+  version = "3.10-beta";
+
+  src = fetchFromGitHub {
+    owner = "Novik";
+    repo = "ruTorrent";
+    rev = "v${version}";
+    sha256 = "0qim3g6xfl9hdyhg6nfyzn594p5b3wbcdzmifdmfpj4kfngwjv1v";
+  };
+
+  installPhase = ''
+    mkdir -p $out/
+    cp -r . $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Yet another web front-end for rTorrent";
+    homepage = "https://github.com/Novik/ruTorrent";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/p2p/rutorrent/default.nix
+++ b/pkgs/applications/networking/p2p/rutorrent/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rutorrent";
-  version = "3.10-beta";
+  version = "3.10";
 
   src = fetchFromGitHub {
     owner = "Novik";
     repo = "ruTorrent";
     rev = "v${version}";
-    sha256 = "0qim3g6xfl9hdyhg6nfyzn594p5b3wbcdzmifdmfpj4kfngwjv1v";
+    sha256 = "1gnqbvyax8w84frx60adm58ixh6nycpm24lqmqa996sy6fpknmg4";
   };
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27554,6 +27554,8 @@ with pkgs;
 
   runc = callPackage ../applications/virtualization/runc {};
 
+  rutorrent = callPackage ../applications/networking/p2p/rutorrent {};
+
   rymcast = callPackage ../applications/audio/rymcast {
     inherit (gnome) zenity;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [rutorrent](https://github.com/Novik/ruTorrent), a web frontend to rtorrent.

###### Things done

Add the package and the NixOS service. It's a beta but the last non-beta release doesn't work with the current rtorrent.
It depends on this PR #83287 for a rtorrent service.

A few things still need to be improved.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
