### PR TITLE
srcOnly: ignore additional arguments

### DIFF
--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, name, src, patches ? [], buildInputs ? [] }:
+{stdenv, name, src, patches ? [], buildInputs ? [], ...}: 
 stdenv.mkDerivation {
   inherit src buildInputs patches name;
   installPhase = "cp -r . $out";


### PR DESCRIPTION
###### Motivation for this change

This reverts commit b32a057425b337b37db41d3b4a67d39657477c05 (#80903),
which breaks even the most straightforward uses of srcOnly:

    nix-repl> srcOnly guile
    error: anonymous function at /home/src/nixpkgs/pkgs/build-support/src-only/default.nix:1:1 called with unexpected argument 'drvPath', at /home/src/nixpkgs/lib/customisation.nix:69:16

    nix-repl> srcOnly hello
    error: anonymous function at /home/src/nixpkgs/pkgs/build-support/src-only/default.nix:1:1 called with unexpected argument 'drvPath', at /home/src/nixpkgs/lib/customisation.nix:69:16


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).