### PR TITLE
gnomeExtensions.window-is-ready-remover: init at unstable-2020-03-25

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/window-is-ready-remover/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/window-is-ready-remover/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-window-is-ready-remover";
+  version = "unstable-2020-03-25";
+
+  src = fetchFromGitHub {
+    owner = "nunofarruca";
+    repo = "WindowIsReady_Remover";
+    rev = "a9f9b3a060a6ba8eec71332f39dc2569b6e93761";
+    sha256 = "0l6cg9kz2plbvsqhgwfajknzw9yv3mg9gxdbsk147gbh2arnp6v3";
+  };
+
+  uuid = "windowIsReady_Remover@nunofarruca@gmail.com";
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/
+    cp -r ${uuid} $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GNOME Shell extension removing window is ready notification";
+    homepage = "https://github.com/nunofarruca/WindowIsReady_Remover";
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24093,6 +24093,7 @@ in
     timepp = callPackage ../desktops/gnome-3/extensions/timepp { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
     window-corner-preview = callPackage ../desktops/gnome-3/extensions/window-corner-preview { };
+    window-is-ready-remover = callPackage ../desktops/gnome-3/extensions/window-is-ready-remover { };
     workspace-matrix = callPackage ../desktops/gnome-3/extensions/workspace-matrix { };
 
     nohotcorner = throw "gnomeExtensions.nohotcorner removed since 2019-10-09: Since 3.34, it is a part of GNOME Shell configurable through GNOME Tweaks.";


### PR DESCRIPTION
###### Motivation for this change 

Window Is Ready - Notification Remover.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
