### PR TITLE
vscode-extensions.streetsidesoftware.code-spell-checker: init at 1.8.0

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -178,6 +178,18 @@ in
     };
   };
 
+  streetsidesoftware.code-spell-checker = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "code-spell-checker";
+      publisher = "streetsidesoftware";
+      version = "1.8.0";
+      sha256 = "189daplk4hsj0jza2ck95g65hg3f9rm39cn2swrhi6z6li4xc7y7";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   vscodevim.vim = buildVscodeMarketplaceExtension {
     mktplcRef = {
       name = "vim";


### PR DESCRIPTION
###### Motivation for this change

Spelling checker for source code.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
