### PR TITLE
nixos/dropbox: new module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -603,6 +603,7 @@
   ./services/networking/dnscrypt-wrapper.nix
   ./services/networking/dnsdist.nix
   ./services/networking/dnsmasq.nix
+  ./services/networking/dropbox.nix
   ./services/networking/ejabberd.nix
   ./services/networking/epmd.nix
   ./services/networking/eternal-terminal.nix

--- a/nixos/modules/services/networking/dropbox.nix
+++ b/nixos/modules/services/networking/dropbox.nix
@@ -1,0 +1,73 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.dropbox;
+
+in
+
+{
+  ###### interface
+
+  options.services.dropbox = {
+
+    enable = mkEnableOption ''
+      Whether to enable the dropbox service globally.
+    '';
+
+    install = mkEnableOption ''
+      Whether to install a user service for the dropbox daemon. Once
+      the service is started, the Dropbox desktop app is available.
+
+      The service must be manually started for each user with
+      "systemctl --user start dropbox" or globally through
+      <varname>services.dropbox.enable</varname>.
+    '';
+
+    openFirewall = mkEnableOption ''
+      Open ports in the firewall for Dropbox.
+
+      UDP: 17500
+      TCP: 17500
+    '';
+
+  };
+
+  ###### implementation
+
+  config = mkIf (cfg.enable || cfg.install) {
+
+    environment.systemPackages = with pkgs; [ dropbox-cli ];
+
+    systemd.user.services.dropbox = {
+      description = "Dropbox daemon";
+      after = [ "xembedsniproxy.service" ];
+      wants = [ "xembedsniproxy.service" ];
+      environment = {
+        QT_PLUGIN_PATH = "/run/current-system/sw/" + pkgs.qt5.qtbase.qtPluginPrefix;
+        QML2_IMPORT_PATH = "/run/current-system/sw/" + pkgs.qt5.qtbase.qtQmlPrefix;
+      };
+      serviceConfig = {
+        ExecStart = "${pkgs.dropbox.out}/bin/dropbox";
+        ExecReload = "${pkgs.coreutils.out}/bin/kill -HUP $MAINPID";
+        KillMode = "control-group"; # upstream recommends process
+        Restart = "on-failure";
+        PrivateTmp = true;
+        ProtectSystem = "full";
+        Nice = 10;
+      };
+    } // optionalAttrs cfg.enable {
+      wantedBy = [ "graphical-session.target" ];
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ 17500 ];
+      allowedUDPPorts = [ 17500 ];
+    };
+
+  };
+
+  meta.maintainers = with lib.maintainers; [ romildo ];
+
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a module for the dropbox service.

See also https://nixos.wiki/wiki/Dropbox

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).