### PR TITLE
urdfdom, console-bridge: init

### DIFF
--- a/pkgs/development/libraries/console-bridge/default.nix
+++ b/pkgs/development/libraries/console-bridge/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, cmake, validatePkgConfig }:
+
+stdenv.mkDerivation rec {
+  pname = "console-bridge";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "ros";
+    repo = "console_bridge";
+    rev = version;
+    sha256 = "14f5i2qgp5clwkm8jjlvv7kxvwx52a607mnbc63x61kx9h6ymxlk";
+  };
+
+  nativeBuildInputs = [ cmake validatePkgConfig ];
+
+  meta = with lib; {
+    description = "A ROS-independent package for logging that seamlessly pipes into rosconsole/rosout for ROS-dependent packages";
+    homepage = "https://github.com/ros/console_bridge";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lopsided98 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/urdfdom-headers/default.nix
+++ b/pkgs/development/libraries/urdfdom-headers/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, validatePkgConfig }:
+
+stdenv.mkDerivation rec {
+  pname = "urdfdom-headers";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "ros";
+    repo = "urdfdom_headers";
+    rev = version;
+    sha256 = "1abzhcyv2vad8l36vy0fcz9kpgns834la7hf9zal962bwycqnkmg";
+  };
+
+  patches = [
+    # Fix CMake relative install dir assumptions (https://github.com/ros/urdfdom_headers/pull/66)
+    (fetchpatch {
+      url = "https://github.com/ros/urdfdom_headers/commit/990fd233b1a3ff68872a3552f3ea5ccbe105848c.patch";
+      sha256 = "1hxf2kw3mkll3fzvsby104b2m854bdpiy9gr3r9ysmw2r537gqdy";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake validatePkgConfig ];
+
+  meta = with lib; {
+    description = "URDF (U-Robot Description Format) headers provides core data structure headers for URDF";
+    homepage = "https://github.com/ros/urdfdom_headers";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lopsided98 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/urdfdom/default.nix
+++ b/pkgs/development/libraries/urdfdom/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config, validatePkgConfig
+, tinyxml, boost, urdfdom-headers, console-bridge }:
+
+stdenv.mkDerivation rec {
+  pname = "urdfdom";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "ros";
+    repo = pname;
+    rev = version;
+    sha256 = "0wambq06d7dvja25zcv4agc055q9rmf3xkrnxy8lsf4nic7ra2rr";
+  };
+
+  patches = [
+    # Fix CMake saying console-bridge 1.0 is incompatible
+    (fetchpatch {
+      url = "https://github.com/ros/urdfdom/commit/6faba176d41cf39114785a3e029013f941ed5a0e.patch";
+      sha256 = "1pn9hcg5wkkc7y28sbkxvffqxgvazzsp3g1xmz6h055v4f9ikjbs";
+    })
+    # Fix CMake relative install dir assumptions (https://github.com/ros/urdfdom/pull/142)
+    (fetchpatch {
+      url = "https://github.com/ros/urdfdom/commit/707c97c3d1f739ba0ab6e93e1bf7cd01d68a8c07.patch";
+      sha256 = "10bv7sv7gfy6lj8z5bkw7v291y12fbrrxsiqxqjxg4i65rfg92ng";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config validatePkgConfig ];
+  buildInputs = [ tinyxml boost ];
+  propagatedBuildInputs = [ urdfdom-headers console-bridge ];
+
+  meta = with lib; {
+    description = "Provides core data structures and a simple XML parser for populating the class data structures from an URDF file";
+    homepage = "https://github.com/ros/urdfdom";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lopsided98 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2750,6 +2750,8 @@ in
 
   conda = callPackage ../tools/package-management/conda { };
 
+  console-bridge = callPackage ../development/libraries/console-bridge { };
+
   convmv = callPackage ../tools/misc/convmv { };
 
   convoy = callPackage ../tools/filesystems/convoy { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7292,6 +7292,8 @@ in
 
   uqmi = callPackage ../tools/networking/uqmi { };
 
+  urdfdom = callPackage ../development/libraries/urdfdom {};
+
   urdfdom-headers = callPackage ../development/libraries/urdfdom-headers {};
 
   uriparser = callPackage ../development/libraries/uriparser {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7292,6 +7292,8 @@ in
 
   uqmi = callPackage ../tools/networking/uqmi { };
 
+  urdfdom-headers = callPackage ../development/libraries/urdfdom-headers {};
+
   uriparser = callPackage ../development/libraries/uriparser {};
 
   urlscan = callPackage ../applications/misc/urlscan { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds some packages that are required by newer versions of the Gazebo simulator. The Gazebo updates will be upstreamed later after I have cleaned them up. `console-bridge` is also an important ROS dependency, so this PR will make my [ROS overlay](https://github.com/lopsided98/nix-ros-overlay) less dependent on my nixpkgs fork.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
