### PR TITLE
linux: version bumps

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -9,11 +9,6 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.116.a/linux-hardened-4.19.116.a.patch",
         "version_suffix": "a"
     },
-    "5.4.33": {
-        "sha256": "1hjfvhyvz5kyvx25809brhsvfv9mjv9q1mw6ydb71gfwhw6q8d8b",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.33.a/linux-hardened-5.4.33.a.patch",
-        "version_suffix": "a"
-    },
     "5.5.18": {
         "sha256": "0v7vla784sf1fk6d8qa5x8hkyhjb1jkw4lxxcgvvlqbmxl8md8ld",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.5.18.a/linux-hardened-5.5.18.a.patch",

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -3,10 +3,5 @@
         "sha256": "0pr3m2j63mc746fcbzg1hlwv85im9f87qkl6r4033gwnpa9brcgk",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.176.a/linux-hardened-4.14.176.a.patch",
         "version_suffix": "a"
-    },
-    "4.19.116": {
-        "sha256": "00y4i905gzs9w9kckrn1frh2vw32fsndz03g2psl1gk17snc3q7c",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.116.a/linux-hardened-4.19.116.a.patch",
-        "version_suffix": "a"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -13,10 +13,5 @@
         "sha256": "0v7vla784sf1fk6d8qa5x8hkyhjb1jkw4lxxcgvvlqbmxl8md8ld",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.5.18.a/linux-hardened-5.5.18.a.patch",
         "version_suffix": "a"
-    },
-    "5.6.5": {
-        "sha256": "19cdpygm5zx3szxl456lfjg5sffqcmn18470wv7prm8rf6liqdj3",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.6.5.a/linux-hardened-5.6.5.a.patch",
-        "version_suffix": "a"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -4,6 +4,11 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.176.a/linux-hardened-4.14.176.a.patch",
         "version_suffix": "a"
     },
+    "5.4.34": {
+        "sha256": "1xwpqr9nzpjg837b3wnzb8fmrl2g9rz8gz5yb55vnnllbzbz36v6",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.34.a/linux-hardened-5.4.34.a.patch",
+        "version_suffix": "a"
+    },
     "5.5.19": {
         "sha256": "1ya5nsfhr3nwz6qiz4pdhvm6k9mx1kr0prhdvhx3p40f1vk281sc",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.5.19.a/linux-hardened-5.5.19.a.patch",

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -4,6 +4,11 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.176.a/linux-hardened-4.14.176.a.patch",
         "version_suffix": "a"
     },
+    "4.19.117": {
+        "sha256": "0c8dvh49nzypxwvsls10i896smvpdrk40x8ybljb3qk3r8j7niaw",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.117.a/linux-hardened-4.19.117.a.patch",
+        "version_suffix": "a"
+    },
     "5.4.34": {
         "sha256": "1xwpqr9nzpjg837b3wnzb8fmrl2g9rz8gz5yb55vnnllbzbz36v6",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.34.a/linux-hardened-5.4.34.a.patch",

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -8,10 +8,5 @@
         "sha256": "00y4i905gzs9w9kckrn1frh2vw32fsndz03g2psl1gk17snc3q7c",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.116.a/linux-hardened-4.19.116.a.patch",
         "version_suffix": "a"
-    },
-    "5.5.18": {
-        "sha256": "0v7vla784sf1fk6d8qa5x8hkyhjb1jkw4lxxcgvvlqbmxl8md8ld",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.5.18.a/linux-hardened-5.5.18.a.patch",
-        "version_suffix": "a"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -3,5 +3,10 @@
         "sha256": "0pr3m2j63mc746fcbzg1hlwv85im9f87qkl6r4033gwnpa9brcgk",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.176.a/linux-hardened-4.14.176.a.patch",
         "version_suffix": "a"
+    },
+    "5.6.6": {
+        "sha256": "0jiqh0frxirjbccgfdk007fca6r6n36n0pkqq4jszkckn59ayl7r",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.6.6.a/linux-hardened-5.6.6.a.patch",
+        "version_suffix": "a"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -4,6 +4,11 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.176.a/linux-hardened-4.14.176.a.patch",
         "version_suffix": "a"
     },
+    "5.5.19": {
+        "sha256": "1ya5nsfhr3nwz6qiz4pdhvm6k9mx1kr0prhdvhx3p40f1vk281sc",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.5.19.a/linux-hardened-5.5.19.a.patch",
+        "version_suffix": "a"
+    },
     "5.6.6": {
         "sha256": "0jiqh0frxirjbccgfdk007fca6r6n36n0pkqq4jszkckn59ayl7r",
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.6.6.a/linux-hardened-5.6.6.a.patch",

--- a/pkgs/os-specific/linux/kernel/linux-4.19.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.19.116";
+  version = "4.19.117";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0r3vdc3npl1bn06w9v6wsq7d5mm7bnhm9wsz36pb9ar3xhimvrlf";
+    sha256 = "12xc1pwhwq4vp67hmn7hdynl4ik76cni79356hpzf1lbiqlrya6n";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.4.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.4.33";
+  version = "5.4.34";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "0q9q48ij6vppfcrdf7fr24pvpwsd13pxjkdni6rnjq9a60hrcmxm";
+    sha256 = "1ljcsrw9jknw2d9hb0yfr1pwy85l8z4rqycgd0kad9mb9lrw2glh";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.5.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.5.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.5.18";
+  version = "5.5.19";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "01iiiq4dsyyc5y6b52wax9as6dzhdi172vd1423sc1yp4rrk8178";
+    sha256 = "1sqiw9d25sqqzdh04dd722i7ff6kchj869jp4l8zalpvf51k6j0l";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.6.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.6.5";
+  version = "5.6.6";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "1rjjkcmzsj9azggh960qnk2x44ns475b8nbd4nxazrz1rgdx76zp";
+    sha256 = "1m3blvkma08v5y11jh0vhf4sr7jbcylkh15bssb5dgp40p8cx134";
   };
 } // (args.argsOverride or {}))


### PR DESCRIPTION
###### Motivation for this change

Versions bumps.
`5.6.5` -> `5.6.6`
`5.5.18` -> `5.5.19`
`5.4.33` -> `5.4.34`
`4.19.116` -> `4.19.117`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
