### PR TITLE
svgwrite: update to 1.4

### DIFF
--- a/pkgs/development/python-modules/svgwrite/default.nix
+++ b/pkgs/development/python-modules/svgwrite/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, pythonAtLeast
 , fetchFromGitHub
 , pyparsing
 , pytest
@@ -8,6 +9,7 @@
 buildPythonPackage rec {
   pname = "svgwrite";
   version = "1.3.1";
+  disabled = pythonAtLeast "3.8";
 
   src = fetchFromGitHub {
     owner = "mozman";
@@ -33,7 +35,6 @@ buildPythonPackage rec {
     description = "A Python library to create SVG drawings";
     homepage = https://github.com/mozman/svgwrite;
     license = licenses.mit;
-    broken = true;
   };
 
 }


### PR DESCRIPTION
@disassembler It seems that ``python3Packages.svgwrite`` was incorrectly marked as broken in c6be4c1. It seems to build fine, and Python can import the resulting package.