### PR TITLE
pyprof2calltree: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/development/python-modules/pyprof2calltree/default.nix
+++ b/pkgs/development/python-modules/pyprof2calltree/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "pyprof2calltree";
-  version = "1.4.4";
+  version = "1.4.5";
 
   # Fetch from GitHub because the PyPi packaged version does not
   # include all test files.
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "pwaller";
     repo = "pyprof2calltree";
     rev = "v" + version;
-    sha256 = "1vrip41ib7nmkwa8rjny1na1wyp7nvvgvm0h9bd21i262kbm4nqx";
+    sha256 = "0akighssiswfhi5285rrj37am6flg3ip17c34bayq3r8yyk1iciy";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Just a new release.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
