### PR TITLE
pyclipper: init at 1.1.0.post3

### DIFF
--- a/pkgs/development/python-modules/pyclipper/default.nix
+++ b/pkgs/development/python-modules/pyclipper/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, setuptools_scm
+, cython
+}:
+
+buildPythonPackage rec {
+  pname = "pyclipper";
+  version = "1.1.0.post3";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "164yksvqwqvwzh8f8lq92asg87hd8rvcy2xb5vm4y4ccvd5xgb7i";
+  };
+
+  nativeBuildInputs = [
+    setuptools_scm
+    cython
+  ];
+
+  # Requires pytest_runner to perform tests, which requires deprecated
+  # features of setuptools. Seems better to not run tests. This should
+  # be fixed upstream.
+  doCheck = false;
+  pythonImportsCheck = [ "pyclipper" ];
+
+  meta = with stdenv.lib; {
+    description = "Cython wrapper for clipper library";
+    homepage    = "https://github.com/fonttools/pyclipper";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ matthuszagh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1071,6 +1071,8 @@ in {
 
   purl = callPackage ../development/python-modules/purl { };
 
+  pyclipper = callPackage ../development/python-modules/pyclipper { };
+
   pymystem3 = callPackage ../development/python-modules/pymystem3 { };
 
   pymysql = callPackage ../development/python-modules/pymysql { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adds [pyclipper](https://github.com/fonttools/pyclipper) python module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
