### PR TITLE
deepin.deepin-anything: fix building with linux kernel 5.6

### DIFF
--- a/pkgs/desktops/deepin/deepin-anything/default.nix
+++ b/pkgs/desktops/deepin/deepin-anything/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qtbase, udisks2-qt5, utillinux,
+{ stdenv, mkDerivation, fetchFromGitHub, fetchpatch, pkgconfig, qtbase, udisks2-qt5, utillinux,
   dtkcore, deepin }:
 
 mkDerivation rec {
@@ -11,6 +11,16 @@ mkDerivation rec {
     rev = version;
     sha256 = "1kvyffrii4b012f6ld1ih14qrn7gg5cxbdpbkac0wxb22hnz0azm";
   };
+
+  patches = [
+    # fix compilation error and add support to kernel 5.6
+    # https://github.com/linuxdeepin/deepin-anything/pull/27
+    (fetchpatch {
+      name = "linux-5.6.patch";
+      url = "https://github.com/linuxdeepin/deepin-anything/commit/764b820c2bcd7248993349b32f91043fc58ee958.patch";
+      sha256 = "1ww4xllxc2s04px6fy8wp5cyw54xaz155ry30sqz21vl8awfr36h";
+    })
+  ];
 
   outputs = [ "out" "modsrc" ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

_Edit:_
Fix compilation error and add support to kernel 5.6.
See https://github.com/linuxdeepin/deepin-anything/pull/27

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).