### PR TITLE
havoc: init at 2019-12-08

### DIFF
--- a/pkgs/applications/misc/havoc/default.nix
+++ b/pkgs/applications/misc/havoc/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub
+, pkgconfig, libxkbcommon, wayland, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+
+  pname = "havoc";
+  version = "2019-12-08";
+
+  src = fetchFromGitHub {
+    owner = "ii8";
+    repo = pname;
+    rev = "507446c92ed7bf8380a58c5ba2b14aba5cdf412c";
+    sha256 = "13nfnan1gmy4cqxmqv0rc8a4mcb1g62v73d56hy7z2psv4am7a09";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libxkbcommon wayland wayland-protocols ];
+
+  dontConfigure = true;
+
+  installFlags = [ "PREFIX=$$out" ];
+
+  postInstall = ''
+    install -D -m 644 havoc.cfg -t $out/etc/${pname}/
+    install -D -m 644 README.md -t $out/share/doc/${pname}-${version}/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A minimal terminal emulator for Wayland";
+    homepage = "https://github.com/ii8/havoc";
+    license = with licenses; [ mit publicDomain ];
+    platforms = with platforms; unix;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19548,6 +19548,8 @@ in
 
   gcalcli = callPackage ../applications/misc/gcalcli { };
 
+  havoc = callPackage ../applications/misc/havoc { };
+
   vcal = callPackage ../applications/misc/vcal { };
 
   gcolor2 = callPackage ../applications/graphics/gcolor2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

havoc is a small terminal emulator for Wayland.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
