### PR TITLE
gpio-tools: init in kernel 5.4

### DIFF
--- a/pkgs/os-specific/linux/kernel/gpio-utils.nix
+++ b/pkgs/os-specific/linux/kernel/gpio-utils.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, linux }:
+
+with lib;
+
+assert versionAtLeast linux.version "4.6";
+
+stdenv.mkDerivation {
+  name = "gpio-utils-${linux.version}";
+
+  inherit (linux) src makeFlags;
+
+  preConfigure = ''
+    cd tools/gpio
+  '';
+
+  separateDebugInfo = true;
+  installFlags = [ "install" "DESTDIR=$(out)" "bindir=/bin" ];
+
+  meta = {
+    description = "Linux tools to inspect the gpiochip interface";
+    maintainers = with stdenv.lib.maintainers; [ kwohlfahrt ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26468,4 +26468,5 @@ in
 
   vpsfree-client = callPackage ../tools/virtualization/vpsfree-client {};
 
+  gpio-utils = callPackage ../os-specific/linux/kernel/gpio-utils.nix { };
 }


### PR DESCRIPTION
Linux provides some tools to interact with the gpiochip interface (which
replaces the deprecated sysfs GPIO interface). Expose these as a
package.

###### Motivation for this change

In the upgrade to 20.03, the sysfs interface for GPIO pins was removed for the stock kernel. The new gpiochip interface is less straightforward to interact with, and these tools were not previously packaged.

###### Things done

I've tested the binaries on a raspberry pi 3.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
