### PR TITLE
ventoy: init at 1.0.07

### DIFF
--- a/pkgs/tools/misc/ventoy/default.nix
+++ b/pkgs/tools/misc/ventoy/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "ventoy";
+  version = "1.0.07";
+
+  src = fetchurl {
+    url = "https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz";
+    sha256 = "13raplng4bls84yfcami69wm7wb53rmv8ml9w8974ssxvidy31vc";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    cp -r . $out
+    mkdir -p $out/bin
+    makeWrapper $out/Ventoy2Disk.sh $out/bin/ventoy
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An open source tool to create bootable USB drive for ISO files";
+    homepage = "https://ventoy.net";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ filalex77 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25953,6 +25953,8 @@ in
     ffmpeg = ffmpeg_4;
   };
 
+  ventoy = callPackage ../tools/misc/ventoy { };
+
   vice = callPackage ../misc/emulators/vice {
     giflib = giflib_4_1;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
[Ventoy](https://ventoy.net) is a tool for creating bootable USBs that allow selecting from ISO files on the drive.
Seems to have no dependencies, and works great for me.

Latest stable release: https://github.com/ventoy/Ventoy/releases/tag/v1.0.07

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
