### PR TITLE
pythonPackages.cloudflare: init at 2.6.5

### DIFF
--- a/pkgs/development/python-modules/auth0-python/default.nix
+++ b/pkgs/development/python-modules/auth0-python/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "auth0-python";
+  version = "3.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c2fdc3ff230638a2776d2b3761e787ca93dc33a26f841504fc260f947256f453";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  checkInputs = [
+    mock
+  ];
+
+  meta = with lib; {
+    description = "Auth0 Python SDK";
+    homepage = "https://github.com/auth0/auth0-python";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/cloudflare/default.nix
+++ b/pkgs/development/python-modules/cloudflare/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, future
+, pyyaml
+, jsonlines
+}:
+
+buildPythonPackage rec {
+  pname = "cloudflare";
+  version = "2.6.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4463d5f2927338384169315f34c2a8ac0840075b59489f8d1d773b91caba6c39";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    future
+    pyyaml
+    jsonlines
+  ];
+
+  # no tests associated with package
+  doCheck = false;
+  pythonImportsCheck = [ "CloudFlare" ];
+
+  meta = with lib; {
+    description = "Python wrapper for the Cloudflare v4 API";
+    homepage = "https://github.com/cloudflare/python-cloudflare";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -248,6 +248,8 @@ in {
 
   authres = callPackage ../development/python-modules/authres { };
 
+  auth0-python = callPackage ../development/python-modules/auth0-python { };
+
   autograd = callPackage ../development/python-modules/autograd { };
 
   autologging = callPackage ../development/python-modules/autologging { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2216,6 +2216,8 @@ in {
 
   closure-linter = callPackage ../development/python-modules/closure-linter { };
 
+  cloudflare = callPackage ../development/python-modules/cloudflare { };
+
   cloudpickle = callPackage ../development/python-modules/cloudpickle { };
 
   cmdline = callPackage ../development/python-modules/cmdline { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Using this for my own development and wanted to push it upstream.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
