### PR TITLE
onionshare: init at 2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4407,6 +4407,16 @@
       fingerprint = "74F5 E5CC 19D3 B5CB 608F  6124 68FF 81E6 A785 0F49";
     }];
   };
+  lourkeur = {
+    name = "Louis Bettens";
+    email = "louis@bettens.info";
+    github = "lourkeur";
+    githubId = 15657735;
+    keys = [{
+      longkeyid = "ed25519/0xDFE1D4A017337E2A";
+      fingerprint = "5B93 9CFA E8FC 4D8F E07A  3AEA DFE1 D4A0 1733 7E2A";
+    }];
+  };
   luis = {
     email = "luis.nixos@gmail.com";
     github = "Luis-Hebendanz";

--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  buildPythonApplication,
+  stdenv,
+  substituteAll,
+  fetchFromGitHub,
+  isPy3k,
+  flask,
+  flask-httpauth,
+  stem,
+  pyqt5,
+  pycrypto,
+  pysocks,
+  pytest,
+  qt5,
+  requests,
+  tor,
+  obfs4,
+}:
+
+let
+  version = "2.2";
+  src = fetchFromGitHub {
+    owner = "micahflee";
+    repo = "onionshare";
+    rev = "v${version}";
+    sha256 = "0m8ygxcyp3nfzzhxs2dfnpqwh1vx0aws44lszpnnczz4fks3a5j4";
+  };
+  meta = with lib; {
+    description = "Securely and anonymously send and receive files";
+    longDescription = ''
+    OnionShare is an open source tool for securely and anonymously sending
+    and receiving files using Tor onion services. It works by starting a web
+    server directly on your computer and making it accessible as an
+    unguessable Tor web address that others can load in Tor Browser to
+    download files from you, or upload files to you. It doesn't require
+    setting up a separate server, using a third party file-sharing service,
+    or even logging into an account.
+
+    Unlike services like email, Google Drive, DropBox, WeTransfer, or nearly
+    any other way people typically send files to each other, when you use
+    OnionShare you don't give any companies access to the files that you're
+    sharing. So long as you share the unguessable web address in a secure way
+    (like pasting it in an encrypted messaging app), no one but you and the
+    person you're sharing with can access the files.
+    '';
+
+    homepage = "https://onionshare.org/";
+
+    license = licenses.gpl3Plus;
+  };
+
+  common = buildPythonApplication {
+    pname = "onionshare-common";
+    inherit version meta src;
+
+    disable = !isPy3k;
+    propagatedBuildInputs = [
+      flask
+      flask-httpauth
+      stem
+      pyqt5
+      pycrypto
+      pysocks
+      requests
+    ];
+    buildInputs = [
+      tor
+      obfs4
+    ];
+
+    patches = [
+      (substituteAll {
+        src = ./fix-paths.patch;
+        inherit tor obfs4;
+        inherit (tor) geoip;
+      })
+    ];
+    postPatch = "substituteInPlace onionshare/common.py --subst-var-by common $out";
+
+    doCheck = false;
+  };
+in
+{
+  onionshare = stdenv.mkDerivation {
+    pname = "onionshare";
+    inherit version meta;
+
+    dontUnpack = true;
+
+    inherit common;
+    installPhase = ''
+      mkdir -p $out/bin
+      cp $common/bin/onionshare -t $out/bin
+    '';
+  };
+  onionshare-gui = stdenv.mkDerivation {
+    pname = "onionshare-gui";
+    inherit version meta;
+
+    nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+
+    dontUnpack = true;
+
+    inherit common;
+    installPhase = ''
+      mkdir -p $out/bin
+      cp $common/bin/onionshare-gui -t $out/bin
+      wrapQtApp $out/bin/onionshare-gui
+    '';
+  };
+}

