### PR TITLE
perlPackages.GitAutofixup: init at 0.002007

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -7878,6 +7878,20 @@ let
     };
   };
 
+  GitAutofixup = buildPerlPackage rec {
+    pname = "GitAutofixup";
+    version = "0.002007";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/T/TO/TORBIAK/App-Git-Autofixup-${version}.tar.gz";
+      sha256 = "1ydy15pibva0qr5vrv5mqyzw3zlc3wbszzv7932vh7m88vv6gfr6";
+    };
+    meta = {
+      maintainers = [ maintainers.DamienCassou ];
+      description = "Create fixup commits for topic branches";
+      license = stdenv.lib.licenses.artistic2;
+    };
+  };
+
   GitPurePerl = buildPerlPackage {
     pname = "Git-PurePerl";
     version = "0.53";


### PR DESCRIPTION
#### Motivation for this change

Add [git autofixup](https://github.com/torbiak/git-autofixup)

###### Things done



- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
