### PR TITLE
tmuxinator: 1.1.4 -> 2.0.0

### DIFF
--- a/pkgs/tools/misc/tmuxinator/default.nix
+++ b/pkgs/tools/misc/tmuxinator/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildRubyGem, ruby }:
+{ lib, buildRubyGem, ruby, installShellFiles }:
 
 # Cannot use bundleEnv because bundleEnv create stub with
 # BUNDLE_FROZEN='1' environment variable set, which broke everything
@@ -36,6 +36,12 @@ buildRubyGem rec {
   };
 
   propagatedBuildInputs = [ erubis thor xdg ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion $GEM_HOME/gems/${gemName}-${version}/completion/tmuxinator.{bash,zsh,fish}
+  '';
 
   meta = with lib; {
     description = "Manage complex tmux sessions easily";

--- a/pkgs/tools/misc/tmuxinator/default.nix
+++ b/pkgs/tools/misc/tmuxinator/default.nix
@@ -8,8 +8,8 @@ buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "tmuxinator";
-  version = "1.1.4";
-  source.sha256 = "06ajfvsmq2040b7nk2ifih3sqxgwzih5j1d25nh4ilgjlrfmha98";
+  version = "2.0.0";
+  source.sha256 = "1q5z6f548138792mc7aksxdgngfgdsyf8s117b4flyb2hqgmv24b";
 
   erubis = buildRubyGem rec {
     inherit ruby;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/tmuxinator/tmuxinator/releases/tag/v1.1.5
https://github.com/tmuxinator/tmuxinator/releases/tag/v2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
