### PR TITLE
kvmtool: Init at 0.20200424

### DIFF
--- a/pkgs/applications/virtualization/kvmtool/default.nix
+++ b/pkgs/applications/virtualization/kvmtool/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit, dtc }:
+
+stdenv.mkDerivation rec {
+  pname = "kvmtool";
+  version = "0.20200424";
+
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/will/${pname}.git";
+    rev = "c0c45eed4f3fb799764979dec5cfb399071d6916";
+    sha256 = "0ir6aqvipss145r85324nw84k4ilzxa2rsa1wr5303p1h6gs0qkk";
+  };
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  buildInputs = [ dtc ];
+
+  meta = with stdenv.lib; {
+    description = "A lightweight tool for hosting KVM guests";
+    homepage =
+      "https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git/tree/README";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.chkno ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20331,6 +20331,8 @@ in
 
   kubeless = callPackage ../applications/networking/cluster/kubeless { };
 
+  kvmtool = callPackage ../applications/virtualization/kvmtool { };
+
   k9s = callPackage ../applications/networking/cluster/k9s { };
 
   fluxctl = callPackage ../applications/networking/cluster/fluxctl { };


### PR DESCRIPTION
###### Motivation for this change
Make kvmtool available.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This project doesn't really do releases or version numbers.  This is the latest git commit, with the git committer date as version number, adopting the same convention that other package repositories are using: https://repology.org/project/kvmtool/versions