### PR TITLE
gnomeExtensions: refactor pnames and derivations headers

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/arc-menu/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/arc-menu/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitLab, glib, gettext, substituteAll, gnome-menus }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-arc-menu";
+  pname = "gnome-shell-extension-arc-menu";
   version = "43";
 
   src = fetchFromGitLab {

--- a/pkgs/desktops/gnome-3/extensions/caffeine/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/caffeine/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, glib, gettext, bash, gnome3 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-extension-caffeine-unstable";
-  version = "2020-03-13";
+  pname = "gnome-shell-extension-caffeine";
+  version = "unstable-2020-03-13";
 
   src = fetchFromGitHub {
     owner = "eonpatapon";

--- a/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
@@ -1,9 +1,10 @@
-{stdenv, fetchurl, cmake, ninja, jq, python3, gnome3, wrapGAppsHook}:
+{ stdenv, fetchurl, cmake, ninja, jq, python3, gnome3, wrapGAppsHook }:
 
 let
   version = "10.1";
 
   inherit (python3.pkgs) python pygobject3 requests;
+
 in stdenv.mkDerivation rec {
   pname = "chrome-gnome-shell";
   inherit version;

--- a/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
@@ -1,12 +1,8 @@
-{ stdenv
-, fetchFromGitHub
-, glib
-, gettext
-}:
+{ stdenv , fetchFromGitHub , glib , gettext }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-dash-to-dock-unstable";
-  version = "2020-04-20";
+  pname = "gnome-shell-extension-dash-to-dock";
+  version = "unstable-2020-04-20";
 
   src = fetchFromGitHub {
     owner = "micheleg";

--- a/pkgs/desktops/gnome-3/extensions/dash-to-panel/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dash-to-panel/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, glib, gettext }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-dash-to-panel";
+  pname = "gnome-shell-extension-dash-to-panel";
   version = "31";
 
   src = fetchFromGitHub {

--- a/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
@@ -1,9 +1,10 @@
 { stdenv, fetchFromGitHub, substituteAll, python3, openssl, gsound
 , meson, ninja, libxml2, pkgconfig, gobject-introspection, wrapGAppsHook
-, glib, gtk3, at-spi2-core, upower, openssh, gnome3, gjs }:
+, glib, gtk3, at-spi2-core, upower, openssh, gnome3, gjs
+}:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-gsconnect";
+  pname = "gnome-shell-extension-gsconnect";
   version = "35";
 
   src = fetchFromGitHub {

--- a/pkgs/desktops/gnome-3/extensions/impatience/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/impatience/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, glib }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-impatience";
+  pname = "gnome-shell-extension-impatience";
   version = "unstable-2019-09-23";
 
   src = fetchFromGitHub {

--- a/pkgs/desktops/gnome-3/extensions/mpris-indicator-button/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/mpris-indicator-button/default.nix
@@ -1,11 +1,8 @@
-{ stdenv
-, fetchFromGitHub
-, gnome3
-}:
+{ stdenv , fetchFromGitHub , gnome3 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-extension-mpris-indicator-button-unstable";
-  version = "2020-03-21";
+  pname = "gnome-shell-extension-mpris-indicator-button";
+  version = "unstable-2020-03-21";
 
   src = fetchFromGitHub {
     owner = "JasonLG1979";

--- a/pkgs/desktops/gnome-3/extensions/sound-output-device-chooser/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/sound-output-device-chooser/default.nix
@@ -1,9 +1,4 @@
-{ stdenv
-, substituteAll
-, fetchFromGitHub
-, libpulseaudio
-, python3
-}:
+{ stdenv , substituteAll , fetchFromGitHub , libpulseaudio , python3 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-sound-output-device-chooser";

--- a/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
@@ -1,7 +1,7 @@
 { stdenv, substituteAll, fetchFromGitHub, glib, glib-networking, libgtop, gnome3 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-system-monitor";
+  pname = "gnome-shell-extension-system-monitor";
   version = "38";
 
   src = fetchFromGitHub {

--- a/pkgs/desktops/gnome-3/extensions/tilingnome/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/tilingnome/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, glib, gnome3 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-extension-tilingnome-unstable";
+  pname = "gnome-shell-extension-tilingnome";
   version = "unstable-2019-09-19";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

Refactoring:
- use `unstable` in version field instead of pname
- pnames have prefix gnome-shell-extension (except GNOME Shell integration)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
