### PR TITLE
remarkable-mouse: init at 5.2.1

### DIFF
--- a/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
+++ b/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonApplication, fetchPypi, python3Packages }:
+
+buildPythonApplication rec {
+  pname = "remarkable-mouse";
+  version = "5.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0k2wjfcgnvb8yqn4c4ddfyyhrvl6hj61kn1ddnyp6ay9vklnw160";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ screeninfo paramiko pynput libevdev ];
+
+  meta = with stdenv.lib; {
+    description = "A program to use a reMarkable as a graphics tablet";
+    homepage = "https://github.com/evidlo/remarkable_mouse";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.nickhu ];
+  };
+}

--- a/pkgs/development/python-modules/libevdev/default.nix
+++ b/pkgs/development/python-modules/libevdev/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, isPy27, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "libevdev";
+  version = "0.7";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10gwj08kn2rs4waq7807mq34cbavgkpg8fpir8mvnba601b8q4r4";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python wrapper around the libevdev C library";
+    homepage = "https://gitlab.freedesktop.org/libevdev/python-libevdev";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nickhu ];
+  };
+}

--- a/pkgs/development/python-modules/pynput/default.nix
+++ b/pkgs/development/python-modules/pynput/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, sphinx, setuptools-lint, xlib }:
+
+buildPythonPackage rec {
+  pname = "pynput";
+  version = "1.6.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16h4wn7f54rw30jrya7rmqkx3f51pxn8cplid95v880md8yqdhb8";
+  };
+
+  nativeBuildInputs = [ sphinx ];
+
+  propagatedBuildInputs = [ setuptools-lint xlib ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A library to control and monitor input devices";
+    homepage = "https://github.com/moses-palmer/pynput";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ nickhu ];
+  };
+}
+

--- a/pkgs/development/python-modules/screeninfo/default.nix
+++ b/pkgs/development/python-modules/screeninfo/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildPythonApplication, fetchPypi, isPy36, dataclasses, libX11, libXinerama, libXrandr }:
+
+buildPythonApplication rec {
+  pname = "screeninfo";
+  version = "0.6.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vcw54crdgmbzwlrfg80kd1a8p9i10yks8k0szzi0k5q80zhp8xz";
+  };
+
+  # dataclasses is a compatibility shim for python 3.6 ONLY
+  patchPhase = if isPy36 then "" else ''
+    substituteInPlace setup.py \
+      --replace "\"dataclasses\"," ""
+  '' + ''
+    substituteInPlace screeninfo/enumerators/xinerama.py \
+      --replace "load_library(\"X11\")" "ctypes.cdll.LoadLibrary(\"${libX11}/lib/libX11.so\")" \
+      --replace "load_library(\"Xinerama\")" "ctypes.cdll.LoadLibrary(\"${libXinerama}/lib/libXinerama.so\")"
+    substituteInPlace screeninfo/enumerators/xrandr.py \
+      --replace "load_library(\"X11\")" "ctypes.cdll.LoadLibrary(\"${libX11}/lib/libX11.so\")" \
+      --replace "load_library(\"Xrandr\")" "ctypes.cdll.LoadLibrary(\"${libXrandr}/lib/libXrandr.so\")"
+  '';
+
+  propagatedBuildInputs = stdenv.lib.optional isPy36 dataclasses;
+
+  buildInputs = [ libX11 libXinerama libXrandr];
+
+  meta = with stdenv.lib; {
+    description = "Fetch location and size of physical screens";
+    homepage = "https://github.com/rr-/screeninfo";
+    license = licenses.mit;
+    maintainers = [ maintainers.nickhu ];
+  };
+}

--- a/pkgs/development/python-modules/setuptools-lint/default.nix
+++ b/pkgs/development/python-modules/setuptools-lint/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, pylint }:
+
+buildPythonPackage rec {
+  pname = "setuptools-lint";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16a1ac5n7k7sx15cnk03gw3fmslab3a7m74dc45rgpldgiff3577";
+  };
+
+  propagatedBuildInputs = [ pylint ];
+
+  meta = with stdenv.lib; {
+    description = "Package to expose pylint as a lint command into setup.py";
+    homepage = "https://github.com/johnnoone/setuptools-pylint";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ nickhu ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2142,6 +2142,8 @@ in
 
   psrecord = python3Packages.callPackage ../tools/misc/psrecord {};
 
+  remarkable-mouse = python3Packages.callPackage ../applications/misc/remarkable/remarkable-mouse { };
+
   scour = with python3Packages; toPythonApplication scour;
 
   s2png = callPackage ../tools/graphics/s2png { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2597,6 +2597,8 @@ in {
 
   libais = callPackage ../development/python-modules/libais { };
 
+  libevdev = callPackage ../development/python-modules/libevdev { };
+
   libfdt = toPythonModule (pkgs.dtc.override {
     inherit python;
     pythonSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3413,6 +3413,8 @@ in {
 
   samplerate = callPackage ../development/python-modules/samplerate { };
 
+  screeninfo = callPackage ../development/python-modules/screeninfo { };
+
   ssdeep = callPackage ../development/python-modules/ssdeep { };
 
   ssdp = callPackage ../development/python-modules/ssdp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3439,6 +3439,8 @@ in {
 
   setuptools-git = callPackage ../development/python-modules/setuptools-git { };
 
+  setuptools-lint = callPackage ../development/python-modules/setuptools-lint { };
+
   sievelib = callPackage ../development/python-modules/sievelib { };
 
   watchdog = callPackage ../development/python-modules/watchdog { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1250,6 +1250,8 @@ in {
 
   pynisher = callPackage ../development/python-modules/pynisher { };
 
+  pynput = callPackage ../development/python-modules/pynput { };
+
   pyparser = callPackage ../development/python-modules/pyparser { };
 
   pyres = callPackage ../development/python-modules/pyres { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [remarkable-mouse](https://github.com/Evidlo/remarkable_mouse/), a
tool to use the reMarkable as a graphics tablet, and its dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).