### PR TITLE
pythonPackages.caldav: unbreak build

### DIFF
--- a/pkgs/development/python-modules/caldav/default.nix
+++ b/pkgs/development/python-modules/caldav/default.nix
@@ -1,5 +1,12 @@
-{ lib, buildPythonPackage, fetchPypi
-, tzlocal, requests, vobject, lxml, nose }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, tzlocal
+, requests
+, vobject
+, lxml
+, nose
+}:
 
 buildPythonPackage rec {
   pname = "caldav";
@@ -12,11 +19,16 @@ buildPythonPackage rec {
     sha256 = "80c33b143539da3a471148ac89512f67d9df3a5286fae5a023e2ad3923246c0d";
   };
 
+  # xandikos is only a optional test dependency, not available for python3
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace ", 'xandikos'" ""
+  '';
+
   meta = with lib; {
     description = "This project is a CalDAV (RFC4791) client library for Python.";
     homepage = "https://pythonhosted.org/caldav/";
     license = licenses.asl20;
     maintainers = with maintainers; [ marenz ];
-    broken = true; # missing xandikos package
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The caldav pkg was marked as broken because of a missing dependency.
The xandikos package is only a optional test dependency, see https://github.com/python-caldav/caldav/commit/45a505680acb1f444131d32a96562fe2d2ee6942.

###### Things done
Patched away the dependency to fix the build.
I think this should be backported to 20.03. (#80379)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@marenz2569 