### PR TITLE
doc: add section on running ad-hoc Perl programs to the nixpkgs manual

### DIFF
--- a/doc/languages-frameworks/perl.xml
+++ b/doc/languages-frameworks/perl.xml
@@ -3,159 +3,193 @@
          xml:id="sec-language-perl">
  <title>Perl</title>
 
- <para>
-  Nixpkgs provides a function <varname>buildPerlPackage</varname>, a generic package builder function for any Perl package that has a standard <varname>Makefile.PL</varname>. It’s implemented in <link
-xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/perl-modules/generic"><filename>pkgs/development/perl-modules/generic</filename></link>.
- </para>
-
- <para>
-  Perl packages from CPAN are defined in <link
-xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/perl-packages.nix"><filename>pkgs/top-level/perl-packages.nix</filename></link>, rather than <filename>pkgs/all-packages.nix</filename>. Most Perl packages are so straight-forward to build that they are defined here directly, rather than having a separate function for each package called from <filename>perl-packages.nix</filename>. However, more complicated packages should be put in a separate file, typically in <filename>pkgs/development/perl-modules</filename>. Here is an example of the former:
-<programlisting>
-ClassC3 = buildPerlPackage rec {
-  name = "Class-C3-0.21";
-  src = fetchurl {
-    url = "mirror://cpan/authors/id/F/FL/FLORA/${name}.tar.gz";
-    sha256 = "1bl8z095y4js66pwxnm7s853pi9czala4sqc743fdlnk27kq94gz";
-  };
-};
-</programlisting>
-  Note the use of <literal>mirror://cpan/</literal>, and the <literal>${name}</literal> in the URL definition to ensure that the name attribute is consistent with the source that we’re actually downloading. Perl packages are made available in <filename>all-packages.nix</filename> through the variable <varname>perlPackages</varname>. For instance, if you have a package that needs <varname>ClassC3</varname>, you would typically write
-<programlisting>
-foo = import ../path/to/foo.nix {
-  inherit stdenv fetchurl ...;
-  inherit (perlPackages) ClassC3;
-};
-</programlisting>
-  in <filename>all-packages.nix</filename>. You can test building a Perl package as follows:
-<screen>
-<prompt>$ </prompt>nix-build -A perlPackages.ClassC3
-</screen>
-  <varname>buildPerlPackage</varname> adds <literal>perl-</literal> to the start of the name attribute, so the package above is actually called <literal>perl-Class-C3-0.21</literal>. So to install it, you can say:
-<screen>
-<prompt>$ </prompt>nix-env -i perl-Class-C3
-</screen>
-  (Of course you can also install using the attribute name: <literal>nix-env -i -A perlPackages.ClassC3</literal>.)
- </para>
-
- <para>
-  So what does <varname>buildPerlPackage</varname> do? It does the following:
-  <orderedlist>
-   <listitem>
-    <para>
-     In the configure phase, it calls <literal>perl Makefile.PL</literal> to generate a Makefile. You can set the variable <varname>makeMakerFlags</varname> to pass flags to <filename>Makefile.PL</filename>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     It adds the contents of the <envar>PERL5LIB</envar> environment variable to <literal>#! .../bin/perl</literal> line of Perl scripts as <literal>-I<replaceable>dir</replaceable></literal> flags. This ensures that a script can find its dependencies. (This can cause this shebang line to become too long for Darwin to handle; see the note below.)
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     In the fixup phase, it writes the propagated build inputs (<varname>propagatedBuildInputs</varname>) to the file <filename>$out/nix-support/propagated-user-env-packages</filename>. <command>nix-env</command> recursively installs all packages listed in this file when you install a package that has it. This ensures that a Perl package can find its dependencies.
-    </para>
-   </listitem>
-  </orderedlist>
- </para>
-
- <para>
-  <varname>buildPerlPackage</varname> is built on top of <varname>stdenv</varname>, so everything can be customised in the usual way. For instance, the <literal>BerkeleyDB</literal> module has a <varname>preConfigure</varname> hook to generate a configuration file used by <filename>Makefile.PL</filename>:
-<programlisting>
-{ buildPerlPackage, fetchurl, db }:
-
-buildPerlPackage rec {
-  name = "BerkeleyDB-0.36";
-
-  src = fetchurl {
-    url = "mirror://cpan/authors/id/P/PM/PMQS/${name}.tar.gz";
-    sha256 = "07xf50riarb60l1h6m2dqmql8q5dij619712fsgw7ach04d8g3z1";
-  };
-
-  preConfigure = ''
-    echo "LIB = ${db.out}/lib" > config.in
-    echo "INCLUDE = ${db.dev}/include" >> config.in
-  '';
-}
-</programlisting>
- </para>
-
- <para>
-  Dependencies on other Perl packages can be specified in the <varname>buildInputs</varname> and <varname>propagatedBuildInputs</varname> attributes. If something is exclusively a build-time dependency, use <varname>buildInputs</varname>; if it’s (also) a runtime dependency, use <varname>propagatedBuildInputs</varname>. For instance, this builds a Perl module that has runtime dependencies on a bunch of other modules:
-<programlisting>
-ClassC3Componentised = buildPerlPackage rec {
-  name = "Class-C3-Componentised-1.0004";
-  src = fetchurl {
-    url = "mirror://cpan/authors/id/A/AS/ASH/${name}.tar.gz";
-    sha256 = "0xql73jkcdbq4q9m0b0rnca6nrlvf5hyzy8is0crdk65bynvs8q1";
-  };
-  propagatedBuildInputs = [
-    ClassC3 ClassInspector TestException MROCompat
-  ];
-};
-</programlisting>
- </para>
-
- <para>
-  On Darwin, if a script has too many <literal>-I<replaceable>dir</replaceable></literal> flags in its first line (its “shebang line”), it will not run. This can be worked around by calling the <literal>shortenPerlShebang</literal> function from the <literal>postInstall</literal> phase:
-<programlisting>
-{ stdenv, buildPerlPackage, fetchurl, shortenPerlShebang }:
-
-ImageExifTool = buildPerlPackage {
-  pname = "Image-ExifTool";
-  version = "11.50";
-
-  src = fetchurl {
-    url = "https://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-11.50.tar.gz";
-    sha256 = "0d8v48y94z8maxkmw1rv7v9m0jg2dc8xbp581njb6yhr7abwqdv3";
-  };
-
-  buildInputs = stdenv.lib.optional stdenv.isDarwin shortenPerlShebang;
-  postInstall = stdenv.lib.optional stdenv.isDarwin ''
-    shortenPerlShebang $out/bin/exiftool
-  '';
-};
-</programlisting>
-  This will remove the <literal>-I</literal> flags from the shebang line, rewrite them in the <literal>use lib</literal> form, and put them on the next line instead. This function can be given any number of Perl scripts as arguments; it will modify them in-place.
- </para>
-
- <section xml:id="ssec-generation-from-CPAN">
-  <title>Generation from CPAN</title>
+ <section xml:id="ssec-perl-running">
+  <title>Running perl programs on the shell</title>
 
   <para>
