### PR TITLE
nixos/containers: move libpod to nixos/podman

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -30,7 +30,7 @@ in
         type = types.bool;
         default = false;
         description = ''
-          This option enables the common libpod container configuration module.
+          This option enables the common /etc/containers configuration module.
         '';
       };
 
@@ -89,34 +89,9 @@ in
       '';
     };
 
-    libpod = mkOption {
-      default = {};
-      description = "Libpod configuration";
-      type = types.submodule {
-        options = {
-
-          extraConfig = mkOption {
-            type = types.lines;
-            default = "";
-            description = ''
-              Extra configuration that should be put in the libpod.conf
-              configuration file
-            '';
-
-          };
-        };
-      };
-    };
-
   };
 
   config = lib.mkIf cfg.enable {
-
-    environment.etc."containers/libpod.conf".text = ''
-      cni_plugin_dir = ["${pkgs.cni-plugins}/bin/"]
-      cni_config_dir = "/etc/cni/net.d/"
-
-    '' + cfg.libpod.extraConfig;
 
     environment.etc."containers/registries.conf".source = toTOML "registries.conf" {
       registries = lib.mapAttrs (n: v: { registries = v; }) cfg.registries;

--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -85,7 +85,7 @@ in
       }
     '';
 
-    # Enable common container configuration, this will create policy.json
+    # Enable common /etc/containers configuration
     virtualisation.containers.enable = true;
 
     systemd.services.crio = {

--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -54,6 +54,25 @@ in
       '';
     };
 
+    libpod = mkOption {
+      default = {};
+      description = "Libpod configuration";
+      type = types.submodule {
+        options = {
+
+          extraConfig = mkOption {
+            type = types.lines;
+            default = "";
+            description = ''
+              Extra configuration that should be put in the libpod.conf
+              configuration file
+            '';
+
+          };
+        };
+      };
+    };
+
   };
 
   config = lib.mkIf cfg.enable {
@@ -70,8 +89,15 @@ in
     ]
     ++ lib.optional cfg.dockerCompat dockerCompat;
 
+    environment.etc."containers/libpod.conf".text = ''
+      cni_plugin_dir = ["${pkgs.cni-plugins}/bin/"]
+      cni_config_dir = "/etc/cni/net.d/"
+
+    '' + cfg.libpod.extraConfig;
+
     environment.etc."cni/net.d/87-podman-bridge.conflist".source = copyFile "${pkgs.podman.src}/cni/87-podman-bridge.conflist";
 
+    # Enable common /etc/containers configuration
     virtualisation.containers.enable = true;
 
   };


### PR DESCRIPTION
`libpod.conf` is Podman specific config, similar to `crio.conf` and CRI-O.

I didn't bother with a rename as it's only a couple of days old.

cc @adisbladis @saschagrunert @vdemeester 