### PR TITLE
magic-vlsi: init at 8.3.5

### DIFF
--- a/pkgs/applications/science/electronics/magic-vlsi/0001-strip-bin-prefix.patch
+++ b/pkgs/applications/science/electronics/magic-vlsi/0001-strip-bin-prefix.patch
@@ -1,0 +1,10 @@
+diff --git a/scripts/makedbh b/scripts/makedbh
+index 01e4fa5..d6299c6 100755
+--- a/scripts/makedbh
++++ b/scripts/makedbh
+@@ -1,4 +1,4 @@
+-#!/bin/csh -f
++#!/usr/bin/env tcsh
+ #
+ # makes the "database.h" (1st argument, $1) file from "database.h.in"
+ # (2nd argument, $2), setting various mask operation definitions

--- a/pkgs/applications/science/electronics/magic-vlsi/0002-fix-format-security.patch
+++ b/pkgs/applications/science/electronics/magic-vlsi/0002-fix-format-security.patch
@@ -1,0 +1,19 @@
+diff --git a/database/DBio.c b/database/DBio.c
+index 93c4b0b..292ea5f 100644
+--- a/database/DBio.c
++++ b/database/DBio.c
+@@ -2378,12 +2378,12 @@ DBCellWriteFile(cellDef, f)
+ 
+ #define FPRINTF(f,s)\
+ {\
+-     if (fprintf(f,s) == EOF) goto ioerror;\
++     if (fprintf(f,"%s",s) == EOF) goto ioerror;\
+      DBFileOffset += strlen(s);\
+ }
+ #define FPRINTR(f,s)\
+ {\
+-     if (fprintf(f,s) == EOF) return 1;\
++     if (fprintf(f,"%s",s) == EOF) return 1;\
+      DBFileOffset += strlen(s);\
+ }
+ 

--- a/pkgs/applications/science/electronics/magic-vlsi/default.nix
+++ b/pkgs/applications/science/electronics/magic-vlsi/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, m4, tcsh, libX11, tcl, tk, cairo, ncurses, mesa_glu, python3 }:
+
+stdenv.mkDerivation {
+  pname = "magic-vlsi";
+  version = "8.3.5";
+
+  src = fetchurl {
+    url = "http://opencircuitdesign.com/magic/archive/magic-8.3.5.tgz";
+    sha256 = "0wv4zmxlqjfaakgp802icn0cd9f8ylkz2sppix83axq8p5cg90yq";
+  };
+
+  buildInputs = [ m4 tcsh libX11 tcl tk cairo ncurses mesa_glu ];
+  nativeBuildInputs = [ python3 ];
+
+  configureFlags = [
+    "--with-tcl=${tcl}"
+    "--with-tk=${tk}"
+    "--disable-werror"
+  ];
+
+  postPatch = ''
+    patchShebangs scripts/*
+  '';
+
+  patches = [
+    ./0001-strip-bin-prefix.patch
+    ./0002-fix-format-security.patch
+  ];
+
+  meta = with stdenv.lib; {
+    description = "VLSI layout tool written in Tcl";
+    homepage = "http://opencircuitdesign.com/magic/";
+    license = licenses.mit;
+    maintainers = [ maintainers.dkudriavtsev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3040,6 +3040,8 @@ in
 
   kramdown-asciidoc = callPackage ../tools/typesetting/kramdown-asciidoc { };
 
+  magic-vlsi = callPackage ../applications/science/electronics/magic-vlsi { };
+
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
   rage = callPackage ../tools/security/rage {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
