### PR TITLE
qimgv: 0.8.9 -> 0.9

### DIFF
--- a/pkgs/applications/graphics/qimgv/default.nix
+++ b/pkgs/applications/graphics/qimgv/default.nix
@@ -1,12 +1,14 @@
 { mkDerivation
 , lib
 , fetchFromGitHub
+, fetchpatch
 
 , cmake
 , pkgconfig
 
 , exiv2
 , mpv
+, opencv4
 , qtbase
 , qtimageformats
 , qtsvg
@@ -14,14 +16,24 @@
 
 mkDerivation rec {
   pname = "qimgv";
-  version = "0.8.9";
+  version = "0.9";
 
   src = fetchFromGitHub {
     owner = "easymodo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0cmya06j466v0pirhxbzbj1vbz0346y7rbc1gbv4n9xcp6c6bln6";
+    sha256 = "1yynjk47gjf2kjfb0ak4blxpb5irgqc1k59z726lwjd6gvg689fl";
   };
+
+  patches = [
+    # QtAtomicInt's `storeRelaxed` was introduced in Qt 5.14, while nixpkgs only
+    # has Qt 5.12. This appears to be the only instance of Qt 5.12
+    # incompatibility, and will be fixed in the next release.
+    (fetchpatch {
+      url = "https://github.com/easymodo/qimgv/commit/a39d6086ceb9445d2c16943e0719096a99920bf8.patch";
+      sha256 = "1z3ngv6i316hrdcdzig4jg6bcdbgfxjaxvm2jcfcw2dnfbfiq47s";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -31,6 +43,7 @@ mkDerivation rec {
   buildInputs = [
     exiv2
     mpv
+    opencv4
     qtbase
     qtimageformats
     qtsvg

--- a/pkgs/applications/graphics/qimgv/qt5-12-compat.diff
+++ b/pkgs/applications/graphics/qimgv/qt5-12-compat.diff
@@ -1,0 +1,13 @@
+diff --git a/qimgv/components/directorymanager/watchers/linux/linuxworker.cpp b/qimgv/components/directorymanager/watchers/linux/linuxworker.cpp
+index 96ec9d3..6d95d08 100644
+--- a/qimgv/components/directorymanager/watchers/linux/linuxworker.cpp
++++ b/qimgv/components/directorymanager/watchers/linux/linuxworker.cpp
+@@ -21,7 +21,7 @@ void LinuxWorker::setDescriptor(int desc) {
+ 
+ void LinuxWorker::run() {
+     emit started();
+-    isRunning.storeRelaxed(true);
++    isRunning.store(true);
+ 
+     if (fd == -1) {
+         qDebug() << TAG << "File descriptor isn't set! Stopping";


### PR DESCRIPTION
https://github.com/easymodo/qimgv/compare/v0.8.9...v0.9

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

~~I've filed https://github.com/easymodo/qimgv/issues/205 to see if we can't get that single Qt 5.12-incompatible change reverted.~~ They've added a patch that fixes this (in record time, if I might add), which will be present in the next release.