### PR TITLE
p7zip: remove non-free RAR support

### DIFF
--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
     substituteInPlace makefile.machine \
       --replace 'CC=gcc'  'CC=${stdenv.cc.targetPrefix}gcc' \
       --replace 'CXX=g++' 'CXX=${stdenv.cc.targetPrefix}g++'
+  '' + ''
+    # Remove non-free RAR source code
+    # (see DOC/License.txt, https://fedoraproject.org/wiki/Licensing:Unrar)
+    rm -r CPP/7zip/Compress/Rar*
+    find . -name makefile'*' -exec sed -i '/Rar/d' {} +
   '';
 
   preConfigure = ''
@@ -42,9 +47,9 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://p7zip.sourceforge.net/";
     description = "A port of the 7-zip archiver";
-    # license = stdenv.lib.licenses.lgpl21Plus; + "unRAR restriction"
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.raskin ];
+    # RAR code is under non-free UnRAR license, but we remove it
     license = stdenv.lib.licenses.lgpl2Plus;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

7-Zip's RAR implementation is built on the non-free UnRAR source code; DOC/License.txt says:

      Licenses for files are:
    
        1) CPP/7zip/Compress/Rar* files:  GNU LGPL + unRAR restriction
        2) All other files:  GNU LGPL
    
      The GNU LGPL + unRAR restriction means that you must follow both 
      GNU LGPL rules and unRAR restriction rules.
    
    ...
    
      unRAR restriction
      -----------------
    
        The decompression engine for RAR archives was developed using source 
        code of unRAR program.
        All copyrights to original unRAR code are owned by Alexander Roshal.
    
        The license for original unRAR code has the following restriction:
    
        The unRAR sources cannot be used to re-create the RAR compression algorithm, 
        which is proprietary. Distribution of modified unRAR sources in separate form 
        or as a part of other software is permitted, provided that it is clearly
        stated in the documentation and source comments that the code may
        not be used to develop a RAR (WinRAR) compatible archiver.

The unrar licensing is [infamously restrictive and non-free][fedora]; it's inappropriate for us to keep the RAR support while labelling the package as free software (and indeed there's a commented-out line pointing out that the current `meta.license` is false). Unfortunately, the 7-Zip upstream seems uninterested in replacing the code with a freely-licensed alternative (see [7-Zip ticket #1229][7zip]).

[fedora]: https://fedoraproject.org/wiki/Licensing:Unrar
[7zip]: https://sourceforge.net/p/sevenzip/feature-requests/1229/

An alternative solution would be to mark the p7zip package as non-free instead; I decided not to because its other functionality (especially `.7z` support) is freely-licensed and useful, and there are free software alternatives for extracting RAR files (e.g. in nixpkgs there's `archiver`, which is written in a memory-safe language, and `unar`, which at least doesn't have two patches for CVEs that haven't been addressed upstream...).

I checked that `7z(1)` fails gracefully on `.rar` files now:
    
    emily@renko ~/tmp> curl -L -O https://www.philippwinterberg.com/download/example.rar
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    100 5715k  100 5715k    0     0  6716k      0 --:--:-- --:--:-- --:--:-- 6716k
    emily@renko ~/tmp> 7z x example.rar
    
    7-Zip [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
    p7zip Version 16.02 (locale=en_CA.UTF-8,Utf16=on,HugeFiles=on,64 bits,8 CPUs x64)
    
    Scanning the drive for archives:
    1 file, 5853119 bytes (5716 KiB)
    
    Extracting archive: example.rar
    ERROR: example.rar
    Can not open the file as archive
    
        
    Can't open as archive: 1
    Files: 0
    Size:       0
    Compressed: 0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).