### PR TITLE
linux-rock64: kernel for Rock64 and RockPro64 systems

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rock64.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rock64.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, modDirVersionArg ? null, ... } @ args:
+
+with stdenv.lib;
+
+buildLinux (args // rec {
+  version = "4.4.202";
+
+  # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+  modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
+
+  # branchVersion needs to be x.y
+  extraMeta.branch = versions.majorMinor version;
+
+  src = fetchFromGitHub {
+    owner = "ayufan-rock64";
+    repo = "linux-kernel";
+    rev = "4.4.202-1237-rockchip-ayufan";
+    sha256 = "1qcw7h8kkj6kv8vzfrnhih0854h1iss65grjc8p8npff1397l48m";
+  };
+
+  defconfig = "rockchip_linux_defconfig";
+
+  autoModules = false;
+
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -92,4 +92,10 @@
     name = "mac_nvme_t2";
     patch = ./mac-nvme-t2.patch;
   };
+
+  toolchain_compat = rec {
+    name = "toolchain_compat";
+    patch = ./toolchain-compat.patch;
+  };
+
 }

--- a/pkgs/os-specific/linux/kernel/toolchain-compat.patch
+++ b/pkgs/os-specific/linux/kernel/toolchain-compat.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm64/crypto/Makefile b/arch/arm64/crypto/Makefile
+index abb79b3cfcfe..a0f8d8f9e88a 100644
+--- a/arch/arm64/crypto/Makefile
++++ b/arch/arm64/crypto/Makefile
+@@ -36,7 +36,7 @@ CFLAGS_aes-glue-ce.o	:= -DUSE_V8_CRYPTO_EXTENSIONS
+
+ obj-$(CONFIG_CRYPTO_CRC32_ARM64) += crc32-arm64.o
+
+-CFLAGS_crc32-arm64.o	:= -mcpu=generic+crc
++CFLAGS_crc32-arm64.o	:= -march=armv8-a+crc
+
+ $(obj)/aes-glue-%.o: $(src)/aes-glue.c FORCE
+ 	$(call if_changed_rule,cc_o_c)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16692,6 +16692,10 @@ in
     kernelPatches = linux_4_19.kernelPatches;
   };
 
+  linux_rock64 = callPackage ../os-specific/linux/kernel/linux-rock64.nix {
+    kernelPatches = linux_4_4.kernelPatches ++ [ kernelPatches.toolchain_compat ];
+  };
+
   linux_rpi1 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
     kernelPatches = with kernelPatches; [
       bridge_stp_helper
@@ -17000,6 +17004,7 @@ in
 
   # Build the kernel modules for the some of the kernels.
   linuxPackages_mptcp = linuxPackagesFor pkgs.linux_mptcp;
+  linuxPackages_rock64 = linuxPackagesFor pkgs.linux_rock64;
   linuxPackages_rpi1 = linuxPackagesFor pkgs.linux_rpi1;
   linuxPackages_rpi2 = linuxPackagesFor pkgs.linux_rpi2;
   linuxPackages_rpi3 = linuxPackagesFor pkgs.linux_rpi3;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This PR adds kernel for Rock64 and RockPro64 systems.

I tried to use 5.4.y and 5.6.y both vanilla and from @lopsided98 repo, but they end up with PCIe issues on my RockPro64:

```
[    2.172391] rockchip-pcie f8000000.pcie: PCIe link training gen1 timeout!
[    2.173158] rockchip-pcie: probe of f8000000.pcie failed with error -110
```

Kernel 4.19.y does not have this issue.

I'd like to provide `sd-image-rock64.nix` in a further PR to allow easy build of SD images for these systems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
