### PR TITLE
wireguard: 1.0.20200401 -> 1.0.20200413

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, kernel, perl, wireguard-tools }:
+{ stdenv, fetchzip, kernel, perl, wireguard-tools, bc }:
 
 # module requires Linux >= 3.10 https://www.wireguard.io/install/#kernel-requirements
 assert stdenv.lib.versionAtLeast kernel.version "3.10";
@@ -7,29 +7,31 @@ assert stdenv.lib.versionOlder kernel.version "5.6";
 
 stdenv.mkDerivation rec {
   pname = "wireguard";
-  version = "1.0.20200401";
+  version = "1.0.20200413";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-${version}.tar.xz";
-    sha256 = "1q4gfpbvbyracnl219xqfz5yqfc08i6g41z6bn2skx5x8jbll3aq";
+    sha256 = "11dpw1inszbc3qjcfnap74kgjxkyyrx90vxv6wmsgkbp8lsl4p66";
   };
-
-  preConfigure = ''
-    cd src
-    sed -i '/depmod/,+1d' Makefile
-  '';
 
   hardeningDisable = [ "pic" ];
 
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
-  INSTALL_MOD_PATH = "\${out}";
 
-  NIX_CFLAGS = ["-Wno-error=cpp"];
+  nativeBuildInputs = [ perl bc ] ++ kernel.moduleBuildDependencies;
 
-  nativeBuildInputs = [ perl ] ++ kernel.moduleBuildDependencies;
-
+  preBuild = "cd src";
   buildFlags = [ "module" ];
-  installTargets = [ "module-install" ];
+
+  INSTALL_MOD_PATH = placeholder "out";
+  installFlags = [ "DEPMOD=true" ];
+  enableParallelBuilding = true;
+
+  passthru = {
+    # remove this when our kernel comes with native wireguard support
+    # and our tests no longer tests this package
+    inherit (wireguard-tools) tests;
+  };
 
   meta = with stdenv.lib; {
     inherit (wireguard-tools.meta) homepage license maintainers;

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -1,12 +1,12 @@
-{
-  stdenv, fetchzip,
-
-  iptables ? null,
-  iproute ? null,
-  makeWrapper ? null,
-  openresolv ? null,
-  procps ? null,
-  wireguard-go ? null,
+{ stdenv
+, fetchzip
+, nixosTests
+, iptables ? null
+, iproute ? null
+, makeWrapper ? null
+, openresolv ? null
+, procps ? null
+, wireguard-go ? null
 }:
 
 with stdenv.lib;
@@ -47,7 +47,12 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  passthru.updateScript = ./update.sh;
+  passthru = {
+    updateScript = ./update.sh;
+    tests = {
+      inherit (nixosTests) wg-quick wireguard-generated wireguard-namespaces;
+    };
+  };
 
   meta = {
     description = "Tools for the WireGuard secure network tunnel";

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = ./update.sh;
     tests = {
-      inherit (nixosTests) wg-quick wireguard-generated wireguard-namespaces;
+      inherit (nixosTests) wireguard wg-quick wireguard-generated wireguard-namespaces;
     };
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
