### PR TITLE
hydroxide: 0.2.11 -> 0.2.14

### DIFF
--- a/pkgs/applications/networking/hydroxide/default.nix
+++ b/pkgs/applications/networking/hydroxide/default.nix
@@ -2,24 +2,16 @@
 
 buildGoModule rec {
   pname = "hydroxide";
-  version = "0.2.11";
+  version = "0.2.14";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0rn35iyli80kgj3yn93lrx0ybgc8fhvmkvx1d18ill7r4cmavand";
+    sha256 = "0d8wjyzmw89yhrszz487f7i19rcz7xlx4w2wd4c69k5nsdrs6dys";
   };
 
-  modSha256 = "0b19rcif8yiyvhrsjd3q5nsvr580lklamlphx4dk47n456ckcqfp";
-
-  # FIXME: remove with next release
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/emersion/hydroxide/commit/80e0fa6f3e0154338fb0af8a82ca32ae6281dd15.patch";
-      sha256 = "1xi0clzgz14a7sxnwr0li7sz9p05sfh3zh5iqg2qz5f415k9jknj";
-    })
-  ];
+  modSha256 = "0888ikywclhjb4n7xqxc7hvzlhx1qhf4c3skaddqs3nrxm171jwn";
 
   subPackages = [ "cmd/hydroxide" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/emersion/hydroxide/releases/tag/v0.2.14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
