### PR TITLE
vdagent: fixing 90s timeout on shutdown

### DIFF
--- a/pkgs/applications/virtualization/spice-vdagent/default.nix
+++ b/pkgs/applications/virtualization/spice-vdagent/default.nix
@@ -8,6 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "0n9k2kna2gd1zi6jv45zsp2jlv439nz5l5jjijirxqaycwi74srf";
   };
   NIX_CFLAGS_COMPILE = [ "-Wno-error=address-of-packed-member" ];
+  patchFlags = [ "-uNp1" ];
+  # included in the next release.
+  patches = [ ./timeout.diff ];
   postPatch = ''
     substituteInPlace data/spice-vdagent.desktop --replace /usr $out
   '';

--- a/pkgs/applications/virtualization/spice-vdagent/timeout.diff
+++ b/pkgs/applications/virtualization/spice-vdagent/timeout.diff
@@ -1,0 +1,84 @@
+diff --git a/src/udscs.c b/src/udscs.c
+index 4de75f8..7c99eed 100644
+--- a/src/udscs.c
++++ b/src/udscs.c
+@@ -186,6 +186,7 @@ struct udscs_server *udscs_server_new(
+     server->read_callback = read_callback;
+     server->error_cb = error_cb;
+     server->service = g_socket_service_new();
++    g_socket_service_stop(server->service);
+ 
+     g_signal_connect(server->service, "incoming",
+         G_CALLBACK(udscs_server_accept_cb), server);
+@@ -223,6 +224,11 @@ void udscs_server_listen_to_address(struct udscs_server *server,
+     g_object_unref(sock_addr);
+ }
+ 
++void udscs_server_start(struct udscs_server *server)
++{
++    g_socket_service_start(server->service);
++}
++
+ void udscs_server_destroy_connection(struct udscs_server *server,
+                                      UdscsConnection     *conn)
+ {
+diff --git a/src/udscs.h b/src/udscs.h
+index 45ebd3f..4f7ea36 100644
+--- a/src/udscs.h
++++ b/src/udscs.h
+@@ -98,6 +98,8 @@ void udscs_server_listen_to_address(struct udscs_server *server,
+                                     const gchar         *addr,
+                                     GError             **err);
+ 
++void udscs_server_start(struct udscs_server *server);
++
+ void udscs_server_destroy_connection(struct udscs_server *server,
+                                      UdscsConnection     *conn);
+ 
+diff --git a/src/vdagentd/vdagentd.c b/src/vdagentd/vdagentd.c
+index cfd0a51..753c9bf 100644
+--- a/src/vdagentd/vdagentd.c
++++ b/src/vdagentd/vdagentd.c
+@@ -1184,10 +1184,6 @@ int main(int argc, char *argv[])
+         uinput_device = g_strdup(DEFAULT_UINPUT_DEVICE);
+     }
+ 
+-    g_unix_signal_add(SIGINT, signal_handler, NULL);
+-    g_unix_signal_add(SIGHUP, signal_handler, NULL);
+-    g_unix_signal_add(SIGTERM, signal_handler, NULL);
+-
+     openlog("spice-vdagentd", do_daemonize ? 0 : LOG_PERROR, LOG_USER);
+ 
+     /* Setup communication with vdagent process(es) */
+@@ -1228,9 +1224,6 @@ int main(int argc, char *argv[])
+         }
+     }
+ 
+-    if (do_daemonize)
+-        daemonize();
+-
+ #ifdef WITH_STATIC_UINPUT
+     uinput = vdagentd_uinput_create(uinput_device, 1024, 768, NULL, 0,
+                                     debug > 1, uinput_fake);
+@@ -1240,6 +1233,13 @@ int main(int argc, char *argv[])
+     }
+ #endif
+ 
++    if (do_daemonize)
++        daemonize();
++
++    g_unix_signal_add(SIGINT, signal_handler, NULL);
++    g_unix_signal_add(SIGHUP, signal_handler, NULL);
++    g_unix_signal_add(SIGTERM, signal_handler, NULL);
++
+     if (want_session_info)
+         session_info = session_info_create(debug);
+     if (session_info) {
+@@ -1252,6 +1252,7 @@ int main(int argc, char *argv[])
+ 
+     active_xfers = g_hash_table_new(g_direct_hash, g_direct_equal);
+ 
++    udscs_server_start(server);
+     loop = g_main_loop_new(NULL, FALSE);
+     g_main_loop_run(loop);
+ 


### PR DESCRIPTION
###### Motivation for this change

In vdagent 0.20.0 was a bug introduced that causes a 90s timeout during shutdown. Upstream it's already fixed: https://gitlab.freedesktop.org/spice/linux/vd_agent/-/merge_requests/7 so the patch just needs to be applied here.

Fixes: https://github.com/NixOS/nixpkgs/issues/85235

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
