### PR TITLE
nixos/{cri-o,podman}: remove cni-plugins from environment.systemPackages

### DIFF
--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -42,7 +42,7 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = with pkgs;
-      [ cri-o cri-tools conmon cni-plugins iptables runc utillinux ];
+      [ cri-o cri-tools conmon iptables runc utillinux ];
     environment.etc."crictl.yaml".text = ''
       runtime-endpoint: unix:///var/run/crio/crio.sock
     '';
@@ -56,6 +56,10 @@ in
       registries = [
         ${concatMapStringsSep ", " (x: "\"" + x + "\"") cfg.registries}
       ]
+
+      [crio.network]
+      plugin_dirs = ["${pkgs.cni-plugins}/bin/"]
+      network_dir = "/etc/cni/net.d/"
 
       [crio.runtime]
       conmon = "${pkgs.conmon}/bin/conmon"

--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -66,7 +66,6 @@ in
       pkgs.slirp4netns # User-mode networking for unprivileged namespaces
       pkgs.fuse-overlayfs # CoW for images, much faster than default vfs
       pkgs.utillinux # nsenter
-      pkgs.cni-plugins # Networking plugins
       pkgs.iptables
     ]
     ++ lib.optional cfg.dockerCompat dockerCompat;


### PR DESCRIPTION
Having `cni-plugins` in systemPackages results in a collision with `iproute`.

```
collision between `/nix/store/8v9yf7card7qpv9rlw84xphvnka96afd-iproute2-5.5.0/bin/bridge' and `/nix/store/xqg5p15znrhbsaszin1vbvmyv076h5az-cni-plugins-0.8.5-bin/bin/bridge'
```

Upstream docs say that a path to the plugins can be passed via config file.

https://github.com/containers/libpod/blob/master/cni/README.md#cni
https://github.com/cri-o/cri-o/blob/master/docs/crio.conf.5.md#crionetwork-table

This is already set for `podman` by [`nixos/containers`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualisation/containers.nix#L115-L119).

cc @adisbladis @saschagrunert @vdemeester 