### PR TITLE
*-wrapper; Switch from `infixSalt` to `suffixSalt`

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -367,6 +367,12 @@ php.override {
      The default output of <literal>buildGoPackage</literal> is now <literal>$out</literal> instead of <literal>$bin</literal>.
    </para>
    </listitem>
+   <listitem>
+   <para>
+     The cc- and binutils-wrapper's "infix salt" and <literal>_BUILD_</literal> and <literal>_TARGET_</literal> user infixes have been replaced with with a "suffix salt" and suffixes and <literal>_FOR_BUILD</literal> and <literal>_FOR_TARGET</literal>.
+      This matches the autotools convention for env vars which standard for these things, making interfacing with other tools easier.
+   </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -182,7 +182,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     configureFlagsArray+=(
       "--cc=$CC"
-      "--host-cc=$BUILD_CC"
+      "--host-cc=$CC_FOR_BUILD"
       "--as=$AS"
       "--nm=$NM"
       "--ar=$AR"

--- a/pkgs/build-support/bintools-wrapper/add-flags.sh
+++ b/pkgs/build-support/bintools-wrapper/add-flags.sh
@@ -1,32 +1,32 @@
 # See cc-wrapper for comments.
 var_templates_list=(
-    NIX+IGNORE_LD_THROUGH_GCC
-    NIX+LDFLAGS
-    NIX+LDFLAGS_BEFORE
-    NIX+LDFLAGS_AFTER
-    NIX+LDFLAGS_HARDEN
-    NIX+HARDENING_ENABLE
+    NIX_IGNORE_LD_THROUGH_GCC
+    NIX_LDFLAGS
+    NIX_LDFLAGS_BEFORE
+    NIX_LDFLAGS_AFTER
+    NIX_LDFLAGS_HARDEN
+    NIX_HARDENING_ENABLE
 )
 var_templates_bool=(
-    NIX+SET_BUILD_ID
-    NIX+DONT_SET_RPATH
+    NIX_SET_BUILD_ID
+    NIX_DONT_SET_RPATH
 )
 
 accumulateRoles
 
 for var in "${var_templates_list[@]}"; do
-    mangleVarList "$var" ${role_infixes[@]+"${role_infixes[@]}"}
+    mangleVarList "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
 done
 for var in "${var_templates_bool[@]}"; do
-    mangleVarBool "$var" ${role_infixes[@]+"${role_infixes[@]}"}
+    mangleVarBool "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
 done
 
 if [ -e @out@/nix-support/libc-ldflags ]; then
-    NIX_@infixSalt@_LDFLAGS+=" $(< @out@/nix-support/libc-ldflags)"
+    NIX_LDFLAGS_@suffixSalt@+=" $(< @out@/nix-support/libc-ldflags)"
 fi
 
 if [ -e @out@/nix-support/libc-ldflags-before ]; then
-    NIX_@infixSalt@_LDFLAGS_BEFORE="$(< @out@/nix-support/libc-ldflags-before) $NIX_@infixSalt@_LDFLAGS_BEFORE"
+    NIX_LDFLAGS_BEFORE_@suffixSalt@="$(< @out@/nix-support/libc-ldflags-before) $NIX_LDFLAGS_BEFORE_@suffixSalt@"
 fi
 
-export NIX_BINTOOLS_WRAPPER_@infixSalt@_FLAGS_SET=1
+export NIX_BINTOOLS_WRAPPER_FLAGS_SET_@suffixSalt@=1

--- a/pkgs/build-support/bintools-wrapper/add-hardening.sh
+++ b/pkgs/build-support/bintools-wrapper/add-hardening.sh
@@ -5,7 +5,7 @@ declare -A hardeningEnableMap=()
 # Intentionally word-split in case 'NIX_HARDENING_ENABLE' is defined in Nix. The
 # array expansion also prevents undefined variables from causing trouble with
 # `set -u`.
-for flag in ${NIX_@infixSalt@_HARDENING_ENABLE-}; do
+for flag in ${NIX_HARDENING_ENABLE_@suffixSalt@-}; do
   hardeningEnableMap["$flag"]=1
 done
 

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -45,7 +45,7 @@ let
   coreutils_bin = if nativeTools then "" else getBin coreutils;
 
   # See description in cc-wrapper.
-  infixSalt = replaceStrings ["-" "."] ["_" "_"] targetPlatform.config;
+  suffixSalt = replaceStrings ["-" "."] ["_" "_"] targetPlatform.config;
 
   # The dynamic linker has different names on different platforms. This is a
   # shell glob that ought to match it.
@@ -83,7 +83,7 @@ stdenv.mkDerivation {
   shell = getBin shell + shell.shellPath or "";
   gnugrep_bin = if nativeTools then "" else gnugrep;
 
-  inherit targetPrefix infixSalt;
+  inherit targetPrefix suffixSalt;
 
   outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (bintools ? info) "info");
 
@@ -95,9 +95,9 @@ stdenv.mkDerivation {
       (mapc
         (lambda (arg)
           (when (file-directory-p (concat arg "/lib"))
-            (setenv "NIX_${infixSalt}_LDFLAGS" (concat (getenv "NIX_${infixSalt}_LDFLAGS") " -L" arg "/lib")))
+            (setenv "NIX_LDFLAGS_${suffixSalt}" (concat (getenv "NIX_LDFLAGS_${suffixSalt}") " -L" arg "/lib")))
           (when (file-directory-p (concat arg "/lib64"))
-            (setenv "NIX_${infixSalt}_LDFLAGS" (concat (getenv "NIX_${infixSalt}_LDFLAGS") " -L" arg "/lib64"))))
+            (setenv "NIX_LDFLAGS_${suffixSalt}" (concat (getenv "NIX_LDFLAGS_${suffixSalt}") " -L" arg "/lib64"))))
         '(${concatStringsSep " " (map (pkg: "\"${pkg}\"") pkgs)}))
     '';
   };

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -16,7 +16,7 @@ fi
 
 source @out@/nix-support/utils.bash
 
