### PR TITLE
asmfmt: 1.1 -> 1.2.1; remove outdated binaries

### DIFF
--- a/pkgs/development/tools/asmfmt/default.nix
+++ b/pkgs/development/tools/asmfmt/default.nix
@@ -27,6 +27,10 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
+  # This package comes with its own version of goimports, gofmt and goreturns
+  # but these binaries are outdated and are offered by other packages.
+  subPackages = [ "cmd/asmfmt" ];
+
   meta = with lib; {
     description = "Go Assembler Formatter";
     homepage = "https://github.com/klauspost/asmfmt";

--- a/pkgs/development/tools/asmfmt/default.nix
+++ b/pkgs/development/tools/asmfmt/default.nix
@@ -6,7 +6,7 @@
 
 buildGoPackage rec {
   pname = "asmfmt";
-  version = "1.1";
+  version = "1.2.1";
 
   goPackagePath = "github.com/klauspost/asmfmt";
 
@@ -14,16 +14,8 @@ buildGoPackage rec {
     owner = "klauspost";
     repo = "asmfmt";
     rev = "v${version}";
-    sha256 = "08mybfizcvck460axakycz9ndzcgwqilp5mmgm4bl8hfrn36mskw";
+    sha256 = "0qwxb4yx12yl817vgbhs7acaj98lgk27dh50mb8sm9ccw1f43h9i";
   };
-
-  patches = [
-    (fetchpatch {
-      excludes = ["README.md"];
-      url = "https://github.com/klauspost/asmfmt/commit/39a37c8aed8095e0fdfb07f78fc8acbd465d9627.patch";
-      sha256 = "18bc77l87mf0yvqc3adlakxz6wflyqfsc2wrmh9q0nlqghlmnw5k";
-    })
-  ];
 
   goDeps = ./deps.nix;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- https://github.com/klauspost/asmfmt/releases/tag/v1.2.1
- asmfmt seems to come with its own, and older version, of gofmt/goimports/goreturns. Keep only asmfmt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
