### PR TITLE
vscode-extensions.ionutvmi.path-autocomplete: init at 1.13.6

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -60,6 +60,18 @@ in
     };
   };
 
+  ionutvmi.path-autocomplete = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "path-autocomplete";
+      publisher = "ionutvmi";
+      version = "1.13.6";
+      sha256 = "1iajr639c41j3zs7qcw6zr16spv1h99gyqsng3bbwla4dic6w0m9";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   james-yu.latex-workshop = buildVscodeMarketplaceExtension {
     mktplcRef = {
       name = "latex-workshop";


### PR DESCRIPTION
###### Motivation for this change

Provides path completion for visual studio code.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
