### PR TITLE
rofi-file-browser: init at 1.1.1

### DIFF
--- a/pkgs/applications/misc/rofi-file-browser/default.nix
+++ b/pkgs/applications/misc/rofi-file-browser/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "marvinkreis";
-    repo = "${pname}";
+    repo = pname;
     rev = version;
     sha256 = "10wk5sif3bmvsgyk2gdy0qhpv1b37zgzf89n3h0yh7pg195fi2gn";
     fetchSubmodules = true;

--- a/pkgs/applications/misc/rofi-file-browser/default.nix
+++ b/pkgs/applications/misc/rofi-file-browser/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, rofi, gtk3 }:
+
+stdenv.mkDerivation rec {
+  pname = "rofi-file-browser-extended";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "marvinkreis";
+    repo = "${pname}";
+    rev = version;
+    sha256 = "10wk5sif3bmvsgyk2gdy0qhpv1b37zgzf89n3h0yh7pg195fi2gn";
+    fetchSubmodules = true;
+  };
+
+  prePatch = ''
+    substituteInPlace ./CMakeLists.txt \
+      --replace ' ''${ROFI_PLUGINS_DIR}' " $out/lib/rofi" \
+      --replace "/usr/share/" "$out/share/"
+  '';
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ rofi gtk3 ];
+
+  ROFI_PLUGINS_DIR = "$out/lib/rofi";
+
+  dontUseCmakeBuildDir = true;
+
+  meta = with stdenv.lib; {
+    description = "Use rofi to quickly open files";
+    homepage = "https://github.com/marvinkreis/rofi-file-browser-extended";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20678,6 +20678,8 @@ in
 
   rofi-emoji = callPackage ../applications/misc/rofi-emoji { };
 
+  rofi-file-browser = callPackage ../applications/misc/rofi-file-browser { };
+
   ympd = callPackage ../applications/audio/ympd { };
 
   nload = callPackage ../applications/networking/nload { };


### PR DESCRIPTION
###### Motivation for this change

Add rofi plugin `rofi-file-browser`.

To test:

```
nix-shell -p "rofi.override {plugins=[rofi-file-browser];}"
rofi -show file-browser -modi file-browser
```

Or add `(rofi.override {plugins=[rofi-file-browser];})` to your list of installed packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
