### PR TITLE
haskellPackages.stylish-haskell: fix broken dependencies

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1432,11 +1432,11 @@ self: super: {
 
   # HsYAML-aeson depends on a more modern version of HsYAML than the one
   # available in stackage's LTS 14.23
-  HsYAML-aeson = unmarkBroken (super.HsYAML-aeson.override {
+  HsYAML-aeson = super.HsYAML-aeson.override {
     HsYAML = self.HsYAML_0_2_1_0;
-  });
+  };
 
-  stylish-haskell = (unmarkBroken super.stylish-haskell).override {
+  stylish-haskell = super.stylish-haskell.override {
     HsYAML = self.HsYAML_0_2_1_0;
   };
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1430,6 +1430,16 @@ self: super: {
     amqp = dontCheck super.amqp_0_19_1;
   };
 
+  # HsYAML-aeson depends on a more modern version of HsYAML than the one
+  # available in stackage's LTS 14.23
+  HsYAML-aeson = unmarkBroken (super.HsYAML-aeson.override {
+    HsYAML = self.HsYAML_0_2_1_0;
+  });
+
+  stylish-haskell = (unmarkBroken super.stylish-haskell).override {
+    HsYAML = self.HsYAML_0_2_1_0;
+  };
+
   # 20.03 broken packages
 
   envy-extensible = markBroken super.envy-extensible;


### PR DESCRIPTION
stylish-haskell depends on a more modern HsYAML version than available in
stackage. Updated to use the hackage version.

Note that `stylish-haskell` builds in master, possibly because master uses a more modern stackage LTS. I am not sure if I should pull request this to the 20.03 branch or just wait until the whole stackage version is updated for 20.03

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
