### PR TITLE
nixos/printers: fix example for hardware.printers.ensurePrinters.*.model

### DIFF
--- a/nixos/modules/hardware/printers.nix
+++ b/nixos/modules/hardware/printers.nix
@@ -84,7 +84,7 @@ in {
             model = mkOption {
               type = types.str;
               example = literalExample ''
-                gutenprint.''${lib.version.majorMinor (lib.getVersion pkgs.cups)}://brother-hl-5140/expert
+                gutenprint.''${lib.versions.majorMinor (lib.getVersion pkgs.gutenprint)}://brother-hl-5140/expert
               '';
               description = ''
                 Location of the ppd driver file for the printer.


### PR DESCRIPTION

###### Motivation for this change

The `version` typo just cost me 30min ;)

```
nix-repl> lib.version.majorMinor "1.2.3"
error: value is a string while a set was expected, at (string):1:1

nix-repl> lib.versions.majorMinor "1.2.3"
"1.2"
```

###### Things done

It's `lib.versions`, not `lib.version`. Also I'm really sure that it's supposed to be the current version of Gutenprint, not Cups, as that's what `lpinfo -m` says on my system (and it works).
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
