### PR TITLE
tmux: install manpages

### DIFF
--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   pname = "tmux";
   version = "3.1";
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" ];
 
   src = fetchFromGitHub {
     owner = "tmux";

--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
   pname = "tmux";
   version = "3.1";
 
-  outputs = [ "out" ];
-
   src = fetchFromGitHub {
     owner = "tmux";
     repo = "tmux";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

On current master, `man tmux` comes empty after in a `nix-shell -p tmux`. This pull request fixes that.

However, I'm a little bit unsure whether this is the correct procedure. I looked at other packages for guidance, but didn't spot a consistent pattern. The packages `feh` and `vdr` both use multiple outputs, as `tmux` did before this pull request; the manpages for `feh` are installed correctly and these for `vdr` are not.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
