### PR TITLE
make libusb1 dependencies explicit

### DIFF
--- a/pkgs/development/libraries/hidapi/default.nix
+++ b/pkgs/development/libraries/hidapi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, systemd, libusb
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, systemd, libusb1
 , darwin }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs = [ ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ libusb systemd ];
+    ++ stdenv.lib.optionals stdenv.isLinux [ libusb1 systemd ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -1,35 +1,36 @@
 { stdenv
 , fetchurl
-, pkgconfig
+, acl
+, cyrus_sasl
+, docbook_xsl
+, epoxy
+, gettext
+, gobject-introspection
+, gst_all_1
+, gtk-doc
+, gtk3
+, json-glib
+, libcacard
+, libdrm
+, libjpeg_turbo
+, libopus
+, libsoup
+, libusb1
+, lz4
 , meson
 , ninja
+, openssl
+, perl
+, phodav
+, pixman
+, pkgconfig
+, polkit
 , python3
 , spice-protocol
-, gettext
-, openssl
-, pixman
-, gobject-introspection
-, libjpeg_turbo
-, zlib
-, cyrus_sasl
 , usbredir
-, libsoup
-, polkit
-, acl
 , usbutils
 , vala
-, gtk3
-, epoxy
-, libdrm
-, gst_all_1
-, phodav
-, libopus
-, gtk-doc
-, json-glib
-, lz4
-, libcacard
-, perl
-, docbook_xsl
+, zlib
 , withPolkit ? true
 }:
 
@@ -99,9 +100,10 @@ stdenv.mkDerivation rec {
     libcacard
     libdrm
     libjpeg_turbo
+    libopus
+    libusb1
     lz4
     openssl
-    libopus
     phodav
     pixman
     spice-protocol

--- a/pkgs/development/libraries/usbredir/default.nix
+++ b/pkgs/development/libraries/usbredir/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libusb }:
+{ stdenv, fetchurl, pkgconfig, libusb1 }:
 
 stdenv.mkDerivation rec {
   pname = "usbredir";
@@ -12,14 +12,13 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libusb ];
-  propagatedBuildInputs = [ libusb ];
+  propagatedBuildInputs = [ libusb1 ];
 
   outputs = [ "out" "dev" ];
 
   meta = with stdenv.lib; {
     description = "USB traffic redirection protocol";
-    homepage = "http://spice-space.org/page/UsbRedir";
+    homepage = "https://www.spice-space.org/usbredir.html";
     license = licenses.lgpl21;
 
     maintainers = [ maintainers.offline ];

--- a/pkgs/development/tools/misc/stlink/default.nix
+++ b/pkgs/development/tools/misc/stlink/default.nix
@@ -18,7 +18,8 @@ in stdenv.mkDerivation rec {
     sha256 = "1mlkrxjxg538335g59hjb0zc739dx4mhbspb26z5gz3lf7d4xv6x";
   };
 
-  buildInputs = [ cmake libusb1' ];
+  buildInputs = [ libusb1' ];
+  nativeBuildInputs = [ cmake ];
   patchPhase = ''
     sed -i 's@/etc/udev/rules.d@$ENV{out}/etc/udev/rules.d@' CMakeLists.txt
     sed -i 's@/etc/modprobe.d@$ENV{out}/etc/modprobe.d@' CMakeLists.txt

--- a/pkgs/development/tools/misc/stlink/default.nix
+++ b/pkgs/development/tools/misc/stlink/default.nix
@@ -1,9 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, libusb1 }:
 
-# IMPORTANT: You need permissions to access the stlink usb devices. 
+let
+  # The Darwin build of stlink explicitly refers to static libusb.
+  libusb1' = if stdenv.isDarwin then libusb1.override { withStatic = true; } else libusb1;
+
+# IMPORTANT: You need permissions to access the stlink usb devices.
 # Add services.udev.pkgs = [ pkgs.stlink ] to your configuration.nix
 
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname = "stlink";
   version = "1.6.0";
 
@@ -14,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mlkrxjxg538335g59hjb0zc739dx4mhbspb26z5gz3lf7d4xv6x";
   };
 
-  buildInputs = [ cmake libusb1 ];
+  buildInputs = [ cmake libusb1' ];
   patchPhase = ''
     sed -i 's@/etc/udev/rules.d@$ENV{out}/etc/udev/rules.d@' CMakeLists.txt
     sed -i 's@/etc/modprobe.d@$ENV{out}/etc/modprobe.d@' CMakeLists.txt

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -13,7 +13,7 @@
 , acl
 , gmp
 , darwin
-, libusb ? null
+, libusb1 ? null
 , gnutls ? null
 , avahi ? null
 , libpaper ? null
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig removeReferencesTo ];
 
-  buildInputs = [ zlib libjpeg libpng libtiff libusb gnutls libpaper ]
+  buildInputs = [ zlib libjpeg libpng libtiff libusb1 gnutls libpaper ]
     ++ optionals stdenv.isLinux [ avahi pam dbus ]
     ++ optional enableSystemd systemd
     # Separate from above only to not modify order, to avoid mass rebuilds; merge this with the above at next big change.
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     "--enable-dbus"
     "--enable-pam"
     "--with-dbusdir=${placeholder "out"}/share/dbus-1"
-  ] ++ optional (libusb != null) "--enable-libusb"
+  ] ++ optional (libusb1 != null) "--enable-libusb"
     ++ optional (gnutls != null) "--enable-ssl"
     ++ optional (avahi != null) "--enable-avahi"
     ++ optional (libpaper != null) "--enable-libpaper"

