### PR TITLE
wxformbuilder: init at unstable-2020-08-18

### DIFF
--- a/pkgs/development/tools/wxformbuilder/default.nix
+++ b/pkgs/development/tools/wxformbuilder/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchFromGitHub
+, wxGTK31
+, meson
+, ninja
+}:
+
+stdenv.mkDerivation {
+  pname = "wxFormBuilder";
+  version = "unstable-2020-08-18";
+
+  src = fetchFromGitHub {
+    owner = "wxFormBuilder";
+    repo = "wxFormBuilder";
+    rev = "d053665cc33a79dd935b518b5e7aea6baf493c92";
+    sha256 = "sha256-hTO7Fyp5ZWpq2CfIYEXB85oOkNrqr6Njfh8h0t9B6wU=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    ninja
+    meson
+  ];
+
+  buildInputs = [
+    wxGTK31
+  ];
+
+  meta = with stdenv.lib; {
+    description = "RAD tool for wxWidgets GUI design";
+    homepage = "https://github.com/wxFormBuilder/wxFormBuilder";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ matthuszagh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15681,6 +15681,8 @@ in
     wt3
     wt4;
 
+  wxformbuilder = callPackage ../development/tools/wxformbuilder { };
+
   wxGTK = wxGTK28;
 
   wxGTK30 = wxGTK30-gtk2;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adds [wxFormBuilder](https://github.com/wxFormBuilder/wxFormBuilder).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
