### PR TITLE
gnucash: 3.9 -> 3.10

### DIFF
--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -25,11 +25,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gnucash";
-  version = "3.9";
+  version = "3.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/gnucash/${pname}-${version}.tar.bz2";
-    sha256 = "1zxrgrjbs13vgr002rvl734w9f7zzxfq4xxmyhj777dwgkfds0ld";
+    sha256 = "05kgg7mhizndwn7icnarqk3c19xrzfawf90y9nb3jdm6fv1741xn";
   };
 
   nativeBuildInputs = [ pkgconfig makeWrapper cmake gtest ];
@@ -69,7 +69,6 @@ stdenv.mkDerivation rec {
   '';
 
   # TODO: The following tests FAILED:
-  #   61 - test-gnc-timezone (Failed)
   #   70 - test-load-c (Failed)
   #   71 - test-modsysver (Failed)
   #   72 - test-incompatdep (Failed)


### PR DESCRIPTION
##### Motivation for this change
New version available: https://www.gnucash.org/news.phtml#n-200412-3.10.news

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    655,783,536 → 655,810,560
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Maintainers: @peti , @domenkozar 