### PR TITLE
nixos/documentation: add option to generate caches

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -469,6 +469,7 @@ rec {
   getBin = getOutput "bin";
   getLib = getOutput "lib";
   getDev = getOutput "dev";
+  getMan = getOutput "man";
 
   /* Pick the outputs of packages to place in buildInputs */
   chooseDevOutputs = drvs: builtins.map getDev drvs;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -77,7 +77,7 @@ let
       genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
-      getLib getDev chooseDevOutputs zipWithNames zip
+      getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs;
     inherit (lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -110,6 +110,15 @@ systemd.services.mysql.serviceConfig.ReadWritePaths = [ "/var/data" ];
 </programlisting>
     </para>
    </listitem>
+   <listitem>
+    <para>
+      Two new option <link linkend="opt-documentation.man.generateCaches">documentation.man.generateCaches</link>
+      has been added to automatically generate the <literal>man-db</literal> caches, which are needed by utilities
+      like <command>whatis</command> and <command>apropos</command>. The caches are generated during the build of
+      the NixOS configuration: since this can be expensive when a large number of packages are installed, the
+      feature is disabled by default.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -15,18 +15,17 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpipeline db groff ]; # (Yes, 'groff' is both native and build input)
   checkInputs = [ libiconv /* for 'iconv' binary */ ];
 
+  patches = [ ./systemwide-man-db-conf.patch ];
+
   postPatch = ''
     # Remove all mandatory manpaths. Nixpkgs makes no requirements on
     # these directories existing.
     sed -i 's/^MANDATORY_MANPATH/# &/' src/man_db.conf.in
 
-    # Add Nixpkgs and NixOS-related manpaths
-    echo "MANPATH_MAP	/run/current-system/sw/bin		/run/current-system/sw/share/man" >> src/man_db.conf.in
-    echo "MANPATH_MAP	/run/wrappers/bin			/run/current-system/sw/share/man" >> src/man_db.conf.in
+    # Add Nix-related manpaths
     echo "MANPATH_MAP	/nix/var/nix/profiles/default/bin	/nix/var/nix/profiles/default/share/man" >> src/man_db.conf.in
 
     # Add mandb locations for the above
-    echo "MANDB_MAP	/run/current-system/sw/share/man	/var/cache/man/nixos" >> src/man_db.conf.in
     echo "MANDB_MAP	/nix/var/nix/profiles/default/share/man	/var/cache/man/nixpkgs" >> src/man_db.conf.in
   '';
 
@@ -34,7 +33,6 @@ stdenv.mkDerivation rec {
     "--disable-setuid"
     "--disable-cache-owner"
     "--localstatedir=/var"
-    # Don't try /etc/man_db.conf by default, so we avoid error messages.
     "--with-config-file=${placeholder "out"}/etc/man_db.conf"
     "--with-systemdtmpfilesdir=${placeholder "out"}/lib/tmpfiles.d"
     "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"

--- a/pkgs/tools/misc/man-db/systemwide-man-db-conf.patch
+++ b/pkgs/tools/misc/man-db/systemwide-man-db-conf.patch
@@ -1,0 +1,39 @@
+commit 9089291006a4258c39c75a920ad536b61504251a
+Author: rnhmjoj <rnhmjoj@inventati.org>
+Date:   Fri May 1 19:32:15 2020 +0200
+
+    check for systemwide man_db.conf before the bundled one
+
+diff --git a/src/manp.c b/src/manp.c
+index 5441339..0bbf566 100644
+--- a/src/manp.c
++++ b/src/manp.c
+@@ -841,18 +841,24 @@ void read_config_file (bool optional)
+ 	}
+ 
+ 	if (getenv ("MAN_TEST_DISABLE_SYSTEM_CONFIG") == NULL) {
+-		config_file = fopen (CONFIG_FILE, "r");
++		const char *config_filepath;
++		if (access ("/etc/man_db.conf", F_OK) != -1) {
++			config_filepath = "/etc/man_db.conf";
++		} else {
++			config_filepath = CONFIG_FILE;
++		}
++		config_file = fopen (config_filepath, "r");
+ 		if (config_file == NULL) {
+ 			if (optional)
+ 				debug ("can't open %s; continuing anyway\n",
+-				       CONFIG_FILE);
++				       config_filepath);
+ 			else
+ 				error (FAIL, 0,
+ 				       _("can't open the manpath "
+ 					 "configuration file %s"),
+-				       CONFIG_FILE);
++				       config_filepath);
+ 		} else {
+-			debug ("From the config file %s:\n", CONFIG_FILE);
++			debug ("From the config file %s:\n", config_filepath);
+ 
+ 			add_to_dirlist (config_file, 0);
+ 			fclose (config_file);


### PR DESCRIPTION
###### Motivation for this change
An alternative approach to #76841 to generate manual pages caches. This will fix https://github.com/NixOS/nixpkgs/issues/14472.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change (mass-rebuild)
- [x] Tested execution of all binary files (`apropos`, `whatis`, `mandb` works as intended)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).