### PR TITLE
nixos/texlive: Fix texlive for ghostscript 9.50

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -277,6 +277,11 @@ dvisvgm = stdenv.mkDerivation {
       stripLen = 1;
       extraPrefix = "texk/dvisvgm/dvisvgm-src/";
     })
+    # Needed for ghostscript>=9.50
+    (fetchpatch {
+      url = "https://github.com/TeX-Live/texlive-source/commit/ebe96188a9699053cc134084f311b876b18bdb58.patch";
+      sha256 = "09km2zqja07sxjkbv9l0kwx9yrmbfv09gp79fz7w7f77lmvyd235";
+    })
   ];
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

The upgrade of ghostscript to 9.50 produced some issues with texlive 2019. This patch adds an additional fix necessary for the upgrade preventing pstricks from working correctly:

https://tug.org/pipermail/dvipdfmx/2019-November/000036.html

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
