### PR TITLE
[20.03] aspell, tla: use HTTPS instead of FTP

### DIFF
--- a/pkgs/applications/version-management/arch/default.nix
+++ b/pkgs/applications/version-management/arch/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "tla-1.3.5";
   
   src = fetchurl {
-    url = "ftp://ftp.gnu.org/old-gnu/gnu-arch/" + name + ".tar.gz";
+    url = "https://ftp.gnu.org/old-gnu/gnu-arch/" + name + ".tar.gz";
     sha256 = "01mfzj1i6p4s8191cgd5850hds1zls88hkf9rb6qx1vqjv585aj0";
   };
 

--- a/pkgs/development/libraries/aspell/default.nix
+++ b/pkgs/development/libraries/aspell/default.nix
@@ -8,7 +8,7 @@ let
   # dictionary like Debian does.
   devaMapsSource = fetchzip {
     name = "aspell-u-deva";
-    url = "ftp://ftp.gnu.org/gnu/aspell/dict/mr/aspell6-mr-0.10-0.tar.bz2";
+    url = "https://ftp.gnu.org/gnu/aspell/dict/mr/aspell6-mr-0.10-0.tar.bz2";
     sha256 = "1v8cdl8x2j1d4vbvsq1xrqys69bbccd6mi03fywrhkrrljviyri1";
   };
 


### PR DESCRIPTION
ftp.gnu.org intends to disable the FTP protocol for downloads on this
server, and strongly recommends using https instead.

(cherry picked from commit 295475a378a58d4ac344944b470eab2d3f97866e)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
