### PR TITLE
nixos/google-oslogin: Move nsswitch config into the module

### DIFF
--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -15,7 +15,6 @@ let
   nsswins = canLoadExternalModules && config.services.samba.nsswins;
   ldap = canLoadExternalModules && (config.users.ldap.enable && config.users.ldap.nsswitch);
   resolved = canLoadExternalModules && config.services.resolved.enable;
-  googleOsLogin = canLoadExternalModules && config.security.googleOsLogin.enable;
 
   hostArray = mkMerge [
     (mkBefore [ "files" ])
@@ -32,7 +31,6 @@ let
     (mkBefore [ "files" ])
     (mkIf ldap [ "ldap" ])
     (mkIf mymachines [ "mymachines" ])
-    (mkIf googleOsLogin [ "cache_oslogin oslogin" ])
     (mkIf canLoadExternalModules (mkAfter [ "systemd" ]))
   ];
 
@@ -172,7 +170,6 @@ in {
     # configured IP addresses, or ::1 and 127.0.0.2 as
     # fallbacks. Systemd also provides nss-mymachines to return IP
     # addresses of local containers.
-    system.nssModules = (optionals canLoadExternalModules [ config.systemd.package.out ])
-      ++ optional googleOsLogin pkgs.google-compute-engine-oslogin.out;
+    system.nssModules = (optionals canLoadExternalModules [ config.systemd.package.out ]);
   };
 }

--- a/nixos/modules/security/google_oslogin.nix
+++ b/nixos/modules/security/google_oslogin.nix
@@ -49,6 +49,7 @@ in
 
     # enable the nss module, so user lookups etc. work
     system.nssModules = [ package ];
+    system.nssDatabases.passwd = [ "cache_oslogin" "oslogin" ];
 
     # Ugly: sshd refuses to start if a store path is given because /nix/store is group-writable.
     # So indirect by a symlink.


### PR DESCRIPTION
###### Motivation for this change
#86350

Tested by running the oslogin vm test. Lookups fail with `system.nssDatabases.passwd = [ "cache_oslogin" "oslogin" ];` unset, succeed with them being set:

```
cat /nix/store/w3cd5hnb2419q89h3hmpl74iy6qz3876-etc-nsswitch.conf
passwd:    files cache_oslogin oslogin mymachines systemd
[…]
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
