### PR TITLE
p7zip: fix two CVEs and mark as insecure

### DIFF
--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -57,6 +57,11 @@ stdenv.mkDerivation rec {
     description = "A port of the 7-zip archiver";
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.raskin ];
+    knownVulnerabilities = [
+      # p7zip is abandoned, according to this thread on its forums:
+      # https://sourceforge.net/p/p7zip/discussion/383043/thread/fa143cf2/#1817
+      "p7zip is abandoned and may not receive important security fixes"
+    ];
     # RAR code is under non-free UnRAR license, but we remove it
     license = if enableUnfree then lib.licenses.unfree else lib.licenses.lgpl2Plus;
   };

--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, enableUnfree ? false }:
+{ stdenv, fetchurl, fetchpatch, lib, enableUnfree ? false }:
 
 stdenv.mkDerivation rec {
   pname = "p7zip";
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
   patches = [
     ./12-CVE-2016-9296.patch
     ./13-CVE-2017-17969.patch
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/termux/termux-packages/master/packages/p7zip/3-CVE-2018-5996.patch";
+      sha256 = "1zivvkazmza0653i498ccp3zbpbpc7dvxl3zxwllbx41b6n589yp";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/termux/termux-packages/master/packages/p7zip/4-CVE-2018-10115.patch";
+      sha256 = "1cr7q8gnrk9yp6dcvxaqi1yhdbgp964nkv65ls41mw1kdfm44zn6";
+    })
   ];
 
   # Default makefile is full of impurities on Darwin. The patch doesn't hurt Linux so I'm leaving it unconditional


### PR DESCRIPTION
###### Motivation for this change

This fixes the two CVEs mentioned in the commit (patches taken from Debian).
Additionally, the p7zip-project is a port of 7zip. 7zip appears alive and well, but p7zip has not seen any development since 2016 and no bugfixes or even security fixes are being released.
As discussed in https://discourse.nixos.org/t/p7zip-and-possible-rces/6951, carrying an abandoned project is a risk, so I'm marking the package as unsafe.
p7zip is used by about 35 other packages, so this will lead to issues in other packages. The following is a list of other affected nix files:

 - nixos/modules/services/misc/nzbget.nix
 - nixos/modules/services/torrent/deluge.nix
 - nixos/tests/nzbget.nix
 - pkgs/applications/editors/jetbrains/common.nix
 - pkgs/applications/graphics/kcc/default.nix
 - pkgs/applications/kde/ark/default.nix
 - pkgs/applications/misc/far2l/default.nix
 - pkgs/applications/misc/lutris/chrootenv.nix
 - pkgs/applications/misc/lutris/default.nix
 - pkgs/applications/misc/multibootusb/default.nix
 - pkgs/applications/misc/playonlinux/default.nix
 - pkgs/applications/misc/sweethome3d/default.nix
 - pkgs/applications/virtualization/driver/win-qemu/default.nix
 - pkgs/applications/virtualization/driver/win-signed-gplpv-drivers/default.nix
 - pkgs/applications/virtualization/driver/win-spice/default.nix
 - pkgs/applications/virtualization/driver/win-virtio/default.nix
 - pkgs/data/fonts/marathi-cursive/default.nix
 - pkgs/data/fonts/oldsindhi/default.nix
 - pkgs/data/fonts/rounded-mgenplus/default.nix
 - pkgs/data/fonts/sarasa-gothic/default.nix
 - pkgs/development/mobile/flashtool/default.nix
 - pkgs/development/python-modules/binwalk/default.nix
 - pkgs/development/tools/flatpak-builder/default.nix
 - pkgs/games/spring/default.nix
 - pkgs/games/tdm/default.nix
 - pkgs/games/zdoom/default.nix
 - pkgs/misc/emulators/wine/winetricks.nix
 - pkgs/os-specific/linux/ply/default.nix
 - pkgs/os-specific/linux/prl-tools/default.nix
 - pkgs/servers/sabnzbd/default.nix
 - pkgs/tools/cd-dvd/unetbootin/default.nix
 - pkgs/tools/compression/dtrx/default.nix
 - pkgs/tools/filesystems/fuse-7z-ng/default.nix
 - pkgs/tools/misc/hostsblock/default.nix
 - pkgs/tools/misc/memtest86-efi/default.nix
 - pkgs/tools/misc/woeusb/default.nix
 - pkgs/tools/security/rarcrack/default.nix


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
