### PR TITLE
doona: init at unstable-2019-03-08

### DIFF
--- a/pkgs/tools/security/doona/default.nix
+++ b/pkgs/tools/security/doona/default.nix
@@ -1,0 +1,36 @@
+{ fetchFromGitHub
+, stdenv
+, perl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "doona";
+  version = "unstable-2019-03-08";
+
+  src = fetchFromGitHub {
+    owner = "wireghoul";
+    repo = pname;
+    rev = "master";
+    sha256 = "0x9irwrw5x2ia6ch6gshadrlqrgdi1ivkadmr7j4m75k04a7nvz1";
+  };
+
+  buildInputs = [ perl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r ${src}/bedmod $out/bin/bedmod
+    cp ${src}/doona.pl $out/bin/doona
+    chmod +x $out/bin/doona
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/wireghoul/doona";
+    description = "A fork of the Bruteforce Exploit Detector Tool (BED)";
+    longDescription = ''
+      A fork of the Bruteforce Exploit Detector Tool (BED).
+      BED is a program which is designed to check daemons for potential buffer overflows, format string bugs etc.
+    '';
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -888,6 +888,8 @@ in
 
   dpt-rp1-py = callPackage ../tools/misc/dpt-rp1-py { };
 
+  doona = callPackage ../tools/security/doona { };
+
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 
   sedutil = callPackage ../tools/security/sedutil { };


### PR DESCRIPTION
###### Motivation for this change

Relates to #81418 .

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
