### PR TITLE
fverb: init at unstable-2020-06-09

### DIFF
--- a/pkgs/applications/audio/fverb/default.nix
+++ b/pkgs/applications/audio/fverb/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchFromGitHub
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fverb";
+  # no release yet: https://github.com/jpcima/fverb/issues/2
+  version = "unstable-2020-06-09";
+
+  src = fetchFromGitHub {
+    owner = "jpcima";
+    repo = pname;
+    rev = "462020e33e24c0204a375dc95e2c28654cc917b8";
+    sha256 = "12nl7qn7mnykk7v8q0j2n8kfq0xc46n0i45z6qcywspadwnncmd4";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postPatch = ''
+    patchShebangs ./dpf/utils/generate-ttl.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A stereo variant of the reverberator by Jon Dattorro, for lv2";
+    homepage = "https://github.com/jpcima/fverb";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.magnetophon ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3555,6 +3555,8 @@ in
 
   fusee-launcher = callPackage ../development/tools/fusee-launcher { };
 
+  fverb = callPackage ../applications/audio/fverb { };
+
   fwknop = callPackage ../tools/security/fwknop { };
 
   exfat = callPackage ../tools/filesystems/exfat { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
