### PR TITLE
The systemd unit for k3s should differ between agents and servers

### DIFF
--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -81,8 +81,8 @@ in
       after = mkIf cfg.docker [ "docker.service" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        # Taken from https://github.com/rancher/k3s/blob/v1.17.4+k3s1/contrib/ansible/roles/k3s/node/templates/k3s.service.j2
-        Type = "notify";
+        # See: https://github.com/rancher/k3s/blob/dddbd16305284ae4bd14c0aade892412310d7edc/install.sh#L197
+        Type = if cfg.role == "agent" then "exec" else "notify";
         KillMode = "process";
         Delegate = "yes";
         Restart = "always";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The agent part of k3s doesn't notify systemd of startup and should therefore be of type "exec" rather than "notify". As far as I can tell the ansible template is wrong. When actually fetching the installation script via https://get.k3s.io you see that they use different systemd types for agents and servers.
Since I've had my own k3s module for a while I happen to know that this is indeed the case since agents won't start properly without this (but you won't notice in single node "clusters" ofc).

Further verification that this is the case here:
https://github.com/rancher/k3s/blob/553517e19433c6b3e58fd25e7ac83ed9b6d5fe1e/pkg/cli/server/server.go#L183 - server does notify systemd

The agent lacks this notification:
https://github.com/rancher/k3s/blob/master/pkg/cli/agent/agent.go

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
