### PR TITLE
terminator: 1.91 -> 1.92

### DIFF
--- a/pkgs/applications/misc/terminator/default.nix
+++ b/pkgs/applications/misc/terminator/default.nix
@@ -1,24 +1,56 @@
-{ stdenv, fetchurl, python2, keybinder3, intltool, file, gtk3, gobject-introspection
-, libnotify, wrapGAppsHook, vte
+{ stdenv
+, fetchFromGitHub
+, python
+, keybinder3
+, intltool
+, file
+, gtk3
+, gobject-introspection
+, libnotify
+, wrapGAppsHook
+, vte
 }:
 
-python2.pkgs.buildPythonApplication rec {
+python.pkgs.buildPythonApplication rec {
   name = "terminator-${version}";
-  version = "1.91";
+  version = "1.92";
 
-  src = fetchurl {
-    url = "https://launchpad.net/terminator/gtk3/${version}/+download/${name}.tar.gz";
-    sha256 = "95f76e3c0253956d19ceab2f8da709a496f1b9cf9b1c5b8d3cd0b6da3cc7be69";
+  src = fetchFromGitHub {
+    owner = "gnome-terminator";
+    repo = "terminator";
+    rev = "bb24273eb40dc5eac97de74064488701fa40a743";
+    sha256 = "105f660wzf9cpn24xzwaaa09igg5h3qhchafv190v5nqck6g1ssh";
   };
 
-  nativeBuildInputs = [ file intltool wrapGAppsHook gobject-introspection ];
-  buildInputs = [ gtk3 vte libnotify keybinder3
-    gobject-introspection # Temporary fix, see https://github.com/NixOS/nixpkgs/issues/56943
+  nativeBuildInputs = [
+    file
+    intltool
+    gobject-introspection
+    wrapGAppsHook
   ];
-  propagatedBuildInputs = with python2.pkgs; [ pygobject3 psutil pycairo ];
+
+  buildInputs = [
+    gtk3
+    gobject-introspection # Temporary fix, see https://github.com/NixOS/nixpkgs/issues/56943
+    keybinder3
+    libnotify
+    python
+    vte
+  ];
+
+  propagatedBuildInputs = with python.pkgs; [
+    configobj
+    dbus-python
+    pygobject3
+    psutil
+    pycairo
+  ];
 
   postPatch = ''
     patchShebangs .
+    # dbus-python is correctly passed in propagatedBuildInputs, but for some reason setup.py complains.
+    # The wrapped terminator has the correct path added, so ignore this.
+    substituteInPlace setup.py --replace "'dbus-python'," ""
   '';
 
   checkPhase = ''
@@ -33,7 +65,7 @@ python2.pkgs.buildPythonApplication rec {
       quadkonsole, etc. in that the main focus is arranging terminals in grids
       (tabs is the most common default method, which Terminator also supports).
     '';
-    homepage = "https://gnometerminator.blogspot.no/p/introduction.html";
+    homepage = "https://github.com/gnome-terminator/terminator";
     license = licenses.gpl2;
     maintainers = with maintainers; [ bjornfor ];
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22034,7 +22034,7 @@ in
 
   terminal-notifier = callPackage ../applications/misc/terminal-notifier {};
 
-  terminator = callPackage ../applications/misc/terminator { };
+  terminator = callPackage ../applications/misc/terminator { python = python3; };
 
   terminus = callPackage ../applications/misc/terminus { };
 


### PR DESCRIPTION
###### Motivation for this change

The terminator project has been picked up by a new team and they have started to release new versions. This latest version also makes terminator compatible with python3.

Attempts to close #86415 .

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Open issue: I have to strip out a check for dbus-python to allow installation to proceed. If I look at the patched/wrapped result dbus-python is correctly added, so for me it didn't seem to cause any problems. A similar thing seems to have been done in https://github.com/NixOS/nixpkgs/commit/3a1033c6d95d2f2dac18b3c8495173716c2b68e3 .