### PR TITLE
19.09 mutter backports

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/3.28.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.28.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = pname;
-    rev = "74e3126b77eb5f27c0ae3f53b0aff2d2eebc15af"; # patches of tip from gnome-3-28 branch
-    sha256 = "0gw1n1w3i040w5mv30kkg7g8a59ymjlc5yaklip0ngg8xv76g0zi";
+    rev = "88e855bf0a5646fdd85a838bfb433451c42513d7"; # patches of tip from gnome-3-28 branch
+    sha256 = "19k99qkjhk3r8rwa1v6wl0frm1wd95iasqmrb9sadyri0mkwxvg4";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -62,6 +62,17 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/mutter/commit/8307c0f7ab60760de53f764e6636893733543be8.diff";
       sha256 = "1hzfva71xdqvvnx5smjsrjlgyrmc7dj94mpylkak0gwda5si0h2n";
     })
+
+    # Fix backported for desktop freezing after ~50 days idle
+    # https://mail.gnome.org/archives/distributor-list/2020-April/msg00001.html
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/002299fbef2fd99fb36e5b881ed7b4095ff481f6.patch";
+      sha256 = "0x3kk75rqmcsyzhmhxjnh8n8ng4zyrbmh0yzvc79zcphzmdckavb";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/c2e12b3434967e520dcda76bf1d562676e8961ff.patch";
+      sha256 = "0l3ckmskxmisbjdhpr30yc2hclyc4l2f0jsgzisnq5aiszy9q0i0";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Same motivation as https://github.com/NixOS/nixpkgs/pull/85966, but we just use patches in `gnome3.mutter`. 
I do updates from `gnome-3-28` branch anyways, so I did the same for `gnome3.mutter328`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
