### PR TITLE
python2Packages.pylatexenc: 2.1 -> 2.2

### DIFF
--- a/pkgs/development/python-modules/pylatexenc/default.nix
+++ b/pkgs/development/python-modules/pylatexenc/default.nix
@@ -1,30 +1,28 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pylatexenc";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner = "phfaist";
-    repo = pname;
+    repo = "pylatexenc";
     rev = "v${version}";
-    sha256 = "0wnl00y5dl56aw9j4y21kqapraaravbycwfxdmjsbgl11nk4llx9";
+    sha256 = "0icwd7iipz3sv4jdh9iam7h4xslvdqg16rwsmczrna3mmjbwccdk";
   };
 
   pythonImportsCheck = [ "pylatexenc" ];
-  checkInputs = [ pytest ];
-  checkPhase = ''
-    pytest
-  '';
+  dontUseSetuptoolsCheck = true;
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Simple LaTeX parser providing latex-to-unicode and unicode-to-latex conversion";
     homepage = "https://pylatexenc.readthedocs.io";
-    downloadPage = "https;//www.github.com/phfaist/pylatexenc";
+    downloadPage = "https://www.github.com/phfaist/pylatexenc/releases";
     license = licenses.mit;
     maintainers = with maintainers; [ drewrisinger ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Version bump hit last night. https://github.com/phfaist/pylatexenc/releases/tag/v2.2
Cleans up some meta/test too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
