### PR TITLE
uriparser: 0.9.1 -> 0.9.3

### DIFF
--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, cmake, gtest, doxygen, graphviz }:
+{ lib, stdenv, fetchurl, fetchpatch, cmake, gtest }:
 
 stdenv.mkDerivation rec {
   pname = "uriparser";
@@ -18,7 +18,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ cmake doxygen graphviz ];
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DURIPARSER_BUILD_DOCS=OFF"
+  ];
 
   checkInputs = [ gtest ];
   doCheck = stdenv.targetPlatform.system == stdenv.hostPlatform.system;

--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -1,19 +1,26 @@
-{ lib, stdenv, fetchurl, gtest, pkgconfig, doxygen, graphviz }:
+{ lib, stdenv, fetchurl, fetchpatch, cmake, gtest, doxygen, graphviz }:
 
 stdenv.mkDerivation rec {
   pname = "uriparser";
-  version = "0.9.1";
+  version = "0.9.3";
 
   # Release tarball differs from source tarball
   src = fetchurl {
     url = "https://github.com/uriparser/uriparser/releases/download/${pname}-${version}/${pname}-${version}.tar.bz2";
-    sha256 = "1gisi7h8hd6mswbiaaa3s25bnb77xf37pzrmjy63rcdpwcyqy93m";
+    sha256 = "13z234jdaqs9jj7i66gcv4q1rgsypjz6cighnlm1j4g80pdlmbr8";
   };
 
-  nativeBuildInputs = [ pkgconfig doxygen graphviz ];
-  buildInputs = lib.optional doCheck gtest;
-  configureFlags = lib.optional (!doCheck) "--disable-tests";
+  patches = [
+    # fixes tests
+    (fetchpatch {
+      url = "https://github.com/uriparser/uriparser/commit/f870e6c68696a6018702caa5c8a2feba9b0f99fa.diff";
+      sha256 = "1nd6bhys9hwy6ippa42vm95zhw6hldm1s4xbdzmdjswc96as1ff5";
+    })
+  ];
 
+  nativeBuildInputs = [ cmake doxygen graphviz ];
+
+  checkInputs = [ gtest ];
   doCheck = stdenv.targetPlatform.system == stdenv.hostPlatform.system;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bump uriparser, reduce build dependencies bloat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
