### PR TITLE
libglvnd: 1.2.0 -> 1.3.1

### DIFF
--- a/pkgs/development/libraries/libglvnd/default.nix
+++ b/pkgs/development/libraries/libglvnd/default.nix
@@ -2,33 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "libglvnd";
-  version = "1.2.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "libglvnd";
     rev = "v${version}";
-    sha256 = "1hyywwjsmvsd7di603f7iznjlccqlc7yvz0j59gax7bljm9wb6ni";
+    sha256 = "0mkzdzdxjxjl794rblq4mq33wmb8ikqmfswbqdbr8gw2kw4wlhdl";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig python3 addOpenGLRunpath ];
   buildInputs = [ libX11 libXext xorgproto ];
-
-  # The following 3 patches should be removed once libglvnd >1.2.0 is released
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/NVIDIA/libglvnd/commit/6f52473dac08c44b081b792874b4ce73122096da.patch";
-      sha256 = "0rd9ihl8n33cm0rya5a7ki0hn31fh52r0gaj5d4w80jrsah2ayij";
-    })
-    (fetchpatch {
-      url = "https://github.com/NVIDIA/libglvnd/commit/51233cc52cbcbe25f8461830913c06f5b5bc9508.patch";
-      sha256 = "1qx3nw8vq5xcrixmi7xw1vpy4gbf7kmx38rx8wg8x046g4mv8ijj";
-    })
-    (fetchpatch {
-      url = "https://github.com/NVIDIA/libglvnd/commit/5dfdc5a6dc60a3bdc63cd4510dabacba388da13a.patch";
-      sha256 = "0gmb3619yz3z7n22afjh8p2y13bmsky4r0z0csm14is3wvdi64ya";
-    })
-  ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/GLX/Makefile.am \


### PR DESCRIPTION
###### Motivation for this change
New upstream version, #86057 (thanks @eadwu!)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
