### PR TITLE
[20.03] alacritty: backport 0.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1427,6 +1427,16 @@
     githubId = 5684605;
     name = "Cole Scott";
   };
+  cole-h = {
+    name = "Cole Helbling";
+    email = "cole.e.helbling@outlook.com";
+    github = "cole-h";
+    githubId = 28582702;
+    keys = [{
+      longkeyid = "rsa4096/0xB37E0F2371016A4C";
+      fingerprint = "68B8 0D57 B2E5 4AC3 EC1F  49B0 B37E 0F23 7101 6A4C";
+    }];
+  };
   copumpkin = {
     email = "pumpkingod@gmail.com";
     github = "copumpkin";

--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -61,7 +61,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "133d8vm7ihlvgw8n1jghhh35h664h0f52h6gci54f11vl6c1spws";
   };
 
-  cargoSha256 = "07gq63qd11zz229b8jp9wqggz39qfpzd223z1zk1xch7rhqq0pn4";
+  cargoSha256 = "0y7yzbl6hyb89f2lcn3s65jbrzibr8b8x7l84iriw6ifsqnvcyg5";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -1,40 +1,38 @@
-{ stdenv,
-  lib,
-  fetchFromGitHub,
-  rustPlatform,
+{ stdenv
+, lib
+, fetchFromGitHub
+, rustPlatform
 
-  cmake,
-  gzip,
-  installShellFiles,
-  makeWrapper,
-  ncurses,
-  pkgconfig,
-  python3,
+, cmake
+, gzip
+, installShellFiles
+, makeWrapper
+, ncurses
+, pkgconfig
+, python3
 
-  expat,
-  fontconfig,
-  freetype,
-  libGL,
-  libX11,
-  libXcursor,
-  libXi,
-  libXrandr,
-  libXxf86vm,
-  libxcb,
-  libxkbcommon,
-  wayland,
-  xdg_utils,
+, expat
+, fontconfig
+, freetype
+, libGL
+, libX11
+, libXcursor
+, libXi
+, libXrandr
+, libXxf86vm
+, libxcb
+, libxkbcommon
+, wayland
+, xdg_utils
 
   # Darwin Frameworks
-  AppKit,
-  CoreGraphics,
-  CoreServices,
-  CoreText,
-  Foundation,
-  OpenGL }:
-
-with rustPlatform;
-
+, AppKit
+, CoreGraphics
+, CoreServices
+, CoreText
+, Foundation
+, OpenGL
+}:
 let
   rpathLibs = [
     expat
@@ -51,18 +49,19 @@ let
     libxkbcommon
     wayland
   ];
-in buildRustPackage rec {
+in
+rustPlatform.buildRustPackage rec {
   pname = "alacritty";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
-    owner = "jwilm";
+    owner = "alacritty";
     repo = pname;
     rev = "v${version}";
-    sha256 = "05jcg33ifngpzw2hdhgb614j87ihhhlqgar0kky183rywg0dxikg";
+    sha256 = "133d8vm7ihlvgw8n1jghhh35h664h0f52h6gci54f11vl6c1spws";
   };
 
-  cargoSha256 = "1kc9n10kb4j87x337pzl6wpi0qj5ib2mqmrjag2yld3138dag71n";
+  cargoSha256 = "07gq63qd11zz229b8jp9wqggz39qfpzd223z1zk1xch7rhqq0pn4";
 
   nativeBuildInputs = [
     cmake
@@ -75,9 +74,17 @@ in buildRustPackage rec {
   ];
 
   buildInputs = rpathLibs
-    ++ lib.optionals stdenv.isDarwin [ AppKit CoreGraphics CoreServices CoreText Foundation OpenGL ];
+  ++ lib.optionals stdenv.isDarwin [
+    AppKit
+    CoreGraphics
+    CoreServices
+    CoreText
+    Foundation
+    OpenGL
+  ];
 
   outputs = [ "out" "terminfo" ];
+
   postPatch = ''
     substituteInPlace alacritty/src/config/mouse.rs \
       --replace xdg-open ${xdg_utils}/bin/xdg-open
@@ -90,14 +97,16 @@ in buildRustPackage rec {
 
     install -D target/release/alacritty $out/bin/alacritty
 
-  '' + (if stdenv.isDarwin then ''
-    mkdir $out/Applications
-    cp -r target/release/osx/Alacritty.app $out/Applications/Alacritty.app
-  '' else ''
-    install -D extra/linux/alacritty.desktop -t $out/share/applications/
-    install -D extra/logo/alacritty-term.svg $out/share/icons/hicolor/scalable/apps/Alacritty.svg
-    patchelf --set-rpath "${stdenv.lib.makeLibraryPath rpathLibs}" $out/bin/alacritty
-  '') + ''
+  '' + (
+    if stdenv.isDarwin then ''
+      mkdir $out/Applications
+      cp -r target/release/osx/Alacritty.app $out/Applications/Alacritty.app
+    '' else ''
+      install -D extra/linux/Alacritty.desktop -t $out/share/applications/
+      install -D extra/logo/alacritty-term.svg $out/share/icons/hicolor/scalable/apps/Alacritty.svg
+      patchelf --set-rpath "${lib.makeLibraryPath rpathLibs}" $out/bin/alacritty
+    ''
+  ) + ''
 
     installShellCompletion --zsh extra/completions/_alacritty
     installShellCompletion --bash extra/completions/alacritty.bash
@@ -116,11 +125,11 @@ in buildRustPackage rec {
 
   dontPatchELF = true;
 
-  meta = with stdenv.lib; {
-    description = "GPU-accelerated terminal emulator";
-    homepage = "https://github.com/jwilm/alacritty";
+  meta = with lib; {
+    description = "A cross-platform, GPU-accelerated terminal emulator";
+    homepage = "https://github.com/alacritty/alacritty";
     license = licenses.asl20;
-    maintainers = with maintainers; [ filalex77 mic92 ];
+    maintainers = with maintainers; [ filalex77 mic92 cole-h ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
##### Motivation for this change
This change was initially motivated by unexpected behavior of alacritty after updating from 19.09 to 20.03. 
The application seemed to randomly close, upon further investigation it turns out that this was probably related to Alacritty not ignoring keyboard events for changing WM focus on X11.
0.4.2 also includes other X11 related bugfixes ( https://github.com/alacritty/alacritty/releases/tag/v0.4.2 )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
