### PR TITLE
[WIP] Pkg jetbrains toolbox

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, callPackage, fetchurl
 , python
 , jdk, cmake, libxml2, zlib, python3, ncurses5
+, autoPatchelfHook, unzip
 }:
 
 with stdenv.lib;
@@ -82,22 +83,25 @@ let
     lib.overrideDerivation (mkJetBrainsProduct {
       inherit name version src wmClass jdk;
       product = "Toolbox";
-
+      
       meta = with stdenv.lib; {
         homepage = "https://www.jetbrains.com/toolbox-app/";
         inherit description license;
         longDescription = "Manage your tools the easy way";
         maintainers = with maintainers; [ loskutov ];
-        platforms = platforms.linux;
+        platforms = platforms.linux;   
       };
     }) (attrs: {
+
+     
       patchPhase = ("") +  optionalString (stdenv.isLinux) ''
-        echo "Empty patchPhase";
+        echo "Empty patchPhase"
       '';
 
       installPhase = ''
-        mkdir -p $out/{bin,share}
-        cp -a . $out/bin
+        pwd
+        ls -lsah jetbrains-toolbox
+        install -m755 -D jetbrains-toolbox $out/bin/jetbrains-toolbox
       '';
     });
 
@@ -290,7 +294,7 @@ in
     description = "Manage your tools the easy way";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
-      url = "https://download.jetbrains.com/toolbox/${name}.tar.gz";
+      url = "https://download.jetbrains.com/toolbox/${name}.tar.gz?platform=linux";
       sha256 = "65a7e446c339de361bf713880b2fb3953de8adeb95a10c9bb4100fcbb249cdf2"; 
     };
     wmClass = "jetbrains-toolbox";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -79,9 +79,10 @@ let
     });
 
   buildJetBrainsToolbox = { name, version, src, license, description, wmClass, ... }:
-    (mkJetBrainsProduct {
+    lib.overrideDerivation (mkJetBrainsProduct {
       inherit name version src wmClass jdk;
-      product = "Toolbox App";
+      product = "Toolbox";
+
       meta = with stdenv.lib; {
         homepage = "https://www.jetbrains.com/toolbox-app/";
         inherit description license;
@@ -89,6 +90,15 @@ let
         maintainers = with maintainers; [ loskutov ];
         platforms = platforms.linux;
       };
+    }) (attrs: {
+      patchPhase = ("") +  optionalString (stdenv.isLinux) ''
+        echo "Empty patchPhase";
+      '';
+
+      installPhase = ''
+        mkdir -p $out/{bin,share}
+        cp -a . $out/bin
+      '';
     });
 
   buildDataGrip = { name, version, src, license, description, wmClass, ... }:
@@ -275,7 +285,6 @@ in
   };
 
   toolbox = buildJetBrainsToolbox rec {
-    # https://download.jetbrains.com/toolbox/jetbrains-toolbox-1.17.6802.tar.gz
     name = "jetbrains-toolbox-${version}";
     version = "1.17.6802";
     description = "Manage your tools the easy way";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -78,6 +78,19 @@ let
       '';
     });
 
