### PR TITLE
crowbar: init at unstable-2020-04-23

### DIFF
--- a/pkgs/tools/security/crowbar/default.nix
+++ b/pkgs/tools/security/crowbar/default.nix
@@ -1,0 +1,42 @@
+{ fetchFromGitHub
+, freerdp
+, nmap
+, openvpn
+, python3Packages
+, stdenv
+, tigervnc
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "crowbar";
+  version = "unstable-2020-04-23";
+
+  src = fetchFromGitHub {
+    owner = "galkan";
+    repo = pname;
+    rev = "500d633ff5ddfcbc70eb6d0b4d2181e5b8d3c535";
+    sha256 = "05m9vywr9976pc7il0ak8nl26mklzxlcqx0p8rlfyx1q766myqzf";
+  };
+
+  propagatedBuildInputs = [ python3Packages.paramiko ];
+
+  patchPhase = ''
+    sed -i 's,/usr/bin/xfreerdp,${freerdp}/bin/xfreerdp,g' lib/main.py
+    sed -i 's,/usr/bin/vncviewer,${tigervnc}/bin/vncviewer,g' lib/main.py
+    sed -i 's,/usr/sbin/openvpn,${openvpn}/bin/openvpn,g' lib/main.py
+
+    sed -i 's,/usr/bin/nmap,${nmap}/bin/nmap,g' lib/nmap.py
+  '';
+
+  # Sanity check
+  checkPhase = ''
+    $out/bin/crowbar --help > /dev/null
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/galkan/crowbar";
+    description = "A brute forcing tool that can be used during penetration tests";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -863,6 +863,8 @@ in
 
   ctrtool = callPackage ../tools/archivers/ctrtool { };
 
+  crowbar = callPackage ../tools/security/crowbar { };
+
   crumbs = callPackage ../applications/misc/crumbs { };
 
   crc32c = callPackage ../development/libraries/crc32c { };


### PR DESCRIPTION
##### Motivation for this change

Bring [crowbar](https://github.com/galkan/crowbar) to nixpkgs as part of #81418 .

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
