### PR TITLE
easysnap: changing format for samba shadow_copy2 to work

### DIFF
--- a/pkgs/tools/backup/easysnap/default.nix
+++ b/pkgs/tools/backup/easysnap/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "easysnap";
-  version = "unstable-2020-04-04";
+  version = "unstable-2020-04-24";
 
   src = fetchFromGitHub {
     owner = "sjau";
     repo = "easysnap";
-    rev = "26f89c0c3cda01e2595ee19ae5fb8518da25b4ef";
-    sha256 = "sha256:1k49k1m7y8s099wyiiz8411i77j1156ncirynmjfyvdhmhcyp5rw";
+    rev = "95cfd1fdda5bc8c111eee171289d29b9f66081cd";
+    sha256 = "1hchqqj0k54f1174fvb6c6r19lrfq0ldfasm05qh6mbfjm6x390v";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Samba's Shadow Copy2 allows to easily show the modifications of a file in Windows based on snapshots made. A format change of the easysnap snapshots was required to accomplish that.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
