### PR TITLE
lib.version: change pre-git to post-git on the release branch

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -178,7 +178,7 @@ rec {
     let suffixFile = ../.version-suffix;
     in if pathExists suffixFile
     then lib.strings.fileContents suffixFile
-    else "pre-git";
+    else "post-git";
 
   /* Attempts to return the the current revision of nixpkgs and
      returns the supplied default value otherwise.


### PR DESCRIPTION
###### Motivation for this change
When there is no .version-suffix file in nixpkgs (like when fetching
nixpkgs with builtins.fetchGit), lib.version suffixes the version string
with "pre-git". The "pre" bit is special cased in
builtins.compareVersions which means "20.03pre-git" is interpreted as
"less than 20.03". This is clearly wrong for the release-20.03 branch
*after* the release has been made.

Change the suffix to "post-git" to make code like this behave the same
whether nixpkgs is fetched from git or the channel (which has
.version-suffix file):

```
lib.versionOlder lib.version "20.03"
lib.versionAtLeast lib.version "20.03"
```

(Currently the result depend on how nixpkgs was obtained!)

This change should be made part of the release process.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @worldofpeace @disassembler  (release managers for NixOS 20.03)