### PR TITLE
qt5: Add missing include path to pkg-config files

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -67,6 +67,11 @@ let
         ./qtbase.patch.d/0010-qtbase-qtpluginpath.patch
         ./qtbase.patch.d/0011-qtbase-assert.patch
         ./qtbase.patch.d/0012-fix-header_module.patch
+
+        # Ensure -I${includedir} is added to Cflags in pkg-config files.
+        # See https://github.com/NixOS/nixpkgs/issues/52457
+        ./qtbase.patch.d/0014-qtbase-pkg-config.patch
+
         # https://bugreports.qt.io/browse/QTBUG-81715
         # remove after updating to qt > 5.12.7
         (fetchpatch {

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0014-qtbase-pkg-config.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0014-qtbase-pkg-config.patch
@@ -1,0 +1,14 @@
+diff --git a/qmake/generators/makefile.cpp b/qmake/generators/makefile.cpp
+--- a/qmake/generators/makefile.cpp
++++ b/qmake/generators/makefile.cpp
+@@ -3390,8 +3390,7 @@ MakefileGenerator::writePkgConfigFile()
+       << varGlue("QMAKE_PKGCONFIG_CFLAGS", "", " ", " ")
+         //      << varGlue("DEFINES","-D"," -D"," ")
+          ;
+-    if (!project->values("QMAKE_DEFAULT_INCDIRS").contains(includeDir))
+-        t << "-I${includedir}";
++    t << "-I${includedir}";
+     if (target_mode == TARG_MAC_MODE && project->isActiveConfig("lib_bundle")
+         && libDir != QLatin1String("/Library/Frameworks")) {
+             t << " -F${libdir}";
+


### PR DESCRIPTION
###### Motivation for this change

To fix #52457.

 This is achieved by patching qtbase `qmake/generators/makefile.cpp` to
    unconditionally add the missing `-I${includedir}`. The include path is
    otherwise conditioned on whether it is already available or not. Since there is
    no unified set of system include paths in nix this cause problems as reported
    in #52457.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested a _sample_ compilation of pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

pkg-config when this fix is applied to staging:
```
 $ grep "Cflags" /nix/store/szikc0g33cgh55ihkfwi983z0psw0ciz-qtdeclarative-5.12.7-dev/lib/pkgconfig/*
/nix/store/szikc0g33cgh55ihkfwi983z0psw0ciz-qtdeclarative-5.12.7-dev/lib/pkgconfig/Qt5Qml.pc:Cflags: -DQT_QML_LIB -I${includedir}/QtQml -I${includedir}
/nix/store/szikc0g33cgh55ihkfwi983z0psw0ciz-qtdeclarative-5.12.7-dev/lib/pkgconfig/Qt5Quick.pc:Cflags: -DQT_QUICK_LIB -I${includedir}/QtQuick -I${includedir}
/nix/store/szikc0g33cgh55ihkfwi983z0psw0ciz-qtdeclarative-5.12.7-dev/lib/pkgconfig/Qt5QuickTest.pc:Cflags: -DQT_QMLTEST_LIB -I${includedir}/QtQuickTest -I${includedir}
/nix/store/szikc0g33cgh55ihkfwi983z0psw0ciz-qtdeclarative-5.12.7-dev/lib/pkgconfig/Qt5QuickWidgets.pc:Cflags: -DQT_QUICKWIDGETS_LIB -I${includedir}/QtQuickWidgets -I${includedir}
```