### PR TITLE
BLAS/LAPACK fix fallout from #83888

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1290,32 +1290,9 @@ self: super: {
 
 ### How to use Intel's MKL with numpy and scipy?
 
-A `site.cfg` is created that configures BLAS based on the `blas` parameter of
-the `numpy` derivation. By passing in `mkl`, `numpy` and packages depending on
-`numpy` will be built with `mkl`.
-
-The following is an overlay that configures `numpy` to use `mkl`:
-
-```nix
-self: super: {
-  python37 = super.python37.override {
-    packageOverrides = python-self: python-super: {
-      numpy = python-super.numpy.override {
-        blas = super.pkgs.mkl;
-      };
-    };
-  };
-}
-```
-
-`mkl` requires an `openmp` implementation when running with multiple processors.
-By default, `mkl` will use Intel's `iomp` implementation if no other is
-specified, but this is a runtime-only dependency and binary compatible with the
-LLVM implementation. To use that one instead, Intel recommends users set it with
-`LD_PRELOAD`.
-
-Note that `mkl` is only available on `x86_64-{linux,darwin}` platforms;
-moreover, Hydra is not building and distributing pre-compiled binaries using it.
+MKL can be configured using an overlay. See the section “[Using
+overlays to configure
+alternatives](#sec-overlays-alternatives-blas-lapack)”.
 
 ### What inputs do `setup_requires`, `install_requires` and `tests_require` map to?
 

--- a/doc/using/overlays.xml
+++ b/doc/using/overlays.xml
@@ -177,7 +177,7 @@ self: super:
          <para>
            <link
            xlink:href="https://software.intel.com/en-us/mkl">Intel
-           MKL</link> (only works on x86 architecture)
+           MKL</link> (only works on x86 architecture, unfree)
          </para>
          <para>
            The Nixpkgs attribute is <literal>mkl</literal>.
@@ -211,6 +211,44 @@ self: super:
        using <literal>LD_PRELOAD</literal> of libblas.so.3 and
        liblapack.so.3.
      </para>
+     <para>
+       Intel MKL requires an <literal>openmp</literal> implementation
+       when running with multiple processors. By default,
+       <literal>mkl</literal> will use Intel’s <literal>iomp</literal>
+       implementation if no other is specified, but this is a
+       runtime-only dependency and binary compatible with the LLVM
+       implementation. To use that one instead, Intel recommends users
+       set it with <literal>LD_PRELOAD</literal>. Note that
+       <literal>mkl</literal> is only available on
+       <literal>x86_64-linux</literal> and
+       <literal>x86_64-darwin</literal>. Moreover, Hydra is not build
+       and distributing pre-compiled binaries using it.
+     </para>
+     <para>
+       For BLAS/LAPACK switching to work correctly, all packages must
+       depend on <literal>blas</literal> or <literal>lapack</literal>.
+       This ensures that only one BLAS/LAPACK library is used at one
+       time. There are two versions versions of BLAS/LAPACK currently
+       in the wild, <literal>LP64</literal> (integer size = 32 bits)
+       and <literal>ILP64</literal> (integer size = 64 bits). Some
+       software needs special flags or patches to work with
+       <literal>ILP64</literal>. You can check if
+       <literal>ILP64</literal> is used in Nixpkgs with
+       <varname>blas.isILP64</varname> and
+       <varname>lapack.isILP64</varname>. Some software does NOT work
+       with <literal>ILP64</literal>, and derivations need to specify
+       an assertion to prevent this. You can prevent
+       <literal>ILP64</literal> from being used with the following:
+     </para>
+     <programlisting>
+{ stdenv, blas, lapack, ... }:
+
+assert (!blas.isILP64) &amp;&amp; (!lapack.isILP64);
+
+stdenv.mkDerivation {
+  ...
+}
+     </programlisting>
    </section>
  </section>
 </chapter>

--- a/doc/using/overlays.xml
+++ b/doc/using/overlays.xml
@@ -137,4 +137,80 @@ self: super:
    Overlays are similar to other methods for customizing Nixpkgs, in particular the <literal>packageOverrides</literal> attribute described in <xref linkend="sec-modify-via-packageOverrides"/>. Indeed, <literal>packageOverrides</literal> acts as an overlay with only the <varname>super</varname> argument. It is therefore appropriate for basic use, but overlays are more powerful and easier to distribute.
   </para>
  </section>
+ <section xml:id="sec-overlays-alternatives">
+   <title>Using overlays to configure alternatives</title>
+   <para>
+     Certain software has different implementations of the same
+     interface. Other distributions have functionality to switch
+     between these. For example, Debian provides <link
+     xlink:href="https://wiki.debian.org/DebianAlternatives">DebianAlternatives</link>.
+     Nixpkgs has what we call <literal>alternatives</literal>, which
+     are configured through overlays.
+   </para>
+   <section xml:id="sec-overlays-alternatives-blas-lapack">
+     <title>BLAS/LAPACK</title>
+     <para>
+       In Nixpkgs, we have multiple implementations of the BLAS/LAPACK
+       numerical linear algebra interfaces. They are:
+     </para>
+     <itemizedlist>
+       <listitem>
+         <para>
+           <link xlink:href="https://www.openblas.net/">OpenBLAS</link>
+         </para>
+         <para>
+           The Nixpkgs attribute is <literal>openblas</literal> for
+           ILP64 and <literal>openblasCompat</literal> for LP64. This
+           is the default.
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           <link xlink:href="http://www.netlib.org/lapack/">LAPACK
+           reference</link> (also provides BLAS)
+         </para>
+         <para>
+           The Nixpkgs attribute is <literal>lapack-reference</literal>.
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           <link
+           xlink:href="https://software.intel.com/en-us/mkl">Intel
+           MKL</link> (only works on x86 architecture)
+         </para>
+         <para>
+           The Nixpkgs attribute is <literal>mkl</literal>.
+         </para>
+       </listitem>
+     </itemizedlist>
+     <para>
+       Introduced in <link
+       xlink:href="https://github.com/NixOS/nixpkgs/pull/83888">PR
+       #83888</link>, we are able to override the ‘blas’ and ‘lapack’
+       packages to use different implementations, through the
+       ‘blasProvider’ and ‘lapackProvider’ argument. This can be used
+       to select a different provider. For example, an overlay can be
+       created that looks like:
+     </para>
+     <programlisting>
+self: super:
+
+{
+  blas = super.blas.override {
+    blasProvider = self.mkl;
+  }
+  lapack = super.lapack.override {
+    lapackProvider = self.mkl;
+  }
+}
+     </programlisting>
+     <para>
+       This overlay uses Intel’s MKL library for both BLAS and LAPACK
+       interfaces. Note that the same can be accomplished at runtime
+       using <literal>LD_PRELOAD</literal> of libblas.so.3 and
+       liblapack.so.3.
+     </para>
+   </section>
+ </section>
 </chapter>

--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -2,7 +2,7 @@
 , libyaml, libxc, fftw, blas, lapack, gsl, netcdf, arpack, autoreconfHook
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "octopus";

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -13,7 +13,7 @@
 assert pythonSupport -> pythonPackages != null;
 assert opencvSupport -> opencv != null;
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 let
   pname = "shogun";

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -9,7 +9,7 @@
 , static ? false
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   name = "R-3.6.3";

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -5,7 +5,7 @@
 }:
 
 assert enableGUI -> libGLU != null && libGL != null && xorg != null && fltk != null;
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "giac${lib.optionalString enableGUI "-with-xcas"}";

--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, cmake, blas, lapack, gfortran, gmm, fltk, libjpeg
 , zlib, libGL, libGLU, xorg, opencascade-occt }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "gmsh";

