### PR TITLE
apitrace: fix to find OpenGL libraries

### DIFF
--- a/pkgs/applications/graphics/apitrace/default.nix
+++ b/pkgs/applications/graphics/apitrace/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, libX11, procps, python2, libdwarf, qtbase, qtwebkit }:
+{ stdenv, fetchFromGitHub, cmake, libX11, procps, python2, libdwarf, qtbase, qtwebkit, wrapQtAppsHook, libglvnd }:
 
 stdenv.mkDerivation rec {
   pname = "apitrace";
@@ -15,7 +15,48 @@ stdenv.mkDerivation rec {
   # of games -- so it's fine to use e.g. bundled snappy.
   buildInputs = [ libX11 procps python2 libdwarf qtbase qtwebkit ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+
+  # Don't automatically wrap all binaries, I prefer to explicitly only wrap
+  # `qapitrace`.
+  dontWrapQtApps = true;
+
+  postFixup = ''
+
+    # Since https://github.com/NixOS/nixpkgs/pull/60985, we add `/run-opengl-driver[-32]`
+    # to the `RUNPATH` of dispatcher libraries `dlopen()` ing OpenGL drivers.
+    # `RUNPATH` doesn't propagate throughout the whole application, but only
+    # from the module performing the `dlopen()`.
+    # 
+    # Apitrace wraps programs by running them with `LD_PRELOAD` pointing to `.so`
+    # files in $out/lib/apitrace/wrappers.
+    # 
+    # Theses wrappers effectively wrap the `dlopen()` calls from `libglvnd`
+    # and other dispatcher libraries, and run `dlopen()`  by themselves.
+    # 
+    # As `RUNPATH` doesn't propagate through the whole library, and they're now the
+    # library doing the real `dlopen()`, they also need to have
+    # `/run-opengl-driver[-32]` added to their `RUNPATH`.
+    #
+    # To stay simple, we add paths for 32 and 64 bits unconditionally.
+    # This doesn't have an impact on closure size, and if the 32 bit drivers
+    # are not available, that folder is ignored.
+    for i in $out/lib/apitrace/wrappers/*.so
+    do
+      echo "Patching OpenGL driver path for $i"
+      patchelf --set-rpath "/run/opengl-driver/lib:/run/opengl-driver-32/lib:$(patchelf --print-rpath $i)" $i
+    done
+
+    # Theses open the OpenGL driver at runtime, but it is not listed as NEEDED libraries. They need
+    # a reference to libglvnd.
+    for i in $out/bin/eglretrace $out/bin/glretrace
+    do
+      echo "Patching RPath for $i"
+      patchelf --set-rpath "${stdenv.lib.makeLibraryPath [libglvnd]}:$(patchelf --print-rpath $i)" $i
+    done
+
+    wrapQtApp $out/bin/qapitrace
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://apitrace.github.io";


### PR DESCRIPTION
###### Motivation for this change

Fix `apitrace` which was not working anymore.

- Tracing was not working because of missing OpenGL libraries, probably due to the recent changes in OpenGL in NixOs.
- Qt GUI to see trace was not working due to the recent QT changes in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions (but need `nixGL` to work properly)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) (1.1 GB versus 1.1 GB)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
