### PR TITLE
xcbuild: add support for exporting sdk info

### DIFF
--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -110,11 +110,15 @@ runCommand "xcodebuild-${xcbuild.version}" {
   mkdir -p $out/Applications/Xcode.app/Contents
   ln -s $out $out/Applications/Xcode.app/Contents/Developer
 
+  # The native xcodebuild command supports an invocation like "xcodebuild -version -sdk" without specifying the specific SDK, so we simulate this by
+  # detecting this case and simulating the output; printing the header and appending the normal output via appending the sdk version to the positional
+  # arguments we pass through to the wrapped xcodebuild.
   makeWrapper ${xcbuild}/bin/xcodebuild $out/bin/xcodebuild \
     --add-flags "-xcconfig ${xcconfig}" \
     --add-flags "DERIVED_DATA_DIR=." \
     --set DEVELOPER_DIR "$out" \
     --set SDKROOT ${sdkName} \
+    --run '[ "$#" -eq 2 ] && [ "$1" = "-version" ] && [ "$2" = "-sdk" ] && echo ${sdkName}.sdk - macOS ${sdkVer} \(macosx${sdkVer}\) && set -- "$@" "${sdkName}"' \
     --run '[ "$1" = "-version" ] && [ "$#" -eq 1 ] && (echo Xcode ${xcodeVer}; echo Build version ${sdkBuildVersion}) && exit 0' \
     --run '[ "$1" = "-license" ] && exit 0'
 


### PR DESCRIPTION
"Real" xcodebuild allows using `xcodebuild -version -sdk` without
an sdk version argument, which will dump sdk info for all the
installed sdks.

Bazel"s "xcode cc toolchain setup on mac" process uses this
to determine which SDK version is actually installed.  This
change allows using a nix-supplied pinned compiler and build
system under bazel.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
