### PR TITLE
gnomeExtensions.gtile: init at 34

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2568,6 +2568,12 @@
     githubId = 415760;
     name = "Jonas Höglund";
   };
+  firmero = {
+    email = "romanfirment@gmail.com";
+    github = "firmero";
+    githubId = 25690815;
+    name = "Roman Firment";
+  };
   fishi0x01 = {
     email = "fishi0x01@gmail.com";
     github = "fishi0x01";

--- a/pkgs/desktops/gnome-3/extensions/gtile/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/gtile/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-gtile";
+  version = "34";
+
+  src = fetchFromGitHub {
+    owner = "gTile";
+    repo = "gTile";
+    rev = "V${version}";
+    sha256 = "1yka4acmrykh4vdd89yvn6yv89c6q16r72lgi3j48my3jghwjiwp";
+  };
+
+  uuid = "gTile@vibou";
+
+  nativeBuildInputs = [ glib ];
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/$uuid
+    cp -r * $out/share/gnome-shell/extensions/$uuid
+
+    schemadir=${glib.makeSchemaPath "$out" "${pname}-${version}"}
+    mkdir -p $schemadir
+    cp -r $out/share/gnome-shell/extensions/$uuid/schemas/* $schemadir
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GNOME shell extension to move/resize windows on a configurable grid scheme";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.firmero ];
+    homepage = "https://github.com/gTile/gTile";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24091,6 +24091,7 @@ in
     draw-on-your-screen = callPackage ../desktops/gnome-3/extensions/draw-on-your-screen { };
     drop-down-terminal = callPackage ../desktops/gnome-3/extensions/drop-down-terminal { };
     gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };
+    gtile = callPackage ../desktops/gnome-3/extensions/gtile { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     impatience = callPackage ../desktops/gnome-3/extensions/impatience { };
     mpris-indicator-button = callPackage ../desktops/gnome-3/extensions/mpris-indicator-button { };


### PR DESCRIPTION
###### Motivation for this change

A window tiling extension for Gnome.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
