### PR TITLE
[20.03] pythonPackages.stem: unmarked as broken

### DIFF
--- a/pkgs/development/python-modules/stem/default.nix
+++ b/pkgs/development/python-modules/stem/default.nix
@@ -26,6 +26,5 @@ buildPythonPackage rec {
     homepage = https://stem.torproject.org/;
     license = licenses.gpl3;
     maintainers = with maintainers; [ phreedom ];
-    broken = true;
   };
 }


### PR DESCRIPTION
The package was marked broken but seems to work on 20.03