### PR TITLE
ipfs: 0.4.23 -> 0.5.0

### DIFF
--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -37,9 +37,7 @@ let
   baseService = recursiveUpdate commonEnv {
     wants = [ "ipfs-init.service" ];
     # NB: migration must be performed prior to pre-start, else we get the failure message!
-    preStart = ''
-      ipfs repo fsck # workaround for BUG #4212 (https://github.com/ipfs/go-ipfs/issues/4214)
-    '' + optionalString cfg.autoMount ''
+    preStart = optionalString cfg.autoMount ''
       ipfs --local config Mounts.FuseAllowOther --json true
       ipfs --local config Mounts.IPFS ${cfg.ipfsMountDir}
       ipfs --local config Mounts.IPNS ${cfg.ipnsMountDir}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -143,6 +143,7 @@ in
   initrdNetwork = handleTest ./initrd-network.nix {};
   installer = handleTest ./installer.nix {};
   iodine = handleTest ./iodine.nix {};
+  ipfs = handleTest ./ipfs.nix {};
   ipv6 = handleTest ./ipv6.nix {};
   jackett = handleTest ./jackett.nix {};
   jellyfin = handleTest ./jellyfin.nix {};

--- a/nixos/tests/ipfs.nix
+++ b/nixos/tests/ipfs.nix
@@ -1,55 +1,25 @@
-
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "ipfs";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ mguentner ];
   };
 
-  nodes = {
-    adder =
-      { ... }:
-      {
-        services.ipfs = {
-          enable = true;
-          defaultMode = "norouting";
-          gatewayAddress = "/ip4/127.0.0.1/tcp/2323";
-          apiAddress = "/ip4/127.0.0.1/tcp/2324";
-        };
-        networking.firewall.allowedTCPPorts = [ 4001 ];
-      };
-    getter =
-      { ... }:
-      {
-        services.ipfs = {
-          enable = true;
-          defaultMode = "norouting";
-          autoMount = true;
-        };
-        networking.firewall.allowedTCPPorts = [ 4001 ];
-      };
+  nodes.machine = { ... }: {
+    services.ipfs = {
+      enable = true;
+      apiAddress = "/ip4/127.0.0.1/tcp/2324";
+    };
   };
 
   testScript = ''
-    startAll;
-    $adder->waitForUnit("ipfs-norouting");
-    $getter->waitForUnit("ipfs-norouting");
+    start_all()
+    machine.wait_for_unit("ipfs")
 
-    # wait until api is available
-    $adder->waitUntilSucceeds("ipfs --api /ip4/127.0.0.1/tcp/2324 id");
-    my $addrId = $adder->succeed("ipfs --api /ip4/127.0.0.1/tcp/2324 id -f=\"<id>\"");
-    my $addrIp = (split /[ \/]+/, $adder->succeed("ip -o -4 addr show dev eth1"))[3];
+    machine.wait_until_succeeds("ipfs --api /ip4/127.0.0.1/tcp/2324 id")
+    ipfs_hash = machine.succeed(
+        "echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add | awk '{ print $2 }'"
+    )
 
-    $adder->mustSucceed("[ -n \"\$(ipfs --api /ip4/127.0.0.1/tcp/2324 config Addresses.Gateway | grep /ip4/127.0.0.1/tcp/2323)\" ]");
-
-    # wait until api is available
-    $getter->waitUntilSucceeds("ipfs --api /ip4/127.0.0.1/tcp/5001 id");
-    my $ipfsHash = $adder->mustSucceed("echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add | cut -d' ' -f2");
-    chomp($ipfsHash);
-
-    $adder->mustSucceed("[ -n \"\$(echo fnord | ipfs --api /ip4/127.0.0.1/tcp/2324 add | grep added)\" ]");
-
-    $getter->mustSucceed("ipfs --api /ip4/127.0.0.1/tcp/5001 swarm connect /ip4/$addrIp/tcp/4001/ipfs/$addrId");
-    $getter->mustSucceed("[ -n \"\$(ipfs --api /ip4/127.0.0.1/tcp/5001 cat /ipfs/$ipfsHash | grep fnord)\" ]");
-    $getter->mustSucceed("[ -n \"$(cat /ipfs/$ipfsHash | grep fnord)\" ]");
-    '';
+    machine.succeed(f"ipfs cat /ipfs/{ipfs_hash.strip()} | grep fnord")
+  '';
 })

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -2,21 +2,26 @@
 
 buildGoModule rec {
   pname = "ipfs";
-  version = "0.4.23";
+  version = "0.5.0";
   rev = "v${version}";
+
+  buildPhase = ''
+    sed -i 'd#\$(d)/preload.sh > $@#' plugin/loader/Rules.mk
+    make install
+  '';
 
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "go-ipfs";
     inherit rev;
-    sha256 = "19m1bhqf1jghdv2ngdnjdk1kvjcxbkgm1ccdkmkabv4ii43h8jwm";
+    sha256 = "0dbyvs49wyqj46c8hvz0fr4vpgfrdj1h8blniwzjf0jabgvw8nik";
   };
 
   postPatch = ''
     rm -rf test/dependencies
   '';
 
-  modSha256 = "12m4ind1s8zaa6kssblc28z2cafy20w2jp80kzif39hg5ar9bijm";
+  modSha256 = "00xgsvpl47miy6paxl8yn6p76h6ssccackh50z0l4r5s7wcc25q8";
 
   meta = with stdenv.lib; {
     description = "A global, versioned, peer-to-peer filesystem";

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoModule, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub, nixosTests }:
 
 buildGoModule rec {
   pname = "ipfs";
@@ -20,6 +20,8 @@ buildGoModule rec {
   buildPhase = ''
     make install
   '';
+
+  passthru.tests.ferm = nixosTests.ferm;
 
   modSha256 = "00xgsvpl47miy6paxl8yn6p76h6ssccackh50z0l4r5s7wcc25q8";
 

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
     make install
   '';
 
-  passthru.tests.ferm = nixosTests.ferm;
+  passthru.tests.ipfs = nixosTests.ipfs;
 
   modSha256 = "00xgsvpl47miy6paxl8yn6p76h6ssccackh50z0l4r5s7wcc25q8";
 

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -5,11 +5,6 @@ buildGoModule rec {
   version = "0.5.0";
   rev = "v${version}";
 
-  buildPhase = ''
-    sed -i 'd#\$(d)/preload.sh > $@#' plugin/loader/Rules.mk
-    make install
-  '';
-
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "go-ipfs";
@@ -19,6 +14,11 @@ buildGoModule rec {
 
   postPatch = ''
     rm -rf test/dependencies
+    patchShebangs plugin/loader/preload.sh
+  '';
+
+  buildPhase = ''
+    make install
   '';
 
   modSha256 = "00xgsvpl47miy6paxl8yn6p76h6ssccackh50z0l4r5s7wcc25q8";


### PR DESCRIPTION
###### Motivation for this change
Major go-ipfs update to 0.5.0

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Perhaps some commits should be squashed. I don't know why I the preload.sh script failed, some weird path problem. Seems to work fine without it. 