### PR TITLE
azpainter: 2.1.5 -> 2.1.6

### DIFF
--- a/pkgs/applications/graphics/azpainter/default.nix
+++ b/pkgs/applications/graphics/azpainter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook
+{ stdenv, fetchFromGitHub
 , libX11, libXext, libXi
 , freetype, fontconfig
 , libpng, libjpeg
@@ -7,16 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "azpainter";
-  version = "2.1.5";
+  version = "2.1.6";
 
   src = fetchFromGitHub {
     owner = "Symbian9";
     repo = pname;
-    rev = "refs/tags/v${version}";
-    sha256 = "0x5jmsprjissqcvwq75pqq9wgv4k9b7cy507hai8xk6xs3vxwgba";
+    rev = "v${version}";
+    sha256 = "sha256-al87Rnf4HkKdmtN3EqxC0zEHgVWwnVi7WttqT/Qxr0Q=";
   };
-
-  nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [
     libX11 libXext libXi
@@ -25,14 +23,11 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  configureFlags = [
-    "--with-freetype-dir=${stdenv.lib.getDev freetype}/include/freetype2"
-  ];
-
   meta = with stdenv.lib; {
     description = "Full color painting software for illustration drawing";
     homepage = "https://osdn.net/projects/azpainter";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dtzWill ];
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/Symbian9/azpainter/releases/tag/v2.1.6)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
