### PR TITLE
spacebar: init at v0.5.0

### DIFF
--- a/pkgs/os-specific/darwin/spacebar/default.nix
+++ b/pkgs/os-specific/darwin/spacebar/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, Carbon, Cocoa, ScriptingBridge }:
+
+stdenv.mkDerivation rec {
+  pname = "spacebar";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "somdoron";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0v8v4xsc67qpzm859r93ggq7rr7hmaj6dahdlg6g3ppj81cq0khz";
+  };
+
+  buildInputs = [ Carbon Cocoa ScriptingBridge ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1/
+    cp ./bin/spacebar $out/bin/spacebar
+    cp ./doc/spacebar.1 $out/share/man/man1/spacebar.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A status bar for yabai tiling window management";
+    homepage = "https://github.com/somdoron/spacebar";
+    platforms = platforms.darwin;
+    maintainers = [ maintainers.cmacrae ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6702,6 +6702,11 @@ in
 
   sourceHighlight = callPackage ../tools/text/source-highlight { };
 
+  spacebar = callPackage ../os-specific/darwin/spacebar {
+    inherit (darwin.apple_sdk.frameworks)
+      Carbon Cocoa ScriptingBridge;
+  };
+
   spaceFM = callPackage ../applications/misc/spacefm { };
 
   speech-denoiser = callPackage ../applications/audio/speech-denoiser {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
A simple statusbar app for macOS to acompany the yabai package I submitted yesterday :)  
Heads up: this is expected to not build on < 10.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
