### PR TITLE
aflplusplus: init at 2.64c

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4827,6 +4827,12 @@
     githubId = 3269878;
     name = "Miguel Madrid Mencía";
   };
+  mindavi = {
+    email = "rol3517@gmail.com";
+    github = "Mindavi";
+    githubId = 9799623;
+    name = "Rick van Schijndel";
+  };
   minijackson = {
     email = "minijackson@riseup.net";
     github = "minijackson";

--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, stdenvNoCC, fetchFromGitHub, makeWrapper, fetchgit
+, clang_9, llvm_9, gcc9, which, gmp, python3
+}:
+
+let
+  aflplusplus = stdenvNoCC.mkDerivation rec {
+    pname = "aflplusplus";
+    version = "2.64c";
+
+    src = fetchFromGitHub {
+      owner = "vanhauser-thc";
+      repo = pname;
+      rev = "${version}";
+      sha256 = "0n618pk6nlmkcbv1qm05fny4mnhcprrw0ppmra1phvk1y22iildj";
+    };
+
+    enableParallelBuilding = true;
+
+    nativeBuildInputs = [ makeWrapper which clang_9 gcc9 ];
+    # python3 is not fully required, but used for the plugin/custom mutator system.
+    buildInputs = [ llvm_9 gmp python3 ];
+
+    makeFlags = [ "PREFIX=$(out)" ];
+    # Only build the source-code fuzzers here for now.
+    buildPhase = ''
+      make source-only $makeFlags -j$NIX_BUILD_CORES
+    '';
+
+    checkPhase = ''
+      make tests
+    '';
+
+    postInstall = ''
+      # Patch shebangs before wrapping
+      patchShebangs $out/bin
+    '';
+
+    meta = {
+      description = "Powerful fuzzer via genetic algorithms and instrumentation";
+      longDescription = ''
+        AFL++ is a fork of AFL with community patches and improved performance.
+        AFL(++) is a fuzzer that can help find bugs in source code written in C or C++.
+        It implements guided fuzzing that helps finding testcases for bugs quickly.
+      '';
+      homepage    = "https://github.com/vanhauser-thc/AFLplusplus";
+      license     = stdenv.lib.licenses.asl20;
+      platforms   = ["x86_64-linux" "i686-linux"];
+      maintainers = with stdenv.lib.maintainers; [ Mindavi ];
+    };
+  };
+in aflplusplus
+

--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -45,7 +45,7 @@ let
       homepage    = "https://github.com/vanhauser-thc/AFLplusplus";
       license     = stdenv.lib.licenses.asl20;
       platforms   = ["x86_64-linux" "i686-linux"];
-      maintainers = with stdenv.lib.maintainers; [ Mindavi ];
+      maintainers = with stdenv.lib.maintainers; [ mindavi ];
     };
   };
 in aflplusplus

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -573,6 +573,11 @@ in
     stdenv = clangStdenv;
   };
 
+  aflplusplus = callPackage ../tools/security/aflplusplus {
+    stdenv = clangStdenv;
+  };
+
+
   libdislocator = callPackage ../tools/security/afl/libdislocator.nix { };
 
   afpfs-ng = callPackage ../tools/filesystems/afpfs-ng { };


### PR DESCRIPTION
This commit adds the aflplusplus package.
The aflplusplus package is a fork of the afl package, which is already
included in the nixpkgs repository. Currently, only source fuzzing mode
is supported, as I'm not too interested in supporting the qemu fuzzing
mode.

AFL or AFLplusplus wraps the compiler (clang or gcc) and adds instrumentation to aid fuzzing. It also includes a set of tools to help with corpus creation and management, and the actual fuzzing application.

**Note: you need to install clang_9 to use the aflplusplus compiler and python3 for some of the included tools**

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I like using AFL for fuzzing, and AFLplusplus has a lot of improvements over AFL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@thoughtpolice and @risicle are listed as maintainers for AFL, maybe they're interested in this too (either for maintaining or as a user).