### PR TITLE
gnome3.updateScript: Add freeze functionality

### DIFF
--- a/pkgs/desktops/gnome-3/find-latest-version.py
+++ b/pkgs/desktops/gnome-3/find-latest-version.py
@@ -4,8 +4,10 @@ import json
 import requests
 import sys
 
+
 def version_to_list(version):
-    return list(map(int, version.split('.')))
+    return list(map(int, version.split(".")))
+
 
 def odd_unstable(version_str, selected):
     version = version_to_list(version_str)
@@ -15,18 +17,21 @@ def odd_unstable(version_str, selected):
     even = version[1] % 2 == 0
     prerelease = (version[1] >= 90 and version[1] < 100) or (version[1] >= 900 and version[1] < 1000)
     stable = even and not prerelease
-    if selected == 'stable':
+    if selected == "stable":
         return stable
     else:
         return True
 
+
 def no_policy(version, selected):
     return True
 
+
 version_policies = {
-    'odd-unstable': odd_unstable,
-    'none': no_policy,
+    "odd-unstable": odd_unstable,
+    "none": no_policy,
 }
+
 
 def make_version_policy(version_predicate, selected, upper_bound):
     if not upper_bound:
@@ -36,33 +41,34 @@ def make_version_policy(version_predicate, selected, upper_bound):
 
     return lambda version: version_predicate(version, selected) and version_to_list(version) < upper_bound
 
-parser = argparse.ArgumentParser(description='Find latest version for a GNOME package by crawling their release server.')
-parser.add_argument('package-name', help='Name of the directory in https://ftp.gnome.org/pub/GNOME/sources/ containing the package.')
-parser.add_argument('version-policy', help='Policy determining which versions are considered stable. For most GNOME packages, odd minor versions are unstable but there are exceptions.', choices=version_policies.keys(), nargs='?', default='odd-unstable')
-parser.add_argument('requested-release', help='Most of the time, we will want to update to stable version but sometimes it is useful to test.', choices=['stable', 'unstable'], nargs='?', default='stable')
-parser.add_argument('--upper-bound', dest='upper-bound', help='Only look for versions older than this one (useful for pinning dependencies).')
+
+parser = argparse.ArgumentParser(description="Find latest version for a GNOME package by crawling their release server.")
+parser.add_argument("package-name", help="Name of the directory in https://ftp.gnome.org/pub/GNOME/sources/ containing the package.")
+parser.add_argument("version-policy", help="Policy determining which versions are considered stable. For most GNOME packages, odd minor versions are unstable but there are exceptions.", choices=version_policies.keys(), nargs="?", default="odd-unstable")
+parser.add_argument("requested-release", help="Most of the time, we will want to update to stable version but sometimes it is useful to test.", choices=["stable", "unstable"], nargs="?", default="stable")
+parser.add_argument("--upper-bound", dest="upper-bound", help="Only look for versions older than this one (useful for pinning dependencies).")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parser.parse_args()
 
-    package_name = getattr(args, 'package-name')
-    requested_release = getattr(args, 'requested-release')
-    upper_bound = getattr(args, 'upper-bound')
-    version_predicate = version_policies[getattr(args, 'version-policy')]
+    package_name = getattr(args, "package-name")
+    requested_release = getattr(args, "requested-release")
+    upper_bound = getattr(args, "upper-bound")
+    version_predicate = version_policies[getattr(args, "version-policy")]
     version_policy = make_version_policy(version_predicate, requested_release, upper_bound)
 
     # The structure of cache.json: https://gitlab.gnome.org/Infrastructure/sysadmin-bin/blob/master/ftpadmin#L762
-    cache = json.loads(requests.get('https://ftp.gnome.org/pub/GNOME/sources/{}/cache.json'.format(package_name)).text)
+    cache = json.loads(requests.get(f"https://ftp.gnome.org/pub/GNOME/sources/{package_name}/cache.json").text)
     if type(cache) != list or cache[0] != 4:
-        print('Unknown format of cache.json file.', file=sys.stderr)
+        print("Unknown format of cache.json file.", file=sys.stderr)
         sys.exit(1)
 
     versions = cache[2][package_name]
     versions = sorted(filter(version_policy, versions), key=version_to_list)
 
     if len(versions) == 0:
-        print('No versions matched.', file=sys.stderr)
+        print("No versions matched.", file=sys.stderr)
         sys.exit(1)
 
     print(versions[-1])

--- a/pkgs/desktops/gnome-3/update.nix
+++ b/pkgs/desktops/gnome-3/update.nix
@@ -1,8 +1,18 @@
-{ stdenv, lib, writeScript, python3, common-updater-scripts }:
-{ packageName, attrPath ? packageName, versionPolicy ? "odd-unstable" }:
+{ stdenv, pkgs, lib, writeScript, python3, common-updater-scripts }:
+{ packageName, attrPath ? packageName, versionPolicy ? "odd-unstable", freeze ? false }:
 
 let
   python = python3.withPackages (p: [ p.requests ]);
+  upperBoundFlag =
+    let
+      package = lib.getAttrFromPath (lib.splitString "." attrPath) pkgs;
+      packageVersion = lib.getVersion package;
+      versionComponents = lib.versions.splitVersion packageVersion;
+      minorVersion = lib.versions.minor packageVersion;
+      minorAvailable = builtins.length versionComponents > 1 && builtins.match "[0-9]+" minorVersion != null;
+      nextMinor = builtins.fromJSON minorVersion + 1;
+      upperBound = "${lib.versions.major packageVersion}.${builtins.toString nextMinor}";
+    in lib.optionalString (minorAvailable && freeze) ''--upper-bound="${upperBound}"'';
   updateScript = writeScript "gnome-update-script" ''
     #!${stdenv.shell}
     set -o errexit
@@ -10,7 +20,7 @@ let
     attr_path="$2"
     version_policy="$3"
     PATH=${lib.makeBinPath [ common-updater-scripts python ]}
-    latest_tag=$(python "${./find-latest-version.py}" "$package_name" "$version_policy" "stable")
+    latest_tag=$(python "${./find-latest-version.py}" "$package_name" "$version_policy" "stable" ${upperBoundFlag})
     update-source-version "$attr_path" "$latest_tag"
   '';
 in [ updateScript packageName attrPath versionPolicy ]


### PR DESCRIPTION

###### Motivation for this change
On stable releases, we will want to change the freeze parameter in `pkgs/desktops/gnome-3/update.nix` to true to limit the gnome update script to only bump patch versions.

###### Things done
- [x] Tested on `release-20.03` branch with `freeze = true`
- [x] Tested on master branch

cc @worldofpeace @hedning 