### PR TITLE
afio: package has moved to GitHub

### DIFF
--- a/pkgs/tools/archivers/afio/default.nix
+++ b/pkgs/tools/archivers/afio/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl } :
+{ stdenv, fetchFromGitHub } :
 
 stdenv.mkDerivation rec {
   version = "2.5.2";
   pname = "afio";
 
-  src = fetchurl {
-    url = "http://members.chello.nl/~k.holtman/${pname}-${version}.tgz";
-    sha256 = "1fa29wlqv76hzf8bxp1qpza1r23pm2f3m7rcf0jpwm6z150s2k66";
+  src = fetchFromGitHub {
+    owner = "kholtman";
+    repo = "afio";
+    rev = "v${version}";
+    sha256 = "1vbxl66r5rp5a1qssjrkfsjqjjgld1cq57c871gd0m4qiq9rmcfy";
   };
 
   /*
@@ -18,7 +20,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "DESTDIR=$(out)" ];
 
   meta = {
-    homepage = "http://members.chello.nl/~k.holtman/afio.html";
+    homepage = "https://github.com/kholtman/afio";
     description = "Fault tolerant cpio archiver targeting backups";
     platforms = stdenv.lib.platforms.all;
     /*


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The old homepage and src URLs no longer exist.  The author of the package
confirms on GitHub that GitHub is now the official homepage (see
kholtman/afio#12).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