-   Nix expressions for Perl packages can be generated (almost) automatically from CPAN. This is done by the program <command>nix-generate-from-cpan</command>, which can be installed as follows:
+   When executing a Perl script, it is possible you get an error such as <literal>./myscript.pl: bad interpreter: /usr/bin/perl: no such file or directory</literal>. This happens when the script expects Perl to be installed at <filename>/usr/bin/perl</filename>, which is not the case when using Perl from nixpkgs. You can fix the script by changing the first line to:
+  <programlisting>
+  #!/usr/bin/env perl
+  </programlisting>
+  to take the Perl installation from the <literal>PATH<literal> environment variable, or invoke Perl directly with:
+  <screen>
+  <prompt>$ </prompt>perl ./myscript.pl
+  </screen>
   </para>
 
-<screen>
-<prompt>$ </prompt>nix-env -i nix-generate-from-cpan
-</screen>
+  <para>
+   When the script is using a Perl library that is not installed globally, you might get an error such as <literal>Can't locate DB_File.pm in @INC (you may need to install the DB_File module)</literal>. In that case, you can use <command>nix-shell</command> to start an ad-hoc shell with that library installed, for instance:
+  <screen>
+  <prompt>$ </prompt>nix-shell -p perl perlPackages.DBFile --run ./myscript.pl
+  </screen>
+  </para>
 
   <para>
-   This program takes a Perl module name, looks it up on CPAN, fetches and unpacks the corresponding package, and prints a Nix expression on standard output. For example:
-<screen>
-<prompt>$ </prompt>nix-generate-from-cpan XML::Simple
-  XMLSimple = buildPerlPackage rec {
-    name = "XML-Simple-2.22";
-    src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRANTM/${name}.tar.gz";
-      sha256 = "b9450ef22ea9644ae5d6ada086dc4300fa105be050a2030ebd4efd28c198eb49";
-    };
-    propagatedBuildInputs = [ XMLNamespaceSupport XMLSAX XMLSAXExpat ];
-    meta = {
-      description = "An API for simple XML files";
-      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-    };
-  };
-</screen>
-   The output can be pasted into <filename>pkgs/top-level/perl-packages.nix</filename> or wherever else you need it.
+  If you are always using the script in places where <command>nix-shell</command> is available, you can embed the <command>nix-shell</command> invocation in the shebang like this:
+  <programlisting>
+  #!/usr/bin/env nix-shell
+  #! nix-shell -i perl -p perl perlPackages.DBFile
+  </programlisting>
   </para>
  </section>
 
