### PR TITLE
nixos/nsswitch: Make databases more configurable

### DIFF
--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -14,7 +14,6 @@ let
   nssmdns = canLoadExternalModules && config.services.avahi.nssmdns;
   nsswins = canLoadExternalModules && config.services.samba.nsswins;
   ldap = canLoadExternalModules && (config.users.ldap.enable && config.users.ldap.nsswitch);
-  sssd = canLoadExternalModules && config.services.sssd.enable;
   resolved = canLoadExternalModules && config.services.resolved.enable;
   googleOsLogin = canLoadExternalModules && config.security.googleOsLogin.enable;
 
@@ -31,7 +30,6 @@ let
 
   passwdArray = mkMerge [
     (mkBefore [ "files" ])
-    (mkIf sssd [ "sss" ])
     (mkIf ldap [ "ldap" ])
     (mkIf mymachines [ "mymachines" ])
     (mkIf googleOsLogin [ "cache_oslogin oslogin" ])
@@ -40,13 +38,7 @@ let
 
   shadowArray = mkMerge [
     (mkBefore [ "files" ])
-    (mkIf sssd [ "sss" ])
     (mkIf ldap [ "ldap" ])
-  ];
-
-  servicesArray = mkMerge [
-    (mkBefore [ "files" ])
-    (mkIf sssd [ "sss" ])
   ];
 
 in {
@@ -172,7 +164,7 @@ in {
       group = passwdArray;
       shadow = shadowArray;
       hosts = hostArray;
-      services = servicesArray;
+      services = mkBefore [ "files" ];
     };
 
     # Systemd provides nss-myhostname to ensure that our hostname

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -10,6 +10,7 @@ let
   canLoadExternalModules = config.services.nscd.enable;
   myhostname = canLoadExternalModules;
   mymachines = canLoadExternalModules;
+  # XXX Move these to their respective modules
   nssmdns = canLoadExternalModules && config.services.avahi.nssmdns;
   nsswins = canLoadExternalModules && config.services.samba.nsswins;
   ldap = canLoadExternalModules && (config.users.ldap.enable && config.users.ldap.nsswitch);
@@ -17,28 +18,36 @@ let
   resolved = canLoadExternalModules && config.services.resolved.enable;
   googleOsLogin = canLoadExternalModules && config.security.googleOsLogin.enable;
 
-  hostArray = [ "files" ]
-    ++ optional mymachines "mymachines"
-    ++ optional nssmdns "mdns_minimal [NOTFOUND=return]"
-    ++ optional nsswins "wins"
-    ++ optional resolved "resolve [!UNAVAIL=return]"
-    ++ [ "dns" ]
-    ++ optional nssmdns "mdns"
-    ++ optional myhostname "myhostname";
+  hostArray = mkMerge [
+    (mkBefore [ "files" ])
+    (mkIf mymachines [ "mymachines" ])
+    (mkIf nssmdns [ "mdns_minimal [NOTFOUND=return]" ])
+    (mkIf nsswins [ "wins" ])
+    (mkIf resolved [ "resolve [!UNAVAIL=return]" ])
+    (mkAfter [ "dns" ])
+    (mkIf nssmdns (mkOrder 1501 [ "mdns" ])) # 1501 to ensure it's after dns
+    (mkIf myhostname (mkOrder 1600 [ "myhostname" ])) # 1600 to ensure it's always the last
+  ];
 
-  passwdArray = [ "files" ]
-    ++ optional sssd "sss"
-    ++ optional ldap "ldap"
-    ++ optional mymachines "mymachines"
-    ++ optional googleOsLogin "cache_oslogin oslogin"
-    ++ [ "systemd" ];
+  passwdArray = mkMerge [
+    (mkBefore [ "files" ])
+    (mkIf sssd [ "sss" ])
+    (mkIf ldap [ "ldap" ])
+    (mkIf mymachines [ "mymachines" ])
+    (mkIf googleOsLogin [ "cache_oslogin oslogin" ])
+    (mkIf canLoadExternalModules (mkAfter [ "systemd" ]))
+  ];
 
-  shadowArray = [ "files" ]
-    ++ optional sssd "sss"
-    ++ optional ldap "ldap";
+  shadowArray = mkMerge [
+    (mkBefore [ "files" ])
+    (mkIf sssd [ "sss" ])
+    (mkIf ldap [ "ldap" ])
+  ];
 
-  servicesArray = [ "files" ]
-    ++ optional sssd "sss";
+  servicesArray = mkMerge [
+    (mkBefore [ "files" ])
+    (mkIf sssd [ "sss" ])
+  ];
 
 in {
   options = {
@@ -61,16 +70,72 @@ in {
         };
     };
 
-    system.nssHosts = mkOption {
-      type = types.listOf types.str;
-      default = [];
-      example = [ "mdns" ];
-      description = ''
-        List of host entries to configure in <filename>/etc/nsswitch.conf</filename>.
-      '';
-    };
+    system.nssDatabases = {
+      passwd = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          List of passwd entries to configure in <filename>/etc/nsswitch.conf</filename>.
 
+          Note that "files" is always prepended while "systemd" is appended if nscd is enabled.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [];
+      };
+
+      group = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          List of group entries to configure in <filename>/etc/nsswitch.conf</filename>.
+
+          Note that "files" is always prepended while "systemd" is appended if nscd is enabled.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [];
+      };
+
+      shadow = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          List of shadow entries to configure in <filename>/etc/nsswitch.conf</filename>.
+
+          Note that "files" is always prepended.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [];
+      };
+
+      hosts = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          List of hosts entries to configure in <filename>/etc/nsswitch.conf</filename>.
+
+          Note that "files" is always prepended, and "dns" and "myhostname" are always appended.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [];
+      };
+
+      services = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          List of services entries to configure in <filename>/etc/nsswitch.conf</filename>.
+
+          Note that "files" is always prepended.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [];
+      };
+    };
   };