--- a/pkgs/applications/science/math/sage/sage-env.nix
+++ b/pkgs/applications/science/math/sage/sage-env.nix
@@ -54,7 +54,7 @@
 , less
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 # This generates a `sage-env` shell file that will be sourced by sage on startup.
 # It sets up various environment variables, telling sage where to find its

--- a/pkgs/applications/science/math/sage/sage-with-env.nix
+++ b/pkgs/applications/science/math/sage/sage-with-env.nix
@@ -23,7 +23,7 @@
 }:
 
 # lots of segfaults with (64 bit) blas
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 # Wrapper that combined `sagelib` with `sage-env` to produce an actually
 # executable sage. No tests are run yet and no documentation is built.

--- a/pkgs/applications/science/math/sage/sagelib.nix
+++ b/pkgs/applications/science/math/sage/sagelib.nix
@@ -53,7 +53,7 @@
 , pplpy
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 # This is the core sage python package. Everything else is just wrappers gluing
 # stuff together. It is not very useful on its own though, since it will not

--- a/pkgs/build-support/alternatives/blas/default.nix
+++ b/pkgs/build-support/alternatives/blas/default.nix
@@ -136,5 +136,6 @@ EOF
   mkdir -p $out/nix-support
   echo 'export MKL_INTERFACE_LAYER=${lib.optionalString isILP64 "I"}LP64,GNU' > $out/nix-support/setup-hook
   ln -s $out/lib/libblas${canonicalExtension} $out/lib/libmkl_rt${stdenv.hostPlatform.extensions.sharedLibrary}
