### PR TITLE
mit-scheme: 9.2 -> 10.1.10

### DIFF
--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -2,12 +2,11 @@
   enableX11 ? false, xlibsWrapper ? null }:
 
 let
-  version = "9.2";
+  version = "10.1.10";
   bootstrapFromC = ! (stdenv.isi686 || stdenv.isx86_64);
 
   arch = if      stdenv.isi686   then "-i386"
-         else if stdenv.isx86_64 then "-x86-64"
-         else                         "";
+         else                         "-x86-64";
 in
 stdenv.mkDerivation {
   name = if enableX11 then "mit-scheme-x11-${version}" else "mit-scheme-${version}";
@@ -20,14 +19,10 @@ stdenv.mkDerivation {
     if stdenv.isi686
     then fetchurl {
       url = "mirror://gnu/mit-scheme/stable.pkg/${version}/mit-scheme-${version}-i386.tar.gz";
-      sha256 = "1fmlpnhf5a75db93phajh4ysbdgrgl72v45lk3kznriprl0a7jc6";
-    } else if stdenv.isx86_64
-    then fetchurl {
+      sha256 = "117lf06vcdbaa5432hwqnskpywc6x8ai0gj99h480a4wzkp3vhy6";
+  } else fetchurl {
       url = "mirror://gnu/mit-scheme/stable.pkg/${version}/mit-scheme-${version}-x86-64.tar.gz";
-      sha256 = "1skzxxhr0iq96bf0j5m7mvf3i4sppfyfa6gpqn34mwgkw1fx8274";
-    } else fetchurl {
-      url = "mirror://gnu/mit-scheme/stable.pkg/${version}/mit-scheme-c-${version}.tar.gz";
-      sha256 = "0w5ib5vsidihb4hb6fma3sp596ykr8izagm57axvgd6lqzwicsjg";
+      sha256 = "1rljv6iddrbssm91c0nn08myj92af36hkix88cc6qwq38xsxs52g";
     };
 
   buildInputs = if enableX11 then [xlibsWrapper] else [];


### PR DESCRIPTION
###### Motivation for this change
The last update has been in 2014 (to 9.2) but a major new release has came out since then (10.x).

Additional notes from commit:

> See discussion at https://discourse.nixos.org/t/6776
> but to sum up:
> 
> The portable  C source and Windows  binaries are not
> available in the latest MIT Scheme release
> (see https://www.gnu.org/software/mit-scheme/release.html )
> Warning: Locale seems not configured
> hence  the  option  to  build from  source has  been
> removed  from  `default.nix`.  Although there  is  a
> source package  included in the release  (in lieu of
> the portable C source), there is a caveat:
> 
> > Note that you cannot build a working system from the
> > source  unless you  have  a  working MIT/GNU  Scheme
> > compiler to do the  compilation. (This doesn't apply
> > to the  portable C source,  which requires only  a C
> > compiler.)  This means  that if  the above  binaries
> > don't work  on your system,  it is pointless  to try
> > building a  custom set  of binaries from  the source
> > code.
> 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions (`Ubuntu 18.04.3 LTS`)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) 
```text
/nix/store/gyszp2r7dl84n8sry6k89c1as74b993p-mit-scheme-9.2	 622.7M
/nix/store/906m1g2z7qncvzcplfys4sqxzw3fxay4-mit-scheme-10.1.10	 273.3M
```
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). (_To the best of my knowledge._)