### PR TITLE
oauth2_proxy: Backport security fix (CVE-2017-1000070)

### DIFF
--- a/pkgs/servers/oauth2_proxy/default.nix
+++ b/pkgs/servers/oauth2_proxy/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoPackage, fetchFromGitHub, fetchpatch }:
 
 buildGoPackage rec {
   pname = "oauth2_proxy";
@@ -14,6 +14,14 @@ buildGoPackage rec {
   };
 
   goDeps = ./deps.nix;
+
+  patches = [ 
+    (fetchpatch {
+        url = https://github.com/oauth2-proxy/oauth2-proxy/commit/a316f8a06f3c0ca2b5fc5fa18a91781b313607b2.patch;
+        excludes = [ "CHANGELOG.md" ];
+        sha256 = "1bnij902418hy1rh9d1g16wpxw5w6zvg52iylbs2y1zi88y7a01c";
+    })
+  ];
 
   meta = with lib; {
     description = "A reverse proxy that provides authentication with Google, Github or other provider";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Since 20.03 still uses old oauth2_proxy (3.2.0), which is not compatible
with the newest one (5.1.0), this change backports an important security
fix to 3.2.0:

https://github.com/oauth2-proxy/oauth2-proxy/commit/a316f8a06f3c0ca2b5fc5fa18a91781b313607b2

The vulnerability is an open redirect, where a bad actor can redirect a
session to another domain using `/\` in redirect URIs.

The patch has been obtained by running:

    git format-patch a316f8a06f3c0ca2b5fc5fa18a91781b313607b2\^..a316f8a06f3c0ca2b5fc5fa18a91781b313607b2

on https://github.com/pusher/oauth2_proxy repository clone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
