### PR TITLE
[20.03] git: 2.25.3 -> 2.25.4 (security, CVE-2020-11008)

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -21,7 +21,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.25.3";
+  version = "2.25.4";
   svn = subversionClient.override { perlBindings = perlSupport; };
 
   gitwebPerlLibs = with perlPackages; [ CGI HTMLParser CGIFast FCGI FCGIProcManager HTMLTagCloud ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "0yvr97cl0dvj3fwblq1mb0cp97v8hrn9l98p8b1jx8815mbsnz9h";
+    sha256 = "11am6s46wmn1yll5614smjhzlghbqq6gysgcs64igjr9y5wzpdxq";
   };
 
   outputs = [ "out" ];

--- a/pkgs/applications/version-management/git-and-tools/git/update.sh
+++ b/pkgs/applications/version-management/git-and-tools/git/update.sh
@@ -4,8 +4,8 @@
 set -eu -o pipefail
 
 oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion git" | tr -d '"')"
-latestTag="$(git ls-remote --tags --sort="v:refname" git://github.com/git/git.git | grep -v '\{\}' | grep -v '\-rc' | tail -1 | sed 's|^.*/v\(.*\)|\1|')"
-targetVersion="${1:-latestTag}"
+latestTag="$(git ls-remote --tags --sort="v:refname" https://github.com/git/git.git | grep -v '\{\}' | grep -v '\-rc' | tail -1 | sed 's|^.*/v\(.*\)|\1|')"
+targetVersion="${1:-$latestTag}"
 
 if [ ! "${oldVersion}" = "${targetVersion}" ]; then
   update-source-version git "${targetVersion}"

--- a/pkgs/applications/version-management/git-and-tools/git/update.sh
+++ b/pkgs/applications/version-management/git-and-tools/git/update.sh
@@ -5,14 +5,15 @@ set -eu -o pipefail
 
 oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion git" | tr -d '"')"
 latestTag="$(git ls-remote --tags --sort="v:refname" git://github.com/git/git.git | grep -v '\{\}' | grep -v '\-rc' | tail -1 | sed 's|^.*/v\(.*\)|\1|')"
+targetVersion="${1:-latestTag}"
 
-if [ ! "${oldVersion}" = "${latestTag}" ]; then
-  update-source-version git "${latestTag}"
+if [ ! "${oldVersion}" = "${targetVersion}" ]; then
+  update-source-version git "${targetVersion}"
   nixpkgs="$(git rev-parse --show-toplevel)"
   default_nix="$nixpkgs/pkgs/applications/version-management/git-and-tools/git/default.nix"
   nix-build -A git
   git add "${default_nix}"
-  git commit -m "git: ${oldVersion} -> ${latestTag}"
+  git commit -m "git: ${oldVersion} -> ${targetVersion}"
 else
   echo "git is already up-to-date"
 fi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Basically #85666 for 20.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
