### PR TITLE
nixos/znc: add proxychains support, maintainers, password tip

### DIFF
--- a/nixos/modules/services/networking/znc/default.nix
+++ b/nixos/modules/services/networking/znc/default.nix
@@ -76,6 +76,7 @@ let
 in
 
 {
+  meta.maintainers = with maintainers; [ infinisil sorki ];
 
   imports = [ ./options.nix ];
 
@@ -141,6 +142,8 @@ in
                   "##linux" = { Disabled = true; };
                 };
               };
+              # generate password with
+              # nix-shell -p znc --run "znc --makepass"
               Pass.password = {
                 Method = "sha256";
                 Hash = "e2ce303c7ea75c571d80d8540a8699b46535be6a085be3414947d638e48d9e93";
@@ -220,6 +223,18 @@ in
         '';
       };
 
+      proxychains = {
+        enable = mkOption {
+          default = false;
+          type = types.bool;
+          description = ''
+            When enabled wraps <literal>znc</literal> executable
+            with <literal>proxychains</literal> to route all traffic
+            via SOCKS proxy.
+          '';
+        };
+      };
+
       extraFlags = mkOption {
         default = [ ];
         example = [ "--debug" ];
@@ -255,7 +270,12 @@ in
         User = cfg.user;
         Group = cfg.group;
         Restart = "always";
-        ExecStart = "${pkgs.znc}/bin/znc --foreground --datadir ${cfg.dataDir} ${escapeShellArgs cfg.extraFlags}";
+        ExecStart = ''
+          ${optionalString cfg.proxychains.enable "${pkgs.proxychains}/bin/proxychains4 "}${pkgs.znc}/bin/znc \
+            --foreground \
+            --datadir ${cfg.dataDir} \
+            ${escapeShellArgs cfg.extraFlags}
+        '';
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         ExecStop = "${pkgs.coreutils}/bin/kill -INT $MAINPID";
       };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Privacy. Weakly depends on #86225.

###### Things done

- `proxychains` support
- Added meta.maintainers
- note about generating new password


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
