### PR TITLE
WIP lbry: init at 0.44.0

### DIFF
--- a/pkgs/applications/video/lbry/default.nix
+++ b/pkgs/applications/video/lbry/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, dpkg
+, fetchurl
+, atomEnv
+, autoPatchelfHook
+, libpulseaudio
+, makeWrapper
+, pulseaudio
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lbry";
+  version = "0.44.0";
+  
+  src = fetchurl {
+    url = "https://github.com/lbryio/lbry-desktop/releases/download/v${version}/LBRY_${version}.deb";
+    sha256 = "0v3w6qi3lyalyaz9n8dpssgjkxjlwn30f7gc4b8fh8cpdkgdk6dp";
+  };
+  
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  buildInputs = atomEnv.packages ++ [ libpulseaudio ];
+  
+  unpackPhase = ''
+    dpkg -x $src /build
+  '';
+  
+  installPhase = ''
+    mkdir -p $out/bin
+    mv usr/share $out/share
+    mv opt/LBRY $out/LBRY
+    makeWrapper $out/LBRY/lbry $out/bin/lbry \
+      --prefix LD_LIBRARY_PATH : ${libpulseaudio}/lib:${pulseaudio}/lib
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20379,6 +20379,8 @@ in
 
   liferea = callPackage ../applications/networking/newsreaders/liferea { };
 
+  lbry = callPackage ../applications/video/lbry { };
+
   lightworks = callPackage ../applications/video/lightworks {
     portaudio = portaudio2014;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
