### PR TITLE
linux_*_hardened: update patches

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -5,9 +5,9 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.176.a/linux-hardened-4.14.176.a.patch"
     },
     "4.19": {
-        "name": "linux-hardened-4.19.117.a.patch",
-        "sha256": "0c8dvh49nzypxwvsls10i896smvpdrk40x8ybljb3qk3r8j7niaw",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.117.a/linux-hardened-4.19.117.a.patch"
+        "name": "linux-hardened-4.19.118.a.patch",
+        "sha256": "120lnn9j9zsx1kcq4frcjmj2vj39x0g1yxrrx9nax2yjrzp4wfdw",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.118.a/linux-hardened-4.19.118.a.patch"
     },
     "5.4": {
         "name": "linux-hardened-5.4.35.a.patch",

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -20,8 +20,8 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.5.19.a/linux-hardened-5.5.19.a.patch"
     },
     "5.6": {
-        "name": "linux-hardened-5.6.6.a.patch",
-        "sha256": "0jiqh0frxirjbccgfdk007fca6r6n36n0pkqq4jszkckn59ayl7r",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.6.6.a/linux-hardened-5.6.6.a.patch"
+        "name": "linux-hardened-5.6.7.a.patch",
+        "sha256": "1dnk9df4v2iw05vpn0s8q6b0ci2rzl2wiq77vhr40mpbg6p18fap",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.6.7.a/linux-hardened-5.6.7.a.patch"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened-patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened-patches.json
@@ -10,9 +10,9 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.117.a/linux-hardened-4.19.117.a.patch"
     },
     "5.4": {
-        "name": "linux-hardened-5.4.34.a.patch",
-        "sha256": "1xwpqr9nzpjg837b3wnzb8fmrl2g9rz8gz5yb55vnnllbzbz36v6",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.34.a/linux-hardened-5.4.34.a.patch"
+        "name": "linux-hardened-5.4.35.a.patch",
+        "sha256": "0vcqgrzns4d3z93mn8mv0sxkmj7ylbr8prff72c4ssvb0kd7agy9",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.35.a/linux-hardened-5.4.35.a.patch"
     },
     "5.5": {
         "name": "linux-hardened-5.5.19.a.patch",


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The hardened kernels were using backported patches, but the upstream patches for the kernel versions we're using are now out.

Also includes some refactoring of the update script including use of `pathlib` and type annotations (requires a local branch of the git version of PyGithub to pass `mypy --strict`, will work on upstreaming that).

@GrahamcOfBorg test hardened latestKernel.hardened

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).