### PR TITLE
esy: init at 0.6.2 WIP

### DIFF
--- a/pkgs/development/ocaml-modules/cudf/default.nix
+++ b/pkgs/development/ocaml-modules/cudf/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, ocaml, ocamlbuild, findlib, ocaml_extlib, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "cudf";
+  version = "0.9";
+
+  src = fetchurl {
+    url = "https://gforge.inria.fr/frs/download.php/36602/cudf-0.9.tar.gz";
+    sha256 = "0771lwljqwwn3cryl0plny5a5dyyrj4z6bw66ha5n8yfbpcy8clr";
+  };
+
+  buildInputs = [
+    ocaml
+    ocamlbuild
+    findlib
+    ocaml_extlib
+    perl
+  ];
+
+  makeFlags = [
+    "OCAMLLIBDIR=$(out)/lib"
+    "BINDIR=$(out)/bin"
+    "LIBDIR=$(out)/lib"
+    "INCDIR=$(out)/include"
+  ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "CUDF (for Common Upgradeability Description Format) is a format for describing upgrade scenarios in package-based Free and Open Source Software distribution.";
+    license = stdenv.lib.licenses.lgpl3;
+    homepage = "http://www.mancoosi.org/cudf/";
+  };
+}

--- a/pkgs/development/ocaml-modules/cudf/default.nix
+++ b/pkgs/development/ocaml-modules/cudf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, ocamlbuild, findlib, ocaml_extlib, perl }:
+{ stdenv, fetchurl, ocaml, ocamlbuild, findlib, ocaml_extlib, perl, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "cudf";
@@ -9,20 +9,28 @@ stdenv.mkDerivation rec {
     sha256 = "0771lwljqwwn3cryl0plny5a5dyyrj4z6bw66ha5n8yfbpcy8clr";
   };
 
+  dontConfigure = true;
+
+  nativeBuildInputs = [ ncurses ];
+
   buildInputs = [
     ocaml
     ocamlbuild
     findlib
-    ocaml_extlib
     perl
   ];
+
+  propagatedBuildInputs = [ ocaml_extlib ];
 
   makeFlags = [
     "OCAMLLIBDIR=$(out)/lib"
     "BINDIR=$(out)/bin"
     "LIBDIR=$(out)/lib"
-    "INCDIR=$(out)/include"
   ];
+
+  buildPhase = ''
+    make all opt
+  '';
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/dose3/default.nix
+++ b/pkgs/development/ocaml-modules/dose3/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ocaml, ocamlbuild, findlib
-, cppo, cudf, ocamlgraph, ocaml_extlib, re, perl }:
+, cppo, cudf, ocamlgraph, ocaml_extlib, re, perl, ncurses }:
 
 let base_patch_url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/dose3/dose3.5.0.1/files";
 in
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  nativeBuildInputs = [ ncurses ]; # for tput
+
   buildInputs = [
     ocaml
     ocamlbuild
@@ -47,8 +49,12 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "BINDIR=$(out)/bin"
     "LIBDIR=$(out)/lib"
-    "INCDIR=$(out)/include"
   ];