--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip, autoconf, automake, cups, glib, libxml2, libusb, libtool
+{ stdenv, lib, fetchzip, autoconf, automake, cups, glib, libxml2, libusb1, libtool
 , withDebug ? false }:
 
 stdenv.mkDerivation {
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    cups automake autoconf glib libxml2 libusb libtool
+    cups automake autoconf glib libxml2 libusb1 libtool
   ];
 
   # lgmon3's --enable-libdir flag is used soley for specifying in which
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
       cd lgmon3
       substituteInPlace src/Makefile.am \
         --replace /usr/include/libusb-1.0 \
-                  ${libusb.dev}/include/libusb-1.0
+                  ${libusb1.dev}/include/libusb-1.0
       ./autogen.sh --prefix=$out --enable-progpath=$out/bin \
                    --datadir=$out/share \
                    --enable-libdir=/var/cache/cups

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchzip,
   autoconf, automake, libtool,
   cups, popt, libtiff, libpng,
-  ghostscript, glib, libusb, libxml2 }:
+  ghostscript, glib, libusb1, libxml2 }:
 
 /* this derivation is basically just a transcription of the rpm .spec
    file included in the tarball */
 
-let arch = 
+let arch =
   if stdenv.hostPlatform.system == "x86_64-linux" then "64"
     else if stdenv.hostPlatform.system == "i686-linux" then "32"
     else throw "Unsupported system ${stdenv.hostPlatform.system}";
@@ -32,7 +32,7 @@ in stdenv.mkDerivation {
 
   buildInputs = [ autoconf libtool automake
                   cups popt libtiff libpng
-                  ghostscript glib libusb libxml2 ];
+                  ghostscript glib libusb1 libxml2 ];
 
   # patches from https://github.com/tokiclover/bar-overlay/tree/master/net-print/cnijfilter
   patches = [
@@ -53,10 +53,10 @@ in stdenv.mkDerivation {
 
   configurePhase = ''
     cd libs
-    ./autogen.sh --prefix=$out 
+    ./autogen.sh --prefix=$out
 
     cd ../bscc2sts
-    ./autogen.sh 
+    ./autogen.sh
 
     cd ../cnijnpr
     ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib
@@ -68,25 +68,25 @@ in stdenv.mkDerivation {
     ./autogen.sh --prefix=$out --enable-progpath=$out/bin
 
     cd ../pstocanonij
-    ./autogen.sh --prefix=$out --enable-progpath=$out/bin 
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin
 
     cd ../backend
     ./autogen.sh --prefix=$out
 
     cd ../backendnet
-    ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib --enable-progpath=$out/bin 
+    ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib --enable-progpath=$out/bin
 
     cd ../cmdtocanonij
     ./autogen.sh --prefix=$out --datadir=$out/share
 
     cd ../cnijbe
-    ./autogen.sh --prefix=$out --enable-progpath=$out/bin 
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin
 
     cd ../lgmon2
     substituteInPlace src/Makefile.am \
         --replace /usr/include/libusb-1.0 \
-                  ${libusb.dev}/include/libusb-1.0
-    ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib --enable-progpath=$out/bin 
+                  ${libusb1.dev}/include/libusb-1.0
+    ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib --enable-progpath=$out/bin
 
     cd ..;
 

--- a/pkgs/servers/brickd/default.nix
+++ b/pkgs/servers/brickd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, libusb, pkgconfig, pmutils, udev} :
+{ stdenv, fetchgit, libusb1, pkgconfig, pmutils, udev} :
 
 let
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libusb pmutils udev ];
+  buildInputs = [ libusb1 pmutils udev ];
 
   # shell thing didn't work so i replaced it using nix
   prePatch = ''

--- a/pkgs/tools/misc/yubikey-personalization/default.nix
+++ b/pkgs/tools/misc/yubikey-personalization/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libusb, libyubikey, json_c }:
+{ stdenv, fetchurl, pkgconfig, libusb1, libyubikey, json_c }:
 
 stdenv.mkDerivation rec {
   pname = "yubikey-personalization";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libusb libyubikey json_c ];
