### PR TITLE
[20.03] emacs: improve setup hook

### DIFF
--- a/pkgs/build-support/emacs/setup-hook.sh
+++ b/pkgs/build-support/emacs/setup-hook.sh
@@ -1,23 +1,15 @@
-addToEmacsLoadPath() {
-  local lispDir="$1"
-  if [[ -d $lispDir && ${EMACSLOADPATH-} != *"$lispDir":* ]] ; then
-    # It turns out, that the trailing : is actually required
-    # see https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Search.html
-    export EMACSLOADPATH="$lispDir:${EMACSLOADPATH-}"
-  fi
-}
-
 addEmacsVars () {
-  addToEmacsLoadPath "$1/share/emacs/site-lisp"
-
-  # Add sub paths to the Emacs load path if it is a directory
-  # containing .el files. This is necessary to build some packages,
-  # e.g., using trivialBuild.
   for lispDir in \
+      "$1/share/emacs/site-lisp" \
       "$1/share/emacs/site-lisp/"* \
       "$1/share/emacs/site-lisp/elpa/"*; do
-    if [[ -d $lispDir && "$(echo "$lispDir"/*.el)" ]] ; then
-      addToEmacsLoadPath "$lispDir"
+    # Add the path to the Emacs load path if it is a directory
+    # containing .el files and it has not already been added to the
+    # load path.
+    if [[ -d $lispDir && "$(echo "$lispDir"/*.el)" && ${EMACSLOADPATH-} != *"$lispDir":* ]] ; then
+      # It turns out, that the trailing : is actually required
+      # see https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Search.html
+      export EMACSLOADPATH="$lispDir:${EMACSLOADPATH-}"
     fi
   done
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backports #78680 to 20.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
