### PR TITLE
[20.03] emacs: improve setup hook

### DIFF
--- a/pkgs/build-support/emacs/setup-hook.sh
+++ b/pkgs/build-support/emacs/setup-hook.sh
@@ -1,13 +1,25 @@
 addEmacsVars () {
-  if test -d $1/share/emacs/site-lisp; then
-      # it turns out, that the trailing : is actually required
+  for lispDir in \
+      "$1/share/emacs/site-lisp" \
+      "$1/share/emacs/site-lisp/"* \
+      "$1/share/emacs/site-lisp/elpa/"*; do
+    # Add the path to the Emacs load path if it is a directory
+    # containing .el files and it has not already been added to the
+    # load path.
+    if [[ -d $lispDir && "$(echo "$lispDir"/*.el)" && ${EMACSLOADPATH-} != *"$lispDir":* ]] ; then
+      # It turns out, that the trailing : is actually required
       # see https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Search.html
-      export EMACSLOADPATH="$1/share/emacs/site-lisp:${EMACSLOADPATH-}"
-  fi
+      export EMACSLOADPATH="$lispDir:${EMACSLOADPATH-}"
+    fi
+  done
 }
 
-# If this is for a wrapper derivation, emacs and the dependencies are all
-# run-time dependencies. If this is for precompiling packages into bytecode,
-# emacs is a compile-time dependency of the package.
-addEnvHooks "$hostOffset" addEmacsVars
-addEnvHooks "$targetOffset" addEmacsVars
+if [[ ! -v emacsHookDone ]]; then
+  emacsHookDone=1
+
+  # If this is for a wrapper derivation, emacs and the dependencies are all
+  # run-time dependencies. If this is for precompiling packages into bytecode,
+  # emacs is a compile-time dependency of the package.
+  addEnvHooks "$hostOffset" addEmacsVars
+  addEnvHooks "$targetOffset" addEmacsVars
+fi

--- a/pkgs/build-support/emacs/setup-hook.sh
+++ b/pkgs/build-support/emacs/setup-hook.sh
@@ -1,15 +1,23 @@
+addToEmacsLoadPath() {
+  local lispDir="$1"
+  if [[ -d $lispDir && ${EMACSLOADPATH-} != *"$lispDir":* ]] ; then
+    # It turns out, that the trailing : is actually required
+    # see https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Search.html
+    export EMACSLOADPATH="$lispDir:${EMACSLOADPATH-}"
+  fi
+}
+
 addEmacsVars () {
+  addToEmacsLoadPath "$1/share/emacs/site-lisp"
+
+  # Add sub paths to the Emacs load path if it is a directory
+  # containing .el files. This is necessary to build some packages,
+  # e.g., using trivialBuild.
   for lispDir in \
-      "$1/share/emacs/site-lisp" \
       "$1/share/emacs/site-lisp/"* \
       "$1/share/emacs/site-lisp/elpa/"*; do
-    # Add the path to the Emacs load path if it is a directory
-    # containing .el files and it has not already been added to the
-    # load path.
-    if [[ -d $lispDir && "$(echo "$lispDir"/*.el)" && ${EMACSLOADPATH-} != *"$lispDir":* ]] ; then
-      # It turns out, that the trailing : is actually required
-      # see https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Search.html
-      export EMACSLOADPATH="$lispDir:${EMACSLOADPATH-}"
+    if [[ -d $lispDir && "$(echo "$lispDir"/*.el)" ]] ; then
+      addToEmacsLoadPath "$lispDir"
     fi
   done
 }


### PR DESCRIPTION
###### Motivation for this change

This PR is a backport of @rycee 's two PRs to improve the emacs setup hooks:

- https://github.com/NixOS/nixpkgs/pull/82604
- https://github.com/NixOS/nixpkgs/pull/84044

These commits fix emacs packages with many dependencies, which currently fail to build in 20.03 (see https://github.com/NixOS/nixpkgs/issues/83230).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
