### PR TITLE
nixos/cri-o: share registries with nixos/containers

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -45,6 +45,11 @@
      There is a new module for Podman(<varname>virtualisation.podman</varname>), a drop-in replacement for the Docker command line.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The new <varname>virtualisation.containers</varname> module manages configuration shared by the CRI-O and Podman modules.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -6,6 +6,10 @@ let
   cfg = config.virtualisation.cri-o;
 in
 {
+  imports = [
+    (mkRenamedOptionModule [ "virtualisation" "cri-o" "registries" ] [ "virtualisation" "containers" "registries" "search" ])
+  ];
+
   meta = {
     maintainers = lib.teams.podman.members;
   };
@@ -36,12 +40,6 @@ in
       default = "/pause";
       description = "Pause command to be executed";
     };
-
-    registries = mkOption {
-      type = types.listOf types.str;
-      default = [ "docker.io" "quay.io" ];
-      description = "Registries to be configured for unqualified image pull";
-    };
   };
 
   config = mkIf cfg.enable {
@@ -57,9 +55,6 @@ in
       [crio.image]
       pause_image = "${cfg.pauseImage}"
       pause_command = "${cfg.pauseCommand}"
-      registries = [
-        ${concatMapStringsSep ", " (x: "\"" + x + "\"") cfg.registries}
-      ]
 
       [crio.network]
       plugin_dirs = ["${pkgs.cni-plugins}/bin/"]


### PR DESCRIPTION
> https://github.com/cri-o/cri-o/blob/master/docs/crio.conf.5.md#crioimage-table

> CRI-O reads its configured registries defaults from the system wide containers-registries.conf(5) located in /etc/containers/registries.conf. If you want to modify just CRI-O, you can change the registries configuration in this file. Otherwise, leave `insecure_registries` and `registries` commented out to use the system's defaults from /etc/containers/registries.conf.

cc @adisbladis @saschagrunert @vdemeester