### PR TITLE
[20.03] python.pkgs.grpcio: use system openssl, zlib, and c-ares

### DIFF
--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, darwin, grpc
 , six, protobuf, enum34, futures, isPy27, pkgconfig
-, cython}:
+, cython, c-ares, openssl, zlib }:
 
 buildPythonPackage rec {
   inherit (grpc) src version;
@@ -9,10 +9,15 @@ buildPythonPackage rec {
   nativeBuildInputs = [ cython pkgconfig ]
                     ++ stdenv.lib.optional stdenv.isDarwin darwin.cctools;
 
+  buildInputs = [ c-ares openssl zlib ];
   propagatedBuildInputs = [ six protobuf ]
                         ++ stdenv.lib.optionals (isPy27) [ enum34 futures ];
 
   preBuild = stdenv.lib.optionalString stdenv.isDarwin "unset AR";
+
+  GRPC_PYTHON_BUILD_SYSTEM_OPENSSL = 1;
+  GRPC_PYTHON_BUILD_SYSTEM_ZLIB = 1;
+  GRPC_PYTHON_BUILD_SYSTEM_CARES = 1;
 
   meta = with stdenv.lib; {
     description = "HTTP/2-based RPC framework";


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/85246 to avoid vendored grpcio dependencies.

(cherry picked from commit 849f26d61cb4fcacb74de3c4d907688b85624f4f)