### PR TITLE
foldingathome: 7.5.1 -> 7.6.9

### DIFF
--- a/pkgs/applications/science/misc/foldingathome/client.nix
+++ b/pkgs/applications/science/misc/foldingathome/client.nix
@@ -10,7 +10,7 @@
 }:
 let
   majMin = stdenv.lib.versions.majorMinor version;
-  version = "7.5.1";
+  version = "7.6.9";
 
   fahclient = stdenv.mkDerivation rec {
     inherit version;
@@ -18,7 +18,7 @@ let
 
     src = fetchurl {
       url = "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v${majMin}/fahclient_${version}_amd64.deb";
-      hash = "sha256-7+RwYdMoZnJZwYFbmLxsN9ozk2P7jpOGZz9qlvTTfSY=";
+      sha256 = "1v4yijjjdq9qx1fp60flp9ya6ywl9qdsgkzwmzjzp8sd5gfvhyr6";
     };
 
     nativeBuildInputs = [

--- a/pkgs/applications/science/misc/foldingathome/control.nix
+++ b/pkgs/applications/science/misc/foldingathome/control.nix
@@ -8,7 +8,7 @@
 }:
 let
   majMin = stdenv.lib.versions.majorMinor version;
-  version = "7.5.1";
+  version = "7.6.9";
 
   python = python2.withPackages
     (
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.foldingathome.org/releases/public/release/fahcontrol/debian-stable-64bit/v${majMin}/fahcontrol_${version}-1_all.deb";
-    hash = "sha256-ydN4I6vmZpI9kD+/TXxgWc+AQqIIlUvABEycWmY1tNg=";
+    sha256 = "1fh7ybbp3qlqzh18c4gva3aaymv7d31mqchrv235a1axldha1s9s";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/science/misc/foldingathome/viewer.nix
+++ b/pkgs/applications/science/misc/foldingathome/viewer.nix
@@ -11,7 +11,7 @@
 }:
 let
   majMin = stdenv.lib.versions.majorMinor version;
-  version = "7.5.1";
+  version = "7.6.9";
 in
 stdenv.mkDerivation rec {
   inherit version;
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.foldingathome.org/releases/public/release/fahviewer/debian-stable-64bit/v${majMin}/fahviewer_${version}_amd64.deb";
-    hash = "sha256-yH0zGjX8aNBEJ5lq7wWydcpp2rO+9Ah++q9eJ+ldeyk=";
+    sha256 = "04wr86g11wpmsczzwzak4gvalcihb47rn3zp6qriawhxyac9nf93";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
the 2 year old version finally got an update
[it allows prioritizing COVID-19 work and includes "important bug fixes and security updates"](https://foldingathome.org/2020/04/17/new-foldinghome-software-with-the-option-to-prioritize-covid-19-projects/)

###### Things done
bump `fahclient`, `fahcontrol` and `fahviewer` to 7.6.1

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - those numbers seem to have gone down, this checklist item needs clarification...
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
