### PR TITLE
libfabric: init at 1.10.0

### DIFF
--- a/pkgs/os-specific/linux/libfabric/default.nix
+++ b/pkgs/os-specific/linux/libfabric/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, libpsm2 }:
+
+stdenv.mkDerivation rec {
+  pname = "libfabric";
+  version = "1.10.0";
+
+  enableParallelBuilding = true;
+
+  src = fetchFromGitHub {
+    owner = "ofiwg";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0amgc5w7qg96r9a21jl92m6jzn4z2j3iyk7jf7kwyzfi4jhlkv89";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ] ;
+
+  buildInputs = [ libpsm2 ] ;
+
+  configureFlags = [ "--enable-psm2=${libpsm2}" ] ;
+
+  meta = with stdenv.lib; {
+    homepage = "http://libfabric.org/";
+    description = "Open Fabric Interfaces";
+    license = with licenses; [ gpl2 bsd2 ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.bzizou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12798,6 +12798,8 @@ in
 
   libf2c = callPackage ../development/libraries/libf2c {};
 
+  libfabric = callPackage ../os-specific/linux/libfabric {};
+
   libfive = callPackage ../development/libraries/libfive { };
 
   libfixposix = callPackage ../development/libraries/libfixposix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

libfabric is necessary for HPC applications running over Intel Omnipath low latency networks

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
