### PR TITLE
gitlab: 12.8.9 -> 12.8.10

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,11 +1,11 @@
 {
-  "version": "12.8.9",
-  "repo_hash": "07vayjy3020hapbdx2wiv91g9xrfmvngbyj05hs2p0p3gwj6g2a4",
+  "version": "12.8.10",
+  "repo_hash": "1njkihj66d8fnk1l0r5pys38akf5srqlrgj2hzc68l5m8d51dk15",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.8.9-ee",
+  "rev": "v12.8.10-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "12.8.9",
+    "GITALY_SERVER_VERSION": "12.8.10",
     "GITLAB_PAGES_VERSION": "1.16.0",
     "GITLAB_SHELL_VERSION": "11.0.0",
     "GITLAB_WORKHORSE_VERSION": "8.21.2"

--- a/pkgs/applications/version-management/gitlab/gitaly/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/gitaly/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     minitest (5.14.0)
     msgpack (1.3.1)
     multipart-post (2.0.0)
-    nokogiri (1.10.7)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
@@ -242,4 +242,4 @@ DEPENDENCIES
   webmock (~> 3.4.0)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -28,14 +28,14 @@ let
     };
   });
 in buildGoPackage rec {
-  version = "12.8.9";
+  version = "12.8.10";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "06q1km2pigpl4yxl8pkzdy2yxzvsfm6n5r3kmd8h19j3sc6imbmh";
+    sha256 = "1vhnpyggh2ch93i75np11rjzvq8d6pwv2kzvwh7ak3fa02w9qdfs";
   };
 
   # Fix a check which assumes that hook files are writeable by their

--- a/pkgs/applications/version-management/gitlab/gitaly/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/gemset.nix
@@ -515,10 +515,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0r0qpgf80h764k176yr63gqbs2z0xbsp8vlvs2a79d5r9vs83kln";
+      sha256 = "12j76d0bp608932xkzmfi638c7aqah57l437q8494znzbj610qnm";
       type = "gem";
     };
-    version = "1.10.7";
+    version = "1.10.9";
   };
   nokogumbo = {
     dependencies = ["nokogiri"];


### PR DESCRIPTION
###### Motivation for this change
https://about.gitlab.com/releases/2020/04/30/security-release-12-10-2-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
