### PR TITLE
Sound Open Firmware support, sof-firmware: init at 1.4.2, update kernel config

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -51,6 +51,7 @@ in {
         rtlwifi_new-firmware
         zd1211fw
         alsa-firmware
+        sof-firmware
         openelec-dvb-firmware
       ] ++ optional (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) raspberrypiWirelessFirmware
         ++ optionals (versionOlder config.boot.kernelPackages.kernel.version "4.13") [

--- a/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  pname = "sof-firmware";
+  version = "1.4.2";
+
+  src = fetchurl {
+    url = "https://www.alsa-project.org/files/pub/misc/sof/${pname}-${version}.tar.bz2";
+    sha256 = "1nkh020gjm45vxd6fvmz63hj16ilff2nl5avvsklajjs6xci1sf5";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    rm lib/firmware/intel/{sof/LICENCE,sof-tplg/LICENCE}
+    mkdir $out
+    cp -r lib $out/lib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Sound Open Firmware";
+    homepage = "https://www.sofproject.org/";
+    license = with licenses; [ bsd3 isc ];
+    maintainers = with maintainers; [ lblasc ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -254,6 +254,27 @@ let
       SND_USB_CAIAQ_INPUT = yes;
       # Enable PSS mixer (Beethoven ADSP-16 and other compatible)
       PSS_MIXER           = whenOlder "4.12" yes;
+    # Enable Sound Open Firmware support
+    } // optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux" &&
+                        versionAtLeast version "5.5") {
+      SND_SOC_SOF_TOPLEVEL              = yes;
+      SND_SOC_SOF_ACPI                  = module;
+      SND_SOC_SOF_PCI                   = module;
+      SND_SOC_SOF_APOLLOLAKE_SUPPORT    = yes;
+      SND_SOC_SOF_CANNONLAKE_SUPPORT    = yes;
+      SND_SOC_SOF_COFFEELAKE_SUPPORT    = yes;
+      SND_SOC_SOF_COMETLAKE_H_SUPPORT   = yes;
+      SND_SOC_SOF_COMETLAKE_LP_SUPPORT  = yes;
+      SND_SOC_SOF_ELKHARTLAKE_SUPPORT   = yes;
+      SND_SOC_SOF_GEMINILAKE_SUPPORT    = yes;
+      SND_SOC_SOF_HDA_AUDIO_CODEC       = yes;
+      SND_SOC_SOF_HDA_COMMON_HDMI_CODEC = yes;
+      SND_SOC_SOF_HDA_LINK              = yes;
+      SND_SOC_SOF_ICELAKE_SUPPORT       = yes;
+      SND_SOC_SOF_INTEL_TOPLEVEL        = yes;
+      SND_SOC_SOF_JASPERLAKE_SUPPORT    = yes;
+      SND_SOC_SOF_MERRIFIELD_SUPPORT    = yes;
+      SND_SOC_SOF_TIGERLAKE_SUPPORT     = yes;
     };
 
     usb-serial = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6666,6 +6666,8 @@ in
     python = python3;
   };
 
+  sof-firmware = callPackage ../os-specific/linux/firmware/sof-firmware { };
+
   softhsm = callPackage ../tools/security/softhsm {
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Motivation for this change
Trying to get microphone working on X1 Carbon gen7, it requires Sound Open Firmware support, as it looks like all the new Intel machines will require it.

Additionally to updated alsa-lib (#83155), sof firmware files and updated kernel config enables dmic microphone support and sound in general using SOF.

I've tested those changes on kernel versions:
* 5.4.35 buggy, it didn't work, I've tried tweaking configuration.nix following [archwiki](https://wiki.archlinux.org/index.php/Lenovo_ThinkPad_X1_Carbon_(Gen_7)) but it didn't help
* 5.5.19 worked out of box, but there were some unrelated Intel DRI issues
* 5.6.7 worked out of box, for now no issues

SOF kernel support is available from 5.2, but I suggest we leave it enabled from 5.5, `dmesg` looks scary in later versions.

Archlinux also enabled SOF in their default kernel [config](https://git.archlinux.org/svntogit/packages.git/tree/trunk/config?h=packages/linux#n6955)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
