### PR TITLE
ctrtool: 0.16 -> 0.7 and fix cross compiling

### DIFF
--- a/pkgs/tools/archivers/ctrtool/default.nix
+++ b/pkgs/tools/archivers/ctrtool/default.nix
@@ -2,22 +2,23 @@
 
 stdenv.mkDerivation rec {
   pname = "ctrtool";
-  version = "0.16";
+  version = "0.7";
 
   src = fetchFromGitHub {
     owner  = "jakcron";
     repo   = "Project_CTR";
-    rev    = "v${version}";
-    sha256 = "1n3j3fd1bqd39v5bdl9mhq4qdrcl1k4ib1yzl3qfckaz3y8bkrap";
+    rev    = "ctrtool-v${version}";
+    sha256 = "07aayck82w5xcp3si35d7ghybmrbqw91fqqvmbpjrjcixc6m42z7";
   };
 
   sourceRoot = "source/ctrtool";
 
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "CXX=${stdenv.cc.targetPrefix}c++"];
   enableParallelBuilding = true;
 
   installPhase = "
     mkdir $out/bin -p
-    cp ctrtool $out/bin/ctrtool
+    cp ctrtool${stdenv.hostPlatform.extensions.executable} $out/bin/
   ";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
update for ctrtool are avalaible

###### Things done
I previously used the 0.16 version, but that was the makerom version, which is hosted on the same repository. I additionnally fixed cross compiling for a number of platform -- including windows.
Checked that it can still read info from a 3ds game too.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
