### PR TITLE
sage: fix doctest matrix_double_dense is_unitary

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -29,6 +29,14 @@ stdenv.mkDerivation rec {
       url = "https://git.sagemath.org/sage.git/patch?id2=8bdc326ba57d1bb9664f63cf165a9e9920cc1afc&id=dc673c17555efca611f68398d5013b66e9825463";
       sha256 = "1hhannz7xzprijakn2w2d0rhd5zv2zikik9p51i87bas3nc658f7";
     })
+    
+    # `is_unitary` test in `matrix_double_dense.pyx` fails with some BLAS implementations
+    # https://trac.sagemath.org/ticket/29297 should be included in 9.1
+    (fetchpatch {
+      name = "is_unitary-special-case.patch";
+      url = "https://git.sagemath.org/sage.git/patch?id=cc3eb9ffa991e328b09028d32aab7e7cc2ddbb6a";
+      sha256 = "0jq4w8hnp5c9q99011ldr4n3knvm1rx2g85z0hidv3i9x868p0ay";
+    })
 
     # Unfortunately inclusion in upstream sage was rejected. Instead the bug was
     # fixed in python, but of course not backported to 2.7. So we'll probably


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
`sage-tests` fails due to `matrix_double_dense` `is_unitary` test https://hydra.nixos.org/build/117853043/nixlog/1

###### Things done
Added patch from upstream to fix test

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
