### PR TITLE
nixos/nginx: run nginx-config-reload as the nginx user and group

### DIFF
--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -114,16 +114,13 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         webserver.wait_for_unit("nginx")
         webserver.succeed("journalctl -u nginx | grep -q -i stopped")
 
-    with subtest("nixos-rebuild --switch should fail when there are configuration errors"):
-        webserver.fail(
+    with subtest(
+        "When switching to a broken configuration, the nginx unit should fail to reload"
+    ):
+        webserver.succeed(
             "${reloadWithErrorsSystem}/bin/switch-to-configuration test >&2"
         )
-        webserver.succeed("[[ $(systemctl is-failed nginx-config-reload) == failed ]]")
+        webserver.succeed("journalctl -u nginx | grep -q -i 'reload failed'")
         webserver.succeed("[[ $(systemctl is-failed nginx) == active ]]")
-        # just to make sure operation is idempotent. During development I had a situation
-        # when first time it shows error, but stops showing it on subsequent rebuilds
-        webserver.fail(
-            "${reloadWithErrorsSystem}/bin/switch-to-configuration test >&2"
-        )
   '';
 })


### PR DESCRIPTION
This unit currently runs `${execCommand} -t` as root, which will cause
nginx to create files in /var/spool/nginx as the "nobody" user (which is
the default if no user/group is specified in the nginx config itself
(which is true in our case, as we run nginx as an unprivileged user and
don't give it a chance to create/chown files and folders for the `nginx`
unit at least.

Reported-By: @tazjin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
