### PR TITLE
cargo-deny: init at 0.6.6

### DIFF
--- a/pkgs/development/tools/rust/cargo-deny/default.nix
+++ b/pkgs/development/tools/rust/cargo-deny/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, lib
+, rustPlatform
+, fetchFromGitHub
+, perl, pkgconfig, openssl, Security, libiconv, curl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-deny";
+  version = "0.6.6";
+
+  src = fetchFromGitHub {
+    owner = "EmbarkStudios";
+    repo = pname;
+    rev = version;
+    sha256 = "0pmh6x7rb0v1g087xgyicw9mm4ayppgh7vzvq3hs8vip2zvy7r56";
+  };
+
+  cargoSha256 = "00lh6nxc17dyl8z2l70gzc7l1vpn448lzi1c69wxxcqnk8y0ka9w";
+
+  nativeBuildInputs = [ perl pkgconfig ];
+
+  buildInputs = [ openssl  ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Security libiconv curl ];
+
+  meta = with lib; {
+    description = "Cargo plugin to generate list of all licenses for a crate";
+    homepage = "https://github.com/EmbarkStudios/cargo-deny";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9036,6 +9036,9 @@ in
   cargo-crev = callPackage ../development/tools/rust/cargo-crev {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-deny = callPackage ../development/tools/rust/cargo-deny {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-expand = callPackage ../development/tools/rust/cargo-expand { };
   cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
   cargo-geiger = callPackage ../development/tools/rust/cargo-geiger {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
