### PR TITLE
nixos/azure-new: use local nixpkgs

### DIFF
--- a/nixos/maintainers/scripts/azure-new/examples/basic/image.nix
+++ b/nixos/maintainers/scripts/azure-new/examples/basic/image.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = (import <nixpkgs> {});
+  pkgs = (import ../../../../../../default.nix {});
   machine = import "${pkgs.path}/nixos/lib/eval-config.nix" {
     system = "x86_64-linux";
     modules = [


### PR DESCRIPTION
###### Motivation for this change
Prevent scenarios like in #86005 by using the local nixpkgs to build the image.

Advanced users that want to build their own image can follow the example to pin nixpkgs as they desire or manually use `<nixpkgs>` (which I don't really recommend).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
