### PR TITLE
Support more than 99 nodes in NixOS tests & export toHex and toBase

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,7 +67,7 @@ let
     inherit (trivial) id const pipe concat or and bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell min max
       importJSON warn info showWarnings nixpkgsVersion version mod compare
-      splitByAndCompare functionArgs setFunctionArgs isFunction;
+      splitByAndCompare functionArgs setFunctionArgs isFunction toHex toBase;
     inherit (fixedPoints) fix fix' converge extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;
     inherit (attrsets) attrByPath hasAttrByPath setAttrByPath

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,7 +67,7 @@ let
     inherit (trivial) id const pipe concat or and bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell min max
       importJSON warn info showWarnings nixpkgsVersion version mod compare
-      splitByAndCompare functionArgs setFunctionArgs isFunction toHex toBase;
+      splitByAndCompare functionArgs setFunctionArgs isFunction toHexString toBaseDigits;
     inherit (fixedPoints) fix fix' converge extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;
     inherit (attrsets) attrByPath hasAttrByPath setAttrByPath

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -102,6 +102,16 @@ runTests {
     expected = 9;
   };
 
+  testToHex = {
+    expr = toHex 250;
+    expected = "FA";
+  };
+
+  testToBase = {
+    expr = toBase 2 6;
+    expected = [ 1 1 0 ];
+  };
+
 # STRINGS
 
   testConcatMapStrings = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -102,13 +102,13 @@ runTests {
     expected = 9;
   };
 
