### PR TITLE
gzip: add setup-hook to stop gzip from adding timestamps to headers

### DIFF
--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, xz }:
+{ stdenv
+, fetchurl
+, xz
+, writeText
+}:
 
 stdenv.mkDerivation rec {
   pname = "gzip";
@@ -24,6 +28,12 @@ stdenv.mkDerivation rec {
   preFixup = ''
     sed -i '1{;/#!\/bin\/sh/aPATH="'$out'/bin:$PATH"
     }' $out/bin/*
+  '';
+
+  # set GZIP env variable to "-n" to stop gzip from adding timestamps
+  # to archive headers: https://github.com/NixOS/nixpkgs/issues/86348
+  setupHook = writeText "setup-hook" ''
+    export GZIP="-n"
   '';
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This will hopefully help with reproducible builds.

See https://github.com/NixOS/nixpkgs/issues/86348 for more info

Closes #86348

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
