### PR TITLE
enlightenment.efl: 1.23.3 -> 1.24.0; new test module

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -85,6 +85,7 @@ in
   ecryptfs = handleTest ./ecryptfs.nix {};
   ejabberd = handleTest ./xmpp/ejabberd.nix {};
   elk = handleTestOn ["x86_64-linux"] ./elk.nix {};
+  enlightenment = handleTest ./enlightenment.nix {};
   env = handleTest ./env.nix {};
   etcd = handleTestOn ["x86_64-linux"] ./etcd.nix {};
   etcd-cluster = handleTestOn ["x86_64-linux"] ./etcd-cluster.nix {};

--- a/nixos/tests/enlightenment.nix
+++ b/nixos/tests/enlightenment.nix
@@ -1,0 +1,101 @@
+import ./make-test-python.nix ({ pkgs, ...} :
+{
+  name = "enlightenment";
+
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ romildo ];
+  };
+
+  machine = { ... }:
+  {
+    imports = [ ./common/user-account.nix ];
+    services.xserver.enable = true;
+    services.xserver.desktopManager.enlightenment.enable = true;
+    services.xserver.displayManager.lightdm = {
+      enable = true;
+      autoLogin = {
+        enable = true;
+        user = "alice";
+      };
+    };
+    hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
+    virtualisation.memorySize = 1024;
+    environment.systemPackages = [ pkgs.xdotool ];
+    services.acpid.enable = true;
+    services.connman.enable = true;
+    services.connman.package = pkgs.connmanMinimal;
+  };
+
+  enableOCR = true;
+
+  testScript = { nodes, ... }: let
+    user = nodes.machine.config.users.users.alice;
+  in ''
+    with subtest("Ensure x starts"):
+        machine.wait_for_x()
+        machine.wait_for_file("${user.home}/.Xauthority")
+        machine.succeed("xauth merge ${user.home}/.Xauthority")
+
+    with subtest("Check that logging in has given the user ownership of devices"):
+        machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
+
+    with subtest("First time wizard"):
+        machine.wait_for_text("Default")  # Language
+        machine.succeed("xdotool mousemove 512 185 click 1")  # Default Language
+        machine.screenshot("wizard1")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("English")  # Keyboard (default)
+        machine.screenshot("wizard2")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("Standard")  # Profile (default)
+        machine.screenshot("wizard3")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("Title")  # Sizing (default)
+        machine.screenshot("wizard4")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("clicked")  # Windows Phocus
+        machine.succeed("xdotool mousemove 512 370 click 1")  # Click
+        machine.screenshot("wizard5")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("bindings")  # Mouse Modifiers (default)
+        machine.screenshot("wizard6")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("Connman")  # Network Management (default)
+        machine.screenshot("wizard7")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("BlusZ")  # Bluetooh Management (default)
+        machine.screenshot("wizard8")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("Compositing")  # Compositing (default)
+        machine.screenshot("wizard9")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("update")  # Updates
+        machine.succeed("xdotool mousemove 512 495 click 1")  # Disable
+        machine.screenshot("wizard10")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("taskbar")  # Taskbar
+        machine.succeed("xdotool mousemove 480 410 click 1")  # Enable
+        machine.screenshot("wizard11")
+        machine.succeed("xdotool mousemove 512 740 click 1")  # Next
+
+        machine.wait_for_text("Home")  # The desktop
+        machine.screenshot("wizard12")
+
+    with subtest("Run Terminology"):
+        machine.succeed("terminology &")
+        machine.sleep(5)
+        machine.send_chars("ls --color -alF\n")
+        machine.sleep(2)
+        machine.screenshot("terminology")
+  '';
+})

--- a/pkgs/desktops/enlightenment/econnman.nix
+++ b/pkgs/desktops/enlightenment/econnman.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, python2Packages, dbus, makeWrapper }:
+{ stdenv, fetchurl, pkgconfig, efl, python3Packages, dbus, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "econnman";
@@ -9,11 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "057pwwavlvrrq26bncqnfrf449zzaim0zq717xv86av4n940gwv0";
   };
 
-  nativeBuildInputs = [ makeWrapper pkgconfig python2Packages.wrapPython ];
+  nativeBuildInputs = [ makeWrapper pkgconfig python3Packages.wrapPython ];
 
-  buildInputs = [ efl python2Packages.python dbus ];
+  buildInputs = [ efl python3Packages.python dbus ];
 
