### PR TITLE
libeatmydata: allow building from checkout

### DIFF
--- a/pkgs/development/libraries/libeatmydata/default.nix
+++ b/pkgs/development/libraries/libeatmydata/default.nix
@@ -1,23 +1,41 @@
-{ stdenv, fetchurl, makeWrapper }:
+{ stdenv, fetchFromGitHub, autoreconfHook, strace, which }:
 
 stdenv.mkDerivation rec {
-  name = "libeatmydata-105";
+  pname = "libeatmydata";
+  version = "105";
 
-  src = fetchurl {
-    url = "https://www.flamingspork.com/projects/libeatmydata/${name}.tar.gz";
-    sha256 = "1pd8sc73cgc41ldsvq6g8ics1m5k8gdcb91as9yg8z5jnrld1lmx";
+  src = fetchFromGitHub {
+    owner = "stewartsmith";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0sx803h46i81h67xbpd3c7ky0nhaw4gij214nsx4lqig70223v9r";
   };
 
   patches = [ ./find-shell-lib.patch ];
+
   patchFlags = "-p0";
+
   postPatch = ''
-    substituteInPlace eatmydata.in --replace NIX_OUT_DIR $out
+    substituteInPlace eatmydata.in \
+      --replace NIX_OUT_DIR $out
+
+    patchShebangs .
   '';
 
-  meta = {
-    homepage = "https://www.flamingspork.com/projects/libeatmydata/";
-    license = stdenv.lib.licenses.gpl3Plus;
+  nativeBuildInputs = [
+    autoreconfHook
+  ] ++ stdenv.lib.optionals doCheck [ strace which ];
+
+  # while we can *build* in parallel, the tests also run in parallel which does
+  # not work with v105. Later versions (unreleased) have a fix for that. The
+  # problem is that on hydra we cannot use strace, so the tests don't run there.
+  enableParallelBuilding = true;
+  doCheck = false;
+
+  meta = with stdenv.lib; {
     description = "Small LD_PRELOAD library to disable fsync and friends";
-    platforms = stdenv.lib.platforms.unix;
+    homepage = "https://www.flamingspork.com/projects/libeatmydata/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Wanted to be able to build from a git checkout ~~and having the tests run is always nice~~.

We cannot enable tests as they fail when run in hydra as strace is not allowed there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).