### PR TITLE
lua51Packages.luaexpat: Removing broken meta attribute.

### DIFF
--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -990,7 +990,6 @@ luaexpat = buildLuarocksPackage {
     license = {
       fullName = "MIT/X11";
     };
-    broken = true;
   };
 };
 luaffi = buildLuarocksPackage {
@@ -1559,4 +1558,3 @@ vstruct = buildLuarocksPackage {
 
 }
 /* GENERATED */
-


### PR DESCRIPTION
###### Motivation for this change
Luaexpat has been mistakenly marked as broken during a
20.03 a zero hydra failures tree-wide commit. Removing the broken meta
attribute.

I discovered this problem when trying to rebuild the prosody XMPP server. Prosody itself is still green on Hydra. I assume marking an input as broken does not change the overall hash hence do not trigger a rebuild? Not sure...


I'm still not 100% sure why this was marked as broken, the build does not seem to be flaky. My current best assumption here is a tooling failure. I'm now wondering whether this same bug could happen somewhere else.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @worldofpeace 
