### PR TITLE
srcOnly: fix invocation and document

### DIFF
--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -11,11 +11,21 @@
 , src
 , stdenv ? orig.stdenv
 , patches ? []
-, buildInputs ? []
-, ... # needed when passing an existing derivation
+, # deprecated, use the nativeBuildInputs
+  buildInputs ? []
+, # used to pass extra unpackers
+  nativeBuildInputs ? []
+, # needed when passing an existing derivation
+  ...
 }:
 stdenv.mkDerivation {
-  inherit src buildInputs patches name;
+  inherit
+    buildInputs
+    name
+    nativeBuildInputs
+    patches
+    src
+    ;
   installPhase = "cp -r . $out";
   phases = ["unpackPhase" "patchPhase" "installPhase"];
 }

--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -1,4 +1,19 @@
-{stdenv, name, src, patches ? [], buildInputs ? [], ...}: 
+{ stdenv }@orig:
+# srcOnly is a utility builder that only fetches and unpacks the given `src`,
+# maybe pathings it in the process with the optional `patches` and
+# `buildInputs` attributes.
+#
+# It can be invoked directly, or be used to wrap an existing derivation. Eg:
+#
+# > srcOnly pkgs.hello
+#
+{ name
+, src
+, stdenv ? orig.stdenv
+, patches ? []
+, buildInputs ? []
+, ... # needed when passing an existing derivation
+}:
 stdenv.mkDerivation {
   inherit src buildInputs patches name;
   installPhase = "cp -r . $out";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -450,7 +450,7 @@ in
 
   singularity-tools = callPackage ../build-support/singularity-tools { };
 
-  srcOnly = args: callPackage ../build-support/src-only args;
+  srcOnly = callPackage ../build-support/src-only { };
 
   substituteAll = callPackage ../build-support/substitute/substitute-all.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Previously, callPackage would try and fill the arguments such as `name`
and `src` which would cause problems if those existed as top-level
attributes. This also makes it clearer what part is the function
signature.

Then document the derivation inline in the code to explain the ellipsis
and various use-cases.

This is a follow-up on #80903

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
