### PR TITLE
domoticz: init at 2020.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2176,6 +2176,12 @@
     githubId = 984691;
     name = "Evan Danaher";
   };
+  edcragg = {
+    email = "ed.cragg@eipi.xyz";
+    github = "nuxeh";
+    githubId = 1516017;
+    name = "Ed Cragg";
+  };
   edef = {
     email = "edef@edef.eu";
     github = "edef1c";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -432,6 +432,7 @@
   ./services/misc/dysnomia.nix
   ./services/misc/disnix.nix
   ./services/misc/docker-registry.nix
+  ./services/misc/domoticz.nix
   ./services/misc/errbot.nix
   ./services/misc/etcd.nix
   ./services/misc/ethminer.nix

--- a/nixos/modules/services/misc/domoticz.nix
+++ b/nixos/modules/services/misc/domoticz.nix
@@ -1,0 +1,89 @@
+{ lib, pkgs, config, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.domoticz;
+  pkgDesc = "Domoticz home automation";
+
+in {
+
+  options = {
+
+    services.domoticz = {
+      enable = mkEnableOption pkgDesc;
+
+      user = mkOption {
+        type = types.str;
+        default = "domoticz";
+        description = "domoticz user";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "domoticz";
+        description = "domoticz group";
+      };
+
+      extraGroups = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Extra groups to add to domoticz user";
+      };
+
+      stateDir = mkOption {
+        type = types.path;
+        default = "/var/lib/domoticz/";
+        description = "The state directory for domoticz";
+        example = "/home/bob/.domoticz/";
+      };
+
+      bind = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        description = "IP address to bind to.";
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 8080;
+        description = "Port to bind to for HTTP, set to 0 to disable HTTP.";
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    users.users."domoticz" = {
+      name = cfg.user;
+      group = cfg.group;
+      extraGroups = cfg.extraGroups;
+      home = cfg.stateDir;
+      createHome = true;
+      description = pkgDesc;
+    };
+
+    users.groups."domoticz" = {
+      name = cfg.group;
+    };
+
+    systemd.services."domoticz" = {
+      description = pkgDesc;
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "always";
+        ExecStart = ''
+          ${pkgs.domoticz}/bin/domoticz -noupdates -www ${toString cfg.port} -wwwbind ${cfg.bind} -sslwww 0 -userdata ${cfg.stateDir} -approot ${pkgs.domoticz}/share/domoticz/ -pidfile /var/run/domoticz.pid
+        '';
+      };
+    };
+
+  };
+
+}

--- a/nixos/modules/services/misc/domoticz.nix
+++ b/nixos/modules/services/misc/domoticz.nix
@@ -14,31 +14,6 @@ in {
     services.domoticz = {
       enable = mkEnableOption pkgDesc;
 
-      user = mkOption {
-        type = types.str;
-        default = "domoticz";
-        description = "domoticz user";
-      };
-
-      group = mkOption {
-        type = types.str;
-        default = "domoticz";
-        description = "domoticz group";
-      };
-
-      extraGroups = mkOption {
-        type = types.listOf types.str;
-        default = [ ];
-        description = "Extra groups to add to domoticz user";
-      };
-
-      stateDir = mkOption {
-        type = types.path;
-        default = "/var/lib/domoticz/";
-        description = "The state directory for domoticz";
-        example = "/home/bob/.domoticz/";
-      };
-
       bind = mkOption {
         type = types.str;
         default = "0.0.0.0";
@@ -57,29 +32,16 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.users."domoticz" = {
-      name = cfg.user;
-      group = cfg.group;
-      extraGroups = cfg.extraGroups;
-      home = cfg.stateDir;
-      createHome = true;
-      description = pkgDesc;
-    };
-
-    users.groups."domoticz" = {
-      name = cfg.group;
-    };
-
     systemd.services."domoticz" = {
       description = pkgDesc;
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
       serviceConfig = {
-        User = cfg.user;
-        Group = cfg.group;
+        DynamicUser = true;
+        StateDirectory = "domoticz";
         Restart = "always";
         ExecStart = ''
-          ${pkgs.domoticz}/bin/domoticz -noupdates -www ${toString cfg.port} -wwwbind ${cfg.bind} -sslwww 0 -userdata ${cfg.stateDir} -approot ${pkgs.domoticz}/share/domoticz/ -pidfile /var/run/domoticz.pid
+          ${pkgs.domoticz}/bin/domoticz -noupdates -www ${toString cfg.port} -wwwbind ${cfg.bind} -sslwww 0 -userdata /var/lib/domoticz -approot ${pkgs.domoticz}/share/domoticz/ -pidfile /var/run/domoticz.pid
         '';
       };
     };

--- a/pkgs/servers/domoticz/default.nix
+++ b/pkgs/servers/domoticz/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
     '';
     maintainers = with maintainers; [ edcragg ];
     homepage = "https://www.domoticz.com/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/domoticz/default.nix
+++ b/pkgs/servers/domoticz/default.nix
@@ -1,0 +1,103 @@
+{ stdenv,
+  fetchzip,
+  makeWrapper,
+  cmake,
+  python3,
+  openssl,
+  pkg-config,
+  mosquitto,
+  lua5_3,
+  sqlite,
+  jsoncpp,
+  zlib,
+  boost,
+  curl,
+  git,
+  libusb-compat-0_1,
+  cereal
+}:
+
+let
+  version = "2020.2";
+  minizip = "f5282643091dc1b33546bb8d8b3c23d78fdba231";
+
+  domoticz-src = fetchzip {
+    url = "https://github.com/domoticz/domoticz/archive/${version}.tar.gz";
+    sha256 = "1b4pkw9qp7f5r995vm4xdnpbwi9vxjyzbnk63bmy1xkvbhshm0g3";
+  };
+
+  minizip-src = fetchzip {
+    url = "https://github.com/domoticz/minizip/archive/${minizip}.tar.gz";
+    sha256 = "1vddrzm4pwl14bms91fs3mbqqjhcxrmpx9a68b6nfbs20xmpnsny";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "domoticz";
+  inherit version;
+
+  src = domoticz-src;
+
+  postUnpack = ''
+    cp -r ${minizip-src}/* $sourceRoot/extern/minizip
+  '';
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    openssl
+    python3
+    mosquitto
+    lua5_3
+    sqlite
+    jsoncpp
+    boost
+    zlib
+    curl
+    git
+    libusb-compat-0_1
+    cereal
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DUSE_BUILTIN_MQTT=false"
+    "-DUSE_BUILTIN_LUA=false"
+    "-DUSE_BUILTIN_SQLITE=false"
+    "-DUSE_BUILTIN_JSONCPP=false"
+    "-DUSE_BUILTIN_ZLIB=false"
+    "-DUSE_OPENSSL_STATIC=false"
+    "-DUSE_STATIC_BOOST=false"
+    "-DUSE_BUILTIN_MINIZIP=true"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/share/domoticz
+    cp -r $src/www $out/share/domoticz/
+    cp -r $src/Config $out/share/domoticz
+    cp -r $src/scripts $out/share/domoticz
+    cp -r $src/plugins $out/share/domoticz
+
+    mkdir -p $out/bin
+    cp domoticz $out/bin
+    wrapProgram $out/bin/domoticz --set LD_LIBRARY_PATH ${python3}/lib;
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Home automation system";
+    longDescription = ''
+      Domoticz is a home automation system that lets you monitor and configure
+      various devices like: lights, switches, various sensors/meters like
+      temperature, rain, wind, UV, electra, gas, water and much more
+    '';
+    maintainers = with maintainers; [ edcragg ];
+    homepage = "https://www.domoticz.com/";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2976,6 +2976,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
   };
 
+  domoticz = callPackage ../servers/domoticz { };
+
   doomseeker = qt5.callPackage ../applications/misc/doomseeker { };
 
   doom-bcc = callPackage ../games/zdoom/bcc-git.nix { };


### PR DESCRIPTION
###### Motivation for this change

Add Domoticz home automation server.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
