### PR TITLE
pythonPackages.bluepy: init at 1.3.0

### DIFF
--- a/pkgs/development/python-modules/bluepy/default.nix
+++ b/pkgs/development/python-modules/bluepy/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pkg-config
+, glib
+}:
+
+buildPythonPackage rec {
+  pname = "bluepy";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1v0wjy1rz0rbwghr1z3xhdm06lqn9iig6vr5j2wmymh3w6pysw9a";
+  };
+
+  buildInputs = [ glib ];
+  nativeBuildInputs = [ pkg-config ];
+
+  # tests try to access hardware
+  checkPhase = ''
+    $out/bin/blescan --help > /dev/null
+    $out/bin/sensortag --help > /dev/null
+    $out/bin/thingy52 --help > /dev/null
+  '';
+  pythonImportsCheck = [ "bluepy" ];
+
+  meta = with stdenv.lib; {
+    description = "Python interface to Bluetooth LE on Linux";
+    homepage = "https://github.com/IanHarvey/bluepy";
+    maintainers = with maintainers; [ georgewhewell ];
+    license = licenses.gpl2;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -518,6 +518,8 @@ in {
 
   blivet = callPackage ../development/python-modules/blivet { };
 
+  bluepy = callPackage ../development/python-modules/bluepy { };
+
   boltons = callPackage ../development/python-modules/boltons { };
 
   bravia-tv = callPackage ../development/python-modules/bravia-tv { };


### PR DESCRIPTION
###### Motivation for this change
add bluepy package

closes #81330

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
