### PR TITLE
nixos/wireguard: test against multiple kernel versions

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -324,10 +324,7 @@ in
   vault = handleTest ./vault.nix {};
   victoriametrics = handleTest ./victoriametrics.nix {};
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
-  wg-quick = handleTest ./wireguard/wg-quick.nix {};
   wireguard = handleTest ./wireguard {};
-  wireguard-generated = handleTest ./wireguard/generated.nix {};
-  wireguard-namespaces = handleTest ./wireguard/namespaces.nix {};
   wordpress = handleTest ./wordpress.nix {};
   xandikos = handleTest ./xandikos.nix {};
   xautolock = handleTest ./xautolock.nix {};

--- a/nixos/tests/wireguard/basic.nix
+++ b/nixos/tests/wireguard/basic.nix
@@ -1,14 +1,13 @@
 { kernelPackages ? null }:
-
-import ../make-test-python.nix ({ pkgs, lib, ... }:
+import ../make-test-python.nix ({ pkgs, lib, ...} :
   let
     wg-snakeoil-keys = import ./snakeoil-keys.nix;
     peer = (import ./make-peer.nix) { inherit lib; };
   in
   {
-    name = "wg-quick";
+    name = "wireguard";
     meta = with pkgs.stdenv.lib.maintainers; {
-      maintainers = [ xwvvvvwx ];
+      maintainers = [ ma27 ];
     };
 
     nodes = {
@@ -18,8 +17,8 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
         extraConfig = {
           boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
           networking.firewall.allowedUDPPorts = [ 23542 ];
-          networking.wg-quick.interfaces.wg0 = {
-            address = [ "10.23.42.1/32" "fc00::1/128" ];
+          networking.wireguard.interfaces.wg0 = {
+            ips = [ "10.23.42.1/32" "fc00::1/128" ];
             listenPort = 23542;
 
             inherit (wg-snakeoil-keys.peer0) privateKey;
@@ -38,8 +37,11 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
         ip6 = "fd00::2";
         extraConfig = {
           boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
-          networking.wg-quick.interfaces.wg0 = {
-            address = [ "10.23.42.2/32" "fc00::2/128" ];
+          networking.wireguard.interfaces.wg0 = {
+            ips = [ "10.23.42.2/32" "fc00::2/128" ];
+            listenPort = 23542;
+            allowedIPsAsRoutes = false;
+
             inherit (wg-snakeoil-keys.peer1) privateKey;
 
             peers = lib.singleton {
@@ -49,6 +51,11 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
 
               inherit (wg-snakeoil-keys.peer0) publicKey;
             };
+
+            postSetup = let inherit (pkgs) iproute; in ''
+              ${iproute}/bin/ip route replace 10.23.42.1/32 dev wg0
+              ${iproute}/bin/ip route replace fc00::1/128 dev wg0
+            '';
           };
         };
       };
@@ -57,8 +64,8 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
     testScript = ''
       start_all()
 
-      peer0.wait_for_unit("wg-quick-wg0.service")
-      peer1.wait_for_unit("wg-quick-wg0.service")
+      peer0.wait_for_unit("wireguard-wg0.service")
+      peer1.wait_for_unit("wireguard-wg0.service")
 
       peer1.succeed("ping -c5 fc00::1")
       peer1.succeed("ping -c5 10.23.42.1")

--- a/nixos/tests/wireguard/generated.nix
+++ b/nixos/tests/wireguard/generated.nix
@@ -1,4 +1,5 @@
-import ../make-test-python.nix ({ pkgs, ...} : {
+{ kernelPackages ? null }:
+import ../make-test-python.nix ({ pkgs, lib, ... } : {
   name = "wireguard-generated";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ma27 grahamc ];
@@ -6,6 +7,7 @@ import ../make-test-python.nix ({ pkgs, ...} : {
 
   nodes = {
     peer1 = {
+      boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
       networking.firewall.allowedUDPPorts = [ 12345 ];
       networking.wireguard.interfaces.wg0 = {
         ips = [ "10.10.10.1/24" ];
@@ -17,6 +19,7 @@ import ../make-test-python.nix ({ pkgs, ...} : {
     };
 
     peer2 = {
+      boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
       networking.firewall.allowedUDPPorts = [ 12345 ];
       networking.wireguard.interfaces.wg0 = {
         ips = [ "10.10.10.2/24" ];

--- a/nixos/tests/wireguard/namespaces.nix
+++ b/nixos/tests/wireguard/namespaces.nix
@@ -1,3 +1,5 @@
+{ kernelPackages ? null }:
+
 let
   listenPort = 12345;
   socketNamespace = "foo";
@@ -13,7 +15,7 @@ let
 
 in
 
-import ../make-test-python.nix ({ pkgs, ...} : {
+import ../make-test-python.nix ({ pkgs, lib, ... } : {
   name = "wireguard-with-namespaces";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ asymmetric ];
@@ -23,6 +25,7 @@ import ../make-test-python.nix ({ pkgs, ...} : {
     # interface should be created in the socketNamespace
     # and not moved from there
     peer0 = pkgs.lib.attrsets.recursiveUpdate node {
+      boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
       networking.wireguard.interfaces.wg0 = {
         preSetup = ''
           ip netns add ${socketNamespace}
@@ -33,6 +36,7 @@ import ../make-test-python.nix ({ pkgs, ...} : {
     # interface should be created in the init namespace
     # and moved to the interfaceNamespace
     peer1 = pkgs.lib.attrsets.recursiveUpdate node {
+      boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
       networking.wireguard.interfaces.wg0 = {
         preSetup = ''
           ip netns add ${interfaceNamespace}
@@ -43,6 +47,7 @@ import ../make-test-python.nix ({ pkgs, ...} : {
     # interface should be created in the socketNamespace
     # and moved to the interfaceNamespace
     peer2 = pkgs.lib.attrsets.recursiveUpdate node {
+      boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
       networking.wireguard.interfaces.wg0 = {
         preSetup = ''
           ip netns add ${socketNamespace}
@@ -54,6 +59,7 @@ import ../make-test-python.nix ({ pkgs, ...} : {
     # interface should be created in the socketNamespace
     # and moved to the init namespace
     peer3 = pkgs.lib.attrsets.recursiveUpdate node {
+      boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
       networking.wireguard.interfaces.wg0 = {
         preSetup = ''
           ip netns add ${socketNamespace}

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -49,9 +49,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = ./update.sh;
-    tests = {
-      inherit (nixosTests) wireguard wg-quick wireguard-generated wireguard-namespaces;
-    };
+    tests = nixosTests.wireguard;
   };
 
   meta = {


### PR DESCRIPTION

###### Motivation for this change

When testing WireGuard updates, I usually run the VM-tests with
different kernels to make sure we're not introducing accidental
regressions for e.g. older kernels.

I figured that we should automate this process to ensure continuously
that WireGuard works fine on several kernels.

For now I decided to test the latest two LTS versions (5.4 and 4.19) and
the latest kernel (currently 5.6). We can add more kernels in the
future, however this seems to significantly slow down evaluation and
test-time.

The `kernelPackages` argument in the tests is null by default to make
sure that it's still possible to invoke the test-files directly. In that
case the default kernel of NixOS (currently 5.4) is used.

-----

Things to consider before merging:

* Just run a subset of those tests by default to speed up evaluation and build-time.
* I'm not 100% sure if passing the `kernelPackages` argument like this has implications for cross-builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
