### PR TITLE
gtk3: 3.24.17 -> 3.24.18

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -48,7 +48,7 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "gtk+3";
-  version = "3.24.17";
+  version = "3.24.18";
 
   outputs = [ "out" "dev" ] ++ optional withGtkDoc "devdoc";
   outputBin = "dev";
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk+/${stdenv.lib.versions.majorMinor version}/gtk+-${version}.tar.xz";
-    sha256 = "1h5snvqz8f6zgwpmq7pblvfwj5dphfckj8bv7vdz1c0w49dja47j";
+    sha256 = "1lia2ybd1661j6mvrc00iyd50gm7sy157bdzlyf4mr028rzzzspm";
   };
 
   patches = [
@@ -73,21 +73,6 @@ stdenv.mkDerivation rec {
 
     # https://gitlab.gnome.org/GNOME/gtk/merge_requests/1002
     ./patches/01-build-Fix-path-handling-in-pkgconfig.patch
-
-    # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/1634
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/79732da1ed8cb167440fb047c72cfc0d888a187b.patch";
-      sha256 = "1ynrx81dkwjfqhvg80q28qbb6jabg4x73fkbrnligzgkzimfjpx3";
-    })
-    # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/1633
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/12fc9a45efcbb546eb7de13c5c4d3183f2f5a3b8.patch";
-      sha256 = "00zrm77qk39p1hgn207az82cgvqiyp6is7dk0ssjxkc34403r78v";
-    })
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/5a52af20cba76474e631b2a7548963bcad22d66d.patch";
-      sha256 = "0sbzzwa0si1w83m5abyf312f4w445wwlms53m5hb7kdgkjbhaa3f";
-    })
   ] ++ optionals stdenv.isDarwin [
     # X11 module requires <gio/gdesktopappinfo.h> which is not installed on Darwin
     # let’s drop that dependency in similar way to how other parts of the library do it


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
GTK 3.24.17 has a critical issue which breaks many applications under Wayland. This issue was fixed in 3.24.18.

cc. @jtojnar @worldofpeace for review
cc. @FRidh for inclusion into the current staging merge

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