+  ln -sf ${blasProvider}/include/* $dev/include
 '');
 }

--- a/pkgs/build-support/alternatives/blas/default.nix
+++ b/pkgs/build-support/alternatives/blas/default.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation {
   dontConfigure = true;
   unpackPhase = "src=$PWD";
 
+  dontPatchELF = true;
+
   installPhase = (''
   mkdir -p $out/lib $dev/include $dev/lib/pkgconfig
 

--- a/pkgs/build-support/alternatives/blas/default.nix
+++ b/pkgs/build-support/alternatives/blas/default.nix
@@ -135,5 +135,6 @@ EOF
 '' + stdenv.lib.optionalString (blasImplementation == "mkl") ''
   mkdir -p $out/nix-support
   echo 'export MKL_INTERFACE_LAYER=${lib.optionalString isILP64 "I"}LP64,GNU' > $out/nix-support/setup-hook
+  ln -s $out/lib/libblas${canonicalExtension} $out/lib/libmkl_rt${stdenv.hostPlatform.extensions.sharedLibrary}
 '');
 }

--- a/pkgs/build-support/alternatives/lapack/default.nix
+++ b/pkgs/build-support/alternatives/lapack/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv
 , lapack-reference, openblasCompat, openblas
-, is64bit ? false
-, lapackProvider ? if is64bit then openblas else openblasCompat }:
+, isILP64 ? false
+, lapackProvider ? if isILP64 then openblas else openblasCompat }:
 
 let
 
@@ -14,7 +14,7 @@ let
 
 in
 
-assert is64bit -> (lapackImplementation == "openblas" && lapackProvider.blas64) || lapackImplementation == "mkl";
+assert isILP64 -> (lapackImplementation == "openblas" && lapackProvider.blas64) || lapackImplementation == "mkl";
 
 stdenv.mkDerivation {
   pname = "lapack";
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    inherit is64bit;
+    inherit isILP64;
     provider = lapackProvider;
     implementation = lapackImplementation;
   };
@@ -108,6 +108,6 @@ Libs: -L$out/lib -llapacke
 EOF
 '' + stdenv.lib.optionalString (lapackImplementation == "mkl") ''
   mkdir -p $out/nix-support
-  echo 'export MKL_INTERFACE_LAYER=${lib.optionalString is64bit "I"}LP64,GNU' > $out/nix-support/setup-hook
+  echo 'export MKL_INTERFACE_LAYER=${lib.optionalString isILP64 "I"}LP64,GNU' > $out/nix-support/setup-hook
 '');
 }

--- a/pkgs/build-support/alternatives/lapack/default.nix
+++ b/pkgs/build-support/alternatives/lapack/default.nix
@@ -109,5 +109,6 @@ EOF
 '' + stdenv.lib.optionalString (lapackImplementation == "mkl") ''
   mkdir -p $out/nix-support
   echo 'export MKL_INTERFACE_LAYER=${lib.optionalString isILP64 "I"}LP64,GNU' > $out/nix-support/setup-hook
+  ln -s $out/lib/liblapack${canonicalExtension} $out/lib/libmkl_rt${stdenv.hostPlatform.extensions.sharedLibrary}
 '');
 }

--- a/pkgs/build-support/alternatives/lapack/default.nix
+++ b/pkgs/build-support/alternatives/lapack/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation {
   dontConfigure = true;
   unpackPhase = "src=$PWD";
 
+  dontPatchELF = true;
+
   installPhase = (''
   mkdir -p $out/lib $dev/include $dev/lib/pkgconfig
 

--- a/pkgs/build-support/alternatives/lapack/default.nix
+++ b/pkgs/build-support/alternatives/lapack/default.nix
@@ -110,5 +110,6 @@ EOF
   mkdir -p $out/nix-support
   echo 'export MKL_INTERFACE_LAYER=${lib.optionalString isILP64 "I"}LP64,GNU' > $out/nix-support/setup-hook
   ln -s $out/lib/liblapack${canonicalExtension} $out/lib/libmkl_rt${stdenv.hostPlatform.extensions.sharedLibrary}
+  ln -sf ${lapackProvider}/include/* $dev/include
 '');
 }

--- a/pkgs/development/compilers/julia/1.3.nix
+++ b/pkgs/development/compilers/julia/1.3.nix
@@ -12,7 +12,7 @@
 , CoreServices, ApplicationServices
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 with stdenv.lib;
 
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
       "SHELL=${stdenv.shell}"
 
       "USE_SYSTEM_BLAS=1"
-      "USE_BLAS64=${if blas.is64bit then "1" else "0"}"
+      "USE_BLAS64=${if blas.isILP64 then "1" else "0"}"
 
       "USE_SYSTEM_LAPACK=1"
 

--- a/pkgs/development/compilers/julia/shared.nix
+++ b/pkgs/development/compilers/julia/shared.nix
@@ -22,7 +22,7 @@
 
 with stdenv.lib;
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 let
   dsfmtVersion = "2.2.3";
@@ -137,7 +137,7 @@ stdenv.mkDerivation rec {
       "SHELL=${stdenv.shell}"
 
       "USE_SYSTEM_BLAS=1"
-      "USE_BLAS64=${if blas.is64bit then "1" else "0"}"
+      "USE_BLAS64=${if blas.isILP64 then "1" else "0"}"
 
       "USE_SYSTEM_LAPACK=1"
 

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -53,7 +53,7 @@
 , darwin
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   version = "5.2.0";
@@ -125,12 +125,12 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   # See https://savannah.gnu.org/bugs/?50339
-  F77_INTEGER_8_FLAG = if blas.is64bit then "-fdefault-integer-8" else "";
+  F77_INTEGER_8_FLAG = if blas.isILP64 then "-fdefault-integer-8" else "";
 
   configureFlags = [
     "--with-blas=blas"
     "--with-lapack=lapack"
-    (if blas.is64bit then "--enable-64" else "--disable-64")
+    (if blas.isILP64 then "--enable-64" else "--disable-64")
   ]
     ++ (if stdenv.isDarwin then [ "--enable-link-all-dependencies" ] else [ ])
     ++ stdenv.lib.optionals enableReadline [ "--enable-readline" ]

--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -2,7 +2,7 @@
 , gmpxx
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "fflas-ffpack";

--- a/pkgs/development/libraries/linbox/default.nix
+++ b/pkgs/development/libraries/linbox/default.nix
@@ -10,7 +10,7 @@
 , withSage ? false # sage support
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "linbox";

--- a/pkgs/development/libraries/qrupdate/default.nix
+++ b/pkgs/development/libraries/qrupdate/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
           -e 's,^LAPACK=.*,LAPACK=-L${lapack}/lib -llapack,' \
           Makeconf
     ''
-    + stdenv.lib.optionalString blas.is64bit
+    + stdenv.lib.optionalString blas.isILP64
     ''
       sed -i Makeconf -e '/^FFLAGS=.*/ s/$/-fdefault-integer-8/'
     '';

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
-    "-DINTERFACE64=${optionalString blas.is64bit "1"}"
+    "-DINTERFACE64=${optionalString blas.isILP64 "1"}"
   ];
 
   preCheck = if stdenv.isDarwin then ''

