### PR TITLE
nixpkgs-fmt: fix erroneous debug output

### DIFF
--- a/pkgs/tools/nix/nixpkgs-fmt/default.nix
+++ b/pkgs/tools/nix/nixpkgs-fmt/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, rustPlatform, fetchFromGitHub, fetchpatch }:
 rustPlatform.buildRustPackage rec {
   pname = "nixpkgs-fmt";
   version = "0.8.0";
@@ -9,6 +9,15 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "09lhi8aidw9qf94n07mgs2nfac32a96wkx50glj35dhn06iwzwqr";
   };
+
+  patches = [
+    # Fixes debug output on stdout mangling some files. Fixed in next release.
+    # https://github.com/nix-community/nixpkgs-fmt/issues/201
+    (fetchpatch {
+      url = "https://github.com/nix-community/nixpkgs-fmt/commit/648f46e1d5507592b246311618f467da282bf1b5.patch";
+      sha256 = "18n4criyl0lydxmjqfkcmwx0pniyqzfgfxcjwz6czqwmx5y7b4rb";
+    })
+  ];
 
   cargoSha256 = "15m40d9354412h51zn806pxsqjai48xiw8chf8slbi0cjxd268j9";
 


### PR DESCRIPTION
Prior to this, when used in conjunction with e.g. `format-all-mode`,
garbage like

    node: NODE_STRING@[8934; 9139), indent: IndentLevel { level: 3, alignment: 0 }

would be written to the file.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
