### PR TITLE
kibi: init at 0.2.0

### DIFF
--- a/pkgs/applications/editors/kibi/default.nix
+++ b/pkgs/applications/editors/kibi/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kibi";
+  version = "0.2.0";
+
+  cargoSha256 = "0zyqzb3k4ak7h58zjbg9b32hz1vgbbn9i9l85j4vd4aw8mhsz0n9";
+
+  src = fetchFromGitHub {
+    owner = "ilai-deutel";
+    repo = "kibi";
+    rev = "v${version}";
+    sha256 = "1cqnzw6gpsmrqcz82zn1x5i6najcr3i7shj0wnqzpwppff9a6yac";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A text editor in ≤1024 lines of code, written in Rust";
+    homepage = "https://github.com/ilai-deutel/kibi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ robertodr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4509,6 +4509,8 @@ in
   kibana = kibana6;
   kibana-oss = kibana6-oss;
 
+  kibi = callPackage ../applications/editors/kibi { };
+
   kismet = callPackage ../applications/networking/sniffers/kismet { };
 
   klick = callPackage ../applications/audio/klick { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

Added the [kibi editor](https://github.com/ilai-deutel/kibi)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
