### PR TITLE
Revert "st: copy config file in 'prePatch' instead of 'preBuild'"

### DIFF
--- a/pkgs/applications/misc/st/default.nix
+++ b/pkgs/applications/misc/st/default.nix
@@ -13,9 +13,8 @@ stdenv.mkDerivation rec {
 
   inherit patches;
 
-  prePatch = optionalString (conf != null) ''
-    cp ${writeText "config.def.h" conf} config.def.h
-  '';
+  configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
+  postPatch = optionalString (conf!=null) "cp ${configFile} config.def.h";
 
   nativeBuildInputs = [ pkgconfig ncurses ];
   buildInputs = [ libX11 libXft ] ++ extraLibs;


### PR DESCRIPTION
If I'm not mistaking, this previously merged PR has broken _common usage_ and the compatibility of patches. 

The following was my argumentation from the PR #85443, as @Mic92 recommended me to create a new PR.

> I'm not quite sure about this changes, but I think it is breaking with common usage. I would guess that most users are adding some provided patches from upstream and a custom configuration file.
>
> By default, the patches were written against the vanilla release version. Thus, by applying the patches first, they should work. The custom configuration file will then just replace the (potentially patched) config file.
>
> However, if the custom configuration is applied at first, some patches are not compatible anymore because they are also adjusting the configuration file. This obviously fails, because it is no longer in its vanilla state.
>
> Furthermore, I think the argumentation is wrong. Afaik, the patch phase is run before the build phase, not afterwards. The explained state in the commit message was already there before.

In a nutshell, this reverts that patches need to be compatible with the user's custom configuration. The user config will override the previously patched default configuration.