### PR TITLE
aflplusplus: 2.59c -> 2.64c

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5064,6 +5064,12 @@
     githubId = 3269878;
     name = "Miguel Madrid Mencía";
   };
+  mindavi = {
+    email = "rol3517@gmail.com";
+    github = "Mindavi";
+    githubId = 9799623;
+    name = "Rick van Schijndel";
+  };
   minijackson = {
     email = "minijackson@riseup.net";
     github = "minijackson";

--- a/pkgs/tools/security/aflplusplus/libdislocator.nix
+++ b/pkgs/tools/security/aflplusplus/libdislocator.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation {
 
   preInstall = ''
     mkdir -p $out/lib/afl
+    # issue is fixed upstream: https://github.com/AFLplusplus/AFLplusplus/commit/2a60ceb6944a7ca273057ddf64dcf837bf7f9521
+    sed -i 's/README\.dislocator\.md/README\.md/g' Makefile
   '';
   postInstall = ''
     mkdir $out/bin

--- a/pkgs/tools/security/aflplusplus/libtokencap.nix
+++ b/pkgs/tools/security/aflplusplus/libtokencap.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation {
 
   preInstall = ''
     mkdir -p $out/lib/afl
+    mkdir -p $out/share/doc/afl
   '';
   postInstall = ''
     mkdir $out/bin

--- a/pkgs/tools/security/aflplusplus/qemu.nix
+++ b/pkgs/tools/security/aflplusplus/qemu.nix
@@ -28,10 +28,16 @@ stdenv.mkDerivation {
     for f in ${aflplusplus.src.name}/qemu_mode/patches/* ; do
       sed -E -i 's|(\.\./)+patches/([a-z-]+\.h)|\2|g' $f
       sed -E -i 's|\.\./\.\./config\.h|afl-config.h|g' $f
+      sed -E -i 's|\.\./\.\./include/cmplog\.h|afl-cmplog.h|g' $f
     done
     cp ${aflplusplus.src.name}/qemu_mode/patches/*.h $sourceRoot/
     cp ${aflplusplus.src.name}/types.h $sourceRoot/afl-types.h
     substitute ${aflplusplus.src.name}/config.h $sourceRoot/afl-config.h \
+      --replace "types.h" "afl-types.h"
+    substitute ${aflplusplus.src.name}/include/cmplog.h $sourceRoot/afl-cmplog.h \
+      --replace "config.h" "afl-config.h" \
+      --replace "forkserver.h" "afl-forkserver.h"
+    substitute ${aflplusplus.src.name}/include/forkserver.h $sourceRoot/afl-forkserver.h \
       --replace "types.h" "afl-types.h"
 
     cat ${aflplusplus.src.name}/qemu_mode/patches/*.diff > all.patch


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` -> **There are no dependencies**
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc: @risicle 