+  buildInputs = [ libusb1 libyubikey json_c ];
 
   configureFlags = [
     "--with-backend=libusb-1.0"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14793,9 +14793,7 @@ in
 
   ustr = callPackage ../development/libraries/ustr { };
 
-  usbredir = callPackage ../development/libraries/usbredir {
-    libusb = libusb1;
-  };
+  usbredir = callPackage ../development/libraries/usbredir { };
 
   uthash = callPackage ../development/libraries/uthash { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25241,9 +25241,7 @@ in
 
   cnijfilter_4_00 = callPackage ../misc/cups/drivers/cnijfilter_4_00 { };
 
-  cnijfilter2 = callPackage ../misc/cups/drivers/cnijfilter2 {
-    libusb = libusb1;
-  };
+  cnijfilter2 = callPackage ../misc/cups/drivers/cnijfilter2 { };
 
   darcnes = callPackage ../misc/emulators/darcnes { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12141,9 +12141,7 @@ in
 
   heyefi = haskellPackages.heyefi;
 
-  hidapi = callPackage ../development/libraries/hidapi {
-    libusb = libusb1;
-  };
+  hidapi = callPackage ../development/libraries/hidapi { };
 
   highfive = callPackage ../development/libraries/highfive { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25191,9 +25191,7 @@ in
 
   clinfo = callPackage ../tools/system/clinfo { };
 
-  cups = callPackage ../misc/cups {
-    libusb = libusb1;
-  };
+  cups = callPackage ../misc/cups { };
 
   cups-filters = callPackage ../misc/cups/filters.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14614,10 +14614,7 @@ in
 
   stfl = callPackage ../development/libraries/stfl { };
 
-  stlink = callPackage ../development/tools/misc/stlink {
-    # The Darwin build of stlink explicitly refers to static libusb.
-    libusb1 = if stdenv.isDarwin then libusb1.override { withStatic = true; } else libusb1;
-  };
+  stlink = callPackage ../development/tools/misc/stlink { };
 
   steghide = callPackage ../tools/security/steghide {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25239,9 +25239,7 @@ in
   # this driver ships with pre-compiled 32-bit binary libraries
   cnijfilter_2_80 = pkgsi686Linux.callPackage ../misc/cups/drivers/cnijfilter_2_80 { };
 
-  cnijfilter_4_00 = callPackage ../misc/cups/drivers/cnijfilter_4_00 {
-    libusb = libusb1;
-  };
+  cnijfilter_4_00 = callPackage ../misc/cups/drivers/cnijfilter_4_00 { };
 
   cnijfilter2 = callPackage ../misc/cups/drivers/cnijfilter2 {
     libusb = libusb1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15062,9 +15062,7 @@ in
 
   yubikey-neo-manager = callPackage ../tools/misc/yubikey-neo-manager { };
 
-  yubikey-personalization = callPackage ../tools/misc/yubikey-personalization {
-    libusb = libusb1;
-  };
+  yubikey-personalization = callPackage ../tools/misc/yubikey-personalization { };
 
   yubikey-personalization-gui = libsForQt5.callPackage ../tools/misc/yubikey-personalization-gui { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5874,9 +5874,7 @@ in
 
   briss = callPackage ../tools/graphics/briss { };
 
-  brickd = callPackage ../servers/brickd {
-    libusb = libusb1;
-  };
+  brickd = callPackage ../servers/brickd { };
 
   bully = callPackage ../tools/networking/bully {
     openssl = openssl_1_0_2;


### PR DESCRIPTION
###### Motivation for this change
This moves the `libusb = libusb1`aliases from `top-level.nix` to individual packages.
These projects are libusb1-specific, and having these aliases in `top-level.nix` only makes things less readable.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
