### PR TITLE
memtest86-efi: replace p7zip with mtools

### DIFF
--- a/pkgs/tools/misc/memtest86-efi/default.nix
+++ b/pkgs/tools/misc/memtest86-efi/default.nix
@@ -1,4 +1,4 @@
-{ fetchzip, lib, p7zip, stdenv }:
+{ fetchzip, lib, stdenv, mtools }:
 
 stdenv.mkDerivation rec {
   pname = "memtest86-efi";
@@ -22,19 +22,19 @@ stdenv.mkDerivation rec {
     stripRoot = false;
   };
 
-  nativeBuildInputs = [ p7zip ];
+  nativeBuildInputs = [ mtools ];
 
   installPhase = ''
-    mkdir -p $out
+    mkdir -p $out $TEMP/memtest86-files
 
     # memtest86 is distributed as a bootable USB image.  It contains the actual
     # memtest86 EFI app.
     #
-    # The following command uses p7zip to extract the actual EFI app from the
+    # The following uses dd and mcopy to extract the actual EFI app from the
     # usb image so that it can be installed directly on the hard drive.
-    7z x -o$TEMP/temp-efi-dirs $src/memtest86-usb.img
-    7z x -o$TEMP/memtest86-files $TEMP/temp-efi-dirs/EFI\ System\ Partition.img
-    cp -r $TEMP/memtest86-files/EFI/BOOT/* $out/
+    dd if=$src/memtest86-usb.img of=$TEMP/ESP.img skip=2048
+    mcopy -i $TEMP/ESP.img ::/EFI/BOOT/ $TEMP/memtest86-files/
+    mv $TEMP/memtest86-files/BOOT/* $out/
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Fix build after #86417

cc @flokli 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
