### PR TITLE
linux: CONFIG_HIDRAW=y

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -609,6 +609,9 @@ let
 
     misc = {
       HID_BATTERY_STRENGTH = yes;
+      # enabled by default in x86_64 but not arm64, so we do that here
+      HIDRAW               = yes;
+
       MODULE_COMPRESS    = yes;
       MODULE_COMPRESS_XZ = yes;
       KERNEL_XZ          = yes;


### PR DESCRIPTION
###### Motivation for this change

The linux kernel [arm64 default config](https://github.com/torvalds/linux/blob/master/arch/arm64/configs/defconfig) doesn't include HIDRAW. The kernel docs list this option as "If unsure, say Y". It's been enabled in x86_64 since [12 years ago](https://github.com/torvalds/linux/commit/622e3f28e50fe30cc199c735440cd7c75e0033b0). It's also been in [OpenWRT](https://dev.archive.openwrt.org/ticket/11145.html) for 5 years. I'm not sure why it's not on by default for arm64.

Motivation for this change is feature parity between platforms. I was able to do hidraw input on my desktop and on rpi4 (with rpi kernel), but not an rpi3 with linuxPackages built for aarch64.

That said, I'm not very knowledgeable about kernel modules, and the warning on top of `common-config.nix` sounds scary :) so I'd appreciate someone with more experience weighing in if this is as harmless as it looks, or if we should be more careful with the change.

I tested this by enabling HIDRAW via kernelPatches, works as expected.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
