### PR TITLE
vscode-extensions.DavidAnson.vscode-markdownlint: init at 0.35.1

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -48,6 +48,18 @@ in
     };
   };
 
+  DavidAnson.vscode-markdownlint = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vscode-markdownlint";
+      publisher = "DavidAnson";
+      version = "0.35.1";
+      sha256 = "1hb0wkdqzpy2g1vf2aahrjw4xhshfs35xnd76px4a5y4gsy9sqlm";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   formulahendry.auto-close-tag = buildVscodeMarketplaceExtension {
     mktplcRef = {
       name = "auto-close-tag";


### PR DESCRIPTION
###### Motivation for this change

Markdown linting and style checking for Visual Studio Code.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
