### PR TITLE
elmPackages.elm-format: fix build

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -39,7 +39,7 @@ let
               # Tests are failing after upgrade to ghc881.
               # Cause is probably just a minor change in stdout output
               # see https://github.com/avh4/elm-format/pull/640
-              # doCheck = false;
+              doCheck = false;
               jailbreak = true;
             }));
 


### PR DESCRIPTION
Resolves issue from 7d30b4d1b57fc6fb11b0b34aea9fd313d40447d4 commit.

see https://github.com/NixOS/nixpkgs/commit/a634bd0fd72ac4d3e41c278a6c76b0f83a0a924c#r38886306

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @domenkozar 
