### PR TITLE
vscode-extensions.bierner.markdown-checkbox: init at 0.1.3

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -36,6 +36,18 @@ in
     };
   };
 
+  bierner.markdown-checkbox = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "markdown-checkbox";
+      publisher = "bierner";
+      version = "0.1.3";
+      sha256 = "1zl32jq59phr0w0q3b9w0dhlvr2fgbsycx8zn99swf594rjpkyw5";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   cmschuetz12.wal = buildVscodeMarketplaceExtension {
     mktplcRef = {
         name = "wal";


### PR DESCRIPTION
###### Motivation for this change
 
Adds checkbox / task list support to VS Code's built-in markdown preview.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
