### PR TITLE
trufflehog: 2.0.97 -> 2.1.11

### DIFF
--- a/pkgs/tools/security/trufflehog/default.nix
+++ b/pkgs/tools/security/trufflehog/default.nix
@@ -3,25 +3,20 @@
 let
   truffleHogRegexes = python3Packages.buildPythonPackage rec {
     pname = "truffleHogRegexes";
-<<<<<<< HEAD
-    version = "0.0.4";
-    src = pythonPackages.fetchPypi {
-=======
     version = "0.0.7";
     src = python3Packages.fetchPypi {
->>>>>>> 2c28266fcef... trufflehog: 2.0.97 -> 2.1.11
       inherit pname version;
-      sha256 = "09vrscbb4h4w01gmamlzghxx6cvrqdscylrbdcnbjsd05xl7zh4z";
+      sha256 = "b81dfc60c86c1e353f436a0e201fd88edb72d5a574615a7858485c59edf32405";
     };
   };
 in
   python3Packages.buildPythonApplication rec {
     pname = "truffleHog";
-    version = "2.0.97";
+    version = "2.1.11";
 
     src = python3Packages.fetchPypi {
       inherit pname version;
-      sha256 = "034kpv1p4m90286slvc6d4mlrzaf0b5jbd4qaj87hj65wbpcpg8r";
+      sha256 = "53619f0c5be082abd377f987291ace80bc3b88f864972b1a30494780980f769e";
     };
 
     # Relax overly restricted version constraint

--- a/pkgs/tools/security/trufflehog/default.nix
+++ b/pkgs/tools/security/trufflehog/default.nix
@@ -1,20 +1,25 @@
-{ lib, pythonPackages }:
+{ lib, python3Packages }:
 
 let
-  truffleHogRegexes = pythonPackages.buildPythonPackage rec {
+  truffleHogRegexes = python3Packages.buildPythonPackage rec {
     pname = "truffleHogRegexes";
+<<<<<<< HEAD
     version = "0.0.4";
     src = pythonPackages.fetchPypi {
+=======
+    version = "0.0.7";
+    src = python3Packages.fetchPypi {
+>>>>>>> 2c28266fcef... trufflehog: 2.0.97 -> 2.1.11
       inherit pname version;
       sha256 = "09vrscbb4h4w01gmamlzghxx6cvrqdscylrbdcnbjsd05xl7zh4z";
     };
   };
 in
-  pythonPackages.buildPythonApplication rec {
+  python3Packages.buildPythonApplication rec {
     pname = "truffleHog";
     version = "2.0.97";
 
-    src = pythonPackages.fetchPypi {
+    src = python3Packages.fetchPypi {
       inherit pname version;
       sha256 = "034kpv1p4m90286slvc6d4mlrzaf0b5jbd4qaj87hj65wbpcpg8r";
     };
@@ -24,7 +29,7 @@ in
       substituteInPlace setup.py --replace "GitPython ==" "GitPython >= "
     '';
 
-    propagatedBuildInputs = [ pythonPackages.GitPython truffleHogRegexes ];
+    propagatedBuildInputs = [ python3Packages.GitPython truffleHogRegexes ];
 
     # Test cases run git clone and require network access
     doCheck = false;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrade Trufflehog to 2.1.11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc: @kalbasit 