### PR TITLE
gtk3: fix version number in pkg-config file

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -73,6 +73,12 @@ stdenv.mkDerivation rec {
 
     # https://gitlab.gnome.org/GNOME/gtk/merge_requests/1002
     ./patches/01-build-Fix-path-handling-in-pkgconfig.patch
+
+    (fetchpatch {
+      name = "fix-version-in-meson-build.patch";
+      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/bcf08abef0981456fd8400707431826e6473a63a.patch";
+      sha256 = "0j3ggmi0bs0xilfk3xfm37q3ynpwgwm2shv7xjfyjgxd4r4z268n";
+    })
   ] ++ optionals stdenv.isDarwin [
     # X11 module requires <gio/gdesktopappinfo.h> which is not installed on Darwin
     # let’s drop that dependency in similar way to how other parts of the library do it


### PR DESCRIPTION
###### Motivation for this change

Currently, `pkg-config --modversion gtk+-3.0` reports “3.24.17” instead of the correct version number.

This PR fixes `ocamlPackages.lablgtk3` and thus `coq_8_10`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
