### PR TITLE
vscode-extensions.bbenoist.vscode-doxygen: init at 1.0.0

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -24,6 +24,18 @@ in
     };
   };
 
+  bbenoist.Doxygen = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "Doxygen";
+      publisher = "bbenoist";
+      version = "1.0.0";
+      sha256 = "0kclb60mnaj3c5lmpwmhkbnx4g8gr4wy66lkcklkwm555nkgw48n";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   bbenoist.Nix = buildVscodeMarketplaceExtension {
     mktplcRef = {
         name = "Nix";


### PR DESCRIPTION
###### Motivation for this change

Doxygen language support for Visual Studio Code.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
