### PR TITLE
acl2: fix AArch64 Linux build

### DIFF
--- a/pkgs/development/interpreters/acl2/0001-Fix-detection-of-RDTSC-on-SBCL.patch
+++ b/pkgs/development/interpreters/acl2/0001-Fix-detection-of-RDTSC-on-SBCL.patch
@@ -1,0 +1,26 @@
+From c53de3a5437751371112422ad95ed2ac2f9505a9 Mon Sep 17 00:00:00 2001
+From: Keshav Kini <keshav.kini@gmail.com>
+Date: Mon, 27 Apr 2020 17:21:25 -0700
+Subject: [PATCH] Fix detection of RDTSC on SBCL
+
+Backported from a subset of https://github.com/acl2/acl2/commit/c3803f5046db4e847f9134a9d9ccec8f499acab8
+---
+ memoize-raw.lisp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/memoize-raw.lisp b/memoize-raw.lisp
+index 205e78653..6d1f8153b 100644
+--- a/memoize-raw.lisp
++++ b/memoize-raw.lisp
+@@ -205,7 +205,7 @@
+ ; a successful build and used it for (profile 'rewrite) followed by
+ ; :mini-proveall and then (memsum), on top of both SBCL 1.1.11 and SBCL 1.4.7.
+ 
+-       (not (ignore-errors (sb-vm::%read-cycle-counter)))
++       (ignore-errors (sb-vm::%read-cycle-counter))
+    (pushnew :RDTSC *features*)))
+ 
+ #+rdtsc
+-- 
+2.25.3
+

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -27,7 +27,10 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  phases = "unpackPhase installPhase";
+  phases = "unpackPhase patchPhase installPhase";
+
+  # Needed for AArch64 build
+  patches = [ ./0001-Fix-detection-of-RDTSC-on-SBCL.patch ];
 
   installSuffix = "acl2";
 
@@ -73,6 +76,5 @@ in stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ kini raskin ];
     platforms = stdenv.lib.platforms.all;
-    broken = stdenv.isAarch64 && stdenv.isLinux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The AArch64 Linux build is broken, so this is an attempt to fix it by backporting a recent bug fix from upstream that isn't in the latest released version (8.3). I don't have an AArch64 machine to test on, so I guess I'll find out if it worked once ofborg tests this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
