### PR TITLE
texlab: 1.10.0 -> 2.0.0

### DIFF
--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -5,17 +5,17 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "texlab";
-  version = "1.10.0";
+  pname = "texlab-unwrapped";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "latex-lsp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "12zfcvbihirh38xxzc8fbx293m4vsrhq6kh0qnhnhlrx75m09l9i";
+    sha256 = "0y8cv8y92a4nqwrvqk2cxgs6nspqjk8jm4spr8rgkwlpfbrg74xn";
   };
 
-  cargoSha256 = "08fi0c4s0d1p2rqxvj1y82zg6xl3n0ikgyhgrjwh6xay8f0121f0";
+  cargoSha256 = "1cxi6bvdyhxb5jnw5dhba5mdsc149cw6mzaf00ayvc4pcdrj323s";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 

--- a/pkgs/development/tools/misc/texlab/wrapper.nix
+++ b/pkgs/development/tools/misc/texlab/wrapper.nix
@@ -1,0 +1,20 @@
+# Texlab supports the following TeX Distributions:
+# - TeX Live
+# - MiKTeX
+# - Tectonic
+
+{ stdenvNoCC, lib, makeWrapper
+, texlab-unwrapped, tex
+}:
+
+stdenvNoCC.mkDerivation {
+  name = "texlab";
+  inherit (texlab-unwrapped) version meta;
+
+  phases = [ "installPhase" ];
+  nativeBuildInputs = [ makeWrapper ];
+  installPhase = ''
+    makeWrapper ${texlab-unwrapped}/bin/texlab "$out/bin/texlab" \
+      --prefix PATH : ${lib.makeBinPath [ tex ]}
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10879,8 +10879,12 @@ in
 
   texi2mdoc = callPackage ../tools/misc/texi2mdoc { };
 
-  texlab = callPackage ../development/tools/misc/texlab {
+  texlab-unwrapped = callPackage ../development/tools/misc/texlab {
     inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
+  texlab = callPackage ../development/tools/misc/texlab/wrapper.nix {
+    tex = texlive.combined.scheme-small;
   };
 
   tflint = callPackage ../development/tools/analysis/tflint { };


### PR DESCRIPTION
Also added a configurable wrapper that puts a TeX Distribution into `PATH`.
Defaults to `texlive.combined.scheme-small`.

Without this wrapper, the following message is displayed on startup:
```
Your TeX distribution could not be detected. Please make sure that your distribution is in your PATH.
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrade to latest version of texlab: https://github.com/latex-lsp/texlab/releases/tag/v2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@doronbehar 
