### PR TITLE
nixos/mindustry: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -331,6 +331,7 @@
   ./services/editors/emacs.nix
   ./services/editors/infinoted.nix
   ./services/games/factorio.nix
+  ./services/games/mindustry.nix
   ./services/games/minecraft-server.nix
   ./services/games/minetest-server.nix
   ./services/games/openarena.nix

--- a/nixos/modules/services/games/mindustry.nix
+++ b/nixos/modules/services/games/mindustry.nix
@@ -1,0 +1,115 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.mindustry;
+  name = "Mindustry";
+
+  serverConfig = {
+    name = cfg.game-name;
+    port = (toString cfg.port);
+  } // cfg.extraConfig;
+  serverConfigCommands = (attrsets.mapAttrsToList (k: v:
+    "config ${k} ${if builtins.isBool v then boolToString v else toString v}")
+    serverConfig);
+  serverCommands = cfg.extraCommands ++ serverConfigCommands
+    ++ [ "host ${cfg.game-map} ${cfg.game-mode}" ];
+in {
+  options = {
+    services.mindustry = {
+      enable = mkEnableOption name;
+      package = mkOption {
+        type = types.package;
+        default = pkgs.mindustry-server;
+        defaultText = "pkgs.mindustry-server";
+        description = ''
+          Mindustry server package to use.
+        '';
+      };
+      port = mkOption {
+        type = types.int;
+        default = 6567;
+        description = ''
+          The port to host on.
+        '';
+      };
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to open ports in the firewall for the server.
+        '';
+      };
+      game-mode = mkOption {
+        type = types.nullOr types.str;
+        default = "";
+        description = ''
+          The gamemode that mindustry-server should host. Leaving both game-mode and game-map empty results in a random survival map.
+        '';
+      };
+      game-map = mkOption {
+        type = types.nullOr types.str;
+        default = "";
+        description = ''
+          The map that mindustry-server should host. Leaving both game-mode and game-map empty results in a random survival map.
+        '';
+      };
+      game-name = mkOption {
+        type = types.str;
+        default = "Mindustry";
+        description = ''
+          The server name as displayed on clients.
+        '';
+      };
+      extraCommands = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "playerlimit 8" "reloadmaps" ];
+        description = ''
+          Extra commands passed to mindustry-server.
+
+          A list of all commands for the current version of mindustry-server can be found via
+          <programlisting language="bash"><![CDATA[mindustry-server help]]></programlisting>
+        '';
+      };
+      extraConfig = mkOption {
+        type = types.attrs;
+        default = { };
+        example = {
+          enableVotekick = true;
+          socketInput = true;
+        };
+        description = ''
+         Extra game configuration passed to mindustry-server via the config argument.
+
+         A list of all game configuration for the current version of mindustry-server can be found via
+         <programlisting language="bash"><![CDATA[mindustry-server config]]></programlisting>
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.mindustry = {
+      description = "Mindustry headless server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Restart = "always";
+        DynamicUser = true;
+        StateDirectory = "mindustry";
+        WorkingDirectory = "/var/lib/mindustry";
+        ExecStart = toString [
+          "${cfg.package}/bin/mindustry-server"
+          (builtins.concatStringsSep "," serverCommands)
+        ];
+      };
+    };
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+      allowedUDPPorts = [ cfg.port ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ oro ];
+}

--- a/nixos/tests/mindustry.nix
+++ b/nixos/tests/mindustry.nix
@@ -1,0 +1,25 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "mindustry";
+  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ oro ]; };
+
+  nodes = {
+    server = { ... }: {
+      services.mindustry = {
+        enable = true;
+        extraConfig.socketInput = true;
+      };
+    };
+  };
+
+  testScript = ''
+    server.start()
+    with subtest("should start mindustry service"):
+        server.wait_for_unit("mindustry.service")
+        server.wait_for_open_port(6567)
+
+    with subtest("should display version"):
+        server.succeed('echo "version" | nc -w1 127.0.0.1 6859')
+        server.succeed('journalctl -u mindustry | grep -q -i "${pkgs.mindustry-server.version}"')
+  '';
+
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
To host a Mindustry server on NixOS via services configuration.
Note that mindustry can open up a socket connection when setup via e.g.
```nix
      services.mindustry = {
        enable = true;
        extraConfig.socketInput = true;
      };
```
This can then be used to send commands to the server (it only listens on localhost) with e.g. nc
```bash
echo "shuffle" | nc -w1 127.0.0.1 6859
```
I am not 100% happy with that, if anyone has gotten some ideas I'd be glad to hear them.

Also, I am not sure how I would be able to implement a graceful shutdown of mindustry-server, again feedback welcome.

CC: @fgaz  maintainer of pkgs.mindustry

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
