### PR TITLE
p7zip: fix two CVEs

### DIFF
--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, enableUnfree ? false }:
+{ stdenv, fetchurl, fetchpatch, lib, enableUnfree ? false }:
 
 stdenv.mkDerivation rec {
   pname = "p7zip";
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
   patches = [
     ./12-CVE-2016-9296.patch
     ./13-CVE-2017-17969.patch
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/termux/termux-packages/master/packages/p7zip/3-CVE-2018-5996.patch";
+      sha256 = "1zivvkazmza0653i498ccp3zbpbpc7dvxl3zxwllbx41b6n589yp";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/termux/termux-packages/master/packages/p7zip/4-CVE-2018-10115.patch";
+      sha256 = "1cr7q8gnrk9yp6dcvxaqi1yhdbgp964nkv65ls41mw1kdfm44zn6";
+    })
   ];
 
   # Default makefile is full of impurities on Darwin. The patch doesn't hurt Linux so I'm leaving it unconditional


### PR DESCRIPTION
###### Motivation for this change

This is a backport of #86417 to the current release. I've excluded the warning about the software effectively having no developer, to avoid breaking existing setups, as there are no more publicly known vulnerabilities at this point.
Not sure what our release managers prefer (@worldofpeace @disassembler) regarding the warning?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
