### PR TITLE
openjdk8 compile statically

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.json
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.json
@@ -5,39 +5,45 @@
         "hotspot": {
           "aarch64": {
             "build": "10",
-            "sha256": "04b77f6754aed68528f39750c5cfd6a439190206aff216aa081d62a0e1a794fa",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.6_10.tar.gz",
-            "version": "11.0.6"
+            "sha256": "3b8b8bba6a0472ec7de5271cbf67f11e6ab525de6dd5d4729300375f1d56b7a1",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
           },
           "armv6l": {
             "build": "10",
-            "sha256": "ab5b76203e54fe7a5221535f6f407efa43153de029a746f60af3cffb7cb5080b",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_arm_linux_hotspot_11.0.6_10.tar.gz",
-            "version": "11.0.6"
+            "sha256": "45c235af67498f87e3dc99642771e57547cf226335eaee8a55d195173e66a2e9",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_arm_linux_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
           },
           "armv7l": {
             "build": "10",
-            "sha256": "ab5b76203e54fe7a5221535f6f407efa43153de029a746f60af3cffb7cb5080b",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_arm_linux_hotspot_11.0.6_10.tar.gz",
-            "version": "11.0.6"
+            "sha256": "45c235af67498f87e3dc99642771e57547cf226335eaee8a55d195173e66a2e9",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_arm_linux_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
             "build": "10",
-            "sha256": "330d19a2eaa07ed02757d7a785a77bab49f5ee710ea03b4ee2fa220ddd0feffc",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz",
-            "version": "11.0.6"
+            "sha256": "ee60304d782c9d5654bf1a6b3f38c683921c1711045e1db94525a51b7024a2ca",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
           }
         },
         "openj9": {
+          "aarch64": {
+            "build": "10",
+            "sha256": "0be01fdcae330e26c489d8d0d0c98c535a2af8cbd0cdcda211776ab9fcd05086",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10_openj9-0.20.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.7_10_openj9-0.20.0.tar.gz",
+            "version": "11.0.7"
+          },
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
             "build": "10",
-            "sha256": "1530172ee98edd129954fcdca1bf725f7b30c8bfc3cdc381c88de96b7d19e690",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10_openj9-0.18.1/OpenJDK11U-jdk_x64_linux_openj9_11.0.6_10_openj9-0.18.1.tar.gz",
-            "version": "11.0.6"
+            "sha256": "526e89f3014fec473b24c10c2464c1343e23703114983fd171b68b1599bba561",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10_openj9-0.20.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.7_10_openj9-0.20.0.tar.gz",
+            "version": "11.0.7"
           }
         }
       },
@@ -45,27 +51,45 @@
         "hotspot": {
           "aarch64": {
             "build": "10",
-            "sha256": "7ed04ed9ed7271528e7f03490f1fd7dfbbc2d391414bd6fe4dd80ec3bad76d30",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.6_10.tar.gz",
-            "version": "11.0.6"
+            "sha256": "cfe504e9e9621b831a5cfd800a2005dafe90a1d11aa14ee35d7b674d68685698",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
+          },
+          "armv6l": {
+            "build": "10",
+            "sha256": "581bae8efcaa40e209a780baa6f96b7c8c9397965bc6d54533f4fd8599d5c742",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_arm_linux_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
+          },
+          "armv7l": {
+            "build": "10",
+            "sha256": "581bae8efcaa40e209a780baa6f96b7c8c9397965bc6d54533f4fd8599d5c742",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_arm_linux_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
             "build": "10",
-            "sha256": "c5a4e69e2be0e3e5f5bb7c759960b20650967d0f571baad4a7f15b2c03bda352",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.6_10.tar.gz",
-            "version": "11.0.6"
+            "sha256": "74b493dd8a884dcbee29682ead51b182d9d3e52b40c3d4cbb3167c2fd0063503",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
           }
         },
         "openj9": {
+          "aarch64": {
+            "build": "10",
+            "sha256": "37ae26443abb02d2ab041eced9be948f0d20db03183aaf3c159ef682eeeabf9b",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10_openj9-0.20.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.7_10_openj9-0.20.0.tar.gz",
+            "version": "11.0.7"
+          },
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
             "build": "10",
-            "sha256": "056e4b5f7166f5daa44f36b06c735913bda52831d2e77fa2ac371505c66d10c1",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10_openj9-0.18.1/OpenJDK11U-jre_x64_linux_openj9_11.0.6_10_openj9-0.18.1.tar.gz",
-            "version": "11.0.6"
+            "sha256": "08258a767a6953bde21d15ef3c08e776d83257afa4acc52b55c70e1ac02f0489",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10_openj9-0.20.0/OpenJDK11U-jre_x64_linux_openj9_11.0.7_10_openj9-0.20.0.tar.gz",
+            "version": "11.0.7"
           }
         }
       }
@@ -77,9 +101,9 @@
           "vmType": "hotspot",
           "x86_64": {
             "build": "10",
-            "sha256": "b87102274d983bf6bb0aa6c2c623301d0ff5eb7f61043ffd04abb00f962c2dcd",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.6_10.tar.gz",
-            "version": "11.0.6"
+            "sha256": "0ab1e15e8bd1916423960e91b932d2b17f4c15b02dbdf9fa30e9423280d9e5cc",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
           }
         },
         "openj9": {
@@ -87,9 +111,9 @@
           "vmType": "openj9",
           "x86_64": {
             "build": "10",
-            "sha256": "9a5c5b3bb51a82e666c46b2d1bbafa8c2bbc3aae50194858c8f96c5d43a96f64",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10_openj9-0.18.1/OpenJDK11U-jdk_x64_mac_openj9_11.0.6_10_openj9-0.18.1.tar.gz",
-            "version": "11.0.6"
+            "sha256": "7e017209063c673a82c4d6047c9165b0fb66054c2bcd6b1f6389ed54f692b0b5",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jdk_x64_mac_openj9_11.0.7_10_openj9-0.20.0.tar.gz",
+            "version": "11.0.7"
           }
         }
       },
@@ -99,9 +123,9 @@
           "vmType": "hotspot",
           "x86_64": {
             "build": "10",
-            "sha256": "ab3c2038a32c62843500109d2efb8f5dacdfa1de3cbb713c8226f26dc603cc33",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_mac_hotspot_11.0.6_10.tar.gz",
-            "version": "11.0.6"
+            "sha256": "931a81f4bed38c48b364db57d4ebdd6e4b4ea1466e9bd0eaf8e0f1e47c4569e9",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_x64_mac_hotspot_11.0.7_10.tar.gz",
+            "version": "11.0.7"
           }
         },
         "openj9": {
@@ -109,9 +133,9 @@
           "vmType": "openj9",
           "x86_64": {
             "build": "10",
-            "sha256": "130850133d9701393352c2ce13ab541b4f900ff1f5ddf8257cda624968aada9f",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10_openj9-0.18.1/OpenJDK11U-jre_x64_mac_openj9_11.0.6_10_openj9-0.18.1.tar.gz",
-            "version": "11.0.6"
+            "sha256": "284341b68cc32c72e777eee078365b28228f44dcd4d960c1200879f799d1beb1",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jre_x64_mac_openj9_11.0.7_10_openj9-0.20.0.tar.gz",
+            "version": "11.0.7"
           }
         }
       }
