### PR TITLE
pop-icon-theme: init at 2020-03-04

### DIFF
--- a/pkgs/data/icons/pop-icon-theme/default.nix
+++ b/pkgs/data/icons/pop-icon-theme/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, gtk3
+, breeze-icons
+, gnome3
+, pantheon
+, hicolor-icon-theme
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pop-icon-theme";
+  version = "2020-03-04";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "icon-theme";
+    rev = "11f18cb48455b47b6535018f1968777100471be1";
+    sha256 = "1s4pjwv2ynw400gnzgzczlxzw3gxh5s8cxxbi9zpxq4wzjg6jqyv";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    gtk3
+  ];
+
+  propagatedBuildInputs = [
+    breeze-icons
+    gnome3.adwaita-icon-theme
+    pantheon.elementary-icon-theme
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
+
+  meta = with stdenv.lib; {
+    description = "Icon theme for Pop!_OS with a semi-flat design and raised 3D motifs";
+    homepage = "https://github.com/pop-os/icon-theme";
+    license = with licenses; [ cc-by-sa-40 gpl3 ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18131,6 +18131,8 @@ in
 
   pop-gtk-theme = callPackage ../data/themes/pop-gtk { };
 
+  pop-icon-theme = callPackage ../data/icons/pop-icon-theme { };
+
   posix_man_pages = callPackage ../data/documentation/man-pages-posix { };
 
   powerline-fonts = callPackage ../data/fonts/powerline-fonts { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [pop-icon-theme](https://github.com/pop-os/icon-theme).

> Pop_Icons is the icon theme for Pop!_OS. It uses a semi-flat design with raised 3D motifs to help give depth to icons.

> Pop_Icons take inspiration from the Adwaita GNOME Icons.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).