### PR TITLE
libfakeXinerama: fix dangling symlinks

### DIFF
--- a/pkgs/tools/X11/xpra/libfakeXinerama.nix
+++ b/pkgs/tools/X11/xpra/libfakeXinerama.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation  rec {
   installPhase = ''
     mkdir -p $out/lib
     cp libfakeXinerama.so.1.0 $out/lib
+    ln -s libfakeXinerama.so.1.0 $out/lib/libXinerama.so.1.0
     ln -s libXinerama.so.1.0 $out/lib/libXinerama.so.1
     ln -s libXinerama.so.1 $out/lib/libXinerama.so
   '';

--- a/pkgs/tools/X11/xpra/libfakeXinerama.nix
+++ b/pkgs/tools/X11/xpra/libfakeXinerama.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation  rec {
 
   buildInputs = [ libX11 libXinerama ];
 
-  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
-
   buildPhase = ''
     gcc -O2 -Wall fakeXinerama.c -fPIC -o libfakeXinerama.so.1.0 -shared
   '';


### PR DESCRIPTION
Fixes #85694

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The invalid libraries were causing a bug in xpra. Also dangling symlinks are usually undesirable.

###### Things done

Add 1 symlink to complete the chain.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
