### PR TITLE
[19.09] openssl: patch CVE-2020-1967

### DIFF
--- a/pkgs/development/libraries/openssl/1.1/cve-2020-1967-test.patch
+++ b/pkgs/development/libraries/openssl/1.1/cve-2020-1967-test.patch
@@ -1,0 +1,114 @@
+From: Benjamin Kaduk <kaduk@mit.edu>
+Date: Fri, 10 Apr 2020 12:27:28 -0700
+Subject: Add test for CVE-2020-1967
+
+Add to test_sslsigalgs a TLSProxy test that injects a
+"signature_algorithms_cert" extension that contains an unallocated
+codepoint.
+
+The test currently fails, since s_server segfaults instead of
+ignoring the unrecognized value.
+
+Since "signature_algorithms" and "signature_algorithms_cert" are very
+similar, also add the analogous test for "signature_algorithms".
+
+[bigeasy: + 2x "fixup! Add test for CVE-2020-1967"]
+---
+ test/recipes/70-test_sslsigalgs.t | 66 +++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 64 insertions(+), 2 deletions(-)
+
+diff --git a/test/recipes/70-test_sslsigalgs.t b/test/recipes/70-test_sslsigalgs.t
+index f805dcf221e8..9fadefdee62d 100644
+--- a/test/recipes/70-test_sslsigalgs.t
++++ b/test/recipes/70-test_sslsigalgs.t
+@@ -44,7 +44,9 @@ use constant {
+     COMPAT_SIGALGS => 6,
+     SIGALGS_CERT_ALL => 7,
+     SIGALGS_CERT_PKCS => 8,
+-    SIGALGS_CERT_INVALID => 9
++    SIGALGS_CERT_INVALID => 9,
++    UNRECOGNIZED_SIGALGS_CERT => 10,
++    UNRECOGNIZED_SIGALG => 11
+ };
+ 
+ #Note: Throughout this test we override the default ciphersuites where TLSv1.2
+@@ -53,7 +55,7 @@ use constant {
+ 
+ #Test 1: Default sig algs should succeed
+ $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+-plan tests => 22;
++plan tests => 24;
+ ok(TLSProxy::Message->success, "Default sigalgs");
+ my $testtype;
+ 
+@@ -261,6 +263,39 @@ SKIP: {
+     ok(TLSProxy::Message->fail, "No matching certificate for sigalgs_cert");
+ }
+ 
++SKIP: {
++    skip "TLS 1.3 disabled", 2 if disabled("tls1_3");
++    #Test 23: Send an unrecognized signature_algorithms_cert
++    #        We should be able to skip over the unrecognized value and use a
++    #        valid one that appears later in the list.
++    $proxy->clear();
++    $proxy->filter(\&inject_unrecognized_sigalg);
++    $proxy->clientflags("-tls1_3");
++    # Use -xcert to get SSL_check_chain() to run in the cert_cb.  This is
++    # needed to trigger (e.g.) CVE-2020-1967
++    $proxy->serverflags("" .
++            " -xcert " . srctop_file("test", "certs", "servercert.pem") .
++            " -xkey " . srctop_file("test", "certs", "serverkey.pem") .
++            " -xchain " . srctop_file("test", "certs", "rootcert.pem"));
++    $testtype = UNRECOGNIZED_SIGALGS_CERT;
++    $proxy->start();
++    ok(TLSProxy::Message->success(), "Unrecognized sigalg_cert in ClientHello");
++
++    #Test 24: Send an unrecognized signature_algorithms
++    #        We should be able to skip over the unrecognized value and use a
++    #        valid one that appears later in the list.
++    $proxy->clear();
++    $proxy->filter(\&inject_unrecognized_sigalg);
++    $proxy->clientflags("-tls1_3");
++    $proxy->serverflags("" .
++            " -xcert " . srctop_file("test", "certs", "servercert.pem") .
++            " -xkey " . srctop_file("test", "certs", "serverkey.pem") .
++            " -xchain " . srctop_file("test", "certs", "rootcert.pem"));
++    $testtype = UNRECOGNIZED_SIGALG;
++    $proxy->start();
++    ok(TLSProxy::Message->success(), "Unrecognized sigalg in ClientHello");
++}
++
+ 
+ 
+ sub sigalgs_filter
+@@ -406,3 +441,30 @@ sub modify_cert_verify_sigalg
+         }
+     }
+ }
++
++sub inject_unrecognized_sigalg
++{
++    my $proxy = shift;
++    my $type;
++
++    # We're only interested in the initial ClientHello
++    if ($proxy->flight != 0) {
++        return;
++    }
++    if ($testtype == UNRECOGNIZED_SIGALGS_CERT) {
++        $type = TLSProxy::Message::EXT_SIG_ALGS_CERT;
++    } elsif ($testtype == UNRECOGNIZED_SIGALG) {
++        $type = TLSProxy::Message::EXT_SIG_ALGS;
++    } else {
++        return;
++    }
++
++    my $ext = pack "C8",
++        0x00, 0x06, #Extension length
++        0xfe, 0x18, #private use
++        0x04, 0x01, #rsa_pkcs1_sha256
++        0x08, 0x04; #rsa_pss_rsae_sha256;
++    my $message = ${$proxy->message_list}[0];
++    $message->set_extension($type, $ext);
++    $message->repack;
++}

