### PR TITLE
lib/tests: Allow overriding pkgs independent of lib being tested

### DIFF
--- a/lib/tests/maintainers.nix
+++ b/lib/tests/maintainers.nix
@@ -1,10 +1,11 @@
-# to run these tests:
-# nix-build nixpkgs/lib/tests/maintainers.nix
-# If nothing is output, all tests passed
-{ pkgs ? import ../.. {} }:
+# to run these tests (and the others)
+# nix-build nixpkgs/lib/tests/release.nix
+{ # The pkgs used for dependencies for the testing itself
+  pkgs
+, lib
+}:
 
 let
-  inherit (pkgs) lib;
   inherit (lib) types;
 
   maintainerModule = { config, ... }: {

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -1,8 +1,17 @@
-{ pkgs ? import ../.. {} }:
+{ # The pkgs used for dependencies for the testing itself
+  # Don't test properties of pkgs.lib, but rather the lib in the parent directory
+  pkgs ? import ../.. {} // { lib = throw "pkgs.lib accessed, but the lib tests should use nixpkgs' lib path directly!"; }
+}:
 
 pkgs.runCommandNoCC "nixpkgs-lib-tests" {
-  buildInputs = [ pkgs.nix (import ./check-eval.nix) (import ./maintainers.nix { inherit pkgs; }) ];
-  NIX_PATH = "nixpkgs=${toString pkgs.path}";
+  buildInputs = [
+    pkgs.nix
+    (import ./check-eval.nix)
+    (import ./maintainers.nix {
+      inherit pkgs;
+      lib = import ../.;
+    })
+  ];
 } ''
     datadir="${pkgs.nix}/share"
     export TEST_ROOT=$(pwd)/test-tmp


### PR DESCRIPTION
###### Motivation for this change
Currently, the lib tests depend on the pkgs in the same nixpkgs tree to run the tests, for trivial things like `pkgs.runCommand` and such. This means when there's mass rebuilds due to a changed stdenv, the lib tests can't be run! Currently @GrahamcOfBorg fails to run the lib tests for stdenv rebuilds because of that, an example: https://github.com/NixOS/nixpkgs/pull/85951.

With this PR, you can now override only the `pkgs` used for the lib tests, e.g.
```
nix-build lib/tests/release.nix --arg pkgs 'import <nixpkgs> {}'
```

would allow you to still run tests even with stdenv rebuilds, assuming you have a somewhat working `<nixpkgs>`. This can then be used by ofborg to always run lib tests (see https://github.com/NixOS/ofborg/pull/472 which implements this)

###### Things done

- [x] Verified that changing stdenv still allows you to run the tests quickly with `--arg pkgs 'import <nixpkgs> {}'`
- [x] Added check that prevents `pkgs.lib` from being used, instead the lib in the nixpkgs tree should be used instead.