### PR TITLE
mosh: fix build with bash-completion 2.10

### DIFF
--- a/pkgs/tools/networking/mosh/bash_completion_datadir.patch
+++ b/pkgs/tools/networking/mosh/bash_completion_datadir.patch
@@ -1,0 +1,19 @@
+diff --git a/configure.ac b/configure.ac
+index 3ad983d..ff8ff96 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -476,13 +476,7 @@ AS_IF([echo "$protobuf_LIBS" | grep -q -- -pthread],
+ 
+ # Bash completion needs to ask where it goes if >= 2.0 is installed.
+ AS_IF([test "$install_completion" != no],
+-  [PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
+-     [if test "$prefix" = "NONE"; then
+-        completions="`pkg-config --variable=completionsdir bash-completion`"
+-      else
+-        completions="`pkg-config --define-variable=prefix=$prefix --variable=completionsdir bash-completion`"
+-      fi],
+-     [completions="${sysconfdir}/bash_completion.d"])
++   [completions="`pkg-config --define-variable=datadir=$datadir --variable=completionsdir bash-completion`"]
+    AC_SUBST([completions])])
+ 
+ AC_CONFIG_FILES([

--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
       url = "https://github.com/mobile-shell/mosh/commit/e5f8a826ef9ff5da4cfce3bb8151f9526ec19db0.patch";
       sha256 = "15518rb0r5w1zn4s6981bf1sz6ins6gpn2saizfzhmr13hw4gmhm";
     })
+    # Fix build with bash-completion 2.10
+    ./bash_completion_datadir.patch
   ];
   postPatch = ''
     substituteInPlace scripts/mosh.pl \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #85893

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @peti (because it involves bash-completion, I want to make sure my patch is reasonable)