### PR TITLE
podman: use $out instead of $bin with buildGoPackage

### DIFF
--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -8,13 +8,11 @@ let
 
   # Provides a fake "docker" binary mapping to podman
   dockerCompat = pkgs.runCommandNoCC "${podmanPackage.pname}-docker-compat-${podmanPackage.version}" {
-    outputs = [ "out" "bin" "man" ];
+    outputs = [ "out" "man" ];
     inherit (podmanPackage) meta;
   } ''
-    mkdir $out
-
-    mkdir -p $bin/bin
-    ln -s ${podmanPackage.bin}/bin/podman $bin/bin/docker
+    mkdir -p $out/bin
+    ln -s ${podmanPackage}/bin/podman $out/bin/docker
 
     mkdir -p $man/share/man/man1
     for f in ${podmanPackage.man}/share/man/man1/*; do

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -34,15 +34,15 @@ in runCommand podman.name {
   ];
 
 } ''
-  # Symlink everything but $bin from podman-unwrapped
+  # Symlink everything but $out from podman-unwrapped
   ${
     lib.concatMapStringsSep "\n"
     (o: "ln -s ${podman.${o}} ${placeholder o}")
-    (builtins.filter (o: o != "bin")
+    (builtins.filter (o: o != "out")
     podman.outputs)}
 
-  mkdir -p $bin/bin
-  ln -s ${podman-unwrapped}/share $bin/share
-  makeWrapper ${podman-unwrapped}/bin/podman $bin/bin/podman \
+  mkdir -p $out/bin
+  ln -s ${podman-unwrapped}/share $out/share
+  makeWrapper ${podman-unwrapped}/bin/podman $out/bin/podman \
     --prefix PATH : ${binPath}
 ''


### PR DESCRIPTION
This reapplies the podman changes https://github.com/NixOS/nixpkgs/commit/c59c4e358989ce49afd177e6899549fbb8f8bf7f#diff-25d004fa5a2ccb61035e5dd01da42798L7.

Also update the podman-wrapper which was added after https://github.com/NixOS/nixpkgs/pull/85535 was merged to staging.

cc @adisbladis @FRidh @Mic92
