### PR TITLE
ibus: fix dconf db installation

### DIFF
--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -64,7 +64,7 @@ in
     # Without dconf enabled it is impossible to use IBus
     programs.dconf.enable = true;
 
-    programs.dconf.profiles.ibus = "${ibusPackage}/etc/dconf/profile/ibus";
+    programs.dconf.packages = [ ibusPackage ];
 
     services.dbus.packages = [
       ibusAutostart

--- a/nixos/modules/programs/dconf.nix
+++ b/nixos/modules/programs/dconf.nix
@@ -4,13 +4,24 @@ with lib;
 
 let
   cfg = config.programs.dconf;
-
-  mkDconfProfile = name: path:
-    {
-      name = "dconf/profile/${name}";
-      value.source = path; 
-    };
-
+  cfgDir = pkgs.symlinkJoin {
+    name = "dconf-system-config";
+    paths = map (x: "${x}/etc/dconf") cfg.packages;
+    postBuild = ''
+      mkdir -p $out/profile
+      mkdir -p $out/db
+    '' + (
+      concatStringsSep "\n" (
+        mapAttrsToList (
+          name: path: ''
+            ln -s ${path} $out/profile/${name}
+          ''
+        ) cfg.profiles
+      )
+    ) + ''
+      ${pkgs.dconf}/bin/dconf update $out/db
+    '';
+  };
 in
 {
   ###### interface
@@ -22,18 +33,22 @@ in
       profiles = mkOption {
         type = types.attrsOf types.path;
         default = {};
-        description = "Set of dconf profile files.";
+        description = "Set of dconf profile files, installed at <filename>/etc/dconf/profiles/<replaceable>name</replaceable></filename>.";
         internal = true;
       };
 
+      packages = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = "A list of packages which provide dconf profiles and databases in <filename>/etc/dconf</filename>.";
+      };
     };
   };
 
   ###### implementation
 
   config = mkIf (cfg.profiles != {} || cfg.enable) {
-    environment.etc = optionalAttrs (cfg.profiles != {})
-      (mapAttrs' mkDconfProfile cfg.profiles);
+    environment.etc.dconf.source = mkIf (cfg.profiles != {} || cfg.packages != []) cfgDir;
 
     services.dbus.packages = [ pkgs.dconf ];
 

--- a/nixos/tests/installed-tests/ibus.nix
+++ b/nixos/tests/installed-tests/ibus.nix
@@ -5,16 +5,12 @@ makeInstalledTest {
 
   testConfig = {
     i18n.inputMethod.enabled = "ibus";
+    systemd.user.services.ibus-daemon = {
+      serviceConfig.ExecStart = "${pkgs.ibus}/bin/ibus-daemon --xim --verbose";
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+    };
   };
 
-  preTestScript = ''
-    # ibus has ibus-desktop-testing-runner but it tries to manage desktop session so we just spawn ibus-daemon ourselves
-    machine.succeed("ibus-daemon --daemonize --verbose")
-  '';
-
   withX11 = true;
-
-  # TODO: ibus-daemon is currently crashing or something
-  # maybe make ibus systemd service that auto-restarts?
-  meta.broken = true;
 }

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -16,6 +16,7 @@
 , gtk2
 , gtk3
 , gtk-doc
+, runCommand
 , isocodes
 , cldr-emoji-annotation
 , unicode-character-database
@@ -47,6 +48,14 @@ let
       makeWrapper ${glib.dev}/bin/glib-mkenums $out/bin/glib-mkenums --unset PYTHONPATH
     '';
   };
+  # make-dconf-override-db.sh needs to execute dbus-launch in the sandbox,
+  # it will fail to read /etc/dbus-1/session.conf unless we add this flag
+  dbus-launch = runCommand "sandbox-dbus-launch" {
+    nativeBuildInputs = [ makeWrapper ];
+  } ''
+      makeWrapper ${dbus}/bin/dbus-launch $out/bin/dbus-launch \
+        --add-flags --config-file=${dbus.daemon}/share/dbus-1/session.conf
+  '';
 in
 
 stdenv.mkDerivation rec {
@@ -71,7 +80,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "installedTests" ];
 
   postPatch = ''
-    echo \#!${runtimeShell} > data/dconf/make-dconf-override-db.sh
+    patchShebangs --build data/dconf/make-dconf-override-db.sh
     cp ${buildPackages.gtk-doc}/share/gtk-doc/data/gtk-doc.make .
   '';
 
@@ -105,6 +114,7 @@ stdenv.mkDerivation rec {
     python3BuildEnv
     vala
     wrapGAppsHook
+    dbus-launch
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Fix a warning when running ibus-daemon:

```
(ibus-dconf:15691): dconf-WARNING **: 21:49:24.018: unable to open file '/etc/dconf/db/ibus': Failed to open file ?/etc/dconf/db/ibus?: open() failed: No such file or directory; expect degraded performance
```

cc @jtojnar @worldofpeace about dconf.

###### Things done

* Tested that ibus still works and that the warning is gone in a vm
* ran the gnome and gnome-xorg tests to ensure the dconf.profiles options has not regressed

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
