### PR TITLE
google-drive-ocamlfuse: 0.7.2 -> 0.7.21

### DIFF
--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -1,23 +1,19 @@
-{ stdenv, fetchFromGitHub, zlib
-, ocaml, dune, ocamlfuse, findlib, gapi_ocaml, ocaml_sqlite3, camlidl }:
+{ stdenv, buildDunePackage, fetchFromGitHub
+, ocamlfuse, gapi_ocaml, ocaml_sqlite3
+}:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
   pname = "google-drive-ocamlfuse";
-  version = "0.7.2";
+  version = "0.7.21";
 
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "google-drive-ocamlfuse";
     rev = "v${version}";
-    sha256 = "1l6b4bs5x373pw210nl8xal03ns2ib1ls49y64s3lqjfh5wjmnjy";
+    sha256 = "0by3qnjrr1mbxyl2n99zggx8dxnqlicsq2b2hhhxb2d0k8qn47sw";
   };
 
-  nativeBuildInputs = [ dune ];
-
-  buildInputs = [ zlib ocaml ocamlfuse findlib gapi_ocaml ocaml_sqlite3 camlidl ];
-
-  buildPhase = "jbuilder build @install";
-  installPhase = "mkdir $out && dune install --prefix $out";
+  buildInputs = [ ocamlfuse gapi_ocaml ocaml_sqlite3 ];
 
   meta = {
     homepage = "http://gdfuse.forge.ocamlcore.org/";

--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, ocurl, cryptokit, ocaml_extlib, yojson, ocamlnet, xmlm }:
+{ stdenv, fetchFromGitHub, buildDunePackage
+, ocurl, cryptokit, ocaml_extlib, yojson, ocamlnet, xmlm
+}:
 
 buildDunePackage rec {
   pname = "gapi-ocaml";
-  version = "0.3.6";
+  version = "0.3.19";
 
   minimumOCamlVersion = "4.02";
 
@@ -10,10 +12,11 @@ buildDunePackage rec {
     owner = "astrada";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0qgsy51bhkpfgl5rdnjw4bqs5fbh2w4vwrfbl8y3lh1wrqmnwci4";
+    sha256 = "04arif1p1vj5yr24cwicj70b7yx17hrgf4pl47vqg8ngcrdh71v9";
   };
 
-  propagatedBuildInputs = [ ocurl cryptokit ocaml_extlib yojson ocamlnet xmlm ];
+  propagatedBuildInputs = [ ocurl cryptokit ocaml_extlib ocamlnet yojson ];
+  buildInputs = [ xmlm ];
 
   meta = {
     description = "OCaml client for google services";

--- a/pkgs/development/ocaml-modules/ocamlfuse/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlfuse/default.nix
@@ -1,22 +1,17 @@
-{ stdenv, fetchFromGitHub, ocaml, camlidl, fuse, findlib }:
+{ stdenv, buildDunePackage, fetchFromGitHub, camlidl, fuse }:
 
-stdenv.mkDerivation rec {
+buildDunePackage {
   pname = "ocamlfuse";
-  version = "2.7.1_cvs5";
+  version = "2.7.1_cvs6_e35e76b";
 
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "ocamlfuse";
-    rev = "v${version}";
-    sha256 = "01ayw2hzpxan95kncbxh9isj9g149cs8scq3xim1vy8bz085wb0m";
+    rev = "e35e76bee3b06806256b5bfca108b7697267cd5c";
+    sha256 = "1v9g0wh7rnjkrjrnw50145g6ry38plyjs8fq8w0nlzwizhf3qhff";
   };
 
-  buildInputs = [ocaml findlib];
-  propagatedBuildInputs = [camlidl fuse];
-  configurePhase = '' ocaml setup.ml -configure --prefix $out '';
-  buildPhase = "ocaml setup.ml -build";
-  installPhase = "ocaml setup.ml -install";
-  createFindlibDestdir = true;
+  propagatedBuildInputs = [ camlidl fuse ];
 
   meta = {
     homepage = "https://sourceforge.net/projects/ocamlfuse";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update `google-drive-ocamlfuse` and its dependencies `ocamlfuse` and `gapi-ocaml` to their latest version. In order for `ocamlfuse` to build, it has to be at its latest, untagged, commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Made sure `google-drive-ocamlfuse` is able to mount a drive folder locally

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
