### PR TITLE
vscode-extensions.ms-vscode.cpptools: 0.27.0 -> 0.27.1

### DIFF
--- a/pkgs/misc/vscode-extensions/cpptools/default.nix
+++ b/pkgs/misc/vscode-extensions/cpptools/default.nix
@@ -33,39 +33,6 @@ assert gdbUseFixed -> null != gdb;
 let
   gdbDefaultsTo = if gdbUseFixed then "${gdb}/bin/gdb" else "gdb";
 
-  langComponentBinaries = stdenv.mkDerivation rec {
-    name = "cpptools-language-component-binaries";
-
-    src = fetchurl {
-      # Follow https://go.microsoft.com/fwlink/?linkid=2037608
-      url = "https://download.visualstudio.microsoft.com/download/pr/fd05d7fd-b771-4746-9c54-b5b30afcd82e/1f443716d6156a265bf50cb6e53fa999/bin_linux.zip";
-      sha256 = "198xnq709clibjmd8rrv0haniy2m3qvhn89hg9hpj6lvg9lsr7a4";
-    };
-
-    sourceRoot = name;
-
-    nativeBuildInputs = [ unzip ];
-
-    unpackPhase = ''
-      runHook preUnpack
-      unzip -d $name $src || true
-      runHook postUnpack
-    '';
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p "$out/bin"
-      cp -a -t "$out/bin" ./bin/*
-      runHook postInstall
-    '';
-
-    postFixup = ''
-      elfInterpreter="$(cat $NIX_CC/nix-support/dynamic-linker)"
-      patchelf --set-interpreter "$elfInterpreter" $out/bin/Microsoft.VSCode.CPP.Extension.linux
-      patchelf --set-interpreter "$elfInterpreter" $out/bin/Microsoft.VSCode.CPP.IntelliSense.Msvc.linux
-      chmod a+x $out/bin/Microsoft.VSCode.CPP.Extension.linux $out/bin/Microsoft.VSCode.CPP.IntelliSense.Msvc.linux
-    '';
-  };
 
   openDebugAD7Script = writeScript "OpenDebugAD7" ''
     #!${runtimeShell}
@@ -79,24 +46,33 @@ let
   '';
 in
 
-vscode-utils.buildVscodeMarketplaceExtension {
+vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "cpptools";
     publisher = "ms-vscode";
-    version = "0.27.0";
-    sha256 = "06l25fjlcj0m7f7883afbh0x2ikgkqi768kv8y4qi1jc1gxndpm0";
+    version = "0.27.1";
   };
+
+  vsix = fetchurl {
+    url = "https://github.com/microsoft/vscode-cpptools/releases/download/${mktplcRef.version}/cpptools-linux.vsix";
+    sha256 = "1if43zis2cy32c6y1zsh0ih0y2kpdag0flkb795b3m5iwm38rjsq";
+  };
+
+  unpackPhase = ''
+    unzip $src
+    cd extension
+  '';
 
   buildInputs = [
     jq
   ];
 
   postPatch = ''
-    mv ./package.json ./package_ori.json
+    mv ./package.json ./package_orig.json
 
     # 1. Add activation events so that the extension is functional. This listing is empty when unpacking the extension but is filled at runtime.
     # 2. Patch `package.json` so that nix's *gdb* is used as default value for `miDebuggerPath`.
-    cat ./package_ori.json | \
+    cat ./package_orig.json | \
       jq --slurpfile actEvts ${./package-activation-events.json} '(.activationEvents) = $actEvts[0]' | \
       jq '(.contributes.debuggers[].configurationAttributes | .attach , .launch | .properties.miDebuggerPath | select(. != null) | select(.default == "/usr/bin/gdb") | .default) = "${gdbDefaultsTo}"' > \
       ./package.json
@@ -104,19 +80,20 @@ vscode-utils.buildVscodeMarketplaceExtension {
     # Prevent download/install of extensions
     touch "./install.lock"
 
-    # Move unused files out of the way.
-    mv ./debugAdapters/bin/OpenDebugAD7.exe.config ./debugAdapters/bin/OpenDebugAD7.exe.config.unused
-
-    # Combining the language component binaries as part of our package.
-    find "${langComponentBinaries}/bin" -mindepth 1 -maxdepth 1 | xargs cp -p -t "./bin"
-
     # Mono runtimes from nix package (used by generated `OpenDebugAD7`).
-    rm "./debugAdapters/OpenDebugAD7"
+    mv ./debugAdapters/OpenDebugAD7 ./debugAdapters/OpenDebugAD7_orig
     cp -p "${openDebugAD7Script}" "./debugAdapters/OpenDebugAD7"
 
     # Clang-format from nix package.
-    mkdir -p "./LLVM"
+    mv  ./LLVM/ ./LLVM_orig
+    mkdir "./LLVM/"
     find "${clang-tools}" -mindepth 1 -maxdepth 1 | xargs ln -s -t "./LLVM"
+
+    # Patching  cpptools and cpptools-srv
+    elfInterpreter="$(cat $NIX_CC/nix-support/dynamic-linker)"
+    patchelf --set-interpreter "$elfInterpreter" ./bin/cpptools
+    patchelf --set-interpreter "$elfInterpreter" ./bin/cpptools-srv
+    chmod a+x ./bin/cpptools{-srv,}
   '';
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Previous version of package doesn't work. Complaining about missing cpptools binaries, probably cause by renaming binaries in [0.27.0](https://github.com/microsoft/vscode-cpptools/releases/tag/0.27.0) version.

Extension is now fetched from the Microsoft repository (instead of the marketplace). It also contains platform-specific binary dependencies. In the previous version they were fetched from the Microsoft website and additionally inserted to the final extension.

Package supports Linux, but there is probably a way no make it work on OSX.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
