### PR TITLE
spidermonkey_68: fix build on armv7l

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/68.nix
+++ b/pkgs/development/interpreters/spidermonkey/68.nix
@@ -17,6 +17,13 @@ in stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
   setOutputFlags = false; # Configure script only understands --includedir
 
+  patches = optionals stdenv.isAarch32 [
+    # Firefox only supports Android on armv7. Systems that use glibc won't
+    # compile without disabling this feature that relies on an Android header.
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1526653
+    ./bug-1526653.patch
+  ];
+
   nativeBuildInputs = [
     autoconf213
     pkgconfig

--- a/pkgs/development/interpreters/spidermonkey/bug-1526653.patch
+++ b/pkgs/development/interpreters/spidermonkey/bug-1526653.patch
@@ -1,0 +1,11 @@
+--- firefox-68.4.2/js/src/wasm/WasmSignalHandlers.cpp.orig	2020-04-30 06:35:16.243047468 +0900
++++ firefox-68.4.2/js/src/wasm/WasmSignalHandlers.cpp	2020-04-30 06:35:44.110598805 +0900
+@@ -243,7 +243,7 @@
+ // If you run into compile problems on a tier-3 platform, you can disable the
+ // emulation here.
+ 
+-#if defined(__linux__) && defined(__arm__)
++#if 0
+ #  define WASM_EMULATE_ARM_UNALIGNED_FP_ACCESS
+ #endif
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Build fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
