### PR TITLE
bat-extras: init at 20200408

### DIFF
--- a/pkgs/tools/misc/bat-extras/default.nix
+++ b/pkgs/tools/misc/bat-extras/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchFromGitHub, bash, less, makeWrapper, ncurses, bat, ripgrep
+, withShFmt ? true, shfmt
+, withPrettier ? true, nodePackages
+, withClangTools ? true, clang-tools
+, withRustFmt ? true, rustfmt
+, withEntr ? true, entr
+}:
+
+stdenv.mkDerivation rec {
+  pname   = "bat-extras";
+  version = "20200408";
+
+  src = fetchFromGitHub {
+    owner  = "eth-p";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "184d5rwasfpgbj2k98alg3wy8jmzna2dgfik98w2a297ky67s51v";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ bash makeWrapper ] ++ stdenv.lib.optional withShFmt shfmt;
+
+  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+
+  buildPhase = ''
+    patchShebangs test.sh
+    patchShebangs .test-framework/bin/best.sh
+
+    chmod u+x .test-framework/lib/print_util.sh
+    wrapProgram .test-framework/lib/print_util.sh \
+      --prefix PATH : "${ncurses}/bin" \
+
+    bash ./build.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/* $out/bin
+
+    substituteInPlace $out/bin/batgrep \
+      --replace '$PAGER' '${less}/bin/less'
+
+    substituteInPlace $out/bin/batwatch \
+      --replace '$PAGER' '${less}/bin/less'
+
+    wrapProgram $out/bin/batwatch \
+      ${stdenv.lib.optionalString withEntr "--prefix PATH ':' '${entr}/bin'"}
+
+    wrapProgram $out/bin/prettybat \
+      ${stdenv.lib.optionalString withClangTools "--prefix PATH ':' '${clang-tools}/bin'"} \
+      ${stdenv.lib.optionalString withPrettier "--prefix PATH ':' '${nodePackages.prettier}/bin'"} \
+      ${stdenv.lib.optionalString withRustFmt "--prefix PATH ':' '${rustfmt}/bin'"} \
+      ${stdenv.lib.optionalString withShFmt "--prefix PATH ':' '${shfmt}/bin'"}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bash scripts that integrate bat with various command line tools";
+    homepage    = "https://github.com/eth-p/bat-extras";
+    license     = with licenses; [ mit ];
+    maintainers = with maintainers; [ bbigras ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1170,6 +1170,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  bat-extras = callPackage ../tools/misc/bat-extras { };
+
   bc = callPackage ../tools/misc/bc { };
 
   bdf2psf = callPackage ../tools/misc/bdf2psf { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Some wrappers tools for `bat`. Not by the same dev but they are linked on https://github.com/sharkdp/bat.

I don't know if I do `chmod u+x` for nothing or if there's a way to force `wrapProgram` even if the sh is not executable. 

The `--replace '$PAGER' '${less}/bin/less'` parts are weird. I tried to replace `less` with `wrapProgram` at first but failed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/zyb128zq9jydyv1l53yjx6bwgw09hwq8-bat-extras-20200408	  36.4M

with all optional enabled
/nix/store/a4jav90xic79vn8kgxm3zi51a9zc9dy5-bat-extras-20200408	   1.1G

maybe cc the bat maintainers @dywedir @lilyball 