### PR TITLE
android-studio: add ps to closure

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -39,6 +39,7 @@
 , nss
 , pciutils
 , pkgsi686Linux
+, ps
 , setxkbmap
 , stdenv
 , systemd
@@ -89,6 +90,7 @@ let
 
           # Runtime stuff
           git
+          ps
         ]}" \
         --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
 


### PR DESCRIPTION
###### Motivation for this change

When killing processes, android-studio uses `ps` to figure out which sub-processes to kill (see https://github.com/JetBrains/intellij-community/blob/902d4d89a3f630c80d5e252214dee48098c169ae/platform/util/src/com/intellij/execution/process/UnixProcessManager.java#L224). Without `ps` in the closure, this fails and the process is never killed.
android-studio then prints the following error to stderr:
```
2020-04-21 08:23:25,287 [3428731]   WARN - ion.process.UnixProcessManager - Error killing the process 
java.lang.IllegalStateException: IDE pid is not found in ps list(13567)
	at com.intellij.execution.process.UnixProcessManager.findChildProcesses(UnixProcessManager.java:194)
	at com.intellij.execution.process.UnixProcessManager.sendSignalToProcessTree(UnixProcessManager.java:141)
	at com.intellij.execution.process.UnixProcessManager.sendSignalToProcessTree(UnixProcessManager.java:129)
	at com.intellij.execution.process.UnixProcessManager.sendSignalToProcessTree(UnixProcessManager.java:117)
	at com.intellij.execution.process.UnixProcessManager.sendSigKillToProcessTree(UnixProcessManager.java:112)
	at com.intellij.execution.process.OSProcessUtil.killProcessTree(OSProcessUtil.java:54)
	at com.intellij.execution.process.impl.OSProcessManagerImpl.killProcessTree(OSProcessManagerImpl.java:20)
	at com.intellij.execution.process.OSProcessHandler.killProcessTreeSync(OSProcessHandler.java:221)
	at com.intellij.execution.process.OSProcessHandler.lambda$killProcessTree$0(OSProcessHandler.java:215)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
