### PR TITLE
yabai: init at 2.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1480,6 +1480,12 @@
     githubId = 848609;
     name = "Michael Bishop";
   };
+  cmacrae = {
+    email = "hi@cmacr.ae";
+    github = "cmacrae";
+    githubId = 3392199;
+    name = "Calum MacRae";
+  };
   cmcdragonkai = {
     email = "roger.qiu@matrix.ai";
     github = "cmcdragonkai";

--- a/pkgs/os-specific/darwin/yabai/default.nix
+++ b/pkgs/os-specific/darwin/yabai/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, Carbon, Cocoa, ScriptingBridge }:
+
+stdenv.mkDerivation rec {
+  pname = "yabai";
+  version = "2.4.3";
+
+  src = fetchFromGitHub {
+    owner = "koekeishiya";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1a6pqms5kwdsvr9vcshfa000xf2f5a2qbp5qapx0b3wzclnchjbn";
+  };
+
+  buildInputs = [ Carbon Cocoa ScriptingBridge ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1/
+    cp ./bin/yabai $out/bin/yabai
+    cp ./doc/yabai.1 $out/share/man/man1/yabai.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      A tiling window manager for macOS based on binary space partitioning
+    '';
+    homepage = https://github.com/koekeishiya/yabai;
+    platforms = platforms.darwin;
+    maintainers = [ maintainers.cmacrae ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26111,6 +26111,11 @@ in
 
   xzoom = callPackage ../tools/X11/xzoom {};
 
+  yabai = callPackage ../os-specific/darwin/yabai {
+    inherit (darwin.apple_sdk.frameworks)
+      Carbon Cocoa ScriptingBridge;
+  };
+
   yabause = libsForQt5.callPackage ../misc/emulators/yabause {
     freeglut = null;
     openal = null;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
These changes add me as a maintainer and introduce a package for yabai, for Darwin systems.  
I've been maintaining my own package for quite some time, so figured it was time to finally share it.  

This PR supersedes #73260 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
