### PR TITLE
nixos/virtualbox-guest: support VMSVGA graphics adapter

### DIFF
--- a/nixos/doc/manual/installation/installing-virtualbox-guest.xml
+++ b/nixos/doc/manual/installation/installing-virtualbox-guest.xml
@@ -49,7 +49,7 @@
   </listitem>
   <listitem>
    <para>
-    Click on Settings / Display / Screen and select VBoxVGA as Graphics Controller
+    Click on Settings / Display / Screen and select VMSVGA as Graphics Controller
    </para>
   </listitem>
   <listitem>

--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -68,7 +68,7 @@ in
         SUBSYSTEM=="misc", KERNEL=="vboxguest", TAG+="systemd"
       '';
   } (mkIf cfg.x11 {
-    services.xserver.videoDrivers = mkOverride 50 [ "virtualbox" "modesetting" ];
+    services.xserver.videoDrivers = mkOverride 50 [ "vmware" "virtualbox" "modesetting" ];
 
     services.xserver.config =
       ''

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -72,6 +72,7 @@ in {
         audiocontroller = "ac97";
         audio = "alsa";
         audioout = "on";
+        graphicscontroller = "vmsvga";
         rtcuseutc = "on";
         usb = "on";
         usbehci = "on";

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -19,6 +19,7 @@ let
   dlopenLibs = [
     { name = "libdbus-1.so"; pkg = dbus; }
     { name = "libXfixes.so"; pkg = xorg.libXfixes; }
+    { name = "libXrandr.so"; pkg = xorg.libXrandr; }
   ];
 
 in stdenv.mkDerivation rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

This makes VMSVGA the default and recommended graphics adapter for virtualbox.

###### Motivation for this change

Currently with virtualbox 6.1.6 [guest resizing is broken](https://www.virtualbox.org/ticket/19496).

Also Virtualbox complains that `VBoxVGA` is not the recommended graphics adaptere for linux guests, and that `VMSVGA` should be used. In newer versions of Virtualbox (6.1+) `VMSVGA` seems to be the only adapter supporting 3D acceleration (https://github.com/NixOS/nixpkgs/issues/81850).

This PR makes `VMSVGA` work out of the box in NixOS, including Auto resize and 3D acceleration.

###### Things done

I tested the resulting machine with:
-  `VMSVGA` with 3D (OK)
- `VMSVGA` without 3D (OK)
- `VBoxVGA` (OK, [no auto resize](https://www.virtualbox.org/ticket/19496))

`VBoxVGA` is still supported, but I could not test autoresizing as it is currently broken, even before my changes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
