### PR TITLE
fish: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -1,20 +1,27 @@
-{ stdenv, fetchurl, coreutils, utillinux,
-  which, gnused, gnugrep,
-  groff, man-db, getent, libiconv, pcre2,
-  gettext, ncurses, python3,
-  cmake
-  , fetchpatch
+{ stdenv
+, lib
+, fetchurl
+, coreutils
+, utillinux
+, which
+, gnused
+, gnugrep
+, groff
+, man-db
+, getent
+, libiconv
+, pcre2
+, gettext
+, ncurses
+, python3
+, cmake
 
-  , writeText
-  , nixosTests
-  , useOperatingSystemEtc ? true
-
+, writeText
+, nixosTests
+, useOperatingSystemEtc ? true
 }:
-
-with stdenv.lib;
-
 let
-  etcConfigAppendixText = ''
+  etcConfigAppendix = writeText "config.fish.appendix" ''
     ############### ↓ Nix hook for sourcing /etc/fish/config.fish ↓ ###############
     #                                                                             #
     # Origin:
@@ -46,7 +53,7 @@ let
     ############### ↑ Nix hook for sourcing /etc/fish/config.fish ↑ ###############
   '';
 
-  fishPreInitHooks = ''
+  fishPreInitHooks = writeText "__fish_build_paths_suffix.fish" ''
     # source nixos environment
     # note that this is required:
     #   1. For all shells, not just login shells (mosh needs this as do some other command-line utilities)
@@ -90,40 +97,45 @@ let
 
   fish = stdenv.mkDerivation rec {
     pname = "fish";
-    version = "3.1.0";
-
-    etcConfigAppendix = builtins.toFile "etc-config.appendix.fish" etcConfigAppendixText;
+    version = "3.1.1";
 
     src = fetchurl {
-      # There are differences between the release tarball and the tarball github packages from the tag
-      # Hence we cannot use fetchFromGithub
+      # There are differences between the release tarball and the tarball GitHub
+      # packages from the tag. Specifically, it comes with a file containing its
+      # version, which is used in `build_tools/git_version_gen.sh` to determine
+      # the shell's actual version (and what it displays when running `fish
+      # --version`), as well as the local documentation for all builtins (and
+      # maybe other things).
       url = "https://github.com/fish-shell/fish-shell/releases/download/${version}/${pname}-${version}.tar.gz";
-      sha256 = "0s2356mlx7fp9kgqgw91lm5ds2i9iq9hq071fbqmcp3875l1xnz5";
+      sha256 = "1f12c56v7n4s0f9mi9xinviwj6kpwlcjwaig1d4vsk5wlgp7ip07";
     };
 
-    nativeBuildInputs = [ cmake ];
-    buildInputs = [ ncurses libiconv pcre2 ];
+    nativeBuildInputs = [
+      cmake
+    ];
+
+    buildInputs = [
+      ncurses
+      libiconv
+      pcre2
+    ];
 
     preConfigure = ''
       patchShebangs ./build_tools/git_version_gen.sh
     '';
 
-    patches = [
-      # Fixes compilation on old Apple SDKs
-      (fetchpatch {
-        url = "https://github.com/fish-shell/fish-shell/commit/10385d422b3e2a823faebfdaf13edd0e7f48a27f.patch";
-        sha256 = "0hj13kyjf5wr9j5afd4mfylcr7mz68ilbncbcf307drk1lv1lvrn";
-      })
-    ];
-
     # Required binaries during execution
     # Python: Autocompletion generated from manpages and config editing
     propagatedBuildInputs = [
-      coreutils gnugrep gnused
-      python3 groff gettext
-    ] ++ optional (!stdenv.isDarwin) man-db;
+      coreutils
+      gnugrep
+      gnused
+      python3
+      groff
+      gettext
+    ] ++ lib.optional (!stdenv.isDarwin) man-db;
 
-    postInstall = ''
+    postInstall = with lib; ''
       sed -r "s|command grep|command ${gnugrep}/bin/grep|" \
           -i "$out/share/fish/functions/grep.fish"
       sed -i "s|which |${which}/bin/which |"               \
@@ -162,14 +174,14 @@ let
       sed -i "s|command manpath|command ${man-db}/bin/manpath|"     \
               "$out/share/fish/functions/man.fish"
     '' + optionalString useOperatingSystemEtc ''
-      tee -a $out/etc/fish/config.fish < ${(writeText "config.fish.appendix" etcConfigAppendixText)}
+      tee -a $out/etc/fish/config.fish < ${etcConfigAppendix}
     '' + ''
-      tee -a $out/share/fish/__fish_build_paths.fish < ${(writeText "__fish_build_paths_suffix.fish" fishPreInitHooks)}
+      tee -a $out/share/fish/__fish_build_paths.fish < ${fishPreInitHooks}
     '';
 
     enableParallelBuilding = true;
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "Smart and user-friendly command line shell";
       homepage = "http://fishshell.com/";
       license = licenses.gpl2;
@@ -188,21 +200,22 @@ let
     # Test the fish_config tool by checking the generated splash page.
     # Since the webserver requires a port to run, it is not started.
     fishConfig =
-      let fishScript = writeText "test.fish" ''
-        set -x __fish_bin_dir ${fish}/bin
-        echo $__fish_bin_dir
-        cp -r ${fish}/share/fish/tools/web_config/* .
-        chmod -R +w *
-        # we delete everything after the fileurl is assigned
-        sed -e '/fileurl =/q' -i webconfig.py
-        echo "print(fileurl)" >> webconfig.py
-        # and check whether the message appears on the page
-        cat (${python3}/bin/python ./webconfig.py \
-          | tail -n1 | sed -ne 's|.*\(/tmp/.*\)|\1|p' \
-        ) | grep 'a href="http://localhost.*Start the Fish Web config'
+      let
+        fishScript = writeText "test.fish" ''
+          set -x __fish_bin_dir ${fish}/bin
+          echo $__fish_bin_dir
+          cp -r ${fish}/share/fish/tools/web_config/* .
+          chmod -R +w *
+          # we delete everything after the fileurl is assigned
+          sed -e '/fileurl =/q' -i webconfig.py
+          echo "print(fileurl)" >> webconfig.py
+          # and check whether the message appears on the page
+          cat (${python3}/bin/python ./webconfig.py \
+            | tail -n1 | sed -ne 's|.*\(/tmp/.*\)|\1|p' \
+          ) | grep 'a href="http://localhost.*Start the Fish Web config'
 
-        # cannot test the http server because it needs a localhost port
-      '';
+          # cannot test the http server because it needs a localhost port
+        '';
       in ''
         HOME=$(mktemp -d)
         ${fish}/bin/fish ${fishScript}
@@ -210,6 +223,6 @@ let
   };
 
   # FIXME(Profpatsch) replace withTests stub
-  withTests = flip const;
-
-in withTests tests fish
+  withTests = with lib; flip const;
+in
+withTests tests fish

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -110,6 +110,10 @@ let
       sha256 = "1f12c56v7n4s0f9mi9xinviwj6kpwlcjwaig1d4vsk5wlgp7ip07";
     };
 
+    # We don't have access to the codesign executable, so we patch this out.
+    # For more information, see: https://github.com/fish-shell/fish-shell/issues/6952
+    patches = lib.optional stdenv.isDarwin ./dont-codesign-on-mac.diff;
+
     nativeBuildInputs = [
       cmake
     ];

--- a/pkgs/shells/fish/dont-codesign-on-mac.diff
+++ b/pkgs/shells/fish/dont-codesign-on-mac.diff
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7d220a032..786b60e6e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -183,7 +183,6 @@ ENDFUNCTION(CODESIGN_ON_MAC target)
+ # Define a function to link dependencies.
+ FUNCTION(FISH_LINK_DEPS_AND_SIGN target)
+   TARGET_LINK_LIBRARIES(${target} fishlib)
+-  CODESIGN_ON_MAC(${target})
+ ENDFUNCTION(FISH_LINK_DEPS_AND_SIGN)
+ 
+ # Define libfish.a.


### PR DESCRIPTION
https://github.com/fish-shell/fish-shell/compare/3.1.0...3.1.1

The patch we had to use for Apple SDKs was merged upstream, so it can be
dropped. I ran nixpkgs-fmt, and removed the `with stdenv.lib;` scope
expander.

Additionally, did a little bit of cleanup. I plan on refactoring this
more down the line, but this'll do for now.

I finally figured out why we use `fetchurl` for the tagged release: the
published release tarballs contain a version file, which the
`build_tools/git_version_gen.sh` script reads (and uses as the version
if it exists). The other thing it contains are pre-generated docs for
various `fish` builtins. I've expanded the comment to document this so
nobody is as confused as I was when I first saw it. (Though I plan to
change this and add sphinx as a native build input in order to build the
docs ourselves.)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @lilyball: Mind testing on macOS, to ensure we don't run into a similar issue to last time?
cc @Profpatsch: Is the `withTests` stuff still necessary? Can I drop it, or is there something you'd like done with it?

EDIT: I also verified that the NixOS module's patch still applies, but if somebody could determine for certain whether or not anything needs to be fixed there, as well, I'd appreciate it.
