### PR TITLE
darwin.binutils: propagate man pages from darwin.cctools

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation {
 
   inherit targetPrefix infixSalt;
 
-  outputs = [ "out" ] ++ optionals propagateDoc [ "man" "info" ];
+  outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (bintools ? info) "info");
 
   passthru = {
     inherit bintools libc nativeTools nativeLibc nativePrefix;
@@ -259,14 +259,15 @@ stdenv.mkDerivation {
       printWords ${bintools_bin} ${if libc == null then "" else libc_bin} > $out/nix-support/propagated-user-env-packages
     ''
 
-    + optionalString propagateDoc ''
+    + optionalString propagateDoc (''
       ##
       ## Man page and info support
       ##
 
       ln -s ${bintools.man} $man
+    '' + optionalString (bintools ? info) ''
       ln -s ${bintools.info} $info
-    ''
+    '')
 
     + ''
       ##

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -16,7 +16,7 @@ in
 stdenv.mkDerivation {
   pname = "${targetPrefix}cctools-binutils-darwin";
   inherit (cctools) version;
-  outputs = [ "out" "info" "man" ];
+  outputs = [ "out" "man" ];
   buildCommand = ''
     mkdir -p $out/bin $out/include
 
@@ -42,12 +42,13 @@ stdenv.mkDerivation {
 
     ln -s ${cctools}/libexec $out/libexec
 
-    mkdir -p "$info/nix-support" "$man/nix-support"
-    printWords ${binutils-unwrapped.info} \
-      >> $info/nix-support/propagated-build-inputs
-    # FIXME: cctools missing man pages
-    printWords ${binutils-unwrapped.man} \
-      >> $man/nix-support/propagated-build-inputs
+    mkdir -p "$man"/share/man/man{1,5}
+    for i in ${builtins.concatStringsSep " " cmds}; do
+      for path in "${cctools.man}"/share/man/man?/$i.*; do
+        dest_path="$man''${path#${cctools.man}}"
+        ln -sv "$path" "$dest_path"
+      done
+    done
   '';
 
   passthru = {

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, autoreconfHook
+, installShellFiles
 , libcxxabi, libuuid
 , libobjc ? null, maloader ? null
 , enableTapiSupport ? true, libtapi
@@ -30,7 +31,7 @@ let
 
     outputs = [ "out" "dev" "man" ];
 
-    nativeBuildInputs = [ autoconf automake libtool autoreconfHook ];
+    nativeBuildInputs = [ autoconf automake libtool autoreconfHook installShellFiles ];
     buildInputs = [ libuuid ]
       ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi libobjc ]
       ++ stdenv.lib.optional enableTapiSupport libtapi;
@@ -88,6 +89,8 @@ let
       pushd include
       make DSTROOT=$out/include RC_OS=common install
       popd
+
+      installManPage ar/ar.{1,5}
     '';
 
     passthru = {

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -28,7 +28,7 @@ let
       sha256 = "0h8b1my0wf1jyjq63wbiqkl2clgxsf87f6i4fjhqs431fzlq8sac";
     };
 
-    outputs = [ "out" "dev" ];
+    outputs = [ "out" "dev" "man" ];
 
     nativeBuildInputs = [ autoconf automake libtool autoreconfHook ];
     buildInputs = [ libuuid ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Man pages from GNU binutils are too useful for darwin binutils.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