-  testToHex = {
-    expr = toHex 250;
+  testToHexString = {
+    expr = toHexString 250;
     expected = "FA";
   };
 
-  testToBase = {
-    expr = toBase 2 6;
+  testToBaseDigits = {
+    expr = toBaseDigits 2 6;
     expected = [ 1 1 0 ];
   };
 

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -332,4 +332,55 @@ rec {
   */
   isFunction = f: builtins.isFunction f ||
     (f ? __functor && isFunction (f.__functor f));
+
+  /* Convert the given positive integer to a string of its hexadecimal
+     representation. For example:
+
+     toHex 0 => "0"
+
+     toHex 16 => "10"
+
+     toHex 250 => "FA"
+  */
+  toHex = i:
+    let
+      toHexDigit = d:
+        if d < 10
+        then toString d
+        else
+          {
+            "10" = "A";
+            "11" = "B";
+            "12" = "C";
+            "13" = "D";
+            "14" = "E";
+            "15" = "F";
+          }.${toString d};
+    in
+      lib.concatMapStrings toHexDigit (toBase 16 i);
+
+  /* `toBase base i` converts the positive integer i to a list of its
+     digits in the given base. For example:
+
+     toBase 10 123 => [ 1 2 3 ]
+
+     toBase 2 6 => [ 1 1 0 ]
+
+     toBase 16 250 => [ 15 10 ]
+  */
+  toBase = base: i:
+    let
+      go = i:
+        if i < base
+        then [i]
+        else
+          let
+            r = i - ((i / base) * base);
+            q = (i - r) / base;
+          in
+            [r] ++ go q;
+    in
+      assert (base >= 2);
+      assert (i >= 0);
+      lib.reverseList (go i);
 }

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -336,13 +336,13 @@ rec {
   /* Convert the given positive integer to a string of its hexadecimal
      representation. For example:
 
-     toHex 0 => "0"
+     toHexString 0 => "0"
 
-     toHex 16 => "10"
+     toHexString 16 => "10"
 
-     toHex 250 => "FA"
+     toHexString 250 => "FA"
   */
-  toHex = i:
+  toHexString = i:
     let
       toHexDigit = d:
         if d < 10
@@ -357,18 +357,18 @@ rec {
             "15" = "F";
           }.${toString d};
     in
-      lib.concatMapStrings toHexDigit (toBase 16 i);
+      lib.concatMapStrings toHexDigit (toBaseDigits 16 i);
 
-  /* `toBase base i` converts the positive integer i to a list of its
+  /* `toBaseDigits base i` converts the positive integer i to a list of its
      digits in the given base. For example:
 
-     toBase 10 123 => [ 1 2 3 ]
+     toBaseDigits 10 123 => [ 1 2 3 ]
 
-     toBase 2 6 => [ 1 1 0 ]
+     toBaseDigits 2 6 => [ 1 1 0 ]
 
-     toBase 16 250 => [ 15 10 ]
+     toBaseDigits 16 250 => [ 15 10 ]
   */
-  toBase = base: i:
+  toBaseDigits = base: i:
     let
       go = i:
         if i < base

--- a/nixos/lib/qemu-flags.nix
+++ b/nixos/lib/qemu-flags.nix
@@ -9,10 +9,11 @@ let
        else pkgs.lib.toHex n);
 in
 
-{
+rec {
+  qemuNicMac = net: machine: "52:54:00:12:${zeroPad net}:${zeroPad machine}";
 
   qemuNICFlags = nic: net: machine:
-    [ "-device virtio-net-pci,netdev=vlan${toString nic},mac=52:54:00:12:${zeroPad net}:${zeroPad machine}"
+    [ "-device virtio-net-pci,netdev=vlan${toString nic},mac=${qemuNicMac net machine}"
       "-netdev vde,id=vlan${toString nic},sock=$QEMU_VDE_SOCKET_${toString net}"
     ];
 

--- a/nixos/lib/qemu-flags.nix
+++ b/nixos/lib/qemu-flags.nix
@@ -6,7 +6,7 @@ let
     pkgs.lib.optionalString (n < 16) "0" +
       (if n > 255
        then throw "Can't have more than 255 nets or nodes!"
-       else pkgs.lib.toHex n);
+       else pkgs.lib.toHexString n);
 in
 
 rec {

--- a/nixos/lib/qemu-flags.nix
+++ b/nixos/lib/qemu-flags.nix
@@ -2,7 +2,11 @@
 { pkgs }:
 
 let
-  zeroPad = n: if n < 10 then "0${toString n}" else toString n;
+  zeroPad = n:
+    pkgs.lib.optionalString (n < 16) "0" +
+      (if n > 255
+       then throw "Can't have more than 255 nets or nodes!"
+       else pkgs.lib.toHex n);
 in
 
 {

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -8,7 +8,9 @@ with import ../lib/testing-python.nix { inherit system pkgs; };
 with pkgs.lib;
 
 let
-  router = { config, pkgs, ... }:
+  qemu-flags = import ../lib/qemu-flags.nix { inherit pkgs; };
+
+  router = { config, pkgs, lib, ... }:
     with pkgs.lib;
     let
       vlanIfs = range 1 (length config.virtualisation.vlans);
@@ -31,16 +33,19 @@ let
         enable = true;
         interfaces = map (n: "eth${toString n}") vlanIfs;
         extraConfig = ''
-          authoritative;
         '' + flip concatMapStrings vlanIfs (n: ''
           subnet 192.168.${toString n}.0 netmask 255.255.255.0 {
             option routers 192.168.${toString n}.1;
-            # XXX: technically it's _not guaranteed_ that IP addresses will be
-            # issued from the first item in range onwards! We assume that in
-            # our tests however.
-            range 192.168.${toString n}.2 192.168.${toString n}.254;
           }
-        '');
+        '')
+        ;
+        machines = lib.flip map vlanIfs (vlan:
+          {
+            hostName = "client${toString vlan}";
+            ethernetAddress = qemu-flags.qemuNicMac vlan 1;
+            ipAddress = "192.168.${toString vlan}.2";
+          }
+        );
       };
       services.radvd = {
         enable = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The current `zeroPad` function, which determines the MAC address of each QEMU VM in NixOS tests, returns a MAC address component in decimal notation while it should return it in hexadecimal. This means that you get inconsistent MAC addresses once you have 10 nodes or more. Worse: when you have 100 or more nodes the MAC address will look like `52:54:00:12:01:100` which is invalid.

###### Things done

This PR fixes the `zeroPad` function to return a proper hexadecimal component which means we can now have up to 254 nodes.

The implementation needed the `toHex` and `toBase` functions which have been added to the `lib` and come with unit tests.

Finally the `dhcpSimple` NixOS test from the `networking` test suite has been modified to give out fixed IP addresses (instead of a range) based on the MAC address.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
