### PR TITLE
jackett: 0.14.365 -> 0.16.175, add aarch64 support

### DIFF
--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "jackett";
-  version = "0.14.365";
+  version = "0.16.175";
 
   src = {
     x86_64-linux = fetchurl {
       url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxAMDx64.tar.gz";
-      sha512 = "28dgaap4aj1ldcfr0lzgz2aq1lbk8vlgbmjwfg4m4s4rlmiadw6wkxy9w7h4fq7gqbj51q8xxqz6y50jfzn124bs9wgi8br4lk3hsw3";
+      sha512 = "269n84qc8sfrmnidgrjywanbqr65mhkmk24dlqfi17pi0l27wi4fc4qmnjj683xwprz5hqjsmkqf963pbx4k3jaz0rp0jnizan91wij";
     };
     aarch64-linux = fetchurl {
       url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxARM64.tar.gz";
-      sha512 = "0kv95yg775lq7lgc4b75rdqfsyzfcj2a1bj0cmhzpjk4sbsg3jayqgjzbhl5h79r9si1y8b7lg8ffl2j83rwap8wyq1dqdjls4savfb";
+      sha512 = "0dmyhprd2vi2z9q5g79psqgsc3w0zdac4s6k20rngi8jxm5jgphzrzcic4rgdijyryap99my619k447w701a08vh9sfcfk0fjg9pgwb";
     };
   }."${stdenv.targetPlatform.system}" or (throw "Missing hash for host system: ${stdenv.targetPlatform.system}");
 

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -4,10 +4,16 @@ stdenv.mkDerivation rec {
   pname = "jackett";
   version = "0.14.365";
 
-  src = fetchurl {
-    url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxAMDx64.tar.gz";
-    sha256 = "0xvlknjhc75km12d8li50ifqpfyl6whymb6gd7ccwyd9lv9xxm27";
-  };
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxAMDx64.tar.gz";
+      sha512 = "28dgaap4aj1ldcfr0lzgz2aq1lbk8vlgbmjwfg4m4s4rlmiadw6wkxy9w7h4fq7gqbj51q8xxqz6y50jfzn124bs9wgi8br4lk3hsw3";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxARM64.tar.gz";
+      sha512 = "0kv95yg775lq7lgc4b75rdqfsyzfcj2a1bj0cmhzpjk4sbsg3jayqgjzbhl5h79r9si1y8b7lg8ffl2j83rwap8wyq1dqdjls4savfb";
+    };
+  }."${stdenv.targetPlatform.system}" or (throw "Missing hash for host system: ${stdenv.targetPlatform.system}");
 
   buildInputs = [ makeWrapper ];
 
@@ -35,6 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Jackett/Jackett/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ edwtjo nyanloutre ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The existing jackett derivation installed the x86_64 binary on all Linux platforms, and was thus broken on aarch64, e.g. Raspberry Pi. The upstream project provides ARM64 Linux binaries: this change adds support for those, and also bumps the packaged version to the latest upstream release.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
