### PR TITLE
wormhole: init at 0.1.5

### DIFF
--- a/pkgs/tools/networking/wormhole/default.nix
+++ b/pkgs/tools/networking/wormhole/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, openssl
+, pkg-config
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wormhole";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "agrinman";
+    repo = pname;
+    rev = version;
+    sha256 = "0aq2myzqd9xqz4zdl03jhdd7f22y9k39xdhiark6ymhwcxijsq8y";
+  };
+
+  cargoSha256 = "1gjqiv8sgdab0i461v72zcvh91cpqmmpcc3qyx3svq0391rwzp46";
+
+  nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ pkg-config ];
+  buildInputs = [ ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ openssl ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];
+
+  meta = with stdenv.lib; {
+    description = "Expose your local web server to the internet with a public URL";
+    homepage = "https://tunnelto.dev";
+    license = licenses.mit;
+    maintainers = with maintainers; [ filalex77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7367,6 +7367,10 @@ in
 
   wootility = callPackage ../tools/misc/wootility { };
 
+  wormhole = callPackage ../tools/networking/wormhole {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   wpscan = callPackage ../tools/security/wpscan { };
 
   wsmancli = callPackage ../tools/system/wsmancli {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
[Wormhole homepage](https://tunnelto.dev)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
