### PR TITLE
nixosTests.redmine: Port to python

### DIFF
--- a/nixos/tests/redmine.nix
+++ b/nixos/tests/redmine.nix
@@ -3,74 +3,42 @@
   pkgs ? import ../.. { inherit system config; }
 }:
 
-with import ../lib/testing.nix { inherit system pkgs; };
+with import ../lib/testing-python.nix { inherit system pkgs; };
 with pkgs.lib;
 
 let
-  mysqlTest = package: makeTest {
-    machine =
-      { config, pkgs, ... }:
-      { services.redmine.enable = true;
-        services.redmine.package = package;
-        services.redmine.database.type = "mysql2";
-        services.redmine.plugins = {
+  redmineTest = { name, type }: makeTest {
+    name = "redmine-${name}";
+    machine = { config, pkgs, ... }: {
+      services.redmine = {
+        enable = true;
+        package = pkgs.redmine;
+        database.type = type;
+        plugins = {
           redmine_env_auth = pkgs.fetchurl {
             url = "https://github.com/Intera/redmine_env_auth/archive/0.7.zip";
             sha256 = "1xb8lyarc7mpi86yflnlgyllh9hfwb9z304f19dx409gqpia99sc";
           };
         };
-        services.redmine.themes = {
+        themes = {
           dkuk-redmine_alex_skin = pkgs.fetchurl {
             url = "https://bitbucket.org/dkuk/redmine_alex_skin/get/1842ef675ef3.zip";
             sha256 = "0hrin9lzyi50k4w2bd2b30vrf1i4fi1c0gyas5801wn8i7kpm9yl";
           };
         };
       };
+    };
 
     testScript = ''
-      startAll;
-      $machine->waitForUnit('redmine.service');
-      $machine->waitForOpenPort('3000');
-      $machine->succeed("curl --fail http://localhost:3000/");
+      start_all()
+      machine.wait_for_unit("redmine.service")
+      machine.wait_for_open_port(3000)
+      machine.succeed("curl --fail http://localhost:3000/")
     '';
-  };
-
-  pgsqlTest = package: makeTest {
-    machine =
-      { config, pkgs, ... }:
-      { services.redmine.enable = true;
-        services.redmine.package = package;
-        services.redmine.database.type = "postgresql";
-        services.redmine.plugins = {
-          redmine_env_auth = pkgs.fetchurl {
-            url = "https://github.com/Intera/redmine_env_auth/archive/0.7.zip";
-            sha256 = "1xb8lyarc7mpi86yflnlgyllh9hfwb9z304f19dx409gqpia99sc";
-          };
-        };
-        services.redmine.themes = {
-          dkuk-redmine_alex_skin = pkgs.fetchurl {
-            url = "https://bitbucket.org/dkuk/redmine_alex_skin/get/1842ef675ef3.zip";
-            sha256 = "0hrin9lzyi50k4w2bd2b30vrf1i4fi1c0gyas5801wn8i7kpm9yl";
-          };
-        };
-      };
-
-    testScript = ''
-      startAll;
-      $machine->waitForUnit('redmine.service');
-      $machine->waitForOpenPort('3000');
-      $machine->succeed("curl --fail http://localhost:3000/");
-    '';
-  };
-in
-{
-  mysql = mysqlTest pkgs.redmine // {
-    name = "mysql";
+  } // {
     meta.maintainers = [ maintainers.aanderse ];
   };
-
-  pgsql = pgsqlTest pkgs.redmine // {
-    name = "pgsql";
-    meta.maintainers = [ maintainers.aanderse ];
-  };
+in {
+  mysql = redmineTest { name = "mysql"; type = "mysql2"; };
+  pgsql = redmineTest { name = "pgsql"; type = "postgresql"; };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
