### PR TITLE
Adding --local-interfaces flag in Agda build

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -49,11 +49,11 @@ let
                   ++ [ "." ];
     buildFlags = stdenv.lib.concatMap (x: ["-i" x]) self.includeDirs;
 
-    agdaWithArgs = "${Agda}/bin/agda ${toString self.buildFlags}";
+    agdaWithArgs = "${Agda}/bin/agda  ${toString self.buildFlags}";
 
     buildPhase = ''
       runHook preBuild
-      ${self.agdaWithArgs} ${self.everythingFile}
+      ${self.agdaWithArgs} --local-interfaces ${self.everythingFile}
       runHook postBuild
     '';
 


### PR DESCRIPTION
This flag is to return the last behavior to generates agdai files inside the directory of the libraries.
This is necessary because nix store is write protected and these files are necessary to run the library without needing to copy it to a different directory.

This link is for the pull request of the Agda compiler changes.
https://github.com/agda/agda/pull/3949

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
