### PR TITLE
qemu: 4.2.0 -> 5.0.0

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -35,15 +35,15 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "4.2.0";
+  version = "5.0.0";
   pname = "qemu"
     + stdenv.lib.optionalString xenSupport "-xen"
     + stdenv.lib.optionalString hostCpuOnly "-host-cpu-only"
     + stdenv.lib.optionalString nixosTestRunner "-for-vm-tests";
 
   src = fetchurl {
-    url = "https://wiki.qemu.org/download/qemu-${version}.tar.bz2";
-    sha256 = "1gczv8hn3wqci86css3mhzrppp3z8vppxw25l08j589k6bvz7x1w";
+    url= "https://download.qemu.org/qemu-${version}.tar.xz";
+    sha256 = "1dlcwyshdp94fwd30pddxf9bn2q8dfw5jsvry2gvdj551wmaj4rg";
   };
 
   nativeBuildInputs = [ python python.pkgs.sphinx pkgconfig flex bison ];
@@ -77,44 +77,6 @@ stdenv.mkDerivation rec {
     ./no-etc-install.patch
     ./fix-qemu-ga.patch
     ./9p-ignore-noatime.patch
-    (fetchpatch {
-      name = "CVE-2019-15890.patch";
-      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=c59279437eda91841b9d26079c70b8a540d41204";
-      sha256 = "1q2rc67mfdz034mk81z9bw105x9zad7n954sy3kq068b1svrf7iy";
-      stripLen = 1;
-      extraPrefix = "slirp/";
-    })
-    # patches listed at: https://nvd.nist.gov/vuln/detail/CVE-2020-7039
-    (fetchpatch {
-      name = "CVE-2020-7039-1.patch";
-      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=2655fffed7a9e765bcb4701dd876e9dab975f289";
-      sha256 = "1jh0k3lg3553c2x1kq1kl3967jabhba5gm584wjpmr5mjqk3lnz1";
-      stripLen = 1;
-      extraPrefix = "slirp/";
-      excludes = ["slirp/CHANGELOG.md"];
-    })
-    (fetchpatch {
-      name = "CVE-2020-7039-2.patch";
-      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=82ebe9c370a0e2970fb5695aa19aa5214a6a1c80";
-      sha256 = "08ccxcmrhzknnzd1a1q2brszv3a7h02n26r73kpli10b0hn12r2l";
-      stripLen = 1;
-      extraPrefix = "slirp/";
-    })
-    (fetchpatch {
-      name = "CVE-2020-7039-3.patch";
-      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=ce131029d6d4a405cb7d3ac6716d03e58fb4a5d9";
-      sha256 = "18ypj9an2jmsmdn58853rbz42r10587h7cz5fdws2x4635778ibd";
-      stripLen = 1;
-      extraPrefix = "slirp/";
-    })
-    # patches listed at: https://nvd.nist.gov/vuln/detail/CVE-2020-7211
-    (fetchpatch {
-      name = "CVE-2020-7211.patch";
-      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=14ec36e107a8c9af7d0a80c3571fe39b291ff1d4";
-      sha256 = "1lc8zabqs580iqrsr5k7zwgkx6qjmja7apwfbc36lkvnrxwfzmrc";
-      stripLen = 1;
-      extraPrefix = "slirp/";
-    })
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {
@@ -145,6 +107,8 @@ stdenv.mkDerivation rec {
       "--sysconfdir=/etc"
       "--localstatedir=/var"
       "--enable-docs"
+      "--enable-tools"
+      "--enable-guest-agent"
     ]
     # disable sysctl check on darwin.
     ++ optional stdenv.isDarwin "--cpu=x86_64"

--- a/pkgs/applications/virtualization/qemu/fix-qemu-ga.patch
+++ b/pkgs/applications/virtualization/qemu/fix-qemu-ga.patch
@@ -1,22 +1,36 @@
-diff --git a/qga/commands-posix.c b/qga/commands-posix.c
-index 0dc219d..9d020d3 100644
+diff -Naur a/qga/commands-posix.c b/qga/commands-posix.c
 --- a/qga/commands-posix.c
 +++ b/qga/commands-posix.c
-@@ -102,6 +102,8 @@ void qmp_guest_shutdown(bool has_mode, const char *mode, Error **errp)
+@@ -109,6 +109,8 @@
          reopen_fd_to_null(1);
          reopen_fd_to_null(2);
-
+ 
 +        execle("/run/current-system/sw/bin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
 +               "hypervisor initiated shutdown", (char*)NULL, environ);
          execle("/sbin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
                 "hypervisor initiated shutdown", (char*)NULL, environ);
          _exit(EXIT_FAILURE);
-@@ -189,6 +191,8 @@ void qmp_guest_set_time(bool has_time, int64_t time_ns, Error **errp)
-
+@@ -157,11 +159,13 @@
+     pid_t pid;
+     Error *local_err = NULL;
+     struct timeval tv;
++    static const char hwclock_path_nix[] = "/run/current-system/sw/bin/hwclock";
+     static const char hwclock_path[] = "/sbin/hwclock";
+     static int hwclock_available = -1;
+ 
+     if (hwclock_available < 0) {
+-        hwclock_available = (access(hwclock_path, X_OK) == 0);
++        hwclock_available = (access(hwclock_path_nix, X_OK) == 0) ||
++                            (access(hwclock_path, X_OK) == 0);
+     }
+ 
+     if (!hwclock_available) {
+@@ -207,6 +211,8 @@
+ 
          /* Use '/sbin/hwclock -w' to set RTC from the system time,
           * or '/sbin/hwclock -s' to set the system time from RTC. */
-+        execle("/run/current-system/sw/bin/hwclock", "hwclock", has_time ? "-w" : "-s",
++        execle(hwclock_path_nix, "hwclock", has_time ? "-w" : "-s",
 +               NULL, environ);
-         execle("/sbin/hwclock", "hwclock", has_time ? "-w" : "-s",
+         execle(hwclock_path, "hwclock", has_time ? "-w" : "-s",
                 NULL, environ);
          _exit(EXIT_FAILURE);


### PR DESCRIPTION
###### Motivation for this change
A new version of qemu is available.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
