### PR TITLE
Use Open Watcom to build VirtualBox BIOS

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -3,6 +3,9 @@
 , libpng, glib, lvm2, libXrandr, libXinerama, libopus, qtbase, qtx11extras
 , qttools, qtsvg, qtwayland, pkgconfig, which, docbook_xsl, docbook_xml_dtd_43
 , alsaLib, curl, libvpx, nettools, dbus, substituteAll, fetchpatch
+# If open-watcom-bin is not passed, VirtualBox will fall back to use
+# the shipped alternative sources (assembly).
+, open-watcom-bin ? null
 , makeself, perl
 , javaBindings ? true, jdk ? null # Almost doesn't affect closure size
 , pythonBindings ? false, python3 ? null
@@ -148,6 +151,7 @@ in stdenv.mkDerivation {
       ${optionalString (!pulseSupport) "--disable-pulse"} \
       ${optionalString (!enableHardening) "--disable-hardening"} \
       ${optionalString (!enable32bitGuests) "--disable-vmmraw"} \
+      ${optionalString (open-watcom-bin != null) "--with-ow-dir=${open-watcom-bin}"} \
       --disable-kmods
     sed -e 's@PKG_CONFIG_PATH=.*@PKG_CONFIG_PATH=${libIDL}/lib/pkgconfig:${glib.dev}/lib/pkgconfig ${libIDL}/bin/libIDL-config-2@' \
         -i AutoConfig.kmk

--- a/pkgs/development/compilers/open-watcom-bin/default.nix
+++ b/pkgs/development/compilers/open-watcom-bin/default.nix
@@ -1,0 +1,67 @@
+{ stdenvNoCC, fetchurl, qemu, expect, writeScript, ncurses }:
+
+let
+
+  # We execute the installer in qemu-user, because otherwise the
+  # installer fails to open itself due to a failed stat() call. This
+  # seems like an incompatibility of new Linux kernels to run this
+  # ancient binary.
+  performInstall = writeScript "perform-ow-install" ''
+    #!${expect}/bin/expect -f
+
+    spawn env TERMINFO=${ncurses}/share/terminfo TERM=vt100 ${qemu}/bin/qemu-i386 [lindex $argv 0]
+
+    # Wait for button saying "I agree" with escape sequences.
+    expect "gree"
+
+    # Navigate to "I Agree!" and hit enter.
+    send "\t\t\n"
+
+    expect "Install Open Watcom"
+
+    # Where do we want to install to.
+    send "$env(out)\n"
+
+    expect "will be installed"
+
+    # Select Full Installation, Next
+    send "fn"
+
+    expect "Setup will now copy"
+
+    # Next
+    send "n"
+
+    expect "completed successfully"
+    send "\n"
+  '';
+
+in
+stdenvNoCC.mkDerivation rec {
+  pname = "open-watcom-bin";
+  version = "1.9";
+
+  src = fetchurl {
+    url = "http://ftp.openwatcom.org/install/open-watcom-c-linux-${version}";
+    sha256 = "1wzkvc6ija0cjj5mcyjng5b7hnnc5axidz030c0jh05pgvi4nj7p";
+  };
+
+  dontUnpack = true;
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    cp ${src} install-bin
+    chmod +x install-bin
+
+    ${performInstall} install-bin
+  '';
+
+  meta = with stdenvNoCC.lib; {
+    description = "A C/C++ Compiler (binary distribution)";
+    homepage = "http://www.openwatcom.org/";
+    license = licenses.watcom;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ maintainers.blitz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8996,6 +8996,8 @@ in
     inherit (ocaml-ng.ocamlPackages_4_05) ocaml;
   };
 
+  open-watcom-bin = callPackage ../development/compilers/open-watcom-bin { };
+
   pforth = callPackage ../development/compilers/pforth {};
 
   picat = callPackage ../development/compilers/picat { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

In order to patch VirtualBox BIOS sources, VirtualBox has to be able to use the (ancient) OpenWatcom C/C++ toolchain to build its BIOS.

This PR adds the latest working Open Watcom release (consisting only of static binaries) and changes VirtualBox to use it to build its BIOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @messemar @tfc @B4dM4n @svanderburg @B4dM4n 