### PR TITLE
wordpress: Patch loader for $WORDPRESS_CONFIG

### DIFF
--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "10zjgbr96ri87r5v7860vg5ndbnjfhjhily4m9nyl60f1lbjdhrr";
   };
 
+  # exposes $WORDPRESS_CONFIG variable to configure wp-config.php path
+  # upstream issue: https://core.trac.wordpress.org/ticket/41710
+  patches = [ ./wordpress-wp-config.patch ];
+
   installPhase = ''
     mkdir -p $out/share/wordpress
     cp -r . $out/share/wordpress

--- a/pkgs/servers/web-apps/wordpress/wordpress-wp-config.patch
+++ b/pkgs/servers/web-apps/wordpress/wordpress-wp-config.patch
@@ -1,0 +1,14 @@
+--- a/wp-load.php
++++ b/wp-load.php
+@@ -31,7 +31,10 @@
+  *
+  * If neither set of conditions is true, initiate loading the setup process.
+  */
+-if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
++if ( !empty( getenv( 'WORDPRESS_CONFIG' ) ) && file_exists( getenv( 'WORDPRESS_CONFIG' ) )  ) {
++	/** Patched by NixOS */
++	require_once( getenv( 'WORDPRESS_CONFIG' ) );
++} elseif ( file_exists( ABSPATH . 'wp-config.php' ) ) {
+ 
+ 	/** The config file resides in ABSPATH */
+ 	require_once( ABSPATH . 'wp-config.php' );


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Patch Wordpress' `wp-loader.php` to load `wp-config.php` from `$WORDPRESS_CONFIG` if the environment variable is set and the file exists.

This makes it possible to run the web application directly from the nix store, without copying all of the files like the wordpress module does.

This is the NixOS configuration I'm using to run it:
```nix
  services.nginx = {
    enable = true;
    virtualHosts = {
      "wordpress.${config.networking.domain}" = {
        root = "${pkgs.wordpress}/share/wordpress";
        locations = {
          "/" = {
            index = "index.php";
            tryFiles = "$uri $uri/ /index.php?$args";
          };
          "^~ /wp-content/".alias = "/var/www/wordpress/wp-content/";
          "~ \\.php$".extraConfig = ''
            include ${pkgs.nginx}/conf/uwsgi_params;
            uwsgi_modifier1 14;
            uwsgi_pass unix:${config.services.uwsgi.instance.vassals.php.socket};
          '';
        };
      };
    };
  };

  services.uwsgi = {
    enable = true;
    user = "nginx";
    group = "nginx";
    instance = {
      type = "emperor";
      vassals = {
        php = {
          type = "normal";
          socket = "/run/uwsgi/php.sock";
          stats = "/run/uwsgi/php-stats.sock";
          master = true;
          vacuum = true;

          php-sapi-name = "apache"; # opcode caching tweak

          php-allowed-ext = [ ".php" ".inc" ];
          socket-modifier1 = 14;
          php-index = "index.php";

          php-set = [
            "date.timezone=${config.time.timeZone}"
            "session.save_handler=files"
            "session.save_path=/tmp/sessions"
            "display_errors=off"
          ];
          env = [
            "WORDPRESS_CONFIG=/var/www/wordpress/wp-config.php"
          ];

          plugins = [ "php" ];
        };
      };
    };
    plugins = [ "php" ];
  };
```

In my `wp-config.php`, I have set `$WP_CONTENT_DIR` to a state directory:
```php
define( 'WP_CONTENT_DIR', dirname(__FILE__) . '/wp-content' );
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
