### PR TITLE
elmerfem: init at release-8.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8247,6 +8247,12 @@
     githubId = 483465;
     name = "Mateusz Wykurz";
   };
+  wulfsta = {
+    email = "wulfstawulfsta@gmail.com";
+    github = "Wulfsta";
+    githubId = 13378502;
+    name = "Wulfsta";
+  };
   wyvie = {
     email = "elijahrum@gmail.com";
     github = "wyvie";

--- a/pkgs/applications/science/physics/elmerfem/default.nix
+++ b/pkgs/applications/science/physics/elmerfem/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, cmake, git, gfortran, openmpi, blas, liblapack, qt4, qwt6_qt4, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "elmerfem";
+  version = "8.4";
+
+  src = fetchFromGitHub {
+    owner = "elmercsc";
+    repo = "elmerfem";
+    rev = "release-${version}";
+    sha256 = "0vk31lplxlng173q8jjcpbyj1gaf98jvkqjvi9077d1nslya7vpm";
+  };
+
+  hardeningDisable = [ "format" ];
+
+  nativeBuildInputs = [ cmake pkg-config git ];
+  buildInputs = [ gfortran openmpi blas liblapack qt4 qwt6_qt4 ];
+
+  preConfigure = ''
+    patchShebangs ./
+  '';
+
+  storepath = placeholder "out";
+
+  cmakeFlags = [
+  "-DELMER_INSTALL_LIB_DIR=${storepath}/lib"
+  "-DWITH_OpenMP:BOOLEAN=TRUE"
+  "-DWITH_MPI:BOOLEAN=TRUE"
+  "-DWITH_ELMERGUI:BOOLEAN=TRUE"
+  "-DCMAKE_INSTALL_LIBDIR=lib"
+  "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  "-DCMAKE_OpenGL_GL_PREFERENCE=GLVND"
+  ];
+
+  patches = [
+    ./fix-cmake.patch
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.elmerfem.org/;
+    description = "A finite element software for multiphysical problems.";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.wulfsta ];
+    license = licenses.lgpl21;
+  };
+
+}

--- a/pkgs/applications/science/physics/elmerfem/fix-cmake.patch
+++ b/pkgs/applications/science/physics/elmerfem/fix-cmake.patch
@@ -1,0 +1,13 @@
+diff --exclude '*~' -ruN A/torch/CMakeLists.txt B/torch/CMakeLists.txt
+--- A/fem/tests/CMakeLists.txt	2020-04-23 02:35:03.243388917 -0400
++++ B/fem/tests/CMakeLists.txt	2018-12-19 20:18:40.671857320 -0400
+@@ -14,7 +14,7 @@ 
+ SET(MESH2D_BIN "${CMAKE_BINARY_DIR}/meshgen2d/src/Mesh2D")
+
+ MACRO(SUBDIRLIST result curdir depth)
+   set(glob_pattern "*")
+-  FOREACH(D RANGE 1 depth)
++  FOREACH(D RANGE 1 ${depth})
+     FILE(GLOB children RELATIVE ${curdir} ${glob_pattern}) 
+     FOREACH(child ${children})
+       IF(IS_DIRECTORY ${curdir}/${child})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24684,7 +24684,9 @@ in
 
   dcmtk = callPackage ../applications/science/medicine/dcmtk { };
 
-  ### PHYSICS
+  ### SCIENCE/PHYSICS
+
+  elmerfem = callPackage ../applications/science/physics/elmerfem {};
 
   sacrifice = callPackage ../applications/science/physics/sacrifice {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add Elmer FEM to Science/Physics.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
