### PR TITLE
Python: introduce NIX_PYTHONPREFIX in order to set site.PREFIXES (20.03 backport)

### DIFF
--- a/pkgs/development/interpreters/python/sitecustomize.py
+++ b/pkgs/development/interpreters/python/sitecustomize.py
@@ -21,10 +21,19 @@ paths = os.environ.pop('NIX_PYTHONPATH', None)
 if paths:
     functools.reduce(lambda k, p: site.addsitedir(p, k), paths.split(':'), site._init_pathinfo())
 
-prefixes = os.environ.pop('NIX_PYTHONPREFIX', None)
-if prefixes:
-    site.PREFIXES.extend(prefixes.split(':'))
+# Check whether we are in a venv. 
+# Note Python 2 does not support base_prefix so we assume we are not in a venv.
+in_venv = sys.version_info.major == 3 and sys.prefix != sys.base_prefix
 
-executable = os.environ.pop('NIX_PYTHONEXECUTABLE', None)
-if 'PYTHONEXECUTABLE' not in os.environ and executable:
-    sys.executable = executable
+if not in_venv:
+    executable = os.environ.pop('NIX_PYTHONEXECUTABLE', None)
+    prefix = os.environ.pop('NIX_PYTHONPREFIX', None)
+
+    if 'PYTHONEXECUTABLE' not in os.environ and executable is not None:
+        sys.executable = executable
+    if prefix is not None:
+        # Because we cannot check with Python 2 whether we are in a venv, 
+        # creating a venv from a Nix env won't work as well with Python 2.
+        # Also, note that sysconfig does not like it when sys.prefix is set to None
+        sys.prefix = sys.exec_prefix = prefix
+        site.PREFIXES.insert(0, prefix)

--- a/pkgs/development/interpreters/python/sitecustomize.py
+++ b/pkgs/development/interpreters/python/sitecustomize.py
@@ -21,6 +21,10 @@ paths = os.environ.pop('NIX_PYTHONPATH', None)
 if paths:
     functools.reduce(lambda k, p: site.addsitedir(p, k), paths.split(':'), site._init_pathinfo())
 
+prefixes = os.environ.pop('NIX_PYTHONPREFIX', None)
+if prefixes:
+    site.PREFIXES.extend(prefixes.split(':'))
+
 executable = os.environ.pop('NIX_PYTHONEXECUTABLE', None)
 if 'PYTHONEXECUTABLE' not in os.environ and executable:
     sys.executable = executable

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -37,7 +37,7 @@ let
             if [ -f "$prg" ]; then
               rm -f "$out/bin/$prg"
               if [ -x "$prg" ]; then
-                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set NIX_PYTHONEXECUTABLE ${pythonExecutable} --set NIX_PYTHONPATH ${pythonPath} ${if permitUserSite then "" else ''--set PYTHONNOUSERSITE "true"''} ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
+                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set NIX_PYTHONPREFIX "$out" --set NIX_PYTHONEXECUTABLE ${pythonExecutable} --set NIX_PYTHONPATH ${pythonPath} ${if permitUserSite then "" else ''--set PYTHONNOUSERSITE "true"''} ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
               fi
             fi
           done


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