+
+  preInstall = ''
+    substituteInPlace Makefile.config \
+      --replace "-destdir \$(LIBDIR)" ""
+  '';
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/dose3/default.nix
+++ b/pkgs/development/ocaml-modules/dose3/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchurl, ocaml, ocamlbuild, findlib
+, cppo, cudf, ocamlgraph, ocaml_extlib, re, perl }:
+
+let base_patch_url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/dose3/dose3.5.0.1/files";
+in
+
+stdenv.mkDerivation rec {
+  pname = "dose3";
+  version = "5.0.1";
+
+  src = fetchurl {
+    url = "https://gforge.inria.fr/frs/download.php/file/36063/dose3-5.0.1.tar.gz";
+    sha256 = "00yvyfm4j423zqndvgc1ycnmiffaa2l9ab40cyg23pf51qmzk2jm";
+  };
+
+  patches = [
+    (fetchurl {
+      url = "${base_patch_url}/0001-Install-mli-cmx-etc.patch";
+      sha256 = "1cp2sjkv5psl7lpy6bziv6vihig1z09pp4xq1fdj7yz6lgz1z7xi";
+    })
+    (fetchurl {
+      url = "${base_patch_url}/0002-dont-make-printconf.patch";
+      sha256 = "0gzqm4p9p2gnn1cgl2r8m4lvzp5ap2lcdzsvi77i4p8pyzrybjnl";
+    })
+    (fetchurl {
+      url = "${base_patch_url}/0003-Fix-for-ocaml-4.06.patch";
+      sha256 = "02zxwn2hh861inc0r5707dymwh2aj9z3maqcan1cnhwfwshp59bv";
+    })
+    (fetchurl {
+      url = "${base_patch_url}/0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch";
+      sha256 = "0zdfh47bcx66b5lch5mn6lwdc67pvlwsnhvfwjrg7kiqssvgn0l1";
+    })
+  ];
+
+  buildInputs = [
+    ocaml
+    ocamlbuild
+    findlib
+    cppo
+    cudf
+    ocamlgraph
+    ocaml_extlib
+    re
+    perl
+  ];
+
+  makeFlags = [
+    "BINDIR=$(out)/bin"
+    "LIBDIR=$(out)/lib"
+    "INCDIR=$(out)/include"
+  ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "Dose library (part of Mancoosi tools).";
+    license = stdenv.lib.licenses.lgpl3;
+    homepage = "http://www.mancoosi.org/software/";
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-core/default.nix
+++ b/pkgs/development/ocaml-modules/opam-core/default.nix
@@ -3,13 +3,13 @@
 
 buildDunePackage rec {
   pname = "opam-core";
-  version = "2.0.5";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = "ocaml";
     repo = "opam";
     rev = version;
-    sha256 = "0pf2smq2sdcxryq5i87hz3dv05pb3zasb1is3kxq1pi1s4cn55mx";
+    sha256 = "1p719ccn9wnzk6impsnwr809yh507h8f37dx9nn64b1hsyb5z8ax";
   };
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/opam-core/default.nix
+++ b/pkgs/development/ocaml-modules/opam-core/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, buildDunePackage
+, cppo, ocamlgraph, opam-file-format, re }:
+
+buildDunePackage rec {
+  pname = "opam-core";
+  version = "2.0.5";
+
+  src = fetchFromGitHub {
+    owner = "ocaml";
+    repo = "opam";
+    rev = version;
+    sha256 = "0pf2smq2sdcxryq5i87hz3dv05pb3zasb1is3kxq1pi1s4cn55mx";
+  };
+
+  buildInputs = [
+    cppo
+  ];
+
+  propagatedBuildInputs = [
+    ocamlgraph
+    opam-file-format
+    re
+  ];
+
+  enable_checks = "no";
+
+  meta = {
+    description = "Small standard library extensions, and generic system interaction modules used by opam.";
+    license = stdenv.lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-format/default.nix
+++ b/pkgs/development/ocaml-modules/opam-format/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, opam-core }:
+
+buildDunePackage rec {
+  pname = "opam-format";
+  inherit (opam-core) version src enable_checks;
+
+  propagatedBuildInputs = [
+    opam-core
+  ];
+
+  meta = {
+    description = "Definition of opam datastructures and its file interface.";
+    license = stdenv.lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-repository/default.nix
+++ b/pkgs/development/ocaml-modules/opam-repository/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, opam-format }:
+
+buildDunePackage rec {
+  pname = "opam-repository";
+  inherit (opam-format) version src enable_checks;
+
+  propagatedBuildInputs = [
+    opam-format
+  ];
+
+  meta = {
+    description = "This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends.";
+    license = stdenv.lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-state/default.nix
+++ b/pkgs/development/ocaml-modules/opam-state/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "opam-state";
   inherit (opam-repository) version src enable_checks;
 
-  buildInputs = [
+  propagatedBuildInputs = [
     opam-repository
   ];
 

--- a/pkgs/development/ocaml-modules/opam-state/default.nix
+++ b/pkgs/development/ocaml-modules/opam-state/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, opam-repository }:
+
+buildDunePackage rec {
+  pname = "opam-state";
+  inherit (opam-repository) version src enable_checks;
+
+  buildInputs = [
+    opam-repository
+  ];
+
+  meta = {
+    description = "Handling of the ~/.opam hierarchy, repository and switch states.";
+    license = stdenv.lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/tools/ocaml/esy/default.nix
+++ b/pkgs/development/tools/ocaml/esy/default.nix
@@ -1,25 +1,62 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, reason }:
-
-with ocamlPackages;
+{ stdenv, fetchFromGitHub, fetchurl, buildDunePackage, ocamlPackages, esy-solve-cudf, reason }:
 
 buildDunePackage rec {
   pname = "esy";
-  version = "0.5.8";
+  version = "0.6.2";
 
-  src = fetchFromGitHub {
-    owner = "esy";
-    repo = "esy";
-    rev = "v${version}";
-    sha256 = "0n2606ci86vqs7sm8icf6077h5k6638909rxyj43lh55ah33l382";
-  };
+  srcs = [
+    (fetchFromGitHub {
+      owner = "esy";
+      repo = "esy";
+      rev = "v${version}";
+      sha256 = "1k2mlykgldm17akk9f7g8na68w7kshffnkpnhbawpk6bczh6xjmx";
+    })
+    (fetchurl {
+      url = "https://registry.npmjs.org/esy/${version}";
+      sha256 = "0byqaby0x54cmrhgsk4p8p4nz2f6cqdxkk2zdz10aja89rp0pj0l";
+    })
+  ];
 
-  buildInputs = [
+  # causes https://github.com/kamilchm/nix-esy/issues/1
+  patches = [
+    (fetchurl {
+      url = "https://patch-diff.githubusercontent.com/raw/esy/esy/pull/988.patch";
+      sha256 = "1cx1f806g8mzhv183cxj7cl8cxfq967ls8pafgdilssg4aj26mj4";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace esy-build/Scope.re \
+      --replace "/bin/bash" "/usr/bin/env bash"
+    substituteInPlace esy-install/Fetch.re \
+      --replace "/bin/bash" "/usr/bin/env bash"
+    substituteInPlace bin/Project.re \
+      --replace "/bin/bash" "/usr/bin/env bash"
+    substituteInPlace bin/esy.re \
+      --replace "/bin/bash" "/usr/bin/env bash"
+  '';
+
+  outputs = [ "out" "npm" ];
+
+  unpackPhase = '' # basically the default unpackPhase, just only on first source
+    runHook preUnpack
+    set -- $srcs
+    unpackFile $1
+    sourceRoot="source"
+    chmod -R u+w -- $sourceRoot
+    runHook postUnpack
+  '';
+
+  useDune2 = true;
+
+  buildInputs = with ocamlPackages; [
     angstrom
     astring
     bos
     cmdliner
     cudf
     dose3
+    dune-configurator
     fmt
     logs
     lwt_ppx
@@ -40,10 +77,52 @@ buildDunePackage rec {
     yojson
   ];
 
+  buildPhase = ''
+    runHook preBuild
+    dune build -p ${pname},${pname}-build-package
+    runHook postBuild
+  '';
+
+  # |- bin
+  #   |- esy
+  # |- lib
+  #   |- default
+  #     |- bin
+  #       |- esy.exe
+  #       |- esyInstallRelease.js
+  #     |- esy-build-package
+  #       |- bin
+  #       |- esyBuildPackageCommand.exe
+  #       |- esyRewritePrefixCommand.exe
+  #   |- node_modules
+  #     |- esy-solve-cudf
+  #       |- package.json
+  #       |- esySolveCudfCommand.exe
+  # |- package.json
+
+  postInstall = ''
+    mkdir -p $out/lib/default/bin
+    mkdir -p $out/lib/default/esy-build-package/bin
+    mkdir -p $out/lib/node_modules/esy-solve-cudf
+    mv $out/bin/esy $out/lib/default/bin/esy.exe
+    mv $out/bin/esyInstallRelease.js $out/lib/default/bin/
+    mv $out/bin/esy-build-package $out/lib/default/esy-build-package/bin/esyBuildPackageCommand.exe
+    mv $out/bin/esy-rewrite-prefix $out/lib/default/esy-build-package/bin/esyRewritePrefixCommand.exe
+    ln -s $out/lib/default/bin/esy.exe $out/bin/esy
+    set -- $srcs
+    cp $2 $out/package.json
+
+    # install esy-solve-cudf dependency
+    cp ${esy-solve-cudf}/bin/esy-solve-cudf $out/lib/node_modules/esy-solve-cudf/esySolveCudfCommand.exe
+    cp ${esy-solve-cudf.npm}/package.json $out/lib/node_modules/esy-solve-cudf/package.json
+
+    mkdir $npm
+    cp $2 $npm/package.json
+  '';
+
   meta = {
     description = "package.json workflow for native development with Reason/OCaml";
     license = stdenv.lib.licenses.bsd2;
-    maintainers = [ stdenv.lib.maintainers.Zimmi48 ];
     homepage = "https://esy.sh";
   };
 }

--- a/pkgs/development/tools/ocaml/esy/default.nix
+++ b/pkgs/development/tools/ocaml/esy/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, ocamlPackages, reason }:
+
+with ocamlPackages;
+
+buildDunePackage rec {
+  pname = "esy";
+  version = "0.5.8";
+
+  src = fetchFromGitHub {
+    owner = "esy";
+    repo = "esy";
+    rev = "v${version}";
+    sha256 = "0n2606ci86vqs7sm8icf6077h5k6638909rxyj43lh55ah33l382";
+  };
+
+  buildInputs = [
+    angstrom
+    astring
+    bos
+    cmdliner
+    cudf
+    dose3
+    fmt
+    logs
+    lwt_ppx
+    opam-file-format
+    opam-format
+    opam-state
+    ppx_deriving
+    ppx_deriving_yojson
+    ppx_expect
+    ppx_here
+    ppx_inline_test
+    ppx_let
+    ppx_sexp_conv
+    ppxlib
+    re
+    reason
+    rresult
+    yojson
+  ];
+
+  meta = {
+    description = "package.json workflow for native development with Reason/OCaml";
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = [ stdenv.lib.maintainers.Zimmi48 ];
+    homepage = "https://esy.sh";
+  };
+}

--- a/pkgs/development/tools/ocaml/esy/solve-cudf.nix
+++ b/pkgs/development/tools/ocaml/esy/solve-cudf.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, fetchFromGitHub, buildDunePackage, ocamlPackages }:
+
+buildDunePackage rec {
+  pname = "esy-solve-cudf";
+  version = "0.1.10";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "andreypopp";
+      repo = "esy-solve-cudf";
+      rev = "d293f2116def0b0b02eef487158ae440d21cc8db";
+      sha256 = "174q1wkr31dn8vsvnlj4hzfgvbamqq74n7wxhbccriqmv8lz5a3g";
+      fetchSubmodules = true;
+    })
+    (fetchurl {
+      url = "https://registry.npmjs.org/esy-solve-cudf/${version}";
+      sha256 = "19m793mydd8gcgw1mbn7pd8fw2rhnd00k5wpa4qkx8a3zn6crjjf";
+    })
+  ];
+
+  outputs = [ "out" "npm" ];
+
+  buildInputs = with ocamlPackages; [ ocaml findlib ];
+  propagatedBuildInputs = with ocamlPackages; [ cmdliner cudf ocaml_extlib ];
+
+  unpackPhase = '' # basically the default unpackPhase, just only on first source
+    runHook preUnpack
+    set -- $srcs
+    unpackFile $1
+    sourceRoot="source"
+    chmod -R u+w -- $sourceRoot
+    runHook postUnpack
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    dune build -p ${pname},mccs
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    mkdir $npm
+    set -- $srcs
+    cp $2 $npm/package.json
+  '';
+
+  meta = {
+    homepage = https://github.com/andreypopp/esy-solve-cudf;
+    description = "package.json workflow for native development with Reason/OCaml";
+    license = stdenv.lib.licenses.gpl3;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -255,6 +255,8 @@ in
 
   etBook = callPackage ../data/fonts/et-book { };
 
+  esy = callPackage ../development/tools/ocaml/esy { };
+
   fetchbower = callPackage ../build-support/fetchbower {
     inherit (nodePackages) bower2nix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -255,7 +255,14 @@ in
 
   etBook = callPackage ../data/fonts/et-book { };
 
-  esy = callPackage ../development/tools/ocaml/esy { };
+  esy = callPackage ../development/tools/ocaml/esy {
+    ocamlPackages = ocaml-ng.esyOcamlPackages;
+    buildDunePackage = ocamlPackages.buildDunePackage;
+    esy-solve-cudf = callPackage ../development/tools/ocaml/esy/solve-cudf.nix {
+      inherit ocamlPackages;
+      inherit (ocamlPackages) buildDunePackage;
+    };
+  };
 
   fetchbower = callPackage ../build-support/fetchbower {
     inherit (nodePackages) bower2nix;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -202,6 +202,8 @@ let
 
     csv-lwt = callPackage ../development/ocaml-modules/csv/lwt.nix { };
 
+    cudf = callPackage ../development/ocaml-modules/cudf/default.nix { };
+
     curses = callPackage ../development/ocaml-modules/curses { };
 
     custom_printf = callPackage ../development/ocaml-modules/custom_printf { };
@@ -223,6 +225,8 @@ let
     dolog = callPackage ../development/ocaml-modules/dolog { };
 
     domain-name = callPackage ../development/ocaml-modules/domain-name { };
+
+    dose3 = callPackage ../development/ocaml-modules/dose3 { };
 
     dtoa = callPackage ../development/ocaml-modules/dtoa { };
 
@@ -699,7 +703,15 @@ let
 
     omd = callPackage ../development/ocaml-modules/omd { };
 
+    opam-core = callPackage ../development/ocaml-modules/opam-core { };
+
     opam-file-format = callPackage ../development/ocaml-modules/opam-file-format { };
+
+    opam-format = callPackage ../development/ocaml-modules/opam-format { };
+
+    opam-repository = callPackage ../development/ocaml-modules/opam-repository { };
+
+    opam-state = callPackage ../development/ocaml-modules/opam-state { };
 
     opium = callPackage ../development/ocaml-modules/opium { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1292,4 +1292,15 @@ in let inherit (pkgs) callPackage; in rec
   ocamlPackages_latest = ocamlPackages_4_10;
 
   ocamlPackages = ocamlPackages_4_09;
+
+  esyOcamlPackages = ocamlPackages.overrideScope' (self: super: {
+    cmdliner = super.cmdliner.overrideAttrs (oldAttrs : {
+      src = pkgs.fetchFromGitHub {
+        owner = "esy-ocaml";
+        repo = "cmdliner";
+        rev = "e9316bc34e4781ffdd51ffe6f2de7c59b36c741e";
+        sha256 = "0dly2gskcfh2cari5s87bfqahkf8jsxrzp2wb0madl3v9dgmil3b";
+      };
+    });
+  });
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A work-in-progress packaging of the [esy](esy.sh) package manager, by building on #65098 and https://github.com/esy/esy/pull/994.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

# Issues to be solved

While the binary seems to work fine, there are some issues. The largest of which is that `esy` doesn't seem able to compile `ocaml` (under NixOS), which I think will be resolved when https://github.com/esy-ocaml/ocaml/commit/1667562d3f6e8ff8d5703b206b43f7a083d6770d hits the npm package registry (I tried *really* hard to just use local version of `esy-ocaml/ocaml`, switching to the latest `4.8.1000+esy` branch, and editing the `package.json` of [what I was trying to compile](https://github.com/esy-ocaml/hello-reason/), but this just made the dependency resolver scream at me - I think it's very broken). As a result, I was unable to get this build of `esy` to build a single package (as it first needs to bootstrap the `ocaml` compiler), suggesting that more work is needed.

`esy` version 0.6.4 is out, but using this version causes complaints about `esy.lock` being corrupt on everything I tried - initially, I thought this was just that the format of `esy.lock` changed in a non-compatible way, but strangely when I tried version 0.6.4 on Arch Linux (by updating the PKGBUILD on the AUR) and it had no such issue. Fortunately, 0.6.2 doesn't seem to invalidate existing `esy.lock` directories. I wasn't able to package 0.6.3 easily because its `package.json` doesn't seem to be on the npm registry.

It might also be necessary to get some binaries (`gnum4`, `coreutils`, etc.) into the `PATH` used by `esy` when it builds too, but adding this to `buildInputs`/`propagateBuildInputs` doesn't seem to work (though strangely when I ran `esy` inside `nix-shell -p gnum4` it was somehow able to find `m4`).

cc @Zimmi48 @kamilchm @anmonteiro 