### PR TITLE
torque: substitute /bin/cp

### DIFF
--- a/pkgs/servers/computing/torque/default.nix
+++ b/pkgs/servers/computing/torque/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, openssl, flex, bison, pkgconfig, groff, libxml2, utillinux
-, file, libtool, which, boost, autoreconfHook
+, coreutils, file, libtool, which, boost, autoreconfHook
 }:
 
 stdenv.mkDerivation rec {
@@ -32,6 +32,10 @@ stdenv.mkDerivation rec {
       --replace "contrib/init.d contrib/systemd" ""
     substituteInPlace src/cmds/Makefile.am \
       --replace "/etc/" "$out/etc/"
+    substituteInPlace src/mom_rcp/pathnames.h \
+      --replace /bin/cp ${coreutils}/bin/cp
+    substituteInPlace src/resmom/requests.c \
+      --replace /bin/cp ${coreutils}/bin/cp
   '';
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
Copying STDOUT/STDERR results fails due to hard-coded /bin/cp

###### Things done
Replace /bin/cp with ${coreutils}/bin/cp

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
