### PR TITLE
ZenStates: init at 0.1.0

### DIFF
--- a/pkgs/os-specific/linux/zenstates/default.nix
+++ b/pkgs/os-specific/linux/zenstates/default.nix
@@ -1,0 +1,54 @@
+# Zenstates provides access to a variety of CPU tunables no Ryzen processors.
+#
+# In particular, I am adding Zenstates because I need it to disable the C6
+# sleep state to stabilize wake from sleep on my Lenovo x395 system. After
+# installing Zenstates, I need a before-sleep script like so:
+#
+# before-sleep = pkgs.writeScript "before-sleep" ''
+#   #!${pkgs.bash}/bin/bash
+#   ${pkgs.zenstates}/bin/zenstates --c6-disable
+# '';
+#
+# ...
+#
+# systemd.services.before-sleep = {
+#     description = "Jobs to run before going to sleep";
+#     serviceConfig = {
+#       Type = "oneshot";
+#       ExecStart = "${before-sleep}";
+#     };
+#     wantedBy = [ "sleep.target" ];
+#     before = [ "sleep.target" ];
+#   };
+
+{ stdenv, fetchFromGitHub, python3 }:
+stdenv.mkDerivation rec {
+  pname = "zenstates";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "r4m0n";
+    repo = "ZenStates-Linux";
+    rev = "0bc27f4740e382f2a2896dc1dabfec1d0ac96818";
+    sha256 = "1h1h2n50d2cwcyw3zp4lamfvrdjy1gjghffvl3qrp6arfsfa615y";
+  };
+
+  buildInputs = [ python3 ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/zenstates.py $out/bin/zenstates
+    chmod +x $out/bin/zenstates
+    patchShebangs --build $out/bin/zenstates
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Linux utility for Ryzen processors and motherboards";
+    homepage = "https://github.com/r4m0n/ZenStates-Linux";
+    license = licenses.mit;
+    maintainers = with maintainers; [ savannidgerinel ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/zenstates/default.nix
+++ b/pkgs/os-specific/linux/zenstates/default.nix
@@ -24,7 +24,7 @@
 { stdenv, fetchFromGitHub, python3 }:
 stdenv.mkDerivation rec {
   pname = "zenstates";
-  version = "0.1.0";
+  version = "0.0.1";
 
   src = fetchFromGitHub {
     owner = "r4m0n";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26505,4 +26505,5 @@ in
 
   jitsi-meet-electron = callPackage ../applications/networking/instant-messengers/jitsi-meet-electron { };
 
+  zenstates = callPackage ../os-specific/linux/zenstates {};
 }


### PR DESCRIPTION
#### Motivation for this change

ZenStates is a small python application that, while unmaintained, is the only known way to manipulate the sleep states on an AMD Ryzen system.

I use the application to disable C6 sleep before my laptop goes to sleep so that I have a much better chance of the laptop successfully waking up.

Story: #85789 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
