### PR TITLE
uftp: 4.10.2 -> 5.0

### DIFF
--- a/pkgs/servers/uftp/default.nix
+++ b/pkgs/servers/uftp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "uftp";
-  version = "4.10.2";
+  version = "5.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/uftp-multicast/source-tar/uftp-${version}.tar.gz";
-    sha256 = "01c54mqz37157dfq47zjqvfy7v98vbi9zn9mzrxszsz0gyq6mazc";
+    sha256 = "1q08schd765fsm9647ac4ic2x70ys2x48mqz97mibdi4bbm72bsn";
   };
 
   buildInputs = [ openssl ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
New major release: 5.0

Excerpt from changelog ( http://uftp-multicast.sourceforge.net/Changes.txt ):
```
Version 5.0 - 4/22/2020
  Major security updates.  The key exchange and key derivation algorithms
    were modified and supported algorithms were pruned using TLS 1.3 as a
    basis.  This includes:
  - HKDF used in multiple stages for key derivation from raw shared secrets.
  - Included addtional context in key derivation and signatures to protect
    against replay attacks and downgrade attacks.
  - Reduced set of supported EC curves to those supported by TLS 1.3
  - Removed RSA key exchange which does not provide perfect forward secrecy.
    All key exchanges now use ECDH.
  - Removed support for SHA-1 hashes in key exchanges.
  - Supported symmetric ciphers are AES in AEAD mode (GCM or CCM).
  - Increased supported RSA key sizes
  Encrypted sessions are now enabled by default.  It can be disabled by
    specifying "none" for the key type in the server's -Y option.
  Backward compatibility retained for version 4.x in clients and proxies.
    When communicating with a 4.x server, only allow algorithms and key
    exchange modes permitted in the new version.
  Clients and proxies no longer need to use signature keys that match the
    type and size used by the server.  As a result, the -k and -K options to
    the client now only accept a single key instead of multiple.  The proxy
    still supports multiple keys for 4.x compatibility, however only the first
    key listed is used for any version 5.x session.
  Proxies now send their keys in a separate message instead of injecting them
    in the ANNOUNCE sent by the server.  This allows clients to be fully
    aware of proixes and allows them to authenticate servers and proxies
    separately.
  Format of client's server list modified to specify the proxy that a server
    communicates through.  Fingerprints listed in this file now always
    specify the server as opposed to having the proxy's key in some cases.
  Added -R option to client to specify a list of proxies along with their
    public key fingerprints.  The old use of -R to specify a version 4.x
    response proxy has moved to -r.
  Previously, using -S in the client or proxy to specify a server list would
    automatically enable source specific multicast (SSM).  The use of SSM is
    now enabled separately via the -o option on both the client and proxy.
  Fixed a bug that caused ECDSA signatures created on Linux with curve
    secp521r1 from being verified successfully on Windows.
  Fixed cleanup on clients and proxies to prevent occasional crashes on
    shutdown under Windows.
  Update timstamps in messages to use 64-bit microseconds since the epoch,
    addressing Y2038 issues.
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
