### PR TITLE
mate.mate-tweak: init at 20.10.0

### DIFF
--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -39,6 +39,7 @@ let
     mate-system-monitor = callPackage ./mate-system-monitor { };
     mate-terminal = callPackage ./mate-terminal { };
     mate-themes = callPackage ./mate-themes { };
+    mate-tweak = callPackage ./mate-tweak { };
     mate-user-guide = callPackage ./mate-user-guide { };
     mate-user-share = callPackage ./mate-user-share { };
     mate-utils = callPackage ./mate-utils { };

--- a/pkgs/desktops/mate/mate-tweak/default.nix
+++ b/pkgs/desktops/mate/mate-tweak/default.nix
@@ -1,0 +1,83 @@
+{ stdenv
+, fetchFromGitHub
+, python3Packages
+, intltool
+, mate
+, libnotify
+, gtk3
+, gdk-pixbuf
+, gobject-introspection
+, wrapGAppsHook
+, glib
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mate-tweak";
+  version = "20.10.0";
+
+  src = fetchFromGitHub {
+    owner = "ubuntu-mate";
+    repo = pname;
+    rev = version;
+    sha256 = "08gw5i5wjxmzn92h9fv6g7q9i00n8shv1wlpy6cb31xy9wbmjph6";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    intltool
+    python3Packages.distutils_extra
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk3
+    gdk-pixbuf
+    libnotify
+    glib
+    mate.mate-applets
+    mate.mate-panel
+    mate.marco
+    mate.libmatekbd
+    mate.mate-session-manager
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    distro
+    pygobject3
+    psutil
+    setproctitle
+  ];
+
+  strictDeps = false;
+
+  dontWrapGApps = true;
+
+  postPatch = ''
+    # mate-tweak hardcodes absolute paths everywhere. Nuke from orbit.
+    find . -type f -exec sed -i \
+      -e s,/usr/lib/mate-tweak,$out/lib/mate-tweak,g \
+      {} +
+
+    sed -i 's,{prefix}/,,g' setup.py
+  '';
+
+  # Arguments to be passed to `makeWrapper`, only used by buildPython*
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postFixup = ''
+    for i in bin/.mate-tweak-wrapped lib/mate-tweak/mate-tweak-helper; do
+      sed -i "s,usr,run/current-system/sw,g" $out/$i
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tweak tool for the MATE Desktop";
+    homepage = "https://github.com/ubuntu-mate/mate-tweak";
+    changelog = "https://github.com/ubuntu-mate/mate-tweak/releases/tag/${version}";
+    license = [ licenses.gpl2Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ luc65r ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add mate-tweak, because it's missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
