### PR TITLE
meson: Clean up build and infra

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -3,20 +3,8 @@
 , stdenv
 , writeTextDir
 , substituteAll
-, targetPackages
 }:
 
-let
-  # See https://mesonbuild.com/Reference-tables.html#cpu-families
-  cpuFamilies = {
-    aarch64  = "aarch64";
-    armv5tel = "arm";
-    armv6l   = "arm";
-    armv7l   = "arm";
-    i686     = "x86";
-    x86_64   = "x86_64";
-  };
-in
 python3Packages.buildPythonApplication rec {
   pname = "meson";
   version = "0.54.0";
@@ -70,26 +58,10 @@ python3Packages.buildPythonApplication rec {
 
   setupHook = ./setup-hook.sh;
 
-  crossFile = writeTextDir "cross-file.conf" ''
-    [binaries]
-    pkgconfig = 'pkg-config'
-
-    [properties]
-    needs_exe_wrapper = true
-
-    [host_machine]
-    system = '${targetPackages.stdenv.targetPlatform.parsed.kernel.name}'
-    cpu_family = '${cpuFamilies.${targetPackages.stdenv.targetPlatform.parsed.cpu.name}}'
-    cpu = '${targetPackages.stdenv.targetPlatform.parsed.cpu.name}'
-    endian = ${if targetPackages.stdenv.targetPlatform.isLittleEndian then "'little'" else "'big'"}
-  '';
-
   # 0.45 update enabled tests but they are failing
   doCheck = false;
   # checkInputs = [ ninja pkgconfig ];
   # checkPhase = "python ./run_project_tests.py";
-
-  isCross = stdenv.targetPlatform != stdenv.hostPlatform;
 
   meta = with lib; {
     homepage = "https://mesonbuild.com";

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -90,8 +90,6 @@ python3Packages.buildPythonApplication rec {
   # checkInputs = [ ninja pkgconfig ];
   # checkPhase = "python ./run_project_tests.py";
 
-  inherit (stdenv) cc;
-
   isCross = stdenv.targetPlatform != stdenv.hostPlatform;
 
   meta = with lib; {

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -45,6 +45,11 @@ python3Packages.buildPythonApplication rec {
     # We remove the check so multiple outputs can work sanely.
     ./allow-dirs-outside-of-prefix.patch
 
+    # Meson is currently inspecting fewer variables than autoconf does, which
+    # makes it harder for us to use setup hooks, etc.  Taken from
+    # https://github.com/mesonbuild/meson/pull/6827
+    ./more-env-vars.patch
+
     # Unlike libtool, vanilla Meson does not pass any information
     # about the path library will be installed to to g-ir-scanner,
     # breaking the GIR when path other than ${!outputLib}/lib is used.
@@ -67,13 +72,7 @@ python3Packages.buildPythonApplication rec {
 
   crossFile = writeTextDir "cross-file.conf" ''
     [binaries]
-    c = '${targetPackages.stdenv.cc.targetPrefix}cc'
-    cpp = '${targetPackages.stdenv.cc.targetPrefix}c++'
-    ar = '${targetPackages.stdenv.cc.bintools.targetPrefix}ar'
-    strip = '${targetPackages.stdenv.cc.bintools.targetPrefix}strip'
     pkgconfig = 'pkg-config'
-    ld = '${targetPackages.stdenv.cc.targetPrefix}ld'
-    objcopy = '${targetPackages.stdenv.cc.targetPrefix}objcopy'
 
     [properties]
     needs_exe_wrapper = true

--- a/pkgs/development/tools/build-managers/meson/more-env-vars.patch
+++ b/pkgs/development/tools/build-managers/meson/more-env-vars.patch
@@ -1,0 +1,16 @@
+diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
+index ac13a710..e0d07c51 100644
+--- a/mesonbuild/envconfig.py
++++ b/mesonbuild/envconfig.py
+@@ -119,9 +119,9 @@ def get_env_var_pair(for_machine: MachineChoice,
+         # compiling we fall back on the unprefixed host version. This
+         # allows native builds to never need to worry about the 'BUILD_*'
+         # ones.
+-        ([var_name + '_FOR_BUILD'] if is_cross else [var_name]),
++        [var_name + '_FOR_BUILD'] + ([] if is_cross else [var_name]),
+         # Always just the unprefixed host verions
+-        ([] if is_cross else [var_name]),
++        [var_name],
+     )[for_machine]
+     for var in candidates:
+         value = os.environ.get(var)

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -25,7 +25,7 @@ mesonConfigurePhase() {
 
     echo "meson flags: $mesonFlags ${mesonFlagsArray[@]}"
 
-    CC=@cc@/bin/cc CXX=@cc@/bin/c++ meson build $mesonFlags "${mesonFlagsArray[@]}"
+    meson build $mesonFlags "${mesonFlagsArray[@]}"
     cd build
 
     if ! [[ -v enableParallelBuilding ]]; then

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -5,11 +5,6 @@ mesonConfigurePhase() {
         mesonFlags="--prefix=$prefix $mesonFlags"
     fi
 
-    # Build release by default.
-    if [ -n "@isCross@" ]; then
-      crossMesonFlags="--cross-file=@crossFile@/cross-file.conf"
-    fi
-
     # See multiple-outputs.sh and meson’s coredata.py
     mesonFlags="\
         --libdir=${!outputLib}/lib --libexecdir=${!outputLib}/libexec \

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -49,6 +49,7 @@ in rec {
     # Configure Phase
     , configureFlags ? []
     , cmakeFlags ? []
+    , mesonFlags ? []
     , # Target is not included by default because most programs don't care.
       # Including it then would cause needless mass rebuilds.
       #
@@ -252,6 +253,34 @@ in rec {
           ++ lib.optional (stdenv.buildPlatform.uname.system != null) "-DCMAKE_HOST_SYSTEM_NAME=${stdenv.buildPlatform.uname.system}"
           ++ lib.optional (stdenv.buildPlatform.uname.processor != null) "-DCMAKE_HOST_SYSTEM_PROCESSOR=${stdenv.buildPlatform.uname.processor}"
           ++ lib.optional (stdenv.buildPlatform.uname.release != null) "-DCMAKE_HOST_SYSTEM_VERSION=${stdenv.buildPlatform.uname.release}";
+
+          mesonFlags = if mesonFlags == null then null else let
+            # See https://mesonbuild.com/Reference-tables.html#cpu-families
+            cpuFamilies = {
+              aarch64  = "aarch64";
+              armv5tel = "arm";
+              armv6l   = "arm";
+              armv7l   = "arm";
+              i686     = "x86";
+              x86_64   = "x86_64";
+            };
+            crossFile = builtins.toFile "cross-file.conf" (''
+              [properties]
+              needs_exe_wrapper = true
+
+              [host_machine]
+              system = '${stdenv.targetPlatform.parsed.kernel.name}'
+              cpu_family = '${cpuFamilies.${stdenv.targetPlatform.parsed.cpu.name}}'
+              cpu = '${stdenv.targetPlatform.parsed.cpu.name}'
+              endian = ${if stdenv.targetPlatform.isLittleEndian then "'little'" else "'big'"}
+            ''
+            # TODO should have target prefix too, issue #86077
+            + ''
+
+              [binaries]
+              pkgconfig = 'pkg-config'
+            '');
+          in [ "--cross-file=${crossFile}" ] ++ mesonFlags;
         } // lib.optionalAttrs (attrs.enableParallelBuilding or false) {
           enableParallelChecking = attrs.enableParallelChecking or true;
         } // lib.optionalAttrs (hardeningDisable != [] || hardeningEnable != []) {


### PR DESCRIPTION
###### Motivation for this change

The big thing that happened is that https://github.com/mesonbuild/meson/pull/6363 was finally merged!

Fixes #58831

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @matthewbauer @jtojnar 