### PR TITLE
directfb: fix build on 32-bit arm with glibc >= 2.28

### DIFF
--- a/pkgs/development/libraries/directfb/default.nix
+++ b/pkgs/development/libraries/directfb/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, perl, pkgconfig, flux, zlib
+{ stdenv, lib, fetchFromGitHub, fetchpatch
+, autoreconfHook, perl, pkgconfig, flux, zlib
 , libjpeg, freetype, libpng, giflib
 , enableX11 ? true, xorg
 , enableSDL ? true, SDL }:
@@ -13,6 +14,16 @@ stdenv.mkDerivation rec {
     rev = "DIRECTFB_${lib.replaceStrings ["."] ["_"] version}";
     sha256 = "0bs3yzb7hy3mgydrj8ycg7pllrd2b6j0gxj596inyr7ihssr3i0y";
   };
+
+  patches = [
+    # Fixes build in "davinci" with glibc >= 2.28
+    # The "davinci" module is only enabled on 32-bit arm.
+    # https://github.com/deniskropp/DirectFB/pull/17
+    (fetchpatch {
+      url = "https://github.com/deniskropp/DirectFB/commit/3a236241bbec3f15b012b6f0dbe94353d8094557.patch";
+      sha256 = "0rj3gv0zlb225sqjz04p4yagy4xacf3210aa8vra8i1f0fv0w4kw";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook perl pkgconfig flux ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Build fix. Most platforms don't build the affected module, but I've included the patch on all platforms so that it doesn't rot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
