### PR TITLE
dt-schema: init at v2019.11

### DIFF
--- a/pkgs/development/tools/dt-schema/default.nix
+++ b/pkgs/development/tools/dt-schema/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, git
+, ruamel_yaml
+, jsonschema
+, rfc3987
+, setuptools
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "dtschema";
+  version = "2020.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zdm0zbn1dfk02yqghfvd0nb26hmzivb6mln6bvxjfdcv6n7pdqf";
+  };
+
+  nativeBuildInputs = [ setuptools_scm git ];
+  propagatedBuildInputs = [
+    setuptools
+    ruamel_yaml
+    jsonschema
+    rfc3987
+  ];
+
+  meta = with lib; {
+    description = "Tooling for devicetree validation using YAML and jsonschema";
+    homepage = "https://github.com/devicetree-org/dt-schema/";
+    # all files have SPDX tags
+    license = with licenses; [ bsd2 gpl2 ];
+    maintainers = with maintainers; [ sorki ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3080,6 +3080,8 @@ in
 
   dtc = callPackage ../development/compilers/dtc { };
 
+  dt-schema = python3Packages.callPackage ../development/tools/dt-schema { };
+
   dub = callPackage ../development/tools/build-managers/dub { };
 
   duc = callPackage ../tools/misc/duc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

DeviceTree schema validation. Upstream issue https://github.com/devicetree-org/dt-schema/issues/35

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
