### PR TITLE
nixos/google-oslogin: bump package, make tests more readable

### DIFF
--- a/nixos/tests/google-oslogin/server.py
+++ b/nixos/tests/google-oslogin/server.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse, parse_qs
 from typing import Dict
 
 SNAKEOIL_PUBLIC_KEY = os.environ['SNAKEOIL_PUBLIC_KEY']
+MOCKUSER="mockuser_nixos_org"
+MOCKADMIN="mockadmin_nixos_org"
 
 
 def w(msg: bytes):
@@ -88,11 +90,11 @@ class ReqHandler(BaseHTTPRequestHandler):
         # users endpoint
         if pu.path == "/computeMetadata/v1/oslogin/users":
             # mockuser and mockadmin are allowed to login, both use the same snakeoil public key
-            if params.get('username') == ['mockuser'] or params.get('uid') == ["1009719690"]:
-                username = "mockuser"
+            if params.get('username') == [MOCKUSER] or params.get('uid') == ["1009719690"]:
+                username = MOCKUSER
                 uid = "1009719690"
-            elif params.get('username') == ['mockadmin'] or params.get('uid') == ["1009719691"]:
-                username = "mockadmin"
+            elif params.get('username') == [MOCKADMIN] or params.get('uid') == ["1009719691"]:
+                username = MOCKADMIN
                 uid = "1009719691"
             else:
                 self._send_404()
@@ -106,7 +108,7 @@ class ReqHandler(BaseHTTPRequestHandler):
             # is user allowed to login?
             if params.get("policy") == ["login"]:
                 # mockuser and mockadmin are allowed to login
-                if params.get('email') == [gen_email("mockuser")] or params.get('email') == [gen_email("mockadmin")]:
+                if params.get('email') == [gen_email(MOCKUSER)] or params.get('email') == [gen_email(MOCKADMIN)]:
                     self._send_json_success()
                     return
                 self._send_json_success(False)
@@ -114,7 +116,7 @@ class ReqHandler(BaseHTTPRequestHandler):
             # is user allowed to become root?
             elif params.get("policy") == ["adminLogin"]:
                 # only mockadmin is allowed to become admin
-                self._send_json_success((params['email'] == [gen_email("mockadmin")]))
+                self._send_json_success((params['email'] == [gen_email(MOCKADMIN)]))
                 return
             # send 404 for other policies
             else:

--- a/nixos/tests/google-oslogin/server.py
+++ b/nixos/tests/google-oslogin/server.py
@@ -7,23 +7,26 @@ import hashlib
 import base64
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
 from typing import Dict
 
 SNAKEOIL_PUBLIC_KEY = os.environ['SNAKEOIL_PUBLIC_KEY']
 
 
-def w(msg):
+def w(msg: bytes):
     sys.stderr.write(f"{msg}\n")
     sys.stderr.flush()
 
 
-def gen_fingerprint(pubkey):
+def gen_fingerprint(pubkey: str):
     decoded_key = base64.b64decode(pubkey.encode("ascii").split()[1])
     return hashlib.sha256(decoded_key).hexdigest()
 
-def gen_email(username):
+
+def gen_email(username: str):
     """username seems to be a 21 characters long number string, so mimic that in a reproducible way"""
     return str(int(hashlib.sha256(username.encode()).hexdigest(), 16))[0:21]
+
 
 def gen_mockuser(username: str, uid: str, gid: str, home_directory: str, snakeoil_pubkey: str) -> Dict:
     snakeoil_pubkey_fingerprint = gen_fingerprint(snakeoil_pubkey)
