### PR TITLE
playonlinux: fix build

### DIFF
--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -9,7 +9,7 @@
 , imagemagick
 , netcat-gnu
 , p7zip
-, python2Packages
+, python2
 , unzip
 , wget
 , wine
@@ -27,25 +27,25 @@
 let
   version = "4.3.4";
 
-  binpath = stdenv.lib.makeBinPath
-    [ cabextract
-      python2Packages.python
-      gettext
-      glxinfo
-      gnupg
-      icoutils
-      imagemagick
-      netcat-gnu
-      p7zip
-      unzip
-      wget
-      wine
-      xdg-user-dirs
-      xterm
-      which
-      curl
-      jq
-    ];
+  binpath = stdenv.lib.makeBinPath [ 
+    cabextract
+    python
+    gettext
+    glxinfo
+    gnupg
+    icoutils
+    imagemagick
+    netcat-gnu
+    p7zip
+    unzip
+    wget
+    wine
+    xdg-user-dirs
+    xterm
+    which
+    curl
+    jq
+  ];
 
   ld32 =
     if stdenv.hostPlatform.system == "x86_64-linux" then "${stdenv.cc}/nix-support/dynamic-linker-m32"
@@ -53,6 +53,11 @@ let
     else throw "Unsupported platform for PlayOnLinux: ${stdenv.hostPlatform.system}";
   ld64 = "${stdenv.cc}/nix-support/dynamic-linker";
   libs = pkgs: stdenv.lib.makeLibraryPath [ xorg.libX11 libGL ];
+
+  python = python2.withPackages(ps: with ps; [
+    wxPython
+    setuptools
+  ]);
 
 in stdenv.mkDerivation {
   pname = "playonlinux";
@@ -65,15 +70,13 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs =
-    [ python2Packages.python
-      python2Packages.wxPython
-      python2Packages.setuptools
-      xorg.libX11
-      libGL
-    ];
+  buildInputs = [ 
+    xorg.libX11
+    libGL
+    python
+  ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs python tests/python
     sed -i "s/ %F//g" etc/PlayOnLinux.desktop
   '';
@@ -85,7 +88,6 @@ in stdenv.mkDerivation {
     install -D -m644 etc/PlayOnLinux.desktop $out/share/applications/playonlinux.desktop
 
     makeWrapper $out/share/playonlinux/playonlinux $out/bin/playonlinux \
-      --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath "$out") \
       --prefix PATH : ${binpath}
 
     bunzip2 $out/share/playonlinux/bin/check_dd_x86.bz2


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
