### PR TITLE
kde/{kate,konqueror,okular}: decrease text mimetype preference

### DIFF
--- a/pkgs/applications/kde/kate.nix
+++ b/pkgs/applications/kde/kate.nix
@@ -14,6 +14,16 @@ mkDerivation {
     maintainers = [ lib.maintainers.ttuegel ];
   };
 
+  # InitialPreference values are too high and end up making kate &
+  # kwrite defaults for anything considered text/plain. Resetting to
+  # 1, which is the default.
+  postPatch = ''
+    substituteInPlace kate/data/org.kde.kate.desktop \
+      --replace InitialPreference=9 InitialPreference=1
+    substituteInPlace kwrite/data/org.kde.kwrite.desktop \
+      --replace InitialPreference=8 InitialPreference=1
+  '';
+
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     libgit2

--- a/pkgs/applications/kde/konqueror.nix
+++ b/pkgs/applications/kde/konqueror.nix
@@ -12,9 +12,17 @@ mkDerivation {
     kdelibs4support kcmutils khtml kdesu
     qtwebkit qtwebengine qtx11extras qtscript qtwayland
   ];
+
+  # InitialPreference values are too high and any text/html ends up
+  # opening konqueror, even if firefox or chromium are also available.
+  # Resetting to 1, which is the default.
+  postPatch = ''
+    substituteInPlace kfmclient_html.desktop \
+      --replace InitialPreference=9 InitialPreference=1
+  '';
+
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ ];
   };
 }
-

--- a/pkgs/applications/kde/okular.nix
+++ b/pkgs/applications/kde/okular.nix
@@ -18,6 +18,15 @@ mkDerivation {
     kwindowsystem libkexiv2 libspectre libzip phonon poppler qca-qt5
     qtdeclarative qtsvg threadweaver kcrash
   ] ++ lib.optional (!stdenv.isAarch64) chmlib;
+
+  # InitialPreference values are too high and end up making okular
+  # default for anything considered text/plain. Resetting to 1, which
+  # is the default.
+  postPatch = ''
+    substituteInPlace generators/txt/okularApplication_txt.desktop \
+      --replace InitialPreference=3 InitialPreference=1
+  '';
+
   meta = with lib; {
     homepage = "http://www.kde.org";
     license = with licenses; [ gpl2 lgpl21 fdl12 bsd3 ];


### PR DESCRIPTION
These .desktop files set InitialPreference>1 which will override other
associations even the .desktop appears first in XDG_DATA_DIRS. This
applies to:

- org.kde.kate.desktop
- org.kde.kwrite.desktop
- kfmclient_html.desktop
- okularApplication_txt.desktop

Fixes #86137

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
