### PR TITLE
journald service: Increase default rate limit 1000 -> 10000.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -269,6 +269,12 @@ environment.systemPackages = [
   <itemizedlist>
    <listitem>
     <para>
+     <option>services.journald.rateLimitBurst</option> was updated from
+     <literal>1000</literal> to <literal>10000</literal> to follow the new
+     upstream systemd default.
+    </para>
+   <listitem>
+    <para>
      The <package>notmuch</package> package move its emacs-related binaries and
      emacs lisp files to a separate output. They're not part
      of the default <literal>out</literal> output anymore - if you relied on the

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -597,7 +597,7 @@ in
     };
 
     services.journald.rateLimitBurst = mkOption {
-      default = 1000;
+      default = 10000;
       type = types.int;
       description = ''
         Configures the rate limiting burst limit (number of messages per


### PR DESCRIPTION
###### Motivation for this change

Follows the upstream change of this default:

https://github.com/systemd/systemd/pull/8660

I also personally think it is a better default; in fact I had changed it for my systems the same way before I noticed that upstream made this change already in 2018 and NixOS was not updated.

Feels like it'd be cool to have something that notifies us of upstream changed defaults that we have copied into Nix configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
