### PR TITLE
espanso: init at 0.6.3

### DIFF
--- a/pkgs/applications/office/espanso/default.nix
+++ b/pkgs/applications/office/espanso/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkgconfig
+, extra-cmake-modules
+, libX11
+, libXi
+, libXtst
+, libnotify
+, openssl
+, xclip
+, xdotool
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "espanso";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "federico-terzi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1x5p7hniapggqd18rx26mjvdf33z7rm7zz5vsqm2siv3mcl19033";
+  };
+
+  cargoSha256 = "0liwwdncymjql5dw7rwhhimcr7qdbyvfgmsd0bawvi0ym7m1v408";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    pkgconfig
+  ];
+
+  buildInputs = [
+    libX11
+    libXtst
+    libXi
+    libnotify
+    openssl
+    xdotool
+  ];
+
+  # Some tests require networking
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform Text Expander written in Rust";
+    homepage = "https://espanso.org";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ kimat ];
+    platforms = platforms.all;
+
+    longDescription = ''
+      Espanso detects when you type a keyword and replaces it while you're typing.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1792,6 +1792,8 @@ in
 
   eschalot = callPackage ../tools/security/eschalot { };
 
+  espanso = callPackage ../applications/office/espanso { };
+
   esphome = callPackage ../tools/misc/esphome { };
 
   esptool = callPackage ../tools/misc/esptool { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add [espanso](https://espanso.org/) to nixpkgs

Took this archlinux build script as reference: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=espanso

- why `doCheck = false;` ? https://gist.github.com/kimat/c0b253dafef640da9cd5371af031a01d
- why openssl ? https://gist.github.com/kimat/79bdd3507a2099c98e01a3714122f5e1

To test this without systemd : run `./result/bin/espanso` then type `:espanso` anywhere and that text replaces itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
