### PR TITLE
everdo: init at 1.3.5

### DIFF
--- a/pkgs/applications/office/everdo/default.nix
+++ b/pkgs/applications/office/everdo/default.nix
@@ -1,0 +1,46 @@
+{ appimageTools, fetchurl, lib, gsettings-desktop-schemas, gtk3 }:
+
+let
+  pname = "everdo";
+  version = "1.3.5";
+
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url =
+      "https://d11l8siwmn8w36.cloudfront.net/${version}/Everdo-${version}.AppImage";
+    sha256 = "1h3ljlc7gqfnyycdrwd76r7vwx8mr7br0lvx4g27kzrmm9yr93hp";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit name src;
+  };
+in appimageTools.wrapType2 rec {
+  inherit name src;
+
+  profile = ''
+    export LC_ALL=C.UTF-8
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+
+  multiPkgs = null; # no 32bit needed
+  extraPkgs = p:
+    (appimageTools.defaultFhsEnvArgs.multiPkgs p)
+    ++ [ p.at-spi2-atk p.at-spi2-core ];
+    extraInstallCommands = ''
+      mv $out/bin/{${name},${pname}}
+      install -m 444 -D ${appimageContents}/everdo.desktop $out/share/applications/everdo.desktop
+      install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/1024x1024/apps/everdo.png \
+        $out/share/icons/hicolor/1024x1024/apps/everdo.png
+      substituteInPlace $out/share/applications/everdo.desktop \
+        --replace 'Exec=AppRun' 'Exec=${pname}'
+    '';
+
+  meta = with lib; {
+    description = "Todo list and Getting Things Done app";
+    homepage = "https://everdo.net";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ i077 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10244,6 +10244,8 @@ in
 
   eresi = callPackage ../development/tools/analysis/eresi { };
 
+  everdo = callPackages ../applications/office/everdo { };
+
   evmdis = callPackage ../development/tools/analysis/evmdis { };
 
   eweb = callPackage ../development/tools/literate-programming/eweb { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
