### PR TITLE
libva: 2.6.1 -> 2.7.1

### DIFF
--- a/pkgs/development/libraries/libva-utils/default.nix
+++ b/pkgs/development/libraries/libva-utils/default.nix
@@ -7,10 +7,10 @@ stdenv.mkDerivation rec {
   inherit (libva) version;
 
   src = fetchFromGitHub {
-    owner  = "01org";
+    owner  = "intel";
     repo   = "libva-utils";
     rev    = version;
-    sha256 = "1yk9bg1wg4nqva3l01s6bghcvc3hb02gp62p1sy5qk0r9mn5kpik";
+    sha256 = "13a0dccphi4cpr2cx45kg4djxsssi3d1fcjrkx27b16xiayp5lx9";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];
@@ -26,10 +26,15 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    description = "VAAPI tools: Video Acceleration API";
-    homepage = "http://www.freedesktop.org/wiki/Software/vaapi";
+    description = "A collection of utilities and examples for VA-API";
+    longDescription = ''
+      libva-utils is a collection of utilities and examples to exercise VA-API
+      in accordance with the libva project.
+    '';
+    homepage = "https://github.com/intel/libva-utils";
+    changelog = "https://raw.githubusercontent.com/intel/libva-utils/${version}/NEWS";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ primeos ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   name = "libva-${lib.optionalString minimal "minimal-"}${version}";
-  version = "2.6.1";
+  version = "2.7.1"; # Also update the hash for libva-utils!
 
   # update libva-utils and vaapiIntel as well
   src = fetchFromGitHub {
-    owner  = "01org";
+    owner  = "intel";
     repo   = "libva";
     rev    = version;
-    sha256 = "1x34kf38p5rf52bf54ljr9f7knnbilm7kbszqnfk3lzsqrfc7r2g";
+    sha256 = "0ywasac7z3hwggj8szp83sbxi2naa0a3amblx64y7i1hyyrn0csq";
   };
 
   outputs = [ "dev" "out" ];
@@ -38,10 +38,17 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "VAAPI library: Video Acceleration API";
-    homepage = "http://www.freedesktop.org/wiki/Software/vaapi";
+    description = "An implementation for VA-API (Video Acceleration API)";
+    longDescription = ''
+      VA-API is an open-source library and API specification, which provides
+      access to graphics hardware acceleration capabilities for video
+      processing. It consists of a main library (this package) and
+      driver-specific acceleration backends for each supported hardware vendor.
+    '';
+    homepage = "https://01.org/linuxmedia/vaapi";
+    changelog = "https://raw.githubusercontent.com/intel/libva/${version}/NEWS";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ primeos ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Fixes #85850.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I built `libva-minimal`, `libva` (covers `mesa` and `libGL` as well), and `libva-utils`.

**Update:**
- Tested: VA using `mpv` with my old HD 6950 (`r600`): Worked fine
- Built: `intel-media-driver` `vaapiIntel` `vaapiVdpau` `libvdpau-va-gl`

Testing was only done via `vainfo`:
```
libva info: VA-API version 1.7.0
libva info: Trying to open /run/opengl-driver/lib/dri/r600_drv_video.so
libva info: Found init function __vaDriverInit_1_6
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.7 (libva 2.7.1)
vainfo: Driver version: Mesa Gallium driver 20.0.2 for AMD CAYMAN (DRM 2.50.0 / 5.4.31, LLVM 9.0.1)
vainfo: Supported profile and entrypoints
      VAProfileMPEG2Simple            :	VAEntrypointVLD
      VAProfileMPEG2Main              :	VAEntrypointVLD
      VAProfileVC1Simple              :	VAEntrypointVLD
      VAProfileVC1Main                :	VAEntrypointVLD
      VAProfileVC1Advanced            :	VAEntrypointVLD
      VAProfileH264ConstrainedBaseline:	VAEntrypointVLD
      VAProfileH264Main               :	VAEntrypointVLD
      VAProfileH264High               :	VAEntrypointVLD
      VAProfileNone                   :	VAEntrypointVideoProc
```

Rebuilding my whole system with this change would take way too long, but I could consider rebuilding a subset (focusing on important direct dependencies) if that would help.
**Update:** See above, I guess this update should be fine (or at least mostly).

Note: I added myself as maintainer as there wasn't one and I noticed both packages could use some other changes/improvements as well, but I'll do that in a separate PR to avoid too many changes at once.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
