### PR TITLE
Revert "ibus: fix dconf db installation"

### DIFF
--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -64,7 +64,7 @@ in
     # Without dconf enabled it is impossible to use IBus
     programs.dconf.enable = true;
 
-    programs.dconf.packages = [ ibusPackage ];
+    programs.dconf.profiles.ibus = "${ibusPackage}/etc/dconf/profile/ibus";
 
     services.dbus.packages = [
       ibusAutostart

--- a/nixos/tests/installed-tests/ibus.nix
+++ b/nixos/tests/installed-tests/ibus.nix
@@ -5,12 +5,16 @@ makeInstalledTest {
 
   testConfig = {
     i18n.inputMethod.enabled = "ibus";
-    systemd.user.services.ibus-daemon = {
-      serviceConfig.ExecStart = "${pkgs.ibus}/bin/ibus-daemon --xim --verbose";
-      wantedBy = [ "graphical-session.target" ];
-      partOf = [ "graphical-session.target" ];
-    };
   };
 
+  preTestScript = ''
+    # ibus has ibus-desktop-testing-runner but it tries to manage desktop session so we just spawn ibus-daemon ourselves
+    machine.succeed("ibus-daemon --daemonize --verbose")
+  '';
+
   withX11 = true;
+
+  # TODO: ibus-daemon is currently crashing or something
+  # maybe make ibus systemd service that auto-restarts?
+  meta.broken = true;
 }

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -16,7 +16,6 @@
 , gtk2
 , gtk3
 , gtk-doc
-, runCommand
 , isocodes
 , cldr-emoji-annotation
 , unicode-character-database
@@ -48,14 +47,6 @@ let
       makeWrapper ${glib.dev}/bin/glib-mkenums $out/bin/glib-mkenums --unset PYTHONPATH
     '';
   };
-  # make-dconf-override-db.sh needs to execute dbus-launch in the sandbox,
-  # it will fail to read /etc/dbus-1/session.conf unless we add this flag
-  dbus-launch = runCommand "sandbox-dbus-launch" {
-    nativeBuildInputs = [ makeWrapper ];
-  } ''
-      makeWrapper ${dbus}/bin/dbus-launch $out/bin/dbus-launch \
-        --add-flags --config-file=${dbus.daemon}/share/dbus-1/session.conf
-  '';
 in
 
 stdenv.mkDerivation rec {
@@ -80,7 +71,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "installedTests" ];
 
   postPatch = ''
-    patchShebangs --build data/dconf/make-dconf-override-db.sh
+    echo \#!${runtimeShell} > data/dconf/make-dconf-override-db.sh
     cp ${buildPackages.gtk-doc}/share/gtk-doc/data/gtk-doc.make .
   '';
 
@@ -114,7 +105,6 @@ stdenv.mkDerivation rec {
     python3BuildEnv
     vala
     wrapGAppsHook
-    dbus-launch
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#85892

Eval issue
```
error: The option `environment.etc.dconf.source' is used but not defined.
```