### PR TITLE
r8125: 9.003.02 -> 9.003.05

### DIFF
--- a/pkgs/os-specific/linux/r8125/default.nix
+++ b/pkgs/os-specific/linux/r8125/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "r8125";
   # On update please verify (using `diff -r`) that the source matches the
   # realtek version.
-  version = "9.003.02";
+  version = "9.003.05";
 
   # This is a mirror. The original website[1] doesn't allow non-interactive
   # downloads, instead emailing you a download link.
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ibmibmibm";
     repo = "r8125";
-    rev = "${version}";
-    sha256 = "09ip17x8nhcpxkkhyyawkmd10n73j2ffh1i2nmsr7l3jfq7f9zac";
+    rev = version;
+    sha256 = "016vh997xjs01si0zzs572vgflq3czxd0v4m7h1m3qxcv2cvq7i0";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested the kernel module ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
