### PR TITLE
coqPackages.coqhammer: 1.1.1 → 1.2

### DIFF
--- a/pkgs/development/coq-modules/coqhammer/default.nix
+++ b/pkgs/development/coq-modules/coqhammer/default.nix
@@ -13,8 +13,12 @@ let
       buildInputs = [ coq.ocamlPackages.camlp5 ];
     };
     "8.10" = {
-      version = "1.1.1";
-      sha256 = "0b6r7bsygl1axbqybkhkr7zlwcd51ski5ql52994klrrxvjd58df";
+      version = "1.2";
+      sha256 = "1ir313mmkgp2c65wgw8c681a15clvri1wb1hyjqmj7ymx4shkl56";
+    };
+    "8.11" = {
+      version = "1.2";
+      sha256 = "1w317h7r5llyamzn1kqb8j6p5sxks2j8vq8wnpzrx01jqbyibxgy";
     };
   };
   param = params.${coq.coq-version};


### PR DESCRIPTION
###### Motivation for this change

Add support for Coq 8.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
