### PR TITLE
babeld: 1.9.1 → 1.9.2

### DIFF
--- a/pkgs/tools/networking/babeld/default.nix
+++ b/pkgs/tools/networking/babeld/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "babeld";
-  version = "1.9.1";
+  version = "1.9.2";
 
   src = fetchurl {
     url = "http://www.pps.univ-paris-diderot.fr/~jch/software/files/${pname}-${version}.tar.gz";
-    sha256 = "1d503igqv9s5pgrhvxp1czjy2xfsjhagyyh2iny7g4cjvl0kq6qy";
+    sha256 = "01vzhrspnm4sy9ggaz9n3bfl5hy3qlynr218j3mdcddzm3h00kqm";
   };
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change
```
Dear all,

Babeld-1.9.2 is available from

  https://www.irif.fr/~jch/software/files/babeld-1.9.2.tar.gz
  https://www.irif.fr/~jch/software/files/babeld-1.9.2.tar.gz.asc

For more information about the Babel routing protocol, please see

  https://www.irif.fr/~jch/software/babel/

This is a bug fix release.  It fixes two bugs where IPv4 prefixes could be
represented incorrectly, with a range of confusing symptoms ; many thanks
to Faban Bläse for diagnosing the issue.  In addition, it fixes incorrect
parsing of unknown address encodings, thanks to Théo Bastian for the fix.

21 April 2020: babeld-1.9.2

  * Fixed two issues that could cause IPv4 routes to be represented
    incorrectly, with a range of confusing symptoms.  Thanks to
    Fabian Bläse.
  * Fixed incorrect parsing of TLVs with an unknown Address Encoding.
    Thanks to Théophile Bastian.
  * Fixed access to mis-aligned data structure.  Thanks to Antonin Décimo.

-- Juliusz Chroboczek

_______________________________________________
Babel-users mailing list
Babel-users@alioth-lists.debian.net
https://alioth-lists.debian.net/cgi-bin/mailman/listinfo/babel-users
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@fpletz 