### PR TITLE
helmsman: init at 3.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4577,6 +4577,12 @@
     githubId = 2057309;
     name = "Sergey Sofeychuk";
   };
+  lynty = {
+    email = "ltdong93+nix@gmail.com";
+    github = "lynty";
+    githubId = 39707188;
+    name = "Lynn Dong";
+  };
   lyt = {
     email = "wheatdoge@gmail.com";
     name = "Tim Liou";

--- a/pkgs/applications/networking/cluster/helmsman/default.nix
+++ b/pkgs/applications/networking/cluster/helmsman/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub, ... }:
+
+buildGoModule rec {
+  pname = "helmsman";
+  version = "3.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Praqma";
+    repo = "helmsman";
+    rev = "v${version}";
+    sha256 = "0i7sg3iwxb07gjxcz6chpdcx3fqykzldmf7s1c9m02hkps910ca8";
+  };
+
+  modSha256 = "19qdrrwmjc32nw8m0zi251z32wqj2d956wgd1dkcvx1x0n4p435g";
+
+  meta = with lib; {
+    description = "Helm Charts (k8s applications) as Code tool";
+    homepage = "https://github.com/Praqma/helmsman";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lynty ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25278,6 +25278,8 @@ in
 
   helmfile = callPackage ../applications/networking/cluster/helmfile { };
 
+  helmsman = callPackage ../applications/networking/cluster/helmsman { };
+
   heptio-ark = callPackage ../applications/networking/cluster/heptio-ark { };
 
   hplip = callPackage ../misc/drivers/hplip { };


### PR DESCRIPTION
###### Motivation for this change

Adds https://github.com/Praqma/helmsman, a useful tool which allows you to automate the deployment/management of your Helm charts from version controlled code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
