### PR TITLE
ssh-chat: init at 1.9

### DIFF
--- a/pkgs/applications/networking/instant-messengers/ssh-chat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ssh-chat/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "ssh-chat";
+  version = "1.9";
+
+  goPackagePath = "github.com/shazow/ssh-chat";
+
+  src = fetchFromGitHub {
+    owner = "shazow";
+    repo = "ssh-chat";
+    rev = "v${version}";
+    sha256 = "04yszan6a7x9498s80xymf7wd10530yjrxcdw4czbplyhjdigxlg";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Chat over SSH";
+    homepage = "https://github.com/shazow/ssh-chat";
+    license = licenses.mit;
+    maintainers = with maintainers; [ luc65r ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/ssh-chat/deps.nix
+++ b/pkgs/applications/networking/instant-messengers/ssh-chat/deps.nix
@@ -1,0 +1,84 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/alexcesaro/log";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alexcesaro/log";
+      rev = "61e686294e58";
+      sha256 = "1ckd5crq9rd12wpclahg2q0wprfg0whd6k9zbfzzkr6l1qpmmfam";
+    };
+  }
+  {
+    goPackagePath = "github.com/howeyc/gopass";
+    fetch = {
+      type = "git";
+      url = "https://github.com/howeyc/gopass";
+      rev = "7cb4b85ec19c";
+      sha256 = "1qyhjd6wx409g9cq3xbpbl2xl41nm00mxzcxm5gbqdlwsd0z80rv";
+    };
+  }
+  {
+    goPackagePath = "github.com/jessevdk/go-flags";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jessevdk/go-flags";
+      rev = "v1.4.0";
+      sha256 = "0algnnigph27spgn655zm4723yfjxjjvlf4k14z9drj3682df25a";
+    };
+  }
+  {
+    goPackagePath = "github.com/shazow/rateio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shazow/rateio";
+      rev = "4461efc8bdc4";
+      sha256 = "1isy75cmm71q18mvs6xaizgdjqnn6pllkj4yvd42brfgfj84qz0w";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "884d27f42877";
+      sha256 = "1ka5kqpw3wr3iawwxq4swmrwbww6v1cmds86z1nm0qb8fvhvpslk";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "eb5bcb51f2a3";
+      sha256 = "17k4g8krxbl84gzcs275b7gsh66dzm15fdxivjnx9xz8q84l4kby";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "1957bb5e6d1f";
+      sha256 = "0imqk4l9785rw7ddvywyf8zn7k3ga6f17ky8rmf8wrri7nknr03f";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.2";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "90fa682c2a6e";
+      sha256 = "03ic2xsy51jw9749wl7gszdbz99iijbd2bckgygl6cm9w5m364ak";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6653,6 +6653,8 @@ in
 
   sshping = callPackage ../tools/networking/sshping {};
 
+  ssh-chat = callPackage ../applications/networking/instant-messengers/ssh-chat { };
+
   suricata = callPackage ../applications/networking/ids/suricata {
     python = python3;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add ssh-chat for #85447 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
