### PR TITLE
podman: Wrap packages required to run containers

### DIFF
--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -77,17 +77,8 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    environment.systemPackages = [
-      pkgs.podman # Docker compat
-      pkgs.runc # Default container runtime
-      pkgs.crun # Default container runtime (cgroups v2)
-      pkgs.conmon # Container runtime monitor
-      pkgs.slirp4netns # User-mode networking for unprivileged namespaces
-      pkgs.fuse-overlayfs # CoW for images, much faster than default vfs
-      pkgs.utillinux # nsenter
-      pkgs.iptables
-    ]
-    ++ lib.optional cfg.dockerCompat dockerCompat;
+    environment.systemPackages = [ pkgs.podman ]
+      ++ lib.optional cfg.dockerCompat dockerCompat;
 
     environment.etc."containers/libpod.conf".text = ''
       cni_plugin_dir = ["${pkgs.cni-plugins}/bin/"]
@@ -95,7 +86,7 @@ in
 
     '' + cfg.libpod.extraConfig;
 
-    environment.etc."cni/net.d/87-podman-bridge.conflist".source = copyFile "${pkgs.podman.src}/cni/87-podman-bridge.conflist";
+    environment.etc."cni/net.d/87-podman-bridge.conflist".source = copyFile "${pkgs.podman-unwrapped.src}/cni/87-podman-bridge.conflist";
 
     # Enable common /etc/containers configuration
     virtualisation.containers.enable = true;

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -1,0 +1,48 @@
+{ podman-unwrapped
+, runCommand
+, makeWrapper
+, lib
+, extraPackages ? []
+, podman # Docker compat
+, runc # Default container runtime
+, crun # Default container runtime (cgroups v2)
+, conmon # Container runtime monitor
+, slirp4netns # User-mode networking for unprivileged namespaces
+, fuse-overlayfs # CoW for images, much faster than default vfs
+, utillinux # nsenter
+, cni-plugins
+, iptables
+}:
+
+let
+  podman = podman-unwrapped;
+
+  binPath = lib.makeBinPath ([
+    runc
+    crun
+    conmon
+    slirp4netns
+    fuse-overlayfs
+    utillinux
+    iptables
+  ] ++ extraPackages);
+
+in runCommand podman.name {
+  inherit (podman) name pname version meta outputs;
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+} ''
+  # Symlink everything but $bin from podman-unwrapped
+  ${
+    lib.concatMapStringsSep "\n"
+    (o: "ln -s ${podman.${o}} ${placeholder o}")
+    (builtins.filter (o: o != "bin")
+    podman.outputs)}
+
+  mkdir -p $bin/bin
+  ln -s ${podman-unwrapped}/share $bin/share
+  makeWrapper ${podman-unwrapped}/bin/podman $bin/bin/podman \
+    --prefix PATH : ${binPath}
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5966,7 +5966,8 @@ in
 
   podiff = callPackage ../tools/text/podiff { };
 
-  podman = callPackage ../applications/virtualization/podman { };
+  podman = callPackage ../applications/virtualization/podman/wrapper.nix { };
+  podman-unwrapped = callPackage ../applications/virtualization/podman { };
 
   podman-compose = python3Packages.callPackage ../applications/virtualization/podman-compose {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/86245

Closure size for `podman` before:
`/nix/store/0vdiml328w6frhl45r52px7kwxq6cpb4-podman-1.9.0-bin	 135.8M`
After:
`/nix/store/sq5nw88ybrkx1c0c1zh8pi8s9ls78h2n-podman-1.9.0-bin	 208.5M`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
