### PR TITLE
pkgsStatic: use clang for C compiler on Darwin

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -15,7 +15,7 @@ rec {
   # Used to override packages in stdenv like Make.  Should not be used
   # for other dependencies.
   overrideInStdenv = stdenv: pkgs:
-    stdenv.override (prev: { allowedRequisites = null; extraBuildInputs = prev.extraBuildInputs or [] ++ pkgs; });
+    stdenv.override (prev: { allowedRequisites = null; extraBuildInputs = (prev.extraBuildInputs or []) ++ pkgs; });
 
 
   # Override the setup script of stdenv.  Useful for testing new
@@ -34,7 +34,7 @@ rec {
   makeStaticBinaries = stdenv:
     let stdenv' = if stdenv.hostPlatform.libc != "glibc" then stdenv else
       stdenv.override (prev: {
-          extraBuildInputs = prev.extraBuildInputs or [] ++ [
+          extraBuildInputs = (prev.extraBuildInputs or []) ++ [
               stdenv.glibc.static
             ];
         });

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -63,6 +63,8 @@ in lib.init bootStages ++ [
              # `tryEval` wouldn't catch, wrecking accessing previous stages
              # when there is a C compiler and everything should be fine.
              then throw "no C compiler provided for this platform"
+           else if crossSystem.isDarwin
+             then buildPackages.llvmPackages.clang
            else if crossSystem.useLLVM or false
              then buildPackages.llvmPackages_8.lldClang
            else buildPackages.gcc;


### PR DESCRIPTION
###### Motivation for this change
As title. Looks like people haven't really been using pkgsStatic on Darwin for a long time.

In addition to the testing steps listed below, I also ran some manual tests since pkgsStatic has very little test coverage in nixpkgs overall.

```
# build a static library
$ nix-build . -A pkgsStatic.bzip2
# build a bin that requires CF
$ nix-build . -A pkgsStatic.htop
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] macOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