+
+  imports = [
+    (mkRenamedOptionModule [ "system" "nssHosts" ] [ "system" "nssDatabases" "hosts" ])
+  ];
 
   config = {
     assertions = [
@@ -87,23 +152,28 @@ in {
     ];
 
     # Name Service Switch configuration file.  Required by the C
-    # library.  !!! Factor out the mdns stuff.  The avahi module
-    # should define an option used by this module.
+    # library.
     environment.etc."nsswitch.conf".text = ''
-      passwd:    ${concatStringsSep " " passwdArray}
-      group:     ${concatStringsSep " " passwdArray}
-      shadow:    ${concatStringsSep " " shadowArray}
+      passwd:    ${concatStringsSep " " config.system.nssDatabases.passwd}
+      group:     ${concatStringsSep " " config.system.nssDatabases.group}
+      shadow:    ${concatStringsSep " " config.system.nssDatabases.shadow}
 
-      hosts:     ${concatStringsSep " " config.system.nssHosts}
+      hosts:     ${concatStringsSep " " config.system.nssDatabases.hosts}
       networks:  files
 
       ethers:    files
-      services:  ${concatStringsSep " " servicesArray}
+      services:  ${concatStringsSep " " config.system.nssDatabases.services}
       protocols: files
       rpc:       files
     '';
 
-    system.nssHosts = hostArray;
+    system.nssDatabases = {
+      passwd = passwdArray;
+      group = passwdArray;
+      shadow = shadowArray;
+      hosts = hostArray;
+      services = servicesArray;
+    };
 
     # Systemd provides nss-myhostname to ensure that our hostname
     # always resolves to a valid IP address.  It returns all locally

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -75,6 +75,11 @@ in {
       };
 
       system.nssModules = optional cfg.enable pkgs.sssd;
+      system.nssDatabases = {
+        passwd = [ "sss" ];
+        shadow = [ "sss" ];
+        services = [ "sss" ];
+      };
       services.dbus.packages = [ pkgs.sssd ];
     })
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Instead of hardcoding all nss modules that are added into nsswitch,
there are now options exposed.
This allows users to add own nss modules (I had this issue with
winbindd, for example).
Also, nss modules could be moved to their NixOS modules which would
make the nsswitch module slimmer.

As the lists are now handled by the modules system, we can use mkOrder
to ensure a proper order as well as mkForce to override one specific
database type instead of the entire file.

cc @Infinisil to make sure I use `mk*` correctly
cc @LnL7 because you were the last to touch the file and I drop your option

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
