### PR TITLE
openexr: Switch to cmake-based build

### DIFF
--- a/pkgs/development/libraries/ilmbase/default.nix
+++ b/pkgs/development/libraries/ilmbase/default.nix
@@ -1,9 +1,13 @@
-{ stdenv, lib, buildPackages, automake, autoconf, libtool, which,
-  fetchpatch, openexr }:
+{ stdenv
+, buildPackages
+, cmake
+, libtool
+, openexr
+}:
 
 stdenv.mkDerivation rec {
   pname = "ilmbase";
-  version = lib.getVersion openexr;
+  version = stdenv.lib.getVersion openexr;
 
   # the project no longer provides separate tarballs. We may even want to merge
   # the ilmbase package into openexr in the future.
@@ -13,19 +17,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  preConfigure = ''
-    patchShebangs ./bootstrap
-    ./bootstrap
-  '';
-
+  nativeBuildInputs = [ cmake libtool ];
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ automake autoconf libtool which ];
 
-  NIX_CFLAGS_LINK = "-pthread";
-
-  patches = [
-    ./cross.patch
-  ];
+  patches = [ ./cross.patch ];
 
   # fails 1 out of 1 tests with
   # "lt-ImathTest: testBoxAlgo.cpp:892: void {anonymous}::boxMatrixTransform(): Assertion `b21 == b2' failed"

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -1,11 +1,13 @@
-{ lib, stdenv, buildPackages, fetchFromGitHub, autoconf, automake, libtool, pkgconfig,
-  zlib, ilmbase, fetchpatch }:
-
-let
-  # Doesn't really do anything when not crosscompiling
-  emulator = stdenv.hostPlatform.emulator buildPackages;
-in
-
+{ lib
+, stdenv
+, buildPackages
+, fetchFromGitHub
+, zlib
+, ilmbase
+, fetchpatch 
+, cmake
+, libtool
+}:
 stdenv.mkDerivation rec {
   pname = "openexr";
   version = "2.4.1";
@@ -17,36 +19,11 @@ stdenv.mkDerivation rec {
     sha256 = "020gyl8zv83ag6gbcchmqiyx9rh2jca7j8n52zx1gk4rck7kwc01";
   };
 
-  sourceRoot = "source/OpenEXR";
-
   outputs = [ "bin" "dev" "out" "doc" ];
-
-  # Needed because there are some generated sources. Solution: just run them under QEMU.
-  postPatch = ''
-    for file in b44ExpLogTable dwaLookups
-    do
-      # Ecape for both sh and Automake
-      emu=${lib.escapeShellArg (lib.replaceStrings ["$"] ["$$"] emulator)}
-      before="./$file > $file.h"
-      after="$emu $before"
-      substituteInPlace IlmImf/Makefile.am \
-        --replace "$before" "$after"
-    done
-
-    # Make sure the patch succeeded
-    [[ $(grep "$emu" IlmImf/Makefile.am | wc -l) = 2 ]]
-  '';
-
-  preConfigure = ''
-    patchShebangs ./bootstrap
-    ./bootstrap
-  '';
-
-  nativeBuildInputs = [ pkgconfig autoconf automake libtool ];
+  nativeBuildInputs = [ cmake libtool ];
   propagatedBuildInputs = [ ilmbase zlib ];
 
   enableParallelBuilding = true;
-  doCheck = false; # fails 1 of 1 tests
 
   meta = with stdenv.lib; {
     description = "A high dynamic-range (HDR) image file format";


### PR DESCRIPTION
It appears that the autotools based build isn't supported on Darwin.
This is an attempt to just use the stdenv-builtin cmake build
everywhere.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #86134 - openexr breaks on darwin due to unsupported autotools based build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @flokli @eraserhd 