### PR TITLE
webcamoid: init at 8.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6496,6 +6496,12 @@
     githubId = 353885;
     name = "Rob Vermaas";
   };
+  robaca = {
+    email = "carsten@r0hrbach.de";
+    github = "robaca";
+    githubId = 580474;
+    name = "Carsten Rohrbach";
+  };
   robberer = {
     email = "robberer@freakmail.de";
     github = "robberer";

--- a/pkgs/applications/video/webcamoid/default.nix
+++ b/pkgs/applications/video/webcamoid/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, pkgconfig, libxcb, mkDerivation, qmake
+, qtbase, qtdeclarative, qtquickcontrols, qtquickcontrols2
+, ffmpeg-full, gstreamer, gst_all_1, libpulseaudio, alsaLib, jack2
+, v4l-utils }:
+mkDerivation rec {
+  pname = "webcamoid";
+  version = "8.7.1";
+
+  src = fetchFromGitHub {
+    sha256 = "1d8g7mq0wf0ycds87xpdhr3zkljgjmb94n3ak9kkxj2fqp9242d2";
+    rev = version;
+    repo = "webcamoid";
+    owner = "webcamoid";
+  };
+
+  buildInputs = [
+    libxcb
+    qtbase qtdeclarative qtquickcontrols qtquickcontrols2
+    ffmpeg-full
+    gstreamer gst_all_1.gst-plugins-base
+    alsaLib libpulseaudio jack2
+    v4l-utils
+  ];
+
+  nativeBuildInputs = [ pkgconfig qmake ];
+
+  qmakeFlags = [
+    "Webcamoid.pro"
+    "INSTALLQMLDIR=${placeholder "out"}/lib/qt/qml"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Webcam Capture Software";
+    longDescription = "Webcamoid is a full featured and multiplatform webcam suite.";
+    homepage = "https://github.com/webcamoid/webcamoid/";
+    license = [ licenses.gpl3Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ robaca ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22513,6 +22513,8 @@ in
 
   wayvnc = callPackage ../applications/networking/remote/wayvnc { };
 
+  webcamoid = libsForQt5.callPackage ../applications/video/webcamoid { };
+
   webmacs = libsForQt5.callPackage ../applications/networking/browsers/webmacs {};
 
   webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop {};


### PR DESCRIPTION
Expression for packaging webcamoid (https://webcamoid.github.io/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
