### PR TITLE
gst-plugins-bad: fix compilation with opencv 4.3

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -104,6 +104,8 @@ in stdenv.mkDerivation rec {
       sha256 = "0l1f6kqcl04q7w12a2b4qibcvjz6gqhs0csdv2wbvfd6zndpjm6p";
     })
     ./fix_pkgconfig_includedir.patch
+    # https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1235
+    ./opencv-4.3.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/bad/opencv-4.3.patch
+++ b/pkgs/development/libraries/gstreamer/bad/opencv-4.3.patch
@@ -1,0 +1,13 @@
+diff --git a/ext/opencv/meson.build b/ext/opencv/meson.build
+index f38b55d..05b142e 100644
+--- a/ext/opencv/meson.build
++++ b/ext/opencv/meson.build
+@@ -65,7 +65,7 @@ if opencv_found
+     endif
+   endforeach
+ else
+-  opencv_dep = dependency('opencv4', version : ['>= 4.0.0', '< 4.2.0'], required : false)
++  opencv_dep = dependency('opencv4', version : ['>= 4.0.0', '< 4.4.0'], required : false)
+   opencv_found = opencv_dep.found()
+   if opencv_found
+     foreach h : libopencv4_headers


### PR DESCRIPTION
###### Motivation for this change
It is broken in staging, compiles fine with 4.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
