### PR TITLE
bront_fonts: init at 2015-06-28

### DIFF
--- a/pkgs/data/fonts/bront/default.nix
+++ b/pkgs/data/fonts/bront/default.nix
@@ -1,0 +1,26 @@
+{ stdenvNoCC, lib, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation {
+  pname = "bront_fonts";
+  version = "2015-06-28";
+
+  src = fetchFromGitHub {
+    owner = "chrismwendt";
+    repo = "bront";
+    rev = "aef23d9a11416655a8351230edb3c2377061c077";
+    sha256 = "1sx2gv19pgdyccb38sx3qnwszksmva7pqa1c8m35s6cipgjhhgb4";
+  };
+
+  installPhase = ''
+    install -m444 -Dt $out/share/fonts/truetype *Bront.ttf
+  '';
+
+  meta = with lib; {
+    description = "Bront Fonts";
+    longDescription = "Ubuntu Mono Bront and DejaVu Sans Mono Bront fonts.";
+    homepage = "https://github.com/chrismwendt/bront";
+    license = licenses.free;
+    platforms = platforms.all;
+    maintainers = [ maintainers.grburst ];
+  };
+}

--- a/pkgs/data/fonts/bront/default.nix
+++ b/pkgs/data/fonts/bront/default.nix
@@ -2,7 +2,7 @@
 
 stdenvNoCC.mkDerivation {
   pname = "bront_fonts";
-  version = "2015-06-28";
+  version = "unstable-2015-06-28";
 
   src = fetchFromGitHub {
     owner = "chrismwendt";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23000,6 +23000,8 @@ with pkgs;
   ucs-fonts = callPackage ../data/fonts/ucs-fonts
     { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
 
+  bront_fonts = callPackage ../data/fonts/bront { };
+
   ultimate-oldschool-pc-font-pack = callPackage ../data/fonts/ultimate-oldschool-pc-font-pack { };
 
   ultralist = callPackage ../applications/misc/ultralist { };


### PR DESCRIPTION
Signed-off-by: GRBurst <GRBurst@protonmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