@@ -56,7 +59,8 @@ def gen_mockuser(username: str, uid: str, gid: str, home_directory: str, snakeoi
 
 
 class ReqHandler(BaseHTTPRequestHandler):
-    def _send_json_ok(self, data):
+
+    def _send_json_ok(self, data: dict):
         self.send_response(200)
         self.send_header('Content-type', 'application/json')
         self.end_headers()
@@ -64,29 +68,62 @@ class ReqHandler(BaseHTTPRequestHandler):
         w(out)
         self.wfile.write(out)
 
+    def _send_json_success(self, success=True):
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+        out = json.dumps({"success": success}).encode()
+        w(out)
+        self.wfile.write(out)
+
+    def _send_404(self):
+        self.send_response(404)
+        self.end_headers()
+
     def do_GET(self):
         p = str(self.path)
-        # mockuser and mockadmin are allowed to login, both use the same snakeoil public key
-        if p == '/computeMetadata/v1/oslogin/users?username=mockuser' \
-            or p == '/computeMetadata/v1/oslogin/users?uid=1009719690':
-            self._send_json_ok(gen_mockuser(username='mockuser', uid='1009719690', gid='1009719690',
-                                            home_directory='/home/mockuser', snakeoil_pubkey=SNAKEOIL_PUBLIC_KEY))
-        elif p == '/computeMetadata/v1/oslogin/users?username=mockadmin' \
-            or p == '/computeMetadata/v1/oslogin/users?uid=1009719691':
-            self._send_json_ok(gen_mockuser(username='mockadmin', uid='1009719691', gid='1009719691',
-                                            home_directory='/home/mockadmin', snakeoil_pubkey=SNAKEOIL_PUBLIC_KEY))
+        pu = urlparse(p)
+        params = parse_qs(pu.query)
 
-        # mockuser is allowed to login
-        elif p == f"/computeMetadata/v1/oslogin/authorize?email={gen_email('mockuser')}&policy=login":
-            self._send_json_ok({'success': True})
+        # users endpoint
+        if pu.path == "/computeMetadata/v1/oslogin/users":
+            # mockuser and mockadmin are allowed to login, both use the same snakeoil public key
+            if params.get('username') == ['mockuser'] or params.get('uid') == ["1009719690"]:
+                username = "mockuser"
+                uid = "1009719690"
+            elif params.get('username') == ['mockadmin'] or params.get('uid') == ["1009719691"]:
+                username = "mockadmin"
+                uid = "1009719691"
+            else:
+                self._send_404()
+                return
 
-        # mockadmin may also become root
-        elif p == f"/computeMetadata/v1/oslogin/authorize?email={gen_email('mockadmin')}&policy=login" or p == f"/computeMetadata/v1/oslogin/authorize?email={gen_email('mockadmin')}&policy=adminLogin":
-            self._send_json_ok({'success': True})
+            self._send_json_ok(gen_mockuser(username=username, uid=uid, gid=uid, home_directory=f"/home/{username}", snakeoil_pubkey=SNAKEOIL_PUBLIC_KEY))
+            return
+
+        # authorize endpoint
+        elif pu.path == "/computeMetadata/v1/oslogin/authorize":
+            # is user allowed to login?
+            if params.get("policy") == ["login"]:
+                # mockuser and mockadmin are allowed to login
+                if params.get('email') == [gen_email("mockuser")] or params.get('email') == [gen_email("mockadmin")]:
+                    self._send_json_success()
+                    return
+                self._send_json_success(False)
+                return
+            # is user allowed to become root?
+            elif params.get("policy") == ["adminLogin"]:
+                # only mockadmin is allowed to become admin
+                self._send_json_success((params['email'] == [gen_email("mockadmin")]))
+                return
+            # send 404 for other policies
+            else:
+                self._send_404()
+                return
         else:
             sys.stderr.write(f"Unhandled path: {p}\n")
             sys.stderr.flush()
-            self.send_response(501)
+            self.send_response(404)
             self.end_headers()
             self.wfile.write(b'')
 


### PR DESCRIPTION
###### Motivation for this change
The OSLogin packages have been moved into a separate repositories, and received some more releases in the meantime. Also, the mockserver we use in the tests was refactored to be a bit more extensible. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
