### PR TITLE
pythonPackages.pymavlink, mavproxy: update

### DIFF
--- a/pkgs/applications/science/robotics/mavproxy/default.nix
+++ b/pkgs/applications/science/robotics/mavproxy/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonApplication rec {
   pname = "MAVProxy";
-  version = "1.8.18";
+  version = "1.8.19";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1fi4m3591wws5cq43q8aljf91mzs6i9yhn9rimhpfrskbyf9knvm";
+    sha256 = "1rbq2nm01212rp5xbl8p8kjl2mpgfppkwjsq3lnfw1v6g0m4359h";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pymavlink/default.nix
+++ b/pkgs/development/python-modules/pymavlink/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pymavlink";
-  version = "2.4.6";
+  version = "2.4.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1c8bxbm18h4idfdxqgklcz4n5bgsyl9y14gl9314fpflwa2c7ds8";
+    sha256 = "1djzr6cg3l19icwplmpii7zzr8gms9qcc2lfr8yc05siqzclk5xk";
   };
 
   propagatedBuildInputs = [ future lxml ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates pymavlink and mavproxy to their latest versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
