### PR TITLE
cinnamon.cinnamon-screensaver: init at 4.4.0

### DIFF
--- a/pkgs/data/icons/iso-flags/default.nix
+++ b/pkgs/data/icons/iso-flags/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchFromGitHub
+, perl
+, perlPackages
+, inkscape
+, pngcrush
+, librsvg
+, targets ? [ "all" ]
+}:
+
+stdenv.mkDerivation {
+  pname = "iso-flags";
+  version = "unstable-18012020";
+
+  src = fetchFromGitHub {
+    owner = "joielechong";
+    repo = "iso-country-flags-svg-collection";
+    rev = "9ebbd577b9a70fbfd9a1931be80c66e0d2f31a9d";
+    sha256 = "17bm7w4md56xywixfvp7vr3d6ihvxk3383i9i4rpmgm6qa9dyxdl";
+  };
+
+  nativeBuildInputs = [
+    perl
+    inkscape
+    librsvg
+    (perl.withPackages(pp: with pp; [ JSON XMLLibXML ]))
+  ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  buildFlags = targets;
+
+  installPhase = ''
+    mkdir -p $out/share
+    mv build $out/share/iso-flags
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/joielechong/iso-country-flags-svg-collection";
+    description = "248 country flag SVG & PNG icons with different icon styles";
+    license = [ licenses.publicDomain ];
+    platforms = platforms.linux; # the output assets should work anywhere, but unsure about the tools to build them...
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -1,0 +1,154 @@
+{ atk
+, autoreconfHook
+, cacert
+, fetchpatch
+, dbus
+, cinnamon-control-center
+, cinnamon-desktop
+, cinnamon-menus
+, cjs
+, fetchFromGitHub
+, gdk-pixbuf
+, libgnomekbd
+, glib
+, gobject-introspection
+, gtk3
+, intltool
+, json-glib
+, libcroco
+, libsoup
+, libstartup_notification
+, libXtst
+, muffin
+, networkmanager
+, pkgconfig
+, polkit
+, stdenv
+, wrapGAppsHook
+, libxml2
+, gtk-doc
+, gnome3
+, python3
+, keybinder3
+, cairo
+, xapps
+, upower
+, nemo
+, libnotify
+, accountsservice
+, gnome-online-accounts
+, glib-networking
+, callPackage
+, pciutils
+, timezonemap
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cinnamon-common";
+  version = "4.4.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "cinnamon";
+    rev = version;
+    sha256 = "0sv7nqd1l6c727qj30dcgdkvfh1wxpszpgmbdyh58ilmc8xklnqd";
+  };
+
+  patches = [
+    # remove dbus-glib
+    (fetchpatch {
+      url = "https://github.com/linuxmint/cinnamon/commit/ce99760fa15c3de2e095b9a5372eeaca646fbed1.patch";
+      sha256 = "0p2sbdi5w7sgblqbgisb6f8lcj1syzq5vlk0ilvwaqayxjylg8gz";
+    })
+  ];
+
+  buildInputs = [
+    # TODO: review if we really need this all
+    (python3.withPackages (pp: with pp; [ dbus-python setproctitle pygobject3 pycairo xapp pillow pytz tinycss pam pexpect ]))
+    atk
+    cacert
+    cinnamon-control-center
+    cinnamon-desktop
+    cinnamon-menus
+    cjs
+    dbus
+    gdk-pixbuf
+    glib
+    gtk3
+    json-glib
+    libcroco
+    libsoup
+    libstartup_notification
+    libXtst
+    muffin
+    networkmanager
+    pkgconfig
+    polkit
+    libxml2
+    libgnomekbd
+
+    # bindings
+    cairo
+    gnome3.caribou
+    keybinder3
+    upower
+    xapps
+    timezonemap
+    nemo
+    libnotify
+    accountsservice
+
+    # gsi bindings
+    gnome-online-accounts
+    glib-networking # for goa
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    autoreconfHook
+    wrapGAppsHook
+    intltool
+    gtk-doc
+  ];
+
+  autoreconfPhase = ''
+    GTK_DOC_CHECK=false NOCONFIGURE=1 bash ./autogen.sh
+  '';
+
+  configureFlags = [ "--disable-static" "--with-ca-certificates=${cacert}/etc/ssl/certs/ca-bundle.crt" "--with-libxml=${libxml2.dev}/include/libxml2" "--enable-gtk-doc=no" ];
+
+  postPatch = ''
+    substituteInPlace src/Makefile.am \
+      --replace "\$(libdir)/muffin" "${muffin}/lib/muffin"
+    patchShebangs autogen.sh
+
+    find . -type f -exec sed -i \
+      -e s,/usr/share/cinnamon,$out/share/cinnamon,g \
+      -e s,/usr/share/locale,/run/current-system/sw/share/locale,g \
+      {} +
+
+    sed "s|/usr/share/sounds|/run/current-system/sw/share/sounds|g" -i ./files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+
+    sed "s|/usr/bin/upload-system-info|${xapps}/bin/upload-system-info|g" -i ./files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+    sed "s|upload-system-info|${xapps}/bin/upload-system-info|g" -i ./files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+
+    sed "s|/usr/bin/cinnamon-control-center|${cinnamon-control-center}/bin/cinnamon-control-center|g" -i ./files/usr/bin/cinnamon-settings
+    # this one really IS optional
+    sed "s|/usr/bin/gnome-control-center|/run/current-system/sw/bin/gnome-control-center|g" -i ./files/usr/bin/cinnamon-settings
+
+    sed "s|\"/usr/lib\"|\"${cinnamon-control-center}/lib\"|g" -i ./files/usr/share/cinnamon/cinnamon-settings/bin/capi.py
+
+    # another bunch of optional stuff
+    sed "s|/usr/bin|/run/current-system/sw/bin|g" -i ./files/usr/bin/cinnamon-launcher
+
+    sed 's|"lspci"|"${pciutils}/bin/lspci"|g' -i ./files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/cinnamon";
+    description = "The Cinnamon desktop environment";
+    license = [ licenses.gpl2 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -15,7 +15,7 @@
 , gtk3
 , intltool
 , json-glib
-, libcroco
+, callPackage
 , libsoup
 , libstartup_notification
 , libXtst
@@ -38,11 +38,13 @@
 , accountsservice
 , gnome-online-accounts
 , glib-networking
-, callPackage
 , pciutils
 , timezonemap
 }:
 
+let
+  libcroco = callPackage ./libcroco.nix { };
+in
 stdenv.mkDerivation rec {
   pname = "cinnamon-common";
   version = "4.4.1";

--- a/pkgs/desktops/cinnamon/cinnamon-common/libcroco.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/libcroco.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, pkgconfig, libxml2, glib, gnome3 }:
+
+stdenv.mkDerivation rec {
+  pname = "libcroco";
+  version = "0.6.13";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1m110rbj5d2raxcdp4iz0qp172284945awrsbdlq99ksmqsc4zkn";
+  };
+
+  outputs = [ "out" "dev" ];
+  outputBin = "dev";
+
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--disable-Bsymbolic";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libxml2 glib ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "GNOME CSS2 parsing and manipulation toolkit";
+    homepage = https://gitlab.gnome.org/GNOME/libcroco;
+    license = licenses.lgpl2;
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
@@ -1,0 +1,111 @@
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, autoreconfHook
+, glib
+, dbus
+, gettext
+, cinnamon-desktop
+, cinnamon-common
+, intltool
+, libxslt
+, gtk3
+, libnotify
+, libxkbfile
+, cinnamon-menus
+, libgnomekbd
+, libxklavier
+, networkmanager
+, libwacom
+, gnome3
+, libtool
+, wrapGAppsHook
+, tzdata
+, glibc
+, gobject-introspection
+, python3
+, pam
+, accountsservice
+, cairo
+, xapps
+, xorg
+, iso-flags-png-320x420
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cinnamon-screensaver";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "03v41wk1gmgmyl31j7a3pav52gfv2faibj1jnpj3ycwcv4cch5w5";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    autoreconfHook
+    wrapGAppsHook
+    gettext
+    intltool
+    dbus # for configure.ac
+    libxslt
+    libtool
+  ];
+
+  buildInputs = [
+    # from configure.ac
+    gobject-introspection
+    gtk3
+    glib
+
+    xorg.libXext
+    xorg.libXinerama
+    xorg.libX11
+    xorg.libXrandr
+
+    (python3.withPackages (pp: with pp; [ pygobject3 setproctitle xapp pycairo ]))
+    xapps
+    pam
+    accountsservice
+    cairo
+    cinnamon-desktop
+    cinnamon-common
+    gnome3.libgnomekbd
+    gnome3.caribou
+
+    # things
+    iso-flags-png-320x420
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0"; # TODO: https://github.com/NixOS/nixpkgs/issues/36468
+
+  postPatch = ''
+    patchShebangs autogen.sh
+
+    sed ${stdenv.lib.escapeShellArg "s&DBUS_SESSION_SERVICE_DIR=.*&DBUS_SESSION_SERVICE_DIR=`$PKG_CONFIG --variable session_bus_services_dir dbus-1 | sed -e 's,/usr/share,\${datarootdir},g' | sed 's|^|$out|'`&g"} -i configure.ac
+
+    # cscreensaver hardcodes absolute paths everywhere. Nuke from orbit.
+    find . -type f -exec sed -i \
+      -e s,/usr/share/locale,/run/current-system/sw/share/locale,g \
+      -e s,/usr/lib/cinnamon-screensaver,$out/lib,g \
+      -e s,/usr/share/cinnamon-screensaver,$out/share,g \
+      -e s,/usr/share/iso-flag-png,${iso-flags-png-320x420}/share/iso-flags-png,g \
+      {} +
+
+    sed "s|/usr/share/locale|/run/current-system/sw/share/locale|g" -i ./src/cinnamon-screensaver-main.py
+  '';
+
+  autoreconfPhase = ''
+    NOCONFIGURE=1 bash ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/cinnamon-screensaver";
+    description = "The Cinnamon screen locker and screensaver program";
+    license = [ licenses.gpl2 licenses.lgpl2 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -16,6 +16,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   cinnamon-desktop = callPackage ./cinnamon-desktop { };
   cinnamon-menus = callPackage ./cinnamon-menus { };
   cinnamon-translations = callPackage ./cinnamon-translations { };
+  cinnamon-screensaver = callPackage ./cinnamon-screensaver { };
   cinnamon-session = callPackage ./cinnamon-session { };
   cinnamon-settings-daemon = callPackage ./cinnamon-settings-daemon { };
   cjs = callPackage ./cjs { };

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -1,6 +1,17 @@
 { pkgs, lib }:
 
 lib.makeScope pkgs.newScope (self: with self; {
+  iso-flags-png-320x420 = pkgs.iso-flags.overrideAttrs(p: p // {
+    buildPhase = "make png-country-320x240-fancy";
+    # installPhase = "mkdir -p $out/share && mv build/png-country-4x2-fancy/res-320x240 $out/share/iso-flags-png-320x420";
+    installPhase = "mkdir -p $out/share && mv build/png-country-4x2-fancy/res-320x240 $out/share/iso-flags-png";
+  });
+
+  iso-flags-svg = pkgs.iso-flags.overrideAttrs(p: p // {
+    buildPhase = "mkdir -p $out/share";
+    installPhase = "mv svg $out/share/iso-flags-svg";
+  });
+
   cinnamon-control-center = callPackage ./cinnamon-control-center { };
   cinnamon-desktop = callPackage ./cinnamon-desktop { };
   cinnamon-menus = callPackage ./cinnamon-menus { };

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -12,6 +12,7 @@ lib.makeScope pkgs.newScope (self: with self; {
     installPhase = "mv svg $out/share/iso-flags-svg";
   });
 
+  cinnamon-common = callPackage ./cinnamon-common { };
   cinnamon-control-center = callPackage ./cinnamon-control-center { };
   cinnamon-desktop = callPackage ./cinnamon-desktop { };
   cinnamon-menus = callPackage ./cinnamon-menus { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12937,6 +12937,8 @@ in
 
   isocodes = callPackage ../development/libraries/iso-codes { };
 
+  iso-flags = callPackage ../data/icons/iso-flags { };
+
   ispc = callPackage ../development/compilers/ispc {
     stdenv = llvmPackages_10.stdenv;
     llvmPackages = llvmPackages_10;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
