### PR TITLE
chromium: 81.0.4044.113 -> 81.0.4044.122

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -11,8 +11,8 @@
     version = "84.0.4115.5";
   };
   stable = {
-    sha256 = "0hsxxw7fm1p8g53msqb644v8vr4cpvjmpln444c2268rm43yik17";
-    sha256bin64 = "0ap7flrw3h885454fa2r7psa4sh8567ql7v7x96q11gh9gjrdvp3";
-    version = "81.0.4044.113";
+    sha256 = "0ahqh3vmzbpai4xwn7qybgw9phc8ssjdvfc7384mxqk9swqgv7qg";
+    sha256bin64 = "0gpgim244594m35qwf625blwdqgjbp4qr846wq75a9a9zqwqs05w";
+    version = "81.0.4044.122";
   };
 }


### PR DESCRIPTION
https://chromereleases.googleblog.com/2020/04/stable-channel-update-for-desktop_21.html

This update includes 8 security fixes.

CVEs: CVE-2020-6459 CVE-2020-6460 CVE-2020-645

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Testing status

| platform | attribute | status | tester |
| --- | --- | --- | --- |
| x86_64 | chromium | :heavy_check_mark: | @danielfullmer |
| x86_64 | nixosTests.chromium | :heavy_check_mark: | @danielfullmer  |
| x86_64 | google-chrome | | @primeos |
| aarch64 | chromium | :heavy_check_mark: | @thefloweringash |

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
