### PR TITLE
shopify-themekit: init at 1.0.3

### DIFF
--- a/pkgs/development/web/shopify-themekit/default.nix
+++ b/pkgs/development/web/shopify-themekit/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "shopify-themekit";
+  version = "1.0.3";
+
+  goPackagePath = "github.com/Shopify/themekit/";
+
+  goDeps = ./shopify-themekit_deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "Shopify";
+    repo = "themekit";
+    rev = "v${version}";
+    sha256 = "1780h33mf2h2lv6mr4xx3shfvsabr7w138yb59vvdgvjng9wjkg0";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A command line tool for shopify themes";
+    homepage = "https://shopify.github.io/themekit/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ maintainers."1000101" ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/web/shopify-themekit/shopify-themekit_deps.nix
+++ b/pkgs/development/web/shopify-themekit/shopify-themekit_deps.nix
@@ -1,0 +1,300 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/VividCortex/ewma";
+    fetch = {
+      type = "git";
+      url = "https://github.com/VividCortex/ewma";
+      rev = "v1.1.1";
+      sha256 = "14v2dy5gqchjn7k0sd6cx59ms42v681r6xz7cb1kspp4b28a74rw";
+    };
+  }
+  {
+    goPackagePath = "github.com/aws/aws-sdk-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev = "1c16cd01d785";
+      sha256 = "129iizv2rny2frg36057hayynpsdav53nhj41dia3mi2r6zyalny";
+    };
+  }
+  {
+    goPackagePath = "github.com/caarlos0/env";
+    fetch = {
+      type = "git";
+      url = "https://github.com/caarlos0/env";
+      rev = "d0de832ed2fb";
+      sha256 = "013shh38rs2jv4a2hsbix0hlanjr2a539akmkqkwwg0il9h3qmq2";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "v1.7.0";
+      sha256 = "0v8msvg38r8d1iiq2i5r4xyfx0invhc941kjrsg5gzwvagv55inv";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev = "v1.25.4";
+      sha256 = "0b6cql5ripbiyrm18d6bfd1rfjnwcbskppw3d0vb80l0wy72d0c6";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-version";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-version";
+      rev = "270f2f71b1ee";
+      sha256 = "1d43wlp932nqbwkca4bhw8l4x6cg25jyh8l1s3814vddscfpfz2v";
+    };
+  }
+  {
+    goPackagePath = "github.com/imdario/mergo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/imdario/mergo";
+      rev = "v0.3.6";
+      sha256 = "1lbzy8p8wv439sqgf0n21q52flf2wbamp6qa1jkyv6an0nc952q7";
+    };
+  }
+  {
+    goPackagePath = "github.com/inconshreveable/go-update";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/go-update";
+      rev = "8152e7eb6ccf";
+      sha256 = "07czhspakpi7al004rm669cmf4h5l0vnygsm11280nkfn2zxqdi3";
+    };
+  }
+  {
+    goPackagePath = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev = "v1.0.0";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath = "github.com/jmespath/go-jmespath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev = "0b12d6b521d8";
+      sha256 = "1vv6hph8j6xgv7gwl9vvhlsaaqsm22sxxqmgmldi4v11783pc1ld";
+    };
+  }
+  {
+    goPackagePath = "github.com/joho/godotenv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/joho/godotenv";
+      rev = "v1.3.0";
+      sha256 = "0ri8if0pc3x6jg4c3i8wr58xyfpxkwmcjk3rp8gb398a1aa3gpjm";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "efa589957cd0";
+      sha256 = "0kshi4hvm0ayrsxqxy0599iv81kryhd2fn9lwjyczpj593cq069r";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.4";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/radovskyb/watcher";
+    fetch = {
+      type = "git";
+      url = "https://github.com/radovskyb/watcher";
+      rev = "v1.0.6";
+      sha256 = "1xlbrfgm6ha161szdjq2rab53plkdhmh5h86lpbk5g7fmq881945";
+    };
+  }
+  {
+    goPackagePath = "github.com/ryanuber/go-glob";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ryanuber/go-glob";
+      rev = "572520ed46db";
+      sha256 = "0dzbpqp1h7gjmlm4irnh6lpbfz5zjc721jidibyvmxj7xcx3wp5d";
+    };
+  }
+  {
+    goPackagePath = "github.com/shibukawa/configdir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shibukawa/configdir";
+      rev = "e180dbdc8da0";
+      sha256 = "0vbma9jkwh0ifz8dk2ssgmy7aiaify63lpa0lah7i4dkkxr94c9z";
+    };
+  }
+  {
+    goPackagePath = "github.com/skratchdot/open-golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/skratchdot/open-golang";
+      rev = "75fb7ed4208c";
+      sha256 = "1b67imqbsdvg19vif1q1dfmapxy3v2anagacbql95fwnnw0v8jga";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev = "7c4570c3ebeb";
+      sha256 = "16amh0prlzqrrbg5j629sg0f688nfzfgn9sair8jyybqampr3wc7";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "v1.0.2";
+      sha256 = "005598piihl3l83a71ahj10cpq9pbhjck4xishx1b4dzc02r9xr2";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.1";
+      sha256 = "0iph0qmpyqg4kwv8jsx6a56a7hhqq8swrazv40ycxk9rzr0s8yls";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.2.2";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+  {
+    goPackagePath = "github.com/vbauerster/mpb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vbauerster/mpb";
+      rev = "v3.3.2";
+      sha256 = "18m66b80iv9z768c15dqsx5mnjq6iaa6b5lckpdqnynqzkkvw8kk";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "a1f597ede03a";
+      sha256 = "0yiczljll72ip2vkxgd6052rhpaba37a68vf6si3v8s8s3g870lc";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/lint";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/lint";
+      rev = "d0100b6bd8b3";
+      sha256 = "0b0amr9x4ji66iv9ayfx7zrfx52k1m5g66qfcxkgj80qrb1y2yn7";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "1272bf9dcd53";
+      sha256 = "1500gryd7jli7yjn4c927ppyllry8lxcmnsmpn7zxfd1k14q7nyv";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "1d60e4601c6f";
+      sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "6c81ef8f67ca";
+      sha256 = "1iqrral339vxb635ip5jjzn84aa86kb629kbp1w29qwyfzbs0yqi";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "3f1ed9edd1b4";
+      sha256 = "00d2h0df03gv57valad4wr3g2rc8dcn8w3ci783x9wzzc86y4giw";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v1";
+      rev = "9f9df34309c0";
+      sha256 = "1r8d346szqa9x8q03wiycik5qy3d6w8qq4hs99z1p64q5lm0g7gm";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6531,6 +6531,8 @@ in
 
   shocco = callPackage ../tools/text/shocco { };
 
+  shopify-themekit = callPackage ../development/web/shopify-themekit { };
+
   shorewall = callPackage ../tools/networking/shorewall { };
 
   shotwell = callPackage ../applications/graphics/shotwell { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Package command line tool for shopify themes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
