### PR TITLE
sooperlooper: unstable-2016-07-19 -> unstable-2019-09-30

### DIFF
--- a/pkgs/applications/audio/sooperlooper/default.nix
+++ b/pkgs/applications/audio/sooperlooper/default.nix
@@ -1,17 +1,32 @@
-{ stdenv, fetchFromGitHub, liblo, libxml2, libjack2, libsndfile, wxGTK, libsigcxx
-, libsamplerate, rubberband, pkgconfig, libtool, gettext, ncurses, which
+{ stdenv
+, fetchFromGitHub
 , autoreconfHook
+, pkgconfig
+, which
+, libtool
+, liblo
+, libxml2
+, libjack2
+, libsndfile
+, wxGTK30
+, libsigcxx
+, libsamplerate
+, rubberband
+, gettext
+, ncurses
+, alsaLib
+, fftw
 }:
 
 stdenv.mkDerivation rec {
-  pname = "sooperlooper-git";
-  version = "2016-07-19";
+  pname = "sooperlooper";
+  version = "unstable-2019-09-30";
 
   src = fetchFromGitHub {
     owner = "essej";
     repo = "sooperlooper";
-    rev = "3bdfe184cd59b51c757b8048536abc1146fb0de4";
-    sha256 = "0qz25h4idv79m97ici2kzx72fwzks3lysyksk3p3rx72lsijhf3g";
+    rev = "4d1da14176e16b0f56b727bb1e6c2e8957515625";
+    sha256 = "1gsgqa7hdymzw2al1ymzv0f33y161dyhh3fmy88lpjwv3bfchamg";
   };
 
   autoreconfPhase = ''
@@ -22,11 +37,21 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig which libtool ];
 
   buildInputs = [
-    liblo libxml2 libjack2 libsndfile wxGTK libsigcxx
-    libsamplerate rubberband gettext ncurses
+    liblo
+    libxml2
+    libjack2
+    libsndfile
+    wxGTK30
+    libsigcxx
+    libsamplerate
+    rubberband
+    gettext
+    ncurses
+    alsaLib
+    fftw
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A live looping sampler capable of immediate loop recording, overdubbing, multiplying, reversing and more";
     longDescription = ''
       It allows for multiple simultaneous multi-channel loops limited only by your computer's available memory.
@@ -35,11 +60,9 @@ stdenv.mkDerivation rec {
       However, this kind of live performance looping tool is most effectively used via hardware (midi footpedals, etc)
       and the engine can be run standalone on a computer without a monitor.
     '';
-
-    version = version;
-    homepage = "http://essej.net/sooperlooper/index.html";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.magnetophon ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "http://essej.net/sooperlooper/"; # https is broken
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Version update + added alsaLib and fftw dependencies

Supersedes https://github.com/NixOS/nixpkgs/pull/86607

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
