### PR TITLE
multibootusb: patchelf syslinux, add missing dependencies

### DIFF
--- a/pkgs/applications/misc/multibootusb/default.nix
+++ b/pkgs/applications/misc/multibootusb/default.nix
@@ -1,4 +1,5 @@
-{ fetchFromGitHub, libxcb, mtools, p7zip, parted, procps,
+{ fetchFromGitHub, libxcb, mtools, p7zip, parted, procps, qemu, unzip, zip,
+  coreutils, gnugrep, which, gnused, e2fsprogs, autoPatchelfHook, gptfdisk,
   python36Packages, qt5, runtimeShell, stdenv, utillinux, wrapQtAppsHook }:
 
 # Note: Multibootusb is tricky to maintain. It relies on the
@@ -19,17 +20,30 @@ python36Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     wrapQtAppsHook
+    autoPatchelfHook
+    unzip
+    zip
+  ];
+
+  runTimeDeps = [
+    coreutils
+    gnugrep
+    which
+    parted
+    utillinux
+    qemu
+    p7zip
+    gnused
+    mtools
+    procps
+    e2fsprogs
+    gptfdisk
   ];
 
   buildInputs = [
     libxcb
-    mtools
-    p7zip
-    parted
-    procps
     python36Packages.python
     qt5.full
-    utillinux
   ];
 
   src = fetchFromGitHub {
@@ -52,6 +66,20 @@ python36Packages.buildPythonApplication rec {
     python36Packages.six
   ];
 
+  # multibootusb ships zips with various versions of syslinux, we need to patchelf them
+  postPatch = ''
+    for zip in $(find . -name "*.zip"); do
+      zip=$(readlink -f $zip)
+      target="$(mktemp -d)"
+      pushd $target
+      unzip $zip
+      rm $zip
+      autoPatchelf .
+      zip -r $zip *
+      popd
+    done
+  '';
+
   postInstall = ''
     # This script doesn't work and it doesn't add much anyway
     rm $out/bin/multibootusb-pkexec
@@ -68,6 +96,9 @@ python36Packages.buildPythonApplication rec {
 
       # Then, add the installed scripts/ directory to the python path
       --prefix "PYTHONPATH" ":" "$out/lib/${python36Packages.python.libPrefix}/site-packages"
+
+      # Add some runtime dependencies
+      --prefix "PATH" ":" "${stdenv.lib.makeBinPath runTimeDeps}"
 
       # Finally, move to directory that contains data
       --run "cd $out/share/${pname}"


### PR DESCRIPTION
Not all dependencies were present on my system.

So I added them until running with an empty path seemed to work.


Persistence did not work because syslinux was not patchelfed.


Is multibootusb supposed to work on nixos isos ? It tells me those are not supported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
