### PR TITLE
watson: added bash/zsh completions

### DIFF
--- a/pkgs/applications/office/watson/default.nix
+++ b/pkgs/applications/office/watson/default.nix
@@ -1,3 +1,4 @@
+{ stdenv, pythonPackages, fetchpatch, installShellFiles }:
 
 with pythonPackages;
 
@@ -15,8 +16,14 @@ buildPythonApplication rec {
     pytest -vs tests
   '';
 
+  postInstall = ''
+    installShellCompletion --bash --name watson watson.completion
+    installShellCompletion --zsh --name _watson watson.zsh-completion
+  '';
+
   checkInputs = [ py pytest pytest-datafiles mock pytest-mock pytestrunner ];
   propagatedBuildInputs = [ requests click arrow ];
+  nativeBuildInputs = [ installShellFiles ];
 
   meta = with stdenv.lib; {
     homepage = "https://tailordev.github.io/Watson/";

--- a/pkgs/applications/office/watson/default.nix
+++ b/pkgs/applications/office/watson/default.nix
@@ -1,4 +1,3 @@
-{ stdenv, pythonPackages, fetchpatch }:
 
 with pythonPackages;
 
@@ -14,7 +13,7 @@ buildPythonApplication rec {
 
   checkPhase = ''
     pytest -vs tests
- '';
+  '';
 
   checkInputs = [ py pytest pytest-datafiles mock pytest-mock pytestrunner ];
   propagatedBuildInputs = [ requests click arrow ];
@@ -23,6 +22,6 @@ buildPythonApplication rec {
     homepage = "https://tailordev.github.io/Watson/";
     description = "A wonderful CLI to track your time!";
     license = licenses.mit;
-    maintainers = with maintainers; [ mguentner nathyong ] ;
+    maintainers = with maintainers; [ mguentner nathyong ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Now the project can be used with bash/zsh completion

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
