### PR TITLE
reason-language-server: init at 1.7.8

### DIFF
--- a/pkgs/development/compilers/bs-platform/build-bs-platform.nix
+++ b/pkgs/development/compilers/bs-platform/build-bs-platform.nix
@@ -57,8 +57,7 @@ stdenv.mkDerivation rec {
     cp jscomp/others/*.ml jscomp/others/*.mli jscomp/others/*.cm* $out/lib/ocaml
     cp jscomp/stdlib-406/*.ml jscomp/stdlib-406/*.mli jscomp/stdlib-406/*.cm* $out/lib/ocaml
     cp bsconfig.json package.json $out
-    ln -s $out/bsb $out/bin/bsb
-    ln -s $out/bsc $out/bin/bsc
-    ln -s $out/bsrefmt $out/bin/bsrefmt
+    ln -s $out/bsb $out/bsc $out/bsrefmt $out/bin
+    ln -s $out/bsb $out/bsc $out/bsrefmt $out/lib
   '';
 }

--- a/pkgs/development/compilers/reason/default.nix
+++ b/pkgs/development/compilers/reason/default.nix
@@ -1,9 +1,7 @@
-{ stdenv, makeWrapper, fetchFromGitHub, ocaml, findlib, dune
-, fix, menhir, merlin-extend, ppx_tools_versioned, utop, cppo
-}:
+{ stdenv, makeWrapper, fetchFromGitHub, ocamlPackages }:
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-reason-${version}";
+  name = "ocaml${ocamlPackages.ocaml.version}-reason-${version}";
   version = "3.6.0";
 
   src = fetchFromGitHub {
@@ -15,17 +13,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  propagatedBuildInputs = [ menhir merlin-extend ppx_tools_versioned ];
+  propagatedBuildInputs = with ocamlPackages; [ menhir merlin-extend ppx_tools_versioned ];
 
-  buildInputs = [ ocaml findlib dune cppo fix utop menhir ];
+  buildInputs = with ocamlPackages; [ ocaml findlib dune cppo fix utop menhir ];
 
   buildFlags = [ "build" ]; # do not "make tests" before reason lib is installed
 
-  inherit (dune) installPhase;
+  inherit (ocamlPackages.dune) installPhase;
 
   postInstall = ''
     wrapProgram $out/bin/rtop \
-      --prefix PATH : "${utop}/bin" \
+      --prefix PATH : "${ocamlPackages.utop}/bin" \
       --prefix CAML_LD_LIBRARY_PATH : "$CAML_LD_LIBRARY_PATH" \
       --prefix OCAMLPATH : "$OCAMLPATH:$OCAMLFIND_DESTDIR"
   '';
@@ -34,7 +32,7 @@ stdenv.mkDerivation rec {
     homepage = "https://reasonml.github.io/";
     description = "Facebook's friendly syntax to OCaml";
     license = licenses.mit;
-    inherit (ocaml.meta) platforms;
+    inherit (ocamlPackages.ocaml.meta) platforms;
     maintainers = [ maintainers.volth ];
   };
 }

--- a/pkgs/development/tools/reason-language-server/default.nix
+++ b/pkgs/development/tools/reason-language-server/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, ocamlPackages, reason }:
+
+let compatibleReason = reason.override { inherit ocamlPackages; };
+in
+buildDunePackage rec {
+  pname = "reason-language-server";
+  version = "1.7.8";
+
+  buildInputs = with ocamlPackages; [ ocaml-migrate-parsetree compatibleReason uri ];
+
+  src = fetchFromGitHub {
+    owner = "jaredly";
+    repo = "reason-language-server";
+    rev = "${version}";
+    sha256 = "03l4fpqli6ma6nkhi168lizvd9nr1m4kbfqbmkwir6z67d51ybm9";
+  };
+
+  preConfigure = ''
+    # manually disable tests
+    rm test/dune util_tests/dune
+  '';
+
+  installPhase = ''
+    install -D _build/default/bin/Bin.exe $out/bin/reason-language-server
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1354,6 +1354,11 @@ in
 
   bs-platform = callPackage ../development/compilers/bs-platform {};
 
+  reason-language-server = callPackage ../development/tools/reason-language-server {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_08;
+    inherit (ocaml-ng.ocamlPackages_4_08) buildDunePackage;
+  };
+
   c3d = callPackage ../applications/graphics/c3d {
     stdenv = gcc8Stdenv;
     inherit (darwin.apple_sdk.frameworks) Cocoa;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Language Server for Reason.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

# How to test

Configure your editor by telling it where the binary lives: `${pkgs.reason-language-server}/bin/reason-language-server`, then

```
nix-shell -p bs-platform
bsb -init my-reason-project -theme basic-reason
cd my-reason project
$EDITOR src/Demo.re
```