### PR TITLE
cri-o: switch to buildGoModule

### DIFF
--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , btrfs-progs
-, buildGoPackage
+, buildGoModule
 , fetchFromGitHub
 , glibc
 , gpgme
@@ -14,11 +14,9 @@
 , pkg-config
 }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "cri-o";
   version = "1.18.0";
-
-  goPackagePath = "github.com/cri-o/cri-o";
 
   src = fetchFromGitHub {
     owner = "cri-o";
@@ -26,9 +24,8 @@ buildGoPackage rec {
     rev = "v${version}";
     sha256 = "142flmv54pj48rjqkd26fbxrcbx2cv6pdmrc33jgyvn6r99zliah";
   };
-
+  vendorSha256 = null;
   outputs = [ "out" "man" ];
-
   nativeBuildInputs = [ installShellFiles pkg-config ];
 
   buildInputs = [
@@ -44,8 +41,6 @@ buildGoPackage rec {
 
   BUILDTAGS = "apparmor seccomp selinux containers_image_ostree_stub";
   buildPhase = ''
-    pushd go/src/${goPackagePath}
-
     sed -i '/version.buildDate/d' Makefile
 
     make binaries docs BUILDTAGS="$BUILDTAGS"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This is just a cleanup to switch from buildGoPackage to buildGoModule.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ x other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/podman