### PR TITLE
[19.09] coturn: apply patch for CVE-2020-6061/6062

### DIFF
--- a/pkgs/servers/coturn/default.nix
+++ b/pkgs/servers/coturn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, openssl, libevent }:
+{ stdenv, fetchFromGitHub, fetchpatch, openssl, libevent }:
 
 stdenv.mkDerivation rec {
   pname = "coturn";
@@ -13,7 +13,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl libevent ];
 
-  patches = [ ./pure-configure.patch ];
+  patches = [
+    ./pure-configure.patch
+    (fetchpatch {
+      name = "CVE-2020-6061+6062.patch";
+      url = "https://sources.debian.org/data/main/c/coturn/4.5.1.1-1.2/debian/patches/CVE-2020-6061+6062.patch";
+      sha256 = "0fcy1wp91bb4hlhnp96sf9bs0d9hf3pwx5f7b1r9cfvr3l5c1bk2";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://coturn.net/;


### PR DESCRIPTION
###### Motivation for this change

Fixes: CVE-2020-6061, CVE-2020-6062

An exploitable heap overflow vulnerability exists in the way CoTURN
4.5.1.1 web server parses POST requests. A specially crafted HTTP
POST request can lead to information leaks and other misbehavior.
An attacker needs to send an HTTPS request to trigger this vulnerability.

An exploitable denial-of-service vulnerability exists in the way
CoTURN 4.5.1.1 web server parses POST requests. A specially crafted
HTTP POST request can lead to server crash and denial of service.
An attacker needs to send an HTTP request to trigger this vulnerability.

(cherry picked from commit 14ade05e74aaa310a42dab480120311f86f1e859)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
