### PR TITLE
libnvidia-container: 1.0.0 -> 1.0.6

### DIFF
--- a/pkgs/applications/virtualization/nvidia-docker/libnvc-ldconfig-and-path-fixes.patch
+++ b/pkgs/applications/virtualization/nvidia-docker/libnvc-ldconfig-and-path-fixes.patch
@@ -71,10 +71,10 @@ index 33d78dd..2b087db 100644
  
  #endif /* HEADER_LDCACHE_H */
 diff --git a/src/nvc_info.c b/src/nvc_info.c
-index cc96542..3fe7612 100644
+index 30e3cfd..6d12a50 100644
 --- a/src/nvc_info.c
 +++ b/src/nvc_info.c
-@@ -163,15 +163,13 @@ find_library_paths(struct error *err, struct nvc_driver_info *info, const char *
+@@ -167,15 +167,13 @@ find_library_paths(struct error *err, struct nvc_driver_info *info, const char *
          if (path_resolve_full(err, path, root, ldcache) < 0)
                  return (-1);
          ldcache_init(&ld, err, path);
@@ -91,7 +91,7 @@ index cc96542..3fe7612 100644
                  goto fail;
  
          info->nlibs32 = size;
-@@ -179,13 +177,11 @@ find_library_paths(struct error *err, struct nvc_driver_info *info, const char *
+@@ -183,13 +181,11 @@ find_library_paths(struct error *err, struct nvc_driver_info *info, const char *
          if (info->libs32 == NULL)
                  goto fail;
          if (ldcache_resolve(&ld, LIB32_ARCH, root, libs,
@@ -106,7 +106,7 @@ index cc96542..3fe7612 100644
          return (rv);
  }
  
-@@ -199,7 +195,7 @@ find_binary_paths(struct error *err, struct nvc_driver_info *info, const char *r
+@@ -203,7 +199,7 @@ find_binary_paths(struct error *err, struct nvc_driver_info *info, const char *r
          char path[PATH_MAX];
          int rv = -1;
  
@@ -116,10 +116,10 @@ index cc96542..3fe7612 100644
                  return (-1);
          }
 diff --git a/src/nvc_ldcache.c b/src/nvc_ldcache.c
-index d41a24d..65b7878 100644
+index 6ff380f..cbe6a69 100644
 --- a/src/nvc_ldcache.c
 +++ b/src/nvc_ldcache.c
-@@ -331,7 +331,7 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
+@@ -340,7 +340,7 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
          if (validate_args(ctx, cnt != NULL) < 0)
                  return (-1);
  

--- a/pkgs/applications/virtualization/nvidia-docker/libnvc.nix
+++ b/pkgs/applications/virtualization/nvidia-docker/libnvc.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, libelf, libcap, libseccomp }:
+{ stdenv, lib, fetchFromGitHub, pkgconfig, libelf, libcap, libseccomp }:
 
 with lib; let
 
@@ -13,13 +13,13 @@ with lib; let
 
 in stdenv.mkDerivation rec {
   pname = "libnvidia-container";
-  version = "1.0.0";
+  version = "1.0.6";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "libnvidia-container";
     rev = "v${version}";
-    sha256 = "1ws6mfsbgxhzlb5w1r8qqg2arvxkr21n59i4cqsyz3h5jsqsflbw";
+    sha256 = "1pnpc9knwh8d1zqb28zc3spkjc00w0z10vd3jna8ksvpl35jl7w3";
   };
 
   # locations of nvidia-driver libraries are not resolved via ldconfig which
@@ -41,6 +41,8 @@ in stdenv.mkDerivation rec {
     chmod -R u+w deps/src
     touch deps/src/nvidia-modprobe-${modp-ver}/.download_stamp
   '';
+
+  nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ libelf libcap libseccomp ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Closes #83713

Should be backported to 20.03

Credit to @averelld 

CC: @tomberek @tbenst 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
