### PR TITLE
vscode-extensions.tomoki1207.pdf: init at 0.6.0

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -192,5 +192,17 @@ in
 
   llvm-org.lldb-vscode = llvmPackages_8.lldb;
 
+  tomoki1207.pdf = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "pdf";
+      publisher = "tomoki1207";
+      version = "0.6.0";
+      sha256 = "0cb7p23h5qrjpgcn22sg09llldxr0vmqjz38sv4ryqm9yjpzx6m9";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   WakaTime.vscode-wakatime = callPackage ./wakatime {};
 }


### PR DESCRIPTION
###### Motivation for this change

Display pdf file in VSCode.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
