### PR TITLE
dockertools: Add a buildLayeredImageWithNixDb function

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -32,7 +32,29 @@
 }:
 
 # WARNING: this API is unstable and may be subject to backwards-incompatible changes in the future.
+let
 
+  mkDbExtraCommand = contents: let
+    contentsList = if builtins.isList contents then contents else [ contents ];
+  in ''
+    echo "Generating the nix database..."
+    echo "Warning: only the database of the deepest Nix layer is loaded."
+    echo "         If you want to use nix commands in the container, it would"
+    echo "         be better to only have one layer that contains a nix store."
+
+    export NIX_REMOTE=local?root=$PWD
+    # A user is required by nix
+    # https://github.com/NixOS/nix/blob/9348f9291e5d9e4ba3c4347ea1b235640f54fd79/src/libutil/util.cc#L478
+    export USER=nobody
+    ${nix}/bin/nix-store --load-db < ${closureInfo {rootPaths = contentsList;}}/registration
+
+    mkdir -p nix/var/nix/gcroots/docker/
+    for i in ${lib.concatStringsSep " " contentsList}; do
+    ln -s $i nix/var/nix/gcroots/docker/$(basename $i)
+    done;
+  '';
+
+in
 rec {
 
   examples = callPackage ./examples.nix {
@@ -874,25 +896,16 @@ rec {
   # contents. The main purpose is to be able to use nix commands in
   # the container.
   # Be careful since this doesn't work well with multilayer.
-  buildImageWithNixDb = args@{ contents ? null, extraCommands ? "", ... }:
-    let contentsList = if builtins.isList contents then contents else [ contents ];
-    in buildImage (args // {
-      extraCommands = ''
-        echo "Generating the nix database..."
-        echo "Warning: only the database of the deepest Nix layer is loaded."
-        echo "         If you want to use nix commands in the container, it would"
-        echo "         be better to only have one layer that contains a nix store."
+  buildImageWithNixDb = args@{ contents ? null, extraCommands ? "", ... }: (
+    buildImage (args // {
+      extraCommands = (mkDbExtraCommand contents) + extraCommands;
+    })
+  );
 
-        export NIX_REMOTE=local?root=$PWD
-        # A user is required by nix
-        # https://github.com/NixOS/nix/blob/9348f9291e5d9e4ba3c4347ea1b235640f54fd79/src/libutil/util.cc#L478
-        export USER=nobody
-        ${nix}/bin/nix-store --load-db < ${closureInfo {rootPaths = contentsList;}}/registration
+  buildLayeredImageWithNixDb = args@{ contents ? null, extraCommands ? "", ... }: (
+    buildLayeredImage (args // {
+      extraCommands = (mkDbExtraCommand contents) + extraCommands;
+    })
+  );
 
-        mkdir -p nix/var/nix/gcroots/docker/
-        for i in ${lib.concatStringsSep " " contentsList}; do
-          ln -s $i nix/var/nix/gcroots/docker/$(basename $i)
-        done;
-      '' + extraCommands;
-    });
 }


### PR DESCRIPTION
This is analogous to `buildImageWithNixDb` but instead uses `buildLayeredImage` under the hood.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
