### PR TITLE
mkDerivation mesonFlags: Fix cross file logic to handle more cases

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -256,21 +256,19 @@ in rec {
 
           mesonFlags = if mesonFlags == null then null else let
             # See https://mesonbuild.com/Reference-tables.html#cpu-families
-            cpuFamilies = {
-              aarch64  = "aarch64";
-              armv5tel = "arm";
-              armv6l   = "arm";
-              armv7l   = "arm";
-              i686     = "x86";
-              x86_64   = "x86_64";
-            };
+            cpuFamily = platform: with platform;
+              /**/ if isAarch64 then "arm"
+              else if isAarch32 then "aarch64"
+              else if isx86_32  then "x86"
+              else if isx86_64  then "x86_64"
+              else platform.parsed.cpu.family + builtins.toString platform.parsed.cpu.bits;
             crossFile = builtins.toFile "cross-file.conf" (''
               [properties]
               needs_exe_wrapper = true
 
               [host_machine]
               system = '${stdenv.targetPlatform.parsed.kernel.name}'
-              cpu_family = '${cpuFamilies.${stdenv.targetPlatform.parsed.cpu.name}}'
+              cpu_family = '${cpuFamily stdenv.targetPlatform}'
               cpu = '${stdenv.targetPlatform.parsed.cpu.name}'
               endian = ${if stdenv.targetPlatform.isLittleEndian then "'little'" else "'big'"}
             ''


### PR DESCRIPTION
###### Motivation for this change

Otherwise eval breaks

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
