### PR TITLE
add openttd `nml` and `grfcodec` tools

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10644,6 +10644,12 @@
     github = "totoroot";
     githubId = 39650930;
   };
+  ToxicFrog = {
+    email = "toxicfrog@ancilla.ca";
+    github = "ToxicFrog";
+    githubId = 90456;
+    name = "Rebecca (Bex) Kelly";
+  };
   travisbhartwell = {
     email = "nafai@travishartwell.net";
     github = "travisbhartwell";

--- a/pkgs/games/openttd/grfcodec.nix
+++ b/pkgs/games/openttd/grfcodec.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, boost, cmake, git }:
+
+stdenv.mkDerivation rec {
+  pname = "openttd-grfcodec";
+  version = "unstable-2021-03-10";
+
+  src = fetchFromGitHub {
+    owner = "OpenTTD";
+    repo = "grfcodec";
+    rev = "045774dee7cab1a618a3e0d9b39bff78a12b6efa";
+    sha256 = "0b4xnnkqc01d3r834lhkq744ymar6c8iyxk51wc4c7hvz0vp9vmy";
+  };
+
+  buildInputs = [boost];
+  nativeBuildInputs = [cmake git];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a grfcodec grfid grfstrip nforenum $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Low-level (dis)assembler and linter for OpenTTD GRF files";
+    homepage    = "http://openttd.org/";
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/games/openttd/nml.nix
+++ b/pkgs/games/openttd/nml.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "openttd-nml";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "OpenTTD";
+    repo = "nml";
+    rev = version;
+    sha256 = "0kfnkshff3wrxsj1wpfbbw2mmgww2q80v63p5d2pp1f38x8j33w9";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ply pillow];
+
+  meta = with lib; {
+    description = "Compiler for OpenTTD NML files";
+    homepage    = "http://openttdcoop.org/";
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28980,6 +28980,7 @@ in
     };
   };
   openttd-grfcodec = callPackage ../games/openttd/grfcodec.nix {};
+  openttd-nml = callPackage ../games/openttd/nml.nix {};
 
   opentyrian = callPackage ../games/opentyrian { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28979,6 +28979,7 @@ in
       static = true;
     };
   };
+  openttd-grfcodec = callPackage ../games/openttd/grfcodec.nix {};
 
   opentyrian = callPackage ../games/opentyrian { };
 


### PR DESCRIPTION
###### Motivation for this change
OpenTTD is already in nixpkgs; this adds two tools used in developing mods for it.

###### Things done
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
