### PR TITLE
arc-theme: change fork, unmark as broken, v20190917 -> v20200416

### DIFF
--- a/pkgs/data/themes/arc/default.nix
+++ b/pkgs/data/themes/arc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "arc-theme";
-  version = "20190917";
+  version = "20200416";
 
   src = fetchFromGitHub {
-    owner  = "arc-design";
+    owner  = "jnsh";
     repo   = pname;
-    rev    = version;
-    sha256 = "1qgpk4p2hi5hd4yy0hj93kq1vs0b32wb8qkaj1wi90c8gwddq5wa";
+    rev    = "0779e1ca84141d8b443cf3e60b85307a145169b6";
+    sha256 = "1ddyi8g4rkd4mxadjvl66wc0lxpa4qdr98nbbhm5abaqfs2yldd4";
   };
 
   nativeBuildInputs = [
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-gnome-shell" # 3.36 not supported
+    "--disable-cinnamon" # not equipped to test
     "--disable-unity"
   ];
 
@@ -44,10 +45,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Flat theme with transparent elements for GTK 3, GTK 2 and Gnome Shell";
-    homepage    = "https://github.com/arc-design/arc-theme";
+    homepage    = "https://github.com/jnsh/arc-theme";
     license     = licenses.gpl3;
     maintainers = with maintainers; [ simonvandel romildo ];
     platforms   = platforms.linux;
-    broken = true; # since libsass 3.6.3
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes `arc-theme` and marks it unbroken after switching to a new fork.

This fork has been been discussed:
* https://www.omgubuntu.co.uk/2020/03/arc-theme-fork

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
