### PR TITLE
vscode-extensions.mhutchie.git-graph: init at 1.22.0

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -84,6 +84,18 @@ in
     };
   };
 
+  mhutchie.git-graph = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "git-graph";
+      publisher = "mhutchie";
+      version = "1.22.0";
+      sha256 = "06j49pxz9vp6z4hax60jsn4fa2iig76d8p9cjhdhbvmyil0dgggx";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+ 
   ms-azuretools.vscode-docker = buildVscodeMarketplaceExtension {
     mktplcRef = {
       name = "vscode-docker";


### PR DESCRIPTION
###### Motivation for this change

View a Git Graph of your repository, and perform Git actions from the graph.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