--- a/pkgs/development/libraries/openssl/1.1/cve-2020-1967.patch
+++ b/pkgs/development/libraries/openssl/1.1/cve-2020-1967.patch
@@ -1,0 +1,42 @@
+From: Benjamin Kaduk <kaduk@mit.edu>
+Date: Fri, 10 Apr 2020 12:27:28 -0700
+Subject: Fix NULL dereference in SSL_check_chain() for TLS 1.3
+
+In the tls1_check_sig_alg() helper function, we loop through the list of
+"signature_algorithms_cert" values received from the client and attempt
+to look up each one in turn in our internal table that maps wire
+codepoint to string-form name, digest and/or signature NID, etc., in
+order to compare the signature scheme from the peer's list against what
+is used to sign the certificates in the certificate chain we're
+checking.  Unfortunately, when the peer sends a value that we don't
+support, the lookup returns NULL, but we unconditionally dereference the
+lookup result for the comparison, leading to an application crash
+triggerable by an unauthenticated client.
+
+Since we will not be able to say anything about algorithms we don't
+recognize, treat NULL return from lookup as "does not match".
+
+We currently only apply the "signature_algorithm_cert" checks on TLS 1.3
+connections, so previous TLS versions are unaffected.  SSL_check_chain()
+is not called directly from libssl, but may be used by the application
+inside a callback (e.g., client_hello or cert callback) to verify that a
+candidate certificate chain will be acceptable to the client.
+
+CVE-2020-1967
+---
+ ssl/t1_lib.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ssl/t1_lib.c b/ssl/t1_lib.c
+index b482019c4c17..5287d10a2d0a 100644
+--- a/ssl/t1_lib.c
++++ b/ssl/t1_lib.c
+@@ -2099,7 +2099,7 @@ static int tls1_check_sig_alg(SSL *s, X509 *x, int default_nid)
+         sigalg = use_pc_sigalgs
+                  ? tls1_lookup_sigalg(s->s3->tmp.peer_cert_sigalgs[i])
+                  : s->shared_sigalgs[i];
+-        if (sig_nid == sigalg->sigandhash)
++        if (sigalg != NULL && sig_nid == sigalg->sigandhash)
+             return 1;
+     }
+     return 0;

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -154,6 +154,10 @@ in {
 
       ./1.1/cve-2019-1551.patch
       ./1.1/cve-2019-1551-improve.patch
+
+      ./1.1/cve-2020-1967.patch
+      ./1.1/cve-2020-1967-test.patch
+
     ];
     withDocs = true;
   };


### PR DESCRIPTION
###### Motivation for this change

Add patches for CVE-2020-1967

https://github.com/openssl/openssl/commit/eb563247aef3e83dda7679c43f9649270462e5b1
https://github.com/openssl/openssl/commit/64eef86733fd40a5b7737dc586754c3fa3414b0c

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@FRidh 