### PR TITLE
Build airsonic from source and allow patches

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8294,6 +8294,12 @@
     githubId = 27586264;
     name = "Tobias Schmidt";
   };
+  ToxicFrog = {
+    email = "toxicfrog@ancilla.ca";
+    github = "ToxicFrog";
+    githubId = 90456;
+    name = "Rebecca (Bex) Kelly";
+  };
   travisbhartwell = {
     email = "nafai@travishartwell.net";
     github = "travisbhartwell";

--- a/pkgs/servers/misc/airsonic/default.nix
+++ b/pkgs/servers/misc/airsonic/default.nix
@@ -1,24 +1,48 @@
-{ stdenv, fetchurl }:
-
-stdenv.mkDerivation rec {
-  pname = "airsonic";
-  version = "10.6.2";
-
-  src = fetchurl {
-    url = "https://github.com/airsonic/airsonic/releases/download/v${version}/airsonic.war";
-    sha256 = "0q3qnqymj3gaa6n79pvbyidn1ga99lpngp5wvhlw1aarg1m7vccl";
+# To update:
+# - fetch mavenix from the URL given below
+# - nix-env path/to/mavenix/checkout
+# - mvnix-update ./default.nix
+# Check mavenix.lock and do a test build before commiting; in particular,
+# mvnix-update has a bug where it may delete the sha256s for extra JARs that
+# are packaged with airsonic (currently dwr and natpmp). If it does so, revert
+# those diff hunks before committing.
+let
+  mavenix-src = fetchTarball {
+    url = "https://github.com/icetan/mavenix/tarball/v2.3.3";
+    sha256 = "1l653ac3ka4apm7s4qrbm4kx7ij7n2zk3b67p9l0nki8vxxi8jv7";
   };
+in {
+  # The slightly weird construction here is necessary for mvnix-update to work
+  # properly. It's not evaluated for normal builds.
+  pkgs ? (import mavenix-src {}).pkgs,
+  mavenix ? import ./mavenix.nix { inherit pkgs; },
+  doCheck ? false,
+}: mavenix.buildMaven rec {
+  inherit doCheck;
+  infoFile = ./mavenix.lock;
+  src = pkgs.fetchFromGitHub {
+    owner = "airsonic";
+    repo = "airsonic";
+    rev = "v10.6.2";
+    sha256 = "1f3mql0d5h1ql95fsnkya3qih0rfcmxwas0r6yld7nv0iximzpsy";
+  };
+  remotes = { local1 = "file://${src}/repo"; };
 
-  buildCommand = ''
-    mkdir -p "$out/webapps"
-    cp "$src" "$out/webapps/airsonic.war"
+  # dependency-check relies on downloading undeclared dependencies at check
+  # time and thus isn't hermetic, nor is it necessary for the build.
+  MAVEN_OPTS = "-Ddependency-check.skip=true";
+
+  # Backwards compatibility with previous Airsonic package.
+  postInstall = ''
+    cd "$out"
+    ln -s share/java/ webapps
   '';
 
-  meta = with stdenv.lib; {
+  meta = with pkgs.stdenv.lib; {
     description = "Personal media streamer";
     homepage = "https://airsonic.github.io";
-    license = stdenv.lib.licenses.gpl3;
+    license = pkgs.stdenv.lib.licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ disassembler ];
+    maintainers = with maintainers; [ disassembler ToxicFrog ];
   };
 }

--- a/pkgs/servers/misc/airsonic/mavenix.lock
+++ b/pkgs/servers/misc/airsonic/mavenix.lock
@@ -1,0 +1,8001 @@
+{
+  "artifactId": "airsonic",
+  "deps": [
+    {
+      "path": "antlr/antlr/2.7.2/antlr-2.7.2.jar",
+      "sha1": "546b5220622c4d9b2da45ad1899224b6ce1c8830"
+    },
+    {
+      "path": "antlr/antlr/2.7.2/antlr-2.7.2.pom",
+      "sha1": "60b2b206af3df735765e8e284396bcfdbced5665"
+    },
+    {
+      "path": "antlr/antlr/2.7.7/antlr-2.7.7.jar",
+      "sha1": "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
+    },
+    {
+      "path": "antlr/antlr/2.7.7/antlr-2.7.7.pom",
+      "sha1": "52f15b99911ab8b8bc8744675f5cf1994a626fb8"
+    },
+    {
+      "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.pom",
+      "sha1": "5128a2b0efbba460a1178d07773618e0986ea152"
+    },
+    {
+      "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
+      "sha1": "0235ba8b489512805ac13a8f9ea77a1ca5ebe3e8"
+    },
+    {
+      "path": "asm/asm/3.2/asm-3.2.pom",
+      "sha1": "f431066f241793ac805272f821a6325d2bd7bbc0"
+    },
+    {
+      "path": "asm/asm/3.3.1/asm-3.3.1.jar",
+      "sha1": "1d5f20b4ea675e6fab6ab79f1cd60ec268ddc015"
+    },
+    {
+      "path": "asm/asm/3.3.1/asm-3.3.1.pom",
+      "sha1": "bbcde0189656fa6cc671f27437432ac7e7f95673"
+    },
+    {
+      "path": "asm/asm-analysis/3.2/asm-analysis-3.2.jar",
+      "sha1": "c624956db93975b7197699dcd7de6145ca7cf2c8"
+    },
+    {
+      "path": "asm/asm-analysis/3.2/asm-analysis-3.2.pom",
+      "sha1": "00d76aa4e2124531798a09a691a75b6fefcb2780"
+    },
+    {
+      "path": "asm/asm-commons/3.2/asm-commons-3.2.pom",
+      "sha1": "9a7cfc3449f0f8ab4a791be1aca5c66aef163ed3"
+    },
+    {
+      "path": "asm/asm-commons/3.3.1/asm-commons-3.3.1.jar",
+      "sha1": "fae85e673c73f6f45386dbbcc2ae3aa6398a773f"
+    },
+    {
+      "path": "asm/asm-commons/3.3.1/asm-commons-3.3.1.pom",
+      "sha1": "532f312cebaa6fecb9b971e557103bf1ae37fa57"
+    },
+    {
+      "path": "asm/asm-parent/3.2/asm-parent-3.2.pom",
+      "sha1": "7397a51cf41c0ca224eb73355bcbde1d51d0092b"
+    },
+    {
+      "path": "asm/asm-parent/3.3.1/asm-parent-3.3.1.pom",
+      "sha1": "72945d9cb6faa5082dcd190da850aa06760e4350"
+    },
+    {
+      "path": "asm/asm-tree/3.2/asm-tree-3.2.pom",
+      "sha1": "b83f9150f107a54f25b04a20bfa100c3e00d912a"
+    },
+    {
+      "path": "asm/asm-tree/3.3.1/asm-tree-3.3.1.jar",
+      "sha1": "c9723d887e26c3049944e46312bb39e7ab1a2ed2"
+    },
+    {
+      "path": "asm/asm-tree/3.3.1/asm-tree-3.3.1.pom",
+      "sha1": "73638fb24d3062f87b86fedb2faf44941793d4f1"
+    },
+    {
+      "path": "asm/asm-util/3.2/asm-util-3.2.jar",
+      "sha1": "37ebfdad34d5f1f45109981465f311bbfbe82dcf"
+    },
+    {
+      "path": "asm/asm-util/3.2/asm-util-3.2.pom",
+      "sha1": "de0424e0d3eabd8ca399bb3ea48bb52f6f462cc1"
+    },
+    {
+      "path": "avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.pom",
+      "sha1": "853c9df18e44caf0bab1eab8be0d482f9ec9bcd7"
+    },
+    {
+      "path": "backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.jar",
+      "sha1": "682f7ac17fed79e92f8e87d8455192b63376347b"
+    },
+    {
+      "path": "backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom",
+      "sha1": "24aa8f29c14d1c63225caa6ad5328f1f7a2497a8"
+    },
+    {
+      "path": "ch/qos/logback/logback-classic/1.1.11/logback-classic-1.1.11.jar",
+      "sha1": "ccedfbacef4a6515d2983e3f89ed753d5d4fb665"
+    },
+    {
+      "path": "ch/qos/logback/logback-classic/1.1.11/logback-classic-1.1.11.pom",
+      "sha1": "f253f9e57aeae9d99b7482d010382f2f2a8a315c"
+    },
+    {
+      "path": "ch/qos/logback/logback-core/1.1.11/logback-core-1.1.11.jar",
+      "sha1": "88b8df40340eed549fb07e2613879bf6b006704d"
+    },
+    {
+      "path": "ch/qos/logback/logback-core/1.1.11/logback-core-1.1.11.pom",
+      "sha1": "ee5b86ecaeaa1d007ffa5ea6bb6a672dd7cc2f54"
+    },
+    {
+      "path": "ch/qos/logback/logback-parent/1.1.11/logback-parent-1.1.11.pom",
+      "sha1": "f0f0629ad8dc9d9db458e5cc968bf9045887bd52"
+    },
+    {
+      "path": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar",
+      "sha1": "05adf2e681c57d7f48038b602f3ca2254ee82d47"
+    },
+    {
+      "path": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom",
+      "sha1": "8c8ad6a96a8c1168f8b12ec8a227b8261b160b26"
+    },
+    {
+      "path": "classworlds/classworlds/1.1/classworlds-1.1.jar",
+      "sha1": "60c708f55deeb7c5dfce8a7886ef09cbc1388eca"
+    },
+    {
+      "path": "classworlds/classworlds/1.1/classworlds-1.1.pom",
+      "sha1": "4703c4199028094698c222c17afea6dcd9f04999"
+    },
+    {
+      "path": "com/auth0/java-jwt/3.10.0/java-jwt-3.10.0.jar",
+      "sha1": "6f617db2952e2b7cc753a592ea2d1da77bd72320"
+    },
+    {
+      "path": "com/auth0/java-jwt/3.10.0/java-jwt-3.10.0.pom",
+      "sha1": "42f374d13831af1d0ddae0cc09174a23ddcb8db2"
+    },
+    {
+      "path": "com/beust/jcommander/1.72/jcommander-1.72.jar",
+      "sha1": "6375e521c1e11d6563d4f25a07ce124ccf8cd171"
+    },
+    {
+      "path": "com/beust/jcommander/1.72/jcommander-1.72.pom",
+      "sha1": "62a1edea66309719b84a86dd707bb7ac280e42c4"
+    },
+    {
+      "path": "com/esotericsoftware/minlog/1.3.1/minlog-1.3.1.pom",
+      "sha1": "477bb29fbfae74e2dffd137334d86a317360e447"
+    },
+    {
+      "path": "com/esotericsoftware/minlog/1.3.1/minlog-1.3.1.jar",
+      "sha1": "a406e29d3a44d5f020d7b3218aee6d0952db4f73"
+    },
+    {
+      "path": "com/fasterxml/classmate/1.3.4/classmate-1.3.4.pom",
+      "sha1": "7cdb40daa6e022a38056c9eeda602b79661cf570"
+    },
+    {
+      "path": "com/fasterxml/classmate/1.3.4/classmate-1.3.4.jar",
+      "sha1": "03d5f48f10bbe4eb7bd862f10c0583be2e0053c6"
+    },
+    {
+      "path": "com/fasterxml/jackson/core/jackson-annotations/2.10.3/jackson-annotations-2.10.3.jar",
+      "sha1": "0f63b3b1da563767d04d2e4d3fc1ae0cdeffebe7"
+    },
+    {
+      "path": "com/fasterxml/jackson/core/jackson-annotations/2.10.3/jackson-annotations-2.10.3.pom",
+      "sha1": "ada903569117fc838a46024b0a908e1dad420322"
+    },
+    {
+      "path": "com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.pom",
+      "sha1": "fd57098f3f964d1a319cb72d039eec0ffa973d39"
+    },
+    {
+      "path": "com/fasterxml/jackson/core/jackson-annotations/2.9.10/jackson-annotations-2.9.10.jar",
+      "sha1": "53ab2f0f92e87ea4874c8c6997335c211d81e636"
+    },
+    {
+      "path": "com/fasterxml/jackson/core/jackson-core/2.10.3/jackson-core-2.10.3.jar",
+      "sha1": "f7ee7b55c7d292ac72fbaa7648c089f069c938d2"
+    },
+    {
+      "path": "com/fasterxml/jackson/core/jackson-core/2.10.3/jackson-core-2.10.3.pom",
+      "sha1": "0f321f1f016b175158a6b0c03321d76c1ad11207"
+    },
+    {
+      "path": "com/fasterxml/jackson/core/jackson-databind/2.10.3/jackson-databind-2.10.3.jar",
+      "sha1": "aae92628b5447fa25af79871ca98668da6edd439"
+    },
+    {
+      "path": "com/fasterxml/jackson/core/jackson-databind/2.10.3/jackson-databind-2.10.3.pom",
+      "sha1": "fe993ccdd013677e2857c22a23e7478fed4501a4"
+    },
+    {
+      "path": "com/fasterxml/jackson/jackson-base/2.10.3/jackson-base-2.10.3.pom",
+      "sha1": "5b71666cdac7330daac5ebf85495cd4f96c606f4"
+    },
+    {
+      "path": "com/fasterxml/jackson/jackson-bom/2.10.3/jackson-bom-2.10.3.pom",
+      "sha1": "f8015a131e9032fade963ad1645c429f510ad5f6"
+    },
+    {
+      "path": "com/fasterxml/jackson/jackson-bom/2.8.11.20181123/jackson-bom-2.8.11.20181123.pom",
+      "sha1": "baa7fa31927125443f26ff57773f511a51bd4534"
+    },
+    {
+      "path": "com/fasterxml/jackson/jackson-parent/2.10/jackson-parent-2.10.pom",
+      "sha1": "c07f59ea3d696225de2aa318a02b33ad0512b151"
+    },
+    {
+      "path": "com/fasterxml/jackson/jackson-parent/2.8/jackson-parent-2.8.pom",
+      "sha1": "d020f5b079a7c1608b08f4f9bd76f73cb9b3a1be"
+    },
+    {
+      "path": "com/fasterxml/jackson/jackson-parent/2.9.1.2/jackson-parent-2.9.1.2.pom",
+      "sha1": "50542d30ee4ab5c75e856417b7b96a442c8a4d08"
+    },
+    {
+      "path": "com/fasterxml/oss-parent/24/oss-parent-24.pom",
+      "sha1": "f4fbf349d22ab6a355ebecdb8a2886dd790b4877"
+    },
+    {
+      "path": "com/fasterxml/oss-parent/27/oss-parent-27.pom",
+      "sha1": "77c5efd41e5c52f4f68c36eeb7fe3ccdf0119e53"
+    },
+    {
+      "path": "com/fasterxml/oss-parent/34/oss-parent-34.pom",
+      "sha1": "0dfa19a9b650d3b6742f2d4c0f1285dd64be9a8b"
+    },
+    {
+      "path": "com/fasterxml/oss-parent/38/oss-parent-38.pom",
+      "sha1": "ff6b9e9e40c23235f87a44b463995b47adca8dc9"
+    },
+    {
+      "path": "com/fasterxml/woodstox/woodstox-core/5.0.3/woodstox-core-5.0.3.jar",
+      "sha1": "10aa199207fda142eff01cd61c69244877d71770"
+    },
+    {
+      "path": "com/fasterxml/woodstox/woodstox-core/5.0.3/woodstox-core-5.0.3.pom",
+      "sha1": "759ba68f56e64d62acb4577a514de244e47627db"
+    },
+    {
+      "path": "com/github/biconou/AudioPlayer/0.2.5/AudioPlayer-0.2.5.pom",
+      "sha1": "bd4a708cada68aebdfc2838138f82ea130dae541"
+    },
+    {
+      "path": "com/github/biconou/AudioPlayer/0.2.5/AudioPlayer-0.2.5.jar",
+      "sha1": "274c70c63ae233b97767ceac258e83bfa191c388"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/chameleon-parent/1.2.1-RELEASE/chameleon-parent-1.2.1-RELEASE.pom",
+      "sha1": "18ffe705fa552bd695dcbc507b2c3260d101e9a3"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/core/1.2.1-RELEASE/core-1.2.1-RELEASE.jar",
+      "sha1": "05f7fe3dbf385fc4f68e84efd33ee11190da0685"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/core/1.2.1-RELEASE/core-1.2.1-RELEASE.pom",
+      "sha1": "f30dd9d170c613f4238ad1c4755d231c0c2e33d3"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-all/1.2.1-RELEASE/playlist-all-1.2.1-RELEASE.jar",
+      "sha1": "b6e01b20690f30ab3e2a3de2afde3e6fff015c28"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-all/1.2.1-RELEASE/playlist-all-1.2.1-RELEASE.pom",
+      "sha1": "13c0852c29438428e98ccb3ba6ebb7be712ba3b8"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-asx/1.2.1-RELEASE/playlist-asx-1.2.1-RELEASE.jar",
+      "sha1": "02b05d6f341ee58eccaad0f029a54b3889e8effe"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-asx/1.2.1-RELEASE/playlist-asx-1.2.1-RELEASE.pom",
+      "sha1": "09f4b228ffeb97edf4e7519c2c2d8b72ae76caca"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-atom/1.2.1-RELEASE/playlist-atom-1.2.1-RELEASE.jar",
+      "sha1": "700f55c81d00471b99fb162b19d498f3ae674dbb"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-atom/1.2.1-RELEASE/playlist-atom-1.2.1-RELEASE.pom",
+      "sha1": "f32d779d3ab28a652610e4d810e4046343f86a91"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-b4s/1.2.1-RELEASE/playlist-b4s-1.2.1-RELEASE.pom",
+      "sha1": "cb20fff0e4631b7e9232fa64fa1568790096b3c9"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-b4s/1.2.1-RELEASE/playlist-b4s-1.2.1-RELEASE.jar",
+      "sha1": "393d850e8abbea2df9df0f69b008b176fbd7d449"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-hypetape/1.2.1-RELEASE/playlist-hypetape-1.2.1-RELEASE.pom",
+      "sha1": "235a5114cadf72b8b8e0e7c7a1c2d66f84dbf7b0"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-hypetape/1.2.1-RELEASE/playlist-hypetape-1.2.1-RELEASE.jar",
+      "sha1": "1a37a616664cd0594865075ded8bd9aaf0556b44"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-kpl/1.2.1-RELEASE/playlist-kpl-1.2.1-RELEASE.jar",
+      "sha1": "ee87e3e5c74643c4c77595784f7c951ed104a506"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-kpl/1.2.1-RELEASE/playlist-kpl-1.2.1-RELEASE.pom",
+      "sha1": "6018ac7fe56843a4256bc05f748d1eeccf619451"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-m3u/1.2.1-RELEASE/playlist-m3u-1.2.1-RELEASE.jar",
+      "sha1": "f95ea24734a04ce6d83a5baec1e7dfbfb661129a"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-m3u/1.2.1-RELEASE/playlist-m3u-1.2.1-RELEASE.pom",
+      "sha1": "4ff16947d26257d4e83f7a540325191b122ed50a"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-mpcpl/1.2.1-RELEASE/playlist-mpcpl-1.2.1-RELEASE.jar",
+      "sha1": "50efefad9b418cd952b47de89b11e38184f745e0"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-mpcpl/1.2.1-RELEASE/playlist-mpcpl-1.2.1-RELEASE.pom",
+      "sha1": "ffc0634692495504ead18a1a1bdf6b41e7cd01c7"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-pla/1.2.1-RELEASE/playlist-pla-1.2.1-RELEASE.pom",
+      "sha1": "52eaee3824092d9b5710e79fb21d4a2487059e1f"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-pla/1.2.1-RELEASE/playlist-pla-1.2.1-RELEASE.jar",
+      "sha1": "dd071ab45f01dfbdebc2baf223d4874abc20b304"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-plist/1.2.1-RELEASE/playlist-plist-1.2.1-RELEASE.jar",
+      "sha1": "c770836bc70596745c55cfce4c34a4bcb3e9b5e7"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-plist/1.2.1-RELEASE/playlist-plist-1.2.1-RELEASE.pom",
+      "sha1": "fd29840af4173d555c089c5be372504f81acf5a6"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-plp/1.2.1-RELEASE/playlist-plp-1.2.1-RELEASE.jar",
+      "sha1": "1361170e6097919ba9171f52142aa4e9020be8a5"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-plp/1.2.1-RELEASE/playlist-plp-1.2.1-RELEASE.pom",
+      "sha1": "a4f922821930213c56a4d28a18f06937f686c0fa"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-pls/1.2.1-RELEASE/playlist-pls-1.2.1-RELEASE.jar",
+      "sha1": "22d1e22eee79d5e0c6ba97623097e2f63ec2160d"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-pls/1.2.1-RELEASE/playlist-pls-1.2.1-RELEASE.pom",
+      "sha1": "03e783299c994f1240ace533b81823f7192c57e5"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-rmp/1.2.1-RELEASE/playlist-rmp-1.2.1-RELEASE.jar",
+      "sha1": "2f88a9e58ca34a4047182940ec507daefc794b5c"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-rmp/1.2.1-RELEASE/playlist-rmp-1.2.1-RELEASE.pom",
+      "sha1": "75727eef0030ad58d07cdd36c92ea4039b819363"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-rss/1.2.1-RELEASE/playlist-rss-1.2.1-RELEASE.jar",
+      "sha1": "9e2bf170ec9352cf8178bf45c0dd1fd7c7a83a19"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-rss/1.2.1-RELEASE/playlist-rss-1.2.1-RELEASE.pom",
+      "sha1": "193f6c6a54b08906cae8e592b18b944f906914ac"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlists/1.2.1-RELEASE/playlists-1.2.1-RELEASE.pom",
+      "sha1": "a33376b78c1e62772f5a81f0fec4cbeae558c795"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-smil/1.2.1-RELEASE/playlist-smil-1.2.1-RELEASE.jar",
+      "sha1": "f8c378f466078b248836a87cb4deeff564dea49a"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-smil/1.2.1-RELEASE/playlist-smil-1.2.1-RELEASE.pom",
+      "sha1": "b70c59baea1cbd9f0fd9087761e30049989e293d"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-wpl/1.2.1-RELEASE/playlist-wpl-1.2.1-RELEASE.jar",
+      "sha1": "096aeaf676a7dfd6a4f9ae0d7aa06a3d79eef773"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-wpl/1.2.1-RELEASE/playlist-wpl-1.2.1-RELEASE.pom",
+      "sha1": "3781ad14720d793859273b818904b22ffe1ea05d"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-xspf/1.2.1-RELEASE/playlist-xspf-1.2.1-RELEASE.jar",
+      "sha1": "1e66ab81092548af51ddc5c34004e642d878310d"
+    },
+    {
+      "path": "com/github/muff1nman/chameleon/playlist-xspf/1.2.1-RELEASE/playlist-xspf-1.2.1-RELEASE.pom",
+      "sha1": "ae45a03fae4375d0fa9f163e93674c1334902eb4"
+    },
+    {
+      "path": "com/github/package-url/packageurl-java/1.1.1/packageurl-java-1.1.1.pom",
+      "sha1": "c0547ceda4cf1ca33264766f8a0b5c92b81c6a0c"
+    },
+    {
+      "path": "com/github/package-url/packageurl-java/1.1.1/packageurl-java-1.1.1.jar",
+      "sha1": "78722cba39507aa906042bc78dfaf76368ec486b"
+    },
+    {
+      "path": "com/github/spotbugs/spotbugs-annotations/3.1.12/spotbugs-annotations-3.1.12.jar",
+      "sha1": "ba2c77a05091820668987292f245f3b089387bfa"
+    },
+    {
+      "path": "com/github/spotbugs/spotbugs-annotations/3.1.12/spotbugs-annotations-3.1.12.pom",
+      "sha1": "f0a0907953841306dd570638c66e5817d840ca2d"
+    },
+    {
+      "path": "com/github/spullara/mustache/java/compiler/0.9.6/compiler-0.9.6.pom",
+      "sha1": "43ddcee2df1c5daa8629bb5b17aabf18e1826e5a"
+    },
+    {
+      "path": "com/github/spullara/mustache/java/compiler/0.9.6/compiler-0.9.6.jar",
+      "sha1": "1b8707299c34406ed0ba40bbf8513352ac4765c9"
+    },
+    {
+      "path": "com/github/spullara/mustache/java/mustache.java/0.9.6/mustache.java-0.9.6.pom",
+      "sha1": "8e428427426803482eb44228808d9770e44c8ae1"
+    },
+    {
+      "path": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar",
+      "sha1": "516c03b21d50a644d538de0f0369c620989cd8f0"
+    },
+    {
+      "path": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom",
+      "sha1": "95efa8cea662452bb74b34abe09a93ff47625c8f"
+    },
+    {
+      "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+      "sha1": "25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+    },
+    {
+      "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom",
+      "sha1": "8d93cdf4d84d7e1de736df607945c6df0730a10f"
+    },
+    {
+      "path": "com/google/code/gson/gson/2.8.5/gson-2.8.5.pom",
+      "sha1": "2c18fa1082aa1c422aece88244c084be50c76500"
+    },
+    {
+      "path": "com/google/code/gson/gson/2.8.5/gson-2.8.5.jar",
+      "sha1": "f645ed69d595b24d4cf8b3fbb64cc505bede8829"
+    },
+    {
+      "path": "com/google/code/gson/gson/2.8.6/gson-2.8.6.jar",
+      "sha1": "9180733b7df8542621dc12e21e87557e8c99b8cb"
+    },
+    {
+      "path": "com/google/code/gson/gson/2.8.6/gson-2.8.6.pom",
+      "sha1": "b9d7e274612598f1e8835d8bbe30baa5b970ca32"
+    },
+    {
+      "path": "com/google/code/gson/gson-parent/2.8.5/gson-parent-2.8.5.pom",
+      "sha1": "40f295fd74fbe91f1589481c967b14f176d6e549"
+    },
+    {
+      "path": "com/google/code/gson/gson-parent/2.8.6/gson-parent-2.8.6.pom",
+      "sha1": "88d12a7aeaeaa9bbc773bc5f32690edf4d3ff9e6"
+    },
+    {
+      "path": "com/google/code/maven-scm-provider-svnjava/maven-scm-provider-svnjava/2.1.1/maven-scm-provider-svnjava-2.1.1.jar",
+      "sha1": "8b1d8e95ee551abda6c8ccb855f49592fdd19492"
+    },
+    {
+      "path": "com/google/code/maven-scm-provider-svnjava/maven-scm-provider-svnjava/2.1.1/maven-scm-provider-svnjava-2.1.1.pom",
+      "sha1": "a10ed7a59b84c351b98aa936617ae64df08c2b20"
+    },
+    {
+      "path": "com/googlecode/soundlibs/jlayer/1.0.1.4/jlayer-1.0.1.4.jar",
+      "sha1": "b8df07ad72b482f7d6e6dee7fed669385e8dd92f"
+    },
+    {
+      "path": "com/googlecode/soundlibs/jlayer/1.0.1.4/jlayer-1.0.1.4.pom",
+      "sha1": "6c10d8065aca356557eced5495acefb6b4e85bfb"
+    },
+    {
+      "path": "com/googlecode/soundlibs/jorbis/0.0.17.4/jorbis-0.0.17.4.pom",
+      "sha1": "f14e832821fc0e4d7136479515cdaf8333fc4d2e"
+    },
+    {
+      "path": "com/googlecode/soundlibs/jorbis/0.0.17.4/jorbis-0.0.17.4.jar",
+      "sha1": "19ddf424c59cc8ed548fad5f33037ff82a915aae"
+    },
+    {
+      "path": "com/googlecode/soundlibs/mp3spi/1.9.5.4/mp3spi-1.9.5.4.jar",
+      "sha1": "3bdf9ffd65c157daec8735e127c3705513bd384d"
+    },
+    {
+      "path": "com/googlecode/soundlibs/mp3spi/1.9.5.4/mp3spi-1.9.5.4.pom",
+      "sha1": "1c5839d15f1ae045db90b71a80708444cac67755"
+    },
+    {
+      "path": "com/googlecode/soundlibs/soundlibs/1.4/soundlibs-1.4.pom",
+      "sha1": "eb710155b5d9707d95c3098d4508bbdc767fd3ab"
+    },
+    {
+      "path": "com/googlecode/soundlibs/tritonus-share/0.3.7.4/tritonus-share-0.3.7.4.pom",
+      "sha1": "7d6272a2e44a8cb341c4cba62d1139da592208b0"
+    },
+    {
+      "path": "com/googlecode/soundlibs/tritonus-share/0.3.7.4/tritonus-share-0.3.7.4.jar",
+      "sha1": "bdddc55194f9cf7b970dd5f3affcbacb88342b0b"
+    },
+    {
+      "path": "com/googlecode/soundlibs/vorbisspi/1.0.3.3/vorbisspi-1.0.3.3.jar",
+      "sha1": "9454df3e9d57bfa5b17292f72c68ac2dbb09de61"
+    },
+    {
+      "path": "com/googlecode/soundlibs/vorbisspi/1.0.3.3/vorbisspi-1.0.3.3.pom",
+      "sha1": "99ca754dc5a7740e9f5861ee53ac74506675efdc"
+    },
+    {
+      "path": "com/google/collections/google-collections/1.0/google-collections-1.0.jar",
+      "sha1": "9ffe71ac6dcab6bc03ea13f5c2e7b2804e69b357"
+    },
+    {
+      "path": "com/google/collections/google-collections/1.0/google-collections-1.0.pom",
+      "sha1": "292197f3cb1ebc0dd03e20897e4250b265177286"
+    },
+    {
+      "path": "com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.jar",
+      "sha1": "88e3c593e9b3586e1c6177f89267da6fc6986f0c"
+    },
+    {
+      "path": "com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.pom",
+      "sha1": "e28b5b546020f18ea29e2b4756023f53ee91492b"
+    },
+    {
+      "path": "com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.jar",
+      "sha1": "dac170e4594de319655ffb62f41cbd6dbb5e601e"
+    },
+    {
+      "path": "com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.pom",
+      "sha1": "9a23fcb83bc8ed502506a8e6c648bf763dc5bcf9"
+    },
+    {
+      "path": "com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0.pom",
+      "sha1": "72e2f31cb1952eada003d2ba7e82874cfe4b738c"
+    },
+    {
+      "path": "com/google/errorprone/error_prone_parent/2.3.4/error_prone_parent-2.3.4.pom",
+      "sha1": "a9b9dd42d174a5f96d6c195525877fc6d0b2028a"
+    },
+    {
+      "path": "com/google/google/1/google-1.pom",
+      "sha1": "c35a5268151b7a1bbb77f7ee94a950f00e32db61"
+    },
+    {
+      "path": "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom",
+      "sha1": "e8160e78fdaaf7088621dc1649d9dd2dfcf8d0e8"
+    },
+    {
+      "path": "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar",
+      "sha1": "1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+    },
+    {
+      "path": "com/google/guava/guava/18.0/guava-18.0.jar",
+      "sha1": "cce0823396aa693798f8882e64213b1772032b09"
+    },
+    {
+      "path": "com/google/guava/guava/18.0/guava-18.0.pom",
+      "sha1": "2ec12f8d27a64e970b8be0fbd1d52dfec51cd41c"
+    },
+    {
+      "path": "com/google/guava/guava/27.1-jre/guava-27.1-jre.jar",
+      "sha1": "e47b59c893079b87743cdcfb6f17ca95c08c592c"
+    },
+    {
+      "path": "com/google/guava/guava/27.1-jre/guava-27.1-jre.pom",
+      "sha1": "db536f4a1c26739eb6ee1cfb707ec3fbe8325c86"
+    },
+    {
+      "path": "com/google/guava/guava/28.2-jre/guava-28.2-jre.pom",
+      "sha1": "360b614be6dda1311de8b0704e0caf0221262cce"
+    },
+    {
+      "path": "com/google/guava/guava/28.2-jre/guava-28.2-jre.jar",
+      "sha1": "8ec9ed76528425762174f0011ce8f74ad845b756"
+    },
+    {
+      "path": "com/google/guava/guava-parent/18.0/guava-parent-18.0.pom",
+      "sha1": "5398932a9ef2828eb9fc4f01e8d6cac626c219d2"
+    },
+    {
+      "path": "com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom",
+      "sha1": "a2c0df489614352b7e8e503e274bd1dee5c42a64"
+    },
+    {
+      "path": "com/google/guava/guava-parent/27.1-jre/guava-parent-27.1-jre.pom",
+      "sha1": "a4686474dcba0d75d89e3d4f9665634832e49b6f"
+    },
+    {
+      "path": "com/google/guava/guava-parent/28.2-jre/guava-parent-28.2-jre.pom",
+      "sha1": "9a6aa66406e84ac13100698e335cbcfe1959a58b"
+    },
+    {
+      "path": "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+      "sha1": "b421526c5f297295adef1c886e5246c39d4ac629"
+    },
+    {
+      "path": "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom",
+      "sha1": "1b77ba79f9b2b7dfd4e15ea7bb0d568d5eb9cb8d"
+    },
+    {
+      "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
+      "sha1": "ed28ded51a8b1c6b112568def5f4b455e6809019"
+    },
+    {
+      "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom",
+      "sha1": "b964a9414771661bdf35a3f10692a2fb0dd2c866"
+    },
+    {
+      "path": "com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar",
+      "sha1": "ba035118bc8bac37d7eff77700720999acd9986d"
+    },
+    {
+      "path": "com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.pom",
+      "sha1": "47e0dd93285dcc6b33181713bc7e8aed66742964"
+    },
+    {
+      "path": "com/google/protobuf/protobuf-java/3.6.1/protobuf-java-3.6.1.jar",
+      "sha1": "0d06d46ecfd92ec6d0f3b423b4cd81cb38d8b924"
+    },
+    {
+      "path": "com/google/protobuf/protobuf-java/3.6.1/protobuf-java-3.6.1.pom",
+      "sha1": "0def95b877c5404acaca7a7ea25113896234c662"
+    },
+    {
+      "path": "com/google/protobuf/protobuf-parent/3.6.1/protobuf-parent-3.6.1.pom",
+      "sha1": "77faca6e2f2194f83c1e6efdd56c82ed7b0a9941"
+    },
+    {
+      "path": "com/h2database/h2/1.4.199/h2-1.4.199.pom",
+      "sha1": "73a72a0d5464768928a697293dcb921d77ab3d63"
+    },
+    {
+      "path": "com/h2database/h2/1.4.199/h2-1.4.199.jar",
+      "sha1": "7bf08152984ed8859740ae3f97fae6c72771ae45"
+    },
+    {
+      "path": "com/h3xstream/retirejs/retirejs-core/3.0.2/retirejs-core-3.0.2.jar",
+      "sha1": "3cfbaff0941598f63c3ca0b64f62afb33425ab0f"
+    },
+    {
+      "path": "com/h3xstream/retirejs/retirejs-core/3.0.2/retirejs-core-3.0.2.pom",
+      "sha1": "5d93885aec77c95aee00b423680367284cf0823e"
+    },
+    {
+      "path": "com/h3xstream/retirejs/retirejs-root-pom/3.0.2/retirejs-root-pom-3.0.2.pom",
+      "sha1": "c8d18fb113a16b3c3fdf524ad5ea47868589ae19"
+    },
+    {
+      "path": "com/hoodcomputing/natpmp/0.1/natpmp-0.1.pom",
+      "sha1": "06723e68b92baa53d63f44553c8f441bb4e772eb"
+    },
+    {
+      "path": "com/hoodcomputing/natpmp/0.1/natpmp-0.1.jar",
+      "sha1": "cd3cdcf418dc1c6ab6b0bb93cf878ec14d77be2c"
+    },
+    {
+      "path": "com/ibm/icu/icu4j/63.1/icu4j-63.1.jar",
+      "sha1": "385682b7fff53cd5ac2cad0fdb4658a7b97e9475"
+    },
+    {
+      "path": "com/ibm/icu/icu4j/63.1/icu4j-63.1.pom",
+      "sha1": "ac9bbff56a4a94b546468cdee50d17ee0fc4c24f"
+    },
+    {
+      "path": "com/jayway/jsonpath/json-path/2.2.0/json-path-2.2.0.jar",
+      "sha1": "22290d17944bd239fabf5ac69005a60a7ecbbbcb"
+    },
+    {
+      "path": "com/jayway/jsonpath/json-path/2.2.0/json-path-2.2.0.pom",
+      "sha1": "0a7d149bf5ecf33fc37ca70cae9a76222be095fe"
+    },
+    {
+      "path": "com/jcraft/jsch/0.1.27/jsch-0.1.27.pom",
+      "sha1": "bd3e22fbac849d8b4b96a7d6a0dbb5e69fd083c1"
+    },
+    {
+      "path": "com/jcraft/jsch/0.1.27/jsch-0.1.27.jar",
+      "sha1": "0dc3be7501b71d413322735295288bdec7633730"
+    },
+    {
+      "path": "com/jcraft/jsch/0.1.38/jsch-0.1.38.jar",
+      "sha1": "0677f7038dd5c8d5d687c558d09c124f820a8fd5"
+    },
+    {
+      "path": "com/jcraft/jsch/0.1.38/jsch-0.1.38.pom",
+      "sha1": "90ff09ba4668324b217d11d51b8f7704aeef7f93"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy/0.0.7/jsch.agentproxy-0.0.7.pom",
+      "sha1": "6ba6a2c8ea312e25f5e58b6ffe1175399f50fe2d"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.connector-factory/0.0.7/jsch.agentproxy.connector-factory-0.0.7.jar",
+      "sha1": "780e0312287dd4e4f3601d401a073a081e403f2d"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.connector-factory/0.0.7/jsch.agentproxy.connector-factory-0.0.7.pom",
+      "sha1": "c273147d51bf5c2d28e82a41f51be0b39a3f2307"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.core/0.0.7/jsch.agentproxy.core-0.0.7.jar",
+      "sha1": "9bcf818dc9e5247b01b1b18671a12caac293ae40"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.core/0.0.7/jsch.agentproxy.core-0.0.7.pom",
+      "sha1": "9977efcc0f20fb8917640ec2b65b688fc9f3ec30"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.pageant/0.0.7/jsch.agentproxy.pageant-0.0.7.jar",
+      "sha1": "b40c0d9b10d79a0683ca93e3f70360b3d8045b62"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.pageant/0.0.7/jsch.agentproxy.pageant-0.0.7.pom",
+      "sha1": "2a3a618c8009af299661bd840b0318a16ad7c010"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.sshagent/0.0.7/jsch.agentproxy.sshagent-0.0.7.jar",
+      "sha1": "5c09a3d2a0562de53cf616794f43f51a3c0a496c"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.sshagent/0.0.7/jsch.agentproxy.sshagent-0.0.7.pom",
+      "sha1": "00934b9b49d1aa63a599842ada80144e22662c3a"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.svnkit-trilead-ssh2/0.0.7/jsch.agentproxy.svnkit-trilead-ssh2-0.0.7.jar",
+      "sha1": "95015f649026507428aa2f37baba69ba8a86dc67"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.svnkit-trilead-ssh2/0.0.7/jsch.agentproxy.svnkit-trilead-ssh2-0.0.7.pom",
+      "sha1": "be16dff34f9acfce8c0b999246e083ed884511ec"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.usocket-jna/0.0.7/jsch.agentproxy.usocket-jna-0.0.7.jar",
+      "sha1": "98cf51ca8d7882c203729ffa48e9b7be4c50b835"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.usocket-jna/0.0.7/jsch.agentproxy.usocket-jna-0.0.7.pom",
+      "sha1": "8bda510351f57e0568d6b5a03d7e69acaee6db51"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.usocket-nc/0.0.7/jsch.agentproxy.usocket-nc-0.0.7.jar",
+      "sha1": "aff6f0f3a68f9731580d7c48075fdf177532dfe6"
+    },
+    {
+      "path": "com/jcraft/jsch.agentproxy.usocket-nc/0.0.7/jsch.agentproxy.usocket-nc-0.0.7.pom",
+      "sha1": "39da0290c5e8e97631d976f0b7458ffe117eb164"
+    },
+    {
+      "path": "com/mattbertolini/liquibase-slf4j/2.0.0/liquibase-slf4j-2.0.0.jar",
+      "sha1": "15d0d15b546ef66caf3385a3c13aeb75663b3ba4"
+    },
+    {
+      "path": "com/mattbertolini/liquibase-slf4j/2.0.0/liquibase-slf4j-2.0.0.pom",
+      "sha1": "fd4df6c876ddb5e22b0615218ab19c80a681b34f"
+    },
+    {
+      "path": "com/moandjiezana/toml/toml4j/0.7.2/toml4j-0.7.2.jar",
+      "sha1": "0a03337911d0bd2c40932aca3946edb30d0e7d0c"
+    },
+    {
+      "path": "com/moandjiezana/toml/toml4j/0.7.2/toml4j-0.7.2.pom",
+      "sha1": "490f35dba169e1feffa4e164cfa0b26e3de2d1e9"
+    },
+    {
+      "path": "commons-beanutils/commons-beanutils/1.6/commons-beanutils-1.6.pom",
+      "sha1": "cb6192708aa48ef75e8d04bcde65bc8d5a6ccdbf"
+    },
+    {
+      "path": "commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.pom",
+      "sha1": "19eca029edacc1be30030faf43ea6acb30556d1a"
+    },
+    {
+      "path": "commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar",
+      "sha1": "5675fd96b29656504b86029551973d60fb41339b"
+    },
+    {
+      "path": "commons-beanutils/commons-beanutils/1.9.3/commons-beanutils-1.9.3.jar",
+      "sha1": "c845703de334ddc6b4b3cd26835458cb1cba1f3d"
+    },
+    {
+      "path": "commons-beanutils/commons-beanutils/1.9.3/commons-beanutils-1.9.3.pom",
+      "sha1": "a0db273e77035b0443974984e92d48896c12ee9c"
+    },
+    {
+      "path": "commons-beanutils/commons-beanutils/1.9.4/commons-beanutils-1.9.4.jar",
+      "sha1": "d52b9abcd97f38c81342bb7e7ae1eee9b73cba51"
+    },
+    {
+      "path": "commons-beanutils/commons-beanutils/1.9.4/commons-beanutils-1.9.4.pom",
+      "sha1": "42e7c39331e1735250b294ce2984d0e434ebc955"
+    },
+    {
+      "path": "commons-chain/commons-chain/1.1/commons-chain-1.1.jar",
+      "sha1": "3038bd41dcdb2b63b8c6dcc8c15f0fdf3f389012"
+    },
+    {
+      "path": "commons-chain/commons-chain/1.1/commons-chain-1.1.pom",
+      "sha1": "9925db0ce8bea3b13afdf0565bb1a14c1c8c645c"
+    },
+    {
+      "path": "commons-cli/commons-cli/1.0/commons-cli-1.0.jar",
+      "sha1": "6dac9733315224fc562f6268df58e92d65fd0137"
+    },
+    {
+      "path": "commons-cli/commons-cli/1.0/commons-cli-1.0.pom",
+      "sha1": "bc51fd74ed7c8ccf75b3abc84b3613d6ba60eb89"
+    },
+    {
+      "path": "commons-cli/commons-cli/1.2/commons-cli-1.2.jar",
+      "sha1": "2bf96b7aa8b611c177d329452af1dc933e14501c"
+    },
+    {
+      "path": "commons-cli/commons-cli/1.2/commons-cli-1.2.pom",
+      "sha1": "e1b71e4b511c3c63f8b19d0302fe1d1c6e79035a"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.10/commons-codec-1.10.jar",
+      "sha1": "4b95f4897fa13f2cd904aee711aeafc0c5295cd8"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.10/commons-codec-1.10.pom",
+      "sha1": "44b9477418d2942d45550f7e7c66c16262062d0e"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.11/commons-codec-1.11.jar",
+      "sha1": "3acb4705652e16236558f0f4f2192cc33c3bd189"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.11/commons-codec-1.11.pom",
+      "sha1": "093ee1760aba62d6896d578bd7d247d0fa52f0e7"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.12/commons-codec-1.12.pom",
+      "sha1": "096b6744065fa0fe57e09b90967482a6ac689995"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.12/commons-codec-1.12.jar",
+      "sha1": "47a28ef1ed31eb182b44e15d49300dee5fadcf6a"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.2/commons-codec-1.2.jar",
+      "sha1": "397f4731a9f9b6eb1907e224911c77ea3aa27a8b"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.2/commons-codec-1.2.pom",
+      "sha1": "3924208ea1e84feb88701e9a5000bc65c66fb335"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.3/commons-codec-1.3.pom",
+      "sha1": "c5a7a1a49dac255ed78180d5fae26cfaa5e48147"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.3/commons-codec-1.3.jar",
+      "sha1": "fd32786786e2adb664d5ecc965da47629dca14ba"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.6/commons-codec-1.6.jar",
+      "sha1": "b7f0fc8f61ecadeb3695f0b9464755eee44374d4"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.6/commons-codec-1.6.pom",
+      "sha1": "9499f0c87ab43a74c456b9847acbcb5e67fe9f32"
+    },
+    {
+      "path": "commons-codec/commons-codec/1.9/commons-codec-1.9.pom",
+      "sha1": "f5357ff0f308600af3660bf00a8be3415a335723"
+    },
+    {
+      "path": "commons-collections/commons-collections/2.0/commons-collections-2.0.pom",
+      "sha1": "b0d78d06e725d7f8176256eaeceb9d5b3f0a7bca"
+    },
+    {
+      "path": "commons-collections/commons-collections/2.1/commons-collections-2.1.pom",
+      "sha1": "03ac124c9f50b403afc9819e1f430d6883e77213"
+    },
+    {
+      "path": "commons-collections/commons-collections/3.1/commons-collections-3.1.pom",
+      "sha1": "f1afb3351823e726793a165ca37dced8f0191370"
+    },
+    {
+      "path": "commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar",
+      "sha1": "761ea405b9b37ced573d2df0d1e3a4e0f9edc668"
+    },
+    {
+      "path": "commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.pom",
+      "sha1": "c812635cfb96cd2431ee315e73418eed86aeb5e4"
+    },
+    {
+      "path": "commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar",
+      "sha1": "8ad72fe39fa8c91eaaf12aadb21e0c3661fe26d5"
+    },
+    {
+      "path": "commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.pom",
+      "sha1": "02a5ba7cb070a882d2b7bd4bf5223e8e445c0268"
+    },
+    {
+      "path": "commons-collections/commons-collections/3.2/commons-collections-3.2.pom",
+      "sha1": "0c8e56dc5476c517f1596f0686d72f51ef24d9e3"
+    },
+    {
+      "path": "commons-digester/commons-digester/1.6/commons-digester-1.6.jar",
+      "sha1": "e2822f655f2c182681c2cf27f224a425ccb2983d"
+    },
+    {
+      "path": "commons-digester/commons-digester/1.6/commons-digester-1.6.pom",
+      "sha1": "807b7186d68503e8a596c19f9d6ff2c70416967c"
+    },
+    {
+      "path": "commons-digester/commons-digester/1.8.1/commons-digester-1.8.1.jar",
+      "sha1": "3dec9b9c7ea9342d4dbe8c38560080d85b44a015"
+    },
+    {
+      "path": "commons-digester/commons-digester/1.8.1/commons-digester-1.8.1.pom",
+      "sha1": "cae9cff19da8617ca1ded86c3c8fe796208ffdbb"
+    },
+    {
+      "path": "commons-digester/commons-digester/1.8/commons-digester-1.8.jar",
+      "sha1": "dc6a73fdbd1fa3f0944e8497c6c872fa21dca37e"
+    },
+    {
+      "path": "commons-digester/commons-digester/1.8/commons-digester-1.8.pom",
+      "sha1": "ceb07daf87a43ec66829fcd8c23a40aead5a4b40"
+    },
+    {
+      "path": "commons-fileupload/commons-fileupload/1.4/commons-fileupload-1.4.jar",
+      "sha1": "f95188e3d372e20e7328706c37ef366e5d7859b0"
+    },
+    {
+      "path": "commons-fileupload/commons-fileupload/1.4/commons-fileupload-1.4.pom",
+      "sha1": "65112009d674333c1acfafb4e198ff250d710764"
+    },
+    {
+      "path": "commons-httpclient/commons-httpclient/3.0/commons-httpclient-3.0.jar",
+      "sha1": "336a280d178bb957e5233189f0f32e067366c4e5"
+    },
+    {
+      "path": "commons-httpclient/commons-httpclient/3.0/commons-httpclient-3.0.pom",
+      "sha1": "cc004962ec1db4e8d43f47ab15d127d44b07037b"
+    },
+    {
+      "path": "commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar",
+      "sha1": "964cd74171f427720480efdec40a7c7f6e58426a"
+    },
+    {
+      "path": "commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.pom",
+      "sha1": "7e64d764d7f7ebc75ae3920490fcb58fbaf504a8"
+    },
+    {
+      "path": "commons-io/commons-io/1.3.2/commons-io-1.3.2.jar",
+      "sha1": "b6dde38349ba9bb5e6ea6320531eae969985dae5"
+    },
+    {
+      "path": "commons-io/commons-io/1.3.2/commons-io-1.3.2.pom",
+      "sha1": "6e24d777140826c244c3c3fd3afdd4ffe6e6159f"
+    },
+    {
+      "path": "commons-io/commons-io/1.4/commons-io-1.4.jar",
+      "sha1": "a8762d07e76cfde2395257a5da47ba7c1dbd3dce"
+    },
+    {
+      "path": "commons-io/commons-io/1.4/commons-io-1.4.pom",
+      "sha1": "526f34cad0a113787f3eb8ee1d0fe0abebcba887"
+    },
+    {
+      "path": "commons-io/commons-io/2.1/commons-io-2.1.pom",
+      "sha1": "bee5c8a3061394d39f7df1e38d25028edac7cdd9"
+    },
+    {
+      "path": "commons-io/commons-io/2.2/commons-io-2.2.jar",
+      "sha1": "83b5b8a7ba1c08f9e8c8ff2373724e33d3c1e22a"
+    },
+    {
+      "path": "commons-io/commons-io/2.2/commons-io-2.2.pom",
+      "sha1": "1ef24807b2eaf9d51b5587710878146d630cc855"
+    },
+    {
+      "path": "commons-io/commons-io/2.4/commons-io-2.4.pom",
+      "sha1": "9ece23effe8bce3904f3797a76b1ba6ab681e1b9"
+    },
+    {
+      "path": "commons-io/commons-io/2.5/commons-io-2.5.jar",
+      "sha1": "2852e6e05fbb95076fc091f6d1780f1f8fe35e0f"
+    },
+    {
+      "path": "commons-io/commons-io/2.5/commons-io-2.5.pom",
+      "sha1": "7e39112810f6096061c43504188d18edc7d7eece"
+    },
+    {
+      "path": "commons-io/commons-io/2.6/commons-io-2.6.pom",
+      "sha1": "5060835593e5b6ed18c82fc2e782f0a3c30a00b1"
+    },
+    {
+      "path": "commons-io/commons-io/2.6/commons-io-2.6.jar",
+      "sha1": "815893df5f31da2ece4040fe0a12fd44b577afaf"
+    },
+    {
+      "path": "commons-lang/commons-lang/2.1/commons-lang-2.1.jar",
+      "sha1": "4763ecc9d78781c915c07eb03e90572c7ff04205"
+    },
+    {
+      "path": "commons-lang/commons-lang/2.1/commons-lang-2.1.pom",
+      "sha1": "a34d992202615804c534953aba402de55d8ee47c"
+    },
+    {
+      "path": "commons-lang/commons-lang/2.4/commons-lang-2.4.jar",
+      "sha1": "16313e02a793435009f1e458fa4af5d879f6fb11"
+    },
+    {
+      "path": "commons-lang/commons-lang/2.4/commons-lang-2.4.pom",
+      "sha1": "dadd4b8eb8f55df27c1e7f9083cb8223bd3e357e"
+    },
+    {
+      "path": "commons-lang/commons-lang/2.5/commons-lang-2.5.jar",
+      "sha1": "b0236b252e86419eef20c31a44579d2aee2f0a69"
+    },
+    {
+      "path": "commons-lang/commons-lang/2.5/commons-lang-2.5.pom",
+      "sha1": "4fca8db5890f26627b09ab48d8888256ccb38dbb"
+    },
+    {
+      "path": "commons-lang/commons-lang/2.6/commons-lang-2.6.jar",
+      "sha1": "0ce1edb914c94ebc388f086c6827e8bdeec71ac2"
+    },
+    {
+      "path": "commons-lang/commons-lang/2.6/commons-lang-2.6.pom",
+      "sha1": "347d60b180fa80e5699d8e2cb72c99c93dda5454"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.0.3/commons-logging-1.0.3.pom",
+      "sha1": "b7de43bb310eb1dbfd00a34cec30500fa13cb577"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar",
+      "sha1": "f029a2aefe2b3e1517573c580f948caac31b1056"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.pom",
+      "sha1": "7d32e7520b801cabc3dc704d2afe59d020d00c45"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.0/commons-logging-1.0.pom",
+      "sha1": "4f58df6cca7ad7b863e8186e5dc25a8ef502e374"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar",
+      "sha1": "5043bfebc3db072ed80fbd362e7caf00e885d8ae"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.pom",
+      "sha1": "76672afb562b9e903674ad3a544cdf2092f1faa3"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.1/commons-logging-1.1.jar",
+      "sha1": "ba24d5de831911b684c92cd289ed5ff826271824"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.1/commons-logging-1.1.pom",
+      "sha1": "d80c5278c4f112aba0a6e987d7321676ce074a22"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+      "sha1": "4bfc12adfe4842bf07b657f0369c4cb522955686"
+    },
+    {
+      "path": "commons-logging/commons-logging/1.2/commons-logging-1.2.pom",
+      "sha1": "075c03ba4b01932842a996ef8d3fc1ab61ddeac2"
+    },
+    {
+      "path": "commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.jar",
+      "sha1": "7d4cf5231d46c8524f9b9ed75bb2d1c69ab93322"
+    },
+    {
+      "path": "commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom",
+      "sha1": "825395875e4a7ac53277f5f746085a3e13a04248"
+    },
+    {
+      "path": "commons-validator/commons-validator/1.2.0/commons-validator-1.2.0.jar",
+      "sha1": "13dcebc00d206605bea72f6191b80370eb3ca805"
+    },
+    {
+      "path": "commons-validator/commons-validator/1.2.0/commons-validator-1.2.0.pom",
+      "sha1": "a7992acb52332d17c1bd9f7f774361b68b183c23"
+    },
+    {
+      "path": "commons-validator/commons-validator/1.3.1/commons-validator-1.3.1.jar",
+      "sha1": "d1fd6b1510f25e827adffcf17de3c85fa00e9391"
+    },
+    {
+      "path": "commons-validator/commons-validator/1.3.1/commons-validator-1.3.1.pom",
+      "sha1": "d152f01fb849a11abbc3ef8d7ed0ae8e00b3b226"
+    },
+    {
+      "path": "commons-validator/commons-validator/1.6/commons-validator-1.6.jar",
+      "sha1": "e989d1e87cdd60575df0765ed5bac65c905d7908"
+    },
+    {
+      "path": "commons-validator/commons-validator/1.6/commons-validator-1.6.pom",
+      "sha1": "cbc0a98f640a70e4b92d0966104eb63b89105f01"
+    },
+    {
+      "path": "com/puppycrawl/tools/checkstyle/8.19/checkstyle-8.19.jar",
+      "sha1": "b89d91993480a473c416f83677ad92dbede809fa"
+    },
+    {
+      "path": "com/puppycrawl/tools/checkstyle/8.19/checkstyle-8.19.pom",
+      "sha1": "db7bb76bc0aefa23d21d36949cec9ab8e0d14e1d"
+    },
+    {
+      "path": "com/sun/activation/all/1.2.0/all-1.2.0.pom",
+      "sha1": "9b1023e38195ea19d1a0ac79192d486da1904f97"
+    },
+    {
+      "path": "com/sun/activation/all/1.2.1/all-1.2.1.pom",
+      "sha1": "efca912f55f71e63ab2eb82552519b66dd123f98"
+    },
+    {
+      "path": "com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1.jar",
+      "sha1": "8013606426a73d8ba6b568370877251e91a38b89"
+    },
+    {
+      "path": "com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1.pom",
+      "sha1": "0923ee5f71c163a4a3c760b42af5e4405b238cc6"
+    },
+    {
+      "path": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar",
+      "sha1": "bf744c1e2776ed1de3c55c8dac1057ec331ef744"
+    },
+    {
+      "path": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.pom",
+      "sha1": "bdb776ae9b888b7ad8f9f424b9e67837eae916c5"
+    },
+    {
+      "path": "com/sun/istack/istack-commons/3.0.5/istack-commons-3.0.5.pom",
+      "sha1": "1133f27849ab919469a9443b7ca1d296550884d2"
+    },
+    {
+      "path": "com/sun/istack/istack-commons/3.0.8/istack-commons-3.0.8.pom",
+      "sha1": "3835dae3b9e529039b70bce883a1c7438713c295"
+    },
+    {
+      "path": "com/sun/istack/istack-commons-runtime/3.0.5/istack-commons-runtime-3.0.5.pom",
+      "sha1": "42f3cf2e2a9547f73f08a3d551064211888cc37c"
+    },
+    {
+      "path": "com/sun/istack/istack-commons-runtime/3.0.5/istack-commons-runtime-3.0.5.jar",
+      "sha1": "8052dc9920dfab5d50b8ca95c95a6ce4296a8f8b"
+    },
+    {
+      "path": "com/sun/istack/istack-commons-runtime/3.0.8/istack-commons-runtime-3.0.8.jar",
+      "sha1": "d6a97364045aa6b99bf2d3c566a3f98599c2d296"
+    },
+    {
+      "path": "com/sun/istack/istack-commons-runtime/3.0.8/istack-commons-runtime-3.0.8.pom",
+      "sha1": "fd5dfcff9a1f1e7e4371c6a998b74ee0e52bdc4a"
+    },
+    {
+      "path": "com/sun/istack/istack-commons-tools/3.0.5/istack-commons-tools-3.0.5.jar",
+      "sha1": "d26daf1d896ae36edcbf571ceefb92b420034334"
+    },
+    {
+      "path": "com/sun/istack/istack-commons-tools/3.0.5/istack-commons-tools-3.0.5.pom",
+      "sha1": "152bd0090eee205551616130c30a448fc50933ba"
+    },
+    {
+      "path": "com/sun/istack/istack-commons-tools/3.0.8/istack-commons-tools-3.0.8.jar",
+      "sha1": "a9bb4e2d83d50623bb2dd26cde8d7dd88e6b7104"
+    },
+    {
+      "path": "com/sun/istack/istack-commons-tools/3.0.8/istack-commons-tools-3.0.8.pom",
+      "sha1": "507c1fd3bebb8ebd932432e2ed1104d6f4c9330e"
+    },
+    {
+      "path": "com/sun/mail/all/1.5.6/all-1.5.6.pom",
+      "sha1": "5efefaab0546e06522d213e0a93e6177cf96dc04"
+    },
+    {
+      "path": "com/sun/mail/all/1.6.4/all-1.6.4.pom",
+      "sha1": "b0c43bf21cfbc745f2fe9c2a49b63a8c177e0960"
+    },
+    {
+      "path": "com/sun/mail/javax.mail/1.5.6/javax.mail-1.5.6.jar",
+      "sha1": "ab5daef2f881c42c8e280cbe918ec4d7fdfd7efe"
+    },
+    {
+      "path": "com/sun/mail/javax.mail/1.5.6/javax.mail-1.5.6.pom",
+      "sha1": "6be7b65dda7896f4590adf12f973c7059419d1cf"
+    },
+    {
+      "path": "com/sun/mail/mailapi/1.6.4/mailapi-1.6.4.jar",
+      "sha1": "82d7d21b34a723b487399032556552c12ca0d80c"
+    },
+    {
+      "path": "com/sun/mail/mailapi/1.6.4/mailapi-1.6.4.pom",
+      "sha1": "b341cf8615e79c5ee697efcd30746db7814d6203"
+    },
+    {
+      "path": "com/sun/org/apache/xml/internal/resolver/20050927/resolver-20050927.pom",
+      "sha1": "d93b62518aa6e65b805f9278c9079bee8f225251"
+    },
+    {
+      "path": "com/sun/org/apache/xml/internal/resolver/20050927/resolver-20050927.jar",
+      "sha1": "ee4db4a5f15cbdb453808c2839f08240ac231e46"
+    },
+    {
+      "path": "com/sun/xml/bind/external/relaxng-datatype/2.3.2/relaxng-datatype-2.3.2.jar",
+      "sha1": "d202e2c8bdd0a5286490260e311f0df1955f4dbf"
+    },
+    {
+      "path": "com/sun/xml/bind/external/relaxng-datatype/2.3.2/relaxng-datatype-2.3.2.pom",
+      "sha1": "fa89d0f8c452c797df1529298f62036848db1b6e"
+    },
+    {
+      "path": "com/sun/xml/bind/external/rngom/2.3.0/rngom-2.3.0.jar",
+      "sha1": "e5405de6a3e4df8e7d45afda9419a65beee4b1ff"
+    },
+    {
+      "path": "com/sun/xml/bind/external/rngom/2.3.0/rngom-2.3.0.pom",
+      "sha1": "1a479c0d1d08131039e90a8e366a71fc7a2f2d41"
+    },
+    {
+      "path": "com/sun/xml/bind/external/rngom/2.3.2/rngom-2.3.2.jar",
+      "sha1": "6b8c5d0984c31a01d98290cee4ab9bde13536431"
+    },
+    {
+      "path": "com/sun/xml/bind/external/rngom/2.3.2/rngom-2.3.2.pom",
+      "sha1": "2c31978da7337be7cef3d250810404b3b9d8239b"
+    },
+    {
+      "path": "com/sun/xml/bind/jaxb-bom-ext/2.3.0/jaxb-bom-ext-2.3.0.pom",
+      "sha1": "e51f5768506c46f1451ea32ea067360cccdb8851"
+    },
+    {
+      "path": "com/sun/xml/bind/jaxb-bom-ext/2.3.2/jaxb-bom-ext-2.3.2.pom",
+      "sha1": "7a92d12e31a67bae498f840c8f7c334a4fee0fbb"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-codemodel-parent/2.3.0/jaxb-codemodel-parent-2.3.0.pom",
+      "sha1": "5833c9c3e2cd6fdbbeeb3299cd8424142fcca9c5"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-codemodel-parent/2.3.2/jaxb-codemodel-parent-2.3.2.pom",
+      "sha1": "e598f8d0840f948eafac9417d71e2b16609e672c"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-external-parent/2.3.0/jaxb-external-parent-2.3.0.pom",
+      "sha1": "cb9eed50d024f3ef7151972af657ebdeb8fdfa68"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-external-parent/2.3.2/jaxb-external-parent-2.3.2.pom",
+      "sha1": "4ce94b35372ca6e9306299117ab848adac8bc026"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-parent/2.3.0/jaxb-parent-2.3.0.pom",
+      "sha1": "eb3abfe34a74d34b2ec6ef073d743624a63a0884"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-parent/2.3.2/jaxb-parent-2.3.2.pom",
+      "sha1": "05d96ada92105844d8a2eedfb63bf782a712cc0a"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-runtime-parent/2.3.0/jaxb-runtime-parent-2.3.0.pom",
+      "sha1": "13f17d9b4d23b4e3a86a35b1c8d699eacf985f0a"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-runtime-parent/2.3.2/jaxb-runtime-parent-2.3.2.pom",
+      "sha1": "b9916bbbf37042807a649a2a7fcb6b97e193c28a"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-txw-parent/2.3.0/jaxb-txw-parent-2.3.0.pom",
+      "sha1": "5f1a2f16c067283c92f5047bc5998ebb32e52b2c"
+    },
+    {
+      "path": "com/sun/xml/bind/mvn/jaxb-txw-parent/2.3.2/jaxb-txw-parent-2.3.2.pom",
+      "sha1": "1f872b3cb7c49c35501651aab063659a9775f06a"
+    },
+    {
+      "path": "com/sun/xml/dtd-parser/dtd-parser/1.2/dtd-parser-1.2.pom",
+      "sha1": "5452666c1bf3454b7cef1521664ab03b6b3ddd1b"
+    },
+    {
+      "path": "com/sun/xml/dtd-parser/dtd-parser/1.2/dtd-parser-1.2.jar",
+      "sha1": "4c66865b0bd521ea46369a615f8f52799e8ac05f"
+    },
+    {
+      "path": "com/sun/xml/dtd-parser/dtd-parser/1.4.1/dtd-parser-1.4.1.pom",
+      "sha1": "130fecfe3a0d77e9e6682d2bab11db3a20f26f7d"
+    },
+    {
+      "path": "com/sun/xml/dtd-parser/dtd-parser/1.4.1/dtd-parser-1.4.1.jar",
+      "sha1": "c5957db3100f10d1604141ae1545e59e774da2e6"
+    },
+    {
+      "path": "com/sun/xml/fastinfoset/FastInfoset/1.2.13/FastInfoset-1.2.13.jar",
+      "sha1": "098f56b9354e27bd2941cc5d461344e240ae51ae"
+    },
+    {
+      "path": "com/sun/xml/fastinfoset/FastInfoset/1.2.13/FastInfoset-1.2.13.pom",
+      "sha1": "bc1ac953addb710ec08dcca6465bb1f6fcfd7ee9"
+    },
+    {
+      "path": "com/sun/xml/fastinfoset/FastInfoset/1.2.16/FastInfoset-1.2.16.jar",
+      "sha1": "4eb6a0adad553bf759ffe86927df6f3b848c8bea"
+    },
+    {
+      "path": "com/sun/xml/fastinfoset/FastInfoset/1.2.16/FastInfoset-1.2.16.pom",
+      "sha1": "e4d2eed02e0e0a9f4c892e6d43bdf3dfdc1fa2ee"
+    },
+    {
+      "path": "com/sun/xml/fastinfoset/fastinfoset-project/1.2.13/fastinfoset-project-1.2.13.pom",
+      "sha1": "db60407ed97748ffda8b69aee0dd10a82851640d"
+    },
+    {
+      "path": "com/sun/xml/fastinfoset/fastinfoset-project/1.2.16/fastinfoset-project-1.2.16.pom",
+      "sha1": "86113f7ee9a5d995429bf75294b57b31f0a17d29"
+    },
+    {
+      "path": "com/thoughtworks/qdox/qdox/2.0-M7/qdox-2.0-M7.pom",
+      "sha1": "711868c26e3909198eff1fb7481b09ee0a0a468b"
+    },
+    {
+      "path": "com/thoughtworks/qdox/qdox/2.0-M7/qdox-2.0-M7.jar",
+      "sha1": "801684e388e7309a510eef9a5d8d100dd167f97c"
+    },
+    {
+      "path": "com/thoughtworks/qdox/qdox/2.0-M8/qdox-2.0-M8.jar",
+      "sha1": "036dc5cbf2aaf642d9ce7d0338591234ca49fcf0"
+    },
+    {
+      "path": "com/thoughtworks/qdox/qdox/2.0-M8/qdox-2.0-M8.pom",
+      "sha1": "8fc15cc55411249f3d89973e6ea55a7c4dc8688f"
+    },
+    {
+      "path": "com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.jar",
+      "sha1": "ea940f1cdba9205d03e4f54b9ac0ec988de751dd"
+    },
+    {
+      "path": "com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.pom",
+      "sha1": "5d3e19942fb302f11734b507b1115700b37f2cac"
+    },
+    {
+      "path": "com/thoughtworks/xstream/xstream/1.4.10/xstream-1.4.10.jar",
+      "sha1": "dfecae23647abc9d9fd0416629a4213a3882b101"
+    },
+    {
+      "path": "com/thoughtworks/xstream/xstream/1.4.10/xstream-1.4.10.pom",
+      "sha1": "b5f26a4ceed48765954eec5755041ad270467fbf"
+    },
+    {
+      "path": "com/thoughtworks/xstream/xstream-parent/1.4.10/xstream-parent-1.4.10.pom",
+      "sha1": "19439f7dd9863b57fa69288efac8b172aeba7627"
+    },
+    {
+      "path": "com/trilead/trilead-ssh2/1.0.0-build217/trilead-ssh2-1.0.0-build217.jar",
+      "sha1": "bd26b6a96923d5112cd20f821a16b589742ce1aa"
+    },
+    {
+      "path": "com/trilead/trilead-ssh2/1.0.0-build217/trilead-ssh2-1.0.0-build217.pom",
+      "sha1": "9c686a0ab1e8bf82504950ea56872c9dd2593591"
+    },
+    {
+      "path": "com/vaadin/external/google/android-json/0.0.20131108.vaadin1/android-json-0.0.20131108.vaadin1.jar",
+      "sha1": "fa26d351fe62a6a17f5cda1287c1c6110dec413f"
+    },
+    {
+      "path": "com/vaadin/external/google/android-json/0.0.20131108.vaadin1/android-json-0.0.20131108.vaadin1.pom",
+      "sha1": "90ebaebd21e7bcfad5416f999926d05f834bfeb5"
+    },
+    {
+      "path": "com/vdurmont/semver4j/3.1.0/semver4j-3.1.0.jar",
+      "sha1": "0de1248f09dfe8df3b021c84e0642ee222cceb13"
+    },
+    {
+      "path": "com/vdurmont/semver4j/3.1.0/semver4j-3.1.0.pom",
+      "sha1": "cf307a0f69d200c2d7c31f19f365fc71b6a5a118"
+    },
+    {
+      "path": "com/yahoo/platform/yui/yuicompressor/2.4.8/yuicompressor-2.4.8.pom",
+      "sha1": "99adc60ea87c167300edc7abb931d29980ab519e"
+    },
+    {
+      "path": "com/yahoo/platform/yui/yuicompressor/2.4.8/yuicompressor-2.4.8.jar",
+      "sha1": "900a7296bb52d740418d53274c1ecac5c83c760e"
+    },
+    {
+      "path": "de/regnis/q/sequence/sequence-library/1.0.2/sequence-library-1.0.2.jar",
+      "sha1": "0531ae7f7a4eac050dbce729edae139c2e546464"
+    },
+    {
+      "path": "de/regnis/q/sequence/sequence-library/1.0.2/sequence-library-1.0.2.pom",
+      "sha1": "80335f2e86013e4720719de7fc0d50fc64acda34"
+    },
+    {
+      "path": "de/triology/recaptchav2-java/recaptchav2-java/1.0.3/recaptchav2-java-1.0.3.jar",
+      "sha1": "7719469d08c3ae92089876f19dc4f606ddc15212"
+    },
+    {
+      "path": "de/triology/recaptchav2-java/recaptchav2-java/1.0.3/recaptchav2-java-1.0.3.pom",
+      "sha1": "c2efd4e04439519980f804266c3ed4c36d495b16"
+    },
+    {
+      "path": "de/u-mass/lastfm-java/0.1.2/lastfm-java-0.1.2.jar",
+      "sha1": "b1d6f0040f614b09bebfde1cf346ab4a6ffff81d"
+    },
+    {
+      "path": "de/u-mass/lastfm-java/0.1.2/lastfm-java-0.1.2.pom",
+      "sha1": "8b6c0d6e962b35819f4426f5f36b6ecd904dadc9"
+    },
+    {
+      "path": "dom4j/dom4j/1.1/dom4j-1.1.pom",
+      "sha1": "5e401c1611e45fb0d472073d394f891fadc99fa6"
+    },
+    {
+      "path": "dom4j/dom4j/1.1/dom4j-1.1.jar",
+      "sha1": "0690b3108a502c8f033ea87e7278aec309ffa668"
+    },
+    {
+      "path": "hsqldb/hsqldb/1.8.0.7/hsqldb-1.8.0.7.jar",
+      "sha1": "20554954120b3cc9f08804524ec90113a73f3015"
+    },
+    {
+      "path": "hsqldb/hsqldb/1.8.0.7/hsqldb-1.8.0.7.pom",
+      "sha1": "453b1a28d2a085dc954a97617e2d71dca8d56527"
+    },
+    {
+      "path": "info/picocli/picocli/3.9.5/picocli-3.9.5.jar",
+      "sha1": "f659a2feef0e8f7f8458aaf7d36c4d92f65320c8"
+    },
+    {
+      "path": "info/picocli/picocli/3.9.5/picocli-3.9.5.pom",
+      "sha1": "b13a5c3a0441370820a2d7bf36cbc4b7be6dd32b"
+    },
+    {
+      "path": "io/dropwizard/metrics/metrics-core/3.1.5/metrics-core-3.1.5.jar",
+      "sha1": "b07d2c8b79a11dd0a7d6d48adc96f396d7b58808"
+    },
+    {
+      "path": "io/dropwizard/metrics/metrics-core/3.1.5/metrics-core-3.1.5.pom",
+      "sha1": "b025987c910be0bc99bb94bbf9fe9bc267df6a18"
+    },
+    {
+      "path": "io/dropwizard/metrics/metrics-parent/3.1.5/metrics-parent-3.1.5.pom",
+      "sha1": "8a4502835002adfa38dcd8d192ec7bfb9be353bf"
+    },
+    {
+      "path": "jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1.jar",
+      "sha1": "562a587face36ec7eff2db7f2fc95425c6602bc1"
+    },
+    {
+      "path": "jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1.pom",
+      "sha1": "b9c1b2502949970360efe8d75ec5268d87d38a82"
+    },
+    {
+      "path": "jakarta/xml/bind/jakarta.xml.bind-api/2.3.2/jakarta.xml.bind-api-2.3.2.jar",
+      "sha1": "8d49996a4338670764d7ca4b85a1c4ccf7fe665d"
+    },
+    {
+      "path": "jakarta/xml/bind/jakarta.xml.bind-api/2.3.2/jakarta.xml.bind-api-2.3.2.pom",
+      "sha1": "6142021e7186bf29f5f7639b968cfe250ce086dd"
+    },
+    {
+      "path": "jakarta/xml/bind/jakarta.xml.bind-api-parent/2.3.2/jakarta.xml.bind-api-parent-2.3.2.pom",
+      "sha1": "7be72e8345e33f747d5d813e313abd8df25f259e"
+    },
+    {
+      "path": "javax/activation/activation/1.1/activation-1.1.jar",
+      "sha1": "e6cb541461c2834bdea3eb920f1884d1eb508b50"
+    },
+    {
+      "path": "javax/activation/activation/1.1/activation-1.1.pom",
+      "sha1": "fd9dd0faa8f03f3ce0dc4eec22e57e818d8b9897"
+    },
+    {
+      "path": "javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.jar",
+      "sha1": "85262acf3ca9816f9537ca47d5adeabaead7cb16"
+    },
+    {
+      "path": "javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.pom",
+      "sha1": "1aa9ef58e50ba6868b2e955d61fcd73be5b4cea5"
+    },
+    {
+      "path": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar",
+      "sha1": "934c04d3cfef185a8008e7bf34331b79730a9d43"
+    },
+    {
+      "path": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.pom",
+      "sha1": "302fe96ef206b17f82893083b51b479541fa25ab"
+    },
+    {
+      "path": "javax/annotation/javax.annotation-api/1.3/javax.annotation-api-1.3.jar",
+      "sha1": "67747496d8b5c1f300ed3cde4ba69d6f453ba984"
+    },
+    {
+      "path": "javax/annotation/javax.annotation-api/1.3/javax.annotation-api-1.3.pom",
+      "sha1": "0df1867b4b7930cc1ec2c1267330720f96cb336c"
+    },
+    {
+      "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+      "sha1": "5025422767732a1ab45d93abfea846513d742dcf"
+    },
+    {
+      "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.pom",
+      "sha1": "828184cb963d953865b5941e416999e376b1c82a"
+    },
+    {
+      "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+      "sha1": "44c453f60909dfc223552ace63e05c694215156b"
+    },
+    {
+      "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.pom",
+      "sha1": "b79b64c2b1cd6ddc1663f9f48dbf527262a2c3e5"
+    },
+    {
+      "path": "javax/inject/javax.inject/1/javax.inject-1.jar",
+      "sha1": "6975da39a7040257bd51d21a231b76c915872d38"
+    },
+    {
+      "path": "javax/inject/javax.inject/1/javax.inject-1.pom",
+      "sha1": "b8e00a8a0deb0ebef447570e37ff8146ccd92cbe"
+    },
+    {
+      "path": "javax/jws/javax.jws-api/1.1/javax.jws-api-1.1.jar",
+      "sha1": "c623941ebd225bb05ea546dc81590a62e40e4fce"
+    },
+    {
+      "path": "javax/jws/javax.jws-api/1.1/javax.jws-api-1.1.pom",
+      "sha1": "5484f7e95e03e883125ea62ad1b037ddbf55737a"
+    },
+    {
+      "path": "javax/mail/javax.mail-api/1.5.6/javax.mail-api-1.5.6.jar",
+      "sha1": "51c7a973efb1123558b62e95e31ab03cfa00fa7a"
+    },
+    {
+      "path": "javax/mail/javax.mail-api/1.5.6/javax.mail-api-1.5.6.pom",
+      "sha1": "ec877acca2732c868a32e671db0116c3e62df0f1"
+    },
+    {
+      "path": "javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.jar",
+      "sha1": "3cd63d075497751784b2fa84be59432f4905bf7c"
+    },
+    {
+      "path": "javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.pom",
+      "sha1": "330afdf2f976af1584c6a18333f4d53d264df1de"
+    },
+    {
+      "path": "javax/servlet/jsp/javax.servlet.jsp-api/2.3.3/javax.servlet.jsp-api-2.3.3.jar",
+      "sha1": "81191ab80e342912dc9cea735c30ff4eddc64de3"
+    },
+    {
+      "path": "javax/servlet/jsp/javax.servlet.jsp-api/2.3.3/javax.servlet.jsp-api-2.3.3.pom",
+      "sha1": "df90d7beda167d0e5b2c6ce2b869ca5f872f7101"
+    },
+    {
+      "path": "javax/servlet/jstl/1.2/jstl-1.2.jar",
+      "sha1": "74aca283cd4f4b4f3e425f5820cda58f44409547"
+    },
+    {
+      "path": "javax/servlet/jstl/1.2/jstl-1.2.pom",
+      "sha1": "f5511508540a7edc79de38d820cfc3a54a32b60d"
+    },
+    {
+      "path": "javax/servlet/servlet-api/2.3/servlet-api-2.3.jar",
+      "sha1": "0137a24e9f62973f01f16dd23fc1b5a9964fd9ef"
+    },
+    {
+      "path": "javax/servlet/servlet-api/2.3/servlet-api-2.3.pom",
+      "sha1": "5a7b9bcc0517b8fc785f306518b66616d9339548"
+    },
+    {
+      "path": "javax/servlet/servlet-api/2.5/servlet-api-2.5.jar",
+      "sha1": "5959582d97d8b61f4d154ca9e495aafd16726e34"
+    },
+    {
+      "path": "javax/servlet/servlet-api/2.5/servlet-api-2.5.pom",
+      "sha1": "a159fa05cce714c83deff647655dd53db064b21c"
+    },
+    {
+      "path": "javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar",
+      "sha1": "8613ae82954779d518631e05daa73a6a954817d5"
+    },
+    {
+      "path": "javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.pom",
+      "sha1": "0d2ad4d1498d1048abc6c6948fd3f835d8fdafb0"
+    },
+    {
+      "path": "javax/ws/rs/javax.ws.rs-api/2.0.1/javax.ws.rs-api-2.0.1.jar",
+      "sha1": "104e9c2b5583cfcfeac0402316221648d6d8ea6b"
+    },
+    {
+      "path": "javax/ws/rs/javax.ws.rs-api/2.0.1/javax.ws.rs-api-2.0.1.pom",
+      "sha1": "187fba25330b7136f3c096c3454681a045bf2b0f"
+    },
+    {
+      "path": "javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.pom",
+      "sha1": "61dab99f547e2110e42e35f659d9ba27bd00108c"
+    },
+    {
+      "path": "javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.jar",
+      "sha1": "99f802e0cb3e953ba3d6e698795c4aeb98d37c48"
+    },
+    {
+      "path": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
+      "sha1": "8531ad5ac454cc2deb9d4d32c40c4d7451939b5d"
+    },
+    {
+      "path": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.pom",
+      "sha1": "c42c51ae84892b73ef7de5351188908e673f5c69"
+    },
+    {
+      "path": "javax/xml/bind/jaxb-api-parent/2.3.0/jaxb-api-parent-2.3.0.pom",
+      "sha1": "813cc0def6b156ec1808f4695a74cf6777030012"
+    },
+    {
+      "path": "javax/xml/bind/jaxb-api-parent/2.3.1/jaxb-api-parent-2.3.1.pom",
+      "sha1": "26101e8a1a09e16cdf277a4591f6d29917b2e06e"
+    },
+    {
+      "path": "javax/xml/soap/javax.xml.soap-api/1.4.0/javax.xml.soap-api-1.4.0.jar",
+      "sha1": "667ef2eee594ca7e05a1cbe0b37a428f7b57778f"
+    },
+    {
+      "path": "javax/xml/soap/javax.xml.soap-api/1.4.0/javax.xml.soap-api-1.4.0.pom",
+      "sha1": "a6ed869fcbf5b962c6d7dc7feb4318532103b048"
+    },
+    {
+      "path": "javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar",
+      "sha1": "d6337b0de8b25e53e81b922352fbea9f9f57ba0b"
+    },
+    {
+      "path": "javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.pom",
+      "sha1": "5379b69f557c5ab7c144d22bf7c3768bd2adb93d"
+    },
+    {
+      "path": "javax/xml/ws/jaxws-api/2.3.1/jaxws-api-2.3.1.jar",
+      "sha1": "15e46dba25b1f767a3f517721badf6cce8dbb13d"
+    },
+    {
+      "path": "javax/xml/ws/jaxws-api/2.3.1/jaxws-api-2.3.1.pom",
+      "sha1": "05622e319cbccb6ad26d73c4232feacac4ceabbf"
+    },
+    {
+      "path": "joda-time/joda-time/2.10.4/joda-time-2.10.4.jar",
+      "sha1": "8c10bb8815109067ce3c91a8e547b5a52e8a1c1a"
+    },
+    {
+      "path": "joda-time/joda-time/2.10.4/joda-time-2.10.4.pom",
+      "sha1": "fc17973f7dec5fb118a7b7b23218580e188118cd"
+    },
+    {
+      "path": "jtidy/jtidy/4aug2000r7-dev/jtidy-4aug2000r7-dev.jar",
+      "sha1": "2aecd44e0c3a7fdcf0ec19f7c58f37a07798f01f"
+    },
+    {
+      "path": "jtidy/jtidy/4aug2000r7-dev/jtidy-4aug2000r7-dev.pom",
+      "sha1": "3237734ff34060ed1ed8e24f5a50568db77e02a6"
+    },
+    {
+      "path": "junit/junit/3.8.1/junit-3.8.1.jar",
+      "sha1": "99129f16442844f6a4a11ae22fbbee40b14d774f"
+    },
+    {
+      "path": "junit/junit/3.8.1/junit-3.8.1.pom",
+      "sha1": "16d74791c801c89b0071b1680ea0bc85c93417bb"
+    },
+    {
+      "path": "junit/junit/4.11/junit-4.11.jar",
+      "sha1": "4e031bb61df09069aeb2bffb4019e7a5034a4ee0"
+    },
+    {
+      "path": "junit/junit/4.11/junit-4.11.pom",
+      "sha1": "cddf7490ffe839978cf5d6c944c01f2a8cb70a49"
+    },
+    {
+      "path": "junit/junit/4.12/junit-4.12.jar",
+      "sha1": "2973d150c0dc1fefe998f834810d68f278ea58ec"
+    },
+    {
+      "path": "junit/junit/4.12/junit-4.12.pom",
+      "sha1": "35fb238baee3f3af739074d723279ebea2028398"
+    },
+    {
+      "path": "junit/junit/4.8.1/junit-4.8.1.jar",
+      "sha1": "f2975548f836416306ef1dee748d956f04733915"
+    },
+    {
+      "path": "junit/junit/4.8.1/junit-4.8.1.pom",
+      "sha1": "86660f9d61b8550c40850922c9053b37e486c48c"
+    },
+    {
+      "path": "junit/junit/4.8.2/junit-4.8.2.jar",
+      "sha1": "c94f54227b08100974c36170dcb53329435fe5ad"
+    },
+    {
+      "path": "junit/junit/4.8.2/junit-4.8.2.pom",
+      "sha1": "c9c2d21b75368533f8a5ec1fefa2633989e80294"
+    },
+    {
+      "path": "log4j/log4j/1.2.12/log4j-1.2.12.pom",
+      "sha1": "70545179454d298d1ff01335fbec3c2acfd381d5"
+    },
+    {
+      "path": "log4j/log4j/1.2.17/log4j-1.2.17.jar",
+      "sha1": "5af35056b4d257e4b64b9e8069c0746e8b08629f"
+    },
+    {
+      "path": "log4j/log4j/1.2.17/log4j-1.2.17.pom",
+      "sha1": "309d3cac016db1a4cd4565ea2b95c0bdf040f8d1"
+    },
+    {
+      "path": "logkit/logkit/1.0.1/logkit-1.0.1.pom",
+      "sha1": "ff3b4e6ced322bc8a21fa3aadfcf7f131a1ee08c"
+    },
+    {
+      "path": "mysql/mysql-connector-java/8.0.19/mysql-connector-java-8.0.19.pom",
+      "sha1": "03272fb6cec7cb0b55b6dc8f1644d6741d941f63"
+    },
+    {
+      "path": "mysql/mysql-connector-java/8.0.19/mysql-connector-java-8.0.19.jar",
+      "sha1": "9af69ef0f68eae737351ff55c0ba6e23a06826a5"
+    },
+    {
+      "path": "nekohtml/nekohtml/1.9.6.2/nekohtml-1.9.6.2.jar",
+      "sha1": "2d960be7b62ae6622dbbbe49ab4ffdc609f85c80"
+    },
+    {
+      "path": "nekohtml/nekohtml/1.9.6.2/nekohtml-1.9.6.2.pom",
+      "sha1": "51d188decc386fe998fa4ece85948c56e4c7d147"
+    },
+    {
+      "path": "nekohtml/xercesMinimal/1.9.6.2/xercesMinimal-1.9.6.2.jar",
+      "sha1": "0d1c5e063683a0e6f77cd5f051a9d4af48346fa6"
+    },
+    {
+      "path": "nekohtml/xercesMinimal/1.9.6.2/xercesMinimal-1.9.6.2.pom",
+      "sha1": "c8845acd7305ffee4c76ef626026fb396cc33463"
+    },
+    {
+      "path": "net/java/dev/javacc/javacc/5.0/javacc-5.0.jar",
+      "sha1": "f19b7d4278b837fe92504946e6860b0bcc180956"
+    },
+    {
+      "path": "net/java/dev/javacc/javacc/5.0/javacc-5.0.pom",
+      "sha1": "d931bbc711ef3646c3d835688870f71145020663"
+    },
+    {
+      "path": "net/java/dev/jna/jna/3.4.0/jna-3.4.0.pom",
+      "sha1": "410f1facad5148c4005bc873c8dbeafde9121ebe"
+    },
+    {
+      "path": "net/java/dev/jna/jna/3.5.2/jna-3.5.2.jar",
+      "sha1": "f1bf9fe267e17c1a8f7d1aa2c985e7fe81a06da6"
+    },
+    {
+      "path": "net/java/dev/jna/jna/3.5.2/jna-3.5.2.pom",
+      "sha1": "03ccf4b1f76b915b1d192955fbb41d704fdf0813"
+    },
+    {
+      "path": "net/java/dev/jna/platform/3.4.0/platform-3.4.0.pom",
+      "sha1": "e4019e7e54ec421080b7f1117ca58e3c8ff18279"
+    },
+    {
+      "path": "net/java/dev/jna/platform/3.5.2/platform-3.5.2.jar",
+      "sha1": "beac07d13858ef3697ceeab43897d70aeb5113c9"
+    },
+    {
+      "path": "net/java/dev/jna/platform/3.5.2/platform-3.5.2.pom",
+      "sha1": "600a41d9a65e12783306d35d630593c47f78894c"
+    },
+    {
+      "path": "net/java/jvnet-parent/1/jvnet-parent-1.pom",
+      "sha1": "b55a1b046dbe82acdee8edde7476eebcba1e57d8"
+    },
+    {
+      "path": "net/java/jvnet-parent/3/jvnet-parent-3.pom",
+      "sha1": "f8f3be3e980551a39b5679411e171aeb6931aaec"
+    },
+    {
+      "path": "net/java/jvnet-parent/5/jvnet-parent-5.pom",
+      "sha1": "5343c954d21549d039feebe5fadef023cdfc1388"
+    },
+    {
+      "path": "net/jthink/jaudiotagger/2.2.5/jaudiotagger-2.2.5.pom",
+      "sha1": "4bb12776b2aee4759711fbeb4f8326879a6e24d4"
+    },
+    {
+      "path": "net/jthink/jaudiotagger/2.2.5/jaudiotagger-2.2.5.jar",
+      "sha1": "e9a1c27942a89439e3f8dca737075b7a354a46e1"
+    },
+    {
+      "path": "net/minidev/accessors-smart/1.1/accessors-smart-1.1.jar",
+      "sha1": "a527213f2fea112a04c9bdf0ec0264e34104cd08"
+    },
+    {
+      "path": "net/minidev/accessors-smart/1.1/accessors-smart-1.1.pom",
+      "sha1": "e497f483105c5fe09ac9014d7ef466924acd5e3e"
+    },
+    {
+      "path": "net/minidev/json-smart/2.2.1/json-smart-2.2.1.jar",
+      "sha1": "5b9e5df7a62d1279b70dc882b041d249c4f0b002"
+    },
+    {
+      "path": "net/minidev/json-smart/2.2.1/json-smart-2.2.1.pom",
+      "sha1": "be61ede235a90e21fcc248f7f34514d800ebc953"
+    },
+    {
+      "path": "net/minidev/minidev-parent/2.2/minidev-parent-2.2.pom",
+      "sha1": "1e83d59a9b4fc254d76b971180b9d67784aed97e"
+    },
+    {
+      "path": "net/nicoulaj/maven/plugins/checksum-maven-plugin/1.8/checksum-maven-plugin-1.8.pom",
+      "sha1": "23a61c8b5afa3c9a2ae62e8c55f86855b2c4c435"
+    },
+    {
+      "path": "net/nicoulaj/maven/plugins/checksum-maven-plugin/1.8/checksum-maven-plugin-1.8.jar",
+      "sha1": "fce7d8c522273b8f27ed73c9c2c17a2782215d10"
+    },
+    {
+      "path": "net/nicoulaj/parent/54/parent-54.pom",
+      "sha1": "9d4d9f27737fe6d633ab8afc28c7bdb87d89f4af"
+    },
+    {
+      "path": "net/sf/ehcache/ehcache-core/2.6.11/ehcache-core-2.6.11.jar",
+      "sha1": "fae7f84a5ffabe1b814e40190650c0ad5aeda5b1"
+    },
+    {
+      "path": "net/sf/ehcache/ehcache-core/2.6.11/ehcache-core-2.6.11.pom",
+      "sha1": "fb843b3da18ac4764c8f707e28bcd05839fa43a0"
+    },
+    {
+      "path": "net/sf/ehcache/ehcache-parent/2.5/ehcache-parent-2.5.pom",
+      "sha1": "6be9170750c766692ff03139229862fb435499f6"
+    },
+    {
+      "path": "net/sf/saxon/Saxon-HE/9.9.1-2/Saxon-HE-9.9.1-2.jar",
+      "sha1": "2f7b0257a1b60990d1909f7fcd33739732dd2843"
+    },
+    {
+      "path": "net/sf/saxon/Saxon-HE/9.9.1-2/Saxon-HE-9.9.1-2.pom",
+      "sha1": "8ed41101df308d914e8572f991eb7a37f4072a86"
+    },
+    {
+      "path": "net/sourceforge/pmd/pmd/6.21.0/pmd-6.21.0.pom",
+      "sha1": "70e64070f6d533de54963432b9624c574500e9ec"
+    },
+    {
+      "path": "net/sourceforge/pmd/pmd-core/6.21.0/pmd-core-6.21.0.jar",
+      "sha1": "72ea7407d2c0b16a7f10211d7d880f05609498f8"
+    },
+    {
+      "path": "net/sourceforge/pmd/pmd-core/6.21.0/pmd-core-6.21.0.pom",
+      "sha1": "64abdc6939f602a55018f4b702c7a241fde19e56"
+    },
+    {
+      "path": "net/sourceforge/pmd/pmd-java/6.21.0/pmd-java-6.21.0.jar",
+      "sha1": "d8732de1cad48084cf0c20436568f9cb64eee696"
+    },
+    {
+      "path": "net/sourceforge/pmd/pmd-java/6.21.0/pmd-java-6.21.0.pom",
+      "sha1": "751f4eaf45d646e68552866a72d884b2b932c3ed"
+    },
+    {
+      "path": "net/sourceforge/pmd/pmd-javascript/6.21.0/pmd-javascript-6.21.0.jar",
+      "sha1": "627dddbf27b82e5b94ebd1493c3db86b3a6ec40c"
+    },
+    {
+      "path": "net/sourceforge/pmd/pmd-javascript/6.21.0/pmd-javascript-6.21.0.pom",
+      "sha1": "7d725ddec32462d2e86ded7415d963905c0a8f75"
+    },
+    {
+      "path": "net/sourceforge/pmd/pmd-jsp/6.21.0/pmd-jsp-6.21.0.jar",
+      "sha1": "1529b7369c5bf2fa0bc6bc1e25b9ee2e86fccbda"
+    },
+    {
+      "path": "net/sourceforge/pmd/pmd-jsp/6.21.0/pmd-jsp-6.21.0.pom",
+      "sha1": "f68a2573f74b714e388cbe924bab26ee3fbaf48b"
+    },
+    {
+      "path": "net/sourceforge/saxon/saxon/9.1.0.8/saxon-9.1.0.8.jar",
+      "sha1": "9ffdd08cb74563cbd431c845238b414e933a0483"
+    },
+    {
+      "path": "net/sourceforge/saxon/saxon/9.1.0.8/saxon-9.1.0.8-dom.jar",
+      "sha1": "d3bc6741b15bb4c57626708287a2417ab5f67ee6"
+    },
+    {
+      "path": "net/sourceforge/saxon/saxon/9.1.0.8/saxon-9.1.0.8.pom",
+      "sha1": "b9e293338606beeebffb2644df76bc177f5b800b"
+    },
+    {
+      "path": "org/airsonic/checkstyle/1.0-RELEASE/checkstyle-1.0-RELEASE.jar",
+      "sha1": "6ee0ce8a4501ab78eccd0acc92d7062ca4f67930"
+    },
+    {
+      "path": "org/airsonic/checkstyle/1.0-RELEASE/checkstyle-1.0-RELEASE.pom",
+      "sha1": "56fa8fa46150789799b2d1647ab9663d8f7c0f85"
+    },
+    {
+      "path": "org/antlr/antlr4-master/4.7.2/antlr4-master-4.7.2.pom",
+      "sha1": "be60f81cb61996f57281497067d890caf8eeece8"
+    },
+    {
+      "path": "org/antlr/antlr4-master/4.7/antlr4-master-4.7.pom",
+      "sha1": "25d7cdbf0bc691efe89fcd4afe4a23a3b5e2e205"
+    },
+    {
+      "path": "org/antlr/antlr4-runtime/4.7.2/antlr4-runtime-4.7.2.jar",
+      "sha1": "e27d8ab4f984f9d186f54da984a6ab1cccac755e"
+    },
+    {
+      "path": "org/antlr/antlr4-runtime/4.7.2/antlr4-runtime-4.7.2.pom",
+      "sha1": "0ef31048e832523e34634045589c56c5e63d4866"
+    },
+    {
+      "path": "org/antlr/antlr4-runtime/4.7/antlr4-runtime-4.7.jar",
+      "sha1": "30b13b7efc55b7feea667691509cf59902375001"
+    },
+    {
+      "path": "org/antlr/antlr4-runtime/4.7/antlr4-runtime-4.7.pom",
+      "sha1": "a79e78706230f4bb28d884c4bd1e5637040ee057"
+    },
+    {
+      "path": "org/antlr/antlr-master/3.4/antlr-master-3.4.pom",
+      "sha1": "2ba30358bdfa2cf23dac9af4e7abf774c55d73aa"
+    },
+    {
+      "path": "org/antlr/antlr-runtime/3.4/antlr-runtime-3.4.pom",
+      "sha1": "f17559949c44edf8a8269187e3cbfe6bd45de315"
+    },
+    {
+      "path": "org/antlr/antlr-runtime/3.4/antlr-runtime-3.4.jar",
+      "sha1": "8f011408269a8e42b8548687e137d8eeb56df4b4"
+    },
+    {
+      "path": "org/apache/ant/ant/1.10.5/ant-1.10.5.jar",
+      "sha1": "4a48332c2df6f535d9dd9d904cd780ab26266e20"
+    },
+    {
+      "path": "org/apache/ant/ant/1.10.5/ant-1.10.5.pom",
+      "sha1": "90efea62f5cc73bf727e6b87fbd7f82d67182e44"
+    },
+    {
+      "path": "org/apache/ant/ant/1.10.6/ant-1.10.6.jar",
+      "sha1": "67d0e4aa9696c463c91178c3bd2928e1c3088bd6"
+    },
+    {
+      "path": "org/apache/ant/ant/1.10.6/ant-1.10.6.pom",
+      "sha1": "546488ce910d54f90e3f7e821059b0eae384ed38"
+    },
+    {
+      "path": "org/apache/ant/ant/1.8.4/ant-1.8.4.jar",
+      "sha1": "8acff3fb57e74bc062d4675d9dcfaffa0d524972"
+    },
+    {
+      "path": "org/apache/ant/ant/1.8.4/ant-1.8.4.pom",
+      "sha1": "8ff925f72a23c485bb18a3d11dd881348643555d"
+    },
+    {
+      "path": "org/apache/ant/ant/1.9.4/ant-1.9.4.pom",
+      "sha1": "3f0b3746c0d89c48db6c46503c798a47718e951e"
+    },
+    {
+      "path": "org/apache/ant/ant/1.9.4/ant-1.9.4.jar",
+      "sha1": "6d473e8653d952045f550f4ef225a9591b79094a"
+    },
+    {
+      "path": "org/apache/ant/ant-launcher/1.10.5/ant-launcher-1.10.5.jar",
+      "sha1": "e84c8cf7b0cbac5ef101cf56ff8d439fa77e36c2"
+    },
+    {
+      "path": "org/apache/ant/ant-launcher/1.10.5/ant-launcher-1.10.5.pom",
+      "sha1": "aed530f6285a6583bd3148621fc36e05e8f79ed9"
+    },
+    {
+      "path": "org/apache/ant/ant-launcher/1.10.6/ant-launcher-1.10.6.jar",
+      "sha1": "7f7521e38c3faab57529892ba30d268d70d232d1"
+    },
+    {
+      "path": "org/apache/ant/ant-launcher/1.10.6/ant-launcher-1.10.6.pom",
+      "sha1": "30ae08c8d8ae582b787fc9ff5edabc08a72a2ea0"
+    },
+    {
+      "path": "org/apache/ant/ant-launcher/1.8.4/ant-launcher-1.8.4.pom",
+      "sha1": "3b8f7cbc83cca7d36da76639cd542d3f5869e774"
+    },
+    {
+      "path": "org/apache/ant/ant-launcher/1.8.4/ant-launcher-1.8.4.jar",
+      "sha1": "22f1e0c32a2bfc8edd45520db176bac98cebbbfe"
+    },
+    {
+      "path": "org/apache/ant/ant-launcher/1.9.4/ant-launcher-1.9.4.jar",
+      "sha1": "334b62cb4be0432769679e8b94e83f8fd5ed395c"
+    },
+    {
+      "path": "org/apache/ant/ant-launcher/1.9.4/ant-launcher-1.9.4.pom",
+      "sha1": "bb691932f5226bfc2b86ccb98b3c1dddff44a749"
+    },
+    {
+      "path": "org/apache/ant/ant-parent/1.10.5/ant-parent-1.10.5.pom",
+      "sha1": "a7c20bf39467e2fc5ec4a1bb67862380d388836f"
+    },
+    {
+      "path": "org/apache/ant/ant-parent/1.10.6/ant-parent-1.10.6.pom",
+      "sha1": "7f9a3912920bd2bb2b0ae8e84adec20a558e7325"
+    },
+    {
+      "path": "org/apache/ant/ant-parent/1.8.4/ant-parent-1.8.4.pom",
+      "sha1": "82a7d6d6d5d8f3e22f72d8e20cc47583db679ffa"
+    },
+    {
+      "path": "org/apache/ant/ant-parent/1.9.4/ant-parent-1.9.4.pom",
+      "sha1": "a8a1ecb1cc4b99a025fd920a12eb79e3bd7b0842"
+    },
+    {
+      "path": "org/apache/apache/10/apache-10.pom",
+      "sha1": "48296e511366fa13aad48c58d8e09721774abec6"
+    },
+    {
+      "path": "org/apache/apache/11/apache-11.pom",
+      "sha1": "cb35e3b8eb7f1adbdc91e015b60d0da3a4e16c4f"
+    },
+    {
+      "path": "org/apache/apache/13/apache-13.pom",
+      "sha1": "15aff1faaec4963617f07dbe8e603f0adabc3a12"
+    },
+    {
+      "path": "org/apache/apache/14/apache-14.pom",
+      "sha1": "5c7956a91f3faaa9534cdc2b571c90bde2235157"
+    },
+    {
+      "path": "org/apache/apache/15/apache-15.pom",
+      "sha1": "95c70374817194cabfeec410fe70c3a6b832bafe"
+    },
+    {
+      "path": "org/apache/apache/16/apache-16.pom",
+      "sha1": "8a90e31780e5cd0685ccaf25836c66e3b4e163b7"
+    },
+    {
+      "path": "org/apache/apache/17/apache-17.pom",
+      "sha1": "c1685ef8de6047fdad5e5fce99a8ccd80fc8b659"
+    },
+    {
+      "path": "org/apache/apache/18/apache-18.pom",
+      "sha1": "bd408bbea3840f2c7f914b29403e39a90f84fd5f"
+    },
+    {
+      "path": "org/apache/apache/19/apache-19.pom",
+      "sha1": "db8bb0231dcbda5011926dbaca1a7ce652fd5517"
+    },
+    {
+      "path": "org/apache/apache/1/apache-1.pom",
+      "sha1": "8902526cc8e0fd0373c42c7f3ddc35560c26bf59"
+    },
+    {
+      "path": "org/apache/apache/21/apache-21.pom",
+      "sha1": "649b700a1b2b4a1d87e7ae8e3f47bfe101b2a4a5"
+    },
+    {
+      "path": "org/apache/apache/2/apache-2.pom",
+      "sha1": "bfe8f1ae400b4fdf0365b6b61cde3a6cae5750e3"
+    },
+    {
+      "path": "org/apache/apache/3/apache-3.pom",
+      "sha1": "1bc0010136a890e2fd38d901a0b7ecdf0e3f9871"
+    },
+    {
+      "path": "org/apache/apache/4/apache-4.pom",
+      "sha1": "602b647986c1d24301bc3d70e5923696bc7f1401"
+    },
+    {
+      "path": "org/apache/apache/5/apache-5.pom",
+      "sha1": "a99e211eb2be05af269c489b0f1abb9e8469fbca"
+    },
+    {
+      "path": "org/apache/apache/6/apache-6.pom",
+      "sha1": "70e78921afc16d914e65611d18ab1b2d6cb20e57"
+    },
+    {
+      "path": "org/apache/apache/7/apache-7.pom",
+      "sha1": "a5f679b14bb06a3cb3769eb04e228c8b9e12908f"
+    },
+    {
+      "path": "org/apache/apache/9/apache-9.pom",
+      "sha1": "de55d73a30c7521f3d55e8141d360ffbdfd88caa"
+    },
+    {
+      "path": "org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar",
+      "sha1": "62ebe7544cb7164d87e0637a2a6a2bdc981395e8"
+    },
+    {
+      "path": "org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.pom",
+      "sha1": "05428d42492ca170947632194080eb9432fbdf6c"
+    },
+    {
+      "path": "org/apache/commons/commons-compress/1.16.1/commons-compress-1.16.1.jar",
+      "sha1": "7b5cdabadb4cf12f5ee0f801399e70635583193f"
+    },
+    {
+      "path": "org/apache/commons/commons-compress/1.16.1/commons-compress-1.16.1.pom",
+      "sha1": "f7a23383b8f77a08c5265c6120a0393673a8f92d"
+    },
+    {
+      "path": "org/apache/commons/commons-compress/1.18/commons-compress-1.18.jar",
+      "sha1": "1191f9f2bc0c47a8cce69193feb1ff0a8bcb37d5"
+    },
+    {
+      "path": "org/apache/commons/commons-compress/1.18/commons-compress-1.18.pom",
+      "sha1": "e200ad298ce5683b6c1546d30b19259e79cd575f"
+    },
+    {
+      "path": "org/apache/commons/commons-compress/1.19/commons-compress-1.19.jar",
+      "sha1": "7e65777fb451ddab6a9c054beb879e521b7eab78"
+    },
+    {
+      "path": "org/apache/commons/commons-compress/1.19/commons-compress-1.19.pom",
+      "sha1": "5fd8e87adb169ab13cb525b6986cf924685c2990"
+    },
+    {
+      "path": "org/apache/commons/commons-compress/1.9/commons-compress-1.9.jar",
+      "sha1": "cc18955ff1e36d5abd39a14bfe82b19154330a34"
+    },
+    {
+      "path": "org/apache/commons/commons-compress/1.9/commons-compress-1.9.pom",
+      "sha1": "f504990212b88933a57d190edc2d7dc89bbde489"
+    },
+    {
+      "path": "org/apache/commons/commons-configuration2/2.7/commons-configuration2-2.7.jar",
+      "sha1": "593326399e5fb5e1f986607f06f63c1250ab36b4"
+    },
+    {
+      "path": "org/apache/commons/commons-configuration2/2.7/commons-configuration2-2.7.pom",
+      "sha1": "0c68e52d5e7af3b587be9b12a0e39f326f3501a5"
+    },
+    {
+      "path": "org/apache/commons/commons-dbcp2/2.7.0/commons-dbcp2-2.7.0.jar",
+      "sha1": "ac3c5077659b4b9140e8fa63e855e0437fe94357"
+    },
+    {
+      "path": "org/apache/commons/commons-dbcp2/2.7.0/commons-dbcp2-2.7.0.pom",
+      "sha1": "b37b9332f78534befd5d710c3c19202364d81ce8"
+    },
+    {
+      "path": "org/apache/commons/commons-jcs/2.2.1/commons-jcs-2.2.1.pom",
+      "sha1": "30444da244f0d646aaa73fa7ef54256a68920a04"
+    },
+    {
+      "path": "org/apache/commons/commons-jcs-core/2.2.1/commons-jcs-core-2.2.1.pom",
+      "sha1": "74fac5ae3dabc3822e6d46c963b892494cec0b08"
+    },
+    {
+      "path": "org/apache/commons/commons-jcs-core/2.2.1/commons-jcs-core-2.2.1.jar",
+      "sha1": "3ffac1956b0d88fff8adefdf1e68d69cfe296191"
+    },
+    {
+      "path": "org/apache/commons/commons-lang3/3.2.1/commons-lang3-3.2.1.jar",
+      "sha1": "66f13681add50ca9e4546ffabafaaac7645db3cf"
+    },
+    {
+      "path": "org/apache/commons/commons-lang3/3.2.1/commons-lang3-3.2.1.pom",
+      "sha1": "193e4596dde9a1879b3d318ae158b94cfee8cb79"
+    },
+    {
+      "path": "org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.pom",
+      "sha1": "08b969f02dfa03fa493fd6eba4cb9dcceea5aefd"
+    },
+    {
+      "path": "org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar",
+      "sha1": "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"
+    },
+    {
+      "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
+      "sha1": "6505a72a097d9270f7a9e7bf42c4238283247755"
+    },
+    {
+      "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.pom",
+      "sha1": "59092f9d06947b986318dfbe297312e08379b0ae"
+    },
+    {
+      "path": "org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
+      "sha1": "0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+    },
+    {
+      "path": "org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.pom",
+      "sha1": "2b7f0896fc2f13bbe7b0022c85738e3b6a3f201a"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/11/commons-parent-11.pom",
+      "sha1": "3f29657e1e3d6856344728ddbcf696477e943d59"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/12/commons-parent-12.pom",
+      "sha1": "cc649b3f6671ff0e0ad57304441e0a5d2610db73"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/17/commons-parent-17.pom",
+      "sha1": "84bc2f457fac92c947cde9c15c81786ded79b3c1"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/22/commons-parent-22.pom",
+      "sha1": "0e895fa7ed472b3b2081ef77e2d5ece78c139d54"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/24/commons-parent-24.pom",
+      "sha1": "dbb7913f93b279ef889f6bad288b82dae58df237"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/25/commons-parent-25.pom",
+      "sha1": "67b84199ca4acf0d8fbc5256d90b80f746737e94"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/32/commons-parent-32.pom",
+      "sha1": "0e51c4223003c2c7c63f38d7b8823e40eb06bd1f"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/34/commons-parent-34.pom",
+      "sha1": "1f6be162a806d8343e3cd238dd728558532473a5"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/35/commons-parent-35.pom",
+      "sha1": "d88c24ebb385e5404f34573f24362b17434e3f33"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/39/commons-parent-39.pom",
+      "sha1": "4bc32d3cda9f07814c548492af7bf19b21798d46"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/3/commons-parent-3.pom",
+      "sha1": "cc68f9bf1b52f227e82308b9157e265e05470804"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/41/commons-parent-41.pom",
+      "sha1": "c88f7453ccb914ba5de83e0557456fadf6db4022"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/42/commons-parent-42.pom",
+      "sha1": "35d45eda74fe511d3d60b68e1dac29ed55043354"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/43/commons-parent-43.pom",
+      "sha1": "a24c1d164086ee8f10c11879da2f86f52cbea7fb"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/47/commons-parent-47.pom",
+      "sha1": "391715f2f4f1b32604a201a2f4ea74a174e1f21c"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/48/commons-parent-48.pom",
+      "sha1": "1cdeb626cf4f0cec0f171ec838a69922efc6ef95"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/50/commons-parent-50.pom",
+      "sha1": "b47c55b7ee647e1c78546791e7f4fe59b842c320"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/5/commons-parent-5.pom",
+      "sha1": "a0a168281558e7ae972f113fa128bc46b4973edd"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/7/commons-parent-7.pom",
+      "sha1": "95db361d9db1474346b2bde93e5402281909144c"
+    },
+    {
+      "path": "org/apache/commons/commons-parent/9/commons-parent-9.pom",
+      "sha1": "217cc375e25b647a61956e1d6a88163f9e3a387c"
+    },
+    {
+      "path": "org/apache/commons/commons-pool2/2.4.3/commons-pool2-2.4.3.jar",
+      "sha1": "e7ab2a5143cb4e0b21d8ca81c265095e4567dd22"
+    },
+    {
+      "path": "org/apache/commons/commons-pool2/2.4.3/commons-pool2-2.4.3.pom",
+      "sha1": "b5813ddd4dd19ac6809bacbb54cbfb2d35a8df73"
+    },
+    {
+      "path": "org/apache/commons/commons-text/1.8/commons-text-1.8.pom",
+      "sha1": "871ec730e2c999bc33a296b9a904cba30a8ae59a"
+    },
+    {
+      "path": "org/apache/commons/commons-text/1.8/commons-text-1.8.jar",
+      "sha1": "879a6bde4c0537a25504c72ec7a94ba4099f469c"
+    },
+    {
+      "path": "org/apache/cxf/cxf/3.3.6/cxf-3.3.6.pom",
+      "sha1": "80cd9b0308490803f39eadd7f1952b9f0354f169"
+    },
+    {
+      "path": "org/apache/cxf/cxf-codegen-plugin/3.3.6/cxf-codegen-plugin-3.3.6.jar",
+      "sha1": "f062337cdef92ab882bb0307dd96ee0afed16c14"
+    },
+    {
+      "path": "org/apache/cxf/cxf-codegen-plugin/3.3.6/cxf-codegen-plugin-3.3.6.pom",
+      "sha1": "d67a5ef3c208267e1775c6e49aa1fec123a0b784"
+    },
+    {
+      "path": "org/apache/cxf/cxf-core/3.3.6/cxf-core-3.3.6.pom",
+      "sha1": "9cd4f2f10896187f8c9d18370674667d0ddff7f8"
+    },
+    {
+      "path": "org/apache/cxf/cxf-core/3.3.6/cxf-core-3.3.6.jar",
+      "sha1": "d0550751b3c42813ff32a95142f29eafc001ec28"
+    },
+    {
+      "path": "org/apache/cxf/cxf-maven-plugins/3.3.6/cxf-maven-plugins-3.3.6.pom",
+      "sha1": "a7428ed679097b2b1747073cce4ec7eb0d08896d"
+    },
+    {
+      "path": "org/apache/cxf/cxf-parent/3.3.6/cxf-parent-3.3.6.pom",
+      "sha1": "93c64f1d69fec408e7a94eea48efd0038c967e43"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-bindings-soap/3.3.6/cxf-rt-bindings-soap-3.3.6.jar",
+      "sha1": "29c6d6b46b78a9e6149cf81c6d7499e2ba853c18"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-bindings-soap/3.3.6/cxf-rt-bindings-soap-3.3.6.pom",
+      "sha1": "37f46fd391a3284a3050744d086256bcd98de7b0"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-bindings-xml/3.3.6/cxf-rt-bindings-xml-3.3.6.jar",
+      "sha1": "e06e072d042308e9368ee2597e0ceb8ad5dfdd04"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-bindings-xml/3.3.6/cxf-rt-bindings-xml-3.3.6.pom",
+      "sha1": "28939270fbcac1ead0ec776bcf90b5fabcb9015e"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-databinding-jaxb/3.3.6/cxf-rt-databinding-jaxb-3.3.6.jar",
+      "sha1": "eb48eea795f4e47da6d232474223e4f1f4218f16"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-databinding-jaxb/3.3.6/cxf-rt-databinding-jaxb-3.3.6.pom",
+      "sha1": "a5cd92ba67c569510e7d9f0178b6154cc08a77fc"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-frontend-jaxws/3.3.6/cxf-rt-frontend-jaxws-3.3.6.jar",
+      "sha1": "49d24a3e1d0044ec9db848c1c5a89832e4ea8865"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-frontend-jaxws/3.3.6/cxf-rt-frontend-jaxws-3.3.6.pom",
+      "sha1": "f23a1db43475aa53099ebbe74ebdac6ce949ec61"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-frontend-simple/3.3.6/cxf-rt-frontend-simple-3.3.6.jar",
+      "sha1": "1a741fd83e7d40de3661d80eea76bc88462cda1d"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-frontend-simple/3.3.6/cxf-rt-frontend-simple-3.3.6.pom",
+      "sha1": "26f59a473b993cf85bbb68310edf643137536da7"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-javascript/3.3.6/cxf-rt-javascript-3.3.6.jar",
+      "sha1": "13d169c59eaceab58557800428938bc09110d836"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-javascript/3.3.6/cxf-rt-javascript-3.3.6.pom",
+      "sha1": "2e970c9fb9966d45c5801b25fd338f63bddf827a"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-transports-http/3.3.6/cxf-rt-transports-http-3.3.6.jar",
+      "sha1": "e5939dc3da573a05c5cc1c9318226faa9c00a3df"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-transports-http/3.3.6/cxf-rt-transports-http-3.3.6.pom",
+      "sha1": "68fdfcfbe57437d8db594f077992caa5f8d6efb9"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-ws-addr/3.3.6/cxf-rt-ws-addr-3.3.6.jar",
+      "sha1": "7cd2e6ae421cef0af5b56b2937196741cd7d8616"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-ws-addr/3.3.6/cxf-rt-ws-addr-3.3.6.pom",
+      "sha1": "f4f33755acb99e07987c7b0887bd42de68ccf1fc"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-wsdl/3.3.6/cxf-rt-wsdl-3.3.6.jar",
+      "sha1": "d8a46a9c17cd57325cb0c29351bfbae75b331aa7"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-wsdl/3.3.6/cxf-rt-wsdl-3.3.6.pom",
+      "sha1": "508fbab107c3f1eac1034d55f9b4ad23dd252cb0"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-ws-policy/3.3.6/cxf-rt-ws-policy-3.3.6.jar",
+      "sha1": "f831e1e6a9df736193f299e4169f0eaceb4d59c1"
+    },
+    {
+      "path": "org/apache/cxf/cxf-rt-ws-policy/3.3.6/cxf-rt-ws-policy-3.3.6.pom",
+      "sha1": "eb34ad5c0dc5c77f0187117c4058408120aacadb"
+    },
+    {
+      "path": "org/apache/cxf/cxf-runtime-javascript/3.3.6/cxf-runtime-javascript-3.3.6.pom",
+      "sha1": "8917ca74bdd9ecc92f06677e4e58f7e8dd3bad71"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-common/3.3.6/cxf-tools-common-3.3.6.jar",
+      "sha1": "5bb130f1326abccea3f148465659afb6fbbbfc11"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-common/3.3.6/cxf-tools-common-3.3.6.pom",
+      "sha1": "6a54032909f9be36ddd304d916642655b521b4ff"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-validator/3.3.6/cxf-tools-validator-3.3.6.jar",
+      "sha1": "3c223b62ec4e2a9db00c6be1ce37ce361743ca63"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-validator/3.3.6/cxf-tools-validator-3.3.6.pom",
+      "sha1": "d71bc5b00c6c6d791e8c967bb318b8930e8905b6"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-wsdlto-core/3.3.6/cxf-tools-wsdlto-core-3.3.6.jar",
+      "sha1": "f076d7e7979de4a7238118392fa4e37c0aca3d1a"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-wsdlto-core/3.3.6/cxf-tools-wsdlto-core-3.3.6.pom",
+      "sha1": "b290f769c7090dea534383d47e84fab118954a15"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-wsdlto-databinding-jaxb/3.3.6/cxf-tools-wsdlto-databinding-jaxb-3.3.6.jar",
+      "sha1": "8ef8ae93d0018d2e032aee85c19dac250fb3bc9e"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-wsdlto-databinding-jaxb/3.3.6/cxf-tools-wsdlto-databinding-jaxb-3.3.6.pom",
+      "sha1": "a26b0c87baff0a06f297b102db73444504f5f3fe"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-wsdlto-frontend-javascript/3.3.6/cxf-tools-wsdlto-frontend-javascript-3.3.6.jar",
+      "sha1": "b88c9bc9ff847c696b66de3f23e116a1ff0958a7"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-wsdlto-frontend-javascript/3.3.6/cxf-tools-wsdlto-frontend-javascript-3.3.6.pom",
+      "sha1": "5b37d3197b6624f5d0d2f9e0f4cbeabb337dc647"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-wsdlto-frontend-jaxws/3.3.6/cxf-tools-wsdlto-frontend-jaxws-3.3.6.jar",
+      "sha1": "4d510ba887d4ab5ba656268e215016aac99c30a1"
+    },
+    {
+      "path": "org/apache/cxf/cxf-tools-wsdlto-frontend-jaxws/3.3.6/cxf-tools-wsdlto-frontend-jaxws-3.3.6.pom",
+      "sha1": "cfb711a221e49a82063691eb7bc454534f1b646c"
+    },
+    {
+      "path": "org/apache/geronimo/genesis/genesis/2.0/genesis-2.0.pom",
+      "sha1": "8d7ac66279bb3dce6f19e43a68d9e761c40b7aa3"
+    },
+    {
+      "path": "org/apache/geronimo/genesis/genesis-default-flava/2.0/genesis-default-flava-2.0.pom",
+      "sha1": "3ad9b678150869f27aa7f92fb5359da79c74cda5"
+    },
+    {
+      "path": "org/apache/geronimo/genesis/genesis-java5-flava/2.0/genesis-java5-flava-2.0.pom",
+      "sha1": "045137568f17802240e75e9776c9d7d948f9673a"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpclient/4.0.2/httpclient-4.0.2.jar",
+      "sha1": "781b68c2fd5335de914166241b8d4bfe8c2f91b7"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpclient/4.0.2/httpclient-4.0.2.pom",
+      "sha1": "f218515f169bb93b7fd6c67fab0dedbaf832a8ae"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar",
+      "sha1": "d1577ae15f01ef5438c5afc62162457c00a34713"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.pom",
+      "sha1": "27f5d747aad49d36750ef3dffa30687963b4ddcd"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar",
+      "sha1": "a25c1be5ce99d0ce99aa43eb982868c796dd0775"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.pom",
+      "sha1": "2b382e49ec08a138a7f0b36916632517f6a6838e"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcomponents-client/4.0.2/httpcomponents-client-4.0.2.pom",
+      "sha1": "f068349e19ba323665d0bc49141333747b174f3f"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcomponents-client/4.5.3/httpcomponents-client-4.5.3.pom",
+      "sha1": "238c16d8fd6e8ac85f603d981f5c20efae9dac01"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcomponents-client/4.5.9/httpcomponents-client-4.5.9.pom",
+      "sha1": "ec94d21b5dacc56fac902390c7e37ca810ab6cff"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcomponents-core/4.0.1/httpcomponents-core-4.0.1.pom",
+      "sha1": "2766fab80fcc4f8bfdfe4f4a7cf151140ec8e0ed"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcomponents-core/4.4.11/httpcomponents-core-4.4.11.pom",
+      "sha1": "3cae168cde302e64df8c7f640102af6c58d2d867"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcomponents-core/4.4.6/httpcomponents-core-4.4.6.pom",
+      "sha1": "b5cd50c09bc253701c1b38d00582920b99ec229e"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcomponents-parent/11/httpcomponents-parent-11.pom",
+      "sha1": "3ee7a841cc49326e8681089ea7ad6a3b81b88581"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcore/4.0.1/httpcore-4.0.1.pom",
+      "sha1": "d965db94102b75a50bd29938ef67105da1535554"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcore/4.0.1/httpcore-4.0.1.jar",
+      "sha1": "e813b8722c387b22e1adccf7914729db09bcb4a9"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcore/4.4.11/httpcore-4.4.11.jar",
+      "sha1": "de748cf874e4e193b42eceea9fe5574fabb9d4df"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcore/4.4.11/httpcore-4.4.11.pom",
+      "sha1": "f055c410b7d91bd8fdcc2efef1fbce44843f2404"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar",
+      "sha1": "e3fd8ced1f52c7574af952e2e6da0df8df08eb82"
+    },
+    {
+      "path": "org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.pom",
+      "sha1": "d14da1e1f5682c8055b81dc87de20f97536a1d06"
+    },
+    {
+      "path": "org/apache/httpcomponents/project/4.0/project-4.0.pom",
+      "sha1": "096553966ef79545593062a0c6057a821e39d284"
+    },
+    {
+      "path": "org/apache/httpcomponents/project/4.1/project-4.1.pom",
+      "sha1": "b63ff67e6ffc1940041319e0e06d7c6b1d671fd2"
+    },
+    {
+      "path": "org/apache/httpcomponents/project/7/project-7.pom",
+      "sha1": "c486760d8e0eafe8d4932450e386c2805364f782"
+    },
+    {
+      "path": "org/apache/jackrabbit/jackrabbit-jcr-commons/1.5.0/jackrabbit-jcr-commons-1.5.0.pom",
+      "sha1": "881b2eb55e9b03c1ad9ba9eb0b60056c8af55bff"
+    },
+    {
+      "path": "org/apache/jackrabbit/jackrabbit-jcr-commons/1.5.0/jackrabbit-jcr-commons-1.5.0.jar",
+      "sha1": "816ca280dc631b277e7b963723f2e99b038383f2"
+    },
+    {
+      "path": "org/apache/jackrabbit/jackrabbit-parent/1.5.0/jackrabbit-parent-1.5.0.pom",
+      "sha1": "d2e72b184d4818d9bc0ae402275c9f1b46db34ec"
+    },
+    {
+      "path": "org/apache/jackrabbit/jackrabbit-webdav/1.5.0/jackrabbit-webdav-1.5.0.pom",
+      "sha1": "f2e6040a9aca2eec20229af0e10b1ac72bec9714"
+    },
+    {
+      "path": "org/apache/jackrabbit/jackrabbit-webdav/1.5.0/jackrabbit-webdav-1.5.0.jar",
+      "sha1": "b14c7fbbd34862d4d51c5e72ba3a69cde892c260"
+    },
+    {
+      "path": "org/apache/logging/log4j/log4j-bom/2.7/log4j-bom-2.7.pom",
+      "sha1": "3cb5745a896d50e860c2548203b1f501e814dce6"
+    },
+    {
+      "path": "org/apache/lucene/lucene-analyzers-common/8.4.1/lucene-analyzers-common-8.4.1.jar",
+      "sha1": "e4abdbc0e40b331b8ae90f7d94aed7f15b1547f1"
+    },
+    {
+      "path": "org/apache/lucene/lucene-analyzers-common/8.4.1/lucene-analyzers-common-8.4.1.pom",
+      "sha1": "c45215d677c5b07825fdebeb195d1220a2dab6f0"
+    },
+    {
+      "path": "org/apache/lucene/lucene-core/8.4.1/lucene-core-8.4.1.jar",
+      "sha1": "3f5ca09644bdbd50593d664766d087c8b82f466d"
+    },
+    {
+      "path": "org/apache/lucene/lucene-core/8.4.1/lucene-core-8.4.1.pom",
+      "sha1": "8216d7d67c643075d5d9315e7cdefb0f5f4eceb6"
+    },
+    {
+      "path": "org/apache/lucene/lucene-parent/8.4.1/lucene-parent-8.4.1.pom",
+      "sha1": "2e49e017bc64686e3473f280130de0722ab1adef"
+    },
+    {
+      "path": "org/apache/lucene/lucene-queries/8.4.1/lucene-queries-8.4.1.pom",
+      "sha1": "0813e7e3b7ce85ecdb8bd7cda23f82421517bd11"
+    },
+    {
+      "path": "org/apache/lucene/lucene-queries/8.4.1/lucene-queries-8.4.1.jar",
+      "sha1": "992e68fb0f2422dc47859a4335d6f80d9ccf4721"
+    },
+    {
+      "path": "org/apache/lucene/lucene-queryparser/8.4.1/lucene-queryparser-8.4.1.jar",
+      "sha1": "32f0491f0f4afa156d0c25d4ca977912a0c6f392"
+    },
+    {
+      "path": "org/apache/lucene/lucene-queryparser/8.4.1/lucene-queryparser-8.4.1.pom",
+      "sha1": "144a4c6d4d4fc9488538f7c0f715081559384612"
+    },
+    {
+      "path": "org/apache/lucene/lucene-sandbox/8.4.1/lucene-sandbox-8.4.1.pom",
+      "sha1": "b262e75298e47716458906cd22af1b6d5e59ccf4"
+    },
+    {
+      "path": "org/apache/lucene/lucene-sandbox/8.4.1/lucene-sandbox-8.4.1.jar",
+      "sha1": "9489233c9a98e524f0b994ba2ebaa9870924848a"
+    },
+    {
+      "path": "org/apache/lucene/lucene-solr-grandparent/8.4.1/lucene-solr-grandparent-8.4.1.pom",
+      "sha1": "301d6bc3b71687d97ef951ead66bc4719cfee391"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom",
+      "sha1": "fff8727b6ff366d624669f4b8dc4d4c7316bbb0c"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.0/doxia-1.0.pom",
+      "sha1": "250d5a027daedc96539e3b3def7da7911feb6aae"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.1.2/doxia-1.1.2.pom",
+      "sha1": "668f8032acaaab3e4afd14ddc2553e60cb583d46"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.1/doxia-1.1.pom",
+      "sha1": "b2306ce11082ee839fa2deee1fe4f1122c15227c"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.2/doxia-1.2.pom",
+      "sha1": "1cd5c098f618eec281c1b8716f90fa2680c5d26a"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.3/doxia-1.3.pom",
+      "sha1": "846b81565bf421e1bff91493d84764c818f42ad0"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.4/doxia-1.4.pom",
+      "sha1": "121c5566d364de8190fcab422b41870acb86f2de"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.6/doxia-1.6.pom",
+      "sha1": "08acdcf813dddb754acb38173b4d764403583bb5"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.7/doxia-1.7.pom",
+      "sha1": "759b18dbe82968819b6ec72ecf3c3d3e595cb91f"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia/1.8/doxia-1.8.pom",
+      "sha1": "ead594fa11c1ab1712a1d4333854cccd28fbff3a"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-core/1.1.2/doxia-core-1.1.2.jar",
+      "sha1": "30b5f95ed31d612ad3c64af82904f82e6d4ab29c"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-core/1.1.2/doxia-core-1.1.2.pom",
+      "sha1": "8b1daa68be3d5596235cd59ff4017673a2a9b2be"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-core/1.2/doxia-core-1.2.jar",
+      "sha1": "58675d96dbee38691c7085d12907a9fd04ff27d3"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-core/1.2/doxia-core-1.2.pom",
+      "sha1": "d3a20de5a35d5f51c06d7d85818a9dee9e6f05fc"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-core/1.4/doxia-core-1.4.jar",
+      "sha1": "1e9ee5aa729da72e9e9884462782c005592d2075"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-core/1.4/doxia-core-1.4.pom",
+      "sha1": "c63b7012f6fc2f9636ed7e37c4e6cf3b59ad4021"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-core/1.7/doxia-core-1.7.jar",
+      "sha1": "2b60ca4ed2fa959361e7107083925973de509126"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-core/1.7/doxia-core-1.7.pom",
+      "sha1": "560e99d8a920499735b05fa7eaf147c9021327dc"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-core/1.8/doxia-core-1.8.pom",
+      "sha1": "e3a58b974e1d3360932f03249dcb8797a7dcb3b7"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.1.2/doxia-decoration-model-1.1.2.jar",
+      "sha1": "172cda539c83280c3f7a60022337f454e98c029d"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.1.2/doxia-decoration-model-1.1.2.pom",
+      "sha1": "31e0c58d7cb9c3ee7ee93f3ce8a3077d0ee8edc3"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.2/doxia-decoration-model-1.2.pom",
+      "sha1": "b21179344a7a25ae86298e1a051508ecb54ff118"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.3/doxia-decoration-model-1.3.pom",
+      "sha1": "b5a1b9d49410326e37020dfa716ceb7901c40469"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.4/doxia-decoration-model-1.4.pom",
+      "sha1": "deaf255b7f237392dde3f76100300a41c8409532"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.4/doxia-decoration-model-1.4.jar",
+      "sha1": "ffa7fabafef8ba0accc794d025f9790320220e1e"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.6/doxia-decoration-model-1.6.pom",
+      "sha1": "4009e46e902f2ebaac97670fc4d0b973206ce78c"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.7.4/doxia-decoration-model-1.7.4.jar",
+      "sha1": "e0b3ed5b1fdd4df92e0981a57796eedd055654c2"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.7.4/doxia-decoration-model-1.7.4.pom",
+      "sha1": "93ac3cc4743537aa38c0c56f93a6d21bea836993"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.7/doxia-decoration-model-1.7.pom",
+      "sha1": "36f76cba50f38bbebbb941bf7e0215dcd32f7b02"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.7/doxia-decoration-model-1.7.jar",
+      "sha1": "7c38b133d2f51cae82e7b3e86a3e9941396fdeda"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-decoration-model/1.8/doxia-decoration-model-1.8.pom",
+      "sha1": "b0bf88afa5dfcff2cda41b80d1806af697da8101"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-integration-tools/1.5/doxia-integration-tools-1.5.jar",
+      "sha1": "ee43d4ccb9e5cc4067ac4f4de9b50e89de2f1191"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-integration-tools/1.5/doxia-integration-tools-1.5.pom",
+      "sha1": "b2384c4865857d55209a95ac4a21f2d358984f57"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-integration-tools/1.6/doxia-integration-tools-1.6.jar",
+      "sha1": "aa12128117facfa64c1ac8b8f70c6cf1dbf8b5ca"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-integration-tools/1.6/doxia-integration-tools-1.6.pom",
+      "sha1": "9793d30249abc7b4d66cc4a45f25dae88c893c7d"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.1.2/doxia-logging-api-1.1.2.jar",
+      "sha1": "13b7385b902c62e0bf7d81b57115c09de92c7dfd"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.1.2/doxia-logging-api-1.1.2.pom",
+      "sha1": "4b9beb2341dcf0755f60503fc210eb9d015b4fba"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.1/doxia-logging-api-1.1.jar",
+      "sha1": "c8fe274396e40452ca3e6121f6dd00220b210d48"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.1/doxia-logging-api-1.1.pom",
+      "sha1": "511c87192bc6c0883d077ba7ae7ddbe8a2d06fa9"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.2/doxia-logging-api-1.2.pom",
+      "sha1": "369a028bcaa2b7aa935cbd0fd1483d2f4a4d64f4"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.3/doxia-logging-api-1.3.pom",
+      "sha1": "7e790be737ddf90d7dc519899c735c34ed80ee4f"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.4/doxia-logging-api-1.4.jar",
+      "sha1": "fd0ab30404ac0fca5f672eee70acf5d17a1ea856"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.4/doxia-logging-api-1.4.pom",
+      "sha1": "042598efe5bf93859b9366c333c2398af28a2bb5"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.6/doxia-logging-api-1.6.pom",
+      "sha1": "483135610509c3ccd9137b3dbdaaed18c338f2d8"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.7/doxia-logging-api-1.7.jar",
+      "sha1": "026b1ace473b018f4b0053f7d525ddd1cfb777df"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.7/doxia-logging-api-1.7.pom",
+      "sha1": "3fe03624c99b6a4e42b9aa5d69483e89f87d8cf2"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.8/doxia-logging-api-1.8.pom",
+      "sha1": "7879a4d6f88550292916db70ad51b80e40d5a8fb"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-logging-api/1.8/doxia-logging-api-1.8.jar",
+      "sha1": "7c6642d71e3d3ec0cb28f59cfa1ce1a8a37f7f48"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-apt/1.4/doxia-module-apt-1.4.jar",
+      "sha1": "2b6fc70f6906e74eee049cc30f8385e49381c16f"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-apt/1.4/doxia-module-apt-1.4.pom",
+      "sha1": "ea9c06223beac7056ead3a5f59089a722cefc3c1"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-fml/1.1.2/doxia-module-fml-1.1.2.pom",
+      "sha1": "a67977d8431a26fa886640f3c465f77cbdfa8ea7"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-fml/1.1.2/doxia-module-fml-1.1.2.jar",
+      "sha1": "923531d55433db173b9479cd7af7ef5c2ee023da"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-fml/1.2/doxia-module-fml-1.2.pom",
+      "sha1": "3cb507500869ea4b9e179bf2a5384707bda2c353"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-fml/1.4/doxia-module-fml-1.4.jar",
+      "sha1": "d27851cfa0a355070acdc0482de3e94c0140b5db"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-fml/1.4/doxia-module-fml-1.4.pom",
+      "sha1": "90437de25862f0793b82ed02794633ef8a7cce7b"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-fml/1.7/doxia-module-fml-1.7.jar",
+      "sha1": "279b3ef8b706a0c00ffaba005022590ba63c9a04"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-fml/1.7/doxia-module-fml-1.7.pom",
+      "sha1": "d20427886992fde3c609be70aab5f030b5857267"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-markdown/1.4/doxia-module-markdown-1.4.jar",
+      "sha1": "90c587acc8b13dea639ffeb43854165a6531a011"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-markdown/1.4/doxia-module-markdown-1.4.pom",
+      "sha1": "24752d9a71235113ead7366fc16d087973583cf9"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-modules/1.1.2/doxia-modules-1.1.2.pom",
+      "sha1": "140b04b333b6c55dc713e3d6903af857bec7148f"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-modules/1.2/doxia-modules-1.2.pom",
+      "sha1": "0fce38d9ab92c6e5bd6decdc4a7713cec1bff714"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-modules/1.4/doxia-modules-1.4.pom",
+      "sha1": "4a72322c7c467a8a4b67993c2d0eee076a294c7c"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-modules/1.7/doxia-modules-1.7.pom",
+      "sha1": "25eca23b98354dd10019d8f405b9691d3127a9f3"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-modules/1.8/doxia-modules-1.8.pom",
+      "sha1": "c63d13ce5af9a69ae9a175f4c1d4734f4dde76f6"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xdoc/1.4/doxia-module-xdoc-1.4.jar",
+      "sha1": "cf7d317034a3c8ab170076a4f82f6371ca5e6791"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xdoc/1.4/doxia-module-xdoc-1.4.pom",
+      "sha1": "e2df0753311a295cfbf6e18894b17b5d1c02b5f8"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xhtml/1.1.2/doxia-module-xhtml-1.1.2.pom",
+      "sha1": "3bc83b22bf4b654b2ed2c1b902b0cabde23c0e4c"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xhtml/1.1.2/doxia-module-xhtml-1.1.2.jar",
+      "sha1": "11566856aa0bd7780842de4be791d583df8ad8bf"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xhtml/1.2/doxia-module-xhtml-1.2.pom",
+      "sha1": "da521780a03c3ef10917fd918e33ee19f2756510"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xhtml/1.4/doxia-module-xhtml-1.4.jar",
+      "sha1": "109b0b6b49fdd166b036c7fce93393fa98002c66"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xhtml/1.4/doxia-module-xhtml-1.4.pom",
+      "sha1": "98902234bd791acb345e987a0513b25daf061196"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xhtml/1.7/doxia-module-xhtml-1.7.pom",
+      "sha1": "d1f0d5a3a7f54e44185eedfd244c4f7a3fb95b56"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xhtml/1.7/doxia-module-xhtml-1.7.jar",
+      "sha1": "feb193a7bf81cca98270657c8757273016abac8a"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xhtml/1.8/doxia-module-xhtml-1.8.jar",
+      "sha1": "9437f7bc2e1edc5b8fbbe0e6d433c7acb88d0fbb"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-module-xhtml/1.8/doxia-module-xhtml-1.8.pom",
+      "sha1": "9817b0901cd586a2f30c29e2f10885797446961c"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar",
+      "sha1": "68464d54384c35119c70684d5d609b64635d1bbd"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom",
+      "sha1": "d8e08f33563f684917311978da2ff03a9d0022ab"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.jar",
+      "sha1": "13f502f2fb1d4e2db6f19352c85b83277084bb98"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.pom",
+      "sha1": "5d842372fdb4c42d78824141f7be4c0d541c983f"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.1.2/doxia-sink-api-1.1.2.pom",
+      "sha1": "75136eed3dde652c62a0e6381e9a2c9aa7d4e406"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.1/doxia-sink-api-1.1.jar",
+      "sha1": "9fc15c69e09a14fd07acba7300009eff6e692a44"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.1/doxia-sink-api-1.1.pom",
+      "sha1": "0a73bb471bb8fe69ed25d59c348139e6afb834bc"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.2/doxia-sink-api-1.2.pom",
+      "sha1": "d50511019c3eae662d803f6722d353fd0af2e37d"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.4/doxia-sink-api-1.4.jar",
+      "sha1": "3cfed174cabb086426a9043da49a70526ff40d16"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.4/doxia-sink-api-1.4.pom",
+      "sha1": "a613738017689a91136272266089def6a2b3db49"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.7/doxia-sink-api-1.7.jar",
+      "sha1": "64482f540f8f45c0749b2febdb78ee3148a52b58"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.7/doxia-sink-api-1.7.pom",
+      "sha1": "f5ddf9d07d15a9d1932f83f9363d83a7af6ff0d7"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sink-api/1.8/doxia-sink-api-1.8.pom",
+      "sha1": "aa28b03f702f14fb1e2592a4ba4383a661f47477"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.1.2/doxia-site-renderer-1.1.2.jar",
+      "sha1": "3b089bbe153468845e6caabd35c2a8b879939ee4"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.1.2/doxia-site-renderer-1.1.2.pom",
+      "sha1": "d573268a39d0a32d2953c64cb50a41310a4a0e54"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.2/doxia-site-renderer-1.2.pom",
+      "sha1": "02d945960abfc9ff27d0b0ad76a5e806c7c776a1"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.4/doxia-site-renderer-1.4.jar",
+      "sha1": "91acd32a131407bccefd2971c1103c5d16002da2"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.4/doxia-site-renderer-1.4.pom",
+      "sha1": "467421ba1c1e1a64e5f201e72c777e5d97abf52d"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.7.4/doxia-site-renderer-1.7.4.pom",
+      "sha1": "00e35ba096e37e3082982af7c839d44d54f532e8"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.7/doxia-site-renderer-1.7.jar",
+      "sha1": "744cb7b750b3c20cab024de81627d3242f37f11f"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.7/doxia-site-renderer-1.7.pom",
+      "sha1": "44ad08c120e723d3495d56d8202defeb8bb27e4d"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.8/doxia-site-renderer-1.8.jar",
+      "sha1": "8d4f7700c17c7b95fef7e569b874efbfbe1b9902"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-site-renderer/1.8/doxia-site-renderer-1.8.pom",
+      "sha1": "76bc8e09c757e643ff183407840f76f39292cec1"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sitetools/1.1.2/doxia-sitetools-1.1.2.pom",
+      "sha1": "bd8d1ffc9be982aa9522fa7919e31bf3db453941"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sitetools/1.2/doxia-sitetools-1.2.pom",
+      "sha1": "78990d3ce17fbf65b8e4290b043bac7868a3e51d"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sitetools/1.3/doxia-sitetools-1.3.pom",
+      "sha1": "3564c1392c7dee9b6b99015fcc96813206266570"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sitetools/1.4/doxia-sitetools-1.4.pom",
+      "sha1": "09cf8365031618c2d39ea0118e1a75be6ba18b66"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sitetools/1.6/doxia-sitetools-1.6.pom",
+      "sha1": "561855c84f27d4c5dd00dda557c3bf9efc1dbad9"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sitetools/1.7.4/doxia-sitetools-1.7.4.pom",
+      "sha1": "08771214df4ba46109dcb2a57842b24e88183317"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sitetools/1.7/doxia-sitetools-1.7.pom",
+      "sha1": "d368229effd28806788a58b85d4b14f40a51f633"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-sitetools/1.8/doxia-sitetools-1.8.pom",
+      "sha1": "82adc678bf107faead3e30289e979b156ace93a6"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-skin-model/1.7.4/doxia-skin-model-1.7.4.pom",
+      "sha1": "d589f14ae6759587cd25f8137d72c91b1556b916"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-skin-model/1.7/doxia-skin-model-1.7.jar",
+      "sha1": "af19669088373e1ac2eb53948b04afb435e0c8fe"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-skin-model/1.7/doxia-skin-model-1.7.pom",
+      "sha1": "8233feaa3d6280880643231c906cccc8871782ea"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-skin-model/1.8/doxia-skin-model-1.8.jar",
+      "sha1": "5ee2a7c03be388e69d502a1ca1d080153fb70dc3"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-skin-model/1.8/doxia-skin-model-1.8.pom",
+      "sha1": "26117432fb09732eaa90eddbc3153edf92311b93"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-tools/2/doxia-tools-2.pom",
+      "sha1": "c13f811b01d98631ebe9131b63aeb6bded234aff"
+    },
+    {
+      "path": "org/apache/maven/doxia/doxia-tools/3/doxia-tools-3.pom",
+      "sha1": "aadd84e5a564ed471990a24e56c5c9b484fb1438"
+    },
+    {
+      "path": "org/apache/maven/enforcer/enforcer/3.0.0-M3/enforcer-3.0.0-M3.pom",
+      "sha1": "d5b86bda7848d3cab31000e677efc026cffeec27"
+    },
+    {
+      "path": "org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.jar",
+      "sha1": "984df5598888ef1502be1f60420f3d5a088d7add"
+    },
+    {
+      "path": "org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.pom",
+      "sha1": "3cdea14463f23dd9d9f6feb6c745c18cb800c7a3"
+    },
+    {
+      "path": "org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.jar",
+      "sha1": "2b5956007000d4e9662cf1aabed785cd6423d727"
+    },
+    {
+      "path": "org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.pom",
+      "sha1": "60f2caf13f736335342d94d1bbf22582ea0c3300"
+    },
+    {
+      "path": "org/apache/maven/jxr/jxr/3.0.0/jxr-3.0.0.pom",
+      "sha1": "d345ebdf3287077ef5b6cc94b97b398fdfc42d7e"
+    },
+    {
+      "path": "org/apache/maven/maven/2.0.10/maven-2.0.10.pom",
+      "sha1": "d79e3299a4ebb7bd50ca8208b86a7c1d9394ae7b"
+    },
+    {
+      "path": "org/apache/maven/maven/2.0.2/maven-2.0.2.pom",
+      "sha1": "816e22beec3ee5c4a344959625a824bb6202daeb"
+    },
+    {
+      "path": "org/apache/maven/maven/2.0.5/maven-2.0.5.pom",
+      "sha1": "9801e4423479367099ad4507c51c4f7f5b19bc6f"
+    },
+    {
+      "path": "org/apache/maven/maven/2.0.6/maven-2.0.6.pom",
+      "sha1": "1991be0ed3e1820e135201406d5acabf8c08d426"
+    },
+    {
+      "path": "org/apache/maven/maven/2.0.8/maven-2.0.8.pom",
+      "sha1": "0b6bdac7d11f0fc5c4c4bb0f336323f7b86cddc0"
+    },
+    {
+      "path": "org/apache/maven/maven/2.0.9/maven-2.0.9.pom",
+      "sha1": "696e3d1eaf254c63347613715faa31e5eecb282d"
+    },
+    {
+      "path": "org/apache/maven/maven/2.2.0/maven-2.2.0.pom",
+      "sha1": "c5bb0fda80306d0d27b3221d511c5032c95b27fa"
+    },
+    {
+      "path": "org/apache/maven/maven/2.2.1/maven-2.2.1.pom",
+      "sha1": "7bc311044fbacb404de025b76feefa3567f0e5d7"
+    },
+    {
+      "path": "org/apache/maven/maven/3.0/maven-3.0.pom",
+      "sha1": "30c961aaf964aadcc028102ebe03d1afff324ec0"
+    },
+    {
+      "path": "org/apache/maven/maven/3.1.0/maven-3.1.0.pom",
+      "sha1": "d529c90764cc6292f9581e33ce828cc3fd4e34c5"
+    },
+    {
+      "path": "org/apache/maven/maven/3.1.1/maven-3.1.1.pom",
+      "sha1": "309f55e492c59e5ad5008dc86293ba0c3b6eb616"
+    },
+    {
+      "path": "org/apache/maven/maven/3.2.1/maven-3.2.1.pom",
+      "sha1": "54af5be0a5677e896e9eaa356bbb82abda06bd76"
+    },
+    {
+      "path": "org/apache/maven/maven/3.6.0/maven-3.6.0.pom",
+      "sha1": "71a9c61a0a83bdcc4ac0dbd0702281cd0105636c"
+    },
+    {
+      "path": "org/apache/maven/maven/3.6.3/maven-3.6.3.pom",
+      "sha1": "e3e8e83914f00e2f6e88b76d600fc7ea7456f6e0"
+    },
+    {
+      "path": "org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.jar",
+      "sha1": "419f5eb63cf743a1a0f2a80ea5dde37fd1a4fec0"
+    },
+    {
+      "path": "org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.pom",
+      "sha1": "a3e7fa0d4d0d26f901c919173681bab824c5588c"
+    },
+    {
+      "path": "org/apache/maven/maven-aether-provider/3.1.0/maven-aether-provider-3.1.0.jar",
+      "sha1": "dda2231a2be2768109d474805c702b76a8e794e6"
+    },
+    {
+      "path": "org/apache/maven/maven-aether-provider/3.1.0/maven-aether-provider-3.1.0.pom",
+      "sha1": "7110ccc3760777302afd19972b8609d5ea167607"
+    },
+    {
+      "path": "org/apache/maven/maven-aether-provider/3.2.1/maven-aether-provider-3.2.1.jar",
+      "sha1": "ab57cafec4e9c2650df963d83cb173d311fcadf0"
+    },
+    {
+      "path": "org/apache/maven/maven-aether-provider/3.2.1/maven-aether-provider-3.2.1.pom",
+      "sha1": "f23de711bad770bc374fa4d3c669bb2e1942f705"
+    },
+    {
+      "path": "org/apache/maven/maven-archiver/2.4.2/maven-archiver-2.4.2.jar",
+      "sha1": "ddcb393749701eb292a263a3500db69df39aef43"
+    },
+    {
+      "path": "org/apache/maven/maven-archiver/2.4.2/maven-archiver-2.4.2.pom",
+      "sha1": "5529ed1bd724ba24d7d170e77e36d7277fefe6a1"
+    },
+    {
+      "path": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar",
+      "sha1": "c999ae305f22ecfc5a000dca12a39b9491778bd5"
+    },
+    {
+      "path": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom",
+      "sha1": "a46a65782b96c7624c0ff64b50a91ba2935d84f6"
+    },
+    {
+      "path": "org/apache/maven/maven-archiver/2.6/maven-archiver-2.6.jar",
+      "sha1": "e0f87fd4d03b9f0c09908c4d0c398acd501a11d8"
+    },
+    {
+      "path": "org/apache/maven/maven-archiver/2.6/maven-archiver-2.6.pom",
+      "sha1": "4ec1cabb4e850b9f5c36761dbf07915f2445d8c1"
+    },
+    {
+      "path": "org/apache/maven/maven-archiver/3.4.0/maven-archiver-3.4.0.pom",
+      "sha1": "aa4c600afe718e77b4c4f46fa6c705d936f49254"
+    },
+    {
+      "path": "org/apache/maven/maven-archiver/3.4.0/maven-archiver-3.4.0.jar",
+      "sha1": "95f7b3498b9295ff203393107fbaf439d08204db"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/2.0.10/maven-artifact-2.0.10.pom",
+      "sha1": "79570a5cf88d69f6472f9b65f86372b6d84a4254"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/2.0.2/maven-artifact-2.0.2.pom",
+      "sha1": "a8b0aa4f932e948f979c872326a5ac9d7f4e123c"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/2.0.5/maven-artifact-2.0.5.pom",
+      "sha1": "d4b90628e1e33c3d2319aa3279f6498905fb7bd8"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom",
+      "sha1": "973c14299a051daf4e767cc60f15788b50c887f2"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar",
+      "sha1": "fcbf6e26a6d26ecaa25c199b6f16bf168b2f28dc"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom",
+      "sha1": "ffc6bb3eabd75a28d704e0431e7a44e7b4dff9bd"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar",
+      "sha1": "66f0c8baa789fffdf54924cf395b26bbc2130435"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.jar",
+      "sha1": "23600f790d4dab2cb965419eaa982e3e84c428f8"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom",
+      "sha1": "e37430ef3c3ee1d33817fdb45a0e538f49932c0a"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.jar",
+      "sha1": "c29cfa43ce2ba09975a07c40d7241655d7c2fa29"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.pom",
+      "sha1": "6823c7ad1a5557c2f96bd2fd312948513af8e524"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/3.1.0/maven-artifact-3.1.0.pom",
+      "sha1": "29d03c0c9e8e47bcc1ab504e574fc235f6e6df83"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/3.1.1/maven-artifact-3.1.1.jar",
+      "sha1": "dbd94f0744545e17caa51db6fc493fc736361837"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/3.1.1/maven-artifact-3.1.1.pom",
+      "sha1": "46d62b88179ee741c0772f4eb959dc23ef403a03"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar",
+      "sha1": "d4c0da647de59c9ccc304a112fe1f1474d49e8eb"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.pom",
+      "sha1": "61b4cf4e87d2e6e4e319c12091d05a2a9d1b0aa2"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/3.6.3/maven-artifact-3.6.3.jar",
+      "sha1": "f8ff8032903882376e8d000c51e3e16d20fc7df7"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact/3.6.3/maven-artifact-3.6.3.pom",
+      "sha1": "c38391246e1dff05f3aca50ad2edb8b0ce2fdfba"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.0.10/maven-artifact-manager-2.0.10.pom",
+      "sha1": "46d1bab9afd325c06e6c26510215949f955e7636"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.jar",
+      "sha1": "982eee8d0feb92587beb60874c731febc6d9ed9d"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.pom",
+      "sha1": "157c24fb3ec09b9a693f88dc571fc17ed0669cca"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar",
+      "sha1": "dc326c3a989c10618e09a7b77cadeff297591942"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom",
+      "sha1": "8cb8b1dc4d9f7fbd90be4e9c8e9a1d353e28666c"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.0.8/maven-artifact-manager-2.0.8.jar",
+      "sha1": "bb5ba069e3460450b139075b91f27f7bd4007877"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.0.8/maven-artifact-manager-2.0.8.pom",
+      "sha1": "5c9b2820e6abe0c070c0dedfdacf642a85abf2e6"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom",
+      "sha1": "84c14dcd1d85eebccbba665f95057b5748f51d83"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar",
+      "sha1": "53224a5254101fb9b6d561d5a53c6d0817036d94"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.2.0/maven-artifact-manager-2.2.0.pom",
+      "sha1": "91b2c4b9a4cb63846da595ff15df78ebc7f1b31f"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.jar",
+      "sha1": "ec355b913c34d37080810f98e3f51abecbe1572b"
+    },
+    {
+      "path": "org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom",
+      "sha1": "062f05a1fc0a40a6ea8fc8f0a1e9e2c02057ebaf"
+    },
+    {
+      "path": "org/apache/maven/maven-compat/3.0/maven-compat-3.0.jar",
+      "sha1": "475f94b86858a1d4660c4b4523aa3362f28d9317"
+    },
+    {
+      "path": "org/apache/maven/maven-compat/3.0/maven-compat-3.0.pom",
+      "sha1": "5d80e73e5627180e3eaf021d63fabaddd6a75a6f"
+    },
+    {
+      "path": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar",
+      "sha1": "33b78ed70029bfca9fadee5c8e7c9b27b9a39443"
+    },
+    {
+      "path": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom",
+      "sha1": "b02365ee1822cff5839d9f85bc9b1cbfab9f5674"
+    },
+    {
+      "path": "org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.jar",
+      "sha1": "6f488e461188496c62e161f32160b3465ce5901e"
+    },
+    {
+      "path": "org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom",
+      "sha1": "c7312a507d519047be160bab5cbb56c07d0247a1"
+    },
+    {
+      "path": "org/apache/maven/maven-core/3.0/maven-core-3.0.jar",
+      "sha1": "73728ce32c9016c8bd05584301fa3ba3a6f5d20a"
+    },
+    {
+      "path": "org/apache/maven/maven-core/3.0/maven-core-3.0.pom",
+      "sha1": "3727542038487060064a4a14b74c7590d364c45b"
+    },
+    {
+      "path": "org/apache/maven/maven-core/3.1.0/maven-core-3.1.0.jar",
+      "sha1": "3aca07a1e496f1fb9c0d2d950b6aac7779c67b98"
+    },
+    {
+      "path": "org/apache/maven/maven-core/3.1.0/maven-core-3.1.0.pom",
+      "sha1": "95634e1849f1d9acd0d2709935417195ddd610c1"
+    },
+    {
+      "path": "org/apache/maven/maven-core/3.1.1/maven-core-3.1.1.jar",
+      "sha1": "ab7a9b58a1a4dec17facebda058d1da2a34871ff"
+    },
+    {
+      "path": "org/apache/maven/maven-core/3.1.1/maven-core-3.1.1.pom",
+      "sha1": "7693daf50b79dcebd24bff6471406964408523f8"
+    },
+    {
+      "path": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar",
+      "sha1": "49f5380c07a79cd91ee09e0cb9063764f1f6525c"
+    },
+    {
+      "path": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom",
+      "sha1": "31c0ce961dfc5b491e92ad0804dd48840dac7796"
+    },
+    {
+      "path": "org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.jar",
+      "sha1": "e81bb342d7d172f23d108dc8fa979a1facdcde8e"
+    },
+    {
+      "path": "org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom",
+      "sha1": "5074991d8d14a88e7c8bff294639a254d7ef387a"
+    },
+    {
+      "path": "org/apache/maven/maven-jxr/3.0.0/maven-jxr-3.0.0.jar",
+      "sha1": "aa5632846150e137dd214c790c91eef150764dc9"
+    },
+    {
+      "path": "org/apache/maven/maven-jxr/3.0.0/maven-jxr-3.0.0.pom",
+      "sha1": "037733c1f2fad927feb26d70651d410371770343"
+    },
+    {
+      "path": "org/apache/maven/maven-model/2.0.10/maven-model-2.0.10.pom",
+      "sha1": "a9d1ee85a9a3194bafc184842ce9054f191523d9"
+    },
+    {
+      "path": "org/apache/maven/maven-model/2.0.5/maven-model-2.0.5.pom",
+      "sha1": "0b5c0e9a116a812ef64831e5be5114bb4f518e58"
+    },
+    {
+      "path": "org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar",
+      "sha1": "9649253c0e68a453f388e0a308c0653309f87807"
+    },
+    {
+      "path": "org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom",
+      "sha1": "ea1dd9b8c7b1c3d2f0bdf314390ed7da7e463460"
+    },
+    {
+      "path": "org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom",
+      "sha1": "0978fe1857f847436fd3c454d25161e26fb2d5ec"
+    },
+    {
+      "path": "org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar",
+      "sha1": "9fb844625928dd992842e180853fbb2b197c9a9d"
+    },
+    {
+      "path": "org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.jar",
+      "sha1": "c0a1c17436ec3ff5a56207c031d82277b4250a29"
+    },
+    {
+      "path": "org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom",
+      "sha1": "548a7e6354c1bc4a49dbec6bd17b4f8e9310201b"
+    },
+    {
+      "path": "org/apache/maven/maven-model/3.0/maven-model-3.0.pom",
+      "sha1": "3aa89da7792286192b860c58841b3907364d33a8"
+    },
+    {
+      "path": "org/apache/maven/maven-model/3.0/maven-model-3.0.jar",
+      "sha1": "24ce598c94a78341c42556fe9192dad6a2822405"
+    },
+    {
+      "path": "org/apache/maven/maven-model/3.1.0/maven-model-3.1.0.jar",
+      "sha1": "82b2f097c1cc9a8d0e6b99af5e56327d5002c30f"
+    },
+    {
+      "path": "org/apache/maven/maven-model/3.1.0/maven-model-3.1.0.pom",
+      "sha1": "3e7b6ecee46f39f4ba482d5ad47669cd4f239a26"
+    },
+    {
+      "path": "org/apache/maven/maven-model/3.1.1/maven-model-3.1.1.jar",
+      "sha1": "ccf79a1a63ef35de038a4226a952175c4e9f4f59"
+    },
+    {
+      "path": "org/apache/maven/maven-model/3.1.1/maven-model-3.1.1.pom",
+      "sha1": "e8dda5a554edf7d4159db58a06f501c1ef074a12"
+    },
+    {
+      "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar",
+      "sha1": "06d73e6218a10cfe82cf0325b582cbed732cc751"
+    },
+    {
+      "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.pom",
+      "sha1": "a9c856704f9dc1b8f416a7587c420629a81cc886"
+    },
+    {
+      "path": "org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.jar",
+      "sha1": "bedc161a3b07a4bcd175b9428cdf18725d292b37"
+    },
+    {
+      "path": "org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.pom",
+      "sha1": "e4b3e5ffec18728f099d8000e400ac763af2cc20"
+    },
+    {
+      "path": "org/apache/maven/maven-model-builder/3.1.0/maven-model-builder-3.1.0.jar",
+      "sha1": "13ba294cedb659c3851f0c2980af7f44bcc6a8e0"
+    },
+    {
+      "path": "org/apache/maven/maven-model-builder/3.1.0/maven-model-builder-3.1.0.pom",
+      "sha1": "c8acc6f639a2ee4206f53a29ceee12c873c5f67f"
+    },
+    {
+      "path": "org/apache/maven/maven-model-builder/3.1.1/maven-model-builder-3.1.1.jar",
+      "sha1": "5fb53c92da84ebeff403414b667611d6bcd477cf"
+    },
+    {
+      "path": "org/apache/maven/maven-model-builder/3.1.1/maven-model-builder-3.1.1.pom",
+      "sha1": "00b55e85ae9eb0b6642c9c22f54ed844e5d4a26d"
+    },
+    {
+      "path": "org/apache/maven/maven-model-builder/3.2.1/maven-model-builder-3.2.1.pom",
+      "sha1": "3ba8977b91655fa79f79e7e3b286a2479ef17eda"
+    },
+    {
+      "path": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar",
+      "sha1": "ab682e67281bb025980181c83acbcad19042a342"
+    },
+    {
+      "path": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom",
+      "sha1": "7ed6529eefa74ca263b65a7c20adf65af5bacdff"
+    },
+    {
+      "path": "org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.jar",
+      "sha1": "afc57c3a1368cd34caccb638e00523701f398c20"
+    },
+    {
+      "path": "org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom",
+      "sha1": "421fcf473a51d9695d8dfe4f8e977ae38087f2ae"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/10/maven-parent-10.pom",
+      "sha1": "281aafa31dfa9544070448ea8f353434f53267e4"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/11/maven-parent-11.pom",
+      "sha1": "4bb80173fa4979737840fda012af86f5beabf1bc"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/15/maven-parent-15.pom",
+      "sha1": "63d5a76e7f9d3c6d7870bde13438856ef5300336"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/16/maven-parent-16.pom",
+      "sha1": "00fed95187c0c9bfd13c08a858cb6f00245a3fa9"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/19/maven-parent-19.pom",
+      "sha1": "181554ae180245d7f653f77ff869790c2062f2d0"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/20/maven-parent-20.pom",
+      "sha1": "b42cda17fc84bcf8b60edc4fdb7b56719cc02a30"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/21/maven-parent-21.pom",
+      "sha1": "0ecebf1043d9c7bdd3d32a4184ad4ef9ad3ea744"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/22/maven-parent-22.pom",
+      "sha1": "b8b69066f9f1c388a977669871df9b66782f751a"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/23/maven-parent-23.pom",
+      "sha1": "f92ae4baba6616609a29f6287626ee3f50ed7d6e"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/24/maven-parent-24.pom",
+      "sha1": "277cf98c25de4d7512aa6403635810c1018e82b0"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/25/maven-parent-25.pom",
+      "sha1": "2e3d7a4d43a1103612cca66127ce6381e8ef85c9"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/26/maven-parent-26.pom",
+      "sha1": "c33a248bd35b9d6b6fbcbe7061a30bb9d422dc42"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/27/maven-parent-27.pom",
+      "sha1": "2672c73b6189bb9ff437ba94ac7f62975e1257dd"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/30/maven-parent-30.pom",
+      "sha1": "c3b2d24677a5f694e069b8210e9793a88c9d28b5"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/31/maven-parent-31.pom",
+      "sha1": "e773af8e851de63461222f3a26d37e4619431e03"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/33/maven-parent-33.pom",
+      "sha1": "9dd736089b07fa56da1259c87a825a097ba0278c"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/4/maven-parent-4.pom",
+      "sha1": "0fc039b0bd4d17d7c147a30e1d83994629c5297c"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/5/maven-parent-5.pom",
+      "sha1": "5c1ab38decaca1ccd08294aeab135047ebbae00d"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/6/maven-parent-6.pom",
+      "sha1": "e9c3dcf052c26ac7340fbd7a03a751e482855330"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/7/maven-parent-7.pom",
+      "sha1": "2426103263cbaf5519433f16bd98cdc31870a10a"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/8/maven-parent-8.pom",
+      "sha1": "6f92a85ec401422bfc6572759a0bab2ff5df525e"
+    },
+    {
+      "path": "org/apache/maven/maven-parent/9/maven-parent-9.pom",
+      "sha1": "a7d098bde368f683c2b51475a903a1e74b61ba32"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/2.0.10/maven-plugin-api-2.0.10.pom",
+      "sha1": "ef7b71a73f87ae6b0b4515c77542acb5091c49db"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar",
+      "sha1": "52b32fd980c8ead7a3858d057330bda1ace72d9d"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom",
+      "sha1": "3af72b052dfefb73ecfae742613012b5396c8863"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar",
+      "sha1": "8b8cae9daa688fdb57995c6835a3e24475d554c0"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom",
+      "sha1": "4f6c3d5d50d1e22dea74629b3c52e22b30b6cbbd"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.jar",
+      "sha1": "d60c36b60f760e0b5b87dd0c6311f93a72dc4585"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom",
+      "sha1": "29a30b7c8180601523293fd61b00fcb298d32230"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.jar",
+      "sha1": "98f886f59bb0e69f8e86cdc082e69f2f4c13d648"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom",
+      "sha1": "9627e130b4f516945f0db03119dbafb86f168026"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/3.1.0/maven-plugin-api-3.1.0.jar",
+      "sha1": "8821fd1b81c6b960f7ce39f5dde612c665146fd8"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/3.1.0/maven-plugin-api-3.1.0.pom",
+      "sha1": "b5099f8ebbd34e79be313854f554a2de0994166b"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/3.1.1/maven-plugin-api-3.1.1.jar",
+      "sha1": "3836a4ea31ca2d1531aa250127bc17e6e876d658"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/3.1.1/maven-plugin-api-3.1.1.pom",
+      "sha1": "26ad41ca9dd27d8259c0691d6f0646c1e4e8cde2"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar",
+      "sha1": "1ad37c33e3f046a84e7394df36a05a7f3b877d55"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.pom",
+      "sha1": "557f5724d69330ae5c12d708a9e805fb4fbd9e72"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar",
+      "sha1": "30a00f4ef12d3901c4f842de99e9363e3743245f"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom",
+      "sha1": "c03fb59f559651730a98907d4acf65e6ffb886d6"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.jar",
+      "sha1": "68d20ae3c40c4664dc52be90338af796db7ffb32"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom",
+      "sha1": "020c06240db8c2f9bcf8450414ef040becef16e0"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar",
+      "sha1": "df6fa6c4adb313cb8937ffae96368bec1fd5d13d"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom",
+      "sha1": "c6403fbdb781a3d47a771656054defe1173ce486"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.jar",
+      "sha1": "1a117baac49437fc5a6fcd9f18f779e6bad4207e"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom",
+      "sha1": "8eb54f97405512e83f680f29ef6163f5ef082acb"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.0.10/maven-plugin-registry-2.0.10.pom",
+      "sha1": "65f0e009b7e9d2a74c5febbe457799b3d696f43d"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.0.10/maven-plugin-registry-2.0.10.jar",
+      "sha1": "d5da46ecb3da41696471510223af256143bc0936"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar",
+      "sha1": "4242ec8629b4797387751379f57e72cb718aac7a"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom",
+      "sha1": "2e13beea3b3511c6075c60384d9e7fad18efbcdf"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.0.8/maven-plugin-registry-2.0.8.jar",
+      "sha1": "37385b508a04d77575c6b5542b88bd96f5257541"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.0.8/maven-plugin-registry-2.0.8.pom",
+      "sha1": "8f64ad448251c2c6007e609088bb7aa45ff337c5"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar",
+      "sha1": "a7172a87a7cb901cf6df4df9fd89a3c2d3f8a770"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom",
+      "sha1": "403ed44092f56e1ebab891f37c69d61936c5c4da"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.2.0/maven-plugin-registry-2.2.0.pom",
+      "sha1": "a28f479f5a2334f4018fd6812a6da2652a11d858"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.jar",
+      "sha1": "72a24b7775649af78f3986b5aa7eb354b9674cfd"
+    },
+    {
+      "path": "org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom",
+      "sha1": "c3575ac9ad32638af33d88829453bdc902ea8711"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.0.10/maven-profile-2.0.10.jar",
+      "sha1": "351665e7af93b60a7ae9c7498d1e6d015ff6ac53"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.0.10/maven-profile-2.0.10.pom",
+      "sha1": "4d0680a07f9a6f9fc812b1ce77ac599e1c9fcfa1"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar",
+      "sha1": "f03cd3820d2b4d60b93ccd17a1c14e8eeef63f79"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom",
+      "sha1": "12d0d8217e613b9cb487c1d1d0db744a4f588528"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.0.8/maven-profile-2.0.8.jar",
+      "sha1": "4da3b9551606437a80bdc695c4fafde03a037ab9"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.0.8/maven-profile-2.0.8.pom",
+      "sha1": "34de742e38173bc6b4bc921ad79567c282f880ab"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom",
+      "sha1": "616ca5d9ab345e415c6e3f5f75ea24a952690ac0"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar",
+      "sha1": "0b9b02df9134bff9edb4f4e1624243d005895234"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.2.0/maven-profile-2.2.0.pom",
+      "sha1": "740bce07af0b724e8e79e62493b537e190d14c1f"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.jar",
+      "sha1": "3950071587027e5086e9c395574a60650c432738"
+    },
+    {
+      "path": "org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom",
+      "sha1": "075b47a5262cae02c228137399b8247e50a43284"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.0.10/maven-project-2.0.10.jar",
+      "sha1": "c82f208e8997fc639279dc4b76d50a1317b2a9f1"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.0.10/maven-project-2.0.10.pom",
+      "sha1": "5d51eba53265db60c55abf8da3555f3f23727e66"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar",
+      "sha1": "c0df764cd8f5bac660bfa53fa97fdd53663ee308"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom",
+      "sha1": "28e9f98ae3688d8831052283b2d65bd18295a7f5"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.0.8/maven-project-2.0.8.jar",
+      "sha1": "00475a52c7181930b1680fce3269245ccc26e3de"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.0.8/maven-project-2.0.8.pom",
+      "sha1": "13398a071f2094acc11add38afc85f75a3faac33"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar",
+      "sha1": "30ec37813df5a212888a1f3df0b27497ecef4ad8"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom",
+      "sha1": "152cb93838c431848f31cd5a7a7a11b98c57135e"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.2.0/maven-project-2.2.0.pom",
+      "sha1": "bce50c677b7219221db29b87470b6ba605ef0d3f"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.jar",
+      "sha1": "8239e98c16f641d55a4ad0e0bab0aee3aff8933f"
+    },
+    {
+      "path": "org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom",
+      "sha1": "d96e4545b4700ac177430b5189c3f2aa54f62ca1"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.0.10/maven-repository-metadata-2.0.10.pom",
+      "sha1": "f14e68c7000dabc2e119bd4bd0a38a74f015efda"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.0.2/maven-repository-metadata-2.0.2.pom",
+      "sha1": "f731304626897c68836461f0df5134f26aeddcf1"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom",
+      "sha1": "bdcd11054562df6124286aaf252ae8f256879e26"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar",
+      "sha1": "ae64379396d2eba33616ce1e0a458c3a744b317b"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.0.8/maven-repository-metadata-2.0.8.pom",
+      "sha1": "741cf565a37d838eb7bebbb3d38a8293835b6cd5"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar",
+      "sha1": "dd79022a827b1d577865d5c97f8ad0c7d6b067b7"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom",
+      "sha1": "dc5dac36e8c773d8645a681b71b3d80a3e3b8916"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.2.0/maven-repository-metadata-2.2.0.pom",
+      "sha1": "7805801e5b7d9eafeb3baf07e864650a62991192"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.jar",
+      "sha1": "98f0c07fcf1eeb213bef8d9316a9935184084b06"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom",
+      "sha1": "415f88d96ea04b0fcef38c50123da1ccc2be49d2"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.pom",
+      "sha1": "5126010cefcb80ed5dc6eb066541b546dbdbc971"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.jar",
+      "sha1": "e3c41f7565b1e189ff7a312796b9d2c470c09a8b"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/3.1.0/maven-repository-metadata-3.1.0.jar",
+      "sha1": "77bb2c383b1654b158cf9f905f4105d9d522fc7e"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/3.1.0/maven-repository-metadata-3.1.0.pom",
+      "sha1": "9f0ec3ca8467110d8fcc9957e6ccdf9e51ef0374"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/3.1.1/maven-repository-metadata-3.1.1.jar",
+      "sha1": "ef5bccf2a7a22a326c8fe94e1d56f6f15419bedd"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/3.1.1/maven-repository-metadata-3.1.1.pom",
+      "sha1": "b3358a184057c8258612eb86b2eddb2c6e66694b"
+    },
+    {
+      "path": "org/apache/maven/maven-repository-metadata/3.2.1/maven-repository-metadata-3.2.1.pom",
+      "sha1": "3a49fe98f8305e105643371df215437d50bd9882"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/2.0.10/maven-settings-2.0.10.pom",
+      "sha1": "82fe60f0a91a6bd644e8888439203c47f057d088"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar",
+      "sha1": "5da16cf9def50e3a352cd7e8923a49ebd72003b8"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.pom",
+      "sha1": "6e8ca6b7fce58a28d2b73774fe277593af14d82a"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.pom",
+      "sha1": "f1fde243f26152cc66f7f1d6b4e3bb19d39d6847"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar",
+      "sha1": "ab8d338c00fab0db29af358ab0676c3c02d7329f"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.jar",
+      "sha1": "2236ffe71fa5f78ce42b0f5fc22c54ed45f14294"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom",
+      "sha1": "d54135b84370b3b0b70d84ffbb4ddf161c303d56"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/3.0/maven-settings-3.0.jar",
+      "sha1": "8ee129adae535dd610f2dc952fddce68ac42fd86"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/3.0/maven-settings-3.0.pom",
+      "sha1": "efc9c618ca5b82f76d1894977482069fe0e4565a"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/3.1.0/maven-settings-3.1.0.pom",
+      "sha1": "5ad20b57975d041847a01814cc9f362c3e6901f8"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/3.1.0/maven-settings-3.1.0.jar",
+      "sha1": "032c65d957271cb15ae3c93c883ab7e6aca39138"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/3.1.1/maven-settings-3.1.1.jar",
+      "sha1": "311d38cf15ec7f5c713985862632db91b7a827af"
+    },
+    {
+      "path": "org/apache/maven/maven-settings/3.1.1/maven-settings-3.1.1.pom",
+      "sha1": "ce08f76064ae401c8362e16c32f3806f0bb8961b"
+    },
+    {
+      "path": "org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.pom",
+      "sha1": "69a41566b573bda12bd2bb7dcb64d30da834cb9c"
+    },
+    {
+      "path": "org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.jar",
+      "sha1": "08234c1bdf7a9a28c671b0abf11f8adaa66440cd"
+    },
+    {
+      "path": "org/apache/maven/maven-settings-builder/3.1.0/maven-settings-builder-3.1.0.jar",
+      "sha1": "ab0e825308fb8862d6d2b6fecea80c0d06c48407"
+    },
+    {
+      "path": "org/apache/maven/maven-settings-builder/3.1.0/maven-settings-builder-3.1.0.pom",
+      "sha1": "1731542d386485f51ffdb9126cb73432ce2f838b"
+    },
+    {
+      "path": "org/apache/maven/maven-settings-builder/3.1.1/maven-settings-builder-3.1.1.pom",
+      "sha1": "ed8372f386790c5bbdf04a89d6dab8d49b4213c5"
+    },
+    {
+      "path": "org/apache/maven/maven-settings-builder/3.1.1/maven-settings-builder-3.1.1.jar",
+      "sha1": "e2d5e96ea4bbd4fc463dbb76d07dd8aefac05e3c"
+    },
+    {
+      "path": "org/apache/maven/maven-toolchain/2.2.1/maven-toolchain-2.2.1.jar",
+      "sha1": "0be589179cfbbad11e48572bf1a28e3490c7b197"
+    },
+    {
+      "path": "org/apache/maven/maven-toolchain/2.2.1/maven-toolchain-2.2.1.pom",
+      "sha1": "ef19c9782d233f4515cf83b4208dd04731ed8989"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-antrun-plugin/1.8/maven-antrun-plugin-1.8.jar",
+      "sha1": "0d02c0af622aa6a0c86e81c519299e888e0a32a3"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-antrun-plugin/1.8/maven-antrun-plugin-1.8.pom",
+      "sha1": "9e81fe7535b053176fcff17837d8a58eb2f93ff3"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-checkstyle-plugin/3.1.0/maven-checkstyle-plugin-3.1.0.jar",
+      "sha1": "4cbc5be82d92e87f8db396f8e1f8c218f6dcce0e"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-checkstyle-plugin/3.1.0/maven-checkstyle-plugin-3.1.0.pom",
+      "sha1": "81d9a6e0b315ba84839c42eff734fd9502d81437"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.jar",
+      "sha1": "75653decaefa85ca8114ff3a4f869bb2ee6d605d"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.pom",
+      "sha1": "8571a1cd21bed4fe28656c3303526fa7d1e582ad"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.jar",
+      "sha1": "be834db00dbace3d7fd08a6e0e96ab5e4af45f99"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.pom",
+      "sha1": "96021d81e9ecaa27aadb861c681840a768ea502b"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-dependency-plugin/3.1.1/maven-dependency-plugin-3.1.1.jar",
+      "sha1": "e348af6765ac0b96de98983f9ac96df3649f0b69"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-dependency-plugin/3.1.1/maven-dependency-plugin-3.1.1.pom",
+      "sha1": "f9e6e390a53b56e126782a083e1424dfb7be4904"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-deploy-plugin/2.7/maven-deploy-plugin-2.7.jar",
+      "sha1": "6dadfb75679ca010b41286794f737088ebfe12fd"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-deploy-plugin/2.7/maven-deploy-plugin-2.7.pom",
+      "sha1": "df67cefd776bb81db9273bc7b9921a47b81428f3"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-enforcer-plugin/3.0.0-M3/maven-enforcer-plugin-3.0.0-M3.jar",
+      "sha1": "c45ecb8536cb08cf2c5e0852465623e846ade760"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-enforcer-plugin/3.0.0-M3/maven-enforcer-plugin-3.0.0-M3.pom",
+      "sha1": "572ff224e4c3b5079dbf4943629d38ee2d341c57"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-install-plugin/2.4/maven-install-plugin-2.4.jar",
+      "sha1": "9d1316166fe4c313f56276935e08df11f45267c2"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-install-plugin/2.4/maven-install-plugin-2.4.pom",
+      "sha1": "a94328f3fcee1cebefa3d1224caa0050682da487"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar",
+      "sha1": "e3200bcf357b5c5e26df072d27df160546bb079a"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom",
+      "sha1": "ae9d54d974e163f260f89ecea8ff6d55e4b0963e"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-jxr-plugin/3.0.0/maven-jxr-plugin-3.0.0.jar",
+      "sha1": "a79f1d4367328f59d8ce80a8b347f6c050c54f32"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-jxr-plugin/3.0.0/maven-jxr-plugin-3.0.0.pom",
+      "sha1": "e86007137981b6ab8a24f25ccc5e9e8b748014e4"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom",
+      "sha1": "beff44ae4eff1e5c79c01972083cd11fa6982462"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom",
+      "sha1": "d40d68ba1f88d8e9b0040f175a6ff41928abd5e7"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-plugins/24/maven-plugins-24.pom",
+      "sha1": "91e68408f2d1774c5f39c0c4cd56a8b83e47c67f"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-plugins/27/maven-plugins-27.pom",
+      "sha1": "7266e797e06d1b9010c6df97cb060a75f0fd4dbc"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-plugins/31/maven-plugins-31.pom",
+      "sha1": "0b5efc4b76da252b79b683e47d3df82752f44093"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-plugins/33/maven-plugins-33.pom",
+      "sha1": "1492c1ec367964ea0a088d128d13b1df4529c8ae"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-pmd-plugin/3.13.0/maven-pmd-plugin-3.13.0.jar",
+      "sha1": "4c299a9b01639f05d7e5d57c4e3ff6b77cefcfe9"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-pmd-plugin/3.13.0/maven-pmd-plugin-3.13.0.pom",
+      "sha1": "8053ec4b90fdf437299483326757486f260786c1"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar",
+      "sha1": "dd093ff6a4b680eae7ae83b5ab04310249fc6590"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom",
+      "sha1": "5db5c3a879f31e8de7b580c79a52b245454c4620"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-shade-plugin/2.2/maven-shade-plugin-2.2.jar",
+      "sha1": "71450816528f4565b853c6ab2e9d4451fc50e130"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-shade-plugin/2.2/maven-shade-plugin-2.2.pom",
+      "sha1": "bcbbc30706f00cb13a1c651a13abba89766b6581"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-site-plugin/3.3/maven-site-plugin-3.3.pom",
+      "sha1": "e790e7e93471cf9245706d76747f4653dd58c0e7"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-site-plugin/3.3/maven-site-plugin-3.3.jar",
+      "sha1": "77ba1752b1ac4c4339d6f11554800960a56a4ae1"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.jar",
+      "sha1": "63d1dd017bfecc64a7b68b964e39e8d9f8f11a14"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.pom",
+      "sha1": "f0bfc47221f365d6812e6c4091227f6425268980"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-war-plugin/3.2.3/maven-war-plugin-3.2.3.pom",
+      "sha1": "bf3c87f991dc11ab544a838d9747bfedd6c87e4d"
+    },
+    {
+      "path": "org/apache/maven/plugins/maven-war-plugin/3.2.3/maven-war-plugin-3.2.3.jar",
+      "sha1": "dbdbad620ccd0c2df06c6b6920242aade8e106c8"
+    },
+    {
+      "path": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.5.2/maven-plugin-annotations-3.5.2.pom",
+      "sha1": "263f39d1cb915beaa94497d2b4b6ec94ca5b1291"
+    },
+    {
+      "path": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.5.2/maven-plugin-annotations-3.5.2.jar",
+      "sha1": "958c81789d4cc52e7f83ede3168633c0b03ea2de"
+    },
+    {
+      "path": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.5/maven-plugin-annotations-3.5.pom",
+      "sha1": "8c8a901b634eda9b3b7aee7863258f9d98bf32de"
+    },
+    {
+      "path": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.5/maven-plugin-annotations-3.5.jar",
+      "sha1": "403ab542cc88975c9fb41c0fba893d5b0d028c97"
+    },
+    {
+      "path": "org/apache/maven/plugin-tools/maven-plugin-tools/3.5.2/maven-plugin-tools-3.5.2.pom",
+      "sha1": "7c1b14adca1eef5063248cb8078b160e48c3a969"
+    },
+    {
+      "path": "org/apache/maven/plugin-tools/maven-plugin-tools/3.5/maven-plugin-tools-3.5.pom",
+      "sha1": "b6d54fdd611d24e0c8edef5a71ba9c92d9840574"
+    },
+    {
+      "path": "org/apache/maven/plugin-tools/maven-plugin-tools-api/3.5.2/maven-plugin-tools-api-3.5.2.jar",
+      "sha1": "1414685e96b5a757777a8749e9762874f697d326"
+    },
+    {
+      "path": "org/apache/maven/plugin-tools/maven-plugin-tools-api/3.5.2/maven-plugin-tools-api-3.5.2.pom",
+      "sha1": "9fb061e542e5273b2ced08744c72d58da7c23f7e"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom",
+      "sha1": "0257fe61312283ef58817edf197e9c90db0bba25"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting/2.2.1/maven-reporting-2.2.1.pom",
+      "sha1": "c68c4978e03d8044ba074130178435a4df1bb3dc"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar",
+      "sha1": "29ec352c90968c345b628be6c40ddfb5ec7010a8"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom",
+      "sha1": "8d8037467cc092dbaf1ca8b513172e2a893b5b9b"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-api/2.2.1/maven-reporting-api-2.2.1.pom",
+      "sha1": "54d326154c3a5befd2fee3ff054ffc8cea635c54"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-api/2.2.1/maven-reporting-api-2.2.1.jar",
+      "sha1": "61942e490c112f84b3a1a61572d570f369414939"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.pom",
+      "sha1": "eca7bd81ad86e6d8a978f37e1d077fee5c59d41e"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.jar",
+      "sha1": "b2541dd07d08cd5eff9bd4554a2ad6a4198e2dfe"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-exec/1.1/maven-reporting-exec-1.1.pom",
+      "sha1": "df01324810b26bb575e9cad5bfba25c7697ef51b"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-exec/1.1/maven-reporting-exec-1.1.jar",
+      "sha1": "6e584f7a77d08716e703aae223809e22cbba3af7"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-impl/2.1/maven-reporting-impl-2.1.jar",
+      "sha1": "898da3a82a8dee7ce1d8a6e1d24efcc52ba28383"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-impl/2.1/maven-reporting-impl-2.1.pom",
+      "sha1": "3ce3717600158fda20c4ea40981be5fb3ff4133a"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-impl/2.3/maven-reporting-impl-2.3.jar",
+      "sha1": "1f70dc5c88c48ba8fc785608228f1b55bfc01e5e"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-impl/2.3/maven-reporting-impl-2.3.pom",
+      "sha1": "c7b6a61fc5cde341d34f7c4030600e3adef1e0f4"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-impl/3.0.0/maven-reporting-impl-3.0.0.pom",
+      "sha1": "8da809795a05e4e01d343e4aecff5c409ab6fe67"
+    },
+    {
+      "path": "org/apache/maven/reporting/maven-reporting-impl/3.0.0/maven-reporting-impl-3.0.0.jar",
+      "sha1": "988c1a6fc3ffc41a5b91621963f99589f9dde566"
+    },
+    {
+      "path": "org/apache/maven/resolver/maven-resolver/1.4.1/maven-resolver-1.4.1.pom",
+      "sha1": "7cffb7488c6b0c702113af053da975fdbd92df3d"
+    },
+    {
+      "path": "org/apache/maven/resolver/maven-resolver-api/1.4.1/maven-resolver-api-1.4.1.jar",
+      "sha1": "ceee6b7ea1bc252afa585fa32f76c2cda206bdcd"
+    },
+    {
+      "path": "org/apache/maven/resolver/maven-resolver-api/1.4.1/maven-resolver-api-1.4.1.pom",
+      "sha1": "4eda1737c26ab3517013e30d9254c868c7097013"
+    },
+    {
+      "path": "org/apache/maven/resolver/maven-resolver-util/1.4.1/maven-resolver-util-1.4.1.jar",
+      "sha1": "3f6d4f4bc3e24b46a776b47ccfeaed9d2ed01549"
+    },
+    {
+      "path": "org/apache/maven/resolver/maven-resolver-util/1.4.1/maven-resolver-util-1.4.1.pom",
+      "sha1": "bf9f92c4886f8281a215b486fc0ccc2242b809b8"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm/1.8/maven-scm-1.8.pom",
+      "sha1": "198e03e318fbb5dbfc0f5c0685a7149c38ecbf49"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm/1.9.4/maven-scm-1.9.4.pom",
+      "sha1": "e8b73cb0f9c4df7aad645172363824ccdd487e71"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-api/1.8/maven-scm-api-1.8.pom",
+      "sha1": "4490b5d6857753d319a9c1900de102622e724629"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-api/1.9.4/maven-scm-api-1.9.4.jar",
+      "sha1": "20007a3e71fda6824900856e63e552416de2b59d"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-api/1.9.4/maven-scm-api-1.9.4.pom",
+      "sha1": "8fb926d97449e710a094a8aa7514694cd14df487"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-manager-plexus/1.9.4/maven-scm-manager-plexus-1.9.4.jar",
+      "sha1": "f0c6254e05cf5594fd797c1476a5b9fa9b6dca1e"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-manager-plexus/1.9.4/maven-scm-manager-plexus-1.9.4.pom",
+      "sha1": "fa8850238b3b2aa16e22309f5e50387aba1f4fa7"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-managers/1.9.4/maven-scm-managers-1.9.4.pom",
+      "sha1": "4000a5db41a63210d2d3b3f2cfe5d0f67700e12e"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-bazaar/1.9.4/maven-scm-provider-bazaar-1.9.4.jar",
+      "sha1": "7ac2bc85a9602df597d9f1b19444a07833626db7"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-bazaar/1.9.4/maven-scm-provider-bazaar-1.9.4.pom",
+      "sha1": "fdaf1252c3c78dc23f5b3d22ed373319176d965c"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-clearcase/1.9.4/maven-scm-provider-clearcase-1.9.4.jar",
+      "sha1": "0070ac0da31600580e80528c6568284a9d129312"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-clearcase/1.9.4/maven-scm-provider-clearcase-1.9.4.pom",
+      "sha1": "23d1ff6fa120d611471d7099510d900fc7acb043"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-cvs-commons/1.9.4/maven-scm-provider-cvs-commons-1.9.4.jar",
+      "sha1": "8626c844aa356469aa7a5a3a56c2a277f94d35ae"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-cvs-commons/1.9.4/maven-scm-provider-cvs-commons-1.9.4.pom",
+      "sha1": "df911ac4f1bc527174b6fcf27e45c9c92799e8f5"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-cvsexe/1.9.4/maven-scm-provider-cvsexe-1.9.4.jar",
+      "sha1": "0c1e7433ccc6ad50cfd57251de35e1b0d7c22b65"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-cvsexe/1.9.4/maven-scm-provider-cvsexe-1.9.4.pom",
+      "sha1": "501f831b72dafa930d89a80f61c59b185a9e29f5"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-git-commons/1.9.4/maven-scm-provider-git-commons-1.9.4.jar",
+      "sha1": "1c32cfc3118f2b93cf7b69fdf614570a3ff28289"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-git-commons/1.9.4/maven-scm-provider-git-commons-1.9.4.pom",
+      "sha1": "d2b29df9d4137b77634fed08c7453b463b54b9d1"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-gitexe/1.9.4/maven-scm-provider-gitexe-1.9.4.pom",
+      "sha1": "98060e4e876493f0b5a58182473e1118f77e21c3"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-gitexe/1.9.4/maven-scm-provider-gitexe-1.9.4.jar",
+      "sha1": "3148252b119204e3483175da4525be5e3e809192"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-hg/1.9.4/maven-scm-provider-hg-1.9.4.jar",
+      "sha1": "a2f2c6e2b730a492beb47fb7316e9e7a6129ff57"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-hg/1.9.4/maven-scm-provider-hg-1.9.4.pom",
+      "sha1": "09d33ad61bc3d98d2992757410d4e3c48a2483c0"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-perforce/1.9.4/maven-scm-provider-perforce-1.9.4.jar",
+      "sha1": "c8d8cfa719a252930f36c814a08c0ab5f8da9607"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-perforce/1.9.4/maven-scm-provider-perforce-1.9.4.pom",
+      "sha1": "b45bb704c4cae2e13b77af988c3638df706c75b0"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-providers/1.8/maven-scm-providers-1.8.pom",
+      "sha1": "1f34e63ecd242e0d92c90590b94eb9dfbb0d5def"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-providers/1.9.4/maven-scm-providers-1.9.4.pom",
+      "sha1": "c2edd429042db993ae641385fe0808cd0e634ac3"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-providers-cvs/1.9.4/maven-scm-providers-cvs-1.9.4.pom",
+      "sha1": "7e4e47d3cf16e01bd325e559efd557ef688bf813"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-providers-git/1.9.4/maven-scm-providers-git-1.9.4.pom",
+      "sha1": "b282e01450dfba3cfcdb003335efa36f0e20233a"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-providers-svn/1.8/maven-scm-providers-svn-1.8.pom",
+      "sha1": "5b7cd68f12a62066db90fa87b6e584873cb4af2a"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-providers-svn/1.9.4/maven-scm-providers-svn-1.9.4.pom",
+      "sha1": "8a3bfeba90163a4020f44d1df393a111f8b7be86"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-starteam/1.9.4/maven-scm-provider-starteam-1.9.4.jar",
+      "sha1": "cbc9a6ff883f7999b9ed6a2e134edceea66bdf19"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-starteam/1.9.4/maven-scm-provider-starteam-1.9.4.pom",
+      "sha1": "61127f2fe41519a7a5de9c24a172d20ea991c452"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-svn-commons/1.8/maven-scm-provider-svn-commons-1.8.pom",
+      "sha1": "380f105c8a06add22991fedc84849c977a54a48c"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-svn-commons/1.9.4/maven-scm-provider-svn-commons-1.9.4.jar",
+      "sha1": "6dff7eb146d8574de821eb82ccbcb501ba41cc7e"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-svn-commons/1.9.4/maven-scm-provider-svn-commons-1.9.4.pom",
+      "sha1": "673c7f1f629c0a317c56052dadfc2746579ca69a"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-svnexe/1.9.4/maven-scm-provider-svnexe-1.9.4.pom",
+      "sha1": "8ee9f8d1cb17e872798b480f194cb72eead945b6"
+    },
+    {
+      "path": "org/apache/maven/scm/maven-scm-provider-svnexe/1.9.4/maven-scm-provider-svnexe-1.9.4.jar",
+      "sha1": "88b6983a85b1e2dcf35c87d0653eb5f965cca87c"
+    },
+    {
+      "path": "org/apache/maven/shared/file-management/1.2.1/file-management-1.2.1.jar",
+      "sha1": "8f98bcaa7fd3625a172fd3de10bba8c32b9820ea"
+    },
+    {
+      "path": "org/apache/maven/shared/file-management/1.2.1/file-management-1.2.1.pom",
+      "sha1": "9aacc3da37949502b89807f0df2e6529ef33da0c"
+    },
+    {
+      "path": "org/apache/maven/shared/file-management/3.0.0/file-management-3.0.0.pom",
+      "sha1": "f6d55739cb1a70aef37b345b89cdd9d4f53ed637"
+    },
+    {
+      "path": "org/apache/maven/shared/file-management/3.0.0/file-management-3.0.0.jar",
+      "sha1": "065d87e03797af7bb5bb199d4d8b50f83cbea3ce"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
+      "sha1": "cb0bc696b1c2380efe81ed2bd628b50d56a3a09b"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.pom",
+      "sha1": "1556dcd3277b99b33e277db7a40717e0fc441d1f"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-artifact-transfer/0.12.0/maven-artifact-transfer-0.12.0.jar",
+      "sha1": "b63d86f97cda1456dcbda78bf57de779c372addd"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-artifact-transfer/0.12.0/maven-artifact-transfer-0.12.0.pom",
+      "sha1": "c3dbc60cf87e50311ccf0f7c87ee43681dfb2edc"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-artifact-transfer/0.9.1/maven-artifact-transfer-0.9.1.jar",
+      "sha1": "b8f0866112547e3f7ea0e683ac50905dae046be0"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-artifact-transfer/0.9.1/maven-artifact-transfer-0.9.1.pom",
+      "sha1": "e78448c32f8de31aa1b659b96e15707f0f97a594"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-common-artifact-filters/1.4/maven-common-artifact-filters-1.4.jar",
+      "sha1": "de97ff2efd804f06c3698a914f2d55205742bcc4"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-common-artifact-filters/1.4/maven-common-artifact-filters-1.4.pom",
+      "sha1": "40c60d137280b0583ebff4b80361cd2a28ea9c42"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.pom",
+      "sha1": "c6e96947d07fc8d9d02f60ebccfd6e8080201676"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
+      "sha1": "1a98d8e3d5610bb0abf09a7756195e8b2ed215e5"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-common-artifact-filters/3.1.0/maven-common-artifact-filters-3.1.0.pom",
+      "sha1": "2b2b1b986c2c758db97d6e6c399aab368e323f98"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-common-artifact-filters/3.1.0/maven-common-artifact-filters-3.1.0.jar",
+      "sha1": "7d1eda9af6db77618766f31cb1971baed2ca3fa3"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-dependency-analyzer/1.10/maven-dependency-analyzer-1.10.jar",
+      "sha1": "0a7378d4cb2d73e403df605f289197afb1b6a437"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-dependency-analyzer/1.10/maven-dependency-analyzer-1.10.pom",
+      "sha1": "a48efb7a09fde095b225b3c0f4a47ba4f55e2fa8"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-dependency-tree/2.1/maven-dependency-tree-2.1.jar",
+      "sha1": "29c4d6aeae519809b9af0607156bbdd174efb0bb"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-dependency-tree/2.1/maven-dependency-tree-2.1.pom",
+      "sha1": "772a49d54d50ffe30dbfc50e86ed8318a188746c"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-dependency-tree/2.2/maven-dependency-tree-2.2.jar",
+      "sha1": "5d9ce6add7b714b8095f0e3e396c5e9f8c5dcfef"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-dependency-tree/2.2/maven-dependency-tree-2.2.pom",
+      "sha1": "1a2de65598fb12cf65c3e435b1c61b4fc743a235"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-dependency-tree/3.0.1/maven-dependency-tree-3.0.1.jar",
+      "sha1": "e9ae9966f1d3a238004c8b15ca4fd0e03d405424"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-dependency-tree/3.0.1/maven-dependency-tree-3.0.1.pom",
+      "sha1": "836669a016f1abbabc9a4776c4b76fa097f8a7d5"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar",
+      "sha1": "c223ff4ef9e9b3b51b2c9310dda59527a4b85baf"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom",
+      "sha1": "58f9827f70cc29dd6aed2477b6384f14462f9576"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.jar",
+      "sha1": "52f2401b6e1a8cc40185da68e5c514f01f7a7a68"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.pom",
+      "sha1": "824f9dbf759d151975d54b0499ea246fe2b279d4"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-mapping/3.0.0/maven-mapping-3.0.0.jar",
+      "sha1": "f482f00127482a4efea14212445a5a1cc4d83766"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-mapping/3.0.0/maven-mapping-3.0.0.pom",
+      "sha1": "4d66ecac2d729ba037976ba4faa6ae8267a97a9a"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/10/maven-shared-components-10.pom",
+      "sha1": "a7dabc7cff7b683d810e33a63c85cbc630c3ebf3"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/15/maven-shared-components-15.pom",
+      "sha1": "ea4cecd1845e61708cd05f20d5d428a3d429e67c"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/16/maven-shared-components-16.pom",
+      "sha1": "214d20fcd1d88118bf0518e65284489aebb71259"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom",
+      "sha1": "9574bbf041ebae3dcf84c221d552dbeb01fe5b40"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom",
+      "sha1": "b9aa57e02b5452a9b6cc9147e40bb0b53a7c8009"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom",
+      "sha1": "650a49682d4c82f060c7cc8005f8734a5fd86af9"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/20/maven-shared-components-20.pom",
+      "sha1": "034b86be6c23134585eb70de40700e59d4afcf92"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/21/maven-shared-components-21.pom",
+      "sha1": "3d9749ccbb40dd6de825e959a6ab23a2bf85513d"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/22/maven-shared-components-22.pom",
+      "sha1": "479ebd33b34a1504708bc85780cbd3c2d6a0d54f"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/30/maven-shared-components-30.pom",
+      "sha1": "fed1e8496612f1fd3621e686a4cee4ea56d04cf9"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/31/maven-shared-components-31.pom",
+      "sha1": "1e54affbd5add6742dadba9ffff35d57512b015e"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/33/maven-shared-components-33.pom",
+      "sha1": "3eb04765b707822b0b97eae2648b1054e21cbdb3"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-components/8/maven-shared-components-8.pom",
+      "sha1": "a6b88e9b00b5eea13069ce324293a85e427e57c6"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar",
+      "sha1": "9d017a7584086755445c0a260dd9a1e9eae161a5"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom",
+      "sha1": "c607b2c64c027151c440f27b5ec86e062b9e9953"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.jar",
+      "sha1": "02e1d57be05ecac7dbe56a3c73b113e98f22240f"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.pom",
+      "sha1": "031970802f3b9937e43a82ff11518e02a51669dc"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-io/3.0.0/maven-shared-io-3.0.0.pom",
+      "sha1": "d0d34db967e12bd9d443d6ce0d80ba7ceddd5f88"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-io/3.0.0/maven-shared-io-3.0.0.jar",
+      "sha1": "fe598062dbcf95ac9eba77840f86d2ff25d81f55"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom",
+      "sha1": "c638aa76e8eb374e14c4a3d25f66f36454645a54"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/0.3/maven-shared-utils-0.3.pom",
+      "sha1": "504b5b905b80c6d88793949a7ea9aec375f9cceb"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/0.3/maven-shared-utils-0.3.jar",
+      "sha1": "e6f2544f67d9747a8d293a8b2b628a6a6c24fdad"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/0.6/maven-shared-utils-0.6.jar",
+      "sha1": "6310f3d6d252fa4da46a05d0c08d2a6a1019299c"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/0.6/maven-shared-utils-0.6.pom",
+      "sha1": "8b703e3862a8c071daeb80934a4e24568897e35e"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/0.7/maven-shared-utils-0.7.jar",
+      "sha1": "0704e679088765e7df5e1ef3eef400c4a061c9ef"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/0.7/maven-shared-utils-0.7.pom",
+      "sha1": "4a7c585a051cd9d9553f25b0d616adcb0d800ac5"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/3.0.0/maven-shared-utils-3.0.0.pom",
+      "sha1": "2157b52fe64a25d8f8db93a5bad36dfa024d70e1"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/3.0.0/maven-shared-utils-3.0.0.jar",
+      "sha1": "542e6f4c7fb03354836bc18e35a3e30417564a9e"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.jar",
+      "sha1": "78d8798fe84d5e095577221d299e9a3c8e696bca"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.pom",
+      "sha1": "96d533d4ae5c8ae5abe3f2e04fea554e2b03fd99"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.jar",
+      "sha1": "294c35ae8260be0660d4e4ba9e64402b84530b4e"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.pom",
+      "sha1": "562babea575ea1aabdea1911ea9d9226bb2c7c78"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+      "sha1": "08dd4dfb1d2d8b6969f6462790f82670bcd35ce2"
+    },
+    {
+      "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.pom",
+      "sha1": "9347480fc0b3162e873c3a1f83af76ee1f909924"
+    },
+    {
+      "path": "org/apache/maven/surefire/maven-surefire-common/2.22.2/maven-surefire-common-2.22.2.jar",
+      "sha1": "d22aaa69c65e96cd9d87f779e45df76fb5040108"
+    },
+    {
+      "path": "org/apache/maven/surefire/maven-surefire-common/2.22.2/maven-surefire-common-2.22.2.pom",
+      "sha1": "7024a6391c6869c06e7b801c9553553884df2fdb"
+    },
+    {
+      "path": "org/apache/maven/surefire/surefire/2.22.2/surefire-2.22.2.pom",
+      "sha1": "2bf172bb2ad3375d96a945775254a5d23f82612e"
+    },
+    {
+      "path": "org/apache/maven/surefire/surefire-api/2.22.2/surefire-api-2.22.2.jar",
+      "sha1": "273caddf446705ccceada91064e7266eb8517608"
+    },
+    {
+      "path": "org/apache/maven/surefire/surefire-api/2.22.2/surefire-api-2.22.2.pom",
+      "sha1": "49b34d166f30020a893551f058148e559779daf2"
+    },
+    {
+      "path": "org/apache/maven/surefire/surefire-booter/2.22.2/surefire-booter-2.22.2.jar",
+      "sha1": "84f8a93e76a7991f7f57d0e3905d8cf76176d3f5"
+    },
+    {
+      "path": "org/apache/maven/surefire/surefire-booter/2.22.2/surefire-booter-2.22.2.pom",
+      "sha1": "378a14fb78a3ba2d3efbb8cce8370937d65d39e3"
+    },
+    {
+      "path": "org/apache/maven/surefire/surefire-logger-api/2.22.2/surefire-logger-api-2.22.2.pom",
+      "sha1": "8170e8a3cd87c73fb8c97233b57d8ea4000dc8bf"
+    },
+    {
+      "path": "org/apache/maven/surefire/surefire-logger-api/2.22.2/surefire-logger-api-2.22.2.jar",
+      "sha1": "7c1513509a6f386711cfe21f50127a2641986163"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon/1.0-alpha-6/wagon-1.0-alpha-6.pom",
+      "sha1": "69aa7db6cd9b32c6026dfb3d77d6a6865a2a9fc3"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon/1.0-beta-2/wagon-1.0-beta-2.pom",
+      "sha1": "6cf8a47018be792d2b1774d2bacd7541c888ae50"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon/1.0-beta-6/wagon-1.0-beta-6.pom",
+      "sha1": "0a5a7966afb1b64f97c2f3f23a3e80592dc94986"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon/1.0/wagon-1.0.pom",
+      "sha1": "eaecb83d41d4c4e674f2c532ef70fddbabc5f247"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon/2.10/wagon-2.10.pom",
+      "sha1": "d51307a7a9d4909736d942b1f8a0711c11f90aca"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2.jar",
+      "sha1": "9274be1ca512ec6c8b9bed28e7d8de016359bea0"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-file/1.0-beta-2/wagon-file-1.0-beta-2.pom",
+      "sha1": "b746465d8086fa0ae2313ba3b56045ab1b90324f"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-file/1.0-beta-6/wagon-file-1.0-beta-6.jar",
+      "sha1": "6c53633505460caf49d2660de1e24744d915afb9"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-file/1.0-beta-6/wagon-file-1.0-beta-6.pom",
+      "sha1": "80898b6c33959b0775bd9fa082ab9d8199d03af6"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http/1.0-beta-6/wagon-http-1.0-beta-6.pom",
+      "sha1": "b197a17cce4c33bde3a0f1fbb88dd3b8d2ea05c4"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http/1.0-beta-6/wagon-http-1.0-beta-6.jar",
+      "sha1": "8c665cbb0ab67c355fbd2c942ad26e39753b6f2e"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2.jar",
+      "sha1": "00d725abe300936ae746b9c8c49782edde256804"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-2/wagon-http-lightweight-1.0-beta-2.pom",
+      "sha1": "1972cc0b2feca7505f6a296469ec9e82dfeb3ab3"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-6/wagon-http-lightweight-1.0-beta-6.pom",
+      "sha1": "0bf29be27632db42d742aa13fbffe0ec20088f76"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http-lightweight/1.0-beta-6/wagon-http-lightweight-1.0-beta-6.jar",
+      "sha1": "b3815078570c3b1f0667e123d59717c6b726c6c2"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2.pom",
+      "sha1": "cbf22d5bace0e46acc52c7da300db6f862a2ed78"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http-shared/1.0-beta-2/wagon-http-shared-1.0-beta-2.jar",
+      "sha1": "7e7d262f132abb9a965cf5a2a5128376878ea2a2"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http-shared/1.0-beta-6/wagon-http-shared-1.0-beta-6.jar",
+      "sha1": "ccd70d7e0d8c085e648a83f072da06ca9a53be94"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-http-shared/1.0-beta-6/wagon-http-shared-1.0-beta-6.pom",
+      "sha1": "b19a35b37860ec29ca2f73044bf9a9f289e74cb0"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.jar",
+      "sha1": "b3c986c63fc873fbaef75ad4e57cd162fd5c9dd6"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.pom",
+      "sha1": "1c1add559b9ed89168c2ae447481cfb63937ce2f"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2.jar",
+      "sha1": "abd1c9ace6e87c94a4b91f5176aeb09d954b23a3"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2.pom",
+      "sha1": "8b3013d0754edbeb694831ddf1c5d1a0019ee042"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.pom",
+      "sha1": "5dfdc8e497311085c9a1d6a634320b553442d281"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.jar",
+      "sha1": "3f952e0282ae77ae59851d96bb18015e520b6208"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/1.0/wagon-provider-api-1.0.jar",
+      "sha1": "12bcd211158c0c09b027d06b70371861398fedea"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/1.0/wagon-provider-api-1.0.pom",
+      "sha1": "26b03d1e63fd15ea5a6898282d4aee600a6170de"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar",
+      "sha1": "0cd9cdde3f56bb5250d87c54592f04cbc24f03bf"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.pom",
+      "sha1": "8f5232e7bd333fe4479e19e62ea8fbeaec6964db"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-providers/1.0-beta-2/wagon-providers-1.0-beta-2.pom",
+      "sha1": "a98eefeb315d771555c8529695630d3baefd1f6d"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-providers/1.0-beta-6/wagon-providers-1.0-beta-6.pom",
+      "sha1": "0874fb30d23af675da41407349b9fd99e513ae13"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2.jar",
+      "sha1": "1ef0e22afcdbe2ef5a3c1ec684443d76a3b50ddd"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh/1.0-beta-2/wagon-ssh-1.0-beta-2.pom",
+      "sha1": "23e01f190b4b8c19732fdf85291958070c6b4fe5"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh/1.0-beta-6/wagon-ssh-1.0-beta-6.jar",
+      "sha1": "37ac531f8159dddffa398a7612d5cbe313228437"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh/1.0-beta-6/wagon-ssh-1.0-beta-6.pom",
+      "sha1": "36261f692f16fd0d2cd0c119db485c83a575572d"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2.jar",
+      "sha1": "f0abd9511ec8d8128ec19cb64a9b7d8e36033b21"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh-common/1.0-beta-2/wagon-ssh-common-1.0-beta-2.pom",
+      "sha1": "782174e46d2080de6735c5fdd365d393ea5c686a"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh-common/1.0-beta-6/wagon-ssh-common-1.0-beta-6.jar",
+      "sha1": "0c654cc7e10e18bedca04a6e42f980d6c68435fc"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh-common/1.0-beta-6/wagon-ssh-common-1.0-beta-6.pom",
+      "sha1": "233ae58a07bed52737378ded6c94f841f731a74c"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2.jar",
+      "sha1": "08b1c48326fccfbf50716b08fc973e494ac585bf"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh-external/1.0-beta-2/wagon-ssh-external-1.0-beta-2.pom",
+      "sha1": "17ff27f9d0af5fc86242e18d81023b6a71e09e09"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh-external/1.0-beta-6/wagon-ssh-external-1.0-beta-6.pom",
+      "sha1": "a54b1bb6fda05c77ecb76bc38afb3c7746a16457"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-ssh-external/1.0-beta-6/wagon-ssh-external-1.0-beta-6.jar",
+      "sha1": "76918505c5fa6e309cd393aca8acd1b236559288"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-webdav-jackrabbit/1.0-beta-6/wagon-webdav-jackrabbit-1.0-beta-6.jar",
+      "sha1": "b694b223d0f19abcb32e304ebd5054061ee0f7b5"
+    },
+    {
+      "path": "org/apache/maven/wagon/wagon-webdav-jackrabbit/1.0-beta-6/wagon-webdav-jackrabbit-1.0-beta-6.pom",
+      "sha1": "d759937bc3adb84a318e59397e987f05c08cd27c"
+    },
+    {
+      "path": "org/apache/neethi/neethi/3.1.1/neethi-3.1.1.jar",
+      "sha1": "3a942a7921e66bb0081b16cf8f8a68e456b91de1"
+    },
+    {
+      "path": "org/apache/neethi/neethi/3.1.1/neethi-3.1.1.pom",
+      "sha1": "dd13800acca3df4af23b497797303e64b56196b9"
+    },
+    {
+      "path": "org/apache/struts/struts-core/1.3.8/struts-core-1.3.8.jar",
+      "sha1": "66178d4a9279ebb1cd1eb79c10dc204b4199f061"
+    },
+    {
+      "path": "org/apache/struts/struts-core/1.3.8/struts-core-1.3.8.pom",
+      "sha1": "ce1c07f0ecddb23c50c2f0a12c0b12d8cf1eb6d5"
+    },
+    {
+      "path": "org/apache/struts/struts-master/4/struts-master-4.pom",
+      "sha1": "1c8da55c806d8fbf788c512e25109c0a000dc19c"
+    },
+    {
+      "path": "org/apache/struts/struts-parent/1.3.8/struts-parent-1.3.8.pom",
+      "sha1": "f3958c3355a5949b1c924b0ea22b0aa5c6d86274"
+    },
+    {
+      "path": "org/apache/struts/struts-taglib/1.3.8/struts-taglib-1.3.8.pom",
+      "sha1": "2aeddb7ea2febcd4734ebcdf33968925c847ead3"
+    },
+    {
+      "path": "org/apache/struts/struts-taglib/1.3.8/struts-taglib-1.3.8.jar",
+      "sha1": "e87e9817bdf03c2367fb5f6d5ead953db2df4c21"
+    },
+    {
+      "path": "org/apache/struts/struts-tiles/1.3.8/struts-tiles-1.3.8.pom",
+      "sha1": "3f13b707b4220197c94b48d366e6ca79cb28f805"
+    },
+    {
+      "path": "org/apache/struts/struts-tiles/1.3.8/struts-tiles-1.3.8.jar",
+      "sha1": "6d212f8ea5d908bc9906e669428b7694dff60785"
+    },
+    {
+      "path": "org/apache/taglibs/taglibs-parent/3/taglibs-parent-3.pom",
+      "sha1": "e5b783bb26fd2b3cb84d7e1e498086f9d44f115e"
+    },
+    {
+      "path": "org/apache/taglibs/taglibs-standard/1.2.5/taglibs-standard-1.2.5.pom",
+      "sha1": "96db99efebc97d491a9d9f43871a658155f4d82f"
+    },
+    {
+      "path": "org/apache/taglibs/taglibs-standard-impl/1.2.5/taglibs-standard-impl-1.2.5.pom",
+      "sha1": "bf1d6db3de4a24ae5dd45b68fbf24ef466c09b83"
+    },
+    {
+      "path": "org/apache/taglibs/taglibs-standard-impl/1.2.5/taglibs-standard-impl-1.2.5.jar",
+      "sha1": "9b9783ccb2a323383e6e20e36d368f8997b71967"
+    },
+    {
+      "path": "org/apache/taglibs/taglibs-standard-spec/1.2.5/taglibs-standard-spec-1.2.5.pom",
+      "sha1": "6e5f587dbddfa61aea4d40261f0ac87382e307b5"
+    },
+    {
+      "path": "org/apache/taglibs/taglibs-standard-spec/1.2.5/taglibs-standard-spec-1.2.5.jar",
+      "sha1": "c3bb98c30f75fef1e229d1d03cf8457de22f1ba0"
+    },
+    {
+      "path": "org/apache/tomcat/embed/tomcat-embed-core/8.5.51/tomcat-embed-core-8.5.51.jar",
+      "sha1": "372fe3f46f18086ae6aa11e2cc9fd645b91f8e44"
+    },
+    {
+      "path": "org/apache/tomcat/embed/tomcat-embed-core/8.5.51/tomcat-embed-core-8.5.51.pom",
+      "sha1": "ab236ed3321ee7013d460542f652fbb76bf25299"
+    },
+    {
+      "path": "org/apache/tomcat/embed/tomcat-embed-el/8.5.51/tomcat-embed-el-8.5.51.jar",
+      "sha1": "1f30b8dbfc5729b74d77c2d330ac5cf3fab91e64"
+    },
+    {
+      "path": "org/apache/tomcat/embed/tomcat-embed-el/8.5.51/tomcat-embed-el-8.5.51.pom",
+      "sha1": "843c255268702bae6ce6ef7d050bc8ab3f24a79b"
+    },
+    {
+      "path": "org/apache/tomcat/embed/tomcat-embed-jasper/8.5.51/tomcat-embed-jasper-8.5.51.jar",
+      "sha1": "6635a4620d27624da35585609ce9f3fbbd32ea23"
+    },
+    {
+      "path": "org/apache/tomcat/embed/tomcat-embed-jasper/8.5.51/tomcat-embed-jasper-8.5.51.pom",
+      "sha1": "5e2048829888323aaa2fb1d8781a4b5b31606a7d"
+    },
+    {
+      "path": "org/apache/tomcat/embed/tomcat-embed-websocket/8.5.51/tomcat-embed-websocket-8.5.51.jar",
+      "sha1": "369f2751f26aa6445afc10aea9d06dc45882d445"
+    },
+    {
+      "path": "org/apache/tomcat/embed/tomcat-embed-websocket/8.5.51/tomcat-embed-websocket-8.5.51.pom",
+      "sha1": "edc230078858b5e233a49e4e6e7d21b77dc9b30b"
+    },
+    {
+      "path": "org/apache/tomcat/tomcat-annotations-api/8.5.51/tomcat-annotations-api-8.5.51.pom",
+      "sha1": "9397303469a01abd8e53f82e7d9e74e9b289c05a"
+    },
+    {
+      "path": "org/apache/tomcat/tomcat-annotations-api/8.5.51/tomcat-annotations-api-8.5.51.jar",
+      "sha1": "8e5f62a9d81f9522466f0be0cb1d7e5c3405e906"
+    },
+    {
+      "path": "org/apache/tomcat/tomcat-jdbc/8.5.51/tomcat-jdbc-8.5.51.jar",
+      "sha1": "cc33280d585e17df50c0ff4476adb988c1ee767a"
+    },
+    {
+      "path": "org/apache/tomcat/tomcat-jdbc/8.5.51/tomcat-jdbc-8.5.51.pom",
+      "sha1": "da81cfde22a4da62cc2527aed0f794daa3fe1941"
+    },
+    {
+      "path": "org/apache/tomcat/tomcat-juli/8.5.51/tomcat-juli-8.5.51.jar",
+      "sha1": "5e5b0b43f98aed549ef63d2a1df43c779e1e2b00"
+    },
+    {
+      "path": "org/apache/tomcat/tomcat-juli/8.5.51/tomcat-juli-8.5.51.pom",
+      "sha1": "10e3fe8b19d415ebfe14a3aa693094a6b1b51e42"
+    },
+    {
+      "path": "org/apache/velocity/velocity/1.5/velocity-1.5.jar",
+      "sha1": "09f306baf7523ffc0e81a6353d08a584d254133b"
+    },
+    {
+      "path": "org/apache/velocity/velocity/1.5/velocity-1.5.pom",
+      "sha1": "106262b58f0f2b44cc0dbb3d0fa77105f28f5e38"
+    },
+    {
+      "path": "org/apache/velocity/velocity/1.6.2/velocity-1.6.2.pom",
+      "sha1": "929626ce5697f341cdf81bbbd9c7387b701a821f"
+    },
+    {
+      "path": "org/apache/velocity/velocity/1.7/velocity-1.7.jar",
+      "sha1": "2ceb567b8f3f21118ecdec129fe1271dbc09aa7a"
+    },
+    {
+      "path": "org/apache/velocity/velocity/1.7/velocity-1.7.pom",
+      "sha1": "6047636d464804f4075f703660a010890e40723d"
+    },
+    {
+      "path": "org/apache/velocity/velocity-engine-core/2.1/velocity-engine-core-2.1.jar",
+      "sha1": "af23c9cc6eafd771a75ef19c4bcaf89337401c10"
+    },
+    {
+      "path": "org/apache/velocity/velocity-engine-core/2.1/velocity-engine-core-2.1.pom",
+      "sha1": "5419d25f6cbfca1a1f5c21ef52821bb92cb75bcb"
+    },
+    {
+      "path": "org/apache/velocity/velocity-engine-core/2.2/velocity-engine-core-2.2.pom",
+      "sha1": "e637e5ccfc021b8b1a94d07bf6e47eca92e44332"
+    },
+    {
+      "path": "org/apache/velocity/velocity-engine-core/2.2/velocity-engine-core-2.2.jar",
+      "sha1": "68d899cb70cd27d495562fa808feb2da4926d38f"
+    },
+    {
+      "path": "org/apache/velocity/velocity-engine-parent/2.1/velocity-engine-parent-2.1.pom",
+      "sha1": "edab0dc883275d004c408e897fee0eea68557b64"
+    },
+    {
+      "path": "org/apache/velocity/velocity-engine-parent/2.2/velocity-engine-parent-2.2.pom",
+      "sha1": "a84af404cf9bb4c7a05255dd791370717cfe3bfc"
+    },
+    {
+      "path": "org/apache/velocity/velocity-master/2/velocity-master-2.pom",
+      "sha1": "174f40d44cd1e99f360524474ac079835a7f2fd3"
+    },
+    {
+      "path": "org/apache/velocity/velocity-master/3/velocity-master-3.pom",
+      "sha1": "6d93fb7546348709202dde19bdc9cddc60745d5a"
+    },
+    {
+      "path": "org/apache/velocity/velocity-tools/2.0/velocity-tools-2.0.jar",
+      "sha1": "69936384de86857018b023a8c56ae0635c56b6a0"
+    },
+    {
+      "path": "org/apache/velocity/velocity-tools/2.0/velocity-tools-2.0.pom",
+      "sha1": "dfbd6d8a50df5de5ba9949e9ca9d0cf9af6ca99e"
+    },
+    {
+      "path": "org/apache/ws/xmlschema/xmlschema/2.2.5/xmlschema-2.2.5.pom",
+      "sha1": "9c71ef15c8d91d466cd9fbf9cefdee881e733a5e"
+    },
+    {
+      "path": "org/apache/ws/xmlschema/xmlschema-core/2.2.5/xmlschema-core-2.2.5.jar",
+      "sha1": "789b4ad32ad7ff021c7731fa43d324c0ce8105f2"
+    },
+    {
+      "path": "org/apache/ws/xmlschema/xmlschema-core/2.2.5/xmlschema-core-2.2.5.pom",
+      "sha1": "7e8900b8e693822215117c8b0b17a4dbcd196c9a"
+    },
+    {
+      "path": "org/apache/xbean/xbean/3.4/xbean-3.4.pom",
+      "sha1": "6b6d0d977f3fb41cfd097a350472baefd82713f5"
+    },
+    {
+      "path": "org/apache/xbean/xbean/3.7/xbean-3.7.pom",
+      "sha1": "7535d6499940c84ce0af8124ea57d3cfd4b2989b"
+    },
+    {
+      "path": "org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar",
+      "sha1": "26fd55dceb037f4789b399b22874d74f4d2db66f"
+    },
+    {
+      "path": "org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom",
+      "sha1": "5027123eb872a166f5205a5eb00d3ed186b63277"
+    },
+    {
+      "path": "org/apache/xbean/xbean-reflect/3.7/xbean-reflect-3.7.pom",
+      "sha1": "c0ade23ea098a70947671b7f612112f133b1dc98"
+    },
+    {
+      "path": "org/assertj/assertj-core/2.6.0/assertj-core-2.6.0.jar",
+      "sha1": "b532c3fc4f66bcfee4989a3514f1cd56203a33ad"
+    },
+    {
+      "path": "org/assertj/assertj-core/2.6.0/assertj-core-2.6.0.pom",
+      "sha1": "c1abd6bd9ca75b99d8c8798d1fa41fefdb61c0ab"
+    },
+    {
+      "path": "org/assertj/assertj-parent-pom/2.1.4/assertj-parent-pom-2.1.4.pom",
+      "sha1": "eb46c0f43b82d7e50ff5ae9015524e955bf5032d"
+    },
+    {
+      "path": "org/beanshell/beanshell/2.0b4/beanshell-2.0b4.pom",
+      "sha1": "d00ea1e44675318c6c9105473bc2168e6df4a9aa"
+    },
+    {
+      "path": "org/beanshell/bsh/2.0b4/bsh-2.0b4.pom",
+      "sha1": "57e0b6a607859774b2cdd680c6f2aab147b83a4f"
+    },
+    {
+      "path": "org/beanshell/bsh/2.0b4/bsh-2.0b4.jar",
+      "sha1": "a05f0a0feefa8d8467ac80e16e7de071489f0d9c"
+    },
+    {
+      "path": "org/bouncycastle/bcprov-jdk15on/1.60/bcprov-jdk15on-1.60.pom",
+      "sha1": "2e5c6ffc32983b3bf170a97d3370b277b9b2ea34"
+    },
+    {
+      "path": "org/bouncycastle/bcprov-jdk15on/1.60/bcprov-jdk15on-1.60.jar",
+      "sha1": "bd47ad3bd14b8e82595c7adaa143501e60842a84"
+    },
+    {
+      "path": "org/checkerframework/checker-qual/2.10.0/checker-qual-2.10.0.jar",
+      "sha1": "5786699a0cb71f9dc32e6cca1d665eef07a0882f"
+    },
+    {
+      "path": "org/checkerframework/checker-qual/2.10.0/checker-qual-2.10.0.pom",
+      "sha1": "aaceb55005b10d5e636a249169afc6d579618fa9"
+    },
+    {
+      "path": "org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.jar",
+      "sha1": "cea74543d5904a30861a61b4643a5f2bb372efc4"
+    },
+    {
+      "path": "org/checkerframework/checker-qual/2.5.2/checker-qual-2.5.2.pom",
+      "sha1": "7cee753353b0fc94e0300ad3dbf155069260c4d7"
+    },
+    {
+      "path": "org/codehaus/castor/castor/1.3.3/castor-1.3.3.pom",
+      "sha1": "2a6f9cde54f5bd11336546403ea92f570ed63cfa"
+    },
+    {
+      "path": "org/codehaus/castor/castor-core/1.3.3/castor-core-1.3.3.jar",
+      "sha1": "2fbb4a27b840e116526a1189dbe53307551ecfb4"
+    },
+    {
+      "path": "org/codehaus/castor/castor-core/1.3.3/castor-core-1.3.3.pom",
+      "sha1": "fabdf4b61227f586e694947601322277577f561e"
+    },
+    {
+      "path": "org/codehaus/castor/castor-xml/1.3.3/castor-xml-1.3.3.jar",
+      "sha1": "1072663e1b7463f6452eba51749bec5526f4883d"
+    },
+    {
+      "path": "org/codehaus/castor/castor-xml/1.3.3/castor-xml-1.3.3.pom",
+      "sha1": "a0bc9174f01de7be6d5bdcec580e6a3b999674ec"
+    },
+    {
+      "path": "org/codehaus/codehaus-parent/3/codehaus-parent-3.pom",
+      "sha1": "0114564290d2a7302bb47931c10aeffba03303d5"
+    },
+    {
+      "path": "org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.jar",
+      "sha1": "f97ce6decaea32b36101e37979f8b647f00681fb"
+    },
+    {
+      "path": "org/codehaus/mojo/animal-sniffer-annotations/1.17/animal-sniffer-annotations-1.17.pom",
+      "sha1": "80948bd07c5db60753d8d5a9164b8b2272e0842a"
+    },
+    {
+      "path": "org/codehaus/mojo/animal-sniffer-parent/1.17/animal-sniffer-parent-1.17.pom",
+      "sha1": "eea4b805793494ebb025e5a9926ea3cf1ee8b34d"
+    },
+    {
+      "path": "org/codehaus/mojo/buildnumber-maven-plugin/1.4/buildnumber-maven-plugin-1.4.jar",
+      "sha1": "af5e3c6d7eb02c125488e83168c179f7c12743fc"
+    },
+    {
+      "path": "org/codehaus/mojo/buildnumber-maven-plugin/1.4/buildnumber-maven-plugin-1.4.pom",
+      "sha1": "560ccedd8cc60bdb5ed3f31b555a3b7f406bce07"
+    },
+    {
+      "path": "org/codehaus/mojo/mojo-parent/38/mojo-parent-38.pom",
+      "sha1": "d1eff1fac710c195be11a8ac729f8b4735ffd3e3"
+    },
+    {
+      "path": "org/codehaus/mojo/mojo-parent/40/mojo-parent-40.pom",
+      "sha1": "d2fa7c95447827e9bbcb8c60bd9484c51202732e"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/1.0.10/plexus-1.0.10.pom",
+      "sha1": "039c3f6a3cbe1f9e7b4a3309d9d7062b6e390fa7"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom",
+      "sha1": "4693d4512d50c5159bef1c49def1d2690a327c30"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/1.0.12/plexus-1.0.12.pom",
+      "sha1": "71d4361c71c7454a2626f3e18c789747256fe0b1"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom",
+      "sha1": "06f66b2f7d2eef1d805c11bca91c89984cda4137"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/1.0.8/plexus-1.0.8.pom",
+      "sha1": "9e7c8432829962afe796b32587c1bfa841a317d5"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/1.0.9/plexus-1.0.9.pom",
+      "sha1": "89d241b1e5ee6a72d3dd95d9eb90f635deebcdb2"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/2.0.2/plexus-2.0.2.pom",
+      "sha1": "b6c97d19090baa51e953fb782e3986b068fb450f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/2.0.3/plexus-2.0.3.pom",
+      "sha1": "bf472ec56fe823f1b4b997fe5b9396490ae9b1dc"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/2.0.5/plexus-2.0.5.pom",
+      "sha1": "c37b8e9129d8860dfdea27da2c5407de7c6faba7"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom",
+      "sha1": "da193f47e5ce5a2cb85931851b3698e61cde8227"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom",
+      "sha1": "f6ee62f8157f273757b8ffda59714a6a279a174d"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom",
+      "sha1": "9ae573423303ba80844ed564756442d32b97cc33"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/3.1/plexus-3.1.pom",
+      "sha1": "b64de86ceaa4f0e4d8ccc44a26c562c6fb7fb230"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/3.2/plexus-3.2.pom",
+      "sha1": "521733c90c6fb160311e47b51f0471642b69f64f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom",
+      "sha1": "f081c65405b2d5e403c9d57e791b23f613966322"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/3.3.2/plexus-3.3.2.pom",
+      "sha1": "7ba5dd42cae4e80cf4d34ecff014dbf34df26b59"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/3.3/plexus-3.3.pom",
+      "sha1": "70ab8436286998acce80e63fe75067a70cfe3e43"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/4.0/plexus-4.0.pom",
+      "sha1": "cdbb31ee91973d16e8f8b0bda51ed4211e7a9f57"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/5.0/plexus-5.0.pom",
+      "sha1": "7733f81581a7b549cef034c9117d4d8c29ea07d6"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus/5.1/plexus-5.1.pom",
+      "sha1": "2fca82e2eb5172f6a2909bea7accc733581a8c71"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/1.0/plexus-archiver-1.0.jar",
+      "sha1": "b564a05aeecd4d81d6b81f57a1d495fc8c0f497f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/1.0/plexus-archiver-1.0.pom",
+      "sha1": "0fe828f728c599c354503a9ec3603f603a7fecec"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/2.0.1/plexus-archiver-2.0.1.pom",
+      "sha1": "dfbf04dfe84e3789b1e7ef3e49c8e9a09df454c9"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom",
+      "sha1": "8e63c83bf055cf0357669ca934f64c6bf27fc640"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar",
+      "sha1": "97853695be4bba3724512226c4d910fed733e608"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/2.8.1/plexus-archiver-2.8.1.jar",
+      "sha1": "303776b3f932488380e34fe43b51ab1bbd717b8a"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/2.8.1/plexus-archiver-2.8.1.pom",
+      "sha1": "fabb4c6b362103ff4bcd7f2b9ece4baec9cfd60a"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/3.6.0/plexus-archiver-3.6.0.jar",
+      "sha1": "1b74dd2c2f4209d227673c2a233a1db60956b8ab"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/3.6.0/plexus-archiver-3.6.0.pom",
+      "sha1": "9929853c94aef0eb677cd2ff39c05a75e57cc199"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/4.1.0/plexus-archiver-4.1.0.jar",
+      "sha1": "0763af859d6f9fafbc61d2034fcf12275e72554e"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/4.1.0/plexus-archiver-4.1.0.pom",
+      "sha1": "e5a347a3656848a40de0c1554ae0517e65efc687"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/4.2.0/plexus-archiver-4.2.0.jar",
+      "sha1": "07dbbceeac12962f85499a2f682749d03a5fbe00"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-archiver/4.2.0/plexus-archiver-4.2.0.pom",
+      "sha1": "b7894bdf4ac829204037f802d97827dbfadb209a"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/1.2-alpha-7/plexus-classworlds-1.2-alpha-7.pom",
+      "sha1": "6944ec0d0cab19adf167332f7197e045d64a577c"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/1.2-alpha-9/plexus-classworlds-1.2-alpha-9.pom",
+      "sha1": "32be3692644bf86d1226e13e2a60b49a9fa49571"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom",
+      "sha1": "df1dfb0099c8759b378fe0af3b4a564d2c16aa18"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom",
+      "sha1": "068f7ac6a425f5e82bbbb5faef91e4b5d3d84f76"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.jar",
+      "sha1": "93b34d7a40ed56fe33274480c5792b656d3697a9"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.4.2/plexus-classworlds-2.4.2.jar",
+      "sha1": "e006f28662eba33d91d1c5e342e0bd66f8e9da18"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.4.2/plexus-classworlds-2.4.2.pom",
+      "sha1": "55f9b6f069b025381e0e0975ce946575a4c49d8d"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.4/plexus-classworlds-2.4.pom",
+      "sha1": "e93052514961d9aebb23ef1090b85292a19af650"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.5.1/plexus-classworlds-2.5.1.jar",
+      "sha1": "98fea8e8c3fb0e8670a69ad6ea445872c9972910"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.5.1/plexus-classworlds-2.5.1.pom",
+      "sha1": "63692250d77f087aa9818ada1c93ec5c69c73794"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+      "sha1": "4abb111bfdace5b8167db4c0ef74644f3f88f142"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.pom",
+      "sha1": "a39bedbc3fa3652d3606821d7c21d80e900f57a0"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-compiler/2.8.4/plexus-compiler-2.8.4.pom",
+      "sha1": "0e54ac334bbea91bcb67325d78871c4082522f28"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.jar",
+      "sha1": "ab13f02c237842b1d81b531fafd27f3c13585a37"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.pom",
+      "sha1": "be4194949f559462e78267207a99360274a58056"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.jar",
+      "sha1": "4a2c03bf7663dff8fd512cc1a7adecacf1a2249b"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.pom",
+      "sha1": "fecd511a1cd70f23ecee2cecc52b4d89124c114c"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.jar",
+      "sha1": "43b09c6b1831e962259634ac9ae2e6ac0467560e"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.pom",
+      "sha1": "578d6fba6c0b8a91884f3e710e051ad466d33425"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-compilers/2.8.4/plexus-compilers-2.8.4.pom",
+      "sha1": "2ee8e7bcc9426c075fa4d0c415fb648ea8a9d701"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-component-annotations/1.5.4/plexus-component-annotations-1.5.4.pom",
+      "sha1": "52093f92fd7f82edf464f86c4f7220f9effc4bf2"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar",
+      "sha1": "c72f2660d0cbed24246ddb55d7fdc4f7374d2078"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom",
+      "sha1": "fd506865d5d083d8cef9fdbf525ad99fcc3416c1"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
+      "sha1": "1a34a4e12b5fded8c548a568f463dfee21500927"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.pom",
+      "sha1": "b3100bff4d6af30a293f11b7a8023110882cfb00"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
+      "sha1": "862abca6deff0fff241a835a33d22559e9132069"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom",
+      "sha1": "e265daf1fcf56a67dd9bae3db80531a9717ccee4"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.1.12/plexus-components-1.1.12.pom",
+      "sha1": "e7332a35914684bab5dd1718aea0202fa5a2bb0d"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom",
+      "sha1": "aed78d67ee20a5038741c7cc2a8124ae20c960ad"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom",
+      "sha1": "44366f11d5b9571c16829ae7f0a7f20e116f6260"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.1.17/plexus-components-1.1.17.pom",
+      "sha1": "9c09b4388c02db50d9aec045e4f38660928ebb91"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.1.18/plexus-components-1.1.18.pom",
+      "sha1": "41abf89f075e6b912a2ff728aa002e98591de425"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom",
+      "sha1": "2c0f4d3bcbcdd8f77521502d886681ed5af38a25"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.1.7/plexus-components-1.1.7.pom",
+      "sha1": "5fcdd5b77b86b603af118b70281f48539031a9f3"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.1.9/plexus-components-1.1.9.pom",
+      "sha1": "4fcb5bb11c1f4afa8cfc4a0cac8578e46a4dc072"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.2/plexus-components-1.2.pom",
+      "sha1": "d0371336a8a00aa8ab99b332ac8eaf1665a9a3e5"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom",
+      "sha1": "4daaf2af8e09587eb3837b80252473d6f423c0f7"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/1.3/plexus-components-1.3.pom",
+      "sha1": "979daf6b32bf4eb1fc8ff51689bf31731651a0c8"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-components/4.0/plexus-components-4.0.pom",
+      "sha1": "dcad998d9c45ca35212ac7efc49b729efce20395"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.0-alpha-20/plexus-container-default-1.0-alpha-20.pom",
+      "sha1": "911e3b5962b6485fd2fac68fa1af066f36388320"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.0-alpha-30/plexus-container-default-1.0-alpha-30.pom",
+      "sha1": "aa1efeb7ed05a3c5037cc194b9e8fbf97e52268a"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.0-alpha-30/plexus-container-default-1.0-alpha-30.jar",
+      "sha1": "669d4ba8e898e37987eb5e30b121ed1d62c5b7b8"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.0-alpha-7/plexus-container-default-1.0-alpha-7.pom",
+      "sha1": "3c22ef49814751f8b2d70e683784a9ce698e1ddc"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.0-alpha-8/plexus-container-default-1.0-alpha-8.pom",
+      "sha1": "3324c2065311b5cd636d3fe37353fe7558a6ec22"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom",
+      "sha1": "d00c65ec36fb3cc8c755182a7ee52d3d80340179"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.jar",
+      "sha1": "50596183cd7b688d9d7b6d868a0193ca1a8a7b3d"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar",
+      "sha1": "94aea3010e250a334d9dab7f591114cd6c767458"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom",
+      "sha1": "f557cb47f4594ac941d0edf08093a03ce15b51ba"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.jar",
+      "sha1": "0265fa2851d31c2e2177859a518987595efe146b"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.pom",
+      "sha1": "f68a6d3761cfdfdf1e13ce2c18327c514acad611"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-container-default/1.7.1/plexus-container-default-1.7.1.pom",
+      "sha1": "896d26462dfe652aa1ef18ec5ca33abe3aa7c929"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom",
+      "sha1": "e16f1c9b83cdeb142fc038dd0262c61121d58c4b"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-containers/1.0-alpha-20/plexus-containers-1.0-alpha-20.pom",
+      "sha1": "5e436ba5a20b19e6b840f087e12e1c993b427de0"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-containers/1.0-alpha-30/plexus-containers-1.0-alpha-30.pom",
+      "sha1": "8b6330c46076c52825feb050aa27c550b24b4a17"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-containers/1.5.4/plexus-containers-1.5.4.pom",
+      "sha1": "b9942b081e9903371eb0c8f5677d1d2564b575ca"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom",
+      "sha1": "cd786b660f8a4c1c520403a5fa04c7be45212b84"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-containers/1.6/plexus-containers-1.6.pom",
+      "sha1": "01ee1c699a2730f9119b35055fb0674af36125ea"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom",
+      "sha1": "7ff4e431b5af8100be6e9fcd946ba7c532d890e2"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-digest/1.0/plexus-digest-1.0.jar",
+      "sha1": "5f6a5a5140cd39e8c987cf6c31429d917b31166e"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-digest/1.0/plexus-digest-1.0.pom",
+      "sha1": "df5c2e55c9f30db34972661819437f1802128861"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-i18n/1.0-beta-7/plexus-i18n-1.0-beta-7.jar",
+      "sha1": "3690f10a668b3c7ac2ef563f14cfb6b2ba30ee57"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-i18n/1.0-beta-7/plexus-i18n-1.0-beta-7.pom",
+      "sha1": "5080cbaf0a98e413017ed074c845673c16546500"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interactivity/1.0-alpha-6/plexus-interactivity-1.0-alpha-6.pom",
+      "sha1": "177759a51876fa734062717a18cb0386e337b2a4"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar",
+      "sha1": "0a8f1178664a5457eef3f4531eb62f9505e1295f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom",
+      "sha1": "1376ffcc4a8d46dee6c1a9096d0dcad3be01f838"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-6/plexus-interactivity-api-1.0-alpha-6.pom",
+      "sha1": "1302bc34bedec5ff61cd28f9e03d12f9dcdff704"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.jar",
+      "sha1": "ad9dddff6043194904ad1d2c00ff1d003c3915f7"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom",
+      "sha1": "f03da80999422b6cc4300735789be83e4498a3bc"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom",
+      "sha1": "101dd833f7186103b61a0281da38c95ae440eb63"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom",
+      "sha1": "5003aac564f8ab42ceede81b114c520b48271873"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar",
+      "sha1": "1740038076cec1946fd28ed5ac5c1688f7cf7630"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar",
+      "sha1": "c88dd864fe8b8256c25558ce7cd63be66ba07693"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.pom",
+      "sha1": "e296d45aff17c16ed268c5b9480214a0d92937ab"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar",
+      "sha1": "d682b4b8c1a92329d5b114a51794ef178168abbe"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom",
+      "sha1": "3dda3be2ada841f5ca3976a48281349a99f27e89"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.16/plexus-interpolation-1.16.jar",
+      "sha1": "a868d4a603bd42c9dee67890c4e60e360a11838c"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.16/plexus-interpolation-1.16.pom",
+      "sha1": "c70b5eaf02d61618e86d8d78e4faf75404046366"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.19/plexus-interpolation-1.19.pom",
+      "sha1": "5a2b6c765a231ca90800a96583016884fd08eceb"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.1/plexus-interpolation-1.1.pom",
+      "sha1": "f14eb0d6ef1381f7199fe0e95407f4d2f391ea04"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
+      "sha1": "f92de59d295f16868001644acc21720f3ec9eb15"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.pom",
+      "sha1": "af59eb04ba7e5a729837c4c6799ef4b80553a92e"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.22/plexus-interpolation-1.22.pom",
+      "sha1": "782dc9485921d413721351372518740805e45694"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24.jar",
+      "sha1": "ff3f217127fbd6846bba831ab156e227db2cf347"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24.pom",
+      "sha1": "1909f6cd42a5ead655435ebc7ecb609e3d6536ac"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
+      "sha1": "3b37b3335e6a97e11e690bbdc22ade1a5deb74d6"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.pom",
+      "sha1": "12076338086123f5e5719c3afd9a5ba98363e35f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/1.0/plexus-io-1.0.jar",
+      "sha1": "bb1de3fa6a3eea8056bd1b165750d2b761514331"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/1.0/plexus-io-1.0.pom",
+      "sha1": "8442373b14f4b75671edaf9017682f380451caf3"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/2.0.1/plexus-io-2.0.1.pom",
+      "sha1": "a9cae1571f6c8c51c5847e220920266c5229fa5f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar",
+      "sha1": "5d1890f1099242d6a1a6a46640eed931a96ef67f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom",
+      "sha1": "d0ad15a280e5bf6c32388cbef26fd7d428fa1623"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/2.3.2/plexus-io-2.3.2.jar",
+      "sha1": "092039985681333499e44f032887b6e340816a1d"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/2.3.2/plexus-io-2.3.2.pom",
+      "sha1": "54127072bc4bd5fe338a195bdad94680aaabe7a2"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/3.0.0/plexus-io-3.0.0.pom",
+      "sha1": "873fa1e145c1f3fbf46d2ccf3e1e353eb3fe9701"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/3.0.0/plexus-io-3.0.0.jar",
+      "sha1": "c1a315327d25865ae90aa6af977f027b35f49275"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/3.0.1/plexus-io-3.0.1.pom",
+      "sha1": "e9b9e28661236bd2a4a6caf1a6c638db90144394"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/3.1.1/plexus-io-3.1.1.jar",
+      "sha1": "3d372932025ed4d545ad0474406e46215432511c"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/3.1.1/plexus-io-3.1.1.pom",
+      "sha1": "57957485ae217ef811c65ec01a85676fbbd39423"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/3.2.0/plexus-io-3.2.0.jar",
+      "sha1": "0f7d52906fe1b21b06fa046a98d6c15c4e595c5e"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-io/3.2.0/plexus-io-3.2.0.pom",
+      "sha1": "f22cb44bfe3065e8508cd5972967a2c308dab19d"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.jar",
+      "sha1": "269ef3b88d500716f958a8e2b78561f34d50df80"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.pom",
+      "sha1": "65d0f66fc4b0adafe01c8b29a8bd692d0d62ba09"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-java/0.9.8/plexus-java-0.9.8.jar",
+      "sha1": "e8c0dea9398b4aa9c6526c09774d2ef3ce9194c1"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-java/0.9.8/plexus-java-0.9.8.pom",
+      "sha1": "9990f0bd332cb0897914c735c0cfba8238ddf05f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-languages/0.9.10/plexus-languages-0.9.10.pom",
+      "sha1": "f7816d2ab70df6ff670bcfb8376d14238a63be72"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-languages/0.9.8/plexus-languages-0.9.8.pom",
+      "sha1": "6df572addc95eb9262d7bd1569a71943126ce139"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-resources/1.0.1/plexus-resources-1.0.1.jar",
+      "sha1": "c98914e8da5475b8eb96586fbdd66891e01cdbb4"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-resources/1.0.1/plexus-resources-1.0.1.pom",
+      "sha1": "620f1c969b8c979c495efcb29c8779912ef397f7"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-resources/1.1.0/plexus-resources-1.1.0.jar",
+      "sha1": "503d473a949a338986104f209a9f805637ffcebf"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-resources/1.1.0/plexus-resources-1.1.0.pom",
+      "sha1": "65abb3affefbfdcc15f7ac660a3c7a5aaf3ac1f6"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom",
+      "sha1": "a82e1ddd2d795616ac58d73ed246b8ec65326dfa"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.pom",
+      "sha1": "15492ecd00920daca9ec15f6acd695b626621e5b"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.3/plexus-utils-1.3.pom",
+      "sha1": "050fadd040060c86cfd5d78ba95dab0cffcbcf5e"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom",
+      "sha1": "0a77530df5e881e55a4ffaea4b6bf33d57bc5b26"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.4.2/plexus-utils-1.4.2.pom",
+      "sha1": "f530a0f2aae3ef8e65ca359e7243d67ecc366076"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom",
+      "sha1": "0bdc8a7fbce7d9007a93d289a029b43e1196d85c"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.4.6/plexus-utils-1.4.6.pom",
+      "sha1": "a734ee9396d2ac09764cef74ebc56ef0339f6bd2"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.4/plexus-utils-1.4.pom",
+      "sha1": "a45f558bfb3da6f8863045578ab62431d088c073"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.10/plexus-utils-1.5.10.jar",
+      "sha1": "f387a2faa309154d90b90cc049e44b7833a6c282"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.10/plexus-utils-1.5.10.pom",
+      "sha1": "57d2292858b9a695b97c9cf426a50d1e9b3b9292"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.12/plexus-utils-1.5.12.pom",
+      "sha1": "208a6bbc01bc37514c2245c5284072c7a8b16e21"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.jar",
+      "sha1": "c689598ce1eb94c304817877ed15911099972526"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom",
+      "sha1": "b1f42bc7ebc5be3c0414f67fe2daf3b183acd74f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom",
+      "sha1": "2a0b3470063440066d3b8a084340ce07dbdbfedc"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom",
+      "sha1": "6d04eaae6db5f8d879332da294a46df0fd81450f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.6/plexus-utils-1.5.6.pom",
+      "sha1": "2df1a6c4e7b1849a10643a37a6f66b21d49bd643"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.6/plexus-utils-1.5.6.jar",
+      "sha1": "8fb6b798a4036048b3005e058553bf21a87802ed"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom",
+      "sha1": "7deaa90e5725075c9f9fb5a2cfbef75c86a5e5b5"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.jar",
+      "sha1": "1a363fa733fba4285967162f9a6ffe6fd356ec24"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.pom",
+      "sha1": "ffd8cee6475d101a5697091e1c18b0d08e3a8ff8"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar",
+      "sha1": "7841ba10ea46c9611ce702c3833ff9fccc8ae6eb"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom",
+      "sha1": "51785edd83de609389ba142c9516752a4246aefc"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.10/plexus-utils-3.0.10.pom",
+      "sha1": "c70632156c3f19286424329d71e82b2026b90471"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.14/plexus-utils-3.0.14.pom",
+      "sha1": "3969b18a951b7a0cf4201f024fc4731c2ecf9cfd"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.15/plexus-utils-3.0.15.pom",
+      "sha1": "b46db4dcfbbcc99f6d9bae21f6bc3634fdf3cf02"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.17/plexus-utils-3.0.17.pom",
+      "sha1": "f2f5fa2f18718b54e0c488e9c40ca68c9e0cd190"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.20/plexus-utils-3.0.20.jar",
+      "sha1": "e121ed37af8ee3928952f6d8a303de24e019aab0"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.20/plexus-utils-3.0.20.pom",
+      "sha1": "43537d18e657a7a965f8e9f71a3fc027927fdc5f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.21/plexus-utils-3.0.21.jar",
+      "sha1": "2ccfd89abf4844d9cf582a50923e6e69d655a565"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.21/plexus-utils-3.0.21.pom",
+      "sha1": "948fbd0f6d89027dd955a0fa3e9193f9c2781bcc"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar",
+      "sha1": "764f26e0ab13a87c48fe55f525dfb6a133b7a92f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.pom",
+      "sha1": "553c5a129da11f6d56a2599ad0b21649a6d6de08"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.24/plexus-utils-3.0.24.jar",
+      "sha1": "b4ac9780b37cb1b736eae9fbcef27609b7c911ef"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.24/plexus-utils-3.0.24.pom",
+      "sha1": "288f4a74efd0cea03e1d59272271f07d598b88d6"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.3/plexus-utils-3.0.3.pom",
+      "sha1": "a9f2c5ea043b39693544c019884d4a7cf9758f56"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.5/plexus-utils-3.0.5.jar",
+      "sha1": "3da9c286180a66aba197db8ffa7bbdc756c3e31f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.5/plexus-utils-3.0.5.pom",
+      "sha1": "880976a01d8f71ced7c8da841e571479bb7b6021"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom",
+      "sha1": "45a8cbe47c297155f2e2ef10c1b7b4707ab55fc6"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar",
+      "sha1": "d63aa0daf60d573bada235e2b4207617dcf24959"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom",
+      "sha1": "fe3d8457b0cf4e219fd8e3edad5054b8e38f17b0"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
+      "sha1": "60eecb6f15abdb1c653ad80abaac6fe188b3feaa"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.pom",
+      "sha1": "8113ec9ba85eb589648929ae5bbd68b1023996c7"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.1.1/plexus-utils-3.1.1.pom",
+      "sha1": "9444be6c0e7197eccde066fc5ed8aaba968e9a16"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.2.0/plexus-utils-3.2.0.pom",
+      "sha1": "1a232f7612ac1d56eadf248d059d58461b1515fe"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.2.0/plexus-utils-3.2.0.jar",
+      "sha1": "d69e11d69dfce0c964587ab97b559187b3c27a6f"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.2.1/plexus-utils-3.2.1.jar",
+      "sha1": "13b015768e0d04849d2794e4c47eb02d01a0de32"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.2.1/plexus-utils-3.2.1.pom",
+      "sha1": "7caaedbb1cfaa1605581d2b0c9b8ced8dea5ebb0"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar",
+      "sha1": "cf43b5391de623b36fe066a21127baef82c64022"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.pom",
+      "sha1": "de5faec837d872a1712aa89242845216118a9405"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-velocity/1.1.7/plexus-velocity-1.1.7.jar",
+      "sha1": "1440fc2552d1405b1c2d380ef3b96c4d9c6dbd0b"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-velocity/1.1.7/plexus-velocity-1.1.7.pom",
+      "sha1": "659f8ef80ef0cc3d101e63535b9c5a39f7bc4b3e"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-velocity/1.1.8/plexus-velocity-1.1.8.jar",
+      "sha1": "d6b34818c82cd2e2f7bc75a2852d31283d154291"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-velocity/1.1.8/plexus-velocity-1.1.8.pom",
+      "sha1": "7023c6a73051a5addaa912405ef0a95e56c64c7e"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-velocity/1.2/plexus-velocity-1.2.jar",
+      "sha1": "1331b9d6bbf99ead362c68c2f318ebe5fedda598"
+    },
+    {
+      "path": "org/codehaus/plexus/plexus-velocity/1.2/plexus-velocity-1.2.pom",
+      "sha1": "ed912aed85e5225ef3dda9a9cd2acaa0a08c643b"
+    },
+    {
+      "path": "org/codehaus/woodstox/stax2-api/3.1.4/stax2-api-3.1.4.jar",
+      "sha1": "ac19014b1e6a7c08aad07fe114af792676b685b7"
+    },
+    {
+      "path": "org/codehaus/woodstox/stax2-api/3.1.4/stax2-api-3.1.4.pom",
+      "sha1": "99256d9abcf494e10152ed6212c05927e3033b01"
+    },
+    {
+      "path": "org/directwebremoting/dwr/3.0.rc1/dwr-3.0.rc1.pom",
+      "sha1": "0402e78d9b977795121f24bed750dff26562cf2a"
+    },
+    {
+      "path": "org/directwebremoting/dwr/3.0.rc1/dwr-3.0.rc1.jar",
+      "sha1": "da11812345d92322a43d5c6fd34066c52f96afd5"
+    },
+    {
+      "path": "org/eclipse/aether/aether/0.9.0.M2/aether-0.9.0.M2.pom",
+      "sha1": "e44bcfab62cbf0ad4f15a47aa9cc48368db2dc6d"
+    },
+    {
+      "path": "org/eclipse/aether/aether/1.0.2.v20150114/aether-1.0.2.v20150114.pom",
+      "sha1": "ec17511fdf4fe911e5b174b1490c2a1876657511"
+    },
+    {
+      "path": "org/eclipse/aether/aether-api/0.9.0.M2/aether-api-0.9.0.M2.jar",
+      "sha1": "97662c999c6b2fbf2ee50e814a34639c1c1d22de"
+    },
+    {
+      "path": "org/eclipse/aether/aether-api/0.9.0.M2/aether-api-0.9.0.M2.pom",
+      "sha1": "3b0bb3ce9bc61aabe2b1a699e2fc92127218f72b"
+    },
+    {
+      "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
+      "sha1": "839f93a5213fb3e233b09bfd6d6b95669f7043c0"
+    },
+    {
+      "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.pom",
+      "sha1": "f498b9a0d199a7f8ec407e880105fa3a8ff490f5"
+    },
+    {
+      "path": "org/eclipse/aether/aether-impl/0.9.0.M2/aether-impl-0.9.0.M2.jar",
+      "sha1": "eab9a4baae8de96a24c04219236363d0ca73e8a9"
+    },
+    {
+      "path": "org/eclipse/aether/aether-impl/0.9.0.M2/aether-impl-0.9.0.M2.pom",
+      "sha1": "62fb6f92ddea8b994756c6cba4198f63effc04c7"
+    },
+    {
+      "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
+      "sha1": "f147539e6e60dfbda9ef7f6d750066170f61b7a1"
+    },
+    {
+      "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.pom",
+      "sha1": "18f6926294a7592d64b067fa9802db14d77e5672"
+    },
+    {
+      "path": "org/eclipse/aether/aether-spi/0.9.0.M2/aether-spi-0.9.0.M2.jar",
+      "sha1": "3647d00620a91360990c9680f29fbcc22d69c2ee"
+    },
+    {
+      "path": "org/eclipse/aether/aether-spi/0.9.0.M2/aether-spi-0.9.0.M2.pom",
+      "sha1": "b2279ec2d571105a2db40191ba78b2fc8202bb7d"
+    },
+    {
+      "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
+      "sha1": "8428dfa330107984f3e3ac05cc3ebd50b2676866"
+    },
+    {
+      "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.pom",
+      "sha1": "d15f1d37ab739d349fe27c40167af7fc3fa60645"
+    },
+    {
+      "path": "org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.jar",
+      "sha1": "b957089deb654647da320ad7507b0a4b5ce23813"
+    },
+    {
+      "path": "org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.pom",
+      "sha1": "938d4a7468d46180927cd14ccec6a5accfc428af"
+    },
+    {
+      "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
+      "sha1": "d2d3c74a5210544b5cdce89a2c1d1c62835692d1"
+    },
+    {
+      "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.pom",
+      "sha1": "05408a6dd910bf6ed5bf5e2ec95f4d12cd6336eb"
+    },
+    {
+      "path": "org/eclipse/ee4j/project/1.0.2/project-1.0.2.pom",
+      "sha1": "5730bedee1faaeeb62b0afc4ed1c4571f87a8eb4"
+    },
+    {
+      "path": "org/eclipse/ee4j/project/1.0.4/project-1.0.4.pom",
+      "sha1": "f989f4c8c35cd09022bbd29ce559edf666ec1821"
+    },
+    {
+      "path": "org/eclipse/ee4j/project/1.0.5/project-1.0.5.pom",
+      "sha1": "d391c5ed15d8fb1dadba9c5d1017006d56c50332"
+    },
+    {
+      "path": "org/eclipse/jdt/ecj/3.12.3/ecj-3.12.3.jar",
+      "sha1": "ade950992eb3caf6ab4f1a88706c755f0bf213d9"
+    },
+    {
+      "path": "org/eclipse/jdt/ecj/3.12.3/ecj-3.12.3.pom",
+      "sha1": "380d6c949f284efa53f97846dc6272c18ab6da2d"
+    },
+    {
+      "path": "org/eclipse/jdt/ecj/3.17.0/ecj-3.17.0.jar",
+      "sha1": "518834df2e8328bd957f0f0893f2727b73bfe5c6"
+    },
+    {
+      "path": "org/eclipse/jdt/ecj/3.17.0/ecj-3.17.0.pom",
+      "sha1": "65e1e05bafe3396a83f987a848288b8d3a8208d8"
+    },
+    {
+      "path": "org/eclipse/jetty/apache-jsp/9.4.26.v20200117/apache-jsp-9.4.26.v20200117.pom",
+      "sha1": "b880d1f3f1646252e4c4e3a39633d212bb4f5a1f"
+    },
+    {
+      "path": "org/eclipse/jetty/apache-jsp/9.4.26.v20200117/apache-jsp-9.4.26.v20200117.jar",
+      "sha1": "dbc56d5c9510aa76558e6d7937814f8c75568267"
+    },
+    {
+      "path": "org/eclipse/jetty/apache-jstl/9.4.26.v20200117/apache-jstl-9.4.26.v20200117.jar",
+      "sha1": "96778d8924d967ad0e655b3bb0d8b5dad3027ddb"
+    },
+    {
+      "path": "org/eclipse/jetty/apache-jstl/9.4.26.v20200117/apache-jstl-9.4.26.v20200117.pom",
+      "sha1": "26b09aff5e18971e245852ca1cf439ce5ef7e520"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-annotations/9.4.26.v20200117/jetty-annotations-9.4.26.v20200117.jar",
+      "sha1": "4fa92f1fac6abe2b113582eb94355180bad82af3"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-annotations/9.4.26.v20200117/jetty-annotations-9.4.26.v20200117.pom",
+      "sha1": "55d8b93e9078eb815b6db6c36e3caf076f28662c"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-http/9.4.26.v20200117/jetty-http-9.4.26.v20200117.jar",
+      "sha1": "1ae2c0291f371d90725beb60639eb6a9bfd799f1"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-http/9.4.26.v20200117/jetty-http-9.4.26.v20200117.pom",
+      "sha1": "750fe7731cbcae7df95a8269b2c58804d5fcd121"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-io/9.4.26.v20200117/jetty-io-9.4.26.v20200117.jar",
+      "sha1": "911080b65ba6e83c92058f7003c3bbdffe113437"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-io/9.4.26.v20200117/jetty-io-9.4.26.v20200117.pom",
+      "sha1": "b8fa31fffb84ed4b56c6e420dc0be9234c224df7"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-jndi/9.4.26.v20200117/jetty-jndi-9.4.26.v20200117.jar",
+      "sha1": "f120aa4732801c7f4d3683962050a348e4132544"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-jndi/9.4.26.v20200117/jetty-jndi-9.4.26.v20200117.pom",
+      "sha1": "bf8218f5c5060d9362331126df30f76b2e363158"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-jspc-maven-plugin/9.4.26.v20200117/jetty-jspc-maven-plugin-9.4.26.v20200117.jar",
+      "sha1": "3524e7afa64a04817df83843c0b8f25ea5b49ebe"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-jspc-maven-plugin/9.4.26.v20200117/jetty-jspc-maven-plugin-9.4.26.v20200117.pom",
+      "sha1": "5818b75664946e180945086cf490240a3f04d30a"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-parent/14/jetty-parent-14.pom",
+      "sha1": "17d9344459471ef3d2792e7452ead549809eccc5"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-plus/9.4.26.v20200117/jetty-plus-9.4.26.v20200117.jar",
+      "sha1": "622811577476cefa46ff7a65384852512f38d965"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-plus/9.4.26.v20200117/jetty-plus-9.4.26.v20200117.pom",
+      "sha1": "512fdac0c571b18f77d6c18afa165ece881cbc1b"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-project/9.4.26.v20200117/jetty-project-9.4.26.v20200117.pom",
+      "sha1": "90d278790549a1ea2e1d8cf939a3a46b3c201ea8"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-security/9.4.26.v20200117/jetty-security-9.4.26.v20200117.jar",
+      "sha1": "fb91edc107c9529c80a99b01619ce9f90a365793"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-security/9.4.26.v20200117/jetty-security-9.4.26.v20200117.pom",
+      "sha1": "11b2d335dfd7fa2f19a98d4534fea2c2c34104a3"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-server/9.4.26.v20200117/jetty-server-9.4.26.v20200117.jar",
+      "sha1": "ccff959b60961969a91bd4564314a75b13a13be6"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-server/9.4.26.v20200117/jetty-server-9.4.26.v20200117.pom",
+      "sha1": "a613b7706f154acfc9e499625220e36eba390f29"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-servlet/9.4.26.v20200117/jetty-servlet-9.4.26.v20200117.pom",
+      "sha1": "fafa89eea543d309ea9f14ee144d921d5755e64f"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-servlet/9.4.26.v20200117/jetty-servlet-9.4.26.v20200117.jar",
+      "sha1": "243f7aba073635a19c5687943db2673dea5e9d17"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-util/9.4.26.v20200117/jetty-util-9.4.26.v20200117.jar",
+      "sha1": "92773fe479178cd35f9b4b4704d94ba0a148a948"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-util/9.4.26.v20200117/jetty-util-9.4.26.v20200117.pom",
+      "sha1": "2964dceb02b4247cdecd8a3d271ebc99fd018e98"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-webapp/9.4.26.v20200117/jetty-webapp-9.4.26.v20200117.jar",
+      "sha1": "f2deb9a1169ced49fcda6a1702bd44af2414727a"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-webapp/9.4.26.v20200117/jetty-webapp-9.4.26.v20200117.pom",
+      "sha1": "abee622a2fa42a8158f115c69c3c8c384747a3df"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-xml/9.4.26.v20200117/jetty-xml-9.4.26.v20200117.jar",
+      "sha1": "78b9dd5d23be4b455ef01abecd81c2eb1d4102b6"
+    },
+    {
+      "path": "org/eclipse/jetty/jetty-xml/9.4.26.v20200117/jetty-xml-9.4.26.v20200117.pom",
+      "sha1": "200d6bedad59c567068253c8cf60fcce3584b308"
+    },
+    {
+      "path": "org/eclipse/jetty/toolchain/jetty-schemas/3.1.2/jetty-schemas-3.1.2.jar",
+      "sha1": "e4fb7fb14038a35ac135a784180f8a51a518eab1"
+    },
+    {
+      "path": "org/eclipse/jetty/toolchain/jetty-schemas/3.1.2/jetty-schemas-3.1.2.pom",
+      "sha1": "4ed209dd6583507bf027e993a311c28be724f99a"
+    },
+    {
+      "path": "org/eclipse/jetty/toolchain/jetty-toolchain/1.6/jetty-toolchain-1.6.pom",
+      "sha1": "347bc6c72efd323614ebe9205130971ca1d7742a"
+    },
+    {
+      "path": "org/eclipse/persistence/org.eclipse.persistence.asm/2.7.6/org.eclipse.persistence.asm-2.7.6.pom",
+      "sha1": "683b2afbd5d425da24c99ef2fb13ae0599440a1d"
+    },
+    {
+      "path": "org/eclipse/persistence/org.eclipse.persistence.asm/2.7.6/org.eclipse.persistence.asm-2.7.6.jar",
+      "sha1": "81efce4c62bcc6fa2187b12439b6d4c7ccdf7c68"
+    },
+    {
+      "path": "org/eclipse/persistence/org.eclipse.persistence.core/2.7.6/org.eclipse.persistence.core-2.7.6.jar",
+      "sha1": "eec411902a53e834549d180aa7c0d2d0912fc150"
+    },
+    {
+      "path": "org/eclipse/persistence/org.eclipse.persistence.core/2.7.6/org.eclipse.persistence.core-2.7.6.pom",
+      "sha1": "28b82e4514d70864fa66774df32238ef95f4bdc0"
+    },
+    {
+      "path": "org/eclipse/persistence/org.eclipse.persistence.moxy/2.7.6/org.eclipse.persistence.moxy-2.7.6.jar",
+      "sha1": "93201000e03fb1736c32bf82408d5c09109836d7"
+    },
+    {
+      "path": "org/eclipse/persistence/org.eclipse.persistence.moxy/2.7.6/org.eclipse.persistence.moxy-2.7.6.pom",
+      "sha1": "2a869e256b45acbc6a0f32a2bc27e6becb5f112d"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.0.0.M2a/org.eclipse.sisu.inject-0.0.0.M2a.pom",
+      "sha1": "c8d14b0e3b9596cd5471c26260421fede4c255a9"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.0.0.M2a/org.eclipse.sisu.inject-0.0.0.M2a.jar",
+      "sha1": "17941e32c751179a9628b25f54ce5641edafb9be"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.0.0.M5/org.eclipse.sisu.inject-0.0.0.M5.jar",
+      "sha1": "4f6bda3f528c60a12e70db2e7a3feee539dcc8cd"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.0.0.M5/org.eclipse.sisu.inject-0.0.0.M5.pom",
+      "sha1": "6780f0971747b219dfa7f290deb58bbd72840361"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar",
+      "sha1": "b163fc1e714db5f9b389ec11f11950b5913e454c"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.pom",
+      "sha1": "da7ffb3f50a2cb024146b5a3b6d921fc357952c9"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M2a/org.eclipse.sisu.plexus-0.0.0.M2a.pom",
+      "sha1": "f14261f55bfc40a5128c648b55575d876053cb90"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M2a/org.eclipse.sisu.plexus-0.0.0.M2a.jar",
+      "sha1": "07510dc8dfe27a0b57c17601bc760b7b0c8f95fa"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M5/org.eclipse.sisu.plexus-0.0.0.M5.jar",
+      "sha1": "8818cc5a4d2afde2fbc87c2a78cf1ebf5719a869"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M5/org.eclipse.sisu.plexus-0.0.0.M5.pom",
+      "sha1": "e76bb6500f462be0edc92013e6b6c76cbd9bf06d"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar",
+      "sha1": "2c892c1fe0cd2dabcc729e1cbff3524b4847b1fe"
+    },
+    {
+      "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.pom",
+      "sha1": "b111d42eec0d9c2e896f22869810b547d4574593"
+    },
+    {
+      "path": "org/eclipse/sisu/sisu-inject/0.0.0.M2a/sisu-inject-0.0.0.M2a.pom",
+      "sha1": "8f2e4e1e01a318dae784b87e385c546939fad605"
+    },
+    {
+      "path": "org/eclipse/sisu/sisu-inject/0.0.0.M5/sisu-inject-0.0.0.M5.pom",
+      "sha1": "bc5f4bf9addfe6b4833dbb1ec3e489f89ac1822a"
+    },
+    {
+      "path": "org/eclipse/sisu/sisu-inject/0.3.3/sisu-inject-0.3.3.pom",
+      "sha1": "1b1efc9140e47fce4bdf274afe36c7d878205fc0"
+    },
+    {
+      "path": "org/eclipse/sisu/sisu-plexus/0.0.0.M2a/sisu-plexus-0.0.0.M2a.pom",
+      "sha1": "411dc8c0610a69f107c76498d30a10bbf7bb0b49"
+    },
+    {
+      "path": "org/eclipse/sisu/sisu-plexus/0.0.0.M5/sisu-plexus-0.0.0.M5.pom",
+      "sha1": "b7fc9ef028fe09ad8f0908eada9f6b76558de1a2"
+    },
+    {
+      "path": "org/eclipse/sisu/sisu-plexus/0.3.3/sisu-plexus-0.3.3.pom",
+      "sha1": "ab33893b7af22e2074242bdf1432e6f9fafca2cb"
+    },
+    {
+      "path": "org/fourthline/cling/cling/2.0.1/cling-2.0.1.pom",
+      "sha1": "55433fecc3a43429e09d581e6705a8298281d9e8"
+    },
+    {
+      "path": "org/fourthline/cling/cling-core/2.0.1/cling-core-2.0.1.pom",
+      "sha1": "7f8b7b85ae0d5434929597075fef20de7eff62ec"
+    },
+    {
+      "path": "org/fourthline/cling/cling-core/2.0.1/cling-core-2.0.1.jar",
+      "sha1": "c588b1493c6f92f3e63755c9b763c740546f805a"
+    },
+    {
+      "path": "org/fourthline/cling/cling-support/2.0.1/cling-support-2.0.1.pom",
+      "sha1": "2305ad60ad8c8d4b1144b8637b42a6fa0181f97c"
+    },
+    {
+      "path": "org/fourthline/cling/cling-support/2.0.1/cling-support-2.0.1.jar",
+      "sha1": "3be864b366ec15b075a936ecaeec731d8c62eba3"
+    },
+    {
+      "path": "org/glassfish/javax.json/1.0.4/javax.json-1.0.4.pom",
+      "sha1": "d2e9a3dae7592cc57e1272dde8c7802da2dc9452"
+    },
+    {
+      "path": "org/glassfish/javax.json/1.0.4/javax.json-1.0.4.jar",
+      "sha1": "3178f73569fd7a1e5ffc464e680f7a8cc784b85a"
+    },
+    {
+      "path": "org/glassfish/jaxb/codemodel/2.3.0/codemodel-2.3.0.jar",
+      "sha1": "9cab11e0d9c9097efdac927c1acf165780c91298"
+    },
+    {
+      "path": "org/glassfish/jaxb/codemodel/2.3.0/codemodel-2.3.0.pom",
+      "sha1": "b078eff0d7016110bd0f3aff04f4c80ba747276a"
+    },
+    {
+      "path": "org/glassfish/jaxb/codemodel/2.3.2/codemodel-2.3.2.jar",
+      "sha1": "143b70e564189b3f71a2e7f02d6bb8c6b16b5632"
+    },
+    {
+      "path": "org/glassfish/jaxb/codemodel/2.3.2/codemodel-2.3.2.pom",
+      "sha1": "49ecae8ab706fa31e3e0c48cb5b52500e6078d6e"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-bom/2.3.0/jaxb-bom-2.3.0.pom",
+      "sha1": "828ddae68e1c63d3b00110dc18ebaf15d38440b0"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-bom/2.3.2/jaxb-bom-2.3.2.pom",
+      "sha1": "c7cd28b5d3871feba8cebf6d4587043fb0d6fd0a"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-core/2.3.0/jaxb-core-2.3.0.jar",
+      "sha1": "b40bc6ae4bc14480204e143377ce6f75ebba5066"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-core/2.3.0/jaxb-core-2.3.0.pom",
+      "sha1": "496068e651e14a7e941f7ea2f76a142f6910274f"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-runtime/2.3.0/jaxb-runtime-2.3.0.jar",
+      "sha1": "c50f1a599ff0fcf3944e7467cf3cfae1374f4fd6"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-runtime/2.3.0/jaxb-runtime-2.3.0.pom",
+      "sha1": "98e3529f67060566bdb9b2ebbabb55ea081f184e"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-runtime/2.3.2/jaxb-runtime-2.3.2.jar",
+      "sha1": "5528bc882ea499a09d720b42af11785c4fc6be2a"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-runtime/2.3.2/jaxb-runtime-2.3.2.pom",
+      "sha1": "f46a0f023205138c366f0b0c9316f8663bb32a4f"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-xjc/2.3.0/jaxb-xjc-2.3.0.jar",
+      "sha1": "24da0f85e47fc0806c819d8c30bc74e5002def9c"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-xjc/2.3.0/jaxb-xjc-2.3.0.pom",
+      "sha1": "fa91194028cdd041e4ea4b2f8690be78938a8fbf"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-xjc/2.3.2/jaxb-xjc-2.3.2.jar",
+      "sha1": "9cfd86529359747d07251c017d4e46254faa2c2b"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-xjc/2.3.2/jaxb-xjc-2.3.2.pom",
+      "sha1": "5504d6c6969a8b9c4a0d6835beb6f36b35a36c0d"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-xjc-jdk9/2.3.0/jaxb-xjc-jdk9-2.3.0.jar",
+      "sha1": "7e6e1a1d92b86351f671f725d2c09c8ee7f523bd"
+    },
+    {
+      "path": "org/glassfish/jaxb/jaxb-xjc-jdk9/2.3.0/jaxb-xjc-jdk9-2.3.0.pom",
+      "sha1": "23b2d932a34eac1594adca7a798372b60b886cac"
+    },
+    {
+      "path": "org/glassfish/jaxb/txw2/2.3.0/txw2-2.3.0.jar",
+      "sha1": "eee383097bb1aeeda6227694bcb88f3082e634bf"
+    },
+    {
+      "path": "org/glassfish/jaxb/txw2/2.3.0/txw2-2.3.0.pom",
+      "sha1": "a2ddfa8ac82dea08614c34b0779469af8f24cf30"
+    },
+    {
+      "path": "org/glassfish/jaxb/txw2/2.3.2/txw2-2.3.2.jar",
+      "sha1": "ce5be7da2e442c25ec14c766cb60cb802741727b"
+    },
+    {
+      "path": "org/glassfish/jaxb/txw2/2.3.2/txw2-2.3.2.pom",
+      "sha1": "22d24b523eb02a955e8bfa7af6572207a3490482"
+    },
+    {
+      "path": "org/glassfish/jaxb/xsom/2.3.0/xsom-2.3.0.jar",
+      "sha1": "97d5d8287a6e67c2626c6662306a70ee821d8323"
+    },
+    {
+      "path": "org/glassfish/jaxb/xsom/2.3.0/xsom-2.3.0.pom",
+      "sha1": "a3012588925ed604962fdac9b7de3bd81e8a0ad1"
+    },
+    {
+      "path": "org/glassfish/jaxb/xsom/2.3.2/xsom-2.3.2.jar",
+      "sha1": "0157dc2bf479c524d63a214e8fe9888f45a667db"
+    },
+    {
+      "path": "org/glassfish/jaxb/xsom/2.3.2/xsom-2.3.2.pom",
+      "sha1": "86dbf7891ddd6a231ae1b7b76bd2a1a56a74be8a"
+    },
+    {
+      "path": "org/glassfish/json/1.0.4/json-1.0.4.pom",
+      "sha1": "eb133db30d301d71aa4710950f1f1e17d391f4d5"
+    },
+    {
+      "path": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+      "sha1": "42a25dc3219429f0e5d060061f71acb49bf010a0"
+    },
+    {
+      "path": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom",
+      "sha1": "872e413497b906e7c9fa85ccc96046c5d1ef7ece"
+    },
+    {
+      "path": "org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar",
+      "sha1": "4785a3c21320980282f9f33d0d1264a69040538f"
+    },
+    {
+      "path": "org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.pom",
+      "sha1": "8e2a1dd4d5ba590c7a904209f1f40f66d9349ee9"
+    },
+    {
+      "path": "org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom",
+      "sha1": "80391bd32bfa4837a15215d5e9f07c60555c379a"
+    },
+    {
+      "path": "org/hibernate/hibernate-validator/5.3.6.Final/hibernate-validator-5.3.6.Final.jar",
+      "sha1": "04c730be8bf55a8e9a61e79a2f2c079abf48b718"
+    },
+    {
+      "path": "org/hibernate/hibernate-validator/5.3.6.Final/hibernate-validator-5.3.6.Final.pom",
+      "sha1": "03ce8c48a3575f5a8b991f8e103b620ab1cd142b"
+    },
+    {
+      "path": "org/hibernate/hibernate-validator-parent/5.3.6.Final/hibernate-validator-parent-5.3.6.Final.pom",
+      "sha1": "3af0b8c1cd6d19ce8fcbc32a554812c07e52e4f3"
+    },
+    {
+      "path": "org/iq80/snappy/snappy/0.4/snappy-0.4.jar",
+      "sha1": "a42b2d92a89efd35bb14738000dabcac6bd07a8d"
+    },
+    {
+      "path": "org/iq80/snappy/snappy/0.4/snappy-0.4.pom",
+      "sha1": "a2a52b5dc6183010d4e3d12a520ced355607ce32"
+    },
+    {
+      "path": "org/jacoco/jacoco-maven-plugin/0.8.5/jacoco-maven-plugin-0.8.5.pom",
+      "sha1": "b3571a8d6e4e96546b96abeea4faacb318e73e4c"
+    },
+    {
+      "path": "org/jacoco/jacoco-maven-plugin/0.8.5/jacoco-maven-plugin-0.8.5.jar",
+      "sha1": "e2e8dce21696db7bd4605e69e79e28d202f6646d"
+    },
+    {
+      "path": "org/jacoco/org.jacoco.agent/0.8.5/org.jacoco.agent-0.8.5.pom",
+      "sha1": "e37d5a9ae7c5263f43695d5c85346d24a69cdf63"
+    },
+    {
+      "path": "org/jacoco/org.jacoco.agent/0.8.5/org.jacoco.agent-0.8.5-runtime.jar",
+      "sha1": "7b6c7f676d78f988b01e9841ab18d389886ffa26"
+    },
+    {
+      "path": "org/jacoco/org.jacoco.build/0.8.5/org.jacoco.build-0.8.5.pom",
+      "sha1": "ad6a35af94c242182132ceba52f07620ca80832a"
+    },
+    {
+      "path": "org/jacoco/org.jacoco.core/0.8.5/org.jacoco.core-0.8.5.jar",
+      "sha1": "1ac96769aa83e5492d1a1a694774f6baec4eb704"
+    },
+    {
+      "path": "org/jacoco/org.jacoco.core/0.8.5/org.jacoco.core-0.8.5.pom",
+      "sha1": "dc976cf0d68a488c893d9b7957d63e61d597c85a"
+    },
+    {
+      "path": "org/jacoco/org.jacoco.report/0.8.5/org.jacoco.report-0.8.5.jar",
+      "sha1": "421e4aab2aaa809d1e66a96feb11f61ea698da19"
+    },
+    {
+      "path": "org/jacoco/org.jacoco.report/0.8.5/org.jacoco.report-0.8.5.pom",
+      "sha1": "3286567a8bfa0818d77837684763891d0d27a672"
+    },
+    {
+      "path": "org/jboss/arquillian/arquillian-bom/1.1.11.Final/arquillian-bom-1.1.11.Final.pom",
+      "sha1": "aa3eef774e9edc576231c294400c4d524bf4022f"
+    },
+    {
+      "path": "org/jboss/jboss-parent/15/jboss-parent-15.pom",
+      "sha1": "76262a90da39e0eecdac4606691ded8a743d752b"
+    },
+    {
+      "path": "org/jboss/logging/jboss-logging/3.3.2.Final/jboss-logging-3.3.2.Final.pom",
+      "sha1": "9a1f200153da9354766ff5e333635bf6da3ce733"
+    },
+    {
+      "path": "org/jboss/logging/jboss-logging/3.3.2.Final/jboss-logging-3.3.2.Final.jar",
+      "sha1": "3789d00e859632e6c6206adc0c71625559e6e3b0"
+    },
+    {
+      "path": "org/jboss/shrinkwrap/descriptors/shrinkwrap-descriptors-bom/2.0.0-alpha-8/shrinkwrap-descriptors-bom-2.0.0-alpha-8.pom",
+      "sha1": "406a55c268791650b8b1c031c35d1948bb3167b6"
+    },
+    {
+      "path": "org/jboss/shrinkwrap/resolver/shrinkwrap-resolver-bom/2.2.0/shrinkwrap-resolver-bom-2.2.0.pom",
+      "sha1": "43ec33eac9ca838cb31059b1fe48b1cca80edbe7"
+    },
+    {
+      "path": "org/jboss/shrinkwrap/shrinkwrap-bom/1.2.3/shrinkwrap-bom-1.2.3.pom",
+      "sha1": "a22be58388597414dc0b46beacc81b11d0b6fb43"
+    },
+    {
+      "path": "org/jboss/weld/weld-api-bom/1.0/weld-api-bom-1.0.pom",
+      "sha1": "efa278108d83f051152fb414e78e231d8ce5b38e"
+    },
+    {
+      "path": "org/jboss/weld/weld-api-parent/1.0/weld-api-parent-1.0.pom",
+      "sha1": "508700c6712082eece7e9e29a99286fd70593afa"
+    },
+    {
+      "path": "org/jboss/weld/weld-parent/6/weld-parent-6.pom",
+      "sha1": "a6f50e34ff79bc4a5761a35b71d89b07a1d051ec"
+    },
+    {
+      "path": "org/jdom/jdom/1.1/jdom-1.1.jar",
+      "sha1": "1d04c0f321ea337f3661cf7ede8f4c6f653a8fdd"
+    },
+    {
+      "path": "org/jdom/jdom/1.1/jdom-1.1.pom",
+      "sha1": "34346a37a2ae0397ece7a64bb61c5618f32a91c6"
+    },
+    {
+      "path": "org/jdom/jdom/2.0.2/jdom-2.0.2.jar",
+      "sha1": "d06c71e0df0ac4b94deb737718580ccce22d92e8"
+    },
+    {
+      "path": "org/jdom/jdom/2.0.2/jdom-2.0.2.pom",
+      "sha1": "3b0d2565fbfa0340c1f082d4eaedbaf770f54292"
+    },
+    {
+      "path": "org/jetbrains/annotations/18.0.0/annotations-18.0.0.jar",
+      "sha1": "7e53956bd57f23498f021e5ddbd11111f7a3af54"
+    },
+    {
+      "path": "org/jetbrains/annotations/18.0.0/annotations-18.0.0.pom",
+      "sha1": "60ad7c64b293fb4e22c0ddce6c33a78651219e16"
+    },
+    {
+      "path": "org/jflac/jflac-codec/1.5.1/jflac-codec-1.5.1.jar",
+      "sha1": "a93b04fd8eed5d71caae0fb293c034535b67002a"
+    },
+    {
+      "path": "org/jflac/jflac-codec/1.5.1/jflac-codec-1.5.1.pom",
+      "sha1": "d23938af87bb518b74b9d6a3ce919909f5487ade"
+    },
+    {
+      "path": "org/jflac/jflac-parent/1.5.1/jflac-parent-1.5.1.pom",
+      "sha1": "76687ff978970140826ee198f12cb1b4ec50ab37"
+    },
+    {
+      "path": "org/jfree/jfreechart/1.5.0/jfreechart-1.5.0.pom",
+      "sha1": "05e49419af77cfdf6a8e71bc0e249b0823f8d9b2"
+    },
+    {
+      "path": "org/jfree/jfreechart/1.5.0/jfreechart-1.5.0.jar",
+      "sha1": "bc7919249bac68c15c433ed51cb798a1bf8cd74e"
+    },
+    {
+      "path": "org/json/json/20190722/json-20190722.jar",
+      "sha1": "07bce7bacf0ab5e9f894d307a3de8b7f540064d5"
+    },
+    {
+      "path": "org/json/json/20190722/json-20190722.pom",
+      "sha1": "5437e21cb8fc6e9ab18a1443deee5cd62f533787"
+    },
+    {
+      "path": "org/jsoup/jsoup/1.12.1/jsoup-1.12.1.jar",
+      "sha1": "55819a28fc834c2f2bcf4dcdb278524dc3cf088f"
+    },
+    {
+      "path": "org/jsoup/jsoup/1.12.1/jsoup-1.12.1.pom",
+      "sha1": "26d4984272ea79e25bacb5dd0317aea869a2998c"
+    },
+    {
+      "path": "org/jvnet/jaxb2/maven2/maven-jaxb23-plugin/0.14.0/maven-jaxb23-plugin-0.14.0.jar",
+      "sha1": "ee80400de7180dd900689a8b83e4464a522db529"
+    },
+    {
+      "path": "org/jvnet/jaxb2/maven2/maven-jaxb23-plugin/0.14.0/maven-jaxb23-plugin-0.14.0.pom",
+      "sha1": "fa2ad07ca55354fe55e0321730b06bc0e719c361"
+    },
+    {
+      "path": "org/jvnet/jaxb2/maven2/maven-jaxb2-plugin/0.14.0/maven-jaxb2-plugin-0.14.0.pom",
+      "sha1": "10e9ebcc0ac8929554d888d53c3ee73c03d4d360"
+    },
+    {
+      "path": "org/jvnet/jaxb2/maven2/maven-jaxb2-plugin/0.14.0/maven-jaxb2-plugin-0.14.0.jar",
+      "sha1": "948a75b56914e27e50d6b473f9e08e62e350e3ab"
+    },
+    {
+      "path": "org/jvnet/jaxb2/maven2/maven-jaxb2-plugin-core/0.14.0/maven-jaxb2-plugin-core-0.14.0.jar",
+      "sha1": "034576211994538b3a1b67cacc5563e50531e6a0"
+    },
+    {
+      "path": "org/jvnet/jaxb2/maven2/maven-jaxb2-plugin-core/0.14.0/maven-jaxb2-plugin-core-0.14.0.pom",
+      "sha1": "71c4eb481aa5a435ac4a1e5b0e4d1e89de1ec058"
+    },
+    {
+      "path": "org/jvnet/jaxb2/maven2/maven-jaxb2-plugin-project/0.14.0/maven-jaxb2-plugin-project-0.14.0.pom",
+      "sha1": "6f5eadfc6a8d3789bbb774ce750a631a53f64a3c"
+    },
+    {
+      "path": "org/jvnet/staxex/stax-ex/1.7.8/stax-ex-1.7.8.jar",
+      "sha1": "377077e4441cc46be5efde9de63efdf790a59cd7"
+    },
+    {
+      "path": "org/jvnet/staxex/stax-ex/1.7.8/stax-ex-1.7.8.pom",
+      "sha1": "6cbca9bc648d1a3ab5d7050d471c040a7ae86acd"
+    },
+    {
+      "path": "org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.jar",
+      "sha1": "78011e483a21102fb4858f3e8f269a677e50aa23"
+    },
+    {
+      "path": "org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.pom",
+      "sha1": "93132b1ebaf1c419ad3d2216924af39c68f43b51"
+    },
+    {
+      "path": "org/jvnet/staxex/stax-ex/1.8.2/stax-ex-1.8.2.jar",
+      "sha1": "2dcf05ea77d5db306c6a0a1943979066788fc369"
+    },
+    {
+      "path": "org/jvnet/staxex/stax-ex/1.8.2/stax-ex-1.8.2.pom",
+      "sha1": "bbb374bda82d79562a3bfc6b1e03cb7abc68cedd"
+    },
+    {
+      "path": "org/liquibase/liquibase-core/3.8.7/liquibase-core-3.8.7.jar",
+      "sha1": "62b3586d39bc44dc1d0a9c4d9388c80ac136574c"
+    },
+    {
+      "path": "org/liquibase/liquibase-core/3.8.7/liquibase-core-3.8.7.pom",
+      "sha1": "aa50659f44988e866af9e41ed67132da08fdcb97"
+    },
+    {
+      "path": "org/mariadb/jdbc/mariadb-java-client/2.5.4/mariadb-java-client-2.5.4.jar",
+      "sha1": "adb3dbc97684a254b9ecf488167bbf177a33d8ba"
+    },
+    {
+      "path": "org/mariadb/jdbc/mariadb-java-client/2.5.4/mariadb-java-client-2.5.4.pom",
+      "sha1": "da75cfd72a5419c88f4613a422ddf022b1861675"
+    },
+    {
+      "path": "org/mockito/mockito-core/1.10.19/mockito-core-1.10.19.jar",
+      "sha1": "e8546f5bef4e061d8dd73895b4e8f40e3fe6effe"
+    },
+    {
+      "path": "org/mockito/mockito-core/1.10.19/mockito-core-1.10.19.pom",
+      "sha1": "228d760941af5e4c6e772d8761794aefe555da22"
+    },
+    {
+      "path": "org/mortbay/jasper/apache-el/8.5.40/apache-el-8.5.40.jar",
+      "sha1": "a05ece147a273aab6e58174d044efe0fbcce8670"
+    },
+    {
+      "path": "org/mortbay/jasper/apache-el/8.5.40/apache-el-8.5.40.pom",
+      "sha1": "f77be803ece610edcfdf57f6b769c48f29f1a429"
+    },
+    {
+      "path": "org/mortbay/jasper/apache-jsp/8.5.40/apache-jsp-8.5.40.pom",
+      "sha1": "2e79e6d9cc4a8f8729f48b15df1e56aff7d6d813"
+    },
+    {
+      "path": "org/mortbay/jasper/apache-jsp/8.5.40/apache-jsp-8.5.40.jar",
+      "sha1": "bd9a5a6a9ead85bb514541c7f37ca91b1eb7dea8"
+    },
+    {
+      "path": "org/mortbay/jasper/jasper-jsp/8.5.40/jasper-jsp-8.5.40.pom",
+      "sha1": "9b955fa9dd10405e5803918bc83ec293ec72be6f"
+    },
+    {
+      "path": "org/mortbay/jetty/jetty/6.1.25/jetty-6.1.25.jar",
+      "sha1": "b242826712e0e5146bf57f07394691cf8cb5f5cd"
+    },
+    {
+      "path": "org/mortbay/jetty/jetty/6.1.25/jetty-6.1.25.pom",
+      "sha1": "16b0d08cbfec501110726bb96e2783b28d0e771d"
+    },
+    {
+      "path": "org/mortbay/jetty/jetty-parent/10/jetty-parent-10.pom",
+      "sha1": "b7bd7f70d9e17ede85e6bd8d4b33d7ffa8ca63f7"
+    },
+    {
+      "path": "org/mortbay/jetty/jetty-parent/7/jetty-parent-7.pom",
+      "sha1": "070ed3160bc4b0ca224b76f828e74e27a133d08e"
+    },
+    {
+      "path": "org/mortbay/jetty/jetty-util/6.1.25/jetty-util-6.1.25.jar",
+      "sha1": "5527b01ad9c4a12b4101f9ddca31c04ac4fe8614"
+    },
+    {
+      "path": "org/mortbay/jetty/jetty-util/6.1.25/jetty-util-6.1.25.pom",
+      "sha1": "bce386b9ab440e507068020dc87df929d1e56317"
+    },
+    {
+      "path": "org/mortbay/jetty/project/6.1.25/project-6.1.25.pom",
+      "sha1": "80c3b0eacdd22e6488a86efffc20e879cbc51e9f"
+    },
+    {
+      "path": "org/mortbay/jetty/servlet-api/2.5-20081211/servlet-api-2.5-20081211.jar",
+      "sha1": "22bff70037e1e6fa7e6413149489552ee2064702"
+    },
+    {
+      "path": "org/mortbay/jetty/servlet-api/2.5-20081211/servlet-api-2.5-20081211.pom",
+      "sha1": "9d00911feeddea2879d48ecf82ebc6da800c8995"
+    },
+    {
+      "path": "org/mozilla/rhino/1.7.7.2/rhino-1.7.7.2.jar",
+      "sha1": "a7c4a9ba8b6922374580d71060ef71eafa994256"
+    },
+    {
+      "path": "org/mozilla/rhino/1.7.7.2/rhino-1.7.7.2.pom",
+      "sha1": "741bec7f31e2980262ebe466970a2a2053369269"
+    },
+    {
+      "path": "org/objenesis/objenesis/2.1/objenesis-2.1.jar",
+      "sha1": "87c0ea803b69252868d09308b4618f766f135a96"
+    },
+    {
+      "path": "org/objenesis/objenesis/2.1/objenesis-2.1.pom",
+      "sha1": "362dfc522ff5a1401838f136cb7a7ec99033fc33"
+    },
+    {
+      "path": "org/objenesis/objenesis/2.6/objenesis-2.6.jar",
+      "sha1": "639033469776fd37c08358c6b92a4761feb2af4b"
+    },
+    {
+      "path": "org/objenesis/objenesis/2.6/objenesis-2.6.pom",
+      "sha1": "b6d1f689e0d2b2d96b0730fad7b5d96902bf64d8"
+    },
+    {
+      "path": "org/objenesis/objenesis-parent/2.1/objenesis-parent-2.1.pom",
+      "sha1": "156a12a0fcf8ed856bdc60ce10550ea46fba8eaa"
+    },
+    {
+      "path": "org/objenesis/objenesis-parent/2.6/objenesis-parent-2.6.pom",
+      "sha1": "cfc0966402e8174fbacd5c5dd355b5815364a4fe"
+    },
+    {
+      "path": "org/ow2/asm/asm/4.1/asm-4.1.jar",
+      "sha1": "ad568238ee36a820bd6c6806807e8a14ea34684d"
+    },
+    {
+      "path": "org/ow2/asm/asm/4.1/asm-4.1.pom",
+      "sha1": "14520f912710fa80079305bdcf8d52bd68764b60"
+    },
+    {
+      "path": "org/ow2/asm/asm/5.1/asm-5.1.jar",
+      "sha1": "5ef31c4fe953b1fd00b8a88fa1d6820e8785bb45"
+    },
+    {
+      "path": "org/ow2/asm/asm/5.1/asm-5.1.pom",
+      "sha1": "87afb3c6d9329d889ef8dc7bded4a5482cb15e99"
+    },
+    {
+      "path": "org/ow2/asm/asm/6.1.1/asm-6.1.1.jar",
+      "sha1": "264754515362d92acd39e8d40395f6b8dee7bc08"
+    },
+    {
+      "path": "org/ow2/asm/asm/6.1.1/asm-6.1.1.pom",
+      "sha1": "a17fe0ad27c271c744e47b42e1c1a68b8c133a01"
+    },
+    {
+      "path": "org/ow2/asm/asm/6.2/asm-6.2.jar",
+      "sha1": "1b6c4ff09ce03f3052429139c2a68e295cae6604"
+    },
+    {
+      "path": "org/ow2/asm/asm/6.2/asm-6.2.pom",
+      "sha1": "c995a570b9984647aa8557f26691f694c93f76af"
+    },
+    {
+      "path": "org/ow2/asm/asm/7.1/asm-7.1.jar",
+      "sha1": "fa29aa438674ff19d5e1386d2c3527a0267f291e"
+    },
+    {
+      "path": "org/ow2/asm/asm/7.1/asm-7.1.pom",
+      "sha1": "7e40eb6619fd20bd7d98bf775bfdd810aec87ac7"
+    },
+    {
+      "path": "org/ow2/asm/asm/7.2/asm-7.2.pom",
+      "sha1": "016cc249bcaaeb17f49622826bc3e17518698088"
+    },
+    {
+      "path": "org/ow2/asm/asm/7.2/asm-7.2.jar",
+      "sha1": "fa637eb67eb7628c915d73762b681ae7ff0b9731"
+    },
+    {
+      "path": "org/ow2/asm/asm-analysis/4.1/asm-analysis-4.1.jar",
+      "sha1": "73401033069e4714f57b60aeae02f97210aaa64e"
+    },
+    {
+      "path": "org/ow2/asm/asm-analysis/4.1/asm-analysis-4.1.pom",
+      "sha1": "f7cedc768009052d59522f8f4976843b84f2c37f"
+    },
+    {
+      "path": "org/ow2/asm/asm-analysis/7.2/asm-analysis-7.2.jar",
+      "sha1": "b6e6abe057f23630113f4167c34bda7086691258"
+    },
+    {
+      "path": "org/ow2/asm/asm-analysis/7.2/asm-analysis-7.2.pom",
+      "sha1": "0ca55cd4c856718f2fe48811c7fb391db48daf38"
+    },
+    {
+      "path": "org/ow2/asm/asm-commons/7.2/asm-commons-7.2.jar",
+      "sha1": "ca2954e8d92a05bacc28ff465b25c70e0f512497"
+    },
+    {
+      "path": "org/ow2/asm/asm-commons/7.2/asm-commons-7.2.pom",
+      "sha1": "d0afab50091f94cd0b09c5cc107f80c068ecc798"
+    },
+    {
+      "path": "org/ow2/asm/asm-parent/4.1/asm-parent-4.1.pom",
+      "sha1": "2c518e0ccd064f01881bc16aec2c14d429f320ef"
+    },
+    {
+      "path": "org/ow2/asm/asm-parent/5.1/asm-parent-5.1.pom",
+      "sha1": "2768685ec9f3a387a328e4851c36716de2b34720"
+    },
+    {
+      "path": "org/ow2/asm/asm-tree/4.1/asm-tree-4.1.jar",
+      "sha1": "51085abcc4cb6c6e1cb5551e6f999eb8e31c5b2d"
+    },
+    {
+      "path": "org/ow2/asm/asm-tree/4.1/asm-tree-4.1.pom",
+      "sha1": "0049fb36ce611fbfb1d11f998022bc697411aca1"
+    },
+    {
+      "path": "org/ow2/asm/asm-tree/7.2/asm-tree-7.2.jar",
+      "sha1": "3a23cc36edaf8fc5a89cb100182758ccb5991487"
+    },
+    {
+      "path": "org/ow2/asm/asm-tree/7.2/asm-tree-7.2.pom",
+      "sha1": "a06d7d67ffee5819c4e72fe79f428d721447a34a"
+    },
+    {
+      "path": "org/ow2/asm/asm-util/4.1/asm-util-4.1.jar",
+      "sha1": "6344065cb0f94e2b930a95e6656e040ebc11df08"
+    },
+    {
+      "path": "org/ow2/asm/asm-util/4.1/asm-util-4.1.pom",
+      "sha1": "4354806dc63ac686ae4cec20192d437e9701dfb5"
+    },
+    {
+      "path": "org/ow2/ow2/1.3/ow2-1.3.pom",
+      "sha1": "f679d6639bfb209b0836a5e7cf09bfbcc1a41f06"
+    },
+    {
+      "path": "org/ow2/ow2/1.5/ow2-1.5.pom",
+      "sha1": "d8edc69335f4d9f95f511716fb689c86fb0ebaae"
+    },
+    {
+      "path": "org/owasp/dependency-check-core/5.3.0/dependency-check-core-5.3.0.jar",
+      "sha1": "fd77d516a0c53ee3ca94e222ef288d30764f710a"
+    },
+    {
+      "path": "org/owasp/dependency-check-core/5.3.0/dependency-check-core-5.3.0.pom",
+      "sha1": "d3f03b10690cdc2aaed338d55027321ecca2a96c"
+    },
+    {
+      "path": "org/owasp/dependency-check-maven/5.3.0/dependency-check-maven-5.3.0.jar",
+      "sha1": "e6e40347f722e382d08a33ff0ee1245d26623a3c"
+    },
+    {
+      "path": "org/owasp/dependency-check-maven/5.3.0/dependency-check-maven-5.3.0.pom",
+      "sha1": "c5671b04f145c22dcaa8e35866e01cb1b2712a36"
+    },
+    {
+      "path": "org/owasp/dependency-check-parent/5.3.0/dependency-check-parent-5.3.0.pom",
+      "sha1": "0af964486f93e5722911f60c34cda3c12682679e"
+    },
+    {
+      "path": "org/owasp/dependency-check-utils/5.3.0/dependency-check-utils-5.3.0.jar",
+      "sha1": "b788238c57f38e7cee6bbceb6e04359cbb2a146d"
+    },
+    {
+      "path": "org/owasp/dependency-check-utils/5.3.0/dependency-check-utils-5.3.0.pom",
+      "sha1": "78b60058016c2ebeb1395a92680fd22dde8dec87"
+    },
+    {
+      "path": "org/parboiled/parboiled-core/1.1.4/parboiled-core-1.1.4.jar",
+      "sha1": "dffdc483d52209c5bd7c7f665f985f6368bc3da7"
+    },
+    {
+      "path": "org/parboiled/parboiled-core/1.1.4/parboiled-core-1.1.4.pom",
+      "sha1": "62965822c34fe24b815e2ee75a5af58fc4e8b8a6"
+    },
+    {
+      "path": "org/parboiled/parboiled-java/1.1.4/parboiled-java-1.1.4.jar",
+      "sha1": "e59a880c51b753d7d25505560cbe256dd8b2c831"
+    },
+    {
+      "path": "org/parboiled/parboiled-java/1.1.4/parboiled-java-1.1.4.pom",
+      "sha1": "182e4b91de08e5db85466f891026b2a466010f54"
+    },
+    {
+      "path": "org/pegdown/pegdown/1.2.1/pegdown-1.2.1.jar",
+      "sha1": "47689e060d90f90431b5ab2df911452b93930d8c"
+    },
+    {
+      "path": "org/pegdown/pegdown/1.2.1/pegdown-1.2.1.pom",
+      "sha1": "5ada4f90b1651ae7b89766df379740215570fec7"
+    },
+    {
+      "path": "org/postgresql/pgjdbc-core-parent/1.1.6/pgjdbc-core-parent-1.1.6.pom",
+      "sha1": "39a7c046015e22fae6fa0de0855c712eb8fb9333"
+    },
+    {
+      "path": "org/postgresql/pgjdbc-versions/1.1.6/pgjdbc-versions-1.1.6.pom",
+      "sha1": "bd30455b0af5dc11b4cbba2b41cac4cc0c2b194e"
+    },
+    {
+      "path": "org/postgresql/postgresql/42.2.10/postgresql-42.2.10.jar",
+      "sha1": "338af492789fd198dbd52735a22b1946030ecc96"
+    },
+    {
+      "path": "org/postgresql/postgresql/42.2.10/postgresql-42.2.10.pom",
+      "sha1": "e19275f142617d763a685b792a979ae4db99da5f"
+    },
+    {
+      "path": "org/seamless/parent/1.1.0/parent-1.1.0.pom",
+      "sha1": "1ad60ee32c135aeccbc2bfd30c97c980ff1a7cc9"
+    },
+    {
+      "path": "org/seamless/seamless-http/1.1.0/seamless-http-1.1.0.pom",
+      "sha1": "5a4a8006eb9eeeddbd4bed6e301bc25c7780ea27"
+    },
+    {
+      "path": "org/seamless/seamless-http/1.1.0/seamless-http-1.1.0.jar",
+      "sha1": "463012d16bcb06a623d3b931a6cfe19e4beace63"
+    },
+    {
+      "path": "org/seamless/seamless-swing/1.1.0/seamless-swing-1.1.0.pom",
+      "sha1": "340b7bc2d023d8edd23cbe566e458c588b6b3834"
+    },
+    {
+      "path": "org/seamless/seamless-swing/1.1.0/seamless-swing-1.1.0.jar",
+      "sha1": "9ceae59cb0b977a4103d9a52b5e777d2e259678b"
+    },
+    {
+      "path": "org/seamless/seamless-util/1.1.0/seamless-util-1.1.0.pom",
+      "sha1": "d1cf387b7ad568954d03a59eafd239d02a1f76fb"
+    },
+    {
+      "path": "org/seamless/seamless-util/1.1.0/seamless-util-1.1.0.jar",
+      "sha1": "ef025cdbb79c4a031148b20a6d59db89c72ea0a3"
+    },
+    {
+      "path": "org/seamless/seamless-xml/1.1.0/seamless-xml-1.1.0.pom",
+      "sha1": "0da22103d0a793f901f360f5ab29f06f5c381b61"
+    },
+    {
+      "path": "org/seamless/seamless-xml/1.1.0/seamless-xml-1.1.0.jar",
+      "sha1": "497f05ee745c564e0ab5c26e66e60d4f7502fba3"
+    },
+    {
+      "path": "org/skyscreamer/jsonassert/1.4.0/jsonassert-1.4.0.jar",
+      "sha1": "9cdbb373a06f6513e51e8c545ee6a5e981463edb"
+    },
+    {
+      "path": "org/skyscreamer/jsonassert/1.4.0/jsonassert-1.4.0.pom",
+      "sha1": "26d96ec1b49679dc555822b659ab3a7903c8ffd4"
+    },
+    {
+      "path": "org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.jar",
+      "sha1": "629680940b7dcb02c3904deb85992b462c42e272"
+    },
+    {
+      "path": "org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom",
+      "sha1": "8aa25adef55174f1436073e551953c2f74a5c71b"
+    },
+    {
+      "path": "org/slf4j/jcl-over-slf4j/1.7.26/jcl-over-slf4j-1.7.26.jar",
+      "sha1": "33fbc2d93de829fa5e263c5ce97f5eab8f57d53e"
+    },
+    {
+      "path": "org/slf4j/jcl-over-slf4j/1.7.26/jcl-over-slf4j-1.7.26.pom",
+      "sha1": "0659c9f5149e663adee4a22490b3e0e24fed836a"
+    },
+    {
+      "path": "org/slf4j/jcl-over-slf4j/1.7.28/jcl-over-slf4j-1.7.28.jar",
+      "sha1": "523cba836932d499fac5eb4f565437642769569a"
+    },
+    {
+      "path": "org/slf4j/jcl-over-slf4j/1.7.28/jcl-over-slf4j-1.7.28.pom",
+      "sha1": "eb30b59476224d23674eab9154c0d309bff5c03e"
+    },
+    {
+      "path": "org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.pom",
+      "sha1": "16087adff3efe354a294183376599d95a2cb0e13"
+    },
+    {
+      "path": "org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.jar",
+      "sha1": "0af5364cd6679bfffb114f0dec8a157aaa283b76"
+    },
+    {
+      "path": "org/slf4j/jul-to-slf4j/1.7.26/jul-to-slf4j-1.7.26.jar",
+      "sha1": "8031352b2bb0a49e67818bf04c027aa92e645d5c"
+    },
+    {
+      "path": "org/slf4j/jul-to-slf4j/1.7.26/jul-to-slf4j-1.7.26.pom",
+      "sha1": "c86321c3aded034349c7481fde63120c076132b2"
+    },
+    {
+      "path": "org/slf4j/log4j-over-slf4j/1.7.26/log4j-over-slf4j-1.7.26.jar",
+      "sha1": "daeb21c5e35d77d550e721c4cf5aaa716496d31a"
+    },
+    {
+      "path": "org/slf4j/log4j-over-slf4j/1.7.26/log4j-over-slf4j-1.7.26.pom",
+      "sha1": "e123059a1e6a5c1b6829adb740e451cbffcdf93d"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.5.3/slf4j-api-1.5.3.pom",
+      "sha1": "619cbd690baf5466300578a3ed7bc257cbe8fe71"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.jar",
+      "sha1": "ec9b7142625dfa1dcaf22db99ecb7c555ffa714d"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom",
+      "sha1": "b79729ffc12292c0ec755db12360486066f6fd34"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
+      "sha1": "da76ca59f6a57ee3102f8f9bd9cee742973efa8a"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.pom",
+      "sha1": "df51c4a85dd6acf8b6cdc9323596766b3d577c28"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.26/slf4j-api-1.7.26.jar",
+      "sha1": "77100a62c2e6f04b53977b9f541044d7d722693d"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.26/slf4j-api-1.7.26.pom",
+      "sha1": "4d3419a58d77c07f49185aaa556a787d50508d27"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.29/slf4j-api-1.7.29.jar",
+      "sha1": "e56bf4473a4c6b71c7dd397a833dce86d1993d9d"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.29/slf4j-api-1.7.29.pom",
+      "sha1": "f6bb48229ddfeb20486473b19b13fd9b72bbdb23"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.pom",
+      "sha1": "02013960e5ee7f712d8fa6f2e618a6ff2e8d98a9"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar",
+      "sha1": "b5a4b6d16ab13e34a88fae84c35cd5d68cac922c"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.jar",
+      "sha1": "6b262da268f8ad9eff941b25503a9198f0a0ac93"
+    },
+    {
+      "path": "org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.pom",
+      "sha1": "8bef62de94ecb16f574fadc01dcd3127ddb1a4da"
+    },
+    {
+      "path": "org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.jar",
+      "sha1": "cc383fbd07dd1826bbcba1b907bbdc0b5be627f1"
+    },
+    {
+      "path": "org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom",
+      "sha1": "cbc0f6b542435be20eba2fc698cf209e606ec1b4"
+    },
+    {
+      "path": "org/slf4j/slf4j-nop/1.5.3/slf4j-nop-1.5.3.pom",
+      "sha1": "3702af7ebca94a25cc9e73c61cdf71e6269cdac9"
+    },
+    {
+      "path": "org/slf4j/slf4j-nop/1.5.3/slf4j-nop-1.5.3.jar",
+      "sha1": "36a3c886235cddd05e55a979cef549196740231a"
+    },
+    {
+      "path": "org/slf4j/slf4j-parent/1.5.3/slf4j-parent-1.5.3.pom",
+      "sha1": "9c2df8a1dea45222191c0e51dab8459cc57ea351"
+    },
+    {
+      "path": "org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom",
+      "sha1": "7e94cd535680417391d54c1b1a14bcf9ed29a400"
+    },
+    {
+      "path": "org/slf4j/slf4j-parent/1.7.25/slf4j-parent-1.7.25.pom",
+      "sha1": "8521938f0f43c60b79f9f73a9409d10e4bac649a"
+    },
+    {
+      "path": "org/slf4j/slf4j-parent/1.7.26/slf4j-parent-1.7.26.pom",
+      "sha1": "624edbef50ed5b9d747125c05e7ef399e594c524"
+    },
+    {
+      "path": "org/slf4j/slf4j-parent/1.7.28/slf4j-parent-1.7.28.pom",
+      "sha1": "f727e63fc98c78a6f2334be269b39d8fa18bf6fb"
+    },
+    {
+      "path": "org/slf4j/slf4j-parent/1.7.29/slf4j-parent-1.7.29.pom",
+      "sha1": "f4c7268ec21397ade8111b7a2576957632c2e6f7"
+    },
+    {
+      "path": "org/slf4j/slf4j-parent/1.7.30/slf4j-parent-1.7.30.pom",
+      "sha1": "d3cf0e0cdb58d3c6f8a08c21e55894422fd725b9"
+    },
+    {
+      "path": "org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.pom",
+      "sha1": "2955681f952b108824dfb16ca366f36f3cef7861"
+    },
+    {
+      "path": "org/sonatype/aether/aether-api/1.7/aether-api-1.7.jar",
+      "sha1": "0c491a637ee6795143b6708ce5f112e6a9f548f4"
+    },
+    {
+      "path": "org/sonatype/aether/aether-api/1.7/aether-api-1.7.pom",
+      "sha1": "07d9331c480f8028c0f009f4b332ff5b18230003"
+    },
+    {
+      "path": "org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.jar",
+      "sha1": "5cc1803eb7126f759d34007b74e6dc44e9a9fb08"
+    },
+    {
+      "path": "org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.pom",
+      "sha1": "1f6352a67ee0e08fa1cac00e982cdc305d10ce67"
+    },
+    {
+      "path": "org/sonatype/aether/aether-parent/1.7/aether-parent-1.7.pom",
+      "sha1": "9272ca55ba8e2a1f03addfd1b698511d5122c646"
+    },
+    {
+      "path": "org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.jar",
+      "sha1": "1ea472b28d9d891d353c0311593f5e2a0e73d4be"
+    },
+    {
+      "path": "org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.pom",
+      "sha1": "0fdd424fc1f7acd9268c0ceb07fd7aceedb1019f"
+    },
+    {
+      "path": "org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar",
+      "sha1": "38485c9c086c3c867c2dd5371909337bd056c492"
+    },
+    {
+      "path": "org/sonatype/aether/aether-util/1.7/aether-util-1.7.pom",
+      "sha1": "3bd750dbf22b2effa411117b7230694cc4095f3f"
+    },
+    {
+      "path": "org/sonatype/buildsupport/buildsupport/13/buildsupport-13.pom",
+      "sha1": "ebb1c5202d3e55fc27f287640a67229279ef8327"
+    },
+    {
+      "path": "org/sonatype/buildsupport/buildsupport/15/buildsupport-15.pom",
+      "sha1": "8db01b208eb6a311fdff09c83344e8fad7ce8dba"
+    },
+    {
+      "path": "org/sonatype/buildsupport/public-parent/13/public-parent-13.pom",
+      "sha1": "df3e551e06e689fc763509516dd4ef17aec5d35a"
+    },
+    {
+      "path": "org/sonatype/buildsupport/public-parent/15/public-parent-15.pom",
+      "sha1": "2a8181023e2d956a4b8aac8924b997db8769743b"
+    },
+    {
+      "path": "org/sonatype/forge/forge-parent/10/forge-parent-10.pom",
+      "sha1": "c24dc843444f348100c19ebd51157e7a5f61bfe7"
+    },
+    {
+      "path": "org/sonatype/forge/forge-parent/3/forge-parent-3.pom",
+      "sha1": "fdc1f6eb65f750775acd57ff4371d5657ae2e6d3"
+    },
+    {
+      "path": "org/sonatype/forge/forge-parent/4/forge-parent-4.pom",
+      "sha1": "564f266ea9323e57e246f0fca8f04f596663fb86"
+    },
+    {
+      "path": "org/sonatype/forge/forge-parent/5/forge-parent-5.pom",
+      "sha1": "a557514263bbd4a6daef8f125ab80e78413292d3"
+    },
+    {
+      "path": "org/sonatype/forge/forge-parent/6/forge-parent-6.pom",
+      "sha1": "8726e91194a5442e05472854652602a3b599f27d"
+    },
+    {
+      "path": "org/sonatype/goodies/package-url-java/1.1.1/package-url-java-1.1.1.jar",
+      "sha1": "d6822ea23182ce388cb67086d92ba40fad6f8e16"
+    },
+    {
+      "path": "org/sonatype/goodies/package-url-java/1.1.1/package-url-java-1.1.1.pom",
+      "sha1": "95578c594b88b4987556c7235d3b4c13e2f3d700"
+    },
+    {
+      "path": "org/sonatype/ossindex/ossindex-service/1.3.0/ossindex-service-1.3.0.pom",
+      "sha1": "6008cbcdc695bf3eaa925e647066fcc76eddba7b"
+    },
+    {
+      "path": "org/sonatype/ossindex/ossindex-service-api/1.3.0/ossindex-service-api-1.3.0.jar",
+      "sha1": "4195d0f88b2f6dfacdc30937c46c02e8a4044deb"
+    },
+    {
+      "path": "org/sonatype/ossindex/ossindex-service-api/1.3.0/ossindex-service-api-1.3.0.pom",
+      "sha1": "cc08b339eaf8642a2325a7a88861554abc3cbf72"
+    },
+    {
+      "path": "org/sonatype/ossindex/ossindex-service-bom/1.3.0/ossindex-service-bom-1.3.0.pom",
+      "sha1": "165bcebce005c0fd4a67d6e40666cdbbb805b7b1"
+    },
+    {
+      "path": "org/sonatype/ossindex/ossindex-service-client/1.3.0/ossindex-service-client-1.3.0.jar",
+      "sha1": "8e9cdf1a180c3a587cf4a8f844ba0457000b2d7b"
+    },
+    {
+      "path": "org/sonatype/ossindex/ossindex-service-client/1.3.0/ossindex-service-client-1.3.0.pom",
+      "sha1": "af6af727959e83fb3ea242037254530d7ada4ad1"
+    },
+    {
+      "path": "org/sonatype/oss/oss-parent/6/oss-parent-6.pom",
+      "sha1": "765c355ec09ad070065d9d12a9245bba5c689d96"
+    },
+    {
+      "path": "org/sonatype/oss/oss-parent/7/oss-parent-7.pom",
+      "sha1": "46b8a785b60a2767095b8611613b58577e96d4c9"
+    },
+    {
+      "path": "org/sonatype/oss/oss-parent/9/oss-parent-9.pom",
+      "sha1": "e5cdc4d23b86d79c436f16fed20853284e868f65"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar",
+      "sha1": "8fdcf45c2fad3052a51385fdfc79753d9124a1a7"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom",
+      "sha1": "df389a276b6c493bcea1937339b29145a7ce99bf"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar",
+      "sha1": "e6ba5cd4bfd8de00235af936e7f63eb24ed436e6"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.pom",
+      "sha1": "1e4a1b9e61ff446213473bbd1f3d970c0d1c4d62"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+      "sha1": "50ade46f23bb38cd984b4ec560c46223432aac38"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom",
+      "sha1": "8c0bee97c1badb926611bf82358e392fedc07764"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
+      "sha1": "dedc02034fb8fcd7615d66593228cb71709134b4"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom",
+      "sha1": "b953c3a84a7d3f2a7f606e18c07ee38fb6766e3d"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
+      "sha1": "43fde524e9b94c883727a9fddb8669181b890ea7"
+    },
+    {
+      "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.pom",
+      "sha1": "18c39936b9da963de44b4d68adf204f7c5df3a45"
+    },
+    {
+      "path": "org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom",
+      "sha1": "11c2c29c95aa9c9d636ac349b33b49de1190deaf"
+    },
+    {
+      "path": "org/sonatype/sisu/inject/guice-parent/3.1.0/guice-parent-3.1.0.pom",
+      "sha1": "6d6fd41163da61fd7f99593de5a6ccdc76c9338c"
+    },
+    {
+      "path": "org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom",
+      "sha1": "9b167556a64cb79acea3a8dbf6c2f580e2699d2b"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar",
+      "sha1": "8cb56e976b8e0e7b23f2969c32bef7b830c6d6ed"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom",
+      "sha1": "f690b118b2c3ca4cf400a558e6d000a971fd8d98"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0-no_aop.jar",
+      "sha1": "97c87d15d749c86b2be1b9809b28321a1d926c7f"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0.pom",
+      "sha1": "1cd0147913832b439befc627758b1b3dcc335adb"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom",
+      "sha1": "780340415a1dc940f10ae38a7b32e84db28c95dd"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar",
+      "sha1": "5cf37202afbaae899d63dd51b46d173df650af1b"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom",
+      "sha1": "8b8bd0a19ec8218bb04e27aca13658605c9d7588"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar",
+      "sha1": "53d863ed4879d4a43ad7aee7bc63f935cc513353"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom",
+      "sha1": "3e27a576e375175ba275f21692d99a386d879405"
+    },
+    {
+      "path": "org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom",
+      "sha1": "11c9a4a343a22f80cfe4e9677d7b0679850e4196"
+    },
+    {
+      "path": "org/sonatype/spice/spice-parent/10/spice-parent-10.pom",
+      "sha1": "8e0e4ba87d63321333c26494698377b1204633a8"
+    },
+    {
+      "path": "org/sonatype/spice/spice-parent/12/spice-parent-12.pom",
+      "sha1": "e86b2d826f53093e27dc579bea3becbf1425d9ba"
+    },
+    {
+      "path": "org/sonatype/spice/spice-parent/15/spice-parent-15.pom",
+      "sha1": "3cfa1d1f3113a8137fdc7b7a67f310abbed4a22d"
+    },
+    {
+      "path": "org/sonatype/spice/spice-parent/16/spice-parent-16.pom",
+      "sha1": "aefd3135046b7c3f5835283bcc3b670fc46692b9"
+    },
+    {
+      "path": "org/sonatype/spice/spice-parent/17/spice-parent-17.pom",
+      "sha1": "7f500699ef371383492a4d6ee799b1a77ffd82cc"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot/1.5.22.RELEASE/spring-boot-1.5.22.RELEASE.jar",
+      "sha1": "61678d6778e3ee6e25a150cd9acc2592cc12de4d"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot/1.5.22.RELEASE/spring-boot-1.5.22.RELEASE.pom",
+      "sha1": "bf0d7967d677448aacf7866e75c2c3cc549e85ec"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-autoconfigure/1.5.22.RELEASE/spring-boot-autoconfigure-1.5.22.RELEASE.pom",
+      "sha1": "013c0e54c3ffb169e73826ae9258b11c94bfa97b"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-autoconfigure/1.5.22.RELEASE/spring-boot-autoconfigure-1.5.22.RELEASE.jar",
+      "sha1": "c33894ae17e8c58baad6b89cc573cbecdb14e06d"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-dependencies/1.5.20.RELEASE/spring-boot-dependencies-1.5.20.RELEASE.pom",
+      "sha1": "772e04c504bf17d7ed21e4226a782d02b8e42305"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-dependencies/1.5.22.RELEASE/spring-boot-dependencies-1.5.22.RELEASE.pom",
+      "sha1": "86dd44dd91a020f7c3299a8e833d72a6eee59112"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-loader-tools/1.5.20.RELEASE/spring-boot-loader-tools-1.5.20.RELEASE.jar",
+      "sha1": "4da07d9cb3d1e7ee26a2b92eadf7316b649fc6d9"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-loader-tools/1.5.20.RELEASE/spring-boot-loader-tools-1.5.20.RELEASE.pom",
+      "sha1": "ec982474d9b61878944ae366b3e150d50f1c08cb"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-maven-plugin/1.5.20.RELEASE/spring-boot-maven-plugin-1.5.20.RELEASE.jar",
+      "sha1": "6760df4b27f7df810ac75869e1d9068c532f4c36"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-maven-plugin/1.5.20.RELEASE/spring-boot-maven-plugin-1.5.20.RELEASE.pom",
+      "sha1": "37c655e531550ce5cc9733653fdb620e2a33689b"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-parent/1.5.20.RELEASE/spring-boot-parent-1.5.20.RELEASE.pom",
+      "sha1": "ca17abc44bbed993f13828dbd831280541822c9e"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-parent/1.5.22.RELEASE/spring-boot-parent-1.5.22.RELEASE.pom",
+      "sha1": "d3b82fdf072a64f7d36500123466d4b9047626db"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter/1.5.22.RELEASE/spring-boot-starter-1.5.22.RELEASE.jar",
+      "sha1": "093d48628e816e2ee95071f1fc18e55cf003636d"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter/1.5.22.RELEASE/spring-boot-starter-1.5.22.RELEASE.pom",
+      "sha1": "466fe246d6df3a615377f9a2ab2e9ef9a8724a8e"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-jdbc/1.5.22.RELEASE/spring-boot-starter-jdbc-1.5.22.RELEASE.jar",
+      "sha1": "6de08ea1ea5a67579c10eb5ab4fd55f8c273d0d6"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-jdbc/1.5.22.RELEASE/spring-boot-starter-jdbc-1.5.22.RELEASE.pom",
+      "sha1": "3eb4522048647de7dc08087c47f6f6790bfee32d"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-logging/1.5.22.RELEASE/spring-boot-starter-logging-1.5.22.RELEASE.pom",
+      "sha1": "49322bf1cd66e448be2f293ad45e58faaf141364"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-logging/1.5.22.RELEASE/spring-boot-starter-logging-1.5.22.RELEASE.jar",
+      "sha1": "d7290632809c26860509d852462d734533e88dcc"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starters/1.5.22.RELEASE/spring-boot-starters-1.5.22.RELEASE.pom",
+      "sha1": "029aed4f19e1b151de18b8105b63cf516626b72f"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-security/1.5.22.RELEASE/spring-boot-starter-security-1.5.22.RELEASE.jar",
+      "sha1": "a366277d69ceb381a9cc55b52daecfbc5af30cc9"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-security/1.5.22.RELEASE/spring-boot-starter-security-1.5.22.RELEASE.pom",
+      "sha1": "5cce74116f9dde0f6b3710a9a6249d692084ea9b"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-test/1.5.22.RELEASE/spring-boot-starter-test-1.5.22.RELEASE.jar",
+      "sha1": "a14581a81d9fa4924a44be29433fab8c19f92797"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-test/1.5.22.RELEASE/spring-boot-starter-test-1.5.22.RELEASE.pom",
+      "sha1": "53e92ed8053754f929e7c272ce8e79bc26d00c91"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-tomcat/1.5.22.RELEASE/spring-boot-starter-tomcat-1.5.22.RELEASE.jar",
+      "sha1": "5e6d7149a1e0542ab80eb1a6f995ade323d893b0"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-tomcat/1.5.22.RELEASE/spring-boot-starter-tomcat-1.5.22.RELEASE.pom",
+      "sha1": "876866740b68b2cd2d76b70c0096916e6c9f9149"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-web/1.5.22.RELEASE/spring-boot-starter-web-1.5.22.RELEASE.jar",
+      "sha1": "d57c76171e59e7b7e8c479e73f27d22d2bb6bffa"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-starter-web/1.5.22.RELEASE/spring-boot-starter-web-1.5.22.RELEASE.pom",
+      "sha1": "abfd65b592b9508233d946ea8e5c7764ff5d0b73"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-test/1.5.22.RELEASE/spring-boot-test-1.5.22.RELEASE.jar",
+      "sha1": "c8db1711e1540051ec3fd44255fcfda474d2a0d3"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-test/1.5.22.RELEASE/spring-boot-test-1.5.22.RELEASE.pom",
+      "sha1": "83d9dbfac084dbb4f2f266b517dd9ee583d9e22a"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-test-autoconfigure/1.5.22.RELEASE/spring-boot-test-autoconfigure-1.5.22.RELEASE.jar",
+      "sha1": "f78acff6d06a1606e802a2914f340348e907abbf"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-test-autoconfigure/1.5.22.RELEASE/spring-boot-test-autoconfigure-1.5.22.RELEASE.pom",
+      "sha1": "9929a682ddcc2419bb17067f45fa1cc392cf5f06"
+    },
+    {
+      "path": "org/springframework/boot/spring-boot-tools/1.5.20.RELEASE/spring-boot-tools-1.5.20.RELEASE.pom",
+      "sha1": "21feeef3623966421acf6afb9d9d18bc4b9dee30"
+    },
+    {
+      "path": "org/springframework/data/build/spring-data-build/1.9.20.RELEASE/spring-data-build-1.9.20.RELEASE.pom",
+      "sha1": "5449315c2cd4a15c71a49618409deefd07000f0f"
+    },
+    {
+      "path": "org/springframework/data/build/spring-data-build/1.9.23.RELEASE/spring-data-build-1.9.23.RELEASE.pom",
+      "sha1": "ec488eb311819e80509b75de6c2c4b439ca5fc38"
+    },
+    {
+      "path": "org/springframework/data/spring-data-releasetrain/Ingalls-SR20/spring-data-releasetrain-Ingalls-SR20.pom",
+      "sha1": "3fc01a59617a6b3d179a4e99d3edce4dff1a26fc"
+    },
+    {
+      "path": "org/springframework/data/spring-data-releasetrain/Ingalls-SR23/spring-data-releasetrain-Ingalls-SR23.pom",
+      "sha1": "7f4535a1489a9f87ca5f12ebf998d4b10b55fcb6"
+    },
+    {
+      "path": "org/springframework/integration/spring-integration-bom/4.3.20.RELEASE/spring-integration-bom-4.3.20.RELEASE.pom",
+      "sha1": "ce3a2ba372b3bcbd88a6b10be7379a32a3045854"
+    },
+    {
+      "path": "org/springframework/integration/spring-integration-bom/4.3.21.RELEASE/spring-integration-bom-4.3.21.RELEASE.pom",
+      "sha1": "5d17a634c4acfeb36caa5f0ee548aa0947117baf"
+    },
+    {
+      "path": "org/springframework/ldap/spring-ldap-core/2.3.2.RELEASE/spring-ldap-core-2.3.2.RELEASE.pom",
+      "sha1": "9caaa05b99ca32223738c9ac211f771ab734a475"
+    },
+    {
+      "path": "org/springframework/ldap/spring-ldap-core/2.3.2.RELEASE/spring-ldap-core-2.3.2.RELEASE.jar",
+      "sha1": "08bd3457711b1746af93daa0aa04c9fc886569b1"
+    },
+    {
+      "path": "org/springframework/security/spring-security-acl/4.2.13.RELEASE/spring-security-acl-4.2.13.RELEASE.jar",
+      "sha1": "2729540b59686f93f04431090bce8242d2a7a5e2"
+    },
+    {
+      "path": "org/springframework/security/spring-security-acl/4.2.13.RELEASE/spring-security-acl-4.2.13.RELEASE.pom",
+      "sha1": "bae7fdae5e32fbc912c7e1fcb8d8cee80dce8b19"
+    },
+    {
+      "path": "org/springframework/security/spring-security-bom/4.2.12.RELEASE/spring-security-bom-4.2.12.RELEASE.pom",
+      "sha1": "84ad375addf90215a429a9037b965a11a59e86c7"
+    },
+    {
+      "path": "org/springframework/security/spring-security-bom/4.2.13.RELEASE/spring-security-bom-4.2.13.RELEASE.pom",
+      "sha1": "71e53bb73e7e01051472a0f2baad9c4a4bb5f736"
+    },
+    {
+      "path": "org/springframework/security/spring-security-config/4.2.13.RELEASE/spring-security-config-4.2.13.RELEASE.jar",
+      "sha1": "00f9ceaddc4f0f91231c5f05d7231adbad5b7519"
+    },
+    {
+      "path": "org/springframework/security/spring-security-config/4.2.13.RELEASE/spring-security-config-4.2.13.RELEASE.pom",
+      "sha1": "1daf0269da6e8519f662e21e13516288eb99bad5"
+    },
+    {
+      "path": "org/springframework/security/spring-security-core/4.2.13.RELEASE/spring-security-core-4.2.13.RELEASE.jar",
+      "sha1": "f42566461bfc4dd6c9ec6e93af14202df3e83fb2"
+    },
+    {
+      "path": "org/springframework/security/spring-security-core/4.2.13.RELEASE/spring-security-core-4.2.13.RELEASE.pom",
+      "sha1": "2c57963e8167b9c3074892c3ef5da3fb04377d0e"
+    },
+    {
+      "path": "org/springframework/security/spring-security-ldap/4.2.13.RELEASE/spring-security-ldap-4.2.13.RELEASE.pom",
+      "sha1": "beb4923f968d03805f54573cd318835281925e56"
+    },
+    {
+      "path": "org/springframework/security/spring-security-ldap/4.2.13.RELEASE/spring-security-ldap-4.2.13.RELEASE.jar",
+      "sha1": "aa743919a091207784e2c2f7c4a26f258c332cbf"
+    },
+    {
+      "path": "org/springframework/security/spring-security-taglibs/4.2.13.RELEASE/spring-security-taglibs-4.2.13.RELEASE.jar",
+      "sha1": "f5cdc684498a1776a5cecf6e2964ab2315785361"
+    },
+    {
+      "path": "org/springframework/security/spring-security-taglibs/4.2.13.RELEASE/spring-security-taglibs-4.2.13.RELEASE.pom",
+      "sha1": "8233e59fd909114fb4b5314aa662141dd9b86812"
+    },
+    {
+      "path": "org/springframework/security/spring-security-test/4.2.13.RELEASE/spring-security-test-4.2.13.RELEASE.pom",
+      "sha1": "0efce13f64fa4ebbf9a34b00b4fb2ab13f2a0670"
+    },
+    {
+      "path": "org/springframework/security/spring-security-test/4.2.13.RELEASE/spring-security-test-4.2.13.RELEASE.jar",
+      "sha1": "cc0003dd62352144fe3f06e51048fb27c18e94cc"
+    },
+    {
+      "path": "org/springframework/security/spring-security-web/4.2.13.RELEASE/spring-security-web-4.2.13.RELEASE.jar",
+      "sha1": "76af1568b513409842dbfd9ff64631526cdbbb2c"
+    },
+    {
+      "path": "org/springframework/security/spring-security-web/4.2.13.RELEASE/spring-security-web-4.2.13.RELEASE.pom",
+      "sha1": "dbb124b073e404495536f1638972209015396e36"
+    },
+    {
+      "path": "org/springframework/spring-aop/4.3.25.RELEASE/spring-aop-4.3.25.RELEASE.pom",
+      "sha1": "7d70e4dc85a1cf3d9ed5528ce1fd66ef5d2bc6a3"
+    },
+    {
+      "path": "org/springframework/spring-aop/4.3.25.RELEASE/spring-aop-4.3.25.RELEASE.jar",
+      "sha1": "b426d37d95562934eb83845709760d69547017c5"
+    },
+    {
+      "path": "org/springframework/spring-aop/5.1.14.RELEASE/spring-aop-5.1.14.RELEASE.jar",
+      "sha1": "dae18b9500c3f0fdd32cc677d64024918ae5d3ee"
+    },
+    {
+      "path": "org/springframework/spring-aop/5.1.14.RELEASE/spring-aop-5.1.14.RELEASE.pom",
+      "sha1": "d39f8f03cdd93aa7d4d90b5ba79d187496baadde"
+    },
+    {
+      "path": "org/springframework/spring-beans/4.3.25.RELEASE/spring-beans-4.3.25.RELEASE.jar",
+      "sha1": "e325c94d71a0d765a7dab7e898ca167803ae43ed"
+    },
+    {
+      "path": "org/springframework/spring-beans/4.3.25.RELEASE/spring-beans-4.3.25.RELEASE.pom",
+      "sha1": "c3b74da8e9fe95866b70e6c3486949dde205fab6"
+    },
+    {
+      "path": "org/springframework/spring-beans/5.1.14.RELEASE/spring-beans-5.1.14.RELEASE.jar",
+      "sha1": "c0dec97d0ba121e14c7f8ad6fcff16b9278f56e6"
+    },
+    {
+      "path": "org/springframework/spring-beans/5.1.14.RELEASE/spring-beans-5.1.14.RELEASE.pom",
+      "sha1": "63bdce297430dda48135bb8d5f426050a8ebd3d9"
+    },
+    {
+      "path": "org/springframework/spring-context/4.3.25.RELEASE/spring-context-4.3.25.RELEASE.jar",
+      "sha1": "3ddec82ce3eda9ac3535e129c79c49cd3ac87180"
+    },
+    {
+      "path": "org/springframework/spring-context/4.3.25.RELEASE/spring-context-4.3.25.RELEASE.pom",
+      "sha1": "ea99c44574d50394d8c87a63af2f7a3eeb15f49d"
+    },
+    {
+      "path": "org/springframework/spring-context/5.1.14.RELEASE/spring-context-5.1.14.RELEASE.jar",
+      "sha1": "a88720ab10b8a6805fbd026c861b7459f9831882"
+    },
+    {
+      "path": "org/springframework/spring-context/5.1.14.RELEASE/spring-context-5.1.14.RELEASE.pom",
+      "sha1": "f941ed6a21edb93492060ff76cd9cfb7c45e520a"
+    },
+    {
+      "path": "org/springframework/spring-core/4.3.23.RELEASE/spring-core-4.3.23.RELEASE.jar",
+      "sha1": "1481429d44ea0deca1d8b9d6d5e948cb7f063bdb"
+    },
+    {
+      "path": "org/springframework/spring-core/4.3.23.RELEASE/spring-core-4.3.23.RELEASE.pom",
+      "sha1": "5a5e39184e80f48982f19e8a7aa7cdfca85b48e6"
+    },
+    {
+      "path": "org/springframework/spring-core/4.3.25.RELEASE/spring-core-4.3.25.RELEASE.jar",
+      "sha1": "584db35a0fd30029a1cd7437c935b87d9a2a9237"
+    },
+    {
+      "path": "org/springframework/spring-core/4.3.25.RELEASE/spring-core-4.3.25.RELEASE.pom",
+      "sha1": "b8257074a07d8670dec979acf3661b12beb33b8e"
+    },
+    {
+      "path": "org/springframework/spring-core/5.1.14.RELEASE/spring-core-5.1.14.RELEASE.pom",
+      "sha1": "fd0b26e944b4cb36e1d79df0fc16d66f0d05db6f"
+    },
+    {
+      "path": "org/springframework/spring-core/5.1.14.RELEASE/spring-core-5.1.14.RELEASE.jar",
+      "sha1": "75df185c9c9dd3f61468137dd766603013e125f2"
+    },
+    {
+      "path": "org/springframework/spring-expression/4.3.25.RELEASE/spring-expression-4.3.25.RELEASE.jar",
+      "sha1": "3b37de6186f6ea2cb454b4e8615b8873b896e574"
+    },
+    {
+      "path": "org/springframework/spring-expression/4.3.25.RELEASE/spring-expression-4.3.25.RELEASE.pom",
+      "sha1": "b98ee19aaff7eda29a752966827b8e3be106def8"
+    },
+    {
+      "path": "org/springframework/spring-expression/5.1.14.RELEASE/spring-expression-5.1.14.RELEASE.jar",
+      "sha1": "6df7421099daa310180b7c06cc661aefe079dd70"
+    },
+    {
+      "path": "org/springframework/spring-expression/5.1.14.RELEASE/spring-expression-5.1.14.RELEASE.pom",
+      "sha1": "ec38c2c129da2ff796750321e874e3a7168e71da"
+    },
+    {
+      "path": "org/springframework/spring-framework-bom/4.3.23.RELEASE/spring-framework-bom-4.3.23.RELEASE.pom",
+      "sha1": "b5a75ee7eafa35d0ba7198d2b9d886fdcbbce74d"
+    },
+    {
+      "path": "org/springframework/spring-framework-bom/4.3.25.RELEASE/spring-framework-bom-4.3.25.RELEASE.pom",
+      "sha1": "dc41c7edc24ccb372b2a47ac80ea966f8db8009d"
+    },
+    {
+      "path": "org/springframework/spring-jcl/5.1.14.RELEASE/spring-jcl-5.1.14.RELEASE.jar",
+      "sha1": "1108c23482bb879bbeea98e5154338bf34227675"
+    },
+    {
+      "path": "org/springframework/spring-jcl/5.1.14.RELEASE/spring-jcl-5.1.14.RELEASE.pom",
+      "sha1": "9817a265ed23e158a2f5ee9de9de9ecd779e8354"
+    },
+    {
+      "path": "org/springframework/spring-jdbc/4.3.25.RELEASE/spring-jdbc-4.3.25.RELEASE.jar",
+      "sha1": "c79a08599f3f35e2dda03867017d4149436ff197"
+    },
+    {
+      "path": "org/springframework/spring-jdbc/4.3.25.RELEASE/spring-jdbc-4.3.25.RELEASE.pom",
+      "sha1": "d9a8162bfce9d11377b16f0d6cdd0ff4a024547d"
+    },
+    {
+      "path": "org/springframework/spring-test/4.3.25.RELEASE/spring-test-4.3.25.RELEASE.jar",
+      "sha1": "4a64c7820499d41025407e02e58d793c0f5e8403"
+    },
+    {
+      "path": "org/springframework/spring-test/4.3.25.RELEASE/spring-test-4.3.25.RELEASE.pom",
+      "sha1": "61466118e302416880216f8d87e8c5768684afe6"
+    },
+    {
+      "path": "org/springframework/spring-tx/4.3.25.RELEASE/spring-tx-4.3.25.RELEASE.jar",
+      "sha1": "fa90985a9f4fa38a90472d343019c88c7a1b3364"
+    },
+    {
+      "path": "org/springframework/spring-tx/4.3.25.RELEASE/spring-tx-4.3.25.RELEASE.pom",
+      "sha1": "51c5ffb9348e0e66dbebeba1815be5fbe7929755"
+    },
+    {
+      "path": "org/springframework/spring-web/4.3.25.RELEASE/spring-web-4.3.25.RELEASE.jar",
+      "sha1": "76d29c076153e09961c8e6fd9b2d5c50bb80b902"
+    },
+    {
+      "path": "org/springframework/spring-web/4.3.25.RELEASE/spring-web-4.3.25.RELEASE.pom",
+      "sha1": "e80303d1b1b61052c5a33d43deb17f776afa72f0"
+    },
+    {
+      "path": "org/springframework/spring-webmvc/4.3.25.RELEASE/spring-webmvc-4.3.25.RELEASE.pom",
+      "sha1": "a6a148898bcf743eb2013813f758fbe475721131"
+    },
+    {
+      "path": "org/springframework/spring-webmvc/4.3.25.RELEASE/spring-webmvc-4.3.25.RELEASE.jar",
+      "sha1": "c9fbfcf99abcd9bd9fd26468d719257841c24352"
+    },
+    {
+      "path": "org/tmatesoft/sqljet/sqljet/1.1.10/sqljet-1.1.10.jar",
+      "sha1": "ede7fbabd4c96d34e48fda0e8feced24c98cedca"
+    },
+    {
+      "path": "org/tmatesoft/sqljet/sqljet/1.1.10/sqljet-1.1.10.pom",
+      "sha1": "3aecdcb0440905dec31cc9dca44ae6f5186f0145"
+    },
+    {
+      "path": "org/tmatesoft/svnkit/svnkit/1.8.5/svnkit-1.8.5.jar",
+      "sha1": "a9600329d7e6271ab8ab7eb769c4df5adcdf503c"
+    },
+    {
+      "path": "org/tmatesoft/svnkit/svnkit/1.8.5/svnkit-1.8.5.pom",
+      "sha1": "25d9cd63d67b473e06276d12790c6eb2ef8341f7"
+    },
+    {
+      "path": "org/tukaani/xz/1.8/xz-1.8.jar",
+      "sha1": "c4f7d054303948eb6a4066194253886c8af07128"
+    },
+    {
+      "path": "org/tukaani/xz/1.8/xz-1.8.pom",
+      "sha1": "83c041bde1965b281cf4e6b31ab11bcf4b68a649"
+    },
+    {
+      "path": "org/vafer/jdependency/0.7/jdependency-0.7.jar",
+      "sha1": "1ff888f026579c58d5b2d730ed2a0e86a36ad46d"
+    },
+    {
+      "path": "org/vafer/jdependency/0.7/jdependency-0.7.pom",
+      "sha1": "9666402d9bdbfb9f5b22fb87fbe166ee1183dfe2"
+    },
+    {
+      "path": "org/yaml/snakeyaml/1.17/snakeyaml-1.17.jar",
+      "sha1": "7a27ea250c5130b2922b86dea63cbb1cc10a660c"
+    },
+    {
+      "path": "org/yaml/snakeyaml/1.17/snakeyaml-1.17.pom",
+      "sha1": "93e6d192f94124d739a3a6ef9d184e0d599758a1"
+    },
+    {
+      "path": "oro/oro/2.0.8/oro-2.0.8.jar",
+      "sha1": "5592374f834645c4ae250f4c9fbb314c9369d698"
+    },
+    {
+      "path": "oro/oro/2.0.8/oro-2.0.8.pom",
+      "sha1": "6d10956ccdb32138560928ba9501648e430c34bb"
+    },
+    {
+      "path": "plexus/plexus-containers/1.0.2/plexus-containers-1.0.2.pom",
+      "sha1": "577ec53cbec032ed3295eef22e6d61556ab992e4"
+    },
+    {
+      "path": "plexus/plexus-root/1.0.3/plexus-root-1.0.3.pom",
+      "sha1": "4b36b9b2ee2fe690af6dd8e11bc25fb0483c040a"
+    },
+    {
+      "path": "plexus/plexus-utils/1.0.2/plexus-utils-1.0.2.pom",
+      "sha1": "e3122ca346960e8be05a087fe466439898af7eab"
+    },
+    {
+      "path": "relaxngDatatype/relaxngDatatype/20020414/relaxngDatatype-20020414.jar",
+      "sha1": "de7952cecd05b65e0e4370cc93fc03035175eef5"
+    },
+    {
+      "path": "relaxngDatatype/relaxngDatatype/20020414/relaxngDatatype-20020414.pom",
+      "sha1": "4b062d8eb2bd190074fc686daea9531411b1e123"
+    },
+    {
+      "path": "sslext/sslext/1.2-0/sslext-1.2-0.jar",
+      "sha1": "c86a7db4ac0bc450e675f3d44b3d64cdc934361b"
+    },
+    {
+      "path": "sslext/sslext/1.2-0/sslext-1.2-0.pom",
+      "sha1": "69e2c447f2c424d95c4a818463d58da1723fce2c"
+    },
+    {
+      "path": "stax/stax/1.2.0/stax-1.2.0.pom",
+      "sha1": "25c804f06fe1d144906fb812b88e60711cc2b3fd"
+    },
+    {
+      "path": "stax/stax/1.2.0/stax-1.2.0.jar",
+      "sha1": "c434800de5e4bbe1822805be5fb1c32d6834f830"
+    },
+    {
+      "path": "stax/stax-api/1.0.1/stax-api-1.0.1.pom",
+      "sha1": "e3a933099229a34b22e9e78b2b999e1eb03b3e4e"
+    },
+    {
+      "path": "stax/stax-api/1.0.1/stax-api-1.0.1.jar",
+      "sha1": "49c100caf72d658aca8e58bd74a4ba90fa2b0d70"
+    },
+    {
+      "path": "taglibs/string/1.1.0/string-1.1.0.jar",
+      "sha1": "d5fb8925565cb83cf61cfd54d4165002b38d889e"
+    },
+    {
+      "path": "taglibs/string/1.1.0/string-1.1.0.pom",
+      "sha1": "b5a3d349093e8d6bfbeb7701cb091d44e812ee19"
+    },
+    {
+      "path": "us/springett/cpe-parser/2.0.2/cpe-parser-2.0.2.jar",
+      "sha1": "677cff319cdc8bd9578a3d04c1fd9c366cc9ff6e"
+    },
+    {
+      "path": "us/springett/cpe-parser/2.0.2/cpe-parser-2.0.2.pom",
+      "sha1": "f64eebed729f3af46153d4929b70c6ac31da63ac"
+    },
+    {
+      "path": "wsdl4j/wsdl4j/1.6.3/wsdl4j-1.6.3.jar",
+      "sha1": "6d106a6845a3d3477a1560008479312888e94f2f"
+    },
+    {
+      "path": "wsdl4j/wsdl4j/1.6.3/wsdl4j-1.6.3.pom",
+      "sha1": "98f47ca3055039009047b158733c28ad23d1ae55"
+    },
+    {
+      "path": "xalan/xalan/2.7.0/xalan-2.7.0.jar",
+      "sha1": "a33c0097f1c70b20fa7ded220ea317eb3500515e"
+    },
+    {
+      "path": "xalan/xalan/2.7.0/xalan-2.7.0.pom",
+      "sha1": "381cc72f23dab23faad6b902e71ba6f3eb245db4"
+    },
+    {
+      "path": "xerces/xercesImpl/2.8.1/xercesImpl-2.8.1.jar",
+      "sha1": "25101e37ec0c907db6f0612cbf106ee519c1aef1"
+    },
+    {
+      "path": "xerces/xercesImpl/2.8.1/xercesImpl-2.8.1.pom",
+      "sha1": "abda46c0359b0e2dcf7a31359128a0c6cecd4dca"
+    },
+    {
+      "path": "xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar",
+      "sha1": "7bc7e49ddfe4fb5f193ed37ecc96c12292c8ceb6"
+    },
+    {
+      "path": "xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.pom",
+      "sha1": "55a24b0cdefdf6002c3d3f9bb400e55a12d2482e"
+    },
+    {
+      "path": "xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar",
+      "sha1": "3136ca936f64c9d68529f048c2618bd356bf85c9"
+    },
+    {
+      "path": "xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.pom",
+      "sha1": "2289016f8b8f6a600ce45a199426fe0f6b2be4b0"
+    },
+    {
+      "path": "xml-apis/xml-apis/1.3.03/xml-apis-1.3.03.pom",
+      "sha1": "b3ba55077dae1297654bb74200fe01a9fe02944c"
+    },
+    {
+      "path": "xml-apis/xml-apis/1.3.04/xml-apis-1.3.04.jar",
+      "sha1": "90b215f48fe42776c8c7f6e3509ec54e84fd65ef"
+    },
+    {
+      "path": "xml-apis/xml-apis/1.3.04/xml-apis-1.3.04.pom",
+      "sha1": "d6174a9fd44cd14ff8dd486d6ac2e64f831db57c"
+    },
+    {
+      "path": "xml-apis/xml-apis/2.0.2/xml-apis-2.0.2.pom",
+      "sha1": "bf2e4baaea312f54f2934c6eb9bbde0a2a4afb07"
+    },
+    {
+      "path": "xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar",
+      "sha1": "2b8e230d2ab644e4ecaa94db7cdedbc40c805dfa"
+    },
+    {
+      "path": "xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.pom",
+      "sha1": "02727a9a35d75a77344fea0e9866477aff7c19d6"
+    },
+    {
+      "path": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar",
+      "sha1": "3d0f97750b3a03e0971831566067754ba4bfd68c"
+    },
+    {
+      "path": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.pom",
+      "sha1": "f18c0830ec69bbd60e39f6c22492e7fd86489f2e"
+    },
+    {
+      "path": "xmlunit/xmlunit/1.5/xmlunit-1.5.jar",
+      "sha1": "7789cef5caffdecab50fd6099535ad2bc2e98044"
+    },
+    {
+      "path": "xmlunit/xmlunit/1.5/xmlunit-1.5.pom",
+      "sha1": "655daccafcc03159a156c0c5de1155c9a33aea40"
+    },
+    {
+      "path": "xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.jar",
+      "sha1": "19d4e90b43059058f6e056f794f0ea4030d60b86"
+    },
+    {
+      "path": "xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.pom",
+      "sha1": "4d2f2cf4e7b090e4c0c3010c6cd27cdb45ca593e"
+    }
+  ],
+  "groupId": "org.airsonic.player",
+  "metas": [],
+  "name": "airsonic-10.6.2-RELEASE",
+  "remotes": {
+    "4thline-repo": "http://4thline.org/m2",
+    "central": "https://repo.maven.apache.org/maven2",
+    "jaudiotagger-repository": "https://dl.bintray.com/ijabz/maven",
+    "local1": "file:///run/user/8509/mvnix-update.Vt43GN/src/airsonic-main/../repo"
+  },
+  "submodules": [
+    {
+      "artifactId": "airsonic",
+      "groupId": "org.airsonic.player",
+      "name": "airsonic-10.6.2-RELEASE",
+      "path": ".",
+      "version": "10.6.2-RELEASE"
+    },
+    {
+      "artifactId": "subsonic-rest-api",
+      "groupId": "org.airsonic.player",
+      "name": "subsonic-rest-api-10.6.2-RELEASE",
+      "path": "./subsonic-rest-api",
+      "version": "10.6.2-RELEASE"
+    },
+    {
+      "artifactId": "airsonic-sonos-api",
+      "groupId": "org.airsonic.player",
+      "name": "airsonic-sonos-api-10.6.2-RELEASE",
+      "path": "./airsonic-sonos-api",
+      "version": "10.6.2-RELEASE"
+    },
+    {
+      "artifactId": "airsonic-main",
+      "groupId": "org.airsonic.player",
+      "name": "airsonic-main-10.6.2-RELEASE",
+      "path": "./airsonic-main",
+      "version": "10.6.2-RELEASE"
+    }
+  ],
+  "version": "10.6.2-RELEASE"
+}

--- a/pkgs/servers/misc/airsonic/mavenix.nix
+++ b/pkgs/servers/misc/airsonic/mavenix.nix
@@ -1,0 +1,279 @@
+# From Mavenix 2.3.3, https://github.com/icetan/mavenix/tarball/v2.3.3
+# Public domain; c.f. https://github.com/nix-community/mavenix/blob/master/UNLICENSE
+{
+  pkgs ? import (fetchGit {
+    url = "https://github.com/NixOS/nixpkgs-channels";
+    ref = "nixos-19.09";
+    rev = "c75de8bc12cc7e713206199e5ca30b224e295041";
+  }) {},
+}:
+
+let
+  inherit (builtins) attrNames attrValues pathExists toJSON foldl' elemAt;
+  inherit (pkgs) stdenv runCommand fetchurl makeWrapper maven writeText
+    requireFile yq;
+  inherit (pkgs.lib) concatLists concatStrings importJSON strings
+    optionalAttrs optionalString;
+
+  maven' = maven;
+  settings' = writeText "settings.xml" ''
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    </settings>
+  '';
+
+  mapmap = fs: ls: concatLists (map (v: map (f: f v) fs) ls);
+
+  urlToScript = remoteList: dep:
+    let
+      inherit (dep) path sha1;
+      authenticated = if (dep?authenticated) then dep.authenticated else false;
+
+      fetch = if authenticated then (requireFile {
+        inherit sha1;
+        url = "${elemAt remoteList 0}/${path}";
+      }) else (fetchurl {
+        inherit sha1;
+        urls = map (r: "${r}/${path}") remoteList;
+      });
+    in ''
+      mkdir -p "$(dirname ${path})"
+      ln -sfv "${fetch}" "${path}"
+    '';
+
+  metadataToScript = remote: meta:
+    let
+      inherit (meta) path content;
+      name = "maven-metadata-${remote}.xml";
+    in ''
+      mkdir -p "${path}"
+      ( cd "${path}"
+        ln -sfv "${writeText "maven-metadata.xml" content}" "${name}"
+        linkSnapshot "${name}" )
+    '';
+
+  drvToScript = drv: ''
+    echo >&2 === building mavenix drvs: ${drv.name} ===
+    props="${drv}/share/java/*.properties"
+    for prop in $props; do getMavenPathFromProperties $prop; done
+  '';
+
+  transInfo = map (drv: importJSON "${drv}/share/mavenix/mavenix.lock");
+
+  transDeps = tinfo: concatLists (map (info: info.deps) tinfo);
+  transMetas = tinfo: concatLists (map (info: info.metas) tinfo);
+  transRemotes = foldl' (acc: info: acc // info.remotes) {};
+
+  mkRepo = {
+    deps ? [],
+    metas ? [],
+    remotes ? {},
+    drvs ? [],
+    drvsInfo ? [],
+    postHook ? "",
+  }: let
+    deps' = deps ++ (transDeps drvsInfo);
+    metas' = metas ++ (transMetas drvsInfo);
+    remotes' = (transRemotes drvsInfo) // remotes;
+    remoteList = attrValues remotes';
+  in runCommand "mk-repo" {} ''
+    set -e
+
+    getMavenPath() {
+      local version=$(sed -n 's|^version=||p' "$1")
+      local groupId=$(sed -n 's|^groupId=||p' "$1")
+      local artifactId=$(sed -n 's|^artifactId=||p' "$1")
+      echo "''${groupId//.//}/$artifactId/$version/$artifactId-$version"
+    }
+
+    linkSnapshot() {
+      [ "$(${yq}/bin/xq '.metadata.versioning.snapshotVersions' "$1")" == "null" ] \
+        && return
+      ${yq}/bin/xq -r '
+        .metadata as $o
+          | [.metadata.versioning.snapshotVersions.snapshotVersion] | flatten | .[]
+          | ((if .classifier? then ("-" + .classifier) else "" end) + "." + .extension) as $e
+          | $o.artifactId + "-" + .value + $e + " " + $o.artifactId + "-" + $o.version + $e
+      ' "$1" | xargs -L1 ln -sfv
+    }
+
+    getMavenPathFromProperties() {
+      local path="$(getMavenPath "$1")"
+      local bpath="$(dirname $path)"
+      local basefilename="''${1%%.properties}"
+
+      if test "$bpath"; then
+        mkdir -p "$bpath"
+        for fn in $basefilename-* $basefilename.{pom,jar}; do
+          test ! -f $fn || ln -sfv "$fn" "$bpath"
+        done
+        ln -sfv "$basefilename.metadata.xml" "$bpath/maven-metadata-local.xml"
+      fi
+    }
+
+    mkdir -p "$out"
+    (cd $out
+      ${concatStrings (map (urlToScript remoteList) deps')}
+      ${concatStrings (mapmap
+        (map metadataToScript (attrNames remotes')) metas')}
+      ${concatStrings (map drvToScript drvs)}
+    )
+
+    ${postHook}
+  '';
+
+  cp-artifact = submod: ''
+    find . -type f \
+      -regex "${submod.path}/target/[^/]*\.\(jar\|war\)$" ! -name "*-sources.jar" \
+      -exec cp -v {} $dir \;
+  '';
+
+  cp-pom = submod: ''
+    cp -v ${submod.path}/pom.xml $dir/${submod.name}.pom
+  '';
+
+  mk-properties = submod: ''
+    echo 'groupId=${submod.groupId}
+    artifactId=${submod.artifactId}
+    version=${submod.version}
+    ' > $dir/${submod.name}.properties
+  '';
+
+  mk-maven-metadata = submod: ''
+    echo '<metadata>
+      <groupId>${submod.groupId}</groupId>
+      <artifactId>${submod.artifactId}</artifactId>
+      <version>${submod.version}</version>
+    </metadata>
+    ' > $dir/${submod.name}.metadata.xml
+  '';
+
+  overrideOverrideAttrs = f: attrs: (f attrs) // {
+    overrideAttrs = f_: overrideOverrideAttrs f (attrs // (f_ attrs));
+  };
+
+  buildMaven = overrideOverrideAttrs ({
+    src,
+    infoFile,
+    deps        ? [],
+    drvs        ? [],
+    settings    ? settings',
+    maven       ? maven',
+
+    nativeBuildInputs ? [],
+    passthru    ? {},
+
+    remotes     ? {},
+
+    postMkRepoHook ? "",
+
+    doCheck     ? true,
+    debug       ? false,
+    build       ? true,
+    ...
+  }@config:
+    let
+      dummy-info = { name = "update"; deps = []; metas = []; };
+
+      info = if build then importJSON infoFile else dummy-info;
+      remotes' = (optionalAttrs (info?remotes) info.remotes) // remotes;
+      drvsInfo = transInfo drvs;
+
+      emptyRepo = mkRepo {
+        inherit drvs drvsInfo;
+        remotes = remotes';
+      };
+
+      repo = mkRepo {
+        inherit (info) deps metas;
+        inherit drvs drvsInfo;
+        remotes = remotes';
+        postHook = postMkRepoHook;
+      };
+
+      # Wrap mvn with settings to improve the nix-shell experience
+      maven' = runCommand "mvn" {
+        nativeBuildInputs = [ makeWrapper ];
+      } ''
+        mkdir -p $out/bin
+        makeWrapper ${maven}/bin/mvn $out/bin/mvn --add-flags "--settings ${settings}"
+      '';
+
+      mvn = "${maven'}/bin/mvn --offline --batch-mode -Dmaven.repo.local=${repo} -nsu ";
+
+    in
+      stdenv.mkDerivation ({
+        name = info.name;
+
+        nativeBuildInputs = nativeBuildInputs ++ [
+          maven' maven.jdk
+          (pkgs.ensureNewerSourcesHook { year = "1980"; })
+        ];
+
+        # Export as environment variable to make it possible to reuse default flags in other phases/hooks
+        inherit mvn;
+
+        postPhases = [ "mavenixDistPhase" ];
+
+        checkPhase = optionalString build ''
+          runHook preCheck
+
+          $mvn test
+
+          runHook postCheck
+        '';
+
+        buildPhase = optionalString build ''
+          runHook preBuild
+
+          $mvn --version
+          $mvn package -DskipTests=true -Dmaven.test.skip.exec=true
+
+          runHook postBuild
+        '';
+
+        installPhase = optionalString build ''
+          runHook preInstall
+
+          dir="$out/share/java"
+          mkdir -p $dir
+
+          ${optionalString (info?submodules) (concatStrings (mapmap
+            [ cp-artifact cp-pom mk-properties mk-maven-metadata ]
+            info.submodules
+          ))}
+
+          runHook postInstall
+        '';
+
+        mavenixDistPhase = optionalString build ''
+          mkdir -p $out/share/mavenix
+          echo copying lock file
+          cp -v ${infoFile} $out/share/mavenix/mavenix.lock
+        '';
+
+        passthru = passthru // {
+          mavenixMeta = {
+            inherit deps emptyRepo settings;
+            infoFile = toString infoFile;
+            srcPath = toString src;
+          };
+        };
+      } // (
+        removeAttrs config [
+          "deps" "drvs" "remotes" "infoFile"
+          "nativeBuildInputs" "passthru"
+        ]
+      ))
+  );
+in rec {
+  version = "2.3.3";
+  name = "mavenix-${version}";
+  updateInfo = f: infoFile:
+    writeText "updated-lock" (
+      toJSON ((x: x // f x) (importJSON infoFile))
+    );
+  inherit buildMaven pkgs;
+}


### PR DESCRIPTION
###### Motivation for this change
The current package simply installs the Airsonic binary. This change (a) makes it build from source instead, so that patches can be applied, and (b) adds a patch that inverts the (hard-coded) podcast sort order so that "play all" on a podcast plays them in chronological order rather than reverse chronological.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
