### PR TITLE
dnsmasq: 2.80 → 2.81

### DIFF
--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -12,21 +12,13 @@ let
   ]);
 in
 stdenv.mkDerivation rec {
-  name = "dnsmasq-2.80";
+  name = "dnsmasq-2.81";
 
   src = fetchurl {
     url = "http://www.thekelleys.org.uk/dnsmasq/${name}.tar.xz";
-    sha256 = "1fv3g8vikj3sn37x1j6qsywn09w1jipvlv34j3q5qrljbrwa5ayd";
+    sha256 = "1yzq6anwgr5rlnwydpszb51cyhp2vjq29b24ck19flbwac1sk73l";
   };
 
-  patches = [
-    # Fix build with nettle 3.5
-    (fetchpatch {
-      name = "nettle-3.5.patch";
-      url = "thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=patch;h=ab73a746a0d6fcac2e682c5548eeb87fb9c9c82e";
-      sha256 = "1hnixij3jp1p6zc3bx2dr92yyf9jp1ahhl9hiiq7bkbhbrw6mbic";
-    })
-  ];
   postPatch = stdenv.lib.optionalString stdenv.hostPlatform.isLinux ''
     sed '1i#include <linux/sockios.h>' -i src/dhcp.c
   '';


### PR DESCRIPTION
Fixes: CVE-2019-14834

A vulnerability was found in dnsmasq before version 2.81, where the
memory leak allows remote attackers to cause a denial of service
(memory consumption) via vectors involving DHCP response creation.

Changelog:
```
version 2.81
	Improve cache behaviour for TCP connections. For ease of
	implementaion, dnsmasq has always forked a new process to handle
	each incoming TCP connection. A side-effect of this is that
	any DNS queries answered from TCP connections are not cached:
	when TCP connections were rare, this was not a problem.
	With the coming of DNSSEC, it is now the case that some
	DNSSEC queries have answers which spill to TCP, and if,
	for instance, this applies to the keys for the root, then
	those never get cached, and performance is very bad.
	This fix passes cache entries back from the TCP child process to
	the main server process, and fixes the problem.

	Remove the NO_FORK compile-time option, and support for uclinux.
	In an era where everything has an MMU, this looks like
	an anachronism, and it adds to (Ok, multiplies!) the
	combinatorial explosion of compile-time options. Thanks to
	Kevin Darbyshire-Bryant for the patch.

	Fix line-counting when reading /etc/hosts and friends; for
	correct error messages. Thanks to Christian Rosentreter
	for reporting this.

	Fix bug in DNS non-terminal code, added in 2.80, which could
	sometimes cause a NODATA rather than an NXDOMAIN reply.
	Thanks to Norman Rasmussen, Sven Mueller and Maciej Żenczykowski
	for spotting and diagnosing the bug and providing patches.

	Support TCP-fastopen (RFC-7413) on both incoming and
	outgoing TCP connections, if supported and enabled in the OS.

	Improve kernel-capability manipulation code under Linux. Dnsmasq
	now fails early if a required capability is not available, and
	tries not to request capabilities not required by its
	configuration.

	Add --shared-network config. This enables allocation of addresses
	by the DHCP server in subnets where the server (or relay) does not
	have an interface on the network in that subnet. Many thanks to
	kamp.de for sponsoring this feature.

	Fix broken contrib/lease_tools/dhcp_lease_time.c. A packet
	validation check got borked in commit 2b38e382 and release 2.80.
	Thanks to Tomasz Szajner for spotting this.

	Fix compilation against nettle version 3.5 and later.

	Fix spurious DNSSEC validation failures when the auth section
	of a reply contains unsigned RRs from a signed zone,
	with the exception that NSEC and NSEC3 RRs must always be signed.
        Thanks to Tore Anderson for spotting and diagnosing the bug.

	Add --dhcp-ignore-clid. This disables reading of DHCP client
	identifier option (option 61), so clients are only identified by
	MAC addresses.

	Fix a bug which stopped --dhcp-name-match from working when a hostname
	is supplied in --dhcp-host. Thanks to James Feeney for spotting this.

	Fix bug which caused very rarely caused zero-length DHCPv6 packets.
	Thanks to Dereck Higgins for spotting this.

	Add --tftp-single-port option.

	Enhance --conf-dir to load files in a deterministic order. Thanks to
	Evgenii Seliavka for the suggestion and initial patch.

	In the router advert code, handle case where we have two
	different interfaces on the same IPv6 net, and we are doing
	RA/DHCP service on only one of them. Thanks to NIIBE Yutaka
	for spotting this case and making the initial patch.

	Support prefixed ranges of ipv6 addresses in dhcp-host.
	This eases problems chain-netbooting, where each link in the
	chain requests an address using a different UID. With a single
	address, only one gets the "static" address, but with this
	fix, enough addresses can be reserved for all the stages of the
	boot. Many thanks to Harald Jensås for his work on this idea and
	earlier patches.

	Add filtering by tag of --dhcp-host directives. Based on a patch
	by Harald Jensås.

	Allow empty server spec in --rev-server, to match --server.

	Remove DSA signature verification from DNSSEC, as specified in
	RFC 8624. Thanks to Loganaden Velvindron for the original patch.

	Add --script-on-renewal option.
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
