### PR TITLE
resholve: init at 0.4.0

### DIFF
--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -1,0 +1,138 @@
+# Using resholve's Nix API
+
+resholve converts bare executable references in shell scripts to absolute
+paths. This will hopefully make its way into the Nixpkgs manual soon, but
+until then I'll outline how to use the `resholvePackage` function.
+
+> Fair warning: resholve does *not* aspire to resolving all valid Shell
+> scripts. It depends on the OSH/Oil parser, which aims to support most (but
+> not all) Bash, and aims to be a ~90% sort of solution.
+
+Let's start with a simple example from one of my own projects:
+
+```nix
+{ stdenv, lib, resholvePackage, fetchFromGitHub, bashup-events44, bashInteractive_5, doCheck ? true, shellcheck }:
+
+resholvePackage rec {
+  pname = "shellswain";
+  version = "unreleased";
+
+  src = fetchFromGitHub {
+    # ...
+  };
+
+  solutions = {
+    profile = {
+      # the only *required* arguments
+      scripts = [ "bin/shellswain.bash" ];
+      interpreter = "none";
+      inputs = [ bashup-events44 ];
+    };
+  };
+
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+
+  inherit doCheck;
+  checkInputs = [ shellcheck ];
+
+  # ...
+}
+```
+
+I'll focus on the `solutions` attribute, since this is the only part
+that differs from other derivations.
+
+Each "solution" (k=v pair)
+describes one resholve invocation. For most shell packages, one
+invocation will probably be enough. resholve will make you be very
+explicit about your script's dependencies, and it may also need your
+help sorting out some references or problems that it can't safely
+handle on its own.
+
+If you have more than one script, and your scripts need conflicting
+directives, you can specify more than one solution to resolve the
+scripts separately, but still produce a single package.
+
+Let's take a closer look:
+
+```nix
+  solutions = {
+    # each solution has a short name; this is what you'd use to
+    # override the settings of this solution, and it may also show up
+    # in (some) error messages.
+    profile = {
+      # specify one or more $out-relative script paths (unlike many
+      # builders, resholve will modify the output files during fixup
+      # to correctly resolve scripts that source within the package)
+      scripts = [ "bin/shellswain.bash" ];
+      # "none" for no shebang, "${bash}/bin/bash" for bash, etc.
+      interpreter = "none";
+      # packages resholve should resolve executables from
+      inputs = [ bashup-events44 ];
+    };
+  };
+```
+
+resholve has a (growing) number of options for handling more complex
+scripts. I won't cover these in excruciating detail here. You can find
+more information about these in `man resholve` via `nixpkgs.resholve`.
+
+Instead, we'll look at the general form of the solutions attrset:
+
+```nix
+solutions = {
+  shortname = {
+    # required
+    # $out-relative paths to try resolving
+    scripts = [ "bin/shunit2" ];
+    # packages to resolve executables from
+    inputs = [ coreutils gnused gnugrep findutils ];
+    # path for shebang, or 'none' to omit shebang
+    interpreter = "${bash}/bin/bash";
+
+    # optional
+    fake = { fake directives };
+    fix = { fix directives };
+    keep = { keep directives };
+    # file to inject before first code-line of script
+    prologue = file;
+    # file to inject after last code-line of script
+    epilogue = file;
+    # extra command-line flags passed to resholve; generally this API
+    # should align with what resholve supports, but flags may help if
+    # you need to override the version of resholve.
+    flags = [ ];
+  };
+};
+```
+
+The main way you'll adjust how resholve handles your scripts are the
+fake, fix, and keep directives. The manpage covers their purpose and
+how to format them on the command-line, so I'll focus on how you'll
+need to translate them into Nix types.
+
+```nix
+# --fake 'f:setUp;tearDown builtin:setopt source:/etc/bashrc'
+fake = {
+    function = [ "setUp" "tearDown" ];
+    builtin = [ "setopt" ];
+    source = [ "/etc/bashrc" ];
+};
+
+# --fix 'aliases xargs:ls $GIT:gix'
+fix = {
+    # all single-word directives use `true` as value
+    aliases = true;
+    xargs = [ "ls" ];
+    "$GIT" = [ "gix" ];
+};
+
+# --keep 'which:git;ls .:$HOME $LS:exa /etc/bashrc ~/.bashrc'
+keep = {
+    which = [ "git" "ls" ];
+    "." = [ "$HOME" ];
+    "$LS" = [ "exa" ];
+    "/etc/bashrc" = true;
+    "~/.bashrc" = true;
+};
+```

--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -1,0 +1,13 @@
+{ callPackage
+, doCheck ? true
+}:
+let
+  resholve = callPackage ./resholve.nix { inherit doCheck; };
+  resholvePackage =
+    callPackage ./resholve-package.nix { inherit resholve; };
+
+in
+{
+  inherit resholve;
+  inherit resholvePackage;
+}

--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -1,13 +1,9 @@
 { callPackage
 , doCheck ? true
 }:
-let
+
+rec {
   resholve = callPackage ./resholve.nix { inherit doCheck; };
   resholvePackage =
     callPackage ./resholve-package.nix { inherit resholve; };
-
-in
-{
-  inherit resholve;
-  inherit resholvePackage;
 }

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -1,5 +1,5 @@
 { stdenv
-, pythonPackages
+, python27Packages
 , fetchFromGitHub
 , makeWrapper
 , # re2c deps
@@ -43,7 +43,7 @@ rec {
     '';
   };
 
-  py-yajl = pythonPackages.buildPythonPackage rec {
+  py-yajl = python27Packages.buildPythonPackage rec {
     pname = "oil-pyyajl-unstable";
     version = "2019-12-05";
     src = fetchFromGitHub {
@@ -58,10 +58,10 @@ rec {
   };
 
   # resholve's primary dependency is this developer build of the oil shell.
-  oildev = pythonPackages.buildPythonPackage rec {
+  oildev = python27Packages.buildPythonPackage rec {
     pname = "oildev-unstable";
     version = "2020-03-31";
-    disabled = !pythonPackages.isPy27;
+    disabled = !python27Packages.isPy27;
 
     src = fetchFromGitHub {
       owner = "oilshell";
@@ -94,7 +94,7 @@ rec {
 
     nativeBuildInputs = [ re2c file ];
 
-    propagatedBuildInputs = with pythonPackages; [ six typing ];
+    propagatedBuildInputs = with python27Packages; [ six typing ];
 
     doCheck = true;
     dontStrip = true;

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -1,4 +1,5 @@
 { stdenv
+, pythonPackages
 , fetchFromGitHub
 , makeWrapper
 , # re2c deps
@@ -8,7 +9,6 @@
 , # oil deps
   readline
 , cmark
-, python27
 , file
 , glibcLocales
 , oilPatches ? [ ]
@@ -43,9 +43,9 @@ rec {
     '';
   };
 
-  py-yajl = python27.pkgs.buildPythonPackage rec {
-    pname = "oil-pyyajl";
-    version = "unreleased";
+  py-yajl = pythonPackages.buildPythonPackage rec {
+    pname = "oil-pyyajl-unstable";
+    version = "2019-12-05";
     src = fetchFromGitHub {
       owner = "oilshell";
       repo = "py-yajl";
@@ -58,9 +58,10 @@ rec {
   };
 
   # resholve's primary dependency is this developer build of the oil shell.
-  oildev = python27.pkgs.buildPythonPackage rec {
-    pname = "oil";
-    version = "undefined";
+  oildev = pythonPackages.buildPythonPackage rec {
+    pname = "oildev-unstable";
+    version = "2020-03-31";
+    disabled = !pythonPackages.isPy27;
 
     src = fetchFromGitHub {
       owner = "oilshell";
@@ -119,7 +120,7 @@ rec {
     nativeBuildInputs = [ re2c file ];
 
     # runtime deps
-    propagatedBuildInputs = with python27.pkgs; [ python27 six typing ];
+    propagatedBuildInputs = with pythonPackages; [ six typing ];
 
     doCheck = true;
     dontStrip = true;

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -1,0 +1,150 @@
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+, # re2c deps
+  autoreconfHook
+, # py-yajl deps
+  git
+, # oil deps
+  readline
+, cmark
+, python27
+, file
+, glibcLocales
+, oilPatches ? [ ]
+}:
+
+/*
+Notes on specific dependencies:
+- if/when python2.7 is removed from nixpkgs, this may need to figure
+  out how to build oil's vendored python2
+- I'm not sure if glibcLocales is worth the addition here. It's to fix
+  a libc test oil runs. My oil fork just disabled the libc tests, but
+  I haven't quite decided if that's the right long-term call, so I
+  didn't add a patch for it here yet.
+*/
+
+rec {
+  # had to add this as well; 1.3 causes a break here; sticking
+  # to oil's official 1.0.3 dep for now.
+  re2c = stdenv.mkDerivation rec {
+    pname = "re2c";
+    version = "1.0.3";
+    sourceRoot = "${src.name}/re2c";
+    src = fetchFromGitHub {
+      owner = "skvadrik";
+      repo = "re2c";
+      rev = version;
+      sha256 = "0grx7nl9fwcn880v5ssjljhcb9c5p2a6xpwil7zxpmv0rwnr3yqi";
+    };
+    nativeBuildInputs = [ autoreconfHook ];
+    preCheck = ''
+      patchShebangs run_tests.sh
+    '';
+  };
+
+  py-yajl = python27.pkgs.buildPythonPackage rec {
+    pname = "oil-pyyajl";
+    version = "unreleased";
+    src = fetchFromGitHub {
+      owner = "oilshell";
+      repo = "py-yajl";
+      rev = "eb561e9aea6e88095d66abcc3990f2ee1f5339df";
+      sha256 = "17hcgb7r7cy8r1pwbdh8di0nvykdswlqj73c85k6z8m0filj3hbh";
+      fetchSubmodules = true;
+    };
+    # just for submodule IIRC
+    nativeBuildInputs = [ git ];
+  };
+
+  # resholve's primary dependency is this developer build of the oil shell.
+  oildev = python27.pkgs.buildPythonPackage rec {
+    pname = "oil";
+    version = "undefined";
+
+    src = fetchFromGitHub {
+      owner = "oilshell";
+      repo = "oil";
+      rev = "ea80cdad7ae1152a25bd2a30b87fe3c2ad32394a";
+      sha256 = "0pxn0f8qbdman4gppx93zwml7s5byqfw560n079v68qjgzh2brq2";
+
+      /*
+      This feels a little dumb; I assume it's wrongish. I was hoping
+      to be able to filter the source down to knock out parts of the
+      source that I'm not using, but I get errors just trying to get
+      *anything* working with the approaches commented out below.
+
+      On IRC eadwu[m] suggested dropping them in extraPostFetch.
+
+      It's not critical to drop most of these; the primary target is
+      the vendored fork of Python-2.7.13, which is ~ 55M and over 3200
+      files, dozens of which get interpreter script patches in fixup.
+      */
+      extraPostFetch = ''
+        #find . -maxdepth 1 -type d | sort
+        rm -rf Python-2.7.13 benchmarks metrics py-yajl rfc gold web testdata services demo devtools cpp
+        # find . -maxdepth 1 -type d | sort
+      ''; # breakers: doc, pgen2, vendor
+    };
+
+    # src = stdenv.lib.cleanSourceWith {
+    #   src = fetchFromGitHub {
+    #     owner = "oilshell";
+    #     repo = "oil";
+    #     rev = "ea80cdad7ae1152a25bd2a30b87fe3c2ad32394a";
+    #     sha256 = "0pxn0f8qbdman4gppx93zwml7s5byqfw560n079v68qjgzh2brq2";
+    #   };
+    #   filter = stdenv.lib.cleanSourceFilter;
+    # };
+
+    # src = stdenv.lib.sourceByRegex (fetchFromGitHub {
+    #   owner = "oilshell";
+    #   repo = "oil";
+    #   rev = "ea80cdad7ae1152a25bd2a30b87fe3c2ad32394a";
+    #   sha256 = "0pxn0f8qbdman4gppx93zwml7s5byqfw560n079v68qjgzh2brq2";
+    # }) [".*"];
+
+    # TODO: not sure why I'm having to set this for nix-build...
+    #       can anyone tell if I'm doing something wrong?
+    SOURCE_DATE_EPOCH = 315532800;
+
+
+    # These aren't, strictly speaking, nix/nixpkgs specific, but I've
+    # had hell upstreaming them. Pulling from resholve source and
+    # passing in from resholve.nix
+    patches = oilPatches;
+
+    buildInputs = [ readline cmark py-yajl makeWrapper ];
+
+    nativeBuildInputs = [ re2c file ];
+
+    # runtime deps
+    propagatedBuildInputs = with python27.pkgs; [ python27 six typing ];
+
+    doCheck = true;
+    dontStrip = true;
+
+    preBuild = ''
+      build/dev.sh all
+    '';
+
+    # Patch shebangs so Nix can find all executables
+    postPatch = ''
+      patchShebangs asdl build core doctools frontend native oil_lang
+    '';
+
+    _NIX_SHELL_LIBCMARK = "${cmark}/lib/libcmark${stdenv.hostPlatform.extensions.sharedLibrary}";
+
+    # See earlier note on glibcLocales
+    LOCALE_ARCHIVE = stdenv.lib.optionalString (stdenv.buildPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
+
+    meta = {
+      description = "A new unix shell";
+      homepage = "https://www.oilshell.org/";
+      license = with stdenv.lib.licenses; [
+        psfl # Includes a portion of the python interpreter and standard library
+        asl20 # Licence for Oil itself
+      ];
+    };
+  };
+}

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -70,13 +70,6 @@ rec {
       sha256 = "0pxn0f8qbdman4gppx93zwml7s5byqfw560n079v68qjgzh2brq2";
 
       /*
-      This feels a little dumb; I assume it's wrongish. I was hoping
-      to be able to filter the source down to knock out parts of the
-      source that I'm not using, but I get errors just trying to get
-      *anything* working with the approaches commented out below.
-
-      On IRC eadwu[m] suggested dropping them in extraPostFetch.
-
       It's not critical to drop most of these; the primary target is
       the vendored fork of Python-2.7.13, which is ~ 55M and over 3200
       files, dozens of which get interpreter script patches in fixup.
@@ -85,30 +78,12 @@ rec {
         #find . -maxdepth 1 -type d | sort
         rm -rf Python-2.7.13 benchmarks metrics py-yajl rfc gold web testdata services demo devtools cpp
         # find . -maxdepth 1 -type d | sort
-      ''; # breakers: doc, pgen2, vendor
+      '';
     };
-
-    # src = stdenv.lib.cleanSourceWith {
-    #   src = fetchFromGitHub {
-    #     owner = "oilshell";
-    #     repo = "oil";
-    #     rev = "ea80cdad7ae1152a25bd2a30b87fe3c2ad32394a";
-    #     sha256 = "0pxn0f8qbdman4gppx93zwml7s5byqfw560n079v68qjgzh2brq2";
-    #   };
-    #   filter = stdenv.lib.cleanSourceFilter;
-    # };
-
-    # src = stdenv.lib.sourceByRegex (fetchFromGitHub {
-    #   owner = "oilshell";
-    #   repo = "oil";
-    #   rev = "ea80cdad7ae1152a25bd2a30b87fe3c2ad32394a";
-    #   sha256 = "0pxn0f8qbdman4gppx93zwml7s5byqfw560n079v68qjgzh2brq2";
-    # }) [".*"];
 
     # TODO: not sure why I'm having to set this for nix-build...
     #       can anyone tell if I'm doing something wrong?
     SOURCE_DATE_EPOCH = 315532800;
-
 
     # These aren't, strictly speaking, nix/nixpkgs specific, but I've
     # had hell upstreaming them. Pulling from resholve source and
@@ -119,7 +94,6 @@ rec {
 
     nativeBuildInputs = [ re2c file ];
 
-    # runtime deps
     propagatedBuildInputs = with pythonPackages; [ six typing ];
 
     doCheck = true;
@@ -129,7 +103,6 @@ rec {
       build/dev.sh all
     '';
 
-    # Patch shebangs so Nix can find all executables
     postPatch = ''
       patchShebangs asdl build core doctools frontend native oil_lang
     '';

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -87,9 +87,9 @@ rec {
     # passing in from resholve.nix
     patches = oilPatches;
 
-    buildInputs = [ readline cmark py-yajl makeWrapper ];
+    buildInputs = [ readline cmark py-yajl ];
 
-    nativeBuildInputs = [ re2c file ];
+    nativeBuildInputs = [ re2c file makeWrapper ];
 
     propagatedBuildInputs = with python27Packages; [ six typing ];
 

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -61,7 +61,6 @@ rec {
   oildev = python27Packages.buildPythonPackage rec {
     pname = "oildev-unstable";
     version = "2020-03-31";
-    disabled = !python27Packages.isPy27;
 
     src = fetchFromGitHub {
       owner = "oilshell";

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -75,9 +75,7 @@ rec {
       files, dozens of which get interpreter script patches in fixup.
       */
       extraPostFetch = ''
-        #find . -maxdepth 1 -type d | sort
         rm -rf Python-2.7.13 benchmarks metrics py-yajl rfc gold web testdata services demo devtools cpp
-        # find . -maxdepth 1 -type d | sort
       '';
     };
 

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -94,7 +94,6 @@ rec {
     propagatedBuildInputs = with python27Packages; [ six typing ];
 
     doCheck = true;
-    dontStrip = true;
 
     preBuild = ''
       build/dev.sh all

--- a/pkgs/development/misc/resholve/resholve-package.nix
+++ b/pkgs/development/misc/resholve/resholve-package.nix
@@ -5,54 +5,101 @@
 , version
 , passthru ? { }
   # resholve-specific API
-  # paths to try resolving
-, scripts
-  # packages to resolve executables from
-, inputs
-, interpreter
-  # see resholve docs for semantics, but fake/fix/keep are all
-  # key: [list] mapped to key:value2;value2
-, fake ? { }
-, fix ? { }
-, keep ? { }
-  # file to inject before first code-line of script
-, prologue ? false
-  # file to inject after last code-line of script
-, epilogue ? false
-  # extra command-line flags passed to resholve; generally the API here
-  # should align with what resholve supports, but flags is helpful if you
-  # need to override the version of resholve in use.
-, flags ? [ ]
+, solutions
+  /* not sure how to document the structure now :[
+    {
+      shortname = {
+        # required
+        # paths to try resolving
+        scripts = [ $out-relative paths ];
+        # packages to resolve executables from
+        inputs = [ packages ];
+        interpreter = "${bash}/bin/bash";
+
+        # optional
+        # see 'man resholve', but fake/fix/keep are mostly
+        # key: [list] mapped to key:value2;value2
+        fake = { fake directives };
+        fix = { fix directives };
+        keep = { keep directives };
+        # file to inject before first code-line of script
+        prologue = file;
+        # file to inject after last code-line of script
+        epilogue = file;
+        # extra command-line flags passed to resholve; generally the API here
+        # should align with what resholve supports, but flags is helpful if you
+        # need to override the version of resholve in use.
+        flags = [ ];
+      };
+    }*/
 , ...
 }@attrs:
 let
   inherit stdenv;
-  self = (stdenv.mkDerivation ((removeAttrs attrs [ "scripts" "inputs" "interpreter" "fake" "fix" "keep" "prologue" "epilogue" "flags" ])
+  /*
+   * function doc TODO if this doesn't get slapped down
+   */
+  nope =
+    path:
+    msg:
+    throw "${lib.concatStringsSep "." path}: ${msg}";
+  spaces = l: builtins.concatStringsSep " " l;
+  makeDirective = sol: env: n: v:
+    if builtins.isInt v then builtins.toString v
+    else if builtins.isString v then n
+    else if true == v then n
+    else if false == v then "" # omit!
+    else if null == v then "" # omit!
+    else if builtins.isList v then "${n}:${builtins.concatStringsSep ";" v}"
+    else nope [ sol env n ] "unexpected type '${builtins.typeOf v}'";
+  makeDirectives =
+    solution:
+    env:
+    v:
+    lib.mapAttrsToList (makeDirective solution env) v;
+  makeEnvVal = solution: env: v:
+    if env == "inputs" then lib.makeBinPath v
+    else if builtins.isString v then v
+    else if builtins.isList v then spaces v
+    else if builtins.isAttrs v then spaces (makeDirectives solution env v)
+    else nope [ solution env ] "type of '${v}' (${builtins.typeOf v})";
+  shellEnv =
+    solution:
+    env:
+    value:
+    lib.escapeShellArg (makeEnvVal solution env value);
+  makeEnv = solution: env: value:
+    "RESHOLVE_${lib.toUpper env}=${shellEnv solution env value}";
+  scrub =
+    value:
+    removeAttrs value [ "scripts" "flags" ];
+  validateSolution = { scripts, inputs, interpreter, ... }: true;
+  makeEnvs =
+    solution:
+    value:
+    lib.concatStringsSep " " (lib.mapAttrsToList (makeEnv solution) (scrub value));
+  makeArgs =
+    { flags ? [ ], scripts, ... }:
+    lib.concatStringsSep " " (flags ++ scripts);
+  makeInvocation =
+    solution:
+    value:
+    if validateSolution value then
+      "${makeEnvs solution value} resholve --overwrite ${makeArgs value}"
+    else throw "invalid solution"; # shouldn't trigger for now
+  makeCommands =
+    solutions:
+    lib.mapAttrsToList makeInvocation solutions;
+
+  self = (stdenv.mkDerivation ((removeAttrs attrs [ "solutions" ])
     // {
     inherit pname version src;
     buildInputs = [ resholve ];
-    RESHOLVE_PATH = "${lib.makeBinPath inputs}";
-    RESHOLVE_INTERPRETER = interpreter;
-    RESHOLVE_FAKE =
-      toString (lib.mapAttrsToList (name: value: map (y: name + ":" + y) value) fake);
-    RESHOLVE_FIX =
-      toString (lib.mapAttrsToList (name: value: if (!builtins.isList value || builtins.length value == 0) then name else (map (y: name + ":" + y) value)) fix);
-    RESHOLVE_KEEP =
-      toString (lib.mapAttrsToList (name: value: if (!builtins.isList value || builtins.length value == 0) then name else (map (y: name + ":" + y) value)) keep);
-    RESHOLVE_PROLOGUE = stdenv.lib.optionalString prologue prologue;
-    RESHOLVE_EPILOGUE = stdenv.lib.optionalString epilogue epilogue;
+
     #LOGLEVEL="INFO";
-    # intentionally not stripping RESHOLVE_PATH or
-    # RESHOLVE_INTERPRETER even empty; required arguments.
     preFixup = ''
-      for resholve_env_var in RESHOLVE_FAKE RESHOLVE_FIX RESHOLVE_KEEP RESHOLVE_PROLOGUE RESHOLVE_EPILOGUE; do
-        real_var="''${!resholve_env_var}"
-        if [[ -z "$real_var" ]]; then
-          unset -v $resholve_env_var
-        fi
-      done
       pushd $out
-      resholve --overwrite ${toString (flags ++ scripts)}
+      ${lib.concatStringsSep "\n" (makeCommands solutions)}
       popd
     '';
   }));

--- a/pkgs/development/misc/resholve/resholve-package.nix
+++ b/pkgs/development/misc/resholve/resholve-package.nix
@@ -4,91 +4,112 @@
 , src
 , version
 , passthru ? { }
-  # resholve-specific API
+  /* Each "solution" (k=v pair) describes one resholve invocation.
+   * See 'man resholve' for option details.
+   *
+   * Example:
+   * {
+   *   # name the script(s) for overrides & error messages
+   *   shortname = {
+   *     # required
+   *     # $out-relative paths to try resolving
+   *     scripts = [ "bin/shunit2" ];
+   *     # packages to resolve executables from
+   *     inputs = [ coreutils gnused gnugrep findutils ];
+   *     # path for shebang, or 'none' to omit shebang
+   *     interpreter = "${bash}/bin/bash";
+   *
+   *     # optional
+   *     # to translate fake/fix/keep directives, convert:
+   *     # - `key:value1;value2` to `key: [ value1 value2 ];`
+   *     # - `value` to `value = true;`
+   *     fake = { fake directives };
+   *     fix = { fix directives };
+   *     keep = { keep directives };
+   *     # file to inject before first code-line of script
+   *     prologue = file;
+   *     # file to inject after last code-line of script
+   *     epilogue = file;
+   *     # extra command-line flags passed to resholve; generally this API
+   *     # should align with what resholve supports, but flags may help if
+   *     # you need to override the version of resholve.
+   *     flags = [ ];
+   *   };
+   * }
+   */
 , solutions
-  /* not sure how to document the structure now :[
-    {
-      shortname = {
-        # required
-        # paths to try resolving
-        scripts = [ $out-relative paths ];
-        # packages to resolve executables from
-        inputs = [ packages ];
-        interpreter = "${bash}/bin/bash";
-
-        # optional
-        # see 'man resholve', but fake/fix/keep are mostly
-        # key: [list] mapped to key:value2;value2
-        fake = { fake directives };
-        fix = { fix directives };
-        keep = { keep directives };
-        # file to inject before first code-line of script
-        prologue = file;
-        # file to inject after last code-line of script
-        epilogue = file;
-        # extra command-line flags passed to resholve; generally the API here
-        # should align with what resholve supports, but flags is helpful if you
-        # need to override the version of resholve in use.
-        flags = [ ];
-      };
-    }*/
 , ...
 }@attrs:
 let
   inherit stdenv;
-  /*
-   * function doc TODO if this doesn't get slapped down
+  /* These functions break up the work of partially validating the
+   * 'solutions' attrset and massaging it into env/cli args.
+   *
+   * Note: some of the left-most args do not *have* to be passed as
+   * deep as they are, but I've done so to provide more error context
    */
-  nope =
-    path:
-    msg:
-    throw "${lib.concatStringsSep "." path}: ${msg}";
+
+  # for brevity / line length
   spaces = l: builtins.concatStringsSep " " l;
-  makeDirective = sol: env: n: v:
-    if builtins.isInt v then builtins.toString v
-    else if builtins.isString v then n
-    else if true == v then n
-    else if false == v then "" # omit!
-    else if null == v then "" # omit!
-    else if builtins.isList v then "${n}:${builtins.concatStringsSep ";" v}"
-    else nope [ sol env n ] "unexpected type '${builtins.typeOf v}'";
-  makeDirectives =
-    solution:
-    env:
-    v:
-    lib.mapAttrsToList (makeDirective solution env) v;
-  makeEnvVal = solution: env: v:
-    if env == "inputs" then lib.makeBinPath v
-    else if builtins.isString v then v
-    else if builtins.isList v then spaces v
-    else if builtins.isAttrs v then spaces (makeDirectives solution env v)
-    else nope [ solution env ] "type of '${v}' (${builtins.typeOf v})";
-  shellEnv =
-    solution:
-    env:
-    value:
+  semicolons = l: builtins.concatStringsSep ";" l;
+
+  /* Throw a fit with dotted attr path context */
+  nope = path: msg:
+    throw "${builtins.concatStringsSep "." path}: ${msg}";
+
+  /* Special-case directive value representations by type */
+  makeDirective = solution: env: name: val:
+    if builtins.isInt val then builtins.toString val
+    else if builtins.isString val then name
+    else if true == val then name
+    else if false == val then "" # omit!
+    else if null == val then "" # omit!
+    else if builtins.isList val then "${name}:${semicolons val}"
+    else nope [ solution env name ] "unexpected type: ${builtins.typeOf val}";
+
+  /* Build fake/fix/keep directives from Nix types */
+  makeDirectives = solution: env: val:
+    lib.mapAttrsToList (makeDirective solution env) val;
+
+  /* Special-case value representation by type/name */
+  makeEnvVal = solution: env: val:
+    if env == "inputs" then lib.makeBinPath val
+    else if builtins.isString val then val
+    else if builtins.isList val then spaces val
+    else if builtins.isAttrs val then spaces (makeDirectives solution env val)
+    else nope [ solution env ] "unexpected type: ${builtins.typeOf val}";
+
+  /* Shell-format each env value */
+  shellEnv = solution: env: value:
     lib.escapeShellArg (makeEnvVal solution env value);
+
+  /* Build a single ENV=val pair */
   makeEnv = solution: env: value:
     "RESHOLVE_${lib.toUpper env}=${shellEnv solution env value}";
-  scrub =
-    value:
+
+  /* Discard attrs claimed by makeArgs */
+  removeCliArgs = value:
     removeAttrs value [ "scripts" "flags" ];
+
+  /* Verify required arguments are present */
   validateSolution = { scripts, inputs, interpreter, ... }: true;
-  makeEnvs =
-    solution:
-    value:
-    lib.concatStringsSep " " (lib.mapAttrsToList (makeEnv solution) (scrub value));
-  makeArgs =
-    { flags ? [ ], scripts, ... }:
-    lib.concatStringsSep " " (flags ++ scripts);
-  makeInvocation =
-    solution:
-    value:
+
+  /* Pull out specific solution keys to build ENV=val pairs */
+  makeEnvs = solution: value:
+    spaces (lib.mapAttrsToList (makeEnv solution) (removeCliArgs value));
+
+  /* Pull out specific solution keys to build CLI argstring */
+  makeArgs = { flags ? [ ], scripts, ... }:
+    spaces (flags ++ scripts);
+
+  /* Build a single resholve invocation */
+  makeInvocation = solution: value:
     if validateSolution value then
       "${makeEnvs solution value} resholve --overwrite ${makeArgs value}"
     else throw "invalid solution"; # shouldn't trigger for now
-  makeCommands =
-    solutions:
+
+  /* Build resholve invocation for each solution. */
+  makeCommands = solutions:
     lib.mapAttrsToList makeInvocation solutions;
 
   self = (stdenv.mkDerivation ((removeAttrs attrs [ "solutions" ])
@@ -98,8 +119,8 @@ let
 
     #LOGLEVEL="INFO";
     preFixup = ''
-      pushd $out
-      ${lib.concatStringsSep "\n" (makeCommands solutions)}
+      pushd "$out"
+      ${builtins.concatStringsSep "\n" (makeCommands solutions)}
       popd
     '';
   }));

--- a/pkgs/development/misc/resholve/resholve-package.nix
+++ b/pkgs/development/misc/resholve/resholve-package.nix
@@ -1,0 +1,60 @@
+{ stdenv, lib, resholve }:
+
+{ pname
+, src
+, version
+, passthru ? { }
+  # resholve-specific API
+  # paths to try resolving
+, scripts
+  # packages to resolve executables from
+, inputs
+, interpreter
+  # see resholve docs for semantics, but fake/fix/keep are all
+  # key: [list] mapped to key:value2;value2
+, fake ? { }
+, fix ? { }
+, keep ? { }
+  # file to inject before first code-line of script
+, prologue ? false
+  # file to inject after last code-line of script
+, epilogue ? false
+  # extra command-line flags passed to resholve; generally the API here
+  # should align with what resholve supports, but flags is helpful if you
+  # need to override the version of resholve in use.
+, flags ? [ ]
+, ...
+}@attrs:
+let
+  inherit stdenv;
+  self = (stdenv.mkDerivation ((removeAttrs attrs [ "scripts" "inputs" "interpreter" "fake" "fix" "keep" "prologue" "epilogue" "flags" ])
+    // {
+    inherit pname version src;
+    buildInputs = [ resholve ];
+    RESHOLVE_PATH = "${lib.makeBinPath inputs}";
+    RESHOLVE_INTERPRETER = interpreter;
+    RESHOLVE_FAKE =
+      toString (lib.mapAttrsToList (name: value: map (y: name + ":" + y) value) fake);
+    RESHOLVE_FIX =
+      toString (lib.mapAttrsToList (name: value: if (!builtins.isList value || builtins.length value == 0) then name else (map (y: name + ":" + y) value)) fix);
+    RESHOLVE_KEEP =
+      toString (lib.mapAttrsToList (name: value: if (!builtins.isList value || builtins.length value == 0) then name else (map (y: name + ":" + y) value)) keep);
+    RESHOLVE_PROLOGUE = stdenv.lib.optionalString prologue prologue;
+    RESHOLVE_EPILOGUE = stdenv.lib.optionalString epilogue epilogue;
+    #LOGLEVEL="INFO";
+    # intentionally not stripping RESHOLVE_PATH or
+    # RESHOLVE_INTERPRETER even empty; required arguments.
+    preFixup = ''
+      for resholve_env_var in RESHOLVE_FAKE RESHOLVE_FIX RESHOLVE_KEEP RESHOLVE_PROLOGUE RESHOLVE_EPILOGUE; do
+        real_var="''${!resholve_env_var}"
+        if [[ -z "$real_var" ]]; then
+          unset -v $resholve_env_var
+        fi
+      done
+      pushd $out
+      resholve --overwrite ${toString (flags ++ scripts)}
+      popd
+    '';
+  }));
+in
+lib.extendDerivation true passthru self

--- a/pkgs/development/misc/resholve/resholve-package.nix
+++ b/pkgs/development/misc/resholve/resholve-package.nix
@@ -4,39 +4,6 @@
 , src
 , version
 , passthru ? { }
-  /* Each "solution" (k=v pair) describes one resholve invocation.
-   * See 'man resholve' for option details.
-   *
-   * Example:
-   * {
-   *   # name the script(s) for overrides & error messages
-   *   shortname = {
-   *     # required
-   *     # $out-relative paths to try resolving
-   *     scripts = [ "bin/shunit2" ];
-   *     # packages to resolve executables from
-   *     inputs = [ coreutils gnused gnugrep findutils ];
-   *     # path for shebang, or 'none' to omit shebang
-   *     interpreter = "${bash}/bin/bash";
-   *
-   *     # optional
-   *     # to translate fake/fix/keep directives, convert:
-   *     # - `key:value1;value2` to `key: [ value1 value2 ];`
-   *     # - `value` to `value = true;`
-   *     fake = { fake directives };
-   *     fix = { fix directives };
-   *     keep = { keep directives };
-   *     # file to inject before first code-line of script
-   *     prologue = file;
-   *     # file to inject after last code-line of script
-   *     epilogue = file;
-   *     # extra command-line flags passed to resholve; generally this API
-   *     # should align with what resholve supports, but flags may help if
-   *     # you need to override the version of resholve.
-   *     flags = [ ];
-   *   };
-   * }
-   */
 , solutions
 , ...
 }@attrs:

--- a/pkgs/development/misc/resholve/resholve-package.nix
+++ b/pkgs/development/misc/resholve/resholve-package.nix
@@ -117,7 +117,9 @@ let
     inherit pname version src;
     buildInputs = [ resholve ];
 
-    #LOGLEVEL="INFO";
+    # enable below for verbose debug info if needed
+    # supports default python.logging levels
+    # LOGLEVEL="INFO";
     preFixup = ''
       pushd "$out"
       ${builtins.concatStringsSep "\n" (makeCommands solutions)}

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -11,12 +11,12 @@
 , doCheck ? true
 }:
 let
-  version = "0.1.1";
+  version = "0.2.0-1";
   rSrc = fetchFromGitHub {
     owner = "abathur";
     repo = "resholve";
     rev = "v${version}";
-    hash = "sha256-G3OMPgG7ZyiFX1GqamXJBjdqmylrGueZNAytlgl/rCg=";
+    hash = "sha256-UncAz/dQjxsJcYC52sNT1R2Wl2X605TbyFe70e2APCk=";
   };
   deps = callPackage ./deps.nix {
     /*

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -11,12 +11,12 @@
 , doCheck ? true
 }:
 let
-  version = "0.2.0";
+  version = "0.2.1";
   rSrc = fetchFromGitHub {
     owner = "abathur";
     repo = "resholve";
     rev = "v${version}";
-    hash = "sha256-4mgU0w/yg9MyArw8uJ8/t1ZReZnNMTteeKtCwG3tGzM=";
+    hash = "sha256-plO5HPtKFELgCI0qgKe8fTNW2Ci5Qp7fIUK4i1zrRNk=";
   };
   deps = callPackage ./deps.nix {
     /*

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -11,12 +11,12 @@
 , doCheck ? true
 }:
 let
-  version = "0.2.1";
+  version = "0.3.0";
   rSrc = fetchFromGitHub {
     owner = "abathur";
     repo = "resholve";
     rev = "v${version}";
-    hash = "sha256-plO5HPtKFELgCI0qgKe8fTNW2Ci5Qp7fIUK4i1zrRNk=";
+    hash = "sha256-K6S0a6y/2oBLW1oB3PO4di4KZEKDb0Yv3myUP8PwvXc=";
   };
   deps = callPackage ./deps.nix {
     /*

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -1,0 +1,78 @@
+{ stdenv
+, callPackage
+, installShellFiles
+, fetchFromGitHub
+, file
+, findutils
+, gettext
+, python27
+, bats
+, bash
+, doCheck ? true
+}:
+let
+  version = "0.1.1";
+  rSrc = fetchFromGitHub {
+    owner = "abathur";
+    repo = "resholve";
+    rev = "v${version}";
+    hash = "sha256-G3OMPgG7ZyiFX1GqamXJBjdqmylrGueZNAytlgl/rCg=";
+  };
+  deps = callPackage ./deps.nix {
+    /*
+    resholve needs to patch Oil, but trying to avoid adding
+    them all *to* nixpkgs, since they aren't specific to
+    nix/nixpkgs.
+    */
+    oilPatches = [
+      "${rSrc}/0001-add_setup_py.patch"
+      "${rSrc}/0002-add_MANIFEST_in.patch"
+      "${rSrc}/0003-fix_codegen_shebang.patch"
+      "${rSrc}/0004-disable-internal-py-yajl-for-nix-built.patch"
+    ];
+  };
+  resolveTimeDeps = [ file findutils gettext ];
+in
+python27.pkgs.buildPythonApplication {
+  pname = "resholve";
+  inherit version;
+  src = rSrc;
+  format = "other";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  propagatedBuildInputs = [ deps.oildev python27.pkgs.ConfigArgParse ];
+
+  patchPhase = ''
+    for file in resholve; do
+      substituteInPlace $file --subst-var-by version ${version}
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install resholve $out/bin/
+    installManPage resholve.1
+  '';
+  inherit doCheck;
+  checkInputs = [ bats ];
+  RESHOLVE_PATH = "${stdenv.lib.makeBinPath resolveTimeDeps}";
+
+  # explicit interpreter for test suite; maybe some better way...
+  INTERP = "${bash}/bin/bash";
+  checkPhase = ''
+    PATH=$out/bin:$PATH
+    patchShebangs .
+    ./test.sh
+  '';
+
+  meta = {
+    description = "Resolve external shell-script dependencies";
+    homepage = "https://github.com/abathur/resholve";
+    license = with stdenv.lib.licenses; [
+      mit
+    ];
+    maintainers = with stdenv.lib.maintainers; [ abathur ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -67,13 +67,11 @@ pythonPackages.buildPythonApplication {
     ./test.sh
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Resolve external shell-script dependencies";
     homepage = "https://github.com/abathur/resholve";
-    license = with stdenv.lib.licenses; [
-      mit
-    ];
-    maintainers = with stdenv.lib.maintainers; [ abathur ];
-    platforms = stdenv.lib.platforms.all;
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ abathur ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -1,6 +1,6 @@
 { stdenv
 , callPackage
-, pythonPackages
+, python27Packages
 , installShellFiles
 , fetchFromGitHub
 , file
@@ -33,16 +33,16 @@ let
   };
   resolveTimeDeps = [ file findutils gettext ];
 in
-pythonPackages.buildPythonApplication {
+python27Packages.buildPythonApplication {
   pname = "resholve";
   inherit version;
   src = rSrc;
   format = "other";
-  disabled = !pythonPackages.isPy27;
+  disabled = !python27Packages.isPy27;
 
   nativeBuildInputs = [ installShellFiles ];
 
-  propagatedBuildInputs = [ deps.oildev pythonPackages.ConfigArgParse ];
+  propagatedBuildInputs = [ deps.oildev python27Packages.ConfigArgParse ];
 
   patchPhase = ''
     for file in resholve; do

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -1,11 +1,11 @@
 { stdenv
 , callPackage
+, pythonPackages
 , installShellFiles
 , fetchFromGitHub
 , file
 , findutils
 , gettext
-, python27
 , bats
 , bash
 , doCheck ? true
@@ -33,15 +33,16 @@ let
   };
   resolveTimeDeps = [ file findutils gettext ];
 in
-python27.pkgs.buildPythonApplication {
+pythonPackages.buildPythonApplication {
   pname = "resholve";
   inherit version;
   src = rSrc;
   format = "other";
+  disabled = !pythonPackages.isPy27;
 
   nativeBuildInputs = [ installShellFiles ];
 
-  propagatedBuildInputs = [ deps.oildev python27.pkgs.ConfigArgParse ];
+  propagatedBuildInputs = [ deps.oildev pythonPackages.ConfigArgParse ];
 
   patchPhase = ''
     for file in resholve; do

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -11,12 +11,12 @@
 , doCheck ? true
 }:
 let
-  version = "0.2.0-1";
+  version = "0.2.0";
   rSrc = fetchFromGitHub {
     owner = "abathur";
     repo = "resholve";
     rev = "v${version}";
-    hash = "sha256-UncAz/dQjxsJcYC52sNT1R2Wl2X605TbyFe70e2APCk=";
+    hash = "sha256-4mgU0w/yg9MyArw8uJ8/t1ZReZnNMTteeKtCwG3tGzM=";
   };
   deps = callPackage ./deps.nix {
     /*

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -50,8 +50,7 @@ python27Packages.buildPythonApplication {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    install resholve $out/bin/
+    install -Dm755 resholve $out/bin/
     installManPage resholve.1
   '';
   inherit doCheck;

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -11,12 +11,12 @@
 , doCheck ? true
 }:
 let
-  version = "0.3.0";
+  version = "0.4.0";
   rSrc = fetchFromGitHub {
     owner = "abathur";
     repo = "resholve";
     rev = "v${version}";
-    hash = "sha256-K6S0a6y/2oBLW1oB3PO4di4KZEKDb0Yv3myUP8PwvXc=";
+    hash = "sha256-wfxcX3wMZqoi5bWjXYRa21UDDJmTDfE+21p4mL2IJog=";
   };
   deps = callPackage ./deps.nix {
     /*

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -49,18 +49,17 @@ python27Packages.buildPythonApplication {
   '';
 
   installPhase = ''
-    install -Dm755 resholve $out/bin/
+    install -dm 755 resholve $out/bin/
     installManPage resholve.1
   '';
+
   inherit doCheck;
   checkInputs = [ bats ];
   RESHOLVE_PATH = "${stdenv.lib.makeBinPath [ file findutils gettext ]}";
 
-  
   checkPhase = ''
     # explicit interpreter for test suite
-    export INTERP="${bash}/bin/bash";
-    export PATH=$out/bin:$PATH
+    export INTERP="${bash}/bin/bash" PATH="$out/bin:$PATH"
     patchShebangs .
     ./test.sh
   '';

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -49,7 +49,7 @@ python27Packages.buildPythonApplication {
   '';
 
   installPhase = ''
-    install -dm 755 resholve $out/bin/
+    install -Dm755 resholve $out/bin/resholve
     installManPage resholve.1
   '';
 

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -38,7 +38,6 @@ python27Packages.buildPythonApplication {
   inherit version;
   src = rSrc;
   format = "other";
-  disabled = !python27Packages.isPy27;
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -31,7 +31,6 @@ let
       "${rSrc}/0004-disable-internal-py-yajl-for-nix-built.patch"
     ];
   };
-  resolveTimeDeps = [ file findutils gettext ];
 in
 python27Packages.buildPythonApplication {
   pname = "resholve";
@@ -55,7 +54,7 @@ python27Packages.buildPythonApplication {
   '';
   inherit doCheck;
   checkInputs = [ bats ];
-  RESHOLVE_PATH = "${stdenv.lib.makeBinPath resolveTimeDeps}";
+  RESHOLVE_PATH = "${stdenv.lib.makeBinPath [ file findutils gettext ]}";
 
   
   checkPhase = ''

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -59,10 +59,11 @@ python27Packages.buildPythonApplication {
   checkInputs = [ bats ];
   RESHOLVE_PATH = "${stdenv.lib.makeBinPath resolveTimeDeps}";
 
-  # explicit interpreter for test suite; maybe some better way...
-  INTERP = "${bash}/bin/bash";
+  
   checkPhase = ''
-    PATH=$out/bin:$PATH
+    # explicit interpreter for test suite
+    export INTERP="${bash}/bin/bash";
+    export PATH=$out/bin:$PATH
     patchShebangs .
     ./test.sh
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6971,6 +6971,8 @@ in
 
   rescuetime = libsForQt5.callPackage ../applications/misc/rescuetime { };
 
+  resholve = callPackage ../development/misc/resholve { };
+
   reuse = callPackage ../tools/package-management/reuse { };
 
   rewritefs = callPackage ../os-specific/linux/rewritefs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6971,7 +6971,7 @@ in
 
   rescuetime = libsForQt5.callPackage ../applications/misc/rescuetime { };
 
-  resholve = callPackage ../development/misc/resholve { };
+  resholve = recurseIntoAttrs (callPackage ../development/misc/resholve { });
 
   reuse = callPackage ../tools/package-management/reuse { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6971,7 +6971,8 @@ in
 
   rescuetime = libsForQt5.callPackage ../applications/misc/rescuetime { };
 
-  resholve = callPackage ../development/misc/resholve { };
+  inherit (callPackage ../development/misc/resholve { })
+    resholve resholvePackage;
 
   reuse = callPackage ../tools/package-management/reuse { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6971,7 +6971,7 @@ in
 
   rescuetime = libsForQt5.callPackage ../applications/misc/rescuetime { };
 
-  resholve = recurseIntoAttrs (callPackage ../development/misc/resholve { });
+  resholve = callPackage ../development/misc/resholve { };
 
   reuse = callPackage ../tools/package-management/reuse { };
 


### PR DESCRIPTION
###### Motivation for this change

Give the Nix ecosystem a new superpower: resolving external dependencies in shell scripts.

Shell scripts/libraries with external dependencies are an odd duck in the Nix ecosystem. Packaging them with Nix doesn't ensure dependencies are available at runtime or address the possibility that the script could run executables provided by packages other than those specified as dependencies, for example.

###### More information

This PR packages a project of mine, https://github.com/abathur/resholve, and provides a Nix build function. resholve is built atop the parser from the Oil shell project. A fair portion of the Nix code in this PR is just packaging/building a development version of Oil. 

The PR itself isn't terribly useful for seeing what it _does_; it'll help to look at some additional resources:
- #107182 shows how I've used it to package a new shell library.
- [This commit](https://github.com/abathur/resholve/commit/7288d42e1fa78e2b228884b495d998e6a35d7708) shows (roughly, I'm synthesizing this) how you'd resholve the existing shunit2, and how it would change the script that ends up in the store.
- The repo includes two demos (shell API, Nix API), which you can read about (including invocation instructions) at https://github.com/abathur/resholve/blob/master/demos.md.

FWIW, I dogfood resholve in my own darwin-configuration, where it is responsible for building a chain of packages structured like:
- my bashrc
   - a bash history-management module I'm developing
      - an event-based shell-profile "orchestration" framework I'm developing to support both of the above
         - a third-party bash event/promise library (now PRed in #107182)

<details>
<summary>A question came up during review about whether some of the packages in `deps.nix` should be split out into standalone packages. I've resolved the thread, but others may have the same question so I'm keeping the answer somewhere easier to find:</summary>

> > BTW, having oilshell and maybe oildev available in `all-packages` is probably a good idea, since those packages are kinda interesting. You could, for example, open a PR with only `oildshell`, `oildev` and maybe `py-yajl`, making it easier to review only those dependencies. Afterwards you could make this PR depends on those dependencies.
> 
> I have reservations about this.
> 
> I'm happy to break these out if there's a clear imperative, but they are all pretty idiomatic (and all ultimately subservient to the oildev package itself). I don't anticipate them adding standalone value to nixpkgs in the short run.
> 
> 1. The Oil shell already has a binary user package included here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/shells/oil/default.nix
> 2. oildev isn't (for now) a _real thing_ that the Oil project intentionally publishes--it's a fiction created by forcibly patching-and-packaging Oil's python code in order to build resholve
>    
>    * Because these Python APIs aren't intentionally published for external consumption and Oil is still a fast-changing young project, they aren't stable. I'd be very surprised if more than one consumer could share a single version of it for long.
>    * AFAIK resholve is the only consumer of this. No one's asked me about using it.
>    * resholve still needs [~140 lines of code](https://github.com/abathur/resholve/blob/d990fc06b504d761ff811bd1ad8075bdceb61dd0/resholve#L23-L161) just to monkeypatch all of oil's packages into a unified oil.* namespace. If anyone used it without this shim, all of its subpackages would leak into the root Python package namespace.
>    * I can't guarantee any Oil code paths that resholve doesn't exercise actually work.
>    * Because resholve is very tightly coupled to Oil's internal Python APIs, there's a fair chance any update of this would break resholve.
> 3. [py-yajl](https://github.com/oilshell/py-yajl) is Oil's fork of https://github.com/rtyler/py-yajl. They've modified it, dropped tests they don't need, and cut code they don't use. I have no idea how suitable it is or isn't for general use. Oil has made no attempt to promote their py-yajl fork, it has no stars, and I have zero reason to expect that Oil would support it in any way.

</details>

cc @grahamc @worldofpeace 

###### Known issues

~The current design of the Nix API assumes all of the shell files can be resolved with the same settings, and it won't be terribly obvious what to do (aside from break it up into multiple derivations, or override to manually invoke resholve) in these cases.~

~I'm not sure what the best approach here is. For reference, here's one possible approach from @grahamc: https://gsc.io/content-addressed/92d2781347e6e0d9b761ff2d4512d6885f48d8fb6a97db15f0ba5f4863ec91bd.nix~

I have pushed a ~tentative~ fix for this; see https://github.com/NixOS/nixpkgs/pull/85827#issuecomment-747831206 and d36bb7d

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions (in CI)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
