### PR TITLE
Bump powershell

### DIFF
--- a/pkgs/shells/powershell/default.nix
+++ b/pkgs/shells/powershell/default.nix
@@ -1,21 +1,21 @@
 { stdenv, autoPatchelfHook, fetchzip, libunwind, libuuid, icu, curl
-, darwin, makeWrapper, less, openssl_1_0_2, pam, lttng-ust }:
+, darwin, makeWrapper, less, openssl_1_1, pam, lttng-ust }:
 
 let platformString = if stdenv.isDarwin then "osx"
                      else if stdenv.isLinux then "linux"
                      else throw "unsupported platform";
-    platformSha = if stdenv.isDarwin then "0jb2xm79m3m14zk7v730ai1zvxcb5a13jbkkya0qy7332k6gn6bl"
-                     else if stdenv.isLinux then "0s0jvc9ha6fw8qy7f5n0v6zf043rawsjdlm5wvqxq1q2idz7xcw1"
+    platformSha = if stdenv.isDarwin then "0c71w6z6sc86si07i6vy4w3069jal7476wyiizyr7qjm9m22963f"
+                     else if stdenv.isLinux then "0m13y66a6w64s31qbi3j5x8jll6dfrin890jah8kyncsvlyisqg3"
                      else throw "unsupported platform";
     platformLdLibraryPath = if stdenv.isDarwin then "DYLD_FALLBACK_LIBRARY_PATH"
                      else if stdenv.isLinux then "LD_LIBRARY_PATH"
                      else throw "unsupported platform";
-                     libraries = [ libunwind libuuid icu curl openssl_1_0_2 ] ++
+                     libraries = [ libunwind libuuid icu curl openssl_1_1 ] ++
                        (if stdenv.isLinux then [ pam lttng-ust ] else [ darwin.Libsystem ]);
 in
 stdenv.mkDerivation rec {
   pname = "powershell";
-  version = "6.2.3";
+  version = "7.0.0";
 
   src = fetchzip {
     url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-${platformString}-x64.tar.gz";
@@ -27,10 +27,20 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/powershell
-    cp -r * $out/share/powershell
-    makeWrapper $out/share/powershell/pwsh $out/bin/pwsh \
+    pslibs=$out/share/powershell
+    mkdir -p $pslibs
+
+    cp -r * $pslibs
+
+	  rm $pslibs/libcrypto.so.1.0.0
+	  rm $pslibs/libssl.so.1.0.0
+
+	  patchelf --replace-needed libcrypto.so.1.0.0 libcrypto.so.1.1 $pslibs/libmi.so
+	  patchelf --replace-needed libssl.so.1.0.0 libssl.so.1.1 $pslibs/libmi.so
+	
+	  mkdir -p $out/bin
+
+    makeWrapper $pslibs/pwsh $out/bin/pwsh \
       --prefix ${platformLdLibraryPath} : "${stdenv.lib.makeLibraryPath libraries}" \
       --set TERM xterm --set POWERSHELL_TELEMETRY_OPTOUT 1 --set DOTNET_CLI_TELEMETRY_OPTOUT 1
   '';
@@ -38,9 +48,9 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   meta = with stdenv.lib; {
-    description = "Cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework";
+    description = "Powerful cross-platform (Windows, Linux, and macOS) shell and scripting language based on .NET";
     homepage = "https://github.com/PowerShell/PowerShell";
-    maintainers = [ maintainers.yrashk ];
+    maintainers = with maintainers; [ yrashk srgom ];
     platforms = [ "x86_64-darwin" "x86_64-linux" ];
     license = with licenses; [ mit ];
   };


### PR DESCRIPTION
###### Motivation for this change
closes: #84454

enables darwin usage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