+  buildJetBrainsToolbox = { name, version, src, license, description, wmClass, ... }:
+    (mkJetBrainsProduct {
+      inherit name version src wmClass jdk;
+      product = "Toolbox App";
+      meta = with stdenv.lib; {
+        homepage = "https://www.jetbrains.com/toolbox-app/";
+        inherit description license;
+        longDescription = "Manage your tools the easy way";
+        maintainers = with maintainers; [ loskutov ];
+        platforms = platforms.linux;
+      };
+    });
+
   buildDataGrip = { name, version, src, license, description, wmClass, ... }:
     (mkJetBrainsProduct {
       inherit name version src wmClass jdk;
@@ -259,6 +272,20 @@ in
     };
     wmClass = "jetbrains-clion";
     update-channel = "CLion RELEASE"; # channel's id as in http://www.jetbrains.com/updates/updates.xml
+  };
+
+  toolbox = buildJetBrainsToolbox rec {
+    # https://download.jetbrains.com/toolbox/jetbrains-toolbox-1.17.6802.tar.gz
+    name = "jetbrains-toolbox-${version}";
+    version = "1.17.6802";
+    description = "Manage your tools the easy way";
+    license = stdenv.lib.licenses.unfree;
+    src = fetchurl {
+      url = "https://download.jetbrains.com/toolbox/${name}.tar.gz";
+      sha256 = "65a7e446c339de361bf713880b2fb3953de8adeb95a10c9bb4100fcbb249cdf2"; 
+    };
+    wmClass = "jetbrains-toolbox";
+    update-channel = "Jetbrains Toolbox App RELEASE";
   };
 
   datagrip = buildDataGrip rec {

--- a/pkgs/applications/editors/jetbrains/toolbox.nix
+++ b/pkgs/applications/editors/jetbrains/toolbox.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv, callPackage, fetchurl
+, autoPatchelfHook, gnutar, glibc, gcc-unwrapped, zlib, fuse
+}:
+
+stdenv.mkDerivation rec {
+  name = "jetbrains-toolbox-${version}";
+  version = "1.17.6802";
+  description = "Manage your JetBrains IDEs";
+
+  dontStrip = true;
+
+  src = fetchurl {
+    # https://download.jetbrains.com/toolbox/jetbrains-toolbox-1.17.6802.tar.gz
+    url = "https://download.jetbrains.com/toolbox/${name}.tar.gz";
+    sha256 = "65a7e446c339de361bf713880b2fb3953de8adeb95a10c9bb4100fcbb249cdf2";
+  };
+
+  nativeBuildInputs = [
+    fuse
+    glibc
+    zlib
+    gnutar
+    autoPatchelfHook
+  ];
+
+  # Required at running time
+  buildInputs = [
+    fuse
+    glibc
+    zlib
+    glibc
+    gcc-unwrapped
+  ];
+
+  
+
+  unpackPhase = ''
+    mkdir jetbrains-toolbox
+    tar -zxvf $src -C jetbrains-toolbox --strip-components 1
+  '';
+
+  installPhase = ''
+    ls -lsah
+    ls -lsah $src
+    ls -lsah jetbrains-toolbox
+    install -m755 -D jetbrains-toolbox/jetbrains-toolbox $out/jetbrains-toolbox
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.jetbrains.com/toolbox-app/";
+    platforms = platforms.linux;
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19351,6 +19351,8 @@ in
 
   goffice = callPackage ../development/libraries/goffice { };
 
+  jetbrains-toolbox = callPackage ../applications/editors/jetbrains/toolbox.nix { };
+
   jetbrains = (recurseIntoAttrs (callPackages ../applications/editors/jetbrains {
     jdk = jetbrains.jdk;
   }) // {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

Note: This is a WIP PR. I have opened this for the possibility of the help I need.


###### Motivation for this change

Addition of JetBrains Toolbox App that can alternatively manage IDE installations and licenses.

However, I am not sure why this change gives me an error after installation: 

```
$ jetbrains-toolbox
Failed to execute process '/home/<user>/.nix-profile/bin/jetbrains-toolbox'. Reason:
The file '/home/<user>/.nix-profile/bin/jetbrains-toolbox' does not exist or could not be executed.
```
When I run the following to "install"

```
$ nix-env -f $NIXPKGS -iA jetbrains.toolbox

installing 'jetbrains-toolbox-1.17.6802'
these derivations will be built:
  /nix/store/sqjk9a9csv2slp66v131abvm6mpp2mrg-jetbrains-toolbox-1.17.6802.drv
building '/nix/store/sqjk9a9csv2slp66v131abvm6mpp2mrg-jetbrains-toolbox-1.17.6802.drv'...
unpacking sources
unpacking source archive /nix/store/7pzqm132hvafgl3npfma47bnil4fha11-jetbrains-toolbox-1.17.6802.tar.gz
source root is jetbrains-toolbox-1.17.6802
setting SOURCE_DATE_EPOCH to timestamp 1586948045 of file jetbrains-toolbox-1.17.6802/jetbrains-toolbox
patching sources
Empty patchPhase
configuring
no configure script, doing nothing
building
no Makefile, doing nothing
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/bn6mxb656ms8cp6c02jfiy9ydxcamqbx-jetbrains-toolbox-1.17.6802
shrinking /nix/store/bn6mxb656ms8cp6c02jfiy9ydxcamqbx-jetbrains-toolbox-1.17.6802/bin/jetbrains-toolbox
strip is /nix/store/nyhj00w339gk2gaj3faz70gjrnbmam8v-binutils-2.31.1/bin/strip
stripping (with command strip and flags -S) in /nix/store/bn6mxb656ms8cp6c02jfiy9ydxcamqbx-jetbrains-toolbox-1.17.6802/bin
patching script interpreter paths in /nix/store/bn6mxb656ms8cp6c02jfiy9ydxcamqbx-jetbrains-toolbox-1.17.6802
checking for references to /build/ in /nix/store/bn6mxb656ms8cp6c02jfiy9ydxcamqbx-jetbrains-toolbox-1.17.6802...
building '/nix/store/hqp069y56ik9dsf9c95wgf7qhcc1f3fb-user-environment.drv'...
warning: skipping dangling symlink '/nix/store/srrmmkb8nh8fa6a9fjv0prv8gcf0c0h2-user-environment/bin/mullvad-problem-report'
created 2135 symlinks in user environment
```

###### Things done (N/A for this PR)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
