### PR TITLE
intltool: add a backup url for a patch

### DIFF
--- a/pkgs/development/tools/misc/intltool/default.nix
+++ b/pkgs/development/tools/misc/intltool/default.nix
@@ -12,8 +12,10 @@ stdenv.mkDerivation rec {
   # fix "unescaped left brace" errors when using intltool in some cases
   patches = [(fetchpatch {
     name = "perl5.26-regex-fixes.patch";
-    url = "https://sources.debian.org/data/main/i/intltool/0.51.0-5"
-      + "/debian/patches/perl5.26-regex-fixes.patch";
+    url = [
+      "https://sources.debian.org/data/main/i/intltool/0.51.0-5/debian/patches/perl5.26-regex-fixes.patch"
+      "https://src.fedoraproject.org/rpms/intltool/raw/d8d2ef29fb122a42a6b6678eb1ec97ae56902af2/f/intltool-perl5.26-regex-fixes.patch"
+    ];
     sha256 = "12q2140867r5d0dysly72khi7b0mm2gd7nlm1k81iyg7fxgnyz45";
   })];
 


### PR DESCRIPTION
Fixes:

  Failed to connect to sources.debian.org port 443: Connection timed out

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
