### PR TITLE
etcd: 3.3.13 -> 3.3.20

### DIFF
--- a/pkgs/servers/etcd/default.nix
+++ b/pkgs/servers/etcd/default.nix
@@ -1,33 +1,40 @@
-{ lib, libpcap, buildGoPackage, fetchFromGitHub }:
-
-with lib;
+{ lib, buildGoPackage, fetchFromGitHub, nixosTests }:
 
 buildGoPackage rec {
   pname = "etcd";
-  version = "3.3.13"; # After updating check that nixos tests pass
-  rev = "v${version}";
+  version = "3.3.20";
 
+  # change to "go.etcd.io/etcd" for >= 3.4
   goPackagePath = "github.com/coreos/etcd";
 
   src = fetchFromGitHub {
-    inherit rev;
-    owner = "coreos";
+    owner = "etcd-io";
     repo = "etcd";
-    sha256 = "1kac4qfr83f2hdz35403f1ald05wc85vvhw79vxb431n61jvyaqy";
+    rev = "v${version}";
+    sha256 = "1iqq12kkky3cl28k7fabqqyx1i0a2wmbkq0bs8yhiwywp076k08w";
   };
 
-  subPackages = [
-    "cmd/etcd"
-    "cmd/etcdctl"
-  ];
+  buildPhase = ''
+    cd go/src/${goPackagePath}
+    patchShebangs .
+    ./build
+    ./functional/build
+  '';
 
-  buildInputs = [ libpcap ];
+  installPhase = ''
+    install -Dm755 bin/* bin/functional/cmd/* -t $bin/bin
+  '';
 
-  meta = {
+  passthru.tests = with nixosTests; {
+    etcd = etcd;
+    etcd-cluster = etcd-cluster;
+  };
+
+  meta = with lib; {
     description = "Distributed reliable key-value store for the most critical data of a distributed system";
     license = licenses.asl20;
-    homepage = "https://coreos.com/etcd/";
-    maintainers = with maintainers; [offline];
-    platforms = with platforms; linux;
+    homepage = "https://etcd.io/";
+    maintainers = with maintainers; [ offline ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
