### PR TITLE
Python on Nix tests

### DIFF
--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -38,17 +38,18 @@ let
       is_nixenv = "False";
     };
 
+  } // lib.optionalAttrs (python.pythonAtLeast "3.8") {
     # Venv built using Python Nix environment (python.buildEnv)
     # TODO: Cannot create venv from a  nix env
     # Error: Command '['/nix/store/ddc8nqx73pda86ibvhzdmvdsqmwnbjf7-python3-3.7.6-venv/bin/python3.7', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1.
-    # nixenv-venv = rec {
-    #   env = runCommand "${python.name}-venv" {} ''
-    #     ${pythonEnv.interpreter} -m venv $out
-    #   '';
-    #   interpreter = "${env}/bin/${pythonEnv.executable}";
-    #   is_venv = "True";
-    #   is_nixenv = "True";
-    # };
+    nixenv-venv = rec {
+      env = runCommand "${python.name}-venv" {} ''
+        ${pythonEnv.interpreter} -m venv $out
+      '';
+      interpreter = "${env}/bin/${pythonEnv.executable}";
+      is_venv = "True";
+      is_nixenv = "True";
+    };
   };
 
   # All PyPy package builds are broken at the moment

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -53,7 +53,7 @@ let
   };
 
   # All PyPy package builds are broken at the moment
-  integrationTests = lib.optionalAttrs (python.isPy3k  && (!python.isPyPy)) rec {
+  integrationTests = lib.optionalAttrs (python.pythonAtLeast "3.7"  && (!python.isPyPy)) rec {
     # Before the addition of NIX_PYTHONPREFIX mypy was broken with typed packages
     nix-pythonprefix-mypy = callPackage ./tests/test_nix_pythonprefix {
       interpreter = python;

--- a/pkgs/development/interpreters/python/tests/test_nix_pythonprefix/typeddep/default.nix
+++ b/pkgs/development/interpreters/python/tests/test_nix_pythonprefix/typeddep/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage }:
+{ buildPythonPackage, pythonOlder }:
 
 
 buildPythonPackage {
@@ -7,5 +7,7 @@ buildPythonPackage {
   version = "1.3.3.7";
 
   src = ./.;
+
+  disabled = pythonOlder "3.7";
 
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