--- a/pkgs/development/libraries/science/math/ipopt/default.nix
+++ b/pkgs/development/libraries/science/math/ipopt/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, unzip, blas, lapack, gfortran }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "ipopt";

--- a/pkgs/development/libraries/science/math/magma/default.nix
+++ b/pkgs/development/libraries/science/math/magma/default.nix
@@ -1,8 +1,4 @@
-{ stdenv, fetchurl, cmake, gfortran, cudatoolkit, libpthreadstubs, lapack, blas
-, mklSupport ? false, mkl ? null
-}:
-
-assert !mklSupport || mkl != null;
+{ stdenv, fetchurl, cmake, gfortran, cudatoolkit, libpthreadstubs, lapack, blas }:
 
 with stdenv.lib;
 
@@ -17,12 +13,9 @@ in stdenv.mkDerivation {
     name = "magma-${version}.tar.gz";
   };
 
-  buildInputs = [ gfortran cudatoolkit libpthreadstubs cmake ]
-    ++ (if mklSupport then [ mkl ] else [ lapack blas ]);
+  buildInputs = [ gfortran cudatoolkit libpthreadstubs cmake lapack blas ];
 
   doCheck = false;
-
-  MKLROOT = optionalString mklSupport mkl;
 
   preConfigure = ''
     export CC=${cudatoolkit.cc}/bin/gcc CXX=${cudatoolkit.cc}/bin/g++

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -2,7 +2,7 @@
 , gfortran, mpi, blas, lapack
 } :
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "scalapack";

--- a/pkgs/development/libraries/science/math/scs/default.nix
+++ b/pkgs/development/libraries/science/math/scs/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, blas, lapack, gfortran, fixDarwinDylibNames }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "scs";

--- a/pkgs/development/libraries/science/math/suitesparse/4.2.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/4.2.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, gfortran, blas, lapack }:
 
 let
-  int_t = if blas.is64bit then "int64_t" else "int32_t";
+  int_t = if blas.isILP64 then "int64_t" else "int32_t";
 in
 stdenv.mkDerivation rec {
   version = "4.2.1";

--- a/pkgs/development/libraries/science/math/suitesparse/4.4.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/4.4.nix
@@ -6,7 +6,7 @@ let
   version = "4.4.4";
   name = "suitesparse-${version}";
 
-  int_t = if blas.is64bit then "int64_t" else "int32_t";
+  int_t = if blas.isILP64 then "int64_t" else "int32_t";
   SHLIB_EXT = stdenv.hostPlatform.extensions.sharedLibrary;
 in
 stdenv.mkDerivation {

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     "BLAS=-lblas"
     "LAPACK=-llapack"
     "MY_METIS_LIB=-lmetis"
-  ] ++ stdenv.lib.optionals blas.is64bit [
+  ] ++ stdenv.lib.optionals blas.isILP64 [
     "CFLAGS=-DBLAS64"
   ] ++ stdenv.lib.optionals enableCuda [
     "CUDA_PATH=${cudatoolkit}"

--- a/pkgs/development/libraries/science/math/superlu/default.nix
+++ b/pkgs/development/libraries/science/math/superlu/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, cmake,
   gfortran, blas, lapack}:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   version = "5.2.1";

--- a/pkgs/development/libraries/sundials/2.x.nix
+++ b/pkgs/development/libraries/sundials/2.x.nix
@@ -8,7 +8,7 @@
 , gfortran
 , lapackSupport ? true }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "sundials";

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -7,7 +7,7 @@
 , gfortran
 , lapackSupport ? true }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "sundials";

--- a/pkgs/development/ocaml-modules/lacaml/default.nix
+++ b/pkgs/development/ocaml-modules/lacaml/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, darwin, ocaml, findlib, dune, base, stdio, lapack, blas }:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.05.0";
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-lacaml";

--- a/pkgs/development/ocaml-modules/owl/default.nix
+++ b/pkgs/development/ocaml-modules/owl/default.nix
@@ -11,7 +11,7 @@
 , npy
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 
 buildDunePackage rec {

--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -14,7 +14,7 @@
 , withFftw ? true
 }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 buildPythonPackage rec {
   pname = "cvxopt";

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -21,9 +21,7 @@ let
       ${blas.implementation} = {
         include_dirs = "${blas}/include:${lapack}/include";
         library_dirs = "${blas}/lib:${lapack}/lib";
-      } // lib.optionalAttrs (blas.implementation == "mkl") {
-        mkl_libs = "mkl_rt";
-        lapack_libs = "";
+        libraries = "lapack,lapacke,blas,cblas";
       };
     });
   };

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -19,7 +19,7 @@ let
     name = "site.cfg";
     text = (lib.generators.toINI {} {
       ${blas.implementation} = {
-        include_dirs = "${blas}/include:${lapack}/include";
+        include_dirs = "${lib.getDev blas}/include:${lib.getDev lapack}/include";
         library_dirs = "${blas}/lib:${lapack}/lib";
         libraries = "lapack,lapacke,blas,cblas";
       };

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -12,7 +12,7 @@
 , setuptoolsBuildHook
  }:
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 let
   cfg = writeTextFile {

--- a/pkgs/tools/misc/hpl/default.nix
+++ b/pkgs/tools/misc/hpl/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, blas, lapack, mpi } :
 
-assert (!blas.is64bit) && (!lapack.is64bit);
+assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "hpl";

--- a/pkgs/top-level/release-alternatives.nix
+++ b/pkgs/top-level/release-alternatives.nix
@@ -59,7 +59,7 @@ in
 {
   blas = mapListToAttrs supportedSystems (system': let system = lib.systems.elaborate { system = system'; };
     in mapListToAttrs (blasProviders system) (provider: let
-      is64bit = builtins.elem provider (["mkl64"] ++ lib.optional system.is64bit "openblas");
+      isILP64 = builtins.elem provider (["mkl64"] ++ lib.optional system.is64bit "openblas");
       pkgs = pkgsFun {
         config = { inherit allowUnfree; };
         system = system';
@@ -68,13 +68,13 @@ in
             lapackProvider = if provider == "mkl64"
                              then super.mkl
                              else builtins.getAttr provider super;
-            inherit is64bit;
+            inherit isILP64;
           };
           blas = super.blas.override {
             blasProvider = if provider == "mkl64"
                            then super.mkl
                            else builtins.getAttr provider super;
-            inherit is64bit;
+            inherit isILP64;
           };
         })];
       };


### PR DESCRIPTION
Commits addressing review from https://github.com/NixOS/nixpkgs/pull/83888.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
