### PR TITLE
rtl8812au: 5.2.20.2_28373.20190903 -> 5.6.4.2_35491.20200318

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "rtl8812au-${kernel.version}-${version}";
-  version = "5.2.20.2_28373.20190903";
+  version = "5.6.4.2_35491.20200318";
 
   src = fetchFromGitHub {
-    owner = "zebulon2";
-    repo = "rtl8812au-driver-5.2.20";
-    rev = "30d47a0a3f43ccb19e8fd59fe93d74a955147bf2";
-    sha256 = "1fy0f8ihxd0i5kr8gmky8v8xl0ns6bhxfdn64c97c5irzdvg37sr";
+    owner = "gordboy";
+    repo = "rtl8812au-5.6.4.2";
+    rev = "49e98ff9bfdbe2ddce843808713de383132002e0";
+    sha256 = "0f4isqasm9rli5v6a7xpphyh509wdxs1zcfvgdsnyhnv8amhqxgs";
   };
 
   nativeBuildInputs = [ bc nukeReferences ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bump package. Fixes building with linux <= 5.6. Tested briefly on linux 5.4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
