### PR TITLE
ocamlPackages.tsdl: 0.9.4 -> 0.9.7

### DIFF
--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, ctypes, result, SDL2, pkgconfig, ocb-stubblr }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
 then throw "tsdl is not available for OCaml ${ocaml.version}"
 else
 
 let
   pname = "tsdl";
-  version = "0.9.4";
+  version = "0.9.7";
   webpage = "https://erratique.ch/software/${pname}";
 in
 
@@ -15,11 +15,11 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "13af37w2wybx8yzgjr5zz5l50402ldl614qiwphl1q69hig5mag2";
+    sha256 = "1zwv0ixkigh1gzk5n49rwvz2f2m62jdkkqg40j7dclg4gri7691f";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ocaml findlib ocamlbuild topkg result ocb-stubblr ];
+  buildInputs = [ ocaml findlib ocamlbuild topkg ];
   propagatedBuildInputs = [ SDL2 ctypes ];
 
   preConfigure = ''
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     homepage = webpage;
     description = "Thin bindings to the cross-platform SDL library";
-    license = licenses.bsd3;
+    license = licenses.isc;
     platforms = ocaml.meta.platforms or [];
   };
 }


### PR DESCRIPTION
From the release notes:
* Require OCaml 4.03 and handle stdlib deprecations.
* Drop result depency.
* Drop ocb-stubblr dependency
The library has also been re-licensed fro BSD3 to ISC

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (x86-64)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

In addition, I confirmed I could run `#require "tsdl";;` in an ocaml repl and access the module values.