### PR TITLE
nixos.users-groups: Set up subuid/subgid mappings for all normal users

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -124,6 +124,12 @@ systemd.services.mysql.serviceConfig.ReadWritePaths = [ "/var/data" ];
      <varname>services.postfix.sslCACert</varname> was replaced by <varname>services.postfix.tlsTrustedAuthorities</varname> which now defaults to system certifcate authorities.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      Subordinate GID and UID mappings are now set up automatically for all normal users.
+      This will make container tools like Podman work as non-root users out of the box.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -375,18 +375,6 @@ let
     };
   };
 
-  mkSubuidEntry = user: concatStrings (
-    map (range: "${user.name}:${toString range.startUid}:${toString range.count}\n")
-      user.subUidRanges);
-
-  subuidFile = concatStrings (map mkSubuidEntry (attrValues cfg.users));
-
-  mkSubgidEntry = user: concatStrings (
-    map (range: "${user.name}:${toString range.startGid}:${toString range.count}\n")
-        user.subGidRanges);
-
-  subgidFile = concatStrings (map mkSubgidEntry (attrValues cfg.users));
-
   idsAreUnique = set: idAttr: !(fold (name: args@{ dup, acc }:
     let
       id = builtins.toString (builtins.getAttr idAttr (builtins.getAttr name set));
@@ -406,6 +394,7 @@ let
       { inherit (u)
           name uid group description home createHome isSystemUser
           password passwordFile hashedPassword
+          isNormalUser subUidRanges subGidRanges
           initialPassword initialHashedPassword;
         shell = utils.toShellPath u.shell;
       }) cfg.users;
@@ -567,16 +556,7 @@ in {
     # Install all the user shells
     environment.systemPackages = systemShells;
 
-    environment.etc = {
-      subuid = {
-        text = subuidFile;
-        mode = "0644";
-      };
-      subgid = {
-        text = subgidFile;
-        mode = "0644";
-      };
-    } // (mapAttrs' (name: { packages, ... }: {
+    environment.etc = (mapAttrs' (name: { packages, ... }: {
       name = "profiles/per-user/${name}";
       value.source = pkgs.buildEnv {
         name = "user-environment";

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -23,6 +23,15 @@ in
     maintainers = [] ++ lib.teams.podman.members;
   };
 
+
+  imports = [
+    (
+      lib.mkRemovedOptionModule
+      [ "virtualisation" "containers" "users" ]
+      "All users with `isNormaUser = true` set now get appropriate subuid/subgid mappings."
+    )
+  ];
+
   options.virtualisation.containers = {
 
     enable =
@@ -99,15 +108,6 @@ in
       '';
     };
 
-    users = mkOption {
-      default = [];
-      type = types.listOf types.str;
-      description = ''
-        List of users to set up subuid/subgid mappings for.
-        This is a requirement for running rootless containers.
-      '';
-    };
-
   };
 
   config = lib.mkIf cfg.enable {
@@ -121,26 +121,6 @@ in
     environment.etc."containers/registries.conf".source = toTOML "registries.conf" {
       registries = lib.mapAttrs (n: v: { registries = v; }) cfg.registries;
     };
-
-    users.extraUsers = builtins.listToAttrs (
-      (
-        builtins.foldl' (
-          acc: user: {
-            values = acc.values ++ [
-              {
-                name = user;
-                value = {
-                  subUidRanges = [ { startUid = acc.offset; count = 65536; } ];
-                  subGidRanges = [ { startGid = acc.offset; count = 65536; } ];
-                };
-              }
-            ];
-            offset = acc.offset + 65536;
-          }
-        )
-        { values = []; offset = 100000; } (lib.unique cfg.users)
-      ).values
-    );
 
     environment.etc."containers/policy.json".source =
       if cfg.policy != {} then pkgs.writeText "policy.json" (builtins.toJSON cfg.policy)

--- a/nixos/tests/podman.nix
+++ b/nixos/tests/podman.nix
@@ -12,9 +12,6 @@ import ./make-test-python.nix (
         { pkgs, ... }:
         {
           virtualisation.podman.enable = true;
-          virtualisation.containers.users = [
-            "alice"
-          ];
 
           users.users.alice = {
             isNormalUser = true;


### PR DESCRIPTION
This is required by (among others) Podman to run containers in rootless mode.

Other distributions such as Fedora and Ubuntu already set up these mappings.

The scheme with a start UID/GID offset starting at 100000 and increasing in 65536 increments is copied from Fedora.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @saschagrunert @vdemeester @zowoq @grahamc @alyssais 