### PR TITLE
[20.03] skypeforlinux: 8.58.0.93 -> 8.59.0.77

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -7,7 +7,7 @@ let
 
   # Please keep the version x.y.0.z and do not update to x.y.76.z because the
   # source of the latter disappears much faster.
-  version = "8.58.0.93";
+  version = "8.59.0.77";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -64,7 +64,7 @@ let
           "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb"
           "https://web.archive.org/web/https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb"
         ];
-        sha256 = "1nqadil50z896jg0r202gw3xmm3diawn0pnh6n6nxn900f02avl3";
+        sha256 = "1cnlwlp84942ywji3x60zvhijavazdxfym3rfzq3ysky28b6mn6i";
       }
     else
       throw "Skype for linux is not supported on ${stdenv.hostPlatform.system}";

--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -62,6 +62,7 @@ let
       fetchurl {
         urls = [
           "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb"
+          "https://mirror.cs.uchicago.edu/skype/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb"
           "https://web.archive.org/web/https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb"
         ];
         sha256 = "1cnlwlp84942ywji3x60zvhijavazdxfym3rfzq3ysky28b6mn6i";


### PR DESCRIPTION


###### Motivation for this change
Backport of #86256
> Update to latest skype version.
> 
> In addition the university of chicago is added as an additional mirror to try to fetch
> the binary from. This reduces the change of #81868 and #85724 happening again in the
> future. This might also be a good candidate to backport to stable releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
