### PR TITLE
systemd: 245.3 -> 245.5

### DIFF
--- a/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
+++ b/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -1,7 +1,7 @@
-From a6c9317a905ef478b8e0d3dad263990feb5d11cb Mon Sep 17 00:00:00 2001
+From 7900e82a60e22354ab2b1c71f4664c1e2357ab23 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Tue, 8 Jan 2013 15:46:30 +0100
-Subject: [PATCH 01/27] Start device units for uninitialised encrypted devices
+Subject: [PATCH 01/18] Start device units for uninitialised encrypted devices
 
 This is necessary because the NixOS service that initialises the
 filesystem depends on the appearance of the device unit.  Also, this
@@ -28,5 +28,5 @@ index c34b606216..3ab8c1c3fe 100644
  SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="gpt-auto-root"
  SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="gpt-auto-root-luks"
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
+++ b/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -1,4 +1,4 @@
-From 7900e82a60e22354ab2b1c71f4664c1e2357ab23 Mon Sep 17 00:00:00 2001
+From b873e4c0de3e24f2ec9370e5a217247217e90587 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Tue, 8 Jan 2013 15:46:30 +0100
 Subject: [PATCH 01/18] Start device units for uninitialised encrypted devices

--- a/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+++ b/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
@@ -1,21 +1,21 @@
-From fd9c882581877eef8ba1b34a9502a1ff546b3833 Mon Sep 17 00:00:00 2001
+From 1e2f2f80e106910bbf3fd27438b794937ff3a1a8 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 12 Apr 2013 13:16:57 +0200
-Subject: [PATCH 03/27] Don't try to unmount /nix or /nix/store
+Subject: [PATCH 02/18] Don't try to unmount /nix or /nix/store
 
 They'll still be remounted read-only.
 
 https://github.com/NixOS/nixos/issues/126
 ---
- src/core/mount.c      | 4 +++-
+ src/core/mount.c      | 2 ++
  src/shutdown/umount.c | 2 ++
- 2 files changed, 5 insertions(+), 1 deletion(-)
+ 2 files changed, 4 insertions(+)
 
 diff --git a/src/core/mount.c b/src/core/mount.c
-index a0dfa6a1a7..4ca6adcdc6 100644
+index 1c4aefd734..a5553226f8 100644
 --- a/src/core/mount.c
 +++ b/src/core/mount.c
-@@ -414,6 +414,8 @@ static bool mount_is_extrinsic(Mount *m) {
+@@ -412,6 +412,8 @@ static bool mount_is_extrinsic(Mount *m) {
  
          if (PATH_IN_SET(m->where,  /* Don't bother with the OS data itself */
                          "/",       /* (strictly speaking redundant: should already be covered by the perpetual flag check above) */
@@ -25,10 +25,10 @@ index a0dfa6a1a7..4ca6adcdc6 100644
                          "/etc"))
                  return true;
 diff --git a/src/shutdown/umount.c b/src/shutdown/umount.c
-index 2d07d3d6c1..8b112f464e 100644
+index 8a5e80eeaa..fab35ed6f3 100644
 --- a/src/shutdown/umount.c
 +++ b/src/shutdown/umount.c
-@@ -373,6 +373,8 @@ static int delete_dm(dev_t devnum) {
+@@ -414,6 +414,8 @@ static int delete_dm(dev_t devnum) {
  
  static bool nonunmountable_path(const char *path) {
          return path_equal(path, "/")
@@ -38,5 +38,5 @@ index 2d07d3d6c1..8b112f464e 100644
                  || path_equal(path, "/usr")
  #endif
 -- 
-2.25.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+++ b/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
@@ -1,4 +1,4 @@
-From 1e2f2f80e106910bbf3fd27438b794937ff3a1a8 Mon Sep 17 00:00:00 2001
+From bdd3ff777dd8253ff5732118dd6de0fa9a9b95fe Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 12 Apr 2013 13:16:57 +0200
 Subject: [PATCH 02/18] Don't try to unmount /nix or /nix/store

--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -1,7 +1,7 @@
-From 58c4a7b4e9d9c34b92deded6aea814738821059d Mon Sep 17 00:00:00 2001
+From 1ff6f3a4250240e1ba56861e31819fe3c5516844 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Wed, 16 Apr 2014 10:59:28 +0200
-Subject: [PATCH 04/27] Fix NixOS containers
+Subject: [PATCH 03/18] Fix NixOS containers
 
 In NixOS containers, the init script is bind-mounted into the
 container, so checking early whether it exists will fail.
@@ -10,10 +10,10 @@ container, so checking early whether it exists will fail.
  1 file changed, 2 insertions(+)
 
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 5d9290b1cf..26615901c3 100644
+index 734dee1130..a97b1a4bc9 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -4924,6 +4924,7 @@ static int run(int argc, char *argv[]) {
+@@ -5018,6 +5018,7 @@ static int run(int argc, char *argv[]) {
                                  goto finish;
                          }
                  } else {
@@ -21,7 +21,7 @@ index 5d9290b1cf..26615901c3 100644
                          const char *p, *q;
  
                          if (arg_pivot_root_new)
-@@ -4938,6 +4939,7 @@ static int run(int argc, char *argv[]) {
+@@ -5032,6 +5033,7 @@ static int run(int argc, char *argv[]) {
                                  r = -EINVAL;
                                  goto finish;
                          }
@@ -30,5 +30,5 @@ index 5d9290b1cf..26615901c3 100644
  
          } else {
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -1,4 +1,4 @@
-From 1ff6f3a4250240e1ba56861e31819fe3c5516844 Mon Sep 17 00:00:00 2001
+From c28b3b2e254433e93549ee6fe8c93b43ce455776 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Wed, 16 Apr 2014 10:59:28 +0200
 Subject: [PATCH 03/18] Fix NixOS containers

--- a/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
+++ b/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
@@ -1,4 +1,4 @@
-From 9cc4c2f4fd5d082aa039073a3620df536261100a Mon Sep 17 00:00:00 2001
+From baf52609ad18785aa1d2cd043185ae9438d59411 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Thu, 1 May 2014 14:10:10 +0200
 Subject: [PATCH 04/18] Look for fsck in the right place

--- a/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
+++ b/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
@@ -1,17 +1,17 @@
-From c841ffab8fb6174b51382b9d4334f78c74018730 Mon Sep 17 00:00:00 2001
+From 9cc4c2f4fd5d082aa039073a3620df536261100a Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Thu, 1 May 2014 14:10:10 +0200
-Subject: [PATCH 06/27] Look for fsck in the right place
+Subject: [PATCH 04/18] Look for fsck in the right place
 
 ---
  src/fsck/fsck.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/fsck/fsck.c b/src/fsck/fsck.c
-index 55e6544d31..3626aadda7 100644
+index 80f7107b9d..74e48a385f 100644
 --- a/src/fsck/fsck.c
 +++ b/src/fsck/fsck.c
-@@ -371,7 +371,7 @@ static int run(int argc, char *argv[]) {
+@@ -370,7 +370,7 @@ static int run(int argc, char *argv[]) {
                  } else
                          dash_c[0] = 0;
  
@@ -21,5 +21,5 @@ index 55e6544d31..3626aadda7 100644
                  cmdline[i++] = "-T";
  
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
+++ b/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
@@ -1,12 +1,12 @@
-From a036a1754104df9b9f7d9b3787840a83b06d0c18 Mon Sep 17 00:00:00 2001
+From 45f80155b7c2edb1e73c233283f1ab1582e1cfbe Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 19 Dec 2014 14:46:17 +0100
 Subject: [PATCH 05/18] Add some NixOS-specific unit directories
 
-Look in /nix/var/nix/profiles/default/lib/systemd for units provided
-by packages in the default (system-wide) profile, and in
-/etc/systemd-mutable/system for persistent, mutable units (not
-recommended).
+Look in `/nix/var/nix/profiles/default/lib/systemd` for units provided
+by packages installed into the default profile via
+`nix-env -iA nixos.$package`, and into `/etc/systemd-mutable/system` for
+persistent, mutable units (used for Dysnomia).
 
 Also, remove /usr and /lib as these don't exist on NixOS.
 ---
@@ -30,7 +30,7 @@ index 8331832c7a..bedb97115d 100644
  systemdusergeneratordir=${prefix}/lib/systemd/user-generators
  systemdsystemgeneratorpath=/run/systemd/system-generators:/etc/systemd/system-generators:/usr/local/lib/systemd/system-generators:${systemdsystemgeneratordir}
 diff --git a/src/shared/path-lookup.c b/src/shared/path-lookup.c
-index 5b16209745..13c0a57637 100644
+index 48e0eec09a..a9d38f16d0 100644
 --- a/src/shared/path-lookup.c
 +++ b/src/shared/path-lookup.c
 @@ -98,17 +98,14 @@ int xdg_user_data_dir(char **ret, const char *suffix) {
@@ -52,7 +52,7 @@ index 5b16209745..13c0a57637 100644
          NULL
  };
  
-@@ -603,15 +600,14 @@ int lookup_paths_init(
+@@ -604,15 +601,14 @@ int lookup_paths_init(
                                          persistent_config,
                                          SYSTEM_CONFIG_UNIT_PATH,
                                          "/etc/systemd/system",
@@ -70,7 +70,7 @@ index 5b16209745..13c0a57637 100644
                                          STRV_IFNOTNULL(generator_late));
                          break;
  
-@@ -627,14 +623,12 @@ int lookup_paths_init(
+@@ -628,14 +624,12 @@ int lookup_paths_init(
                                          persistent_config,
                                          USER_CONFIG_UNIT_PATH,
                                          "/etc/systemd/user",
@@ -87,7 +87,7 @@ index 5b16209745..13c0a57637 100644
                                          STRV_IFNOTNULL(generator_late));
                          break;
  
-@@ -823,14 +817,12 @@ char **generator_binary_paths(UnitFileScope scope) {
+@@ -824,14 +818,12 @@ char **generator_binary_paths(UnitFileScope scope) {
          case UNIT_FILE_SYSTEM:
                  return strv_new("/run/systemd/system-generators",
                                  "/etc/systemd/system-generators",

--- a/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
+++ b/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
@@ -1,7 +1,7 @@
-From 8c0be07ccbad35d0c1106015057996aa55b9a1f9 Mon Sep 17 00:00:00 2001
+From a036a1754104df9b9f7d9b3787840a83b06d0c18 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 19 Dec 2014 14:46:17 +0100
-Subject: [PATCH 07/27] Add some NixOS-specific unit directories
+Subject: [PATCH 05/18] Add some NixOS-specific unit directories
 
 Look in /nix/var/nix/profiles/default/lib/systemd for units provided
 by packages in the default (system-wide) profile, and in
@@ -15,7 +15,7 @@ Also, remove /usr and /lib as these don't exist on NixOS.
  2 files changed, 7 insertions(+), 15 deletions(-)
 
 diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
-index 5d1ddd7620..21b977d6fc 100644
+index 8331832c7a..bedb97115d 100644
 --- a/src/core/systemd.pc.in
 +++ b/src/core/systemd.pc.in
 @@ -17,8 +17,8 @@ systemduserunitdir=${prefix}/lib/systemd/user
@@ -28,12 +28,12 @@ index 5d1ddd7620..21b977d6fc 100644
 +systemduserunitpath=${systemduserconfdir}:/etc/systemd/user:/etc/systemd-mutable/user:/nix/var/nix/profiles/default/lib/systemd/system:/run/systemd/user:${systemduserunitdir}
  systemdsystemgeneratordir=${rootprefix}/lib/systemd/system-generators
  systemdusergeneratordir=${prefix}/lib/systemd/user-generators
- systemdsleepdir=${rootprefix}/lib/systemd/system-sleep
+ systemdsystemgeneratorpath=/run/systemd/system-generators:/etc/systemd/system-generators:/usr/local/lib/systemd/system-generators:${systemdsystemgeneratordir}
 diff --git a/src/shared/path-lookup.c b/src/shared/path-lookup.c
-index 6bf0ff0316..2b6324ad8c 100644
+index 5b16209745..13c0a57637 100644
 --- a/src/shared/path-lookup.c
 +++ b/src/shared/path-lookup.c
-@@ -99,17 +99,14 @@ int xdg_user_data_dir(char **ret, const char *suffix) {
+@@ -98,17 +98,14 @@ int xdg_user_data_dir(char **ret, const char *suffix) {
  }
  
  static const char* const user_data_unit_paths[] = {
@@ -52,7 +52,7 @@ index 6bf0ff0316..2b6324ad8c 100644
          NULL
  };
  
-@@ -604,15 +601,14 @@ int lookup_paths_init(
+@@ -603,15 +600,14 @@ int lookup_paths_init(
                                          persistent_config,
                                          SYSTEM_CONFIG_UNIT_PATH,
                                          "/etc/systemd/system",
@@ -70,7 +70,7 @@ index 6bf0ff0316..2b6324ad8c 100644
                                          STRV_IFNOTNULL(generator_late));
                          break;
  
-@@ -628,14 +624,12 @@ int lookup_paths_init(
+@@ -627,14 +623,12 @@ int lookup_paths_init(
                                          persistent_config,
                                          USER_CONFIG_UNIT_PATH,
                                          "/etc/systemd/user",
@@ -87,7 +87,7 @@ index 6bf0ff0316..2b6324ad8c 100644
                                          STRV_IFNOTNULL(generator_late));
                          break;
  
-@@ -824,14 +818,12 @@ char **generator_binary_paths(UnitFileScope scope) {
+@@ -823,14 +817,12 @@ char **generator_binary_paths(UnitFileScope scope) {
          case UNIT_FILE_SYSTEM:
                  return strv_new("/run/systemd/system-generators",
                                  "/etc/systemd/system-generators",
@@ -103,5 +103,5 @@ index 6bf0ff0316..2b6324ad8c 100644
  
          default:
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
+++ b/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
@@ -1,7 +1,7 @@
-From 99c86daa5244d45a19f75f6ce92bd4255edef420 Mon Sep 17 00:00:00 2001
+From d96e5224001ea437549eae7b00173b61d459209e Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Mon, 11 May 2015 15:39:38 +0200
-Subject: [PATCH 09/27] Get rid of a useless message in user sessions
+Subject: [PATCH 06/18] Get rid of a useless message in user sessions
 
 Namely lots of variants of
 
@@ -13,10 +13,10 @@ in containers.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/core/unit.c b/src/core/unit.c
-index a1dc76aa6a..07670af8e2 100644
+index 2816bcef55..0e5102a28c 100644
 --- a/src/core/unit.c
 +++ b/src/core/unit.c
-@@ -2045,7 +2045,8 @@ static void unit_check_binds_to(Unit *u) {
+@@ -2043,7 +2043,8 @@ static void unit_check_binds_to(Unit *u) {
          }
  
          assert(other);
@@ -27,5 +27,5 @@ index a1dc76aa6a..07670af8e2 100644
          /* A unit we need to run is gone. Sniff. Let's stop this. */
          r = manager_add_job(u->manager, JOB_STOP, u, JOB_FAIL, NULL, &error, NULL);
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
+++ b/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
@@ -1,4 +1,4 @@
-From d96e5224001ea437549eae7b00173b61d459209e Mon Sep 17 00:00:00 2001
+From d52058070c0c12bb05f82460f0b4b55678b724e9 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Mon, 11 May 2015 15:39:38 +0200
 Subject: [PATCH 06/18] Get rid of a useless message in user sessions
@@ -13,7 +13,7 @@ in containers.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/core/unit.c b/src/core/unit.c
-index 2816bcef55..0e5102a28c 100644
+index 97e1b0004c..d3cc2ba9ec 100644
 --- a/src/core/unit.c
 +++ b/src/core/unit.c
 @@ -2043,7 +2043,8 @@ static void unit_check_binds_to(Unit *u) {

--- a/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
+++ b/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
@@ -1,4 +1,4 @@
-From 23d17b5f60d9b494ee8b7399350478d24e91e460 Mon Sep 17 00:00:00 2001
+From 409fc808794942ad1736c2cc74853d9792e4ad02 Mon Sep 17 00:00:00 2001
 From: Gabriel Ebner <gebner@gebner.org>
 Date: Sun, 6 Dec 2015 14:26:36 +0100
 Subject: [PATCH 07/18] hostnamed, localed, timedated: disable methods that

--- a/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
+++ b/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
@@ -1,7 +1,7 @@
-From cec1430f72edfedb951fe34e87765ef422ea9843 Mon Sep 17 00:00:00 2001
+From 23d17b5f60d9b494ee8b7399350478d24e91e460 Mon Sep 17 00:00:00 2001
 From: Gabriel Ebner <gebner@gebner.org>
 Date: Sun, 6 Dec 2015 14:26:36 +0100
-Subject: [PATCH 10/27] hostnamed, localed, timedated: disable methods that
+Subject: [PATCH 07/18] hostnamed, localed, timedated: disable methods that
  change system settings.
 
 ---
@@ -11,10 +11,10 @@ Subject: [PATCH 10/27] hostnamed, localed, timedated: disable methods that
  3 files changed, 28 insertions(+)
 
 diff --git a/src/hostname/hostnamed.c b/src/hostname/hostnamed.c
-index 9e4f4fb59e..141b8acc08 100644
+index 21f6471495..8c5af7619f 100644
 --- a/src/hostname/hostnamed.c
 +++ b/src/hostname/hostnamed.c
-@@ -423,6 +423,9 @@ static int method_set_hostname(sd_bus_message *m, void *userdata, sd_bus_error *
+@@ -422,6 +422,9 @@ static int method_set_hostname(sd_bus_message *m, void *userdata, sd_bus_error *
          if (r < 0)
                  return r;
  
@@ -24,7 +24,7 @@ index 9e4f4fb59e..141b8acc08 100644
          if (isempty(name))
                  name = c->data[PROP_STATIC_HOSTNAME];
  
-@@ -479,6 +482,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
+@@ -478,6 +481,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
          if (r < 0)
                  return r;
  
@@ -34,7 +34,7 @@ index 9e4f4fb59e..141b8acc08 100644
          name = empty_to_null(name);
  
          if (streq_ptr(name, c->data[PROP_STATIC_HOSTNAME]))
-@@ -536,6 +542,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
+@@ -535,6 +541,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
          if (r < 0)
                  return r;
  
@@ -45,10 +45,10 @@ index 9e4f4fb59e..141b8acc08 100644
  
          if (streq_ptr(name, c->data[prop]))
 diff --git a/src/locale/localed.c b/src/locale/localed.c
-index 8d0eec96a5..0b1c1d664e 100644
+index 09f16d25f4..c1cb87cef1 100644
 --- a/src/locale/localed.c
 +++ b/src/locale/localed.c
-@@ -276,6 +276,9 @@ static int method_set_locale(sd_bus_message *m, void *userdata, sd_bus_error *er
+@@ -275,6 +275,9 @@ static int method_set_locale(sd_bus_message *m, void *userdata, sd_bus_error *er
          if (r < 0)
                  return r;
  
@@ -58,7 +58,7 @@ index 8d0eec96a5..0b1c1d664e 100644
          /* If single locale without variable name is provided, then we assume it is LANG=. */
          if (strv_length(l) == 1 && !strchr(*l, '=')) {
                  if (!locale_is_valid(*l))
-@@ -411,6 +414,9 @@ static int method_set_vc_keyboard(sd_bus_message *m, void *userdata, sd_bus_erro
+@@ -410,6 +413,9 @@ static int method_set_vc_keyboard(sd_bus_message *m, void *userdata, sd_bus_erro
          if (r < 0)
                  return r;
  
@@ -68,7 +68,7 @@ index 8d0eec96a5..0b1c1d664e 100644
          keymap = empty_to_null(keymap);
          keymap_toggle = empty_to_null(keymap_toggle);
  
-@@ -587,6 +593,9 @@ static int method_set_x11_keyboard(sd_bus_message *m, void *userdata, sd_bus_err
+@@ -586,6 +592,9 @@ static int method_set_x11_keyboard(sd_bus_message *m, void *userdata, sd_bus_err
          if (r < 0)
                  return r;
  
@@ -79,10 +79,10 @@ index 8d0eec96a5..0b1c1d664e 100644
          model = empty_to_null(model);
          variant = empty_to_null(variant);
 diff --git a/src/timedate/timedated.c b/src/timedate/timedated.c
-index 6c94b23de4..fa20d22cde 100644
+index 5e2fb50d83..63865f557c 100644
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
-@@ -653,6 +653,10 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
+@@ -652,6 +652,10 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
          if (r < 0)
                  return r;
  
@@ -93,7 +93,7 @@ index 6c94b23de4..fa20d22cde 100644
          if (!timezone_is_valid(z, LOG_DEBUG))
                  return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Invalid or not installed time zone '%s'", z);
  
-@@ -732,6 +736,9 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error
+@@ -731,6 +735,9 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error
          if (r < 0)
                  return r;
  
@@ -103,7 +103,7 @@ index 6c94b23de4..fa20d22cde 100644
          if (lrtc == c->local_rtc)
                  return sd_bus_reply_method_return(m, NULL);
  
-@@ -924,6 +931,9 @@ static int method_set_ntp(sd_bus_message *m, void *userdata, sd_bus_error *error
+@@ -923,6 +930,9 @@ static int method_set_ntp(sd_bus_message *m, void *userdata, sd_bus_error *error
          if (r < 0)
                  return r;
  
@@ -114,5 +114,5 @@ index 6c94b23de4..fa20d22cde 100644
          if (r < 0)
                  return r;
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
@@ -1,7 +1,7 @@
-From 0f434c6baee63eff913f36aee839df3718a75d4a Mon Sep 17 00:00:00 2001
+From e827145cf4390cf926897f591f0105b43e6fc3e2 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 7 Jul 2016 02:47:13 +0300
-Subject: [PATCH 11/27] Fix hwdb paths
+Subject: [PATCH 08/18] Fix hwdb paths
 
 Patch by vcunat.
 ---
@@ -9,10 +9,10 @@ Patch by vcunat.
  1 file changed, 1 insertion(+), 6 deletions(-)
 
 diff --git a/src/libsystemd/sd-hwdb/sd-hwdb.c b/src/libsystemd/sd-hwdb/sd-hwdb.c
-index 58124abd21..d80e408b8c 100644
+index b3febdbb31..eba00a5bc7 100644
 --- a/src/libsystemd/sd-hwdb/sd-hwdb.c
 +++ b/src/libsystemd/sd-hwdb/sd-hwdb.c
-@@ -298,13 +298,8 @@ static int trie_search_f(sd_hwdb *hwdb, const char *search) {
+@@ -297,13 +297,8 @@ static int trie_search_f(sd_hwdb *hwdb, const char *search) {
  }
  
  static const char hwdb_bin_paths[] =
@@ -28,5 +28,5 @@ index 58124abd21..d80e408b8c 100644
  _public_ int sd_hwdb_new(sd_hwdb **ret) {
          _cleanup_(sd_hwdb_unrefp) sd_hwdb *hwdb = NULL;
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
@@ -1,4 +1,4 @@
-From e827145cf4390cf926897f591f0105b43e6fc3e2 Mon Sep 17 00:00:00 2001
+From b56fc7b6ae8014eb2f71924c89498f395a1a81bd Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 7 Jul 2016 02:47:13 +0300
 Subject: [PATCH 08/18] Fix hwdb paths

--- a/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -1,7 +1,7 @@
-From 78479b75c9f9342646223b3db6b4b0744817dc24 Mon Sep 17 00:00:00 2001
+From 5da944d33a915222509ecd73c69fe7ae8917334f Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Tue, 11 Oct 2016 13:12:08 +0300
-Subject: [PATCH] Change /usr/share/zoneinfo to /etc/zoneinfo
+Subject: [PATCH 09/18] Change /usr/share/zoneinfo to /etc/zoneinfo
 
 NixOS uses this path.
 ---
@@ -66,10 +66,10 @@ index 105584e2e7..5238f69931 100644
                  return -EINVAL;
  
 diff --git a/src/firstboot/firstboot.c b/src/firstboot/firstboot.c
-index 528e6452cf..c712ca9072 100644
+index 901fbf0815..b57bdd8fbe 100644
 --- a/src/firstboot/firstboot.c
 +++ b/src/firstboot/firstboot.c
-@@ -443,7 +443,7 @@ static int process_timezone(void) {
+@@ -431,7 +431,7 @@ static int process_timezone(void) {
          if (isempty(arg_timezone))
                  return 0;
  
@@ -79,10 +79,10 @@ index 528e6452cf..c712ca9072 100644
          (void) mkdir_parents(etc_localtime, 0755);
          if (symlink(e, etc_localtime) < 0)
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 873a76596f..a024b10f32 100644
+index a97b1a4bc9..aed60439e3 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -1642,8 +1642,8 @@ static int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t u
+@@ -1657,8 +1657,8 @@ static int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t u
  static const char *timezone_from_path(const char *path) {
          return PATH_STARTSWITH_SET(
                          path,
@@ -94,7 +94,7 @@ index 873a76596f..a024b10f32 100644
  
  static bool etc_writable(void) {
 diff --git a/src/timedate/timedated.c b/src/timedate/timedated.c
-index 5e2fb50d83..02eb2ca11d 100644
+index 63865f557c..8021a8b753 100644
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
 @@ -264,7 +264,7 @@ static int context_read_data(Context *c) {
@@ -128,5 +128,5 @@ index 5e2fb50d83..02eb2ca11d 100644
                          return -ENOMEM;
  
 -- 
-2.25.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -1,4 +1,4 @@
-From 5da944d33a915222509ecd73c69fe7ae8917334f Mon Sep 17 00:00:00 2001
+From 4d304a321796db4de827aa39a149bea23d039214 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Tue, 11 Oct 2016 13:12:08 +0300
 Subject: [PATCH 09/18] Change /usr/share/zoneinfo to /etc/zoneinfo

--- a/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
+++ b/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
@@ -1,4 +1,4 @@
-From d5637ccec3c32919e8aef2dc59b97fdbe3923ba1 Mon Sep 17 00:00:00 2001
+From cb3f1ec1793cbf74c4b5663e038bd49ff4576192 Mon Sep 17 00:00:00 2001
 From: Imuli <i@imu.li>
 Date: Wed, 19 Oct 2016 08:46:47 -0400
 Subject: [PATCH 10/18] localectl: use /etc/X11/xkb for list-x11-*

--- a/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
+++ b/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
@@ -1,7 +1,7 @@
-From 5365ffbfba2de03628e8bbb6cc0bc022272436a1 Mon Sep 17 00:00:00 2001
+From d5637ccec3c32919e8aef2dc59b97fdbe3923ba1 Mon Sep 17 00:00:00 2001
 From: Imuli <i@imu.li>
 Date: Wed, 19 Oct 2016 08:46:47 -0400
-Subject: [PATCH 13/27] localectl: use /etc/X11/xkb for list-x11-*
+Subject: [PATCH 10/18] localectl: use /etc/X11/xkb for list-x11-*
 
 NixOS has an option to link the xkb data files to /etc/X11, but not to
 /usr/share/X11.
@@ -10,10 +10,10 @@ NixOS has an option to link the xkb data files to /etc/X11, but not to
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/locale/localectl.c b/src/locale/localectl.c
-index 9fb5152110..9554c2cf76 100644
+index 6f2d37d222..7aa2310d48 100644
 --- a/src/locale/localectl.c
 +++ b/src/locale/localectl.c
-@@ -287,7 +287,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
+@@ -286,7 +286,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
          } state = NONE, look_for;
          int r;
  
@@ -23,5 +23,5 @@ index 9fb5152110..9554c2cf76 100644
                  return log_error_errno(errno, "Failed to open keyboard mapping list. %m");
  
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
+++ b/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
@@ -1,4 +1,4 @@
-From f488835c587d79ba824302a8933b47a83ddc2d57 Mon Sep 17 00:00:00 2001
+From 0ffb786d0e12a61899af448b1e4dd32a53ea5a8e Mon Sep 17 00:00:00 2001
 From: Franz Pletz <fpletz@fnordicwalking.de>
 Date: Sun, 11 Feb 2018 04:37:44 +0100
 Subject: [PATCH 11/18] build: don't create statedir and don't touch prefixdir

--- a/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
+++ b/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
@@ -1,17 +1,17 @@
-From 1408762890aba25e58598d1e4dfa17ed2b75de26 Mon Sep 17 00:00:00 2001
+From f488835c587d79ba824302a8933b47a83ddc2d57 Mon Sep 17 00:00:00 2001
 From: Franz Pletz <fpletz@fnordicwalking.de>
 Date: Sun, 11 Feb 2018 04:37:44 +0100
-Subject: [PATCH 16/27] build: don't create statedir and don't touch prefixdir
+Subject: [PATCH 11/18] build: don't create statedir and don't touch prefixdir
 
 ---
  meson.build | 3 ---
  1 file changed, 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 8ccc947e37..263cc7189a 100644
+index fc216d22da..078db3bb5d 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2944,9 +2944,6 @@ install_data('LICENSE.GPL2',
+@@ -3176,9 +3176,6 @@ install_data('LICENSE.GPL2',
               'src/libsystemd/sd-bus/GVARIANT-SERIALIZATION',
               install_dir : docdir)
  
@@ -22,5 +22,5 @@ index 8ccc947e37..263cc7189a 100644
  
  meson_check_help = find_program('tools/meson-check-help.sh')
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
+++ b/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
@@ -1,4 +1,4 @@
-From be87849145bc50ab0b16c63fe2b748de13974f0e Mon Sep 17 00:00:00 2001
+From 3dbcdab1ba22c4eeca6d61718c09bcb9b5551764 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Mon, 26 Feb 2018 14:25:57 +0000
 Subject: [PATCH 12/18] Install default configuration into $out/share/factory

--- a/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
+++ b/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
@@ -1,7 +1,7 @@
-From a087cb535b2d3c7a5d989b5aabc0a257369e9f9d Mon Sep 17 00:00:00 2001
+From be87849145bc50ab0b16c63fe2b748de13974f0e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Mon, 26 Feb 2018 14:25:57 +0000
-Subject: [PATCH 18/27] Install default configuration into $out/share/factory
+Subject: [PATCH 12/18] Install default configuration into $out/share/factory
 
 By default systemd should read all its configuration from /etc. Therefor
 we rely on -Dsysconfdir=/etc in meson as default value. Unfortunately
@@ -11,7 +11,7 @@ this commit introduces two new configuration variables `factoryconfdir`
 and `factorypkgconfdir` to install systemd's own configuration into nix
 store again, while having executables looking up files in /etc.
 ---
- hwdb.d/meson.build               |  2 +-
+ hwdb.d/meson.build             |  2 +-
  meson.build                    | 11 +++++++----
  network/meson.build            |  2 +-
  src/core/meson.build           | 10 +++++-----
@@ -27,14 +27,14 @@ store again, while having executables looking up files in /etc.
  src/udev/meson.build           |  4 ++--
  sysctl.d/meson.build           |  2 +-
  tmpfiles.d/meson.build         |  2 +-
- units/meson.build              |  3 ++-
- 17 files changed, 30 insertions(+), 26 deletions(-)
+ units/meson.build              |  2 +-
+ 17 files changed, 29 insertions(+), 26 deletions(-)
 
 diff --git a/hwdb.d/meson.build b/hwdb.d/meson.build
-index badf39f555..8fd9c7639f 100644
+index 4df6dabf89..02d8d69095 100644
 --- a/hwdb.d/meson.build
 +++ b/hwdb.d/meson.build
-@@ -26,7 +26,7 @@ if conf.get('ENABLE_HWDB') == 1
+@@ -27,7 +27,7 @@ if conf.get('ENABLE_HWDB') == 1
                       install_dir : udevhwdbdir)
  
          meson.add_install_script('sh', '-c',
@@ -43,15 +43,11 @@ index badf39f555..8fd9c7639f 100644
  
          meson.add_install_script('sh', '-c',
                                   'test -n "$DESTDIR" || @0@/systemd-hwdb update'
-                                  .format(rootbindir))
- endif
- 
- ############################################################
 diff --git a/meson.build b/meson.build
-index 263cc7189a..7a67078208 100644
+index 078db3bb5d..6e1a6483fc 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -151,6 +151,9 @@ udevhwdbdir = join_paths(udevlibexecdir, 'hwdb.d')
+@@ -154,6 +154,9 @@ udevhwdbdir = join_paths(udevlibexecdir, 'hwdb.d')
  catalogdir = join_paths(prefixdir, 'lib/systemd/catalog')
  kernelinstalldir = join_paths(prefixdir, 'lib/kernel/install.d')
  factorydir = join_paths(datadir, 'factory')
@@ -61,7 +57,7 @@ index 263cc7189a..7a67078208 100644
  bootlibdir = join_paths(prefixdir, 'lib/systemd/boot/efi')
  testsdir = join_paths(prefixdir, 'lib/systemd/tests')
  systemdstatedir = join_paths(localstatedir, 'lib/systemd')
-@@ -2287,7 +2290,7 @@ if conf.get('ENABLE_BINFMT') == 1
+@@ -2503,7 +2506,7 @@ if conf.get('ENABLE_BINFMT') == 1
          meson.add_install_script('sh', '-c',
                                   mkdir_p.format(binfmtdir))
          meson.add_install_script('sh', '-c',
@@ -69,8 +65,8 @@ index 263cc7189a..7a67078208 100644
 +                                 mkdir_p.format(join_paths(factoryconfdir, 'binfmt.d')))
  endif
  
- if conf.get('ENABLE_VCONSOLE') == 1
-@@ -2373,7 +2376,7 @@ executable('systemd-sleep',
+ if conf.get('ENABLE_REPART') == 1
+@@ -2604,7 +2607,7 @@ executable('systemd-sleep',
             install_dir : rootlibexecdir)
  
  install_data('src/sleep/sleep.conf',
@@ -79,7 +75,7 @@ index 263cc7189a..7a67078208 100644
  
  exe = executable('systemd-sysctl',
                   'src/sysctl/sysctl.c',
-@@ -2685,7 +2688,7 @@ if conf.get('HAVE_KMOD') == 1
+@@ -2916,7 +2919,7 @@ if conf.get('HAVE_KMOD') == 1
          meson.add_install_script('sh', '-c',
                                   mkdir_p.format(modulesloaddir))
          meson.add_install_script('sh', '-c',
@@ -88,7 +84,7 @@ index 263cc7189a..7a67078208 100644
  endif
  
  exe = executable('systemd-nspawn',
-@@ -2927,7 +2930,7 @@ install_subdir('factory/etc',
+@@ -3159,7 +3162,7 @@ install_subdir('factory/etc',
                 install_dir : factorydir)
  
  install_data('xorg/50-systemd-user.sh',
@@ -98,10 +94,10 @@ index 263cc7189a..7a67078208 100644
               install_dir : modprobedir)
  install_data('LICENSE.GPL2',
 diff --git a/network/meson.build b/network/meson.build
-index 59d4be1a17..72da2c16a2 100644
+index 544dcf4387..1828c50863 100644
 --- a/network/meson.build
 +++ b/network/meson.build
-@@ -7,7 +7,7 @@ if conf.get('ENABLE_NETWORKD') == 1
+@@ -10,7 +10,7 @@ if conf.get('ENABLE_NETWORKD') == 1
                       install_dir : networkdir)
  
          meson.add_install_script('sh', '-c',
@@ -111,7 +107,7 @@ index 59d4be1a17..72da2c16a2 100644
  
  install_data('99-default.link',
 diff --git a/src/core/meson.build b/src/core/meson.build
-index df3aa5c6c1..305f67a80a 100644
+index 3586838f59..02ddf1a123 100644
 --- a/src/core/meson.build
 +++ b/src/core/meson.build
 @@ -179,8 +179,8 @@ libcore = static_library(
@@ -125,7 +121,7 @@ index df3aa5c6c1..305f67a80a 100644
              ['systemd.pc',       pkgconfigdatadir],
              ['triggers.systemd', '']]
  
-@@ -210,6 +210,6 @@ meson.add_install_script('sh', '-c', mkdir_p.format(systemsleepdir))
+@@ -212,6 +212,6 @@ meson.add_install_script('sh', '-c', mkdir_p.format(systemsleepdir))
  meson.add_install_script('sh', '-c', mkdir_p.format(systemgeneratordir))
  meson.add_install_script('sh', '-c', mkdir_p.format(usergeneratordir))
  
@@ -207,10 +203,10 @@ index 0a7d3d5440..ff90149c1c 100644
          install_data('org.freedesktop.login1.conf',
                       install_dir : dbuspolicydir)
 diff --git a/src/network/meson.build b/src/network/meson.build
-index 6bed37a170..35f15bcaf1 100644
+index c1c02cfda1..1bfa79a03b 100644
 --- a/src/network/meson.build
 +++ b/src/network/meson.build
-@@ -168,7 +168,7 @@ if conf.get('ENABLE_NETWORKD') == 1
+@@ -201,7 +201,7 @@ if conf.get('ENABLE_NETWORKD') == 1
          endif
  
          install_data('networkd.conf',
@@ -231,10 +227,10 @@ index adbac24b54..e9dc88dfa2 100644
 +                     install_dir : factorypkgconfdir)
  endif
 diff --git a/src/resolve/meson.build b/src/resolve/meson.build
-index 92b67b6333..ac5b9a0b0a 100644
+index c4d8d4e5d9..f550c289a5 100644
 --- a/src/resolve/meson.build
 +++ b/src/resolve/meson.build
-@@ -168,7 +168,7 @@ if conf.get('ENABLE_RESOLVE') == 1
+@@ -170,7 +170,7 @@ if conf.get('ENABLE_RESOLVE') == 1
                  output : 'resolved.conf',
                  configuration : substs)
          install_data(resolved_conf,
@@ -257,10 +253,10 @@ index e5c118c8db..19235df9ca 100644
                       install_dir : dbuspolicydir)
          install_data('org.freedesktop.timesync1.service',
 diff --git a/src/udev/meson.build b/src/udev/meson.build
-index 511fe428b9..32333efea6 100644
+index 173b10be50..82638cf5a9 100644
 --- a/src/udev/meson.build
 +++ b/src/udev/meson.build
-@@ -186,7 +186,7 @@ foreach prog : [['ata_id/ata_id.c'],
+@@ -187,7 +187,7 @@ foreach prog : [['ata_id/ata_id.c'],
  endforeach
  
  install_data('udev.conf',
@@ -269,7 +265,7 @@ index 511fe428b9..32333efea6 100644
  
  configure_file(
          input : 'udev.pc.in',
-@@ -195,7 +195,7 @@ configure_file(
+@@ -196,7 +196,7 @@ configure_file(
          install_dir : pkgconfigdatadir == 'no' ? '' : pkgconfigdatadir)
  
  meson.add_install_script('sh', '-c',
@@ -300,10 +296,10 @@ index e77f46d06b..04d2ef621d 100644
 +                mkdir_p.format(join_paths(factoryconfdir, 'tmpfiles.d')))
  endif
 diff --git a/units/meson.build b/units/meson.build
-index 476991edba..3d9dc6e1c8 100644
+index ea91f0cc9e..8622054ca5 100644
 --- a/units/meson.build
 +++ b/units/meson.build
-@@ -308,7 +308,7 @@ install_data('user-.slice.d/10-defaults.conf',
+@@ -323,7 +323,7 @@ install_data('user-.slice.d/10-defaults.conf',
  
  meson.add_install_script(meson_make_symlink,
                           join_paths(pkgsysconfdir, 'user'),
@@ -313,5 +309,5 @@ index 476991edba..3d9dc6e1c8 100644
                           join_paths(dbussystemservicedir, 'org.freedesktop.systemd1.service'),
                           join_paths(dbussessionservicedir, 'org.freedesktop.systemd1.service'))
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
+++ b/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
@@ -1,7 +1,7 @@
-From 3eb1716dd80c245a2883da04156af79fb9097519 Mon Sep 17 00:00:00 2001
+From d16a7d5580adcf5737c7be3b02d411097a498256 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Fri, 2 Nov 2018 21:15:42 +0100
-Subject: [PATCH 19/27] inherit systemd environment when calling generators.
+Subject: [PATCH 13/18] inherit systemd environment when calling generators.
 
 Systemd generators need access to the environment configured in
 stage-2-init.sh since it schedules fsck and mkfs executions based on
@@ -16,10 +16,10 @@ executables that are being called from managers.
  1 file changed, 8 insertions(+), 3 deletions(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index d9114bb0c5..22c3b6ff76 100644
+index 25afdbea04..7afd5e5a37 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -3868,9 +3868,14 @@ static int manager_run_generators(Manager *m) {
+@@ -3896,9 +3896,14 @@ static int manager_run_generators(Manager *m) {
          argv[4] = NULL;
  
          RUN_WITH_UMASK(0022)
@@ -38,5 +38,5 @@ index d9114bb0c5..22c3b6ff76 100644
  
  finish:
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
+++ b/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
@@ -1,4 +1,4 @@
-From d16a7d5580adcf5737c7be3b02d411097a498256 Mon Sep 17 00:00:00 2001
+From 0b0510aa72cf8026f34f300efa3f150f45971404 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Fri, 2 Nov 2018 21:15:42 +0100
 Subject: [PATCH 13/18] inherit systemd environment when calling generators.

--- a/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
@@ -1,4 +1,4 @@
-From ac4a62d0be763846e244ff9032635c8041ad7881 Mon Sep 17 00:00:00 2001
+From 4bd20cf0450455e2f9831b09ba91811ba3d58961 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Thu, 9 May 2019 11:15:22 +0200
 Subject: [PATCH 14/18] add rootprefix to lookup dir paths

--- a/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
@@ -1,7 +1,7 @@
-From 8d1618a97ad08078815f409f03b45aff3ae6bd0a Mon Sep 17 00:00:00 2001
+From ac4a62d0be763846e244ff9032635c8041ad7881 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Thu, 9 May 2019 11:15:22 +0200
-Subject: [PATCH 21/27] add rootprefix to lookup dir paths
+Subject: [PATCH 14/18] add rootprefix to lookup dir paths
 
 systemd does not longer use the UDEVLIBEXEC directory as root for
 discovery default udev rules. By adding `$out/lib` to the lookup paths
@@ -12,7 +12,7 @@ files that I might have missed.
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/src/basic/def.h b/src/basic/def.h
-index 2af0b763f0..17959b07e8 100644
+index 970654a1ad..bb261040f8 100644
 --- a/src/basic/def.h
 +++ b/src/basic/def.h
 @@ -39,13 +39,15 @@
@@ -34,5 +34,5 @@ index 2af0b763f0..17959b07e8 100644
  #define CONF_PATHS(n)                           \
          CONF_PATHS_USR(n)                       \
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+++ b/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
@@ -1,7 +1,7 @@
-From 859c16c52cdd61ec99d256bf5b35637d59e5dac9 Mon Sep 17 00:00:00 2001
+From 8a5db86ace1d7729f2c8ccacddbf5ca17fe86274 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:45:55 +0300
-Subject: [PATCH 22/27] systemd-shutdown: execute scripts in
+Subject: [PATCH 15/18] systemd-shutdown: execute scripts in
  /etc/systemd/system-shutdown
 
 This is needed for NixOS to use such scripts as systemd directory is immutable.
@@ -10,10 +10,10 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/shutdown/shutdown.c b/src/shutdown/shutdown.c
-index 0eb17989d0..93e619c58a 100644
+index 15e6c1799e..412bdefe74 100644
 --- a/src/shutdown/shutdown.c
 +++ b/src/shutdown/shutdown.c
-@@ -299,7 +299,7 @@ int main(int argc, char *argv[]) {
+@@ -298,7 +298,7 @@ int main(int argc, char *argv[]) {
          _cleanup_free_ char *cgroup = NULL;
          char *arguments[3], *watchdog_device;
          int cmd, r, umount_log_level = LOG_INFO;
@@ -23,5 +23,5 @@ index 0eb17989d0..93e619c58a 100644
          /* The log target defaults to console, but the original systemd process will pass its log target in through a
           * command line argument, which will override this default. Also, ensure we'll never log to the journal or
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+++ b/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
@@ -1,4 +1,4 @@
-From 8a5db86ace1d7729f2c8ccacddbf5ca17fe86274 Mon Sep 17 00:00:00 2001
+From f23a1e00de028048a2a21d322493039cce7ee214 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:45:55 +0300
 Subject: [PATCH 15/18] systemd-shutdown: execute scripts in

--- a/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+++ b/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
@@ -1,7 +1,7 @@
-From 9be689d5243d0c78bec7b285774c58749da08c9c Mon Sep 17 00:00:00 2001
+From 858fbf641ff5cd207282f3ad9d7458b2be2dcdb8 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:46:58 +0300
-Subject: [PATCH 23/27] systemd-sleep: execute scripts in
+Subject: [PATCH 16/18] systemd-sleep: execute scripts in
  /etc/systemd/system-sleep
 
 This is needed for NixOS to use such scripts as systemd directory is immutable.
@@ -10,10 +10,10 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+)
 
 diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
-index b9fe96635d..f1c3ca06a3 100644
+index fbfddc0262..d2530b9421 100644
 --- a/src/sleep/sleep.c
 +++ b/src/sleep/sleep.c
-@@ -191,6 +191,7 @@ static int execute(char **modes, char **states) {
+@@ -178,6 +178,7 @@ static int execute(char **modes, char **states) {
          };
          static const char* const dirs[] = {
                  SYSTEM_SLEEP_PATH,
@@ -22,5 +22,5 @@ index b9fe96635d..f1c3ca06a3 100644
          };
  
 -- 
-2.24.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+++ b/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
@@ -1,4 +1,4 @@
-From 858fbf641ff5cd207282f3ad9d7458b2be2dcdb8 Mon Sep 17 00:00:00 2001
+From 758b8211e6e76524d62a2e0ffcf37dcf55e3be87 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:46:58 +0300
 Subject: [PATCH 16/18] systemd-sleep: execute scripts in

--- a/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
+++ b/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
@@ -1,4 +1,4 @@
-From da86057b6d1c0d39622977cfb85b7edaeeeb795e Mon Sep 17 00:00:00 2001
+From ce9fe2249c91fdfb224eaffce63e3dbdb4a5c25d Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sat, 7 Mar 2020 22:40:27 +0100
 Subject: [PATCH 17/18] kmod-static-nodes.service: Update ConditionFileNotEmpty

--- a/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
+++ b/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
@@ -1,7 +1,7 @@
-From 7db89c2236158461c99fe5c5da7ddb7feab825cf Mon Sep 17 00:00:00 2001
+From da86057b6d1c0d39622977cfb85b7edaeeeb795e Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sat, 7 Mar 2020 22:40:27 +0100
-Subject: [PATCH] kmod-static-nodes.service: Update ConditionFileNotEmpty
+Subject: [PATCH 17/18] kmod-static-nodes.service: Update ConditionFileNotEmpty
 
 On NixOS, kernel modules of the currently booted systems are located at
 /run/booted-system/kernel-modules/lib/modules/%v/, not /lib/modules/%v/.
@@ -23,5 +23,5 @@ index 0971edf9ec..87105a87b9 100644
  [Service]
  Type=oneshot
 -- 
-2.25.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -1,7 +1,7 @@
-From 0939ac4be7ced099670979f26adf8a579173ce4b Mon Sep 17 00:00:00 2001
+From b35237652b2244397b6a4350e156e4bfe025e13a Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sun, 8 Mar 2020 01:05:54 +0100
-Subject: [PATCH] path-util.h: add placeholder for DEFAULT_PATH_NORMAL
+Subject: [PATCH 18/18] path-util.h: add placeholder for DEFAULT_PATH_NORMAL
 
 This will be the $PATH used to lookup ExecStart= etc. options, which
 systemd itself uses extensively.
@@ -10,7 +10,7 @@ systemd itself uses extensively.
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/basic/path-util.h b/src/basic/path-util.h
-index 111d85d445..cfd92aeb73 100644
+index 30031fca8e..d97145539a 100644
 --- a/src/basic/path-util.h
 +++ b/src/basic/path-util.h
 @@ -24,11 +24,11 @@
@@ -29,5 +29,5 @@ index 111d85d445..cfd92aeb73 100644
  #if HAVE_SPLIT_USR
  #  define DEFAULT_PATH DEFAULT_PATH_SPLIT_USR
 -- 
-2.25.1
+2.26.2
 

--- a/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -1,4 +1,4 @@
-From b35237652b2244397b6a4350e156e4bfe025e13a Mon Sep 17 00:00:00 2001
+From 55b69fc1b5441e3aff8f1ab684ba8eed3718a32d Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sun, 8 Mar 2020 01:05:54 +0100
 Subject: [PATCH 18/18] path-util.h: add placeholder for DEFAULT_PATH_NORMAL

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -45,23 +45,23 @@ in stdenv.mkDerivation {
 
   patches = [
     ./0001-Start-device-units-for-uninitialised-encrypted-devic.patch
-    ./0003-Don-t-try-to-unmount-nix-or-nix-store.patch
-    ./0004-Fix-NixOS-containers.patch
-    ./0006-Look-for-fsck-in-the-right-place.patch
-    ./0007-Add-some-NixOS-specific-unit-directories.patch
-    ./0009-Get-rid-of-a-useless-message-in-user-sessions.patch
-    ./0010-hostnamed-localed-timedated-disable-methods-that-cha.patch
-    ./0011-Fix-hwdb-paths.patch
-    ./0012-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
-    ./0013-localectl-use-etc-X11-xkb-for-list-x11.patch
-    ./0016-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
-    ./0018-Install-default-configuration-into-out-share-factory.patch
-    ./0019-inherit-systemd-environment-when-calling-generators.patch
-    ./0021-add-rootprefix-to-lookup-dir-paths.patch
-    ./0022-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
-    ./0023-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
-    ./0024-kmod-static-nodes.service-Update-ConditionFileNotEmpty.patch
-    ./0025-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+    ./0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+    ./0003-Fix-NixOS-containers.patch
+    ./0004-Look-for-fsck-in-the-right-place.patch
+    ./0005-Add-some-NixOS-specific-unit-directories.patch
+    ./0006-Get-rid-of-a-useless-message-in-user-sessions.patch
+    ./0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
+    ./0008-Fix-hwdb-paths.patch
+    ./0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+    ./0010-localectl-use-etc-X11-xkb-for-list-x11.patch
+    ./0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
+    ./0012-Install-default-configuration-into-out-share-factory.patch
+    ./0013-inherit-systemd-environment-when-calling-generators.patch
+    ./0014-add-rootprefix-to-lookup-dir-paths.patch
+    ./0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+    ./0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+    ./0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
+    ./0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
   ];
 
   postPatch = ''

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -31,7 +31,7 @@ let gnupg-minimal = gnupg.override {
   bzip2 = null;
 };
 in stdenv.mkDerivation {
-  version = "245.3";
+  version = "245.5";
   pname = "systemd";
 
   # When updating, use https://github.com/systemd/systemd-stable tree, not the development one!
@@ -39,8 +39,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "systemd-stable";
-    rev = "0f5047b7d393cfba37f91e25cae559a0bc910582";
-    sha256 = "0wyh14gbvvpgdmk1mjgpxr9i4pv1i9n7pnwpa0gvjh6hq948fyn2";
+    rev = "9a506b7e9291d997a920af9ac299e7b834368119";
+    sha256 = "19qd92hjlsljr6x5mbw1l2vdzz5y9hy7y7g0dwgpfifb0lwkxqbr";
   };
 
   patches = [


### PR DESCRIPTION
This bumps systemd to the latest stable release, 245.5.

I regenerated the patches - `git am` seems to be a bit more picky than `patch -p1 < $file`.

Changelog:

```* 9a506b7e92 - (tag: v245.5, systemd-stable/v245-stable) network: use "FooOverUDP" as one word (12 days ago) <Zbigniew Jędrzejewski-Szmek>
* c5e3469059 - network: fix static assertion on IPPROTO_MAX range (12 days ago) <Zbigniew Jędrzejewski-Szmek>
* a71980e030 - resolved: tone down comment in /run/systemd/{stub-,}resolve.conf (12 days ago) <Lennart Poettering>
* 7a2b5237d1 - logind: skip polkit query with --no-wall (12 days ago) <Zbigniew Jędrzejewski-Szmek>
* e7ee906371 - verify: ignore nonexistent executables if required (12 days ago) <Giedrius Statkevičius>
* 037b5e2281 - hwdb: optimize isatty()-per-line away (12 days ago) <Lennart Poettering>
* 2099a9e58d - fileio: extend comment a bit (12 days ago) <Lennart Poettering>
* abbfa8fdfa - fileio: optionally allow telling read_line_full() whether we are processing a tty or not (12 days ago) <Lennart Poettering>
* 10731dde42 - fileio: fileno() can realistically return -1 (12 days ago) <Lennart Poettering>
* 40b2a5975c - coredumpctl: support --file=PATH (12 days ago) <Frantisek Sumsal>
* 059211c7c6 - Fix pam_systemd_home's debug parameter to match man page description (12 days ago) <Joel Shapiro>
* c4883fe438 - core: make sure ProtectHostname= is handled gracefully in containers lacking seccomp (12 days ago) <Lennart Poettering>
* 3ad42f3837 - test: wait a bit after stopping the test service (13 days ago) <Frantisek Sumsal>
* 76e0d8b380 - catalog: add entry for SD_MESSAGE_UNSAFE_USER_NAME (13 days ago) <Lennart Poettering>
* ed86450ff4 - docs: hook up the new USER_NAMES document everywhere (13 days ago) <Lennart Poettering>
* 64fdacd5f1 - user-util: rework how we validate user names (13 days ago) <Lennart Poettering>
* 110d89cb65 - userdbctl: drop redundant user name validity check (13 days ago) <Lennart Poettering>
* f0300901ba - man: explicitly note that ExecSt*Post does count for After/Before ordering (13 days ago) <Luca Boccassi>
* 78b3f7348d - sleep: improve log msg slightly (13 days ago) <Lennart Poettering>
* 680d485902 - man: correct the default slice for systemd-run units (13 days ago) <Lennart Poettering>
* e04ee3c708 - hwdb: Update database of Bluetooth company identifiers (13 days ago) <Marcel Holtmann>
* d830b0574e - detect-virt: also detect "microsoft" as WSL (13 days ago) <Zbigniew Jędrzejewski-Szmek>
* dea7e0dd97 - dbus-execute: show also ProtectClock (13 days ago) <Topi Miettinen>
* 8a2b89b5d6 - man: add note that --no-hostname has limited effect (13 days ago) <Zbigniew Jędrzejewski-Szmek>
* 8b0368f511 - journal-remote: fix description of option (13 days ago) <Zbigniew Jędrzejewski-Szmek>
* da2125b6a2 - capability: don't skip ambient caps setup if we actually have something to set (13 days ago) <Lennart Poettering>
* e3b6d65c53 - shared/dissect-image: log messages from cryptsetup (13 days ago) <Topi Miettinen>
* 9c61b53c74 - resolve: reload /etc/hosts on inode change (13 days ago) <Giedrius Statkevičius>
* d540b947f4 - string-util: make sure we eat even half complete words in split() (13 days ago) <Lennart Poettering>
* 3fa7fdce59 - udev: Fix SIGSEGV in AlternativeNamesPolicy handling (13 days ago) <Lénaïc Huard>
* 2c4229221c - (tag: v245.4) man: mention that stdout logging works the same as stderr logging (4 weeks ago) <Lennart Poettering>
* 1e4711af5b - userwork: fix signal worker sends to manager requesting more workers (4 weeks ago) <Lennart Poettering>
* c7f9da1e4a - units: do not pull in home.mount from systemd-homed.service (4 weeks ago) <Lennart Poettering>
* 3469a951fa - home: fix several typos (4 weeks ago) <Vito Caputo>
* 2c5ae0f58a - homectl: fix a typo (4 weeks ago) <Piero La Terza>
* 5eedafd01a - import: Only keep RO copy if ETag header is set (4 weeks ago) <Kevin Kuehler>
* 5b434d7209 - nss-systemd: add missing jump to unlock mutex (4 weeks ago) <Zbigniew Jędrzejewski-Szmek>
* 1a2f596bcb - basic: Fix capability_ambient_set_apply for kernels < 4.3 (4 weeks ago) <Kevin Kuehler>
* e4b7c40dca - sd-journal: remove the dead code and actually fix #14695 (4 weeks ago) <Michal Sekletár>
* a0b77ea24b - user-util: switch order of checks in valid_user_group_name_or_id_full() (4 weeks ago) <Lennart Poettering>
* d71c24910d - user-util: Allow names starting with a digit (4 weeks ago) <Balint Reczey>
* 9ac3070285 - Remove stale doc about PrivateNetwork and type (4 weeks ago) <Zhu Li>
* d822e2a524 - Add `shell` to machinectl ZSH completion (4 weeks ago) <Pieter Lexis>
* 60521ea904 - Silence Wstring-plus-int warning when using clangd with GCC. (4 weeks ago) <Daan De Meyer>
* e6fcb95f4a - path-lookup: Use default value for XDG_CONFIG_DIRS if environment is not set (4 weeks ago) <David Edmundson>


```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
