### PR TITLE
ocamlPackages.owl: unbreak by reversing previous edits

### DIFF
--- a/pkgs/development/ocaml-modules/owl/default.nix
+++ b/pkgs/development/ocaml-modules/owl/default.nix
@@ -6,13 +6,11 @@
 , eigen
 , stdio
 , stdlib-shims
-, openblas, blas, lapack
+, openblasCompat
 , owl-base
 , npy
 }:
 
-assert (!blas.isILP64) && (!lapack.isILP64);
-assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 
 buildDunePackage rec {
   pname = "owl";
@@ -22,7 +20,7 @@ buildDunePackage rec {
   checkInputs = [ alcotest ];
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [
-    eigen stdio stdlib-shims openblas owl-base npy
+    eigen stdio stdlib-shims openblasCompat owl-base npy
   ];
 
   doCheck = !stdenv.isDarwin;  # https://github.com/owlbarn/owl/issues/462


### PR DESCRIPTION
 - package was broken by 1c8aba83 (#83888)
 - fixes #85915.

cc @vbgl @matthewbauer 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
