### PR TITLE
filezilla: 3.46.3 -> 3.48.0

### DIFF
--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -1,10 +1,8 @@
 { stdenv
 , fetchurl
-
 , dbus
 , gettext
 , gnutls
-, gtk2
 , libfilezilla
 , libidn
 , nettle
@@ -16,14 +14,26 @@
 , xdg_utils
 }:
 
+let
+  # we can drop this when wxgtk is built with gtk3 by default
+  # see: https://github.com/NixOS/nixpkgs/pull/73145
+  wxgtk' = wxGTK30.override { compat26 = false; withGtk2 = false; };
+
+in
 stdenv.mkDerivation rec {
   pname = "filezilla";
-  version = "3.46.3";
+  version = "3.48.0";
 
   src = fetchurl {
     url = "https://download.filezilla-project.org/client/FileZilla_${version}_src.tar.bz2";
-    sha256 = "15bkg9qs07h4pzkxba1gymp8f264dk0zrzd9brx48fcwm7qbzigi";
+    sha256 = "0msxl8ihbycd56hmn1q8sl1gzmsxc7j8ar9k4zsryd0ayyz7wv05";
   };
+
+  # https://www.linuxquestions.org/questions/slackware-14/trouble-building-filezilla-3-47-2-1-current-4175671182/#post6099769
+  postPatch = ''
+    sed -i src/interface/Mainfrm.h \
+      -e '/^#define/a #include <list>'
+  '';
 
   configureFlags = [
     "--disable-manualupdatecheck"
@@ -31,18 +41,19 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ pkgconfig ];
+
   buildInputs = [
     dbus
     gettext
     gnutls
-    gtk2
     libfilezilla
     libidn
     nettle
     pugixml
     sqlite
     tinyxml
-    wxGTK30
+    wxgtk'
+    wxgtk'.gtk
     xdg_utils
   ];
 

--- a/pkgs/development/libraries/libfilezilla/default.nix
+++ b/pkgs/development/libraries/libfilezilla/default.nix
@@ -9,15 +9,18 @@
 
 stdenv.mkDerivation rec {
   pname = "libfilezilla";
-  version = "0.19.3";
+  version = "0.21.0";
 
   src = fetchurl {
     url = "https://download.filezilla-project.org/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "0fml6whdbfcwc8nfjhvrnidkscv6q2x988zf3alfjl2mdpw4jgd4";
+    sha256 = "1wjvxi3spkp58lay590bs5s2i8fn94lqkc7qvq4q7ns4l9k9z3av";
   };
 
   nativeBuildInputs = [ pkgconfig ];
+
   buildInputs = [ gettext gnutls nettle ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = "https://lib.filezilla-project.org/";


### PR DESCRIPTION
Also moves from gtk2 to gtk3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).