-if [ -z "${NIX_BINTOOLS_WRAPPER_@infixSalt@_FLAGS_SET:-}" ]; then
+if [ -z "${NIX_BINTOOLS_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
@@ -24,7 +24,7 @@ fi
 # Optionally filter out paths not refering to the store.
 expandResponseParams "$@"
 if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "${NIX_STORE:-}"
-        && ( -z "$NIX_@infixSalt@_IGNORE_LD_THROUGH_GCC" || -z "${NIX_@infixSalt@_LDFLAGS_SET:-}" ) ]]; then
+        && ( -z "$NIX_IGNORE_LD_THROUGH_GCC_@suffixSalt@" || -z "${NIX_LDFLAGS_SET_@suffixSalt@:-}" ) ]]; then
     rest=()
     nParams=${#params[@]}
     declare -i n=0
@@ -60,12 +60,12 @@ source @out@/nix-support/add-hardening.sh
 extraAfter=()
 extraBefore=(${hardeningLDFlags[@]+"${hardeningLDFlags[@]}"})
 
-if [ -z "${NIX_@infixSalt@_LDFLAGS_SET:-}" ]; then
-    extraAfter+=($NIX_@infixSalt@_LDFLAGS)
-    extraBefore+=($NIX_@infixSalt@_LDFLAGS_BEFORE)
+if [ -z "${NIX_LDFLAGS_SET_@suffixSalt@:-}" ]; then
+    extraAfter+=($NIX_LDFLAGS_@suffixSalt@)
+    extraBefore+=($NIX_LDFLAGS_BEFORE_@suffixSalt@)
 fi
 
-extraAfter+=($NIX_@infixSalt@_LDFLAGS_AFTER)
+extraAfter+=($NIX_LDFLAGS_AFTER_@suffixSalt@)
 
 # Specify the target emulation if nothing is passed in ("-m" overrides this
 # environment variable). Ensures we never blindly fallback on targeting the host
@@ -84,8 +84,8 @@ declare -A libs
 declare -i relocatable=0 link32=0
 
 if
-    [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ] \
-        || [ "$NIX_@infixSalt@_SET_BUILD_ID" = 1 ] \
+    [ "$NIX_DONT_SET_RPATH_@suffixSalt@" != 1 ] \
+        || [ "$NIX_SET_BUILD_ID_@suffixSalt@" = 1 ] \
         || [ -e @out@/nix-support/dynamic-linker-m32 ]
 then
     prev=
@@ -144,7 +144,7 @@ if [ -e "@out@/nix-support/dynamic-linker-m32" ] && (( "$link32" )); then
 fi
 
 # Add all used dynamic libraries to the rpath.
-if [ "$NIX_@infixSalt@_DONT_SET_RPATH" != 1 ]; then
+if [ "$NIX_DONT_SET_RPATH_@suffixSalt@" != 1 ]; then
     # For each directory in the library search path (-L...),
     # see if it contains a dynamic library used by a -l... flag.  If
     # so, add the directory to the rpath.
@@ -186,7 +186,7 @@ fi
 
 # Only add --build-id if this is a final link. FIXME: should build gcc
 # with --enable-linker-build-id instead?
-if [ "$NIX_@infixSalt@_SET_BUILD_ID" = 1 ] && ! (( "$relocatable" )); then
+if [ "$NIX_SET_BUILD_ID_@suffixSalt@" = 1 ] && ! (( "$relocatable" )); then
     extraAfter+=(--build-id)
 fi
 

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -10,11 +10,11 @@
 
 bintoolsWrapper_addLDVars () {
     # See ../setup-hooks/role.bash
-    local role_post role_pre
+    local role_post
     getHostRoleEnvHook
 
     if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
-        export NIX_${role_pre}LDFLAGS+=" -L$1/lib64"
+        export NIX_LDFLAGS${role_post}+=" -L$1/lib64"
     fi
 
     if [[ -d "$1/lib" ]]; then
@@ -24,7 +24,7 @@ bintoolsWrapper_addLDVars () {
         # directories and bloats the size of the environment variable space.
         local -a glob=( $1/lib/lib* )
         if [ "${#glob[*]}" -gt 0 ]; then
-            export NIX_${role_pre}LDFLAGS+=" -L$1/lib"
+            export NIX_LDFLAGS${role_post}+=" -L$1/lib"
         fi
     fi
 }
@@ -52,7 +52,7 @@ fi
 
 # Export tool environment variables so various build systems use the right ones.
 
-export NIX_${role_pre}BINTOOLS=@out@
+export NIX_BINTOOLS${role_post}=@out@
 
 for cmd in \
     ar as ld nm objcopy objdump readelf ranlib strip strings size windres
@@ -60,7 +60,6 @@ do
     if
         PATH=$_PATH type -p "@targetPrefix@${cmd}" > /dev/null
     then
-        export "${role_pre}${cmd^^}=@targetPrefix@${cmd}";
         export "${cmd^^}${role_post}=@targetPrefix@${cmd}";
     fi
 done
@@ -70,4 +69,4 @@ done
 export NIX_HARDENING_ENABLE
 
 # No local scope in sourced file
-unset -v role_pre role_post cmd upper_case
+unset -v role_post cmd upper_case

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -58,7 +58,7 @@ let
 
     # Force compilers and other tools to look in default search paths
     unset NIX_ENFORCE_PURITY
-    export NIX_CC_WRAPPER_${stdenv.cc.infixSalt}_TARGET_HOST=1
+    export NIX_CC_WRAPPER_TARGET_HOST_${stdenv.cc.suffixSalt}=1
     export NIX_CFLAGS_COMPILE='-idirafter /usr/include'
     export NIX_CFLAGS_LINK='-L/usr/lib -L/usr/lib32'
     export NIX_LDFLAGS='-L/usr/lib -L/usr/lib32'

--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -5,15 +5,15 @@
 # wrapped binary just inherit the work of the forker's wrapper script.
 
 var_templates_list=(
-    NIX+CFLAGS_COMPILE
-    NIX+CFLAGS_COMPILE_BEFORE
-    NIX+CFLAGS_LINK
-    NIX+CXXSTDLIB_COMPILE
-    NIX+CXXSTDLIB_LINK
-    NIX+GNATFLAGS_COMPILE
+    NIX_CFLAGS_COMPILE
+    NIX_CFLAGS_COMPILE_BEFORE
+    NIX_CFLAGS_LINK
+    NIX_CXXSTDLIB_COMPILE
+    NIX_CXXSTDLIB_LINK
+    NIX_GNATFLAGS_COMPILE
 )
 var_templates_bool=(
-    NIX+ENFORCE_NO_NATIVE
+    NIX_ENFORCE_NO_NATIVE
 )
 
 accumulateRoles
@@ -21,37 +21,37 @@ accumulateRoles
 # We need to mangle names for hygiene, but also take parameters/overrides
 # from the environment.
 for var in "${var_templates_list[@]}"; do
-    mangleVarList "$var" ${role_infixes[@]+"${role_infixes[@]}"}
+    mangleVarList "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
 done
 for var in "${var_templates_bool[@]}"; do
-    mangleVarBool "$var" ${role_infixes[@]+"${role_infixes[@]}"}
+    mangleVarBool "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
 done
 
 # `-B@out@/bin' forces cc to use ld-wrapper.sh when calling ld.
-NIX_@infixSalt@_CFLAGS_COMPILE="-B@out@/bin/ $NIX_@infixSalt@_CFLAGS_COMPILE"
+NIX_CFLAGS_COMPILE_@suffixSalt@="-B@out@/bin/ $NIX_CFLAGS_COMPILE_@suffixSalt@"
 
 # Export and assign separately in order that a failing $(..) will fail
 # the script.
 
 if [ -e @out@/nix-support/libc-cflags ]; then
-    NIX_@infixSalt@_CFLAGS_COMPILE="$(< @out@/nix-support/libc-cflags) $NIX_@infixSalt@_CFLAGS_COMPILE"
+    NIX_CFLAGS_COMPILE_@suffixSalt@="$(< @out@/nix-support/libc-cflags) $NIX_CFLAGS_COMPILE_@suffixSalt@"
 fi
 
 if [ -e @out@/nix-support/cc-cflags ]; then
-    NIX_@infixSalt@_CFLAGS_COMPILE="$(< @out@/nix-support/cc-cflags) $NIX_@infixSalt@_CFLAGS_COMPILE"
+    NIX_CFLAGS_COMPILE_@suffixSalt@="$(< @out@/nix-support/cc-cflags) $NIX_CFLAGS_COMPILE_@suffixSalt@"
 fi
 
 if [ -e @out@/nix-support/gnat-cflags ]; then
-    NIX_@infixSalt@_GNATFLAGS_COMPILE="$(< @out@/nix-support/gnat-cflags) $NIX_@infixSalt@_GNATFLAGS_COMPILE"
+    NIX_GNATFLAGS_COMPILE_@suffixSalt@="$(< @out@/nix-support/gnat-cflags) $NIX_GNATFLAGS_COMPILE_@suffixSalt@"
 fi
 
 if [ -e @out@/nix-support/cc-ldflags ]; then
-    NIX_@infixSalt@_LDFLAGS+=" $(< @out@/nix-support/cc-ldflags)"
+    NIX_LDFLAGS_@suffixSalt@+=" $(< @out@/nix-support/cc-ldflags)"
 fi
 
 if [ -e @out@/nix-support/cc-cflags-before ]; then
-    NIX_@infixSalt@_CFLAGS_COMPILE_BEFORE="$(< @out@/nix-support/cc-cflags-before) $NIX_@infixSalt@_CFLAGS_COMPILE_BEFORE"
+    NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@="$(< @out@/nix-support/cc-cflags-before) $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@"
 fi
 
 # That way forked processes will not extend these environment variables again.
-export NIX_CC_WRAPPER_@infixSalt@_FLAGS_SET=1
+export NIX_CC_WRAPPER_FLAGS_SET_@suffixSalt@=1

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -5,7 +5,7 @@ declare -A hardeningEnableMap=()
 # Intentionally word-split in case 'NIX_HARDENING_ENABLE' is defined in Nix. The
 # array expansion also prevents undefined variables from causing trouble with
 # `set -u`.
-for flag in ${NIX_@infixSalt@_HARDENING_ENABLE-}; do
+for flag in ${NIX_HARDENING_ENABLE_@suffixSalt@-}; do
   hardeningEnableMap["$flag"]=1
 done
 

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -18,12 +18,12 @@ fi
 source @out@/nix-support/utils.bash
 
 # Flirting with a layer violation here.
-if [ -z "${NIX_BINTOOLS_WRAPPER_@infixSalt@_FLAGS_SET:-}" ]; then
+if [ -z "${NIX_BINTOOLS_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @bintools@/nix-support/add-flags.sh
 fi
 
 # Put this one second so libc ldflags take priority.
-if [ -z "${NIX_CC_WRAPPER_@infixSalt@_FLAGS_SET:-}" ]; then
+if [ -z "${NIX_CC_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
@@ -113,7 +113,7 @@ fi
 
 
 # Clear march/mtune=native -- they bring impurity.
-if [ "$NIX_@infixSalt@_ENFORCE_NO_NATIVE" = 1 ]; then
+if [ "$NIX_ENFORCE_NO_NATIVE_@suffixSalt@" = 1 ]; then
     rest=()
     # Old bash empty array hack
     for p in ${params+"${params[@]}"}; do
@@ -129,36 +129,36 @@ fi
 
 if [[ "$isCpp" = 1 ]]; then
     if [[ "$cppInclude" = 1 ]]; then
-        NIX_@infixSalt@_CFLAGS_COMPILE+=" ${NIX_@infixSalt@_CXXSTDLIB_COMPILE:-@default_cxx_stdlib_compile@}"
+        NIX_CFLAGS_COMPILE_@suffixSalt@+=" ${NIX_CXXSTDLIB_COMPILE_@suffixSalt@:-@default_cxx_stdlib_compile@}"
     fi
-    NIX_@infixSalt@_CFLAGS_LINK+=" $NIX_@infixSalt@_CXXSTDLIB_LINK"
+    NIX_CFLAGS_LINK_@suffixSalt@+=" $NIX_CXXSTDLIB_LINK_@suffixSalt@"
 fi
 
 source @out@/nix-support/add-hardening.sh
 
 # Add the flags for the C compiler proper.
-extraAfter=($NIX_@infixSalt@_CFLAGS_COMPILE)
-extraBefore=(${hardeningCFlags[@]+"${hardeningCFlags[@]}"} $NIX_@infixSalt@_CFLAGS_COMPILE_BEFORE)
+extraAfter=($NIX_CFLAGS_COMPILE_@suffixSalt@)
+extraBefore=(${hardeningCFlags[@]+"${hardeningCFlags[@]}"} $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@)
 
 if [ "$dontLink" != 1 ]; then
 
     # Add the flags that should only be passed to the compiler when
     # linking.
-    extraAfter+=($NIX_@infixSalt@_CFLAGS_LINK)
+    extraAfter+=($NIX_CFLAGS_LINK_@suffixSalt@)
 
     # Add the flags that should be passed to the linker (and prevent
-    # `ld-wrapper' from adding NIX_@infixSalt@_LDFLAGS again).
-    for i in $NIX_@infixSalt@_LDFLAGS_BEFORE; do
+    # `ld-wrapper' from adding NIX_LDFLAGS_@suffixSalt@ again).
+    for i in $NIX_LDFLAGS_BEFORE_@suffixSalt@; do
         extraBefore+=("-Wl,$i")
     done
-    for i in $NIX_@infixSalt@_LDFLAGS; do
+    for i in $NIX_LDFLAGS_@suffixSalt@; do
         if [ "${i:0:3}" = -L/ ]; then
             extraAfter+=("$i")
         else
             extraAfter+=("-Wl,$i")
         fi
     done
-    export NIX_@infixSalt@_LDFLAGS_SET=1
+    export NIX_LDFLAGS_SET_@suffixSalt@=1
 fi
 
 # As a very special hack, if the arguments are just `-v', then don't

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -53,12 +53,12 @@ let
     "-isystem ${libcxx}/include/c++/v1"
   else "";
 
-  # The "infix salt" is a arbitrary string added in the middle of env vars
+  # The "suffix salt" is a arbitrary string added in the end of env vars
   # defined by cc-wrapper's hooks so that multiple cc-wrappers can be used
   # without interfering. For the moment, it is defined as the target triple,
   # adjusted to be a valid bash identifier. This should be considered an
   # unstable implementation detail, however.
-  infixSalt = replaceStrings ["-" "."] ["_" "_"] targetPlatform.config;
+  suffixSalt = replaceStrings ["-" "."] ["_" "_"] targetPlatform.config;
 
   expand-response-params =
     if buildPackages.stdenv.hasCC && buildPackages.stdenv.cc != "/dev/null"
@@ -105,7 +105,7 @@ stdenv.mkDerivation {
   shell = getBin shell + shell.shellPath or "";
   gnugrep_bin = if nativeTools then "" else gnugrep;
 
-  inherit targetPrefix infixSalt;
+  inherit targetPrefix suffixSalt;
 
   outputs = [ "out" ] ++ optionals propagateDoc [ "man" "info" ];
 
@@ -122,7 +122,7 @@ stdenv.mkDerivation {
       (mapc
         (lambda (arg)
           (when (file-directory-p (concat arg "/include"))
-            (setenv "NIX_${infixSalt}_CFLAGS_COMPILE" (concat (getenv "NIX_${infixSalt}_CFLAGS_COMPILE") " -isystem " arg "/include"))))
+            (setenv "NIX_CFLAGS_COMPILE_${suffixSalt}" (concat (getenv "NIX_CFLAGS_COMPILE_${suffixSalt}") " -isystem " arg "/include"))))
         '(${concatStringsSep " " (map (pkg: "\"${pkg}\"") pkgs)}))
     '';
   };

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -18,12 +18,12 @@ fi
 source @out@/nix-support/utils.bash
 
 # Flirting with a layer violation here.
-if [ -z "${NIX_BINTOOLS_WRAPPER_@infixSalt@_FLAGS_SET:-}" ]; then
+if [ -z "${NIX_BINTOOLS_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @bintools@/nix-support/add-flags.sh
 fi
 
 # Put this one second so libc ldflags take priority.
-if [ -z "${NIX_CC_WRAPPER_@infixSalt@_FLAGS_SET:-}" ]; then
+if [ -z "${NIX_CC_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
@@ -108,7 +108,7 @@ fi
 
 
 # Clear march/mtune=native -- they bring impurity.
-if [ "$NIX_@infixSalt@_ENFORCE_NO_NATIVE" = 1 ]; then
+if [ "$NIX_ENFORCE_NO_NATIVE_@suffixSalt@" = 1 ]; then
     rest=()
     # Old bash empty array hack
     for p in ${params+"${params[@]}"}; do
@@ -124,12 +124,12 @@ fi
 
 if [ "$(basename $0)x" = "gnatmakex" ]; then
     extraBefore=("--GNATBIND=@out@/bin/gnatbind" "--GNATLINK=@out@/bin/gnatlink")
-    extraAfter=($NIX_@infixSalt@_GNATFLAGS_COMPILE)
+    extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
 fi
 
 if [ "$(basename $0)x" = "gnatbindx" ]; then
     extraBefore=()
-    extraAfter=($NIX_@infixSalt@_GNATFLAGS_COMPILE)
+    extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
 fi
 
 if [ "$(basename $0)x" = "gnatlinkx" ]; then

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -6,9 +6,9 @@
 # tools. For example:
 #
 #   # Flags for compiling (whether or not linking) C code for the...
-#   NIX_BUILD_CFLAGS_COMPILE  # ...build platform
-#   NIX_CFLAGS_COMPILE        # ...host platform
-#   NIX_TARGET_CFLAGS_COMPILE # ...target platform
+#   NIX_CFLAGS_COMPILE_FOR_BUILD  # ...build platform
+#   NIX_CFLAGS_COMPILE            # ...host platform
+#   NIX_CFLAGS_COMPILE_FOR_TARGET # ...target platform
 #
 # Notice that these platforms are the 3 *relative* to the package using
 # cc-wrapper, not absolute like `x86_64-pc-linux-gnu`.
@@ -33,12 +33,12 @@
 # The basic strategy is:
 #
 #  - Everyone exclusively *adds information* to relative-platform-specific
-#    environment variables, like `NIX_TARGET_CFLAGS_COMPILE`, to communicate
+#    environment variables, like `NIX_CFLAGS_COMPILE_FOR_TARGET`, to communicate
 #    with the wrapped binaries.
 #
 #  - The wrapped binaries will exclusively *read* cc-wrapper-derivation-specific
-#    environment variables distinguished with with `infixSalt`, like
-#    `NIX_@infixSalt@_CFLAGS_COMPILE`.
+#    environment variables distinguished with with `suffixSalt`, like
+#    `NIX_CFLAGS_COMPILE_@suffixSalt@`.
 #
 #  - `add-flags`, beyond its old task of reading extra flags stuck inside the
 #    cc-wrapper derivation, will convert the relative-platform-specific
@@ -65,15 +65,15 @@
 # function is guaranteed to be exactly the same.
 ccWrapper_addCVars () {
     # See ../setup-hooks/role.bash
-    local role_post role_pre
+    local role_post
     getHostRoleEnvHook
 
     if [ -d "$1/include" ]; then
-        export NIX_${role_pre}CFLAGS_COMPILE+=" -isystem $1/include"
+        export NIX_CFLAGS_COMPILE${role_post}+=" -isystem $1/include"
     fi
 
     if [ -d "$1/Library/Frameworks" ]; then
-        export NIX_${role_pre}CFLAGS_COMPILE+=" -iframework $1/Library/Frameworks"
+        export NIX_CFLAGS_COMPILE${role_post}+=" -iframework $1/Library/Frameworks"
     fi
 }
 
@@ -105,10 +105,10 @@ fi
 
 # Export tool environment variables so various build systems use the right ones.
 
-export NIX_${role_pre}CC=@out@
+export NIX_CC${role_post}=@out@
 
-export ${role_pre}CC=@named_cc@
-export ${role_pre}CXX=@named_cxx@
+export CC${role_post}=@named_cc@
+export CXX${role_post}=@named_cxx@
 export CC${role_post}=@named_cc@
 export CXX${role_post}=@named_cxx@
 
@@ -117,4 +117,4 @@ export CXX${role_post}=@named_cxx@
 export NIX_HARDENING_ENABLE
 
 # No local scope in sourced file
-unset -v role_pre role_post
+unset -v role_post

--- a/pkgs/build-support/setup-hooks/role.bash
+++ b/pkgs/build-support/setup-hooks/role.bash
@@ -3,21 +3,17 @@
 # derivation) in which the derivation is used.
 #
 # The role is intened to be use as part of other variables names like
-#  - $NIX_${role_pre}_SOMETHING
-#  - $NIX_SOMETHING_${role_post}
+#  - $NIX_SOMETHING${role_post}
 
 function getRole() {
     case $1 in
         -1)
-            role_pre='BUILD_'
             role_post='_FOR_BUILD'
             ;;
         0)
-            role_pre=''
             role_post=''
             ;;
         1)
-            role_pre='TARGET_'
             role_post='_FOR_TARGET'
             ;;
         *)
@@ -54,18 +50,18 @@ function getTargetRoleEnvHook() {
 }
 
 # This variant is inteneded specifically for code-prodocing tool wrapper scripts
-# `NIX_@wrapperName@_@infixSalt@_TARGET_*` tracks this (needs to be an exported
+# `NIX_@wrapperName@_TARGET_*_@suffixSalt@` tracks this (needs to be an exported
 # env var so can't use fancier data structures).
 function getTargetRoleWrapper() {
     case $targetOffset in
         -1)
-            export NIX_@wrapperName@_@infixSalt@_TARGET_BUILD=1
+            export NIX_@wrapperName@_TARGET_BUILD_@suffixSalt@=1
             ;;
         0)
-            export NIX_@wrapperName@_@infixSalt@_TARGET_HOST=1
+            export NIX_@wrapperName@_TARGET_HOST_@suffixSalt@=1
             ;;
         1)
-            export NIX_@wrapperName@_@infixSalt@_TARGET_TARGET=1
+            export NIX_@wrapperName@_TARGET_TARGET_@suffixSalt@=1
             ;;
         *)
             echo "@name@: used as improper sort of dependency" >2

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -1,29 +1,29 @@
-# Accumulate infixes for taking in the right input parameters with the `mangle*`
+# Accumulate suffixes for taking in the right input parameters with the `mangle*`
 # functions below. See setup-hook for details.
 accumulateRoles() {
-    declare -ga role_infixes=()
-    if [ "${NIX_@wrapperName@_@infixSalt@_TARGET_BUILD:-}" ]; then
-        role_infixes+=(_BUILD_)
+    declare -ga role_suffixes=()
+    if [ "${NIX_@wrapperName@_TARGET_BUILD_@suffixSalt@:-}" ]; then
+        role_suffixes+=('_FOR_BUILD')
     fi
-    if [ "${NIX_@wrapperName@_@infixSalt@_TARGET_HOST:-}" ]; then
-        role_infixes+=(_)
+    if [ "${NIX_@wrapperName@_TARGET_HOST_@suffixSalt@:-}" ]; then
+        role_suffixes+=('')
     fi
-    if [ "${NIX_@wrapperName@_@infixSalt@_TARGET_TARGET:-}" ]; then
-        role_infixes+=(_TARGET_)
+    if [ "${NIX_@wrapperName@_TARGET_TARGET_@suffixSalt@:-}" ]; then
+        role_suffixes+=('_FOR_TARGET')
     fi
 }
 
 mangleVarList() {
     local var="$1"
     shift
-    local -a role_infixes=("$@")
+    local -a role_suffixes=("$@")
 
-    local outputVar="${var/+/_@infixSalt@_}"
+    local outputVar="${var}_@suffixSalt@"
     declare -gx ${outputVar}+=''
     # For each role we serve, we accumulate the input parameters into our own
     # cc-wrapper-derivation-specific environment variables.
-    for infix in "${role_infixes[@]}"; do
-        local inputVar="${var/+/${infix}}"
+    for suffix in "${role_suffixes[@]}"; do
+        local inputVar="${var}${suffix}"
         if [ -v "$inputVar" ]; then
             export ${outputVar}+="${!outputVar:+ }${!inputVar}"
         fi
@@ -33,12 +33,12 @@ mangleVarList() {
 mangleVarBool() {
     local var="$1"
     shift
-    local -a role_infixes=("$@")
+    local -a role_suffixes=("$@")
 
-    local outputVar="${var/+/_@infixSalt@_}"
+    local outputVar="${var}_@suffixSalt@"
     declare -gxi ${outputVar}+=0
-    for infix in "${role_infixes[@]}"; do
-        local inputVar="${var/+/${infix}}"
+    for suffix in "${role_suffixes[@]}"; do
+        local inputVar="${var}${suffix}"
         if [ -v "$inputVar" ]; then
             # "1" in the end makes `let` return success error code when
             # expression itself evaluates to zero.

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -239,8 +239,8 @@ stdenv.mkDerivation ({
     (import ../common/extra-target-flags.nix {
       inherit stdenv crossStageStatic libcCross threadsCross;
     })
-    EXTRA_TARGET_FLAGS
-    EXTRA_TARGET_LDFLAGS
+    EXTRA_FLAGS_FOR_TARGET
+    EXTRA_LDFLAGS_FOR_TARGET
     ;
 
   passthru = {

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -264,8 +264,8 @@ stdenv.mkDerivation ({
     (import ../common/extra-target-flags.nix {
       inherit stdenv crossStageStatic libcCross threadsCross;
     })
-    EXTRA_TARGET_FLAGS
-    EXTRA_TARGET_LDFLAGS
+    EXTRA_FLAGS_FOR_TARGET
+    EXTRA_LDFLAGS_FOR_TARGET
     ;
 
   passthru = {

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -276,8 +276,8 @@ stdenv.mkDerivation ({
     (import ../common/extra-target-flags.nix {
       inherit stdenv crossStageStatic libcCross threadsCross;
     })
-    EXTRA_TARGET_FLAGS
-    EXTRA_TARGET_LDFLAGS
+    EXTRA_FLAGS_FOR_TARGET
+    EXTRA_LDFLAGS_FOR_TARGET
     ;
 
   passthru = {

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -292,8 +292,8 @@ stdenv.mkDerivation ({
     (import ../common/extra-target-flags.nix {
       inherit stdenv crossStageStatic libcCross threadsCross;
     })
-    EXTRA_TARGET_FLAGS
-    EXTRA_TARGET_LDFLAGS
+    EXTRA_FLAGS_FOR_TARGET
+    EXTRA_LDFLAGS_FOR_TARGET
     ;
 
   passthru = {

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -247,8 +247,8 @@ stdenv.mkDerivation ({
     (import ../common/extra-target-flags.nix {
       inherit stdenv crossStageStatic libcCross threadsCross;
     })
-    EXTRA_TARGET_FLAGS
-    EXTRA_TARGET_LDFLAGS
+    EXTRA_FLAGS_FOR_TARGET
+    EXTRA_LDFLAGS_FOR_TARGET
     ;
 
   passthru = {

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -234,8 +234,8 @@ stdenv.mkDerivation ({
     (import ../common/extra-target-flags.nix {
       inherit stdenv crossStageStatic libcCross threadsCross;
     })
-    EXTRA_TARGET_FLAGS
-    EXTRA_TARGET_LDFLAGS
+    EXTRA_FLAGS_FOR_TARGET
+    EXTRA_LDFLAGS_FOR_TARGET
     ;
 
   passthru = {

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -239,8 +239,8 @@ stdenv.mkDerivation ({
     (import ../common/extra-target-flags.nix {
       inherit stdenv crossStageStatic libcCross threadsCross;
     })
-    EXTRA_TARGET_FLAGS
-    EXTRA_TARGET_LDFLAGS
+    EXTRA_FLAGS_FOR_TARGET
+    EXTRA_LDFLAGS_FOR_TARGET
     ;
 
   passthru = {

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -5,7 +5,7 @@ let
 in
 
 {
-  EXTRA_TARGET_FLAGS = let
+  EXTRA_FLAGS_FOR_TARGET = let
       mkFlags = dep: lib.optionals (targetPlatform != hostPlatform && dep != null) ([
         "-idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
       ] ++ stdenv.lib.optionals (! crossStageStatic) [
@@ -15,7 +15,7 @@ in
     ++ lib.optionals (!crossStageStatic) (mkFlags threadsCross)
     ;
 
-  EXTRA_TARGET_LDFLAGS = let
+  EXTRA_LDFLAGS_FOR_TARGET = let
       mkFlags = dep: lib.optionals (targetPlatform != hostPlatform && dep != null) ([
         "-Wl,-L${lib.getLib dep}${dep.libdir or "/lib"}"
       ] ++ (if crossStageStatic then [

--- a/pkgs/development/compilers/gcc/libstdc++-hook.sh
+++ b/pkgs/development/compilers/gcc/libstdc++-hook.sh
@@ -1,4 +1,4 @@
 # See pkgs/build-support/setup-hooks/role.bash
 getHostRole
 
-export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/@targetConfig@"
+export NIX_CXXSTDLIB_COMPILE${role_post}+=" -isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/@targetConfig@"

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -462,7 +462,7 @@ in rec {
         export CC="gcc"
         export CPP="gcc -E"
         export NIX_CXXSTDLIB_LINK=""
-        export NIX_TARGET_CXXSTDLIB_LINK=""
+        export NIX_CXXSTDLIB_LINK_FOR_TARGET=""
         export OPENSSL_PREFIX=$(realpath openssl)
         # this fixes error: impure path 'LibFFIHeaderDirectives' used in link
         export NIX_ENFORCE_PURITY=0

--- a/pkgs/development/compilers/llvm/10/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/10/libc++/setup-hook.sh
@@ -2,5 +2,5 @@
 getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_CXXSTDLIB_COMPILE${role_post}+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK${role_post}=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/5/libc++/setup-hook.sh
@@ -2,5 +2,5 @@
 getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_CXXSTDLIB_COMPILE${role_post}+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK${role_post}=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/6/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/6/libc++/setup-hook.sh
@@ -2,5 +2,5 @@
 getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_CXXSTDLIB_COMPILE${role_post}+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK${role_post}=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/7/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/7/libc++/setup-hook.sh
@@ -2,5 +2,5 @@
 getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_CXXSTDLIB_COMPILE${role_post}+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK${role_post}=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/8/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/8/libc++/setup-hook.sh
@@ -2,5 +2,5 @@
 getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_CXXSTDLIB_COMPILE${role_post}+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK${role_post}=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/9/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/9/libc++/setup-hook.sh
@@ -2,5 +2,5 @@
 getHostRole
 
 linkCxxAbi="@linkCxxAbi@"
-export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
-export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"
+export NIX_CXXSTDLIB_COMPILE${role_post}+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK${role_post}=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/idris-modules/idris-wrapper.nix
+++ b/pkgs/development/idris-modules/idris-wrapper.nix
@@ -7,7 +7,7 @@ symlinkJoin {
   postBuild = ''
     wrapProgram $out/bin/idris \
       --run 'export IDRIS_CC=''${IDRIS_CC:-${stdenv.cc}/bin/cc}' \
-      --set NIX_CC_WRAPPER_${stdenv.cc.infixSalt}_TARGET_HOST 1 \
+      --set 'NIX_CC_WRAPPER_TARGET_HOST_${stdenv.cc.suffixSalt}' 1 \
       --prefix NIX_CFLAGS_COMPILE " " "-I${lib.getDev gmp}/include" \
       --prefix NIX_CFLAGS_LINK " " "-L${lib.getLib gmp}/lib"
   '';

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -13,5 +13,5 @@ addEnvHooks "$hostOffset" gettextDataDirsHook
 if [ -n "@gettextNeedsLdflags@" -a -z "${dontAddExtraLibs-}" ]; then
     # See pkgs/build-support/setup-hooks/role.bash
     getHostRole
-    export NIX_${role_pre}LDFLAGS+=" -lintl"
+    export NIX_LDFLAGS${role_post}+=" -lintl"
 fi

--- a/pkgs/development/libraries/libiconv/setup-hook.sh
+++ b/pkgs/development/libraries/libiconv/setup-hook.sh
@@ -4,5 +4,5 @@
 # See pkgs/build-support/setup-hooks/role.bash
 if [ -z "${dontAddExtraLibs-}" ]; then
     getHostRole
-    export NIX_${role_pre}LDFLAGS+=" -liconv"
+    export NIX_LDFLAGS${role_post}+=" -liconv"
 fi

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -63,8 +63,10 @@ stdenv.mkDerivation rec {
       --subst-var-by libc_lib ${lib.getLib stdenv.cc.libc}
     substituteInPlace Modules/FindCxxTest.cmake \
       --replace "$""{PYTHON_EXECUTABLE}" ${stdenv.shell}
-    # BUILD_CC and BUILD_CXX are used to bootstrap cmake
-    configureFlags="--parallel=''${NIX_BUILD_CORES:-1} CC=$BUILD_CC CXX=$BUILD_CXX $configureFlags"
+  ''
+  # CC_FOR_BUILD and CXX_FOR_BUILD are used to bootstrap cmake
+  + ''
+    configureFlags="--parallel=''${NIX_BUILD_CORES:-1} CC=$CC_FOR_BUILD CXX=$CXX_FOR_BUILD $configureFlags"
   '';
 
   configureFlags = [

--- a/pkgs/development/tools/misc/texinfo/cross-tools-flags.patch
+++ b/pkgs/development/tools/misc/texinfo/cross-tools-flags.patch
@@ -4,7 +4,7 @@ diff -ur texinfo-6.5/configure texinfo-6.5-patched/configure
 @@ -23281,7 +23281,7 @@
    # env -i gives this build host configure a clean environment;
    # consequently, we have to re-initialize $PATH.
-   env -i CC="$BUILD_CC" AR="$BUILD_AR" RANLIB="$BUILD_RANLIB" \
+   env -i CC="$CC_FOR_BUILD" AR="$AR_FOR_BUILD" RANLIB="$RANLIB_FOR_BUILD" \
 -      PATH="$PATH" \
 +      PATH="$PATH" CFLAGS="$NATIVE_TOOLS_CFLAGS" LDFLAGS="$NATIVE_TOOLS_LDFLAGS" \
        tools_only=1 \

--- a/pkgs/os-specific/bsd/netbsd/compat-setup-hook.sh
+++ b/pkgs/os-specific/bsd/netbsd/compat-setup-hook.sh
@@ -1,6 +1,6 @@
 # See pkgs/build-support/setup-hooks/role.bash
 getHostRole
 
-export NIX_${role_pre}LDFLAGS+=" -lnbcompat"
-export NIX_${role_pre}CFLAGS_COMPILE+=" -DHAVE_NBTOOL_CONFIG_H"
-export NIX_${role_pre}CFLAGS_COMPILE+=" -include nbtool_config.h"
+export NIX_LDFLAGS${role_post}+=" -lnbcompat"
+export NIX_CFLAGS_COMPILE${role_post}+=" -DHAVE_NBTOOL_CONFIG_H"
+export NIX_CFLAGS_COMPILE${role_post}+=" -include nbtool_config.h"

--- a/pkgs/os-specific/bsd/netbsd/fts-setup-hook.sh
+++ b/pkgs/os-specific/bsd/netbsd/fts-setup-hook.sh
@@ -1,4 +1,4 @@
 # See pkgs/build-support/setup-hooks/role.bash
 getHostRole
 
-export NIX_${role_pre}LDFLAGS+=" -lfts"
+export NIX_LDFLAGS${role_post}+=" -lfts"

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -29,8 +29,8 @@ let
       "cc-version:=9999"
       "cc-fullversion:=999999"
       # `$(..)` expanded by make alone
-      "HOSTCC:=$(BUILD_CC)"
-      "HOSTCXX:=$(BUILD_CXX)"
+      "HOSTCC:=$(CC_FOR_BUILD)"
+      "HOSTCXX:=$(CXX_FOR_BUILD)"
     ];
 
     # Skip clean on darwin, case-sensitivity issues.

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -98,7 +98,7 @@ let
       # TODO: This really wants to be in stdenv/darwin but we don't have hostPlatform
       # there (yet?) so it goes here until then.
       preHook = preHook+ lib.optionalString buildPlatform.isDarwin ''
-        export NIX_BUILD_DONT_SET_RPATH=1
+        export NIX_DONT_SET_RPATH_FOR_BUILD=1
       '' + lib.optionalString (hostPlatform.isDarwin || (hostPlatform.parsed.kernel.execFormat != lib.systems.parse.execFormats.elf && hostPlatform.parsed.kernel.execFormat != lib.systems.parse.execFormats.macho)) ''
         export NIX_DONT_SET_RPATH=1
         export NIX_NO_SELF_RPATH=1
@@ -107,7 +107,7 @@ let
       # think the best solution would just be to fixup linux RPATHs so we don't
       # need to set `-rpath` anywhere.
       # + lib.optionalString targetPlatform.isDarwin ''
-      #   export NIX_TARGET_DONT_SET_RPATH=1
+      #   export NIX_DONT_SET_RPATH_FOR_TARGET=1
       # ''
       ;
 


### PR DESCRIPTION
###### Motivation for this change

I hate the thing too even though I made it, and rather just get rid of
it. But we can't do that yet. In the meantime, this brings us more
inline with autoconf and will make it slightly easier for me to write a
pkg-config wrapper, which we need.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built stdenv on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