- <section xml:id="ssec-perl-cross-compilation">
-  <title>Cross-compiling modules</title>
+ <section xml:id="ssec-perl-packaging">
+  <title>Packaging Perl programs</title>
 
   <para>
-   Nixpkgs has experimental support for cross-compiling Perl modules. In many cases, it will just work out of the box, even for modules with native extensions. Sometimes, however, the Makefile.PL for a module may (indirectly) import a native module. In that case, you will need to make a stub for that module that will satisfy the Makefile.PL and install it into <filename>lib/perl5/site_perl/cross_perl/${perl.version}</filename>. See the <varname>postInstall</varname> for <varname>DBI</varname> for an example.
+   Nixpkgs provides a function <varname>buildPerlPackage</varname>, a generic package builder function for any Perl package that has a standard <varname>Makefile.PL</varname>. It’s implemented in <link
+ xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/perl-modules/generic"><filename>pkgs/development/perl-modules/generic</filename></link>.
   </para>
+
+  <para>
+   Perl packages from CPAN are defined in <link
+ xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/perl-packages.nix"><filename>pkgs/top-level/perl-packages.nix</filename></link>, rather than <filename>pkgs/all-packages.nix</filename>. Most Perl packages are so straight-forward to build that they are defined here directly, rather than having a separate function for each package called from <filename>perl-packages.nix</filename>. However, more complicated packages should be put in a separate file, typically in <filename>pkgs/development/perl-modules</filename>. Here is an example of the former:
+ <programlisting>
+ ClassC3 = buildPerlPackage rec {
+   name = "Class-C3-0.21";
+   src = fetchurl {
+     url = "mirror://cpan/authors/id/F/FL/FLORA/${name}.tar.gz";
+     sha256 = "1bl8z095y4js66pwxnm7s853pi9czala4sqc743fdlnk27kq94gz";
+   };
+ };
+ </programlisting>
+   Note the use of <literal>mirror://cpan/</literal>, and the <literal>${name}</literal> in the URL definition to ensure that the name attribute is consistent with the source that we’re actually downloading. Perl packages are made available in <filename>all-packages.nix</filename> through the variable <varname>perlPackages</varname>. For instance, if you have a package that needs <varname>ClassC3</varname>, you would typically write
+ <programlisting>
+ foo = import ../path/to/foo.nix {
+   inherit stdenv fetchurl ...;
+   inherit (perlPackages) ClassC3;
+ };
+ </programlisting>
+   in <filename>all-packages.nix</filename>. You can test building a Perl package as follows:
+ <screen>
+ <prompt>$ </prompt>nix-build -A perlPackages.ClassC3
+ </screen>
+   <varname>buildPerlPackage</varname> adds <literal>perl-</literal> to the start of the name attribute, so the package above is actually called <literal>perl-Class-C3-0.21</literal>. So to install it, you can say:
+ <screen>
+ <prompt>$ </prompt>nix-env -i perl-Class-C3
+ </screen>
+   (Of course you can also install using the attribute name: <literal>nix-env -i -A perlPackages.ClassC3</literal>.)
+  </para>
+
+  <para>
+   So what does <varname>buildPerlPackage</varname> do? It does the following:
+   <orderedlist>
+    <listitem>
+     <para>
+      In the configure phase, it calls <literal>perl Makefile.PL</literal> to generate a Makefile. You can set the variable <varname>makeMakerFlags</varname> to pass flags to <filename>Makefile.PL</filename>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      It adds the contents of the <envar>PERL5LIB</envar> environment variable to <literal>#! .../bin/perl</literal> line of Perl scripts as <literal>-I<replaceable>dir</replaceable></literal> flags. This ensures that a script can find its dependencies. (This can cause this shebang line to become too long for Darwin to handle; see the note below.)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      In the fixup phase, it writes the propagated build inputs (<varname>propagatedBuildInputs</varname>) to the file <filename>$out/nix-support/propagated-user-env-packages</filename>. <command>nix-env</command> recursively installs all packages listed in this file when you install a package that has it. This ensures that a Perl package can find its dependencies.
+     </para>
+    </listitem>
+   </orderedlist>
+  </para>
+
+  <para>
+   <varname>buildPerlPackage</varname> is built on top of <varname>stdenv</varname>, so everything can be customised in the usual way. For instance, the <literal>BerkeleyDB</literal> module has a <varname>preConfigure</varname> hook to generate a configuration file used by <filename>Makefile.PL</filename>:
+ <programlisting>
+ { buildPerlPackage, fetchurl, db }:
+
+ buildPerlPackage rec {
+   name = "BerkeleyDB-0.36";
+
+   src = fetchurl {
+     url = "mirror://cpan/authors/id/P/PM/PMQS/${name}.tar.gz";
+     sha256 = "07xf50riarb60l1h6m2dqmql8q5dij619712fsgw7ach04d8g3z1";
+   };
+
+   preConfigure = ''
+     echo "LIB = ${db.out}/lib" > config.in
+     echo "INCLUDE = ${db.dev}/include" >> config.in
+   '';
+ }
+ </programlisting>
+  </para>
+
+  <para>
+   Dependencies on other Perl packages can be specified in the <varname>buildInputs</varname> and <varname>propagatedBuildInputs</varname> attributes. If something is exclusively a build-time dependency, use <varname>buildInputs</varname>; if it’s (also) a runtime dependency, use <varname>propagatedBuildInputs</varname>. For instance, this builds a Perl module that has runtime dependencies on a bunch of other modules:
+ <programlisting>
+ ClassC3Componentised = buildPerlPackage rec {
+   name = "Class-C3-Componentised-1.0004";
+   src = fetchurl {
+     url = "mirror://cpan/authors/id/A/AS/ASH/${name}.tar.gz";
+     sha256 = "0xql73jkcdbq4q9m0b0rnca6nrlvf5hyzy8is0crdk65bynvs8q1";
+   };
+   propagatedBuildInputs = [
+     ClassC3 ClassInspector TestException MROCompat
+   ];
+ };
+ </programlisting>
+  </para>
+
+  <para>
+   On Darwin, if a script has too many <literal>-I<replaceable>dir</replaceable></literal> flags in its first line (its “shebang line”), it will not run. This can be worked around by calling the <literal>shortenPerlShebang</literal> function from the <literal>postInstall</literal> phase:
+ <programlisting>
+ { stdenv, buildPerlPackage, fetchurl, shortenPerlShebang }:
+
+ ImageExifTool = buildPerlPackage {
+   pname = "Image-ExifTool";
+   version = "11.50";
+
+   src = fetchurl {
+     url = "https://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-11.50.tar.gz";
+     sha256 = "0d8v48y94z8maxkmw1rv7v9m0jg2dc8xbp581njb6yhr7abwqdv3";
+   };
+
+   buildInputs = stdenv.lib.optional stdenv.isDarwin shortenPerlShebang;
+   postInstall = stdenv.lib.optional stdenv.isDarwin ''
+     shortenPerlShebang $out/bin/exiftool
+   '';
+ };
+ </programlisting>
+   This will remove the <literal>-I</literal> flags from the shebang line, rewrite them in the <literal>use lib</literal> form, and put them on the next line instead. This function can be given any number of Perl scripts as arguments; it will modify them in-place.
+  </para>
+
+  <section xml:id="ssec-generation-from-CPAN">
+   <title>Generation from CPAN</title>
+
+   <para>
+    Nix expressions for Perl packages can be generated (almost) automatically from CPAN. This is done by the program <command>nix-generate-from-cpan</command>, which can be installed as follows:
+   </para>
+
+ <screen>
+ <prompt>$ </prompt>nix-env -i nix-generate-from-cpan
+ </screen>
+
+   <para>
+    This program takes a Perl module name, looks it up on CPAN, fetches and unpacks the corresponding package, and prints a Nix expression on standard output. For example:
+ <screen>
+ <prompt>$ </prompt>nix-generate-from-cpan XML::Simple
+   XMLSimple = buildPerlPackage rec {
+     name = "XML-Simple-2.22";
+     src = fetchurl {
+       url = "mirror://cpan/authors/id/G/GR/GRANTM/${name}.tar.gz";
+       sha256 = "b9450ef22ea9644ae5d6ada086dc4300fa105be050a2030ebd4efd28c198eb49";
+     };
+     propagatedBuildInputs = [ XMLNamespaceSupport XMLSAX XMLSAXExpat ];
+     meta = {
+       description = "An API for simple XML files";
+       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+     };
+   };
+ </screen>
+    The output can be pasted into <filename>pkgs/top-level/perl-packages.nix</filename> or wherever else you need it.
+   </para>
+  </section>
+
+  <section xml:id="ssec-perl-cross-compilation">
+   <title>Cross-compiling modules</title>
+
+   <para>
+    Nixpkgs has experimental support for cross-compiling Perl modules. In many cases, it will just work out of the box, even for modules with native extensions. Sometimes, however, the Makefile.PL for a module may (indirectly) import a native module. In that case, you will need to make a stub for that module that will satisfy the Makefile.PL and install it into <filename>lib/perl5/site_perl/cross_perl/${perl.version}</filename>. See the <varname>postInstall</varname> for <varname>DBI</varname> for an example.
+   </para>
+  </section>
  </section>
 </section>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).