### PR TITLE
nixos/systemd.nix: don’t require online for multi-user.target

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1033,7 +1033,6 @@ in
     systemd.services.systemd-journald.stopIfChanged = false;
     systemd.targets.local-fs.unitConfig.X-StopOnReconfiguration = true;
     systemd.targets.remote-fs.unitConfig.X-StopOnReconfiguration = true;
-    systemd.targets.network-online.wantedBy = [ "multi-user.target" ];
     systemd.services.systemd-binfmt.wants = [ "proc-sys-fs-binfmt_misc.mount" ];
 
     # Don't bother with certain units in containers.


### PR DESCRIPTION
Second attempt of https://github.com/NixOS/nixpkgs/pull/86273.

Original revert message:
```
    Revert "nixos/systemd.nix: don’t require online for multi-user.target"
    
    This reverts commit 764c8203b833176d546395a5c1adf193a9ca73f8.
    
    While this is desireable in principle, some of our modules and services
    fail during service startup if no network is available don't currently
    properly set Wants=network-online.target.
    
    If nothing pulls in this target anymore, systemd won't try to reach it.
    
    We have many VM tests waiting for `network-online.target`, and after
    764c8203b833176d546395a5c1adf193a9ca73f8 fail with the following error
    message:
    
    ```
    error: unit "network-online.target" is inactive and there are no pending jobs
    ```
    
    Most likely, test scripts shouldn't wait for `network-online.target` in
    first place (as `network-online.target` says nothing about whether a
    service has been started), but instead, the script should wait for the
    network ports of the corresponding service to be open.
    
    Let's revert this for now, and re-apply in a draft PR, fixing the tests
    before merging it back in.
```

This re-applies the original commit, but fixing some of the VM tests and modules afterwards.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
