### PR TITLE
nixos/texlive: Fix texlive pstricks

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -76,6 +76,14 @@ let
         url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/texlive-poppler-0.86.patch?h=packages/texlive-bin&id=60244e41bb6f1501e8ed1fc9e6b7ba8d3f283398";
         sha256 = "0pdvhaqc3zgz7hp0x3a4qs0nh26fkvgmr6w1cjljqhp1nyiw2f1l";
       })
+
+      # Needed for ghostscript>=9.50
+      (fetchpatch {
+        name = "xdvipdfm-fix.patch";
+        url = "https://www.tug.org/svn/texlive/trunk/Build/source/texk/dvipdfm-x/spc_dvips.c?view=patch&r1=52765&r2=52764&pathrev=52765";
+        sha256 = "0qvrc7yxhbl5f4g340z8aql388bwib0m2gxd473skbmviy5bjr3f";
+        stripLen = 2;
+      })
     ];
 
     # remove when removing synctex-missing-header.patch


### PR DESCRIPTION
###### Motivation for this change

The upgrade of ghostscript to 9.50 produced some issues with texlive 2019. This patch adds an additional fix necessary for the upgrade preventing pstricks from working correctly:

https://tug.org/pipermail/dvipdfmx/2019-November/000036.html

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
