### PR TITLE
lutris: add gtk3 and glib setup hooks

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -1,5 +1,5 @@
 { buildPythonApplication, lib, fetchFromGitHub, fetchpatch
-, wrapGAppsHook, gobject-introspection, glib-networking, gnome-desktop, libnotify, libgnome-keyring, pango
+, wrapGAppsHook, gtk3, glib, gobject-introspection, glib-networking, gnome-desktop, libnotify, libgnome-keyring, pango
 , gdk-pixbuf, atk, webkitgtk, gst_all_1
 , dbus-python, evdev, pyyaml, pygobject3, requests, pillow
 , xrandr, pciutils, psmisc, glxinfo, vulkan-tools, xboxdrv, pulseaudio, p7zip, xgamma
@@ -42,9 +42,12 @@ in buildPythonApplication rec {
 
   nativeBuildInputs = [ wrapGAppsHook ];
   buildInputs = [
+    gtk3 glib
     gobject-introspection glib-networking gnome-desktop libnotify libgnome-keyring pango
     gdk-pixbuf atk webkitgtk
   ] ++ gstDeps;
+  # Needed for gtk and glib to run their setup hooks https://nixos.org/nixpkgs/manual/#sec-language-gnome
+  strictDeps = false;
 
   makeWrapperArgs = [
     "--prefix PATH : ${binPath}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/78439#pullrequestreview-399928033

Also the glib-networking Gog fix was not working for @aanderse. Can you please check that this resolves it?

###### Things done
Added gtk3 and glib to `nativeBuildInputs` for their setup hooks.

gtk3 adds a variable which may be relevant to pixbuf
```
+export GDK_PIXBUF_MODULE_FILE='/nix/store/88v2qm0ivij7ynybzh8zfpz9ar3dkyjl-gdk-pixbuf-2.40.0/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache'
```
and glib adds paths for gsettings, I'm not sure how/if they are used
```
+export XDG_DATA_DIRS='/nix/store/78x2nyfhhili5ijd6l74z3flj63p92s0-gsettings-desktop-schemas-3.36.0/share/gsettings-schemas/gsettings-desktop-schemas-3.36.0:/nix/store/6yrlycwcnxlgg6bkhq4jvwmahyrj00id-gtk+3-3.24.17/share/gsettings-schemas/gtk+3-3.24.17'${XDG_DATA_DIRS:+':'}$XDG_DATA_DIRS
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