-  pythonPath = [ python2Packages.pythonefl python2Packages.dbus-python ];
+  pythonPath = [ python3Packages.pythonefl python3Packages.dbus-python ];
 
   postInstall = ''
     wrapPythonPrograms

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -1,11 +1,57 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, SDL, SDL2, alsaLib,
-  avahi, bullet, check, curl, dbus, doxygen, expat, fontconfig,
-  freetype, fribidi, ghostscript, giflib, glib, gst_all_1, gtk3,
-  harfbuzz, hicolor-icon-theme, ibus, jbig2dec, libGL, libdrm,
-  libinput, libjpeg, libpng, libpulseaudio, libraw, librsvg,
-  libsndfile, libspectre, libtiff, libwebp, libxkbcommon, luajit, lz4,
-  mesa, openjpeg, openssl, poppler, python27Packages, systemd, udev,
-  utillinux, writeText, xorg, zlib }:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, SDL
+, SDL2
+, alsaLib
+, avahi
+, bullet
+, check
+, curl
+, dbus
+, doxygen
+, expat
+, fontconfig
+, freetype
+, fribidi
+, ghostscript
+, giflib
+, glib
+, gst_all_1
+, gtk3
+, harfbuzz
+, hicolor-icon-theme
+, ibus
+, jbig2dec
+, libGL
+, libdrm
+, libinput
+, libjpeg
+, libpng
+, libpulseaudio
+, libraw
+, librsvg
+, libsndfile
+, libspectre
+, libtiff
+, libwebp
+, libxkbcommon
+, luajit
+, lz4
+, mesa
+, openjpeg
+, openssl
+, poppler
+, python27Packages
+, systemd
+, udev
+, utillinux
+, writeText
+, xorg
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "efl";

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -44,7 +44,7 @@
 , openjpeg
 , openssl
 , poppler
-, python27Packages
+, python3Packages
 , systemd
 , udev
 , utillinux
@@ -123,7 +123,7 @@ stdenv.mkDerivation rec {
     luajit
     openjpeg
     poppler
-    python27Packages.dbus-python
+    python3Packages.dbus-python
     utillinux
     xorg.libXScrnSaver
     xorg.libXcomposite

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -55,11 +55,11 @@
 
 stdenv.mkDerivation rec {
   pname = "efl";
-  version = "1.23.3";
+  version = "1.24.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "00b9lp3h65254kdb1ys15fv7p3ln7qsvf15jkw4kli5ymagadkjk";
+    sha256 = "1yhck2g4rwlzgnzqa4wjxw3lf6k6rd730hz4bwzajdjy7i26xfdk";
   };
 
   nativeBuildInputs = [
@@ -148,6 +148,7 @@ stdenv.mkDerivation rec {
     "-D build-tests=false" # disable build tests, which are not working
     "-D drm=true"
     "-D embedded-lz4=false"
+    "-D ecore-imf-loaders-disabler=ibus,scim" # ibus is disalbed by default, scim is not availabe in nixpkgs
     "-D evas-loaders-disabler=json"
     "-D fb=true"
     "-D opengl=full"

--- a/pkgs/development/python-modules/python-efl/default.nix
+++ b/pkgs/development/python-modules/python-efl/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, fetchurl, buildPythonPackage, pkgconfig, python, enlightenment }:
+{ stdenv
+, fetchurl
+, buildPythonPackage
+, pkgconfig
+, python
+, enlightenment
+}:
 
 # Should be bumped along with EFL!
 
@@ -18,12 +24,16 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ python.pkgs.dbus-python ];
 
   preConfigure = ''
-    export NIX_CFLAGS_COMPILE="$(pkg-config --cflags efl) -I${stdenv.lib.getDev python.pkgs.dbus-python}/include/dbus-1.0 $NIX_CFLAGS_COMPILE"
+    NIX_CFLAGS_COMPILE="$(pkg-config --cflags efl) -I${stdenv.lib.getDev python.pkgs.dbus-python}/include/dbus-1.0 $NIX_CFLAGS_COMPILE"
   '';
 
-  preBuild = "${python.interpreter} setup.py build_ext";
+  preBuild = ''
+    ${python.interpreter} setup.py build_ext
+  '';
 
-  installPhase= "${python.interpreter} setup.py install --prefix=$out";
+  installPhase = ''
+    ${python.interpreter} setup.py install --prefix=$out
+  '';
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/python-efl/default.nix
+++ b/pkgs/development/python-modules/python-efl/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , pkgconfig
 , python
+, dbus-python
 , enlightenment
 }:
 
@@ -10,21 +11,21 @@
 
 buildPythonPackage rec {
   pname = "python-efl";
-  version = "1.23.0";
+  version = "1.24.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/bindings/python/${pname}-${version}.tar.xz";
-    sha256 = "16yn6a1b9167nfmryyi44ma40m20ansfpwgrvqzfvwix7qaz9pib";
+    sha256 = "1vk1cdd959gia4a9qzyq56a9zw3lqf9ck66k8c9g3c631mp5cfpy";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ enlightenment.efl ];
 
-  propagatedBuildInputs = [ python.pkgs.dbus-python ];
+  propagatedBuildInputs = [ dbus-python ];
 
   preConfigure = ''
-    NIX_CFLAGS_COMPILE="$(pkg-config --cflags efl) -I${stdenv.lib.getDev python.pkgs.dbus-python}/include/dbus-1.0 $NIX_CFLAGS_COMPILE"
+    NIX_CFLAGS_COMPILE="$(pkg-config --cflags efl evas) $NIX_CFLAGS_COMPILE"
   '';
 
   preBuild = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- enlightenment.efl: format with nixpkgs-fmt
- enlightenment.efl: 1.23.3 -> [1.24.0](https://www.enlightenment.org/news/efl-1.24.0)
- enlightenment.efl: migrate to python3
- enlightenment.econnman: migrate to python3
- pythonPackages.pythonefl: format
- pythonPackages.python-efl: 1.23.0 -> [1.24.0](https://sourceforge.net/p/enlightenment/mailman/message/36997426/)

_Added_:
- nixos/tests: add enlightenment desktop environment

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).