### PR TITLE
[20.03] re2c: 1.2.1 -> 1.3 + patch

### DIFF
--- a/pkgs/development/tools/parsing/re2c/default.nix
+++ b/pkgs/development/tools/parsing/re2c/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "re2c";
-  version = "1.2.1";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner  = "skvadrik";
     repo   = "re2c";
     rev    = version;
-    sha256 = "1qj0ck9msb9h8g9qb1lr57jmlj8x68ini3y3ccdifjjahhhr0hd4";
+    sha256 = "0aqlf2h6i2m3dq11dkq89p4w4c9kp4x66s5rhp84gmpz5xqv1x5h";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/development/tools/parsing/re2c/default.nix
+++ b/pkgs/development/tools/parsing/re2c/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook }:
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "re2c";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "0aqlf2h6i2m3dq11dkq89p4w4c9kp4x66s5rhp84gmpz5xqv1x5h";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-11958.patch";
+      url = "https://github.com/skvadrik/re2c/commit/c4603ba5ce229db83a2a4fb93e6d4b4e3ec3776a.patch";
+      sha256 = "1d95ahxk92g7k87sda9gxgmr3blyfzwd2y7h9jxj8zkd74knd9zh";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
 


### PR DESCRIPTION
Backport of #86413.

----

https://github.com/skvadrik/re2c/blob/1.3/CHANGELOG

###### Motivation for this change

* https://nvd.nist.gov/vuln/detail/CVE-2020-11958

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).