### PR TITLE
xow: actually launch when enabled

### DIFF
--- a/pkgs/misc/drivers/xow/default.nix
+++ b/pkgs/misc/drivers/xow/default.nix
@@ -1,14 +1,19 @@
-{ stdenv, fetchFromGitHub, libusb1 }:
+{ stdenv, cabextract, fetchurl, fetchFromGitHub, libusb1 }:
 
 stdenv.mkDerivation rec {
   pname = "xow";
-  version = "0.4";
+  version = "0.5";
 
   src = fetchFromGitHub {
     owner = "medusalix";
     repo = "xow";
     rev = "v${version}";
-    sha256 = "1xkwcx2gqip9v2h3zjmrn7sgcck3midl5alhsmr3zivgdipamynv";
+    sha256 = "071r2kx44k1sc49cad3i607xg618mf34ki1ykr5lnfx9y6qyz075";
+  };
+
+  firmware = fetchurl {
+    url = "http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab";
+    sha256 = "013g1zngxffavqrk5jy934q3bdhsv6z05ilfixdn8dj0zy26lwv5";
   };
 
   makeFlags = [
@@ -20,7 +25,14 @@ stdenv.mkDerivation rec {
     "MODPDIR=${placeholder ''out''}/lib/modprobe.d"
     "SYSDDIR=${placeholder ''out''}/lib/systemd/system"
   ];
+
+  postUnpack = ''
+    cabextract -F FW_ACC_00U.bin ${firmware}
+    mv FW_ACC_00U.bin source/firmware.bin
+  '';
+
   enableParallelBuilding = true;
+  nativeBuildInputs = [ cabextract ];
   buildInputs = [ libusb1 ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Service was working fine but not actually starting automatically when enabled in nixos config.
