### PR TITLE
fasttext: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/applications/science/machine-learning/fasttext/default.nix
+++ b/pkgs/applications/science/machine-learning/fasttext/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fasttext";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "facebookresearch";
     repo = "fastText";
     rev = "v${version}";
-    sha256 = "1cbzz98qn8aypp4r5kwwwc9wiq5bwzv51kcsb15xjfs9lz8h3rii";
+    sha256 = "07cz2ghfq6amcljaxpdr5chbd64ph513y8zqmibfx2xwfp74xkhn";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/fasttext/default.nix
+++ b/pkgs/development/python-modules/fasttext/default.nix
@@ -5,6 +5,8 @@ buildPythonPackage rec {
 
   buildInputs = [ pybind11 ];
 
+  pythonImportsCheck = [ "fasttext" ];
+
   propagatedBuildInputs = [ numpy ];
 
   preBuild = ''

--- a/pkgs/development/python-modules/fasttext/default.nix
+++ b/pkgs/development/python-modules/fasttext/default.nix
@@ -1,15 +1,7 @@
-{stdenv, buildPythonPackage, fetchFromGitHub, numpy, pybind11}:
+{stdenv, buildPythonPackage, fetchFromGitHub, numpy, pkgs, pybind11 }:
 
 buildPythonPackage rec {
-  pname = "fasttext";
-  version = "0.9.1";
-
-  src = fetchFromGitHub {
-    owner = "facebookresearch";
-    repo = "fastText";
-    rev = "v${version}";
-    sha256 = "1cbzz98qn8aypp4r5kwwwc9wiq5bwzv51kcsb15xjfs9lz8h3rii";
-  };
+  inherit (pkgs.fasttext) pname version src;
 
   buildInputs = [ pybind11 ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog:

https://github.com/facebookresearch/fastText/releases/tag/v0.9.2

The second commit changes the `python3Packages.fasttext` derivation to use the `pname`, `version`, and `src` attributes from the `fasttext` derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
