### PR TITLE
ispc: 1.10.0 -> 1.13.0, cleanup, (co)maintain

### DIFF
--- a/pkgs/development/compilers/ispc/default.nix
+++ b/pkgs/development/compilers/ispc/default.nix
@@ -1,42 +1,44 @@
-{stdenv, fetchFromGitHub, cmake, which, m4, python, bison, flex, llvmPackages,
-testedTargets ? ["sse2"] # the default test target is sse4, but that is not supported by all Hydra agents
+{ stdenv, fetchFromGitHub
+, cmake, which, m4, python3, bison, flex, llvmPackages
+
+  # the default test target is sse4, but that is not supported by all Hydra agents
+, testedTargets ? [ "sse2" ]
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.10.0";
-  rev = "v${version}";
+  pname   = "ispc";
+  version = "1.13.0";
+
+  src = fetchFromGitHub {
+    owner  = pname;
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "1l74xkpwwxc38k2ngg7mpvswziiy91yxslgfad6688hh1n5jvayd";
+  };
+
+  nativeBuildInputs = [ cmake which m4 bison flex python3 ];
+  buildInputs = with llvmPackages; [
+    # we need to link against libclang, so we need the unwrapped
+    llvm llvmPackages.clang-unwrapped
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace curses ncurses
+    substituteInPlace cmake/GenerateBuiltins.cmake \
+      --replace 'bit 32 64' 'bit 64'
+  '';
 
   inherit testedTargets;
 
-  pname = "ispc";
-
-  src = fetchFromGitHub {
-    owner = "ispc";
-    repo = "ispc";
-    inherit rev;
-    sha256 = "1x07n2gaff3v32yvddrb659mx5gg12bnbsqbyfimp396wn04w60b";
-  };
-
+  # needs 'transcendentals' executable, which is only on linux
   doCheck = stdenv.isLinux;
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = with llvmPackages; [
-    which
-    m4
-    python
-    bison
-    flex
-    llvm
-    llvmPackages.clang-unwrapped # we need to link against libclang, so we need the unwrapped
-  ];
-
-  postPatch = "sed -i -e 's/curses/ncurses/g' CMakeLists.txt";
-
-  # TODO: this correctly catches errors early, but also some things that are just weird and don't seem to be real
-  # errors
-  #configurePhase = ''
-  #  makeFlagsArray=( SHELL="${bash}/bin/bash -o pipefail" )
-  #'';
+  # the compiler enforces -Werror, and -fno-strict-overflow makes it mad.
+  # hilariously this is something of a double negative: 'disable' the
+  # 'strictoverflow' hardening protection actually means we *allow* the compiler
+  # to do strict overflow optimization. somewhat misleading...
+  hardeningDisable = [ "strictoverflow" ];
 
   checkPhase = ''
     export ISPC_HOME=$PWD/bin
@@ -55,13 +57,14 @@ stdenv.mkDerivation rec {
     "-DCLANG_EXECUTABLE=${llvmPackages.clang}/bin/clang"
     "-DISPC_INCLUDE_EXAMPLES=OFF"
     "-DISPC_INCLUDE_UTILS=OFF"
-    ];
+    "-DARM_ENABLED=FALSE"
+  ];
 
   meta = with stdenv.lib; {
-    homepage = "https://ispc.github.io/";
+    homepage    = "https://ispc.github.io/";
     description = "Intel 'Single Program, Multiple Data' Compiler, a vectorised language";
-    license = licenses.bsd3;
-    platforms = ["x86_64-linux" "x86_64-darwin"]; # TODO: buildable on more platforms?
-    maintainers = [ maintainers.aristid ];
+    license     = licenses.bsd3;
+    platforms   = [ "x86_64-linux" "x86_64-darwin" ]; # TODO: buildable on more platforms?
+    maintainers = with maintainers; [ aristid thoughtpolice ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12299,8 +12299,8 @@ in
   isocodes = callPackage ../development/libraries/iso-codes { };
 
   ispc = callPackage ../development/compilers/ispc {
-    llvmPackages = llvmPackages_6;
-    stdenv = llvmPackages_6.stdenv;
+    stdenv = llvmPackages_10.stdenv;
+    llvmPackages = llvmPackages_10;
   };
 
   isso = callPackage ../servers/isso { };


### PR DESCRIPTION
This includes several enhancements in the underlying compiler, including
codegen improvements for AVX-512, Ice Lake CPU definitions,
cross-{arch,os} compilation (currently unsupported due to multilib
issues), and more.

This also bumps the LLVM backend to the 10.0 release. Note that ispc
itself requires a few extra stability patches on top of 10.0 for AVX-512
support, but these aren't applied for us. Therefore AVX-512 still has
some extra, rough edges.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
