### PR TITLE
nixos-containers: add docs about nested containers

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -440,7 +440,9 @@ in
       default = false;
       description = ''
         Whether this NixOS machine is a lightweight container running
-        in another NixOS system.
+        in another NixOS system. If set to true, support for nested
+        containers is disabled by default, but can be reenabled by
+        setting <config>boot.enableContainers</config> to true.
       '';
     };
 
@@ -448,7 +450,11 @@ in
       type = types.bool;
       default = !config.boot.isContainer;
       description = ''
-        Whether to enable support for NixOS containers.
+        Whether to enable support for NixOS containers. Defaults to true
+        (at no cost if containers are not actually used), but only if the
+        system is not itself a lightweight container of a host.
+        To enable support for nested containers, this option has to be
+        explicitly set to true (in the outer container).
       '';
     };
 
@@ -596,7 +602,7 @@ in
               type = with types; attrsOf (submodule { options = networkOptions; });
               default = {};
               description = ''
-                Extra veth-pairs to be created for the container
+                Extra veth-pairs to be created for the container.
               '';
             };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Recently I started experimenting with our lightweight containers and was very impressed by how well they work. I'm grateful to all who have worked to bring this feature to light.

I was also pleasantly surprised to notice that nested containers work just fine. However, I fell into a small trap, which this pull request hopefully removes by improving the documentation:

By default, support for containers is disabled for machines which are themselves containers to a host. This default is readily apparent from the source (`default = !config.boot.isContainer`) but not from the generated documentation (which simply lists `Default: true`). This pull request adds two short sentences to the documentation, hopefully clarifying the situation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