--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -48,6 +48,7 @@ let
     homepage = "https://onionshare.org/";
 
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lourkeur ];
   };
 
   common = buildPythonApplication {

--- a/pkgs/applications/networking/onionshare/fix-paths.patch
+++ b/pkgs/applications/networking/onionshare/fix-paths.patch
@@ -1,0 +1,134 @@
+diff --git a/onionshare/common.py b/onionshare/common.py
+index 3373462..7fd245b 100644
+--- a/onionshare/common.py
++++ b/onionshare/common.py
+@@ -87,66 +87,16 @@ class Common(object):
+                 ),
+                 "share",
+             )
+-            if not os.path.exists(prefix):
+-                # While running tests during stdeb bdist_deb, look 3 directories up for the share folder
+-                prefix = os.path.join(
+-                    os.path.dirname(
+-                        os.path.dirname(os.path.dirname(os.path.dirname(prefix)))
+-                    ),
+-                    "share",
+-                )
+-
+-        elif self.platform == "BSD" or self.platform == "Linux":
+-            # Assume OnionShare is installed systemwide in Linux, since we're not running in dev mode
+-            prefix = os.path.join(sys.prefix, "share/onionshare")
+-
+-        elif getattr(sys, "frozen", False):
+-            # Check if app is "frozen"
+-            # https://pythonhosted.org/PyInstaller/#run-time-information
+-            if self.platform == "Darwin":
+-                prefix = os.path.join(sys._MEIPASS, "share")
+-            elif self.platform == "Windows":
+-                prefix = os.path.join(os.path.dirname(sys.executable), "share")
++        else:
++            prefix = "@common@/share/onionshare"
+
+         return os.path.join(prefix, filename)
+
+     def get_tor_paths(self):
+-        if self.platform == "Linux":
+-            tor_path = "/usr/bin/tor"
+-            tor_geo_ip_file_path = "/usr/share/tor/geoip"
+-            tor_geo_ipv6_file_path = "/usr/share/tor/geoip6"
+-            obfs4proxy_file_path = "/usr/bin/obfs4proxy"
+-        elif self.platform == "Windows":
+-            base_path = os.path.join(
+-                os.path.dirname(os.path.dirname(self.get_resource_path(""))), "tor"
+-            )
+-            tor_path = os.path.join(os.path.join(base_path, "Tor"), "tor.exe")
+-            obfs4proxy_file_path = os.path.join(
+-                os.path.join(base_path, "Tor"), "obfs4proxy.exe"
+-            )
+-            tor_geo_ip_file_path = os.path.join(
+-                os.path.join(os.path.join(base_path, "Data"), "Tor"), "geoip"
+-            )
+-            tor_geo_ipv6_file_path = os.path.join(
+-                os.path.join(os.path.join(base_path, "Data"), "Tor"), "geoip6"
+-            )
+-        elif self.platform == "Darwin":
+-            base_path = os.path.dirname(
+-                os.path.dirname(os.path.dirname(self.get_resource_path("")))
+-            )
+-            tor_path = os.path.join(base_path, "Resources", "Tor", "tor")
+-            tor_geo_ip_file_path = os.path.join(base_path, "Resources", "Tor", "geoip")
+-            tor_geo_ipv6_file_path = os.path.join(
+-                base_path, "Resources", "Tor", "geoip6"
+-            )
+-            obfs4proxy_file_path = os.path.join(
+-                base_path, "Resources", "Tor", "obfs4proxy"
+-            )
+-        elif self.platform == "BSD":
+-            tor_path = "/usr/local/bin/tor"
+-            tor_geo_ip_file_path = "/usr/local/share/tor/geoip"
+-            tor_geo_ipv6_file_path = "/usr/local/share/tor/geoip6"
+-            obfs4proxy_file_path = "/usr/local/bin/obfs4proxy"
++        tor_path = "@tor@/bin/tor"
++        tor_geo_ip_file_path = "@geoip@/share/tor/geoip"
++        tor_geo_ipv6_file_path = "@geoip@/share/tor/geoip6"
++        obfs4proxy_file_path = "@obfs4@/bin/obfs4proxy"
+
+         return (
+             tor_path,
+diff --git a/setup.py b/setup.py
+index 9af72fc..53ca47b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -70,41 +70,41 @@ classifiers = [
+ ]
+ data_files = [
+     (
+-        os.path.join(sys.prefix, "share/applications"),
++        "share/applications",
+         ["install/org.onionshare.OnionShare.desktop"],
+     ),
+     (
+-        os.path.join(sys.prefix, "share/icons/hicolor/scalable/apps"),
++        "share/icons/hicolor/scalable/apps",
+         ["install/org.onionshare.OnionShare.svg"],
+     ),
+     (
+-        os.path.join(sys.prefix, "share/metainfo"),
++        "share/metainfo",
+         ["install/org.onionshare.OnionShare.appdata.xml"],
+     ),
+-    (os.path.join(sys.prefix, "share/onionshare"), file_list("share")),
+-    (os.path.join(sys.prefix, "share/onionshare/images"), file_list("share/images")),
+-    (os.path.join(sys.prefix, "share/onionshare/locale"), file_list("share/locale")),
++    ( "share/onionshare", file_list("share")),
++    ( "share/onionshare/images", file_list("share/images")),
++    ( "share/onionshare/locale", file_list("share/locale")),
+     (
+-        os.path.join(sys.prefix, "share/onionshare/templates"),
++        "share/onionshare/templates",
+         file_list("share/templates"),
+     ),
+     (
+-        os.path.join(sys.prefix, "share/onionshare/static/css"),
++        "share/onionshare/static/css",
+         file_list("share/static/css"),
+     ),
+     (
+-        os.path.join(sys.prefix, "share/onionshare/static/img"),
++        "share/onionshare/static/img",
+         file_list("share/static/img"),
+     ),
+     (
+-        os.path.join(sys.prefix, "share/onionshare/static/js"),
++        "share/onionshare/static/js",
+         file_list("share/static/js"),
+     ),
+ ]
+ if not platform.system().endswith("BSD") and platform.system() != "DragonFly":
+     data_files.append(
+         (
+-            "/usr/share/nautilus-python/extensions/",
++            "share/nautilus-python/extensions/",
+             ["install/scripts/onionshare-nautilus.py"],
+         )
+     )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21068,6 +21068,8 @@ in
 
   omxplayer = callPackage ../applications/video/omxplayer { };
 
+  inherit (python3Packages.callPackage ../applications/networking/onionshare { }) onionshare onionshare-gui;
+
   openbox = callPackage ../applications/window-managers/openbox { };
 
   openbox-menu = callPackage ../applications/misc/openbox-menu {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Meet #83029

###### Things done
- Add derivation
- Add myself as maintainer
- Link derivation in pkgs/top-level
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
