### PR TITLE
Revert grub update, grub 2.04 -> 2.02

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -31,7 +31,7 @@ let
   canEfi = any (system: stdenv.hostPlatform.system == system) (mapAttrsToList (name: _: name) efiSystemsBuild);
   inPCSystems = any (system: stdenv.hostPlatform.system == system) (mapAttrsToList (name: _: name) pcSystems);
 
-  version = "2.04";
+  version = "2.04-rc1";
 
 in (
 
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.savannah.gnu.org/grub.git";
     rev = "${pname}-${version}";
-    sha256 = "02gly3xw88pj4zzqjniv1fxa1ilknbq1mdk30bj6qy8n44g90i8w";
+    sha256 = "0xkcfxs0hbzvi33kg4abkayl8b7gym9sv8ljbwlh2kpz8i4kmnk0";
   };
 
   patches = [

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, flex, bison, python, autoconf, automake, gnulib, libtool
+{ stdenv, fetchurl, fetchpatch, flex, bison, python
 , gettext, ncurses, libusb, freetype, qemu, lvm2, unifont, pkgconfig
 , fuse # only needed for grub-mount
 , zfs ? null
@@ -31,7 +31,7 @@ let
   canEfi = any (system: stdenv.hostPlatform.system == system) (mapAttrsToList (name: _: name) efiSystemsBuild);
   inPCSystems = any (system: stdenv.hostPlatform.system == system) (mapAttrsToList (name: _: name) pcSystems);
 
-  version = "2.04-rc1";
+  version = "2.02";
 
 in (
 
@@ -43,18 +43,28 @@ stdenv.mkDerivation rec {
   pname = "grub";
   inherit version;
 
-  src = fetchgit {
-    url = "git://git.savannah.gnu.org/grub.git";
-    rev = "${pname}-${version}";
-    sha256 = "0xkcfxs0hbzvi33kg4abkayl8b7gym9sv8ljbwlh2kpz8i4kmnk0";
+  src = fetchurl {
+    url = "mirror://gnu/grub/${pname}-${version}.tar.xz";
+    sha256 = "03vvdfhdmf16121v7xs8is2krwnv15wpkhkf16a4yf8nsfc3f2w1";
   };
 
   patches = [
     ./fix-bash-completion.patch
+    # This patch makes grub compatible with the XFS sparse inode
+    # feature introduced by xfsprogs-4.16.
+    # to be removed in grub-2.03
+    (fetchpatch {
+      url = https://git.savannah.gnu.org/cgit/grub.git/patch/?id=cda0a857dd7a27cd5d621747464bfe71e8727fff;
+      sha256 = "0k9qrkdxwdqk6sz05q9smqwjr6pvgc9adx1mlf0807g4im91xnm0";
+    })
+    ./relocation-not-implemented.diff
   ];
+  postPatch = ''
+    substituteInPlace ./configure --replace '/usr/share/fonts/unifont' '${unifont}/share/fonts'
+  '';
 
-  nativeBuildInputs = [ bison flex python pkgconfig autoconf automake ];
-  buildInputs = [ ncurses libusb freetype gettext lvm2 fuse libtool ]
+  nativeBuildInputs = [ bison flex python pkgconfig ];
+  buildInputs = [ ncurses libusb freetype gettext lvm2 fuse ]
     ++ optional doCheck qemu
     ++ optional zfsSupport zfs;
 
@@ -82,12 +92,6 @@ stdenv.mkDerivation rec {
            -e's/qemu-system-i386/qemu-system-x86_64 -nodefaults/g'
 
       unset CPP # setting CPP intereferes with dependency calculation
-
-      patchShebangs .
-
-      ./bootstrap --no-git --gnulib-srcdir=${gnulib}
-
-      substituteInPlace ./configure --replace '/usr/share/fonts/unifont' '${unifont}/share/fonts'
     '';
 
   configureFlags = [ "--enable-grub-mount" ] # dep of os-prober

--- a/pkgs/tools/misc/grub/relocation-not-implemented.diff
+++ b/pkgs/tools/misc/grub/relocation-not-implemented.diff
@@ -1,0 +1,25 @@
+https://git.savannah.gnu.org/cgit/grub.git/commit/util?id=842c390469e2c2e10b5
+diff --git a/util/grub-mkimagexx.c b/util/grub-mkimagexx.c
+index a2bb054..39d7efb 100644
+--- a/util/grub-mkimagexx.c
++++ b/util/grub-mkimagexx.c
+@@ -841,6 +841,7 @@ SUFFIX (relocate_addresses) (Elf_Ehdr *e, Elf_Shdr *sections,
+ 		  break;
+ 
+ 		case R_X86_64_PC32:
++		case R_X86_64_PLT32:
+ 		  {
+ 		    grub_uint32_t *t32 = (grub_uint32_t *) target;
+ 		    *t32 = grub_host_to_target64 (grub_target_to_host32 (*t32)
+diff --git a/util/grub-module-verifier.c b/util/grub-module-verifier.c
+index 9179285..a79271f 100644
+--- a/util/grub-module-verifier.c
++++ b/util/grub-module-verifier.c
+@@ -19,6 +19,7 @@ struct grub_module_verifier_arch archs[] = {
+       -1
+     }, (int[]){
+       R_X86_64_PC32,
++      R_X86_64_PLT32,
+       -1
+     }
+   },


### PR DESCRIPTION
###### Motivation for this change
This was already done for 19.09 (see https://github.com/NixOS/nixpkgs/commit/862f05cb00da70f86705ec6c70c2efb2fcd02e60 and parent) since Grub 2.04 seemed to cause problems for some people: https://github.com/NixOS/nixpkgs/issues/61718. This revert apparently never went into master though, so both 20.03 and master currently still use Grub 2.04. @emptyflask reported that they got hit by this issue when updating to 20.03. So let's revert it until we know more about it before we break more boot loaders.

Needs to be backported.

Ping @gnidorah @worldofpeace @disassembler @lheckemann 