### PR TITLE
nixos/libinput: Add package and xf86inputlibinput.package options

### DIFF
--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -191,6 +191,25 @@ in {
         '';
       };
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.libinput;
+        defaultText = "pkgs.libinput";
+        description = ''
+          The libinput package to use.
+        '';
+      };
+
+      xf86inputlibinput = {
+        package = mkOption {
+          type = types.package;
+          default = pkgs.xorg.xf86inputlibinput;
+          defaultText = "pkgs.xorg.xf86inputlibinput";
+          description = ''
+            The xf86-input-libinput package to use.
+          '';
+        };
+      };
     };
 
   };
@@ -198,19 +217,19 @@ in {
 
   config = mkIf cfg.enable {
 
-    services.xserver.modules = [ pkgs.xorg.xf86inputlibinput ];
+    services.xserver.modules = [ cfg.xf86inputlibinput.package ];
 
-    environment.systemPackages = [ pkgs.xorg.xf86inputlibinput ];
+    environment.systemPackages = [ cfg.xf86inputlibinput.package ];
 
     environment.etc =
       let cfgPath = "X11/xorg.conf.d/40-libinput.conf";
       in {
         ${cfgPath} = {
-          source = pkgs.xorg.xf86inputlibinput.out + "/share/" + cfgPath;
+          source = cfg.xf86inputlibinput.package.out + "/share/" + cfgPath;
         };
       };
 
-    services.udev.packages = [ pkgs.libinput.out ];
+    services.udev.packages = [ cfg.package.out ];
 
     services.xserver.config =
       ''


### PR DESCRIPTION
**Edit:** ~~I forgot to actually wait until the build is finished. I'll update this in a bit.~~ It built successfully.

###### Motivation for this change
Originally circumventing #85707, could theoretically be used for other things in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Note - tested on top of 1e90c46c2d9 instead of master.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [N/A] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
