### PR TITLE
remarkable-toolchain: init at 1.8-23.9.2019

### DIFF
--- a/pkgs/development/tools/misc/remarkable/remarkable-toolchain/default.nix
+++ b/pkgs/development/tools/misc/remarkable/remarkable-toolchain/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, libarchive, python3, file }:
+
+stdenv.mkDerivation rec {
+  pname = "remarkable-toolchain";
+  version = "1.8-23.9.2019";
+
+  src = fetchurl {
+    url = "https://remarkable.engineering/oecore-x86_64-cortexa9hf-neon-toolchain-zero-gravitas-${version}.sh";
+    sha256 = "6299955721bcd9bef92a87ad3cfe4d31df8e2da95b0c4b2cdded4431aa6748b0";
+  };
+
+  nativeBuildInputs = [
+    libarchive
+    python3
+    file
+  ];
+
+  unpackCmd = "mkdir src; install $curSrc src/install-toolchain.sh";
+
+  dontBuild = true;
+
+  installPhase = ''
+    patchShebangs install-toolchain.sh
+    sed -i -e '3,9d' install-toolchain.sh # breaks PATH
+    sed -i 's|PYTHON=.*$|PYTHON=${python3}/bin/python|' install-toolchain.sh
+    ./install-toolchain.sh -D -y -d $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A toolchain for cross-compiling to reMarkable tablets";
+    homepage = "https://remarkable.engineering/";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.nickhu ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8512,6 +8512,8 @@ in
 
   pscid = nodePackages.pscid;
 
+  remarkable-toolchain = callPackage ../development/tools/misc/remarkable/remarkable-toolchain { };
+
   tacacsplus = callPackage ../servers/tacacsplus { };
 
   tamarin-prover =


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add the cross-compile toolchain targeting the reMarkable tablet. This
toolchain can be added to Qt Creator, as described
[here](https://remarkablewiki.com/devel/qt_creator) for reMarkable
development. The main utility of this package is running
`autoPatchelfHook` to make the binaries work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).