### PR TITLE
bluez-alsa: fix installation of D-Bus policy and alsa config

### DIFF
--- a/pkgs/tools/bluetooth/bluez-alsa/default.nix
+++ b/pkgs/tools/bluetooth/bluez-alsa/default.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
   ++ optional aacSupport fdk_aac;
 
   configureFlags = [
-    "--with-alsaplugindir=\$out/lib/alsa-lib"
-    "--with-dbusconfdir=\$out/etc/dbus-1"
+    "--with-alsaplugindir=${placeholder "out"}/lib/alsa-lib"
+    "--with-dbusconfdir=${placeholder "out"}/share/dbus-1/system.d"
     "--enable-rfcomm"
     "--enable-hcitop"
   ]


### PR DESCRIPTION
###### Motivation for this change
Allow bluez-alsa to run again. The `$out`s weren't expanded correctly, resulting in installation to a directory named "ut" in the build dir.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Will backport once merged since it's a bugfix.