### PR TITLE
minio: 2020-03-25 -> 2020-05-01, minio-client: 2020-04-04 -> 2020-04-25

### DIFF
--- a/nixos/tests/minio.nix
+++ b/nixos/tests/minio.nix
@@ -44,7 +44,7 @@ in {
 
     # Create a test bucket on the server
     machine.succeed(
-        "mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} S3v4"
+        "mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} --api s3v4"
     )
     machine.succeed("mc mb minio/test-bucket")
     machine.succeed("${minioPythonScript}")

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -2,21 +2,21 @@
 
 buildGoModule rec {
   pname = "minio";
-  version = "2020-03-25T07-03-04Z";
+  version = "2020-05-01T22-19-14Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "0xdflc7pfx1misbh695x8kmqpysi5iydsarr9mwmjragf5b1kbl5";
+    sha256 = "0yyq5j82rcl8yhn2jg8sjfxii6kzbrbmxvb05yiwv7p0q42ag5rn";
   };
 
-  modSha256 = "09kbibsfa7qq55paqr7wcs4gpwk6g5pknc5fjssmd12nm2cji96k";
+  modSha256 = "1g5vwllxpiy4qlfhn3v5k6sn4g4qpbv0hpg32y1vi2q342lag116";
 
   subPackages = [ "." ];
 
   buildFlagsArray = [''-ldflags=
-    -X github.com/minio/minio/cmd.Version=${version}
+    -s -w -X github.com/minio/minio/cmd.Version=${version}
   ''];
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoModule, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub, nixosTests }:
 
 buildGoModule rec {
   pname = "minio";
@@ -18,6 +18,8 @@ buildGoModule rec {
   buildFlagsArray = [''-ldflags=
     -s -w -X github.com/minio/minio/cmd.Version=${version}
   ''];
+
+  passthru.tests.minio = nixosTests.minio;
 
   meta = with stdenv.lib; {
     homepage = "https://www.minio.io/";

--- a/pkgs/tools/networking/minio-client/default.nix
+++ b/pkgs/tools/networking/minio-client/default.nix
@@ -2,22 +2,20 @@
 
 buildGoModule rec {
   pname = "minio-client";
-  version = "2020-04-04T05-28-55Z";
+  version = "2020-04-25T00-43-23Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "mc";
     rev = "RELEASE.${version}";
-    sha256 = "09z28fq492d4l0089d1knq4zah9p2b212pkz777vznw9lzfqqip8";
+    sha256 = "0ff2fyr3787zp0lpgbph064am33py2wzjikzmxd3zwp3y0dic770";
   };
 
-  modSha256 = "0cv824ar5ifsg93sylrfjmax6zqm5073y95hqqfcc1dfp0mv2ki3";
+  modSha256 = "1bcz7jchfnglypr2md9hhqbvcbghic2yp6njdrx3m5nqhylypzfx";
 
   subPackages = [ "." ];
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags=-X github.com/minio/mc/cmd.Version=${version}")
-  '';
+  buildFlagsArray = [ "-ldflags=-s -w -X github.com/minio/mc/cmd.Version=${version}" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/minio/mc";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