@@ -122,68 +146,68 @@
       "jdk": {
         "hotspot": {
           "aarch64": {
-            "build": "33",
-            "sha256": "74f4110333ac4239564ed864b1d7d69b7af32af39efcfbde9816e1486cb5ae07",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_aarch64_linux_hotspot_13_33.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "0e6081cb51f8a6f3062bef4f4c45dbe1fccfd3f3b4b5d52522a3edb76581e3af",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_aarch64_linux_hotspot_13.0.2_8.tar.gz",
+            "version": "13.0.2"
           },
           "armv6l": {
-            "build": "33",
-            "sha256": "477e1b8d26a220d6d570765e9e0a4a34dbb489fab63a420d0859d173efc59adb",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_arm_linux_hotspot_13_33.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "9beec080f2b2a7f6883b024272f4e8d5a0b027325e83647be318215781af1d1a",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_arm_linux_hotspot_13.0.2_8.tar.gz",
+            "version": "13.0.2"
           },
           "armv7l": {
-            "build": "33",
-            "sha256": "477e1b8d26a220d6d570765e9e0a4a34dbb489fab63a420d0859d173efc59adb",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_arm_linux_hotspot_13_33.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "9beec080f2b2a7f6883b024272f4e8d5a0b027325e83647be318215781af1d1a",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_arm_linux_hotspot_13.0.2_8.tar.gz",
+            "version": "13.0.2"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "33",
-            "sha256": "e562caeffa89c834a69a44242d802eae3523875e427f07c05b1902c152638368",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_x64_linux_hotspot_13_33.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "9ccc063569f19899fd08e41466f8c4cd4e05058abdb5178fa374cb365dcf5998",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_x64_linux_hotspot_13.0.2_8.tar.gz",
+            "version": "13.0.2"
           }
         },
         "openj9": {
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "33",
-            "sha256": "68ebab0021c719694be8fc868478725a69c5c515cdb62e2933eefe87ba6437df",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33_openj9-0.16.0/OpenJDK13U-jdk_x64_linux_openj9_13_33_openj9-0.16.0.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "aeecf6d30d0c847db81d07793cf97e5dc44890c29366d7d9f8f9f397f6c52590",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8_openj9-0.18.0/OpenJDK13U-jdk_x64_linux_openj9_13.0.2_8_openj9-0.18.0.tar.gz",
+            "version": "13.0.2"
           }
         }
       },
       "jre": {
         "hotspot": {
           "aarch64": {
-            "build": "33",
-            "sha256": "2365b7fbba8d9125fb091933aad9f38f8cc1fbb0217cdec9ec75d2000f6d451a",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jre_aarch64_linux_hotspot_13_33.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "6c4b69d1609f4c65c576c80d6aa101de80048f8ce5566f890e8fff5349228bae",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jre_aarch64_linux_hotspot_13.0.2_8.tar.gz",
+            "version": "13.0.2"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "33",
-            "sha256": "73800a0d7c4e81df408a8518d282aa2c001ce4ee15541574c639dfc3564f708f",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jre_x64_linux_hotspot_13_33.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "897f16fe8e056395209e35d2384013bd1ff250e717465769079e3f4793628c34",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jre_x64_linux_hotspot_13.0.2_8.tar.gz",
+            "version": "13.0.2"
           }
         },
         "openj9": {
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "33",
-            "sha256": "2ee59be5062a81daa7be85be161cab6b245f9a2e2cbd4769ae9edefaac41e31d",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33_openj9-0.16.0/OpenJDK13U-jre_x64_linux_openj9_13_33_openj9-0.16.0.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "a0ab38607811e282f64082edc68a2dea3fa6a5113391efb124a6d7d02883110a",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8_openj9-0.18.0/OpenJDK13U-jre_x64_linux_openj9_13.0.2_8_openj9-0.18.0.tar.gz",
+            "version": "13.0.2"
           }
         }
       }
@@ -194,20 +218,20 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "33",
-            "sha256": "f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_x64_mac_hotspot_13_33.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "0ddb24efdf5aab541898d19b7667b149a1a64a8bd039b708fc58ee0284fa7e07",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_x64_mac_hotspot_13.0.2_8.tar.gz",
+            "version": "13.0.2"
           }
         },
         "openj9": {
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "33",
-            "sha256": "583e0defd5c062550896ead7cac383be16f1a81d9b6492dfec26da9af5dcc1c0",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33_openj9-0.16.0/OpenJDK13U-jdk_x64_mac_openj9_13_33_openj9-0.16.0.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "dd8d92eec98a3455ec5cd065a0a6672cc1aef280c6a68c507c372ccc1d98fbaa",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8_openj9-0.18.0/OpenJDK13U-jdk_x64_mac_openj9_13.0.2_8_openj9-0.18.0.tar.gz",
+            "version": "13.0.2"
           }
         }
       },
@@ -216,20 +240,20 @@
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "33",
-            "sha256": "1c23efba7908de9a611a98e755602f45381a8f7c957adb3fc4012ab1369a352c",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jre_x64_mac_hotspot_13_33.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "3149b9ebf0db1eaf2dc152df9efae82003e7971efb1cf550060e6a4798fe8c5c",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jre_x64_mac_hotspot_13.0.2_8.tar.gz",
+            "version": "13.0.2"
           }
         },
         "openj9": {
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "33",
-            "sha256": "33a60b78138d50cb02325156c7d1fcf588697749a4401f6c11a3cbefa3033127",
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33_openj9-0.16.0/OpenJDK13U-jre_x64_mac_openj9_13_33_openj9-0.16.0.tar.gz",
-            "version": "13.0.0"
+            "build": "8",
+            "sha256": "6a8a636fca4c7e368241e232a37cd73c9867cdec8f0869fd158b1f58c6128cc2",
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8_openj9-0.18.0/OpenJDK13U-jre_x64_mac_openj9_13.0.2_8_openj9-0.18.0.tar.gz",
+            "version": "13.0.2"
           }
         }
       }
@@ -241,51 +265,39 @@
         "hotspot": {
           "aarch64": {
             "build": "9",
-            "sha256": "35799a2fd4b467115aff1bc3a54853b5131ba9068e53e1ab0fbe5521a3f2ba83",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u232b09.tar.gz",
-            "version": "8.0.232"
+            "sha256": "536bf397d98174b376da9ed49d2f659d65c7310318d8211444f4b7ba7c15e453",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           },
           "armv6l": {
             "build": "9",
-            "sha256": "fdd9f61f1b2df74242da54ee3b3231b0123782a917e9673351276da439c7cab1",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_arm_linux_hotspot_8u232b09.tar.gz",
-            "version": "8.0.232"
+            "sha256": "5b401ad3c9b246281bd6df34b1abaf75e10e5cad9c6b26b55232b016e90e411a",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_arm_linux_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           },
           "armv7l": {
             "build": "9",
-            "sha256": "fdd9f61f1b2df74242da54ee3b3231b0123782a917e9673351276da439c7cab1",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_arm_linux_hotspot_8u232b09.tar.gz",
-            "version": "8.0.232"
-          },
-          "armv6l": {
-            "build": "10",
-            "sha256": "7b3d6ade8c25adca01095ba66642132d8c87a1a8caf3883850e34778453afcec",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_arm_linux_hotspot_8u222b10.tar.gz",
-            "version": "8.0.222"
-          },
-          "armv7l": {
-            "build": "10",
-            "sha256": "7b3d6ade8c25adca01095ba66642132d8c87a1a8caf3883850e34778453afcec",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_arm_linux_hotspot_8u222b10.tar.gz",
-            "version": "8.0.222"
+            "sha256": "5b401ad3c9b246281bd6df34b1abaf75e10e5cad9c6b26b55232b016e90e411a",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_arm_linux_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "8",
-            "sha256": "f39b523c724d0e0047d238eb2bb17a9565a60574cf651206c867ee5fc000ab43",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u242b08.tar.gz",
-            "version": "8.0.242"
+            "build": "9",
+            "sha256": "2b59b5282ff32bce7abba8ad6b9fde34c15a98f949ad8ae43e789bbd78fc8862",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           }
         },
         "openj9": {
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "ca785af638b24f9d4df896f5a9f557cc9f1e5fa5e2b1174d6b906e3fd5474c2e",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08_openj9-0.18.1/OpenJDK8U-jdk_x64_linux_openj9_8u242b08_openj9-0.18.1.tar.gz",
-            "version": "8.0.242"
+            "build": "9",
+            "sha256": "910ae847109a6dd1b6cf69baa7615ea2cce8cff787e5a9349a5331ce7604f3a5",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09_openj9-0.20.0/OpenJDK8U-jdk_x64_linux_openj9_8u252b09_openj9-0.20.0.tar.gz",
+            "version": "8.0.252"
           }
         }
       },
