### PR TITLE
black: make available as application

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9935,6 +9935,8 @@ in
   bison = callPackage ../development/tools/parsing/bison { };
   yacc = bison; # TODO: move to aliases.nix
 
+  black = with python3Packages; toPythonApplication black;
+
   blackmagic = callPackage ../development/tools/misc/blackmagic { };
 
   bloaty = callPackage ../development/tools/bloaty { };


### PR DESCRIPTION
Make Black available as application, but keep it as a lib, too, because some software in NixPkgs imports it as a module. (At least [`python3Packages.pyls-black`](https://nixos.org/nixos/packages.html?channel=nixpkgs-unstable&query=python%5Cd%5CdPackages%5C.pyls-black%24) 0.4.4 imports it [in `pyls_black/plugin.py`](https://github.com/rupert/pyls-black/blob/v0.4.4/pyls_black/plugin.py#L3).)

###### Motivation for this change

Primary use of this Python package is as an application (CLI tool `black`).

As far as I can see, [Black's documentation](https://black.readthedocs.io/) doesn't even mention the possibility to import it as a module. But it [does warn](https://black.readthedocs.io/en/stable/reference/reference_summary.html) that the exposed internals "are subject to change."

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

----

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
<br>- black
</details>