### PR TITLE
doc: Add PHP section to index

### DIFF
--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -21,6 +21,7 @@
  <xi:include href="node.section.xml" />
  <xi:include href="ocaml.xml" />
  <xi:include href="perl.xml" />
+ <xi:include href="php.section.xml" />
  <xi:include href="python.section.xml" />
  <xi:include href="qt.xml" />
  <xi:include href="r.section.xml" />

--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -62,7 +62,7 @@ To build your list of extensions from the ground up, you can simply
 ignore `enabled`:
 
 ```nix
-php.withExtensions ({ all, ... }: with all; [ opcache imagick ])
+php.withExtensions ({ all, ... }: with all; [ imagick opcache ])
 ```
 
 `php.withExtensions` provides extensions by wrapping a minimal php
@@ -94,7 +94,7 @@ follows:
 
 ```nix
 let
-  myPhp = php.withExtensions ({ all, ... }: with all; [ opcache imagick ]);
+  myPhp = php.withExtensions ({ all, ... }: with all; [ imagick opcache ]);
 in {
   services.phpfpm.pools."foo".phpPackage = myPhp;
 };
@@ -118,4 +118,20 @@ with the extensions `imagick` and `opcache` enabled:
 
 ```sh
 nix-shell -p 'php.withExtensions ({ all, ... }: with all; [ imagick opcache ])'
+```
+
+### Installing PHP packages with extensions {#ssec-php-user-guide-installing-packages-with-extensions}
+
+All interactive tools use the PHP package you get them from, so all
+packages at `php.packages.*` use the `php` package with its default
+extensions. Sometimes this default set of extensions isn't enough and
+you may want to extend it. A common case of this is the `composer`
+package: a project may depend on certain extensions and `composer`
+won't work with that project unless those extensions are loaded.
+
+Example of building `composer` with additional extensions:
+```nix
+(php.withExtensions ({ all, enabled }:
+  enabled ++ (with all; [ imagick redis ]))
+).packages.composer
 ```

--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -1,10 +1,8 @@
-# PHP
+# PHP {#sec-php}
 
-## User Guide
+## User Guide {#ssec-php-user-guide}
 
-### Using PHP
-
-#### Overview
+### Overview {#ssec-php-user-guide-overview}
 
 Several versions of PHP are available on Nix, each of which having a
 wide variety of extensions and libraries available.
@@ -36,7 +34,7 @@ opcache extension shipped with PHP is available at
 `php.extensions.opcache` and the third-party ImageMagick extension at
 `php.extensions.imagick`.
 
-#### Installing PHP with extensions
+### Installing PHP with extensions {#ssec-php-user-guide-installing-with-extensions}
 
 A PHP package with specific extensions enabled can be built using
 `php.withExtensions`. This is a function which accepts an anonymous
@@ -89,7 +87,7 @@ php.buildEnv {
 }
 ```
 
-##### Example setup for `phpfpm`
+#### Example setup for `phpfpm` {#ssec-php-user-guide-installing-with-extensions-phpfpm}
 
 You can use the previous examples in a `phpfpm` pool called `foo` as
 follows:
@@ -113,7 +111,7 @@ in {
 };
 ```
 
-##### Example usage with `nix-shell`
+#### Example usage with `nix-shell` {#ssec-php-user-guide-installing-with-extensions-nix-shell}
 
 This brings up a temporary environment that contains a PHP interpreter
 with the extensions `imagick` and `opcache` enabled:


### PR DESCRIPTION
###### Motivation for this change
I guess this should work? We have the markdown file from before and I guess that is converted to xml somehow?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
