### PR TITLE
tartube: init at 2.0.016

### DIFF
--- a/pkgs/applications/video/tartube/default.nix
+++ b/pkgs/applications/video/tartube/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gdk-pixbuf
+, gobject-introspection
+, gtk3
+, libnotify
+, pango
+, python3Packages
+, wrapGAppsHook
+, youtube-dl
+, glib
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "tartube";
+  version = "2.0.016";
+
+  src = fetchFromGitHub {
+    owner = "axcore";
+    repo = "tartube";
+    rev = "v${version}";
+    sha256 = "1y77ykihyi4v6xlsm5xldbs9lzq229l574rxz6qfvrjcbbwajfj9";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  strictDeps = false;
+
+  propagatedBuildInputs = with python3Packages; [
+    moviepy
+    pygobject3
+    pyxdg
+    requests
+  ];
+
+  buildInputs = [
+    gdk-pixbuf
+    gtk3
+    glib
+    libnotify
+    pango
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/{man/man1,applications,pixmaps}
+    cp pack/tartube.1 $out/share/man/man1
+    cp pack/tartube.desktop $out/share/applications
+    cp pack/tartube.{png,xpm} $out/share/pixmaps
+  '';
+
+  doCheck = false;
+
+  makeWrapperArgs = [
+    "--prefix PATH : ${stdenv.lib.makeBinPath [ youtube-dl ]}"
+  ];
+
+  meta = with lib; {
+    description = "A GUI front-end for youtube-dl";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mkg20001 luc65r ];
+    homepage = "https://tartube.sourceforge.io/";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6870,6 +6870,8 @@ in
 
   tarsnapper = callPackage ../tools/backup/tarsnapper { };
 
+  tartube = callPackage ../applications/video/tartube { };
+
   tayga = callPackage ../tools/networking/tayga { };
 
   tcpcrypt = callPackage ../tools/security/tcpcrypt { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/84655
This work uses @pbogdan's expression from https://github.com/NixOS/nixpkgs/issues/84655#issuecomment-614146162

@pbogdan: I didn't find any issues with the app, it seems to work. I also have made you the author of the commit, since I believe you should get the honor of being the commit author. Just comment if you don't like that.

I've added myself and @luc65r as a maintainer - I've asked him about that and he aggreed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
