### PR TITLE
openexr, imlbase: unbreak on macOS

### DIFF
--- a/pkgs/development/libraries/ilmbase/default.nix
+++ b/pkgs/development/libraries/ilmbase/default.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation rec {
     ./bootstrap
   '';
 
+  # otherwise, the pkgconfig info for the libraries will not match the filenames
+  configureFlags = stdenv.lib.optionalString stdenv.isDarwin "--enable-namespaceversioning=no";
+  
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ automake autoconf libtool which ];
 

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -42,6 +42,9 @@ stdenv.mkDerivation rec {
     ./bootstrap
   '';
 
+  # otherwise, the pkgconfig info for the libraries will not match the filenames
+  configureFlags = stdenv.lib.optionalString stdenv.isDarwin "--enable-namespaceversioning=no";
+
   nativeBuildInputs = [ pkgconfig autoconf automake libtool ];
   propagatedBuildInputs = [ ilmbase zlib ];
 


### PR DESCRIPTION
With the default configuration, the libraries are generated with a
-2_4.24.dylib suffix, and linking with -l...-2_4  doesn't work.  Pass
the configure option to turn off the suffix.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

openexr did not build on macOS, as it couldn't find the ilmbase libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
