### PR TITLE
webkitgtk: 2.28.1 → 2.28.2

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -61,13 +61,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
-  version = "2.28.1";
+  version = "2.28.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "rLwmo+1cE/OeRodc9EepwFQbbPsX+eeIQyNDHLMn89g=";
+    sha256 = "udI1Jc/Y0iw3tdlkqf6ajOdYMEKi+NOSLnHmu8aMML0=";
   };
 
   patches = optionals stdenv.isLinux [


### PR DESCRIPTION
###### Motivation for this change


* https://webkitgtk.org/security/WSA-2020-0005.html
* https://webkitgtk.org/2020/04/24/webkitgtk2.28.2-released.html



###### Things done
Did not build since it takes ages.