### PR TITLE
libpsm2: init at 11.2.156 

### DIFF
--- a/pkgs/os-specific/linux/libpsm2/default.nix
+++ b/pkgs/os-specific/linux/libpsm2/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/intel/opa-psm2";
     description = "The PSM2 library supports a number of fabric media and stacks";
     license = with licenses; [ gpl2 bsd3 ];
-    platforms = platforms.linux;
+   platforms = [ "x86_64-linux" ];
     maintainers = [ maintainers.bzizou ];
   };
 }

--- a/pkgs/os-specific/linux/libpsm2/default.nix
+++ b/pkgs/os-specific/linux/libpsm2/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, numactl, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "libpsm2";
+  version = "11.2.156";
+  ifs_version = "10_10_2_0_44";
+
+  preConfigure= ''
+    export UDEVDIR=$out/etc/udev
+    substituteInPlace ./Makefile --replace "udevrulesdir}" "prefix}/etc/udev";
+  '';
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ numactl pkgconfig ];
+
+  installFlags = [ 
+    "DESTDIR=$(out)"
+    "UDEVDIR=/etc/udev"
+    "LIBPSM2_COMPAT_CONF_DIR=/etc"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "opa-psm2";
+    rev = "IFS_RELEASE_${ifs_version}";
+    sha256 = "0ckrfzih1ga9yvximxjdh0z05kn9l858ykqiblv18w6ka3gra1xz";
+  };
+
+  postInstall = ''
+    mv $out/usr/* $out
+    rmdir $out/usr
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/intel/opa-psm2;
+    description = "The PSM2 library supports a number of fabric media and stacks";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bzizou ];
+  };
+}

--- a/pkgs/os-specific/linux/libpsm2/default.nix
+++ b/pkgs/os-specific/linux/libpsm2/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/intel/opa-psm2;
     description = "The PSM2 library supports a number of fabric media and stacks";
-    license = stdenv.lib.licenses.gpl2;
+    license = with licenses; [ gpl2 bsd3 ];
     platforms = platforms.linux;
     maintainers = [ maintainers.bzizou ];
   };

--- a/pkgs/os-specific/linux/libpsm2/default.nix
+++ b/pkgs/os-specific/linux/libpsm2/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/intel/opa-psm2;
+    homepage = "https://github.com/intel/opa-psm2";
     description = "The PSM2 library supports a number of fabric media and stacks";
     license = with licenses; [ gpl2 bsd3 ];
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2089,6 +2089,8 @@ in
 
   xkbd = callPackage ../applications/misc/xkbd { };
 
+  libpsm2 = callPackage ../os-specific/linux/libpsm2 { };
+
   optar = callPackage ../tools/graphics/optar {};
 
   obinskit = callPackage ../applications/misc/obinskit {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is a necessary library for HPC systems using an Intel Omnipath network. This library is a dependency for openmpi on such systems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
