### PR TITLE
emacs-modes: build MELPA package sets without null packages

### DIFF
--- a/pkgs/applications/editors/emacs-modes/libgenerated.nix
+++ b/pkgs/applications/editors/emacs-modes/libgenerated.nix
@@ -61,8 +61,9 @@ in {
         pname = builtins.replaceStrings [ "@" ] [ "at" ] ename;
         broken = ! isNull error;
       in
-      lib.nameValuePair ename (if hasSource then (
-        self.callPackage ({ melpaBuild, fetchurl, ... }@pkgargs:
+      if hasSource then
+        lib.nameValuePair ename (
+          self.callPackage ({ melpaBuild, fetchurl, ... }@pkgargs:
           melpaBuild {
             inherit pname;
             ename = ename;
@@ -85,6 +86,8 @@ in {
             };
           }
         ) {}
-      ) else null);
+      )
+    else
+      null;
 
 }

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -42,7 +42,9 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
   }: let
 
     inherit (import ./libgenerated.nix lib self) melpaDerivation;
-    super = lib.listToAttrs (map (melpaDerivation variant) (lib.importJSON archiveJson));
+    super = lib.listToAttrs (builtins.filter (s: s != null)
+                                             (map (melpaDerivation variant)
+                                                  (lib.importJSON archiveJson)));
 
     overrides = rec {
       shared = rec {
@@ -268,10 +270,6 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
 
         # Map legacy renames from emacs2nix since code generation was ported to emacs lisp
         _0blayout = super."0blayout";
-        _0xc = super."0xc";
-        _2048-game = super."2048-game";
-        _4clojure = super."4clojure";
-        at = super."@";
         desktop-plus = super."desktop+";
         ghub-plus = super."ghub+";
         git-gutter-plus = super."git-gutter+";
@@ -282,10 +280,6 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
         markdown-mode-plus = super."markdown-mode+";
         package-plus = super."package+";
         rect-plus = super."rect+";
-        term-plus = super."term+";
-        term-plus-key-intercept = super."term+key-intercept";
-        term-plus-mux = super."term+mux";
-        xml-plus = super."xml+";
       };
 
       stable = shared // {
@@ -413,6 +407,16 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
         });
         # Legacy alias
         emacs-libvterm = unstable.vterm;
+
+        # Map legacy renames from emacs2nix since code generation was ported to emacs lisp
+        _0xc = super."0xc";
+        _2048-game = super."2048-game";
+        _4clojure = super."4clojure";
+        at = super."@";
+        term-plus = super."term+";
+        term-plus-key-intercept = super."term+key-intercept";
+        term-plus-mux = super."term+mux";
+        xml-plus = super."xml+";
 
         w3m = super.w3m.override (args: {
           melpaBuild = drv: args.melpaBuild (drv // {


### PR DESCRIPTION
This is the counterpart or #83378 to get the fix into 20.03.

###### Motivation for this change

See #83378

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
