### PR TITLE
dump: init at 0.4b46

### DIFF
--- a/pkgs/tools/backup/dump/default.nix
+++ b/pkgs/tools/backup/dump/default.nix
@@ -1,0 +1,24 @@
+# Tested with simple dump and restore -i, but complains that
+# /nix/store/.../etc/dumpdates doesn't exist.
+
+{ stdenv, fetchurl, pkgconfig,
+  e2fsprogs, ncurses, readline }:
+
+stdenv.mkDerivation rec {
+  pname = "dump";
+  version = "0.4b46";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/dump/dump-${version}.tar.gz";
+    sha256 = "15rg5y15ak0ppqlhcih78layvg7cwp6hc16p3c58xs8svlkxjqc0";
+  };
+
+  buildInputs = [ e2fsprogs pkgconfig ncurses readline ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://dump.sourceforge.io/";
+    description = "Linux Ext2 filesystem dump/restore utilities";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ falsifian ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25284,6 +25284,8 @@ in
 
   dumb = callPackage ../misc/dumb { };
 
+  dump = callPackage ../tools/backup/dump { };
+
   ecdsatool = callPackage ../tools/security/ecdsatool { };
 
   emulationstation = callPackage ../misc/emulators/emulationstation { };


### PR DESCRIPTION
Tested by dumping a small filesystem and extracting files from the dump using
restore -i. It worked, but complained:

    DUMP: WARNING: no file `/nix/store/y7r0q9l7663vii0j0lqlrwyi073z81n8-dump-0.4b46/etc/dumpdates'

Still, it is enough for my purposes; and I think it would be a useful addition to nixpkgs.


###### Motivation for this change

I'm trying out this classic dump/restore utility for simple backups.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