@@ -293,51 +305,39 @@
         "hotspot": {
           "aarch64": {
             "build": "9",
-            "sha256": "4540db665260fdc84ae2f191e21beec9168a70a4227718bee5edd317707e2fda",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jre_aarch64_linux_hotspot_8u232b09.tar.gz",
-            "version": "8.0.232"
+            "sha256": "30bba4425497f5b4aabcba7b45db69d582d278fb17357d64c22c9dc6b2d29ca1",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_aarch64_linux_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           },
           "armv6l": {
             "build": "9",
-            "sha256": "8ab786fc2fa0a282f5cf57f6040f1976c32c3c5e480e900ce5925de6543f6688",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jre_arm_linux_hotspot_8u232b09.tar.gz",
-            "version": "8.0.232"
+            "sha256": "107699a88f611e0c2d57816be25821ef9b17db860b14402c4e9e5bf0b9cf16fd",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_arm_linux_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           },
           "armv7l": {
             "build": "9",
-            "sha256": "8ab786fc2fa0a282f5cf57f6040f1976c32c3c5e480e900ce5925de6543f6688",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jre_arm_linux_hotspot_8u232b09.tar.gz",
-            "version": "8.0.232"
-          },
-          "armv6l": {
-            "build": "10",
-            "sha256": "19de77b74812b90851816bdb991d6473488a10d3ac293c6accf46ae9b1f714a0",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jre_arm_linux_hotspot_8u222b10.tar.gz",
-            "version": "8.0.222"
-          },
-          "armv7l": {
-            "build": "10",
-            "sha256": "19de77b74812b90851816bdb991d6473488a10d3ac293c6accf46ae9b1f714a0",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jre_arm_linux_hotspot_8u222b10.tar.gz",
-            "version": "8.0.222"
+            "sha256": "107699a88f611e0c2d57816be25821ef9b17db860b14402c4e9e5bf0b9cf16fd",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_arm_linux_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "8",
-            "sha256": "5edfaefdbb0469d8b24d61c8aef80c076611053b1738029c0232b9a632fe2708",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jre_x64_linux_hotspot_8u242b08.tar.gz",
-            "version": "8.0.242"
+            "build": "9",
+            "sha256": "a93be303ed62398dba9acb0376fb3caf8f488fcde80dc62d0a8e46256b3adfb1",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_x64_linux_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           }
         },
         "openj9": {
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "985d3134b64c6196d4c9ddbc87af0c62b0e643cef71b29f3d25a8c7811811745",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08_openj9-0.18.1/OpenJDK8U-jre_x64_linux_openj9_8u242b08_openj9-0.18.1.tar.gz",
-            "version": "8.0.242"
+            "build": "9",
+            "sha256": "5c0ab4691ff5f8e69bb14462f2afb8d73d751b01048eacf4b426ed6d6646dc63",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09_openj9-0.20.0/OpenJDK8U-jre_x64_linux_openj9_8u252b09_openj9-0.20.0.tar.gz",
+            "version": "8.0.252"
           }
         }
       }
@@ -348,20 +348,20 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "8",
-            "sha256": "06675b7d65bce0313ee1f2e888dd44267e8afeced75e0b39b5ad1f5fdff54e0b",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u242b08.tar.gz",
-            "version": "8.0.242"
+            "build": "9",
+            "sha256": "2caed3ec07d108bda613f9b4614b22a8bdd196ccf2a432a126161cd4077f07a5",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_mac_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           }
         },
         "openj9": {
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "665dc9c8239b7270b007ab9dd7522570e2686e327d89caf57a6aa6e5c6450078",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08_openj9-0.18.1/OpenJDK8U-jdk_x64_mac_openj9_8u242b08_openj9-0.18.1.tar.gz",
-            "version": "8.0.242"
+            "build": "9",
+            "sha256": "b695f8e95ee548f354fe647abd45612be8318063ea14dfd410b4bc22000fa095",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jdk_x64_mac_openj9_8u252b09_openj9-0.20.0.tar.gz",
+            "version": "8.0.252"
           }
         }
       },
@@ -370,20 +370,20 @@
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "8",
-            "sha256": "fae3777e3441dc7384c339a9054aa7efc40cd2c501625a535c2d4648367ccca3",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08/OpenJDK8U-jre_x64_mac_hotspot_8u242b08.tar.gz",
-            "version": "8.0.242"
+            "build": "9",
+            "sha256": "f8206f0fef194c598de6b206a4773b2e517154913ea0e26c5726091562a034c8",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jre_x64_mac_hotspot_8u252b09.tar.gz",
+            "version": "8.0.252"
           }
         },
         "openj9": {
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "d4a924558ddda0aed671a67f71714b71c25871a7659fd4c505851cf5ee866de5",
-            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08_openj9-0.18.1/OpenJDK8U-jre_x64_mac_openj9_8u242b08_openj9-0.18.1.tar.gz",
-            "version": "8.0.242"
+            "build": "9",
+            "sha256": "4f4b0349d4ebfbdd58026c0db6965fd3eead2495835bb9fa9481afd6ae2b970a",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jre_x64_mac_openj9_8u252b09_openj9-0.20.0.tar.gz",
+            "version": "8.0.252"
           }
         }
       }

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -2,7 +2,7 @@
 , cups, freetype, alsaLib, cacert, perl, liberation_ttf, fontconfig, zlib, glibc
 , libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor, libXrandr
 , xorgproto, libxcb, xtrans, libpthreadstubs, libXau, xcbproto, libXdmcp, xcbutilkeysyms
-, autoconf, bzip2, libpng, libjpeg, giflib
+, autoconf, libpng, libjpeg, giflib
 , openjdk8-bootstrap
 , setJavaClassPath
 , headless ? false
@@ -97,7 +97,6 @@ let
         "--enable-static"
         "--disable-shared"
       ];
-      # postInstall = "rm -rf $out/lib/*.la";
     });
   libX11-static = libX11
     .overrideAttrs(oldAttrs: {
@@ -106,7 +105,6 @@ let
         "--disable-shared"
         "--enable-malloc0returnsnull"
       ];
-      # postInstall = "rm -rf $out/lib/*.la";
     });
   libpng-static = libpng
     .overrideAttrs(oldAttrs: {
@@ -122,7 +120,7 @@ let
         "--disable-shared"
       ];
     });
-  bzip2-static = bzip2.override { linkStatic = true;};
+  # bzip2-static = bzip2.override { linkStatic = true;};
 
 
   openjdk8 = stdenv.mkDerivation {
@@ -144,7 +142,7 @@ let
       gtk2 gnome_vfs GConf glib
     ] ++ lib.optionals (static) [
       autoconf
-      bzip2-static
+      # bzip2-static
       freetype-static
       glibc
       glibc.static
@@ -191,7 +189,7 @@ let
       substituteInPlace configure --replace /bin/bash "${bash}/bin/bash"
       substituteInPlace hotspot/make/linux/adlc_updater --replace /bin/sh "${stdenv.shell}"
       substituteInPlace hotspot/make/linux/makefiles/dtrace.make --replace /usr/include/sys/sdt.h "/no-such-path"
-      '';
+    '';
 
     configureFlags = [
       "--with-boot-jdk=${openjdk8-bootstrap.home}"
@@ -206,7 +204,7 @@ let
       "--disable-freetype-bundling"
       "--with-zlib=system"
       "--with-giflib=system"
-    ] ++ lib.optionals static [
+     ] ++ lib.optionals static [
       "--enable-static-build=yes"
       "--verbose"
       "--host=${stdenv.hostPlatform.system}"
@@ -307,7 +305,7 @@ let
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
       EOF
     '';
-/*
+
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
@@ -326,7 +324,7 @@ let
         done
       done
     '';
-*/
+
     disallowedReferences = [ openjdk8-bootstrap ];
 
     meta = with lib; {

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -1,10 +1,12 @@
 { stdenv, lib, fetchurl, pkgconfig, lndir, bash, cpio, file, which, unzip, zip
-, cups, freetype, alsaLib, cacert, perl, liberation_ttf, fontconfig, zlib
+, cups, freetype, alsaLib, cacert, perl, liberation_ttf, fontconfig, zlib, glibc
 , libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor, libXrandr
-, libjpeg, giflib
+, xorgproto, libxcb, xtrans, libpthreadstubs, libXau, xcbproto, libXdmcp, xcbutilkeysyms
+, autoconf, bzip2, libpng, libjpeg, giflib
 , openjdk8-bootstrap
 , setJavaClassPath
 , headless ? false
+, static ? false
 , enableGnome2 ? true, gtk2, gnome_vfs, glib, GConf
 }:
 
@@ -19,8 +21,8 @@ let
     aarch64-linux = "aarch64";
   }.${stdenv.system} or (throw "Unsupported platform");
 
-  update = "242";
-  build = "b08";
+  update = "252";
+  build = "b09";
   baseurl = if stdenv.isAarch64 then "https://hg.openjdk.java.net/aarch64-port/jdk8u-shenandoah"
             else "https://hg.openjdk.java.net/jdk8u/jdk8u";
   repover = lib.optionalString stdenv.isAarch64 "aarch64-shenandoah-"
@@ -29,51 +31,100 @@ let
   jdk8 = fetchurl {
              name = "jdk8-${repover}.tar.gz";
              url = "${baseurl}/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "0qpmr267qcxhmw398zbl1axd161yxn4k4hfz1jlxlmdvg70p7h90"
-                      else "1crs4hmzmgm6fkwfq0d3xz9lph0nd33fngrqv2rz1mkkqcrjx18z";
+             sha256 = if stdenv.isAarch64 then "0h8kb7139gmnnqqddj54a1p2wkb5sy5xpisk32i42hw437p85ilj"
+                      else "01f0d262wzy30q75dff8185brwqxg5vs094kwhzcjc3c46xddy55";
           };
   langtools = fetchurl {
              name = "langtools-${repover}.tar.gz";
              url = "${baseurl}/langtools/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "1rhhi4kgmxvnyl3ic5p008p1n7zyji5nw99blm1lr5fw7ry7df24"
-                      else "1aaxd1rl7dlk4kxdivvqvripsbn0d5vny0jvjksycsm97vrfiry4";
+             sha256 = if stdenv.isAarch64 then "1zprms6bl6x8mpak1m9355zwrk88qi7w46mhjq5hymfqqdwgawd9"
+                      else "09zffnvxwmk01siq92q88w7bwqrh8j5wcjb0frmaskylxi1xs00r";
           };
   hotspot = fetchurl {
              name = "hotspot-${repover}.tar.gz";
              url = "${baseurl}/hotspot/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "0lphrhjqlavd6qlkh7h4sd2bqf5gd0cchkcnvy87703fbd7gy5ii"
-                      else "18i4if16zikgda9k5bgqyx0p2104db23zlnclq512178z0p9yycb";
+             sha256 = if stdenv.isAarch64 then "1j22m8hfnasncb0hg6h814qfdw34d7dvr3ljkgwax71938x12ni5"
+                      else "1kq3a6qll1sp1wppfg4dqy8j7qx4hpjs732l5m2a95l31ip1p5fr";
           };
   corba = fetchurl {
              name = "corba-${repover}.tar.gz";
              url = "${baseurl}/corba/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "18h0v566v420d00na6x4jrs41v4aa39byk15fi8k6dcn0dmirhvg"
-                      else "1298k8p2dsj7xc4h2ayk5nl4ssrcgncn06ysyqrmnwrb8gj8s1w4";
+             sha256 = if stdenv.isAarch64 then "1yrrcnya40sghyyg8m5ncm2giwxlc8j1brif1428qr8anrb6pvaw"
+                      else "15s4q5rlpm9dc8v6q648d1l4i4jz29j1lqi1b73nkag2b3vglxax";
           };
   jdk = fetchurl {
              name = "jdk-${repover}.tar.gz";
              url = "${baseurl}/jdk/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "0xxy7rkj8ah263nnzkd4mg9dai5qix3l9cyilm47dig5hv7g8aq0"
-                      else "0vqlbks3cy3cnmnrnhbjkqinvp8bcy2h96xvx81cvlza4s2hszvz";
+             sha256 = if stdenv.isAarch64 then "1lf1y3ig8mimsgabd6agsr2j9yv8w9qfcrvsh5hgwj73f23qb6pc"
+                      else "0zg2lwk8bbmc1hrzgd951ksb7jrh0rv3zpbg3vdfbhnwq5gq89y1";
           };
   jaxws = fetchurl {
              name = "jaxws-${repover}.tar.gz";
              url = "${baseurl}/jaxws/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "0ajqm2l9g5w5ag5s4vl4ldpbm99pqa6d342hrzvv7psqn3zf6ar5"
-                      else "1wg9fbiz09arj0llavnzrmbhw8nx0dw8dcjkrzxw78rj1cadflzc";
+             sha256 = if stdenv.isAarch64 then "0yw3lmqvn4fsis83wlain3xgn54ryn6vs4bv4is5im7kc8ijpbln"
+                      else "117q0x2gzihwra0cf53svjdmikn5fagygc3g4lk4xwsg2jw1whv2";
           };
   jaxp = fetchurl {
              name = "jaxp-${repover}.tar.gz";
              url = "${baseurl}/jaxp/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "03zjh6xvza05abxz9d9j2w9xndw9n07f8lrn6dymj7f4imals831"
-                      else "1i5xrk8r8pcgnc68zrgp3hd1a1nzcm99swpmdnlb424qlg5nnrcf";
+             sha256 = if stdenv.isAarch64 then "0bd8ganxg37pry9j89z7p79dp8nqv9cdqq38iw22w2a77n0yapyy"
+                      else "0zfpr0j3i0skb2k4mq2z8nbdkm3f4ncxrrmvf3cmy6j60ck9m30j";
           };
   nashorn = fetchurl {
              name = "nashorn-${repover}.tar.gz";
              url = "${baseurl}/nashorn/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "0n809w264ndxksva9c81x0m1fsyg8c627w571f72xxxl9c1bnrmp"
-                      else "0qlxaz7sriy709vcyzz48s2v4p5h4d31my33whip018c4j5gkfqq";
+             sha256 = if stdenv.isAarch64 then "0lhy2b3vpbjp7zq1kz5mapnasnq0zrfckihwsh77ni9c0hmh9m02"
+                      else "1rwgxj5fyarx6n4mhi23f84g8h5m0lpyyj88ym1n7q90chhrfxkx";
           };
+
+  libXdmcp-static = libXdmcp
+    .overrideAttrs(oldAttrs: {
+      configureFlags = (oldAttrs.configureFlags or []) ++ [
+        "--enable-static"
+        "--disable-shared"
+      ];
+    });
+  libXau-static = libXau
+    .overrideAttrs(oldAttrs: {
+      configureFlags = (oldAttrs.configureFlags or []) ++ [
+        "--enable-static"
+        "--disable-shared"
+      ];
+    });
+  libxcb-static = libxcb
+    .overrideAttrs(oldAttrs: {
+      configureFlags = (oldAttrs.configureFlags or []) ++ [
+        "--enable-static"
+        "--disable-shared"
+      ];
+      # postInstall = "rm -rf $out/lib/*.la";
+    });
+  libX11-static = libX11
+    .overrideAttrs(oldAttrs: {
+      configureFlags = (oldAttrs.configureFlags or []) ++ [
+        "--enable-static"
+        "--disable-shared"
+        "--enable-malloc0returnsnull"
+      ];
+      # postInstall = "rm -rf $out/lib/*.la";
+    });
+  libpng-static = libpng
+    .overrideAttrs(oldAttrs: {
+      configureFlags = (oldAttrs.configureFlags or []) ++ [
+        "--enable-static"
+        "--disable-shared"
+      ];
+    });
+  freetype-static = freetype
+    .overrideAttrs(oldAttrs: {
+      configureFlags = (oldAttrs.configureFlags or []) ++ [
+        "--enable-static"
+        "--disable-shared"
+      ];
+    });
+  bzip2-static = bzip2.override { linkStatic = true;};
+
+
   openjdk8 = stdenv.mkDerivation {
     pname = "openjdk" + lib.optionalString headless "-headless";
     version = "8u${update}-${build}";
@@ -85,11 +136,25 @@ let
 
     nativeBuildInputs = [ pkgconfig lndir ];
     buildInputs = [
-      cpio file which unzip zip perl openjdk8-bootstrap zlib cups freetype alsaLib
+      cpio file which unzip zip perl bash
+      openjdk8-bootstrap zlib cups freetype alsaLib
       libjpeg giflib libX11 libICE libXext libXrender libXtst libXt libXtst
       libXi libXinerama libXcursor libXrandr fontconfig
     ] ++ lib.optionals (!headless && enableGnome2) [
       gtk2 gnome_vfs GConf glib
+    ] ++ lib.optionals (static) [
+      autoconf
+      bzip2-static
+      freetype-static
+      glibc
+      glibc.static
+      libpng-static
+      libpthreadstubs
+      libXau-static
+      libXdmcp-static
+      libxcb-static
+      libX11-static
+      zlib.static
     ];
 
     # move the seven other source dirs under the main jdk8u directory,
@@ -108,17 +173,25 @@ let
       ./currency-date-range-jdk8.patch
     ] ++ lib.optionals (!headless && enableGnome2) [
       ./swing-use-gtk-jdk8.patch
+    ] ++ lib.optionals static [
+      ./openjdk_jvmci_top.patch
+      ./openjdk_jvmci_jdk.patch
+      ./openjdk8-gcc-static-ld-genSocketOptionRegistry.patch
+    ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+      ./musl-hotspot-jdk8.patch
+      ./musl-hotspot-noagent-jdk8.patch
     ];
 
     # Hotspot cares about the host(!) version otherwise
     DISABLE_HOTSPOT_OS_VERSION_CHECK = "ok";
 
     preConfigure = ''
+      ${lib.optionalString static "(cd common/autoconf && bash autogen.sh)"}
       chmod +x configure
       substituteInPlace configure --replace /bin/bash "${bash}/bin/bash"
       substituteInPlace hotspot/make/linux/adlc_updater --replace /bin/sh "${stdenv.shell}"
       substituteInPlace hotspot/make/linux/makefiles/dtrace.make --replace /usr/include/sys/sdt.h "/no-such-path"
-    '';
+      '';
 
     configureFlags = [
       "--with-boot-jdk=${openjdk8-bootstrap.home}"
@@ -127,11 +200,17 @@ let
       "--with-milestone=fcs"
       "--enable-unlimited-crypto"
       "--with-native-debug-symbols=internal"
+    ] ++ lib.optional headless "--disable-headful"
+      ++ lib.optionals (!static) [
+      "--with-stdc++lib=dynamic"
       "--disable-freetype-bundling"
       "--with-zlib=system"
       "--with-giflib=system"
-      "--with-stdc++lib=dynamic"
-    ] ++ lib.optional headless "--disable-headful";
+    ] ++ lib.optionals static [
+      "--enable-static-build=yes"
+      "--verbose"
+      "--host=${stdenv.hostPlatform.system}"
+    ];
 
     separateDebugInfo = true;
 
@@ -148,13 +227,7 @@ let
       "-Wno-error"
     ]);
 
