### PR TITLE
sooperlooper: Add alsa library build dependency

### DIFF
--- a/pkgs/applications/audio/sooperlooper/default.nix
+++ b/pkgs/applications/audio/sooperlooper/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchFromGitHub, liblo, libxml2, libjack2, libsndfile, wxGTK, libsigcxx
 , libsamplerate, rubberband, pkgconfig, libtool, gettext, ncurses, which
 , autoreconfHook
+, alsaLib
 }:
 
 stdenv.mkDerivation rec {
   pname = "sooperlooper-git";
-  version = "2016-07-19";
+  version = "2016-07-19.1";
 
   src = fetchFromGitHub {
     owner = "essej";
@@ -24,6 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     liblo libxml2 libjack2 libsndfile wxGTK libsigcxx
     libsamplerate rubberband gettext ncurses
+    alsaLib
   ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Currently, sooperlooper is built without alsa support:

    checking alsa/asoundlib.h usability... no
    checking alsa/asoundlib.h presence... no
    checking for alsa/asoundlib.h... no

This causes sooperlooper to have no midi ports, which prevents it from being controlled by a hardware midi controller.

###### Things done

This change adds alsaLib as a build dependency. With this change the package is build with support for alsa midi ports.

This is my very first nixpkgs pull request, if anything is suboptimal I will happily fix it. Just give me a note.

I have built and tested the package on nixOS 20.03 without problems. The change should not affect any other package.

- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).