### PR TITLE
coq-zorns-lemma: 8.9.0 -> 8.11.0

### DIFF
--- a/pkgs/development/coq-modules/contribs/default.nix
+++ b/pkgs/development/coq-modules/contribs/default.nix
@@ -1031,10 +1031,10 @@ let mkContrib = repo: revs: param:
     sha256 = "0iwkpmc22nwasrk4g7ki4s5y05zjs7kmqk3j98giwp2wiavhgapn";
   };
 
-  zorns-lemma = mkContrib "zorns-lemma" [ "8.6" "8.7" "8.8" "8.9" ] {
-    version = "v8.9.0";
-    rev = "6ac9bb914f6017cdd9a544ff4b0bef73fd33b44c";
-    sha256 = "1vdsl5gxpadkjjjw314s4fawzlssdmp4qkwrjz5qdmyl2dcpil4p";
+  zorns-lemma = mkContrib "zorns-lemma" [ "8.10" "8.11" ] {
+    version = "v8.11.0";
+    rev = "a573b50fff994f996b8e15dec2079490a5233dc6";
+    sha256 = "0jbp1ay6abal66glbablbqsh5hzgd5fv81dc1vzn65jw0iiznxyq";
   };
 
   zsearch-trees = mkContrib "zsearch-trees" [ "8.6" "8.7" ] {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

To support building latest Coq Topology library. (It's CI depends on Nixpkgs.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

-----

Tested with `nix-build . -A coqPackages_8_11.contribs.zorns-lemma --option sandbox true`