### PR TITLE
libsass: fix unpacking on ZFS Nix store with normalization=formD

### DIFF
--- a/pkgs/development/libraries/libsass/default.nix
+++ b/pkgs/development/libraries/libsass/default.nix
@@ -9,10 +9,15 @@ stdenv.mkDerivation rec {
     repo = pname;
     rev = version;
     sha256 = "1q6lvd8sj5k5an32qir918pa5khhcb8h08dzrg1bcxmw7a23j514";
-    # Remove unicode file names which leads to different checksums on HFS+
+    # Exclude unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
-    extraPostFetch = ''
-      rm -r $out/test/e2e/unicode-pwd
+    # Or leads to a collision when moving the unpacked source
+    # from a tmpfs $TMPDIR to a ZFS Nix store using normalization=formD.
+    postFetch = ''
+      tar -C "$out" \
+       --strip-components=1 \
+       --exclude=test/e2e/unicode-pwd \
+       -xf "$downloadedFile"
     '';
   };
 


### PR DESCRIPTION
###### Motivation for this change
using a /nix/store over a ZFS  dataset using normalization=formD breaks the libsass unpacking, which contains two directories whose names have the same normalization

###### Things done
Use tar options to exclude the colliding paths.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
