### PR TITLE
gobject-introspection: Ensure the giDiscoverSelf is run before gappsWrapperArgsHook

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/setup-hook.sh
+++ b/pkgs/development/libraries/gobject-introspection/setup-hook.sh
@@ -18,7 +18,14 @@ giDiscoverSelf() {
     fi
 }
 
-preFixupHooks+=(giDiscoverSelf)
+# gappsWrapperArgsHook expects GI_TYPELIB_PATH variable to be set by this.
+# Until we have dependency mechanism in generic builder, we need to use this ugly hack.
+if [[ " ${preFixupPhases:-} " =~ " gappsWrapperArgsHook " ]]; then
+    preFixupPhases+=" "
+    preFixupPhases="${preFixupPhases/ gappsWrapperArgsHook / giDiscoverSelf gappsWrapperArgsHook }"
+else
+    preFixupPhases+=" giDiscoverSelf"
+fi
 
 _multioutMoveGlibGir() {
   moveToOutput share/gir-1.0 "${!outputDev}"


### PR DESCRIPTION
`gappsWrapperArgsHook` tries to collect `GI_TYPELIB_PATH` environment variable so if we want it to see the path `giDiscoverSelf` adds, we need to force the order.

Fixes: #85515 

cc @worldofpeace @globin 

- [x] Tested using wrapGAppsHook test (https://github.com/NixOS/nixpkgs/pull/85976#issuecomment-622020545)