### PR TITLE
glibcCross: add arm entry for meson flags

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -258,6 +258,7 @@ in rec {
             # See https://mesonbuild.com/Reference-tables.html#cpu-families
             cpuFamilies = {
               aarch64  = "aarch64";
+              arm      = "arm";
               armv5tel = "arm";
               armv6l   = "arm";
               armv7l   = "arm";


### PR DESCRIPTION
###### Motivation for this change
Fixes evaluation of `pkgsCross.arm-embedded.newlibCross`
in which it would produce the following error:

```
attribute 'arm' missing, at ... pkgs/stdenv/generic/make-derivation.nix:273:31
```
example error:  https://gist.github.com/GrahamcOfBorg/0bd43f44fc2113856214c08ff5ddf4b8
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
