### PR TITLE
libvorbis: fix 404'ing patch

### DIFF
--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://gitlab.xiph.org/xiph/vorbis/uploads/a68cf70fa10c8081a633f77b5c6576b7/0001-CVE-2017-14160-make-sure-we-don-t-overflow.patch";
-      sha256 = "0v21p59cb3z77ch1v6q5dcrd733h91f3m8ifnd7kkkr8gzn17d5x";
+      url = "https://gitlab.xiph.org/xiph/vorbis/commit/018ca26dece618457dd13585cad52941193c4a25.patch";
+      sha256 = "18k4vp0nmrxxpis641ylnw6dgwxrymh5bf74njr6v8dizmmz1bkj";
       name = "CVE-2017-14160+CVE-2018-10393.patch";
     })
     (fetchpatch {
-      url = "https://gitlab.xiph.org/xiph/vorbis/commit/112d3bd0aaa.diff";
+      url = "https://gitlab.xiph.org/xiph/vorbis/commit/112d3bd0aaacad51305e1464d4b381dabad0e88b.diff";
       sha256 = "1k77y3q36npy8mkkz40f6cb46l2ldrwyrd191m29s8rnbhnafdf7";
       name = "CVE-2018-10392.patch";
     })


### PR DESCRIPTION
Also use full commit for the other patch, just in case there's ever a
collision, as unlikely as that may be.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Thanks to Kyndig on IRC, again.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'll open backport PRs after this is merged. @veprbl, since you did that last time for the ninja 404, should I backport to 19.03 and 19.09 as well? (20.03 is a given)