### PR TITLE
[20.03] rtl8812au: 5.2.20.2_28373.20190903 -> 5.6.4.2_35491.20200318

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "rtl8812au-${kernel.version}-${version}";
-  version = "5.2.20.2_28373.20190903";
+  version = "5.6.4.2_35491.20200318";
 
   src = fetchFromGitHub {
-    owner = "zebulon2";
-    repo = "rtl8812au-driver-5.2.20";
-    rev = "30d47a0a3f43ccb19e8fd59fe93d74a955147bf2";
-    sha256 = "1fy0f8ihxd0i5kr8gmky8v8xl0ns6bhxfdn64c97c5irzdvg37sr";
+    owner = "gordboy";
+    repo = "rtl8812au-5.6.4.2";
+    rev = "49e98ff9bfdbe2ddce843808713de383132002e0";
+    sha256 = "0f4isqasm9rli5v6a7xpphyh509wdxs1zcfvgdsnyhnv8amhqxgs";
   };
 
   nativeBuildInputs = [ bc nukeReferences ];


### PR DESCRIPTION
Backport of #85705
Tested compilation.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
