### PR TITLE
python3Packages.python-gitlab: 1.15.0 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/python-gitlab/default.nix
+++ b/pkgs/development/python-modules/python-gitlab/default.nix
@@ -1,7 +1,7 @@
 { stdenv, buildPythonPackage, fetchPypi, requests, six, mock, httmock }:
 
 buildPythonPackage rec {
-  pname   = "python-gitlab";
+  pname = "python-gitlab";
   version = "1.15.0";
 
   src = fetchPypi {
@@ -15,8 +15,8 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Interact with GitLab API";
-    homepage    = "https://github.com/python-gitlab/python-gitlab";
-    license     = licenses.lgpl3;
+    homepage = "https://github.com/python-gitlab/python-gitlab";
+    license = licenses.lgpl3;
     maintainers = with maintainers; [ nyanloutre ];
   };
 }

--- a/pkgs/development/python-modules/python-gitlab/default.nix
+++ b/pkgs/development/python-modules/python-gitlab/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, buildPythonPackage, fetchPypi, requests, six, mock, httmock }:
+{ stdenv, buildPythonPackage, fetchPypi, requests, mock, httmock, pythonOlder }:
 
 buildPythonPackage rec {
   pname = "python-gitlab";
-  version = "1.15.0";
+  version = "2.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "45125a0ed4d0027d4317bdbd71ca02fc52b0ac160b9d2c3c5be131b4d19f867e";
+    sha256 = "4c4ea60c8303f4214522b18038df017cae35afda7474efa0b4e19c2e73bc3ae2";
   };
 
-  propagatedBuildInputs = [ requests six ];
+  propagatedBuildInputs = [ requests ];
 
   checkInputs = [ mock httmock ];
+
+  disabled = pythonOlder "3.6";
 
   meta = with stdenv.lib; {
     description = "Interact with GitLab API";


### PR DESCRIPTION
###### Motivation for this change

upstream releases (see [PyPI](https://pypi.org/project/python-gitlab/2.2.0/#history) for SHA256 hashes & [GitHub](https://github.com/python-gitlab/python-gitlab/releases) for release notes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
----
Result of `nixpkgs-review pr 86269` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
<br>- python37Packages.python-gitlab
<br>- python38Packages.python-gitlab
</details>