### PR TITLE
[19.09] Use qt5's mkDerivation in packages that otherwise crash

### DIFF
--- a/pkgs/applications/audio/dfasma/default.nix
+++ b/pkgs/applications/audio/dfasma/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fftw, libsndfile, qtbase, qtmultimedia, qmake }:
+{ mkDerivation, stdenv, fetchFromGitHub, fftw, libsndfile, qtbase, qtmultimedia, qmake }:
 
 let
 
@@ -26,7 +26,7 @@ let
     };
   };
 
-in stdenv.mkDerivation rec {
+in mkDerivation rec {
   pname = "dfasma";
   version = "1.4.5";
 

--- a/pkgs/applications/audio/iannix/default.nix
+++ b/pkgs/applications/audio/iannix/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, alsaLib, pkgconfig, qtbase, qtscript, qmake
+{ mkDerivation, stdenv, fetchFromGitHub, alsaLib, pkgconfig, qtbase, qtscript, qmake
 }:
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "iannix";
   version = "2016-01-31";
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/traverso/default.nix
+++ b/pkgs/applications/audio/traverso/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, cmake, pkgconfig
+{ mkDerivation, stdenv, fetchurl, cmake, pkgconfig
 , alsaLib, fftw, flac, lame, libjack2, libmad, libpulseaudio
 , libsamplerate, libsndfile, libvorbis, portaudio, qtbase, wavpack
 }:
-stdenv.mkDerivation {
+mkDerivation {
   pname = "traverso";
   version = "0.49.6";
 

--- a/pkgs/applications/editors/mindforger/default.nix
+++ b/pkgs/applications/editors/mindforger/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, qmake, qtbase, qtwebkit }:
+{ mkDerivation, stdenv, fetchurl, qmake, qtbase, qtwebkit }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "mindforger";
   version = "1.48.2";
 

--- a/pkgs/applications/editors/okteta/default.nix
+++ b/pkgs/applications/editors/okteta/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, extra-cmake-modules, kdoctools, qtscript, kconfig
+{ mkDerivation, stdenv, fetchurl, extra-cmake-modules, kdoctools, qtscript, kconfig
 , kinit, karchive, kcrash, kcmutils, kconfigwidgets, knewstuff, kparts
 , qca-qt5, shared-mime-info }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "okteta";
   version = "0.26.2";
 

--- a/pkgs/applications/graphics/awesomebump/default.nix
+++ b/pkgs/applications/graphics/awesomebump/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, qtbase, qmake, makeWrapper, qtscript, flex, bison, qtdeclarative }:
+{ mkDerivation, lib, fetchgit, qtbase, qmake, qtscript, flex, bison, qtdeclarative }:
 
 
 let
@@ -11,7 +11,7 @@ let
     fetchSubmodules = true;
   };
 
-  qtnproperty = stdenv.mkDerivation {
+  qtnproperty = mkDerivation {
     name = "qtnproperty";
     inherit src;
     sourceRoot = "AwesomeBump/Sources/utils/QtnProperty";
@@ -22,7 +22,7 @@ let
       install -D bin-linux/QtnPEG $out/bin/QtnPEG
     '';
   };
-in stdenv.mkDerivation {
+in mkDerivation {
   pname = "awesomebump";
   inherit version;
 
@@ -30,12 +30,13 @@ in stdenv.mkDerivation {
 
   buildInputs = [ qtbase qtscript qtdeclarative ];
 
-  nativeBuildInputs = [ qmake makeWrapper ];
+  nativeBuildInputs = [ qmake ];
 
   preBuild = ''
     ln -sf ${qtnproperty}/bin/QtnPEG Sources/utils/QtnProperty/bin-linux/QtnPEG
   '';
 
+  dontWrapQtApps = true;
   postInstall = ''
     d=$out/libexec/AwesomeBump
 
@@ -44,7 +45,7 @@ in stdenv.mkDerivation {
     cp -prd Bin/Configs Bin/Core $d/
 
     # AwesomeBump expects to find Core and Configs in its current directory.
-    makeWrapper $d/AwesomeBump $out/bin/AwesomeBump \
+    makeQtWrapper $d/AwesomeBump $out/bin/AwesomeBump \
         --run "cd $d"
   '';
 

--- a/pkgs/applications/graphics/phototonic/default.nix
+++ b/pkgs/applications/graphics/phototonic/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qtbase, qmake, exiv2 }:
+{ mkDerivation, stdenv, fetchFromGitHub, qtbase, qmake, exiv2 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "phototonic";
   version = "2.1";
 

--- a/pkgs/applications/graphics/qcomicbook/default.nix
+++ b/pkgs/applications/graphics/qcomicbook/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools, qtx11extras, poppler }:
+{ mkDerivation, stdenv, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools, qtx11extras, poppler }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "qcomicbook";
   version = "0.9.1";
 

--- a/pkgs/applications/misc/candle/default.nix
+++ b/pkgs/applications/misc/candle/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qtbase, qtserialport, qmake }:
+{ mkDerivation, stdenv, fetchFromGitHub, qtbase, qtserialport, qmake }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "candle";
   version = "1.1";
 

--- a/pkgs/applications/misc/openbrf/default.nix
+++ b/pkgs/applications/misc/openbrf/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, qtbase, vcg, glew, qmake, libGLU_combined }:
+{ mkDerivation, stdenv, fetchFromGitHub, qtbase, vcg, glew, qmake, libGLU_combined }:
 
 
-stdenv.mkDerivation {
+mkDerivation {
   name = "openbrf-unstable-2016-01-09";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/misc/qt-box-editor/default.nix
+++ b/pkgs/applications/misc/qt-box-editor/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ mkDerivation
+, stdenv
 , fetchFromGitHub
 , qtbase
 , qtsvg
@@ -7,7 +8,7 @@
 , tesseract
 }:
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "qt-box-editor";
   version = "unstable-2019-07-12";
 

--- a/pkgs/applications/misc/valentina/default.nix
+++ b/pkgs/applications/misc/valentina/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchhg
+{ mkDerivation, stdenv, fetchhg
 , qmake, qttools
 , qtbase, qtsvg, qtxmlpatterns
 , poppler_utils
@@ -6,7 +6,7 @@
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "valentina";
   version = "0.6.1";
 

--- a/pkgs/applications/networking/instant-messengers/ricochet/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ricochet/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, pkgconfig, makeDesktopItem
+{ mkDerivation, stdenv, fetchurl, pkgconfig, makeDesktopItem
 , qtbase, qttools, qtmultimedia, qtquick1, qtquickcontrols
 , openssl, protobuf, qmake
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "ricochet";
   version = "1.1.4";
 

--- a/pkgs/applications/networking/instant-messengers/swift-im/default.nix
+++ b/pkgs/applications/networking/instant-messengers/swift-im/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, pkgconfig, qttools, scons
+{ mkDerivation, stdenv, fetchurl, pkgconfig, qttools, scons
 , GConf, avahi, boost, hunspell, libXScrnSaver, libedit, libidn, libnatpmp, libxml2
 , lua, miniupnpc, openssl, qtbase, qtmultimedia, qtsvg, qtwebkit, qtx11extras, zlib
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "swift-im";
   version = "4.0.2";
 

--- a/pkgs/applications/networking/instant-messengers/tensor/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tensor/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchgit, qtbase, qtquickcontrols, qmake, makeDesktopItem }:
+{ mkDerivation, stdenv, fetchgit, qtbase, qtquickcontrols, qmake, makeDesktopItem }:
 
 # we now have libqmatrixclient so a future version of tensor that supports it
 # should use that
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "tensor-git";
   version = "2017-02-21";
 

--- a/pkgs/applications/science/electronics/caneda/default.nix
+++ b/pkgs/applications/science/electronics/caneda/default.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchFromGitHub, cmake, qtbase, qttools, qtsvg, qwt }:
+{ mkDerivation, stdenv, fetchFromGitHub, cmake, qtbase, qttools, qtsvg, qwt }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "caneda";
   version = "0.3.1";
 

--- a/pkgs/applications/video/bomi/default.nix
+++ b/pkgs/applications/video/bomi/default.nix
@@ -1,7 +1,7 @@
-{ config, stdenv, fetchFromGitHub
+{ mkDerivation, config, stdenv, fetchFromGitHub
 , fetchpatch, pkgconfig, perl, python, which
 , libX11, libxcb, libGLU_combined
-, qtbase, qtdeclarative, qtquickcontrols, qttools, qtx11extras, qmake, makeWrapper
+, qtbase, qtdeclarative, qtquickcontrols, qttools, qtx11extras, qmake
 , libchardet
 , ffmpeg
 
@@ -29,7 +29,7 @@ assert pulseSupport -> libpulseaudio != null;
 assert cddaSupport -> libcdda != null;
 assert youtubeSupport -> youtube-dl != null;
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "bomi";
   version = "0.9.11";
 
@@ -90,8 +90,9 @@ stdenv.mkDerivation rec {
     patchShebangs build-mpv
   '';
 
+  dontWrapQtApps = true;
   postInstall = ''
-    wrapProgram $out/bin/bomi \
+    wrapQtApp $out/bin/bomi \
       ${optionalString youtubeSupport "--prefix PATH ':' '${youtube-dl}/bin'"}
   '';
 
@@ -105,7 +106,7 @@ stdenv.mkDerivation rec {
                    ++ optional cddaSupport "--enable-cdda"
                    ;
 
-  nativeBuildInputs = [ makeWrapper pkgconfig perl python which qttools qmake ];
+  nativeBuildInputs = [ pkgconfig perl python which qttools qmake ];
 
   meta = with stdenv.lib; {
     description = "Powerful and easy-to-use multimedia player";

--- a/pkgs/applications/video/qmediathekview/default.nix
+++ b/pkgs/applications/video/qmediathekview/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qtbase, qttools, xz, boost, qmake, pkgconfig }:
+{ mkDerivation, stdenv, fetchFromGitHub, qtbase, qttools, xz, boost, qmake, pkgconfig }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "QMediathekView";
   version = "2019-01-06";
 

--- a/pkgs/applications/video/qstopmotion/default.nix
+++ b/pkgs/applications/video/qstopmotion/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, qt5, ffmpeg, guvcview, cmake, ninja, libxml2
+{ mkDerivation, stdenv, fetchurl, qt5, ffmpeg, guvcview, cmake, ninja, libxml2
 , gettext, pkgconfig, libgphoto2, gphoto2, v4l-utils, libv4l, pcre
 , qwt, extra-cmake-modules }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "qstopmotion";
   version = "2.4.1";
 

--- a/pkgs/applications/virtualization/aqemu/default.nix
+++ b/pkgs/applications/virtualization/aqemu/default.nix
@@ -1,7 +1,7 @@
-{ cmake, fetchFromGitHub, libvncserver, qemu, qtbase, stdenv
+{ mkDerivation, cmake, fetchFromGitHub, libvncserver, qemu, qtbase, stdenv
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "aqemu";
   version = "0.9.2";
 

--- a/pkgs/games/enyo-doom/default.nix
+++ b/pkgs/games/enyo-doom/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitLab, cmake, qtbase }:
+{ mkDerivation, stdenv, fetchFromGitLab, cmake, qtbase }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "enyo-doom";
   version = "1.06.9";
 

--- a/pkgs/games/pro-office-calculator/default.nix
+++ b/pkgs/games/pro-office-calculator/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, tinyxml-2, cmake, qtbase, qtmultimedia }:
-stdenv.mkDerivation rec {
+{ mkDerivation, stdenv, fetchFromGitHub, tinyxml-2, cmake, qtbase, qtmultimedia }:
+mkDerivation rec {
   version = "1.0.13";
   pname = "pro-office-calculator";
 

--- a/pkgs/misc/calaos/installer/default.nix
+++ b/pkgs/misc/calaos/installer/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qmake, qttools, qtbase }:
+{ mkDerivation, stdenv, fetchFromGitHub, qmake, qttools, qtbase }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "calaos_installer-3.1";
   version = "3.1";
 

--- a/pkgs/misc/emulators/firebird-emu/default.nix
+++ b/pkgs/misc/emulators/firebird-emu/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qmake, qtbase, qtdeclarative }:
+{ mkDerivation, stdenv, fetchFromGitHub, qmake, qtbase, qtdeclarative }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "firebird-emu";
   version = "1.4";
 

--- a/pkgs/misc/emulators/yabause/default.nix
+++ b/pkgs/misc/emulators/yabause/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, cmake, pkgconfig, qtbase, qt5, libGLU_combined
+{ mkDerivation, stdenv, fetchurl, cmake, pkgconfig, qtbase, qt5, libGLU_combined
 , freeglut ? null, openal ? null, SDL2 ? null }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "yabause";
   version = "0.9.15";
 

--- a/pkgs/tools/backup/httrack/qt.nix
+++ b/pkgs/tools/backup/httrack/qt.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, cmake, pkgconfig, makeWrapper
+{ mkDerivation, stdenv, fetchurl, cmake, pkgconfig, makeWrapper
 , httrack, qtbase, qtmultimedia }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "httraqt";
   version = "1.4.9";
 

--- a/pkgs/tools/graphics/rocket/default.nix
+++ b/pkgs/tools/graphics/rocket/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qmake, qtbase }:
+{ mkDerivation, stdenv, fetchFromGitHub, qmake, qtbase }:
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "rocket";
   version = "2018-06-09";
 

--- a/pkgs/tools/misc/colord-kde/default.nix
+++ b/pkgs/tools/misc/colord-kde/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, lib, fetchurl
+{ mkDerivation, lib, fetchurl
 , extra-cmake-modules, ki18n
 , kconfig, kconfigwidgets, kcoreaddons, kdbusaddons, kiconthemes, kcmutils
 , kio, knotifications, plasma-framework, kwidgetsaddons, kwindowsystem
 , kitemviews, lcms2, libXrandr, qtx11extras
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "colord-kde";
   version = "0.5.0";
 

--- a/pkgs/tools/text/glogg/default.nix
+++ b/pkgs/tools/text/glogg/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, qmake, boost }:
+{ mkDerivation, stdenv, fetchurl, qmake, boost }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
 
   pname = "glogg";
   version = "1.1.4";


### PR DESCRIPTION
Backport of #84673. 