### PR TITLE
bgpq4: init at 0.0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8798,6 +8798,16 @@
       fingerprint = "B3C0 DA1A C18B 82E8 CA8B  B1D1 4F62 CD07 CE64 796A";
     }];
   };
+  vincentbernat = {
+    email = "vincent@bernat.ch";
+    github = "vincentbernat";
+    githubId = 631446;
+    name = "Vincent Bernat";
+    keys = [{
+      longkeyid = "rsa4096/0x95A42FE8353525F9";
+      fingerprint = "AEF2 3487 66F3 71C6 89A7  3600 95A4 2FE8 3535 25F9";
+    }];
+  };
   vinymeuh = {
     email = "vinymeuh@gmail.com";
     github = "vinymeuh";

--- a/pkgs/tools/networking/bgpq4/default.nix
+++ b/pkgs/tools/networking/bgpq4/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "bgpq4";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    owner = "bgp";
+    repo = pname;
+    rev = version;
+    sha256 = "1n6d6xq7vafx1la0fckqv0yjr245ka9dgbcqaz9m6dcdk0fdlkks";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  meta = with stdenv.lib; {
+    description = "BGP filtering automation tool";
+    homepage = "https://github.com/bgp/bgpq4";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ vincentbernat ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19551,6 +19551,8 @@ in
 
   bgpq3 = callPackage ../tools/networking/bgpq3 { };
 
+  bgpq4 = callPackage ../tools/networking/bgpq4 { };
+
   blackbox = callPackage ../applications/version-management/blackbox { };
 
   bleachbit = callPackage ../applications/misc/bleachbit { };


### PR DESCRIPTION
###### Motivation for this change

This is a fork of bgpq3. It is still unclear if it will superseed
bgpq3. It is mostly compatible with additional features, like support
for Mikrotik devices. It also defaults to NTT IRR server instead of
RADB.

cc @B4dM4n 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
