### PR TITLE
chocolate-doom: 2.3.0 -> 3.0.0

### DIFF
--- a/pkgs/games/chocolate-doom/default.nix
+++ b/pkgs/games/chocolate-doom/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, autoreconfHook, pkgconfig, SDL, SDL_mixer, SDL_net, fetchurl }:
+{ stdenv, autoreconfHook, pkgconfig, SDL2, SDL2_mixer, SDL2_net, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "chocolate-doom-2.3.0";
-  src = fetchurl {
-    url = "https://github.com/chocolate-doom/chocolate-doom/archive/${name}.tar.gz";
-    sha256 = "0i57smxmbhxj0wgvxq845ba9zsn5nx5wmzkl71rdchyd4q5jmida";
+  pname = "chocolate-doom";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "chocolate-doom";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0ajzb767wyj8vzhjpsmgslw42b0155ji4alk26shxl7k5ijbzn0j";
   };
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ SDL SDL_mixer SDL_net ];
-  patchPhase = ''
+
+  postPatch = ''
     sed -e 's#/games#/bin#g' -i src{,/setup}/Makefile.am
   '';
 
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ SDL2 SDL2_mixer SDL2_net ];
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I've updated Chocolate-Doom as it has not been updated for a while. Chocolate-Doom 3.0 now uses SDL2 instead of the original SDL. 

Chocolate-Doom has the same build system as Crispy-Doom, so the configuration file was modified to reflect what can be seen in [crispy-doom's config file](https://github.com/NixOS/nixpkgs/blob/master/pkgs/games/crispy-doom/default.nix). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
