### PR TITLE
dotnet: add initial support for arm64

### DIFF
--- a/pkgs/development/compilers/dotnet/buildDotnet.nix
+++ b/pkgs/development/compilers/dotnet/buildDotnet.nix
@@ -13,10 +13,14 @@ assert builtins.elem type [ "aspnetcore" "netcore" "sdk"];
 , curl
 }: 
 let pname = if type == "aspnetcore" then "aspnetcore-runtime" else if type == "netcore" then "dotnet-runtime" else "dotnet-sdk";
+    suffix = {
+      x86_64-linux  = "x64";
+      aarch64-linux = "arm64";
+    }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
     urls = {
-        aspnetcore = "https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/${pname}-${version}-linux-x64.tar.gz";
-        netcore = "https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/${pname}-${version}-linux-x64.tar.gz";
-        sdk = "https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/${pname}-${version}-linux-x64.tar.gz";
+        aspnetcore = "https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/${pname}-${version}-linux-${suffix}.tar.gz";
+        netcore = "https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/${pname}-${version}-linux-${suffix}.tar.gz";
+        sdk = "https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/${pname}-${version}-linux-${suffix}.tar.gz";
     };
     descriptions = {
         aspnetcore = "ASP .NET Core runtime ${version}";
@@ -30,7 +34,7 @@ in stdenv.mkDerivation rec {
 
     src = fetchurl {
         url = builtins.getAttr type urls;
-        inherit sha512;
+        sha512 = sha512."${stdenv.hostPlatform.system}"  or (throw "Missing hash for host system: ${stdenv.hostPlatform.system}");
     };
 
     sourceRoot = ".";
@@ -61,7 +65,7 @@ in stdenv.mkDerivation rec {
     meta = with stdenv.lib; {
         homepage = "https://dotnet.github.io/";
         description = builtins.getAttr type descriptions;
-        platforms = [ "x86_64-linux" ];
+        platforms = [ "x86_64-linux" "aarch64-linux" ];
         maintainers = with maintainers; [ kuznero ];
         license = licenses.mit;
     };

--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -5,27 +5,37 @@ dotnetCombined = with dotnetCorePackages; combinePackages [ sdk_3_1 sdk_2_2 sdk_
 { callPackage }:
 let
   buildDotnet = attrs: callPackage (import ./buildDotnet.nix attrs) {};
-  buildAspNetCore = attrs: buildDotnet (attrs // { type = "aspnetcore"; } );
-  buildNetCore = attrs: buildDotnet (attrs // { type = "netcore"; } );
-  buildNetCoreSdk = attrs: buildDotnet (attrs // { type = "sdk"; } );
-in rec {
+  buildAspNetCore = attrs: buildDotnet (attrs // { type = "aspnetcore"; });
+  buildNetCore = attrs: buildDotnet (attrs // { type = "netcore"; });
+  buildNetCoreSdk = attrs: buildDotnet (attrs // { type = "sdk"; });
+in
+rec {
   combinePackages = attrs: callPackage (import ./combinePackages.nix attrs) {};
 
   # v2.1.15 (LTS)
 
   aspnetcore_2_1 = buildAspNetCore {
     version = "2.1.16";
-    sha512 = "0awdzi8dysbg8xcy4l8wx2sb8gaaklphmwv61qxh7dj6ih4nla34l02xdax1l8nw41znnnqzsa77avglnrz36pckm9mc52m7wc7877h";
+    sha512 = {
+      x86_64-linux = "0awdzi8dysbg8xcy4l8wx2sb8gaaklphmwv61qxh7dj6ih4nla34l02xdax1l8nw41znnnqzsa77avglnrz36pckm9mc52m7wc7877h";
+      aarch64-linux = null; # no aarch64 version of this package is available
+    };
   };
 
   netcore_2_1 = buildNetCore {
     version = "2.1.16";
-    sha512 = "07vvmza32hsblpw4zpcksm2gicy4agh0d1fwradqj16y6xbh3frdp87mqgbj5m54mmyfp5bc8c46v1w6dfm1w3y80v2y46aynild45l";
+    sha512 = {
+      x86_64-linux = "07vvmza32hsblpw4zpcksm2gicy4agh0d1fwradqj16y6xbh3frdp87mqgbj5m54mmyfp5bc8c46v1w6dfm1w3y80v2y46aynild45l";
+      aarch64-linux = "27ab982vz9rn2vzpq68dqfzhryfixq3s0apx7vi0cwiray3scgfmf45fm7qj63k9mvaqnk5g69i339109yasw3q5vpvpyjc1ykbi710";
+    };
   };
 
   sdk_2_1 = buildNetCoreSdk {
     version = "2.1.804";
-    sha512 = "1kbzxcdgyvs94kkm6ikr1j0p0k3zq30d10sl69ig0rgbqbqm4rpqi6dq94jjbw7q3jlwz83vgq3549q38d2s9kalmzv9lmddn2kkc42";
+    sha512 = {
+      x86_64-linux = "1kbzxcdgyvs94kkm6ikr1j0p0k3zq30d10sl69ig0rgbqbqm4rpqi6dq94jjbw7q3jlwz83vgq3549q38d2s9kalmzv9lmddn2kkc42";
+      aarch64-linux = "2d97xvhxnkdgghqlichkwdxxh641dzkd9hq5xgffgvbqv1qsh31k9yib2q1nsarpnbx0d758bdn2jm2wvsj7nx0gpxlb3nab0b3hc2g";
+    };
   };
 
   # v2.2
@@ -36,33 +46,51 @@ in rec {
 
   aspnetcore_3_0 = buildAspNetCore {
     version = "3.0.3";
-    sha512 = "342v6kxxbxky09d1c392vvr9rm30lf75wccka1bk2h4advlcga5nlgv93g7vrq48bsyxfi5gc36r3b0dlwl1g409g5mlk1042n6d0yq";
+    sha512 = {
+      x86_64-linux = "342v6kxxbxky09d1c392vvr9rm30lf75wccka1bk2h4advlcga5nlgv93g7vrq48bsyxfi5gc36r3b0dlwl1g409g5mlk1042n6d0yq";
+      aarch64-linux = "2xkg4q88q5jw6jdz6cxj8vsjr475nd0fcvifkv1shdm2j9dsjy233hwpxbr140m5n5ggyh6z99238z9j4kp2az977y8y8irz8m8ppvf";
+    };
   };
 
   netcore_3_0 = buildNetCore {
     version = "3.0.3";
-    sha512 = "32ykpcw2xx708r2lxcwcbxnmy4sk159rlfjfvkw990qh7n79pm3lm2qwa3zhqcslznmpg18kwxz8qb5fgsa0h49g843xx4kyai0n7rx";
+    sha512 = {
+      x86_64-linux = "32ykpcw2xx708r2lxcwcbxnmy4sk159rlfjfvkw990qh7n79pm3lm2qwa3zhqcslznmpg18kwxz8qb5fgsa0h49g843xx4kyai0n7rx";
+      aarch64-linux = "1lp8din7d5jv5fkyq1a7m01i1xg9jwpiljvam1kcyzsnwzvi0cb4ji336cfx4lqrn95gvc75gkzi6q8b4fz0h21gvk6z6kmlcr63nyg";
+    };
   };
 
   sdk_3_0 = buildNetCoreSdk {
     version = "3.0.103";
-    sha512 = "2diiplgxs92fkb6ym68b02d79z4qn63x5qlky5lvr757c1zkh0vfpk3khawdg94kdn4qkn6dmyqr0msxqgmiqyhp63cadzqq4vx7b12";
+    sha512 = {
+      x86_64-linux = "2diiplgxs92fkb6ym68b02d79z4qn63x5qlky5lvr757c1zkh0vfpk3khawdg94kdn4qkn6dmyqr0msxqgmiqyhp63cadzqq4vx7b12";
+      aarch64-linux = "32843q2lj7dgciq62g9v1q31vwfjyv5vaxrz712d942mcg5lyzjygwri106bv4naq3a22131ldzwnsifbdn2vq1iz60raqdb7ss9vnf";
+    };
   };
 
   # v3.1.1 (LTS)
 
   aspnetcore_3_1 = buildAspNetCore {
     version = "3.1.2";
-    sha512 = "27708bk5liz8r39p4dzs41clgq298d49g8ipzdj56pz613vkfyv7bp91666ydz36aazm265j2g9ji3sk1f9kbgv6024zwrly5w9vqrm";
+    sha512 = {
+      x86_64-linux = "27708bk5liz8r39p4dzs41clgq298d49g8ipzdj56pz613vkfyv7bp91666ydz36aazm265j2g9ji3sk1f9kbgv6024zwrly5w9vqrm";
+      aarch64-linux = "2sm5yf376w5dm0za3gbcj251kc909fmlasmlyn70zhqp2jiii075vcqh40racjlwlhsfydx32cw7kgnv238lad5mw5jxy143zql5xl3";
+    };
   };
 
   netcore_3_1 = buildNetCore {
     version = "3.1.2";
-    sha512 = "3zwg1anrcni9kagmjxn485bpjvb146hkm7irmikq3v879gjhd2fgpscg226ds83l4pxll3r7lwris6ij952xmy8lsqraapd9111ba14";
+    sha512 = {
+      x86_64-linux = "3zwg1anrcni9kagmjxn485bpjvb146hkm7irmikq3v879gjhd2fgpscg226ds83l4pxll3r7lwris6ij952xmy8lsqraapd9111ba14";
+      aarch64-linux = "3hf61d5adlfffy51627ypp36qc5r55g9xwgfxqd0c7vj9bqmpiph673bvqqpr189df9shxr21p94cwrc5n36z72a37vw4ic8ks2yayx";
+    };
   };
 
   sdk_3_1 = buildNetCoreSdk {
     version = "3.1.102";
-    sha512 = "0lmz8ac5j0i4zcq4904kr6qibvyjcm2ckfg27kqyqfii00qmm80xb5sk3i7f06xqkbgkrqkbg9rsldk75akw6m5dxg932j602bxrb4w";
+    sha512 = {
+      x86_64-linux = "0lmz8ac5j0i4zcq4904kr6qibvyjcm2ckfg27kqyqfii00qmm80xb5sk3i7f06xqkbgkrqkbg9rsldk75akw6m5dxg932j602bxrb4w";
+      aarch64-linux = "34k6cm69gxm7vcd9m6bp47sdx96j32z6lfhb2vjcdznc6xgs2wy8zcang3b1mjm5919dq7v6iysm6ffcpgjhhphy7prlnaqa69q5mks";
+    };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`jellyfin` appeared unsupported on `aarch64` due to `dotnet` platform support in nixpkgs, but there are ARM64 downloads of the `dotnet` SDKs available. This change follows the kind of pattern used in the `firecracker` packaging to support selective x86_64/arm64 downloads.

With this change I can build `jellyfin` on a Raspberry Pi 4, ~but it wasn't obviously practical to go through all the SDK versions to fill in the ARM64 content hashes, so I have punted on those that were not immediately necessary.~

I'd be very happy to receive guidance if this is a wrongheaded approach or if further work is needed. Thanks!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
