### PR TITLE
vscode-extensions.slevesque.vscode-hexdump: init at 1.7.2

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -178,6 +178,18 @@ in
     };
   };
 
+  slevesque.vscode-hexdump = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vscode-hexdump";
+      publisher = "slevesque";
+      version = "1.7.2";
+      sha256 = "0l1nm0w3615fha65kpv3ada5vnnaw2wgjwlksi4lda3qxlbwrchj";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   vscodevim.vim = buildVscodeMarketplaceExtension {
     mktplcRef = {
       name = "vim";


### PR DESCRIPTION
###### Motivation for this change

Display a specified file in hexadecimal.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
