### PR TITLE
[wip] p4v: 2017.3.1601999 -> 2020.1.1946989

### DIFF
--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, lib, qtbase, qtmultimedia, qtscript, qtsensors, qtwebkit, openssl_1_0_2, xkeyboard_config, wrapQtAppsHook }:
+{ stdenv, fetchurl, lib, qtbase, qtscript, qtwebengine, qtwebkit, openssl_1_1, xkeyboard_config, wrapQtAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "p4v";
-  version = "2017.3.1601999";
+  version = "2020.1.1946989";
 
   src = fetchurl {
-    url = "https://cdist2.perforce.com/perforce/r17.3/bin.linux26x86_64/p4v.tgz";
-    sha256 = "9ded42683141e1808535ec3e87d3149f890315c192d6e97212794fd54862b9a4";
+    url = "https://www.perforce.com/downloads/perforce/r20.1/bin.linux26x86_64/p4v.tgz";
+    sha256 = "67aa4949fb29b04b537f32b3f8fc18a24ef3ce12f81a38ffea46210a89553a89";
   };
 
   dontBuild = true;
@@ -15,21 +15,20 @@ stdenv.mkDerivation rec {
   ldLibraryPath = lib.makeLibraryPath [
       stdenv.cc.cc.lib
       qtbase
-      qtmultimedia
       qtscript
-      qtsensors
+      qtwebengine
       qtwebkit
-      openssl_1_0_2
+      openssl_1_1
   ];
 
   dontWrapQtApps = true;
   installPhase = ''
     mkdir $out
     cp -r bin $out
-    mkdir -p $out/lib/p4v
-    cp -r lib/p4v/P4VResources $out/lib/p4v
+    mkdir -p $out/lib
+    cp -r lib/P4VResources $out/lib
 
-    for f in $out/bin/*.bin ; do
+    for f in $out/bin/{*.bin,helixmfa,QtWebEngineProcess} ; do
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $f
 
       wrapQtApp $f \


### PR DESCRIPTION
###### Motivation for this change
Updating the `p4v` version to get rid of `openssl_1_0_2`.

Unfortunately, this does not work. When running `p4merge -V`, the following error is printed:
```
$ p4merge -V
/nix/store/q9xqk2ysx5vd7q8qh5msklq9jwcfn9bh-p4v-2020.1.1946989/bin/p4merge.bin: symbol lookup error: /nix/store/q9xqk2ysx5vd7q8qh5msklq9jwcfn9bh-p4v-2020.1.1946989/bin/p4merge.bin: undefined symbol: _ZNSt20bad_array_new_lengthD1Ev, version Qt_5
```

When I use the whole `/lib` folder as provided by upstream, then it works, but obviously it does not use the system Qt version then and I don't know what effects this might have.

@ttuegel can you help me out here what the problem might be? 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
