### PR TITLE
_3mux: 0.2.0 -> 1.0.1

### DIFF
--- a/pkgs/tools/misc/3mux/default.nix
+++ b/pkgs/tools/misc/3mux/default.nix
@@ -13,6 +13,10 @@ buildGoModule rec {
 
   vendorSha256 = "1pyik8d1syjvwvkp7i94z1jmflw01wqpafmn1hsnbn034z4ygimd";
 
+  preBuild = ''
+    export CGO_ENABLED=${if stdenv.isLinux then "1" else "0"}
+  '';
+
   excludedPackages = [ "fuzz" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/3mux/default.nix
+++ b/pkgs/tools/misc/3mux/default.nix
@@ -2,16 +2,18 @@
 
 buildGoModule rec {
   pname = "3mux";
-  version = "0.2.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "aaronjanse";
     repo = pname;
     rev = "v${version}";
-    sha256 = "02ry066psvlqdyhimci7nskw4sfb70dw5z7ag7s7rz36gmx1vnmr";
+    sha256 = "0kgbqxw92ffvq8aws0rljarzsfxs8hdi8k37zx964fvigcdhrqba";
   };
 
-  vendorSha256 = "1hjzpg3q4znvgzk0wbl8rq6cq877xxdsf950bcsks92cs8386847";
+  vendorSha256 = "1pyik8d1syjvwvkp7i94z1jmflw01wqpafmn1hsnbn034z4ygimd";
+
+  excludedPackages = [ "fuzz" ];
 
   meta = with stdenv.lib; {
     description = "Terminal multiplexer inspired by i3";

--- a/pkgs/tools/misc/3mux/default.nix
+++ b/pkgs/tools/misc/3mux/default.nix
@@ -20,7 +20,5 @@ buildGoModule rec {
     homepage = "https://github.com/aaronjanse/3mux";
     license = licenses.mit;
     maintainers = with maintainers; [ aaronjanse filalex77 ];
-    # TODO: fix modules build on darwin
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/aaronjanse/3mux/releases/tag/v1.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
