### PR TITLE
memtest86plus: 5.0.1-coreboot-002 -> 5.31b

### DIFF
--- a/pkgs/tools/misc/memtest86+/default.nix
+++ b/pkgs/tools/misc/memtest86+/default.nix
@@ -1,31 +1,28 @@
-{ lib, stdenv, fetchgit }:
+{ lib, stdenv, fetchurl }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "memtest86+";
-  version = "5.01-coreboot-002";
+  version = "5.31b";
 
-  src = fetchgit {
-    url = "https://review.coreboot.org/memtest86plus.git";
-    rev = "v002";
-    sha256 = "0cwx20yja24bfknqh1rjb5rl2c0kwnppzsisg1dibbak0l8mxchk";
+  src = fetchurl {
+    url = "https://www.memtest.org/download/${version}/memtest86+-${version}.tar.gz";
+    sha256 = "028zrch87ggajlb5xx1c2ab85ggl9qldpibf45735sy0haqzyiki";
   };
-
-  NIX_CFLAGS_COMPILE = "-I. -std=gnu90";
 
   hardeningDisable = [ "all" ];
 
-  buildFlags = [ "memtest.bin" ];
-
-  doCheck = false; # fails
+  doCheck = stdenv.isi686;
+  checkTarget = "run_self_test";
 
   installPhase = ''
     install -Dm0444 -t $out/ memtest.bin
   '';
 
-  meta = {
-    homepage = "http://www.memtest.org/";
-    description = "A tool to detect memory errors";
-    license = lib.licenses.gpl2;
+  meta = with lib; {
+    homepage = "https://www.memtest.org/";
+    description = "An advanced memory diagnostic tool";
+    license = licenses.gpl2Only;
     platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ evils ];
   };
 }


### PR DESCRIPTION
#### CAUTION, beta release
[`This build is not ready for production yet, because it lacks some feedbacks from beta-testers.`](https://www.memtest.org/#change)
despite this, i'd still like to see this merged as i have not found anyone for whom the current package works on bare metal

###### Motivation for this change
coreboot's v002 is broken for me, a significantly newer version than their master branch is available.

###### Things done

switched source from coreboot to memtest.org
(partially?) fixed checkPhase
set the description to the project's own
added myself as a maintainer as there currently isn't one set

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notes
- I'd love to see a nixos test for this :D