### PR TITLE
hpcg: init at 3.1

### DIFF
--- a/pkgs/tools/misc/hpcg/default.nix
+++ b/pkgs/tools/misc/hpcg/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, openmpi } :
+
+stdenv.mkDerivation rec {
+  pname = "hpcg";
+  version = "3.1";
+
+  src = fetchurl {
+    url = "http://www.hpcg-benchmark.org/downloads/${pname}-${version}.tar.gz";
+    sha256 = "197lw2nwmzsmfsbvgvi8z7kj69n374kgfzzp8pkmk7mp2vkk991k";
+  };
+
+  dontConfigure = true;
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ openmpi ];
+
+  makeFlags = [ "arch=Linux_MPI" ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/hpcg
+
+    cp bin/xhpcg $out/bin
+    cp bin/hpcg.dat $out/share/hpcg
+  '';
+
+  meta = with stdenv.lib; {
+    description = "HPC conjugate gradient benchmark";
+    homepage = "https://www.hpcg-benchmark.org";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19899,6 +19899,8 @@ in
 
   howl = callPackage ../applications/editors/howl { };
 
+  hpcg = callPackage ../tools/misc/hpcg/default.nix { };
+
   hpl = callPackage ../tools/misc/hpl { mpi = openmpi; };
 
   hpmyroom = libsForQt5.callPackage ../applications/networking/hpmyroom { };


### PR DESCRIPTION
###### Motivation for this change
HPCG is a benchmarking suite that aims at complementing linpack  (HPL).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
