### PR TITLE
timg: init at 2020-04-09, tiv: init at 2020-04-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8294,6 +8294,12 @@
     githubId = 27586264;
     name = "Tobias Schmidt";
   };
+  ToxicFrog = {
+    email = "toxicfrog@ancilla.ca";
+    github = "ToxicFrog";
+    githubId = 90456;
+    name = "Rebecca (Bex) Kelly";
+  };
   travisbhartwell = {
     email = "nafai@travishartwell.net";
     github = "travisbhartwell";

--- a/pkgs/tools/misc/timg/default.nix
+++ b/pkgs/tools/misc/timg/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, pkgs, fetchFromGitHub }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "timg-${version}";
+  version = "2018-04-22";
+
+  src = fetchFromGitHub {
+    owner = "hzeller";
+    repo = "timg";
+    rev = "4a300cfe9c159ffb5d357b41b3c69c57219da9e8";
+    sha256 = "0vx4i1ibgc0rmjdb607qbdbwxz9m89vam3hgzz2kvji1zl4b90ns";
+  };
+
+  nativeBuildInputs = with pkgs; [gnumake];
+  buildInputs = with pkgs; [libwebp graphicsmagick];
+
+  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+
+  buildPhase = ''make -C src'';
+  installPhase = ''
+    mkdir -p "$out/bin/"
+    cp -a src/timg "$out/bin/timg"
+  '';
+
+  meta = {
+    license = licenses.gpl2;
+    homepage = "https://github.com/hzeller/timg";
+    description = "A viewer that uses 24-Bit color capabilities and 1x2 unicode character blocks to display images in the terminal.";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/tools/misc/tiv/default.nix
+++ b/pkgs/tools/misc/tiv/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, pkgs, fetchFromGitHub }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "tiv-${version}";
+  version = "2020-04-09";
+
+  src = fetchFromGitHub {
+    owner = "stefanhaustein";
+    repo = "TerminalImageViewer";
+    rev = "f78b65c1f375e688c7500f644a1766e48b783933";
+    sha256 = "055qf1fpapvrckkwlx1zsy1z4dyr87zjj79l7z6vh7d54fs4alpv";
+  };
+
+  nativeBuildInputs = with pkgs; [gnumake gcc];
+  buildInputs = with pkgs; [imagemagick];
+  phases = ["unpackPhase" "buildPhase" "installPhase"];
+  buildPhase = ''make -C src/main/cpp'';
+  installPhase = ''
+    mkdir -p "$out/bin/"
+    cp -a src/main/cpp/tiv "$out/bin/"
+  '';
+
+  meta = {
+    license = licenses.asl20;
+    homepage = "https://github.com/stefanhaustein/TerminalImageViewer";
+    description = "Small C++ program to display images in a (modern) terminal using RGB ANSI codes and unicode 4x8 block graphic characters.";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22815,6 +22815,8 @@ in
 
   timewarrior = callPackage ../applications/misc/timewarrior { };
 
+  timg = callPackage ../tools/misc/timg { };
+
   timidity = callPackage ../tools/misc/timidity { };
 
   tint2 = callPackage ../applications/misc/tint2 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22827,6 +22827,8 @@ in
 
   tipp10 = qt5.callPackage ../applications/misc/tipp10 { };
 
+  tiv = callPackage ../tools/misc/tiv { };
+
   tixati = callPackage ../applications/networking/p2p/tixati { };
 
   tkcvs = callPackage ../applications/version-management/tkcvs { };


### PR DESCRIPTION
###### Motivation for this change
These are simple image viewers for the tty, similar to `catimg` but with different feature sets -- `timg` has better scaling options, and `tiv` uses 8x4 block drawing characters to achieve higher resolution.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
