### PR TITLE
mpvScripts.mpris: 0.4 -> 0.5

### DIFF
--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -2,7 +2,8 @@
 , yad, mkvtoolnix-cli, libnotify }:
 
 stdenv.mkDerivation {
-  name = "mpv-convert-script-2016-03-18.lua";
+  pname = "mpv-convert-script";
+  version = "2016-03-18";
   src = fetchgit {
     url = "https://gist.github.com/Zehkul/25ea7ae77b30af959be0";
     rev = "f95cee43e390e843a47e8ec9d1711a12a8cd343d";
@@ -24,8 +25,10 @@ stdenv.mkDerivation {
 
   dontBuild = true;
   installPhase = ''
-    cp convert_script.lua $out
+    mkdir -p $out/share/mpv/scripts
+    cp convert_script.lua $out/share/mpv/scripts
   '';
+  passthru.scriptName = "convert_script.lua";
 
   meta = {
     description = "Convert parts of a video while you are watching it in mpv";

--- a/pkgs/applications/video/mpv/scripts/mpris.nix
+++ b/pkgs/applications/video/mpv/scripts/mpris.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mpv-mpris-${version}.so";
-  version = "0.4";
+  version = "0.5";
 
   src = fetchFromGitHub {
     owner = "hoyon";
     repo = "mpv-mpris";
     rev = version;
-    sha256 = "1fr3jvja8s2gdpx8qyk9r17977flms3qpm8zci62nd9r5wjdvr5i";
+    sha256 = "07p6li5z38pkfd40029ag2jqx917vyl3ng5p2i4v5a0af14slcnk";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/video/mpv/scripts/mpris.nix
+++ b/pkgs/applications/video/mpv/scripts/mpris.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     description = "MPRIS plugin for mpv";
     homepage = "https://github.com/hoyon/mpv-mpris";
     license = licenses.mit;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ jfrankenau ];
   };
 }

--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -9,6 +9,6 @@ symlinkJoin {
 
   postBuild = ''
     wrapProgram $out/bin/mpv \
-      --add-flags "${stdenv.lib.concatMapStringsSep " " (x: "--script=" + x) scripts}"
+      --add-flags "${stdenv.lib.concatMapStringsSep " " (x: "--script=${x}/share/mpv/scripts/${x.scriptName}") scripts}"
   '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20738,7 +20738,7 @@ in
 
   mpv-with-scripts = callPackage ../applications/video/mpv/wrapper.nix { };
 
-  mpvScripts = {
+  mpvScripts = recurseIntoAttrs {
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).