### PR TITLE
colorls: 1.2.0 -> 1.3.3

### DIFF
--- a/pkgs/tools/system/colorls/Gemfile.lock
+++ b/pkgs/tools/system/colorls/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     clocale (0.0.4)
-    colorls (1.2.0)
+    colorls (1.3.3)
       clocale (~> 0)
       filesize (~> 0)
       manpages (~> 0)

--- a/pkgs/tools/system/colorls/default.nix
+++ b/pkgs/tools/system/colorls/default.nix
@@ -12,7 +12,7 @@ bundlerApp {
     description = "Prettified LS";
     homepage    = "https://github.com/athityakumar/colorls";
     license     = with licenses; mit;
-    maintainers = with maintainers; [ lukebfox nicknovitski ];
+    maintainers = with maintainers; [ lukebfox nicknovitski cbley ];
     platforms   = ruby.meta.platforms;
   };
 }

--- a/pkgs/tools/system/colorls/gemset.nix
+++ b/pkgs/tools/system/colorls/gemset.nix
@@ -15,10 +15,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0bcrig88ipzj43lnkrb5qmimdrml4lx15rcrhr6m2hxb0pks8932";
+      sha256 = "07rvm3g65slnqzal718qwfmgsjnkysx00jn8dnv96317yx0mxfx6";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.3.3";
   };
   filesize = {
     groups = ["default"];


### PR DESCRIPTION
###### Motivation for this change

new upstream version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