-    NIX_LDFLAGS= toString (lib.optionals (!headless) [
-      "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"
-    ] ++ lib.optionals (!headless && enableGnome2) [
-      "-lgtk-x11-2.0" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
-    ]);
-
-    buildFlags = [ "all" ];
+    buildFlags = if (static) then [ "images" ] else [ "all" ];
 
     doCheck = false; # fails with "No rule to make target 'y'."
 
@@ -234,7 +307,7 @@ let
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
       EOF
     '';
-
+/*
     postFixup = ''
       # Build the set of output library directories to rpath against
       LIBDIRS=""
@@ -253,7 +326,7 @@ let
         done
       done
     '';
-
+*/
     disallowedReferences = [ openjdk8-bootstrap ];
 
     meta = with lib; {

--- a/pkgs/development/compilers/openjdk/musl-hotspot-jdk8.patch
+++ b/pkgs/development/compilers/openjdk/musl-hotspot-jdk8.patch
@@ -1,0 +1,103 @@
+:100644 100644 ba84788a1b 0000000000 M	hotspot/src/os/linux/vm/jvm_linux.cpp
+:100644 100644 03cabfefb4 0000000000 M	hotspot/src/os/linux/vm/os_linux.cpp
+:100644 100644 a23bd56313 0000000000 M	hotspot/src/os/linux/vm/os_linux.inline.hpp
+:100644 100644 1a7375afc7 0000000000 M	hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+:100644 100644 efa0b4e1ad 0000000000 M	hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
+
+diff --git a/hotspot/src/os/linux/vm/jvm_linux.cpp b/hotspot/src/os/linux/vm/jvm_linux.cpp
+index ba84788a1b..c22281f7ca 100644
+--- a/hotspot/src/os/linux/vm/jvm_linux.cpp
++++ b/hotspot/src/os/linux/vm/jvm_linux.cpp
+@@ -154,7 +154,9 @@ struct siglabel siglabels[] = {
+ #ifdef SIGSTKFLT
+   "STKFLT",     SIGSTKFLT,      /* Stack fault.  */
+ #endif
++#ifdef SIGCLD
+   "CLD",        SIGCLD,         /* Same as SIGCHLD (System V).  */
++#endif
+   "CHLD",       SIGCHLD,        /* Child status has changed (POSIX).  */
+   "CONT",       SIGCONT,        /* Continue (POSIX).  */
+   "STOP",       SIGSTOP,        /* Stop, unblockable (POSIX).  */
+diff --git a/hotspot/src/os/linux/vm/os_linux.cpp b/hotspot/src/os/linux/vm/os_linux.cpp
+index 03cabfefb4..c20a674fa2 100644
+--- a/hotspot/src/os/linux/vm/os_linux.cpp
++++ b/hotspot/src/os/linux/vm/os_linux.cpp
+@@ -95,7 +95,6 @@
+ # include <string.h>
+ # include <syscall.h>
+ # include <sys/sysinfo.h>
+-# include <gnu/libc-version.h>
+ # include <sys/ipc.h>
+ # include <sys/shm.h>
+ # include <link.h>
+@@ -581,6 +580,12 @@ void os::Linux::hotspot_sigmask(Thread* thread) {
+ // detecting pthread library
+ 
+ void os::Linux::libpthread_init() {
++#if 1
++  os::Linux::set_glibc_version("glibc 2.9");
++  os::Linux::set_libpthread_version("NPTL");
++  os::Linux::set_is_NPTL();
++  os::Linux::set_is_floating_stack();
++#else
+   // Save glibc and pthread version strings. Note that _CS_GNU_LIBC_VERSION
+   // and _CS_GNU_LIBPTHREAD_VERSION are supported in glibc >= 2.3.2. Use a
+   // generic name for earlier versions.
+@@ -639,6 +644,7 @@ void os::Linux::libpthread_init() {
+   if (os::Linux::is_NPTL() || os::Linux::supports_variable_stack_size()) {
+      os::Linux::set_is_floating_stack();
+   }
++#endif
+ }
+ 
+ /////////////////////////////////////////////////////////////////////////////
+@@ -2932,6 +2938,9 @@ int os::Linux::sched_getcpu_syscall(void) {
+ extern "C" JNIEXPORT void numa_warn(int number, char *where, ...) { }
+ extern "C" JNIEXPORT void numa_error(char *where) { }
+ extern "C" JNIEXPORT int fork1() { return fork(); }
++static void *dlvsym(void *handle, const char *name, const char *ver) {
++  return dlsym(handle, name);
++}
+ 
+ // Handle request to load libnuma symbol version 1.1 (API v1). If it fails
+ // load symbol from base version instead.
+diff --git a/hotspot/src/os/linux/vm/os_linux.inline.hpp b/hotspot/src/os/linux/vm/os_linux.inline.hpp
+index a23bd56313..9d56de0ef0 100644
+--- a/hotspot/src/os/linux/vm/os_linux.inline.hpp
++++ b/hotspot/src/os/linux/vm/os_linux.inline.hpp
+@@ -33,7 +33,7 @@
+ 
+ #include <unistd.h>
+ #include <sys/socket.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <netdb.h>
+ 
+ inline void* os::thread_local_storage_at(int index) {
+diff --git a/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp b/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+index 1a7375afc7..e6859306fd 100644
+--- a/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
++++ b/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+@@ -72,7 +72,8 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-# include <fpu_control.h>
++#define _FPU_GETCW(cw) __asm__ __volatile__ ("fnstcw %0" : "=m" (*&cw))
++#define _FPU_SETCW(cw) __asm__ __volatile__ ("fldcw %0" : : "m" (*&cw))
+ 
+ #ifdef AMD64
+ #define REG_SP REG_RSP
+diff --git a/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp b/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
+index efa0b4e1ad..6df2302ee8 100644
+--- a/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
++++ b/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
+@@ -235,7 +235,7 @@ inline int g_isnan(double f) { return isnand(f); }
+ #elif defined(__APPLE__)
+ inline int g_isnan(double f) { return isnan(f); }
+ #elif defined(LINUX) || defined(_ALLBSD_SOURCE)
+-inline int g_isnan(float  f) { return isnanf(f); }
++inline int g_isnan(float  f) { return isnan(f); }
+ inline int g_isnan(double f) { return isnan(f); }
+ #else
+ #error "missing platform-specific definition here"

--- a/pkgs/development/compilers/openjdk/musl-hotspot-noagent-jdk8.patch
+++ b/pkgs/development/compilers/openjdk/musl-hotspot-noagent-jdk8.patch
@@ -1,0 +1,59 @@
+:100644 100644 6f6c52a11a 0000000000 M	common/autoconf/jdk-options.m4
+:100644 100644 496c3e128a 0000000000 M	hotspot/make/linux/makefiles/defs.make
+:100644 100644 ffc0ec5ce5 0000000000 M	hotspot/make/linux/makefiles/saproc.make
+
+diff --git a/common/autoconf/jdk-options.m4 b/common/autoconf/jdk-options.m4
+index 6f6c52a11a..e94c38e73c 100644
+--- a/common/autoconf/jdk-options.m4
++++ b/common/autoconf/jdk-options.m4
+@@ -151,7 +151,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JVM_VARIANTS],
+   AC_SUBST(JVM_VARIANT_ZEROSHARK)
+   AC_SUBST(JVM_VARIANT_CORE)
+ 
+-  INCLUDE_SA=true
++  INCLUDE_SA=false
+   if test "x$JVM_VARIANT_ZERO" = xtrue ; then
+     INCLUDE_SA=false
+   fi
+diff --git a/hotspot/make/linux/makefiles/defs.make b/hotspot/make/linux/makefiles/defs.make
+index 496c3e128a..3c853ce66b 100644
+--- a/hotspot/make/linux/makefiles/defs.make
++++ b/hotspot/make/linux/makefiles/defs.make
+@@ -296,6 +296,7 @@ endif
+ 
+ # Serviceability Binaries
+ # No SA Support for PPC, IA64, ARM or zero
++ifeq (0,1)
+ ADD_SA_BINARIES/x86   = $(EXPORT_JRE_LIB_ARCH_DIR)/libsaproc.$(LIBRARY_SUFFIX) \
+                         $(EXPORT_LIB_DIR)/sa-jdi.jar
+ ADD_SA_BINARIES/sparc = $(EXPORT_JRE_LIB_ARCH_DIR)/libsaproc.$(LIBRARY_SUFFIX) \
+@@ -311,6 +312,11 @@ ifeq ($(ENABLE_FULL_DEBUG_SYMBOLS),1)
+     endif
+   endif
+ endif
++else
++ADD_SA_BINARIES/x86 =
++ADD_SA_BINARIES/sparc =
++ADD_SA_BINARIES/aarch64 =
++endif
+ ADD_SA_BINARIES/ppc   =
+ ADD_SA_BINARIES/ia64  =
+ ADD_SA_BINARIES/arm   =
+diff --git a/hotspot/make/linux/makefiles/saproc.make b/hotspot/make/linux/makefiles/saproc.make
+index ffc0ec5ce5..7686302743 100644
+--- a/hotspot/make/linux/makefiles/saproc.make
++++ b/hotspot/make/linux/makefiles/saproc.make
+@@ -67,11 +67,13 @@ endif
+ # if $(AGENT_DIR) does not exist, we don't build SA
+ # also, we don't build SA on Itanium or zero.
+ 
++ifeq (0,1)
+ ifneq ($(wildcard $(AGENT_DIR)),)
+ ifneq ($(filter-out ia64 zero,$(SRCARCH)),)
+   BUILDLIBSAPROC = $(LIBSAPROC)
+ endif
+ endif
++endif
+ 
+ ifneq ($(ALT_SASRCDIR),)
+ ALT_SAINCDIR=-I$(ALT_SASRCDIR) -DALT_SASRCDIR

--- a/pkgs/development/compilers/openjdk/openjdk8-gcc-static-ld-genSocketOptionRegistry.patch
+++ b/pkgs/development/compilers/openjdk/openjdk8-gcc-static-ld-genSocketOptionRegistry.patch
@@ -1,0 +1,13 @@
+diff --git a/jdk/make/gensrc/GensrcMisc.gmk b/jdk/make/gensrc/GensrcMisc.gmk
+index 9db5c9d6f7..84a3c27e7d 100644
+--- a/jdk/make/gensrc/GensrcMisc.gmk
++++ b/jdk/make/gensrc/GensrcMisc.gmk
+@@ -76,7 +76,7 @@ $(eval $(call SetupNativeCompilation,BUILD_GENSRC_SOR_EXE, \
+     INCLUDE_FILES := $(GENSRC_SOR_SRC_FILE), \
+     LANG := C, \
+     CC := $(BUILD_CC), \
+-    LDEXE := $(BUILD_LD), \
++    LDEXE := $(BUILD_CC), \
+     OBJECT_DIR := $(GENSRC_SOR_BIN), \
+     OUTPUT_DIR := $(GENSRC_SOR_BIN), \
+     PROGRAM := genSocketOptionRegistry))

--- a/pkgs/development/compilers/openjdk/openjdk_jvmci_jdk.patch
+++ b/pkgs/development/compilers/openjdk/openjdk_jvmci_jdk.patch
@@ -1,0 +1,191 @@
+diff --git a/jdk/make/BuildJdk.gmk b/jdk/make/BuildJdk.gmk
+--- a/jdk/make/BuildJdk.gmk
++++ b/jdk/make/BuildJdk.gmk
+@@ -99,6 +99,7 @@
+ # in these cases.
+ images:
+ 	+$(MAKE) PROFILE="" -f CreateJars.gmk
++	+$(MAKE) PROFILE="" -f StaticLibs.gmk
+ 	+$(MAKE) PROFILE="" -f Images.gmk
+         ifeq ($(OPENJDK_TARGET_OS), macosx)
+ 	  +$(MAKE) -f Bundles.gmk
+diff --git a/jdk/make/StaticLibs.gmk b/jdk/make/StaticLibs.gmk
+new file mode 100644
+--- /dev/null
++++ b/jdk/make/StaticLibs.gmk
+@@ -0,0 +1,56 @@
++#
++# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
++# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++#
++# This code is free software; you can redistribute it and/or modify it
++# under the terms of the GNU General Public License version 2 only, as
++# published by the Free Software Foundation.  Oracle designates this
++# particular file as subject to the "Classpath" exception as provided
++# by Oracle in the LICENSE file that accompanied this code.
++#
++# This code is distributed in the hope that it will be useful, but WITHOUT
++# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++# version 2 for more details (a copy is included in the LICENSE file that
++# accompanied this code).
++#
++# You should have received a copy of the GNU General Public License version
++# 2 along with this work; if not, write to the Free Software Foundation,
++# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++#
++# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++# or visit www.oracle.com if you need additional information or have any
++# questions.
++#
++
++include $(SPEC)
++include MakeBase.gmk
++include JavaCompilation.gmk
++include Setup.gmk
++
++default: jdk-static-libs
++
++ifeq ($(STATIC_BUILD),true)
++JDK_STATIC_LIB_TARGETS = $(JDK_OUTPUTDIR)/lib/$(LIBRARY_PREFIX)java$(STATIC_LIBRARY_SUFFIX) \
++                  $(JDK_OUTPUTDIR)/lib/$(LIBRARY_PREFIX)net$(STATIC_LIBRARY_SUFFIX) \
++                  $(JDK_OUTPUTDIR)/lib/$(LIBRARY_PREFIX)nio$(STATIC_LIBRARY_SUFFIX) \
++                  $(JDK_OUTPUTDIR)/lib/$(LIBRARY_PREFIX)zip$(STATIC_LIBRARY_SUFFIX) \
++                  $(JDK_OUTPUTDIR)/lib/$(LIBRARY_PREFIX)fdlibm$(STATIC_LIBRARY_SUFFIX) \
++                  $(JDK_OUTPUTDIR)/lib/$(LIBRARY_PREFIX)jaas$(STATIC_LIBRARY_SUFFIX) \
++                  $(JDK_OUTPUTDIR)/lib/$(LIBRARY_PREFIX)sunec$(STATIC_LIBRARY_SUFFIX)
++
++jdk-static-libs: $(JDK_STATIC_LIB_TARGETS)
++
++$(JDK_STATIC_LIB_TARGETS):
++	$(CD) $(JDK_OUTPUTDIR)/objs/lib$(patsubst $(LIBRARY_PREFIX)%,%,$(basename $(notdir $@))) && \
++	$(AR) $(AR_OUT_OPTION)$(LIBRARY_PREFIX)$(patsubst $(LIBRARY_PREFIX)%,%,$(basename $(notdir $@)))$(STATIC_LIBRARY_SUFFIX) *$(OBJ_SUFFIX)
++	$(CD) $(JDK_OUTPUTDIR)/objs/lib$(patsubst $(LIBRARY_PREFIX)%,%,$(basename $(notdir $@))) && \
++	$(CP) $(LIBRARY_PREFIX)$(patsubst $(LIBRARY_PREFIX)%,%,$(basename $(notdir $@)))$(STATIC_LIBRARY_SUFFIX) \
++$(JDK_OUTPUTDIR)/lib/$(LIBRARY_PREFIX)$(patsubst $(LIBRARY_PREFIX)%,%,$(basename $(notdir $@)))$(STATIC_LIBRARY_SUFFIX)
++
++else
++JDK_STATIC_LIB_TARGETS =
++
++jdk-static-libs:
++endif
++
++.PHONY: jdk-static-libs
++
+diff --git a/jdk/src/share/native/common/check_version.c b/jdk/src/share/native/common/check_version.c
+--- a/jdk/src/share/native/common/check_version.c
++++ b/jdk/src/share/native/common/check_version.c
+@@ -27,7 +27,8 @@
+ #include "jvm.h"
+
+ JNIEXPORT jint JNICALL
++#define JNI_REQ_VERSION JNI_VERSION_1_8
++JNI_OnLoad_java(JavaVM *vm, void *reserved)
+-JNI_OnLoad(JavaVM *vm, void *reserved)
+ {
+     jint vm_version = JVM_GetInterfaceVersion();
+     if (vm_version != JVM_INTERFACE_VERSION) {
+@@ -35,10 +41,11 @@
+         char buf[128];
+         sprintf(buf, "JVM interface version mismatch: expecting %d, got %d.",
+                 JVM_INTERFACE_VERSION, (int)vm_version);
+-        (*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_2);
++        (*vm)->GetEnv(vm, (void **)&env, JNI_REQ_VERSION);
+         if (env) {
+             (*env)->FatalError(env, buf);
+         }
+     }
+-    return JNI_VERSION_1_2;
++    return JNI_REQ_VERSION;
+ }
++
+diff --git a/jdk/src/share/native/java/net/net_util.c b/jdk/src/share/native/java/net/net_util.c
+--- a/jdk/src/share/native/java/net/net_util.c
++++ b/jdk/src/share/native/java/net/net_util.c
+@@ -38,7 +38,8 @@
+ }
+
+ JNIEXPORT jint JNICALL
++#define JNI_REQ_VERSION JNI_VERSION_1_8
++JNI_OnLoad_net(JavaVM *vm, void *reserved)
+-JNI_OnLoad(JavaVM *vm, void *reserved)
+ {
+     JNIEnv *env;
+     jclass iCls;
+@@ -50,15 +56,15 @@
+         if (JVM_InitializeSocketLibrary() < 0) {
+             JNU_ThrowByName(env, "java/lang/UnsatisfiedLinkError",
+                             "failed to initialize net library.");
+-            return JNI_VERSION_1_2;
++            return JNI_REQ_VERSION;
+         }
+     }
+     iCls = (*env)->FindClass(env, "java/lang/Boolean");
+-    CHECK_NULL_RETURN(iCls, JNI_VERSION_1_2);
++    CHECK_NULL_RETURN(iCls, JNI_REQ_VERSION);
+     mid = (*env)->GetStaticMethodID(env, iCls, "getBoolean", "(Ljava/lang/String;)Z");
+-    CHECK_NULL_RETURN(mid, JNI_VERSION_1_2);
++    CHECK_NULL_RETURN(mid, JNI_REQ_VERSION);
+     s = (*env)->NewStringUTF(env, "java.net.preferIPv4Stack");
+-    CHECK_NULL_RETURN(s, JNI_VERSION_1_2);
++    CHECK_NULL_RETURN(s, JNI_REQ_VERSION);
+     preferIPv4Stack = (*env)->CallStaticBooleanMethod(env, iCls, mid, s);
+
+     /*
+@@ -70,7 +76,7 @@
+     platformInit();
+     parseExclusiveBindProperty(env);
+
+-    return JNI_VERSION_1_2;
++    return JNI_REQ_VERSION;
+ }
+
+ static int initialized = 0;
+diff --git a/jdk/src/share/native/java/util/zip/ZipFile.c b/jdk/src/share/native/java/util/zip/ZipFile.c
+--- a/jdk/src/share/native/java/util/zip/ZipFile.c
++++ b/jdk/src/share/native/java/util/zip/ZipFile.c
+@@ -55,6 +55,12 @@
+ static int OPEN_READ = java_util_zip_ZipFile_OPEN_READ;
+ static int OPEN_DELETE = java_util_zip_ZipFile_OPEN_DELETE;
+
++JNIEXPORT jint JNICALL
++JNI_OnLoad_zip(JavaVM *vm, void *reserved)
++{
++    return JNI_VERSION_1_8;
++}
++
+ JNIEXPORT void JNICALL
+ Java_java_util_zip_ZipFile_initIDs(JNIEnv *env, jclass cls)
+ {
+diff --git a/jdk/src/solaris/native/sun/nio/ch/FileChannelImpl.c b/jdk/src/solaris/native/sun/nio/ch/FileChannelImpl.c
+--- a/jdk/src/solaris/native/sun/nio/ch/FileChannelImpl.c
++++ b/jdk/src/solaris/native/sun/nio/ch/FileChannelImpl.c
+@@ -52,6 +52,12 @@
+
+ static jfieldID chan_fd;        /* jobject 'fd' in sun.io.FileChannelImpl */
+
++JNIEXPORT jint JNICALL
++JNI_OnLoad_nio(JavaVM *vm, void *reserved)
++{
++    return JNI_VERSION_1_8;
++}
++
+ JNIEXPORT jlong JNICALL
+ Java_sun_nio_ch_FileChannelImpl_initIDs(JNIEnv *env, jclass clazz)
+ {
+diff --git a/jdk/src/windows/native/sun/nio/ch/FileChannelImpl.c b/jdk/src/windows/native/sun/nio/ch/FileChannelImpl.c
+--- a/jdk/src/windows/native/sun/nio/ch/FileChannelImpl.c
++++ b/jdk/src/windows/native/sun/nio/ch/FileChannelImpl.c
+@@ -38,6 +38,12 @@
+
+ static jfieldID chan_fd; /* id for jobject 'fd' in java.io.FileChannel */
+
++JNIEXPORT jint JNICALL
++JNI_OnLoad_nio(JavaVM *vm, void *reserved)
++{
++    return JNI_VERSION_1_8;
++}
++
+ /**************************************************************
+  * static method to store field ID's in initializers
+  * and retrieve the allocation granularity

--- a/pkgs/development/compilers/openjdk/openjdk_jvmci_top.patch
+++ b/pkgs/development/compilers/openjdk/openjdk_jvmci_top.patch
@@ -1,0 +1,97 @@
+diff --git a/common/autoconf/configure.ac b/common/autoconf/configure.ac
+--- a/common/autoconf/configure.ac
++++ b/common/autoconf/configure.ac
+@@ -188,6 +188,7 @@
+ PLATFORM_SETUP_OPENJDK_TARGET_ENDIANNESS
+
+ # Configure flags for the tools
++JDKOPT_SETUP_STATIC_BUILD
+ FLAGS_SETUP_COMPILER_FLAGS_FOR_LIBS
+ FLAGS_SETUP_COMPILER_FLAGS_FOR_OPTIMIZATION
+ FLAGS_SETUP_COMPILER_FLAGS_FOR_JDK
+diff --git a/common/autoconf/flags.m4 b/common/autoconf/flags.m4
+--- a/common/autoconf/flags.m4
++++ b/common/autoconf/flags.m4
+@@ -440,6 +440,21 @@
+   LEGACY_EXTRA_CXXFLAGS="$LEGACY_EXTRA_CXXFLAGS $with_extra_cxxflags"
+   LEGACY_EXTRA_LDFLAGS="$LEGACY_EXTRA_LDFLAGS $with_extra_ldflags"
+
++  if test "x$STATIC_BUILD" = xtrue; then
++    CFLAGS_JDK="${CFLAGS_JDK} $with_extra_cflags -DSTATIC_BUILD=1"
++    LEGACY_EXTRA_CFLAGS="${LEGACY_EXTRA_CFLAGS} $with_extra_cflags -DSTATIC_BUILD=1"
++    if test "x$TOOLCHAIN_TYPE" = xgcc; then
++      CFLAGS_SECTIONS="-ffunction-sections -fdata-sections"
++      CFLAGS_JDK="${CFLAGS_JDK} ${CFLAGS_SECTIONS}"
++      LEGACY_EXTRA_CFLAGS="${LEGACY_EXTRA_CFLAGS} ${CFLAGS_SECTIONS}"
++    fi
++    if test "x$TOOLCHAIN_TYPE" = xclang; then
++      CFLAGS_SECTIONS="-ffunction-sections -fdata-sections"
++      CFLAGS_JDK="${CFLAGS_JDK} ${CFLAGS_SECTIONS}"
++      LEGACY_EXTRA_CFLAGS="${LEGACY_EXTRA_CFLAGS} ${CFLAGS_SECTIONS}"
++    fi
++  fi
++
+   AC_SUBST(LEGACY_EXTRA_CFLAGS)
+   AC_SUBST(LEGACY_EXTRA_CXXFLAGS)
+   AC_SUBST(LEGACY_EXTRA_LDFLAGS)
+diff --git a/common/autoconf/jdk-options.m4 b/common/autoconf/jdk-options.m4
+--- a/common/autoconf/jdk-options.m4
++++ b/common/autoconf/jdk-options.m4
+@@ -691,6 +691,28 @@
+   AC_SUBST(ZIP_DEBUGINFO_FILES)
+ ])
+
++################################################################################
++#
++# Static build support.  When enabled will generate static
++# libraries instead of shared libraries for all JDK libs.
++#
++AC_DEFUN_ONCE([JDKOPT_SETUP_STATIC_BUILD],
++[
++  AC_ARG_ENABLE([static-build], [AS_HELP_STRING([--enable-static-build],
++    [enable static library build @<:@disabled@:>@])])
++  STATIC_BUILD=false
++  if test "x$enable_static_build" = "xyes"; then
++    STATIC_BUILD=true
++  elif test "x$enable_static_build" = "xno"; then
++    AC_MSG_CHECKING([if static build is enabled])
++    AC_MSG_RESULT([no])
++  elif test "x$enable_static_build" != "x"; then
++    AC_MSG_ERROR([--enable-static-build can only be assigned "yes" or "no"])
++  fi
++
++  AC_SUBST(STATIC_BUILD)
++])
++
+ # Support for customization of the build process. Some build files
+ # will include counterparts from this location, if they exist. This allows
+ # for a degree of customization of the build targets and the rules/recipes
+diff --git a/common/autoconf/spec.gmk.in b/common/autoconf/spec.gmk.in
+--- a/common/autoconf/spec.gmk.in
++++ b/common/autoconf/spec.gmk.in
+@@ -443,6 +443,7 @@
+ STATIC_LIBRARY_SUFFIX:=@STATIC_LIBRARY_SUFFIX@
+ EXE_SUFFIX:=@EXE_SUFFIX@
+ OBJ_SUFFIX:=@OBJ_SUFFIX@
++STATIC_BUILD:=@STATIC_BUILD@
+
+ POST_STRIP_CMD:=@POST_STRIP_CMD@
+ POST_MCS_CMD:=@POST_MCS_CMD@
+diff --git a/make/common/NativeCompilation.gmk b/make/common/NativeCompilation.gmk
+--- a/make/common/NativeCompilation.gmk
++++ b/make/common/NativeCompilation.gmk
+@@ -411,6 +411,7 @@
+   # mapfile doesnt seem to be implemented on macosx (yet??)
+   ifneq ($(OPENJDK_TARGET_OS),macosx)
+     ifneq ($(OPENJDK_TARGET_OS),windows)
++      ifneq ($(STATIC_BUILD),true)
+       $1_REAL_MAPFILE:=$$($1_MAPFILE)
+       ifneq (,$$($1_REORDER))
+         $1_REAL_MAPFILE:=$$($1_OBJECT_DIR)/mapfile
+@@ -421,6 +422,7 @@
+ 		$$(SED) -e 's=OUTPUTDIR=$$($1_OBJECT_DIR)=' $$($1_REORDER) >> $$@.tmp
+ 		$$(MV) $$@.tmp $$@
+       endif
++      endif
+     endif
+   endif


### PR DESCRIPTION
EDITED 28/04/2020: I was able to solve the static compilation problem. With these changes I can finally compile graalvm native images. I didn't pay much attention to linting etc, so don't hesitate to ask questions about my decision or potential blunders. I will very likely need to make similar changes to jdk11, but this brings me step closer to getting graalvm 20 to compile on nixpkgs.

~~Preface: plz help and/or look over, I've been struggling with this for few days.~~ I've been able to build openjdk8 statically with patches pointed out here https://github.com/graalvm/openjdk8-jvmci-builder/issues/11#issuecomment-542195999 I've been successfull with both musl and gcc (I think I'll be focusing on gcc since the official CE is distributed with gcc, but this could be irrelevant). ~~Ending with the same error over and over~~
[deleted]

###### Motivation for this change

As part of upgrading graalvm8, I will need to use statically compiled openjdk8 as basis for jvmci8 to build native-image/substratevm. I believe the same applies for openjdk11, but I haven't reached that far yet.


###### Things done

- Added optional attribute "static" to openjdk8
- Added patches needed to compile statically in gcc and musl (gcc should work fine as I write this, musl I haven't tested for few days, darwin-clang I never tried so far).
- Bumped openjdk8 and adoptjdk-bin both to `252-b09`

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
