### PR TITLE
twitter-color-emoji: 12.1.2 -> 12.1.5

### DIFF
--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -1,4 +1,4 @@
-# Based upon https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/tree/454acad50ba584d9602ccd4238fc5e585abc15c9
+# Based upon https://src.fedoraproject.org/rpms/twitter-twemoji-fonts
 # The main difference is that we use “Twitter Color Emoji” name (which is recognized by upstream fontconfig)
 
 { stdenv
@@ -15,14 +15,14 @@
 }:
 
 let
-  version = "12.1.2";
+  version = "12.1.5";
 
   twemojiSrc = fetchFromGitHub {
     name = "twemoji";
     owner = "twitter";
     repo = "twemoji";
     rev = "v${version}";
-    sha256 = "0vzmlp83vnk4njcfkn03jcc1vkg2rf12zf5kj3p3a373xr4ds1zn";
+    hash = "sha256-qb3bLiUgtA8QQ13u928kvM+3qwmQpyjUk0EPKja1kSk=";
   };
 
 in
@@ -54,10 +54,10 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # ImageMagick -> GrahphicsMagick
+    # ImageMagick -> GraphicsMagick
     (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/raw/3bc176c10ced2824fe03da5ff561e22a36bf8ccd/f/noto-emoji-use-gm.patch";
-      sha256 = "0yfmfzaaiq5163c06172g4r734aysiqyv1s28siv642vqzsqh4i2";
+      url = "https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/raw/07778605d50696f6aa929020e82611a01d254c90/f/noto-emoji-use-gm.patch";
+      sha256 = "sha256-kyJwT1SKS1vnXxvPTiIMK6TRHMp1ZOSlb6rodL4Jbxs=";
     })
   ];
 
@@ -114,7 +114,9 @@ stdenv.mkDerivation rec {
     # In twemoji source
     ## Artwork is Creative Commons Attribution 4.0 International
     ## Non-artwork is MIT
+    # In Fedora twitter-twemoji-fonts source
+    ## spec files are MIT: https://fedoraproject.org/wiki/Licensing:Main#License_of_Fedora_SPEC_Files
     license = with licenses; [ asl20 ofl cc-by-40 mit ];
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ jtojnar emily ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Twemoji version bump, plus a Fedora patch update to fix emoji size: https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/c/282c789d3742d223968a7ddcae6e65374f6dcae1?branch=master

Didn’t finish building locally because Zopfli is really slow, let’s saddle ofborg with it instead…

cc @jtojnar – out of curiosity, is there any particular reason to keep the ImageMagick → GraphicsMagick patch around, other than keeping close to the Fedora upstream? It seems like the only functional change it had was accidental…

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).