### PR TITLE
ocamlPackages.dns: 4.4.1 -> 4.5.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -4,19 +4,19 @@ assert stdenv.lib.versionAtLeast ocamlPackages.ocaml.version "4.07";
 
 stdenv.mkDerivation {
   pname = "jackline";
-  version = "unstable-2020-03-22";
+  version = "unstable-2020-04-24";
 
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "jackline";
-    rev    = "52f84525c74c43e8d03fb1e6ff025ccb2699e4aa";
-    sha256 = "0wir573ah1w16xzdn9rfwk3569zq4ff5frp0ywq70va4gdlb679c";
+    rev    = "885b97b90d565f5f7c2b5f66f5edf14a82251b87";
+    sha256 = "1mdn413ya2g0a1mrdbh1b65gnygrxb08k99z5lmidhh34kd1llsj";
   };
 
   buildInputs = with ocamlPackages; [
                   ocaml ocamlbuild findlib topkg ppx_sexp_conv ppx_deriving
                   erm_xmpp tls mirage-crypto mirage-crypto-pk x509 domain-name
-                  ocaml_lwt otr astring ptime mtime notty sexplib hex uutf
+                  ocaml_lwt otr astring ptime notty sexplib hex uutf
                   dns-client base64
                 ];
 

--- a/pkgs/development/ocaml-modules/dns/client.nix
+++ b/pkgs/development/ocaml-modules/dns/client.nix
@@ -1,10 +1,14 @@
-{ lib, buildDunePackage, dns, ocaml_lwt, mirage-clock, mirage-random, mirage-stack, mtime, randomconv }:
+{ lib, buildDunePackage, dns, ocaml_lwt, mirage-clock, mirage-time
+, mirage-random, mirage-stack, mirage-crypto-rng, mtime, randomconv }:
 
 buildDunePackage {
   pname = "dns-client";
   inherit (dns) src version;
 
-  propagatedBuildInputs = [ dns mtime ocaml_lwt mirage-clock mirage-random mirage-stack randomconv ];
+  useDune2 = true;
+
+  propagatedBuildInputs = [ dns mtime ocaml_lwt randomconv mirage-clock mirage-time
+                            mirage-random mirage-stack mirage-crypto-rng ];
 
   meta = dns.meta // {
     description = "Pure DNS resolver API";

--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -4,13 +4,13 @@
 
 buildDunePackage rec {
   pname = "dns";
-  version = "4.4.1";
+  version = "4.5.0";
 
   minimumOCamlVersion = "4.07";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-v${version}.tbz";
-    sha256 = "18c09jf0kicv2xz40n367y774rg8qs07rr1vdk8bx8f7hnaa9cn8";
+    sha256 = "10jrnnxvp06rvzk285wibyi9hn15qhjnqjy9xsfbwl8yhmzzqnq0";
   };
 
   propagatedBuildInputs = [ cstruct domain-name duration gmap ipaddr logs lru metrics ptime rresult ];

--- a/pkgs/development/ocaml-modules/mirage-time/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-time/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, fetchurl, ocaml_lwt }:
+
+buildDunePackage rec {
+  minimumOCamlVersion = "4.06";
+
+  pname = "mirage-time";
+  version = "2.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-time/releases/download/v${version}/mirage-time-v${version}.tbz";
+    sha256 = "1w6mm4g7fc19cs0ncs0s9fsnb1k1s04qqzs9bsqvq8ngsb90cbh0";
+  };
+
+  propagatedBuildInputs = [ ocaml_lwt ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mirage/mirage-time";
+    description = "Time operations for MirageOS";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-time/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-time/unix.nix
@@ -1,0 +1,13 @@
+{ buildDunePackage, fetchurl, mirage-time, ocaml_lwt, duration }:
+
+buildDunePackage {
+  pname = "mirage-time-unix";
+
+  inherit (mirage-time) src version minimumOCamlVersion;
+
+  propagatedBuildInputs = [ mirage-time ocaml_lwt duration ];
+
+  meta = mirage-time.meta // {
+    description = "Time operations for MirageOS on Unix";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -562,6 +562,10 @@ let
 
     mirage-stack = callPackage ../development/ocaml-modules/mirage-stack { };
 
+    mirage-time = callPackage ../development/ocaml-modules/mirage-time { };
+
+    mirage-time-unix = callPackage ../development/ocaml-modules/mirage-time/unix.nix { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };


### PR DESCRIPTION
Also adds new dependency `mirage-time` and its associated unix variant.

~~This update currently breaks `jackline`, waiting on upstream to fix it / [my fix](https://github.com/hannesm/jackline/pull/211) to get merged. Just opening this PR already so nobody else needlessly starts working on it :)~~

cc @vbgl