### PR TITLE
php.buildPecl: Make it possible for PECLs to depend on other PECLs, fix apcu_bc and couchbase

### DIFF
--- a/pkgs/build-support/build-pecl.nix
+++ b/pkgs/build-support/build-pecl.nix
@@ -3,6 +3,7 @@
 { pname
 , version
 , internalDeps ? []
+, peclDeps ? []
 , buildInputs ? []
 , nativeBuildInputs ? []
 , postPhpize ? ""
@@ -16,11 +17,12 @@
 
 stdenv.mkDerivation (args // {
   name = "php-${pname}-${version}";
+  extensionName = pname;
 
   inherit src;
 
   nativeBuildInputs = [ autoreconfHook re2c ] ++ nativeBuildInputs;
-  buildInputs = [ php ] ++ buildInputs;
+  buildInputs = [ php ] ++ peclDeps ++ buildInputs;
 
   makeFlags = [ "EXTENSION_DIR=$(out)/lib/php/extensions" ] ++ makeFlags;
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -67,7 +67,7 @@ let
               getDepsRecursively = extensions:
                 let
                   deps = lib.concatMap
-                           (ext: ext.internalDeps or [])
+                           (ext: (ext.internalDeps or []) ++ (ext.peclDeps or []))
                            extensions;
                 in
                   if ! (deps == []) then
@@ -86,12 +86,12 @@ let
                   (map (ext:
                     let
                       extName = getExtName ext;
+                      phpDeps = (ext.internalDeps or []) ++ (ext.peclDeps or []);
                       type = "${lib.optionalString (ext.zendExtension or false) "zend_"}extension";
                     in
                       lib.nameValuePair extName {
                         text = "${type}=${ext}/lib/php/extensions/${extName}.so";
-                        deps = lib.optionals (ext ? internalDeps)
-                          (map getExtName ext.internalDeps);
+                        deps = map getExtName phpDeps;
                       })
                     (enabledExtensions ++ (getDepsRecursively enabledExtensions)));
 
@@ -112,7 +112,7 @@ let
                   phpIni = "${phpWithExtensions}/lib/php.ini";
                   unwrapped = php;
                   tests = nixosTests.php;
-                  inherit (php-packages) packages extensions;
+                  inherit (php-packages) packages extensions buildPecl;
                   meta = php.meta // {
                     outputsToInstall = [ "out" ];
                   };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -320,10 +320,15 @@ in
 
       sha256 = "0ma00syhk2ps9k9p02jz7rii6x3i2p986il23703zz5npd6y9n20";
 
+      peclDeps = [ php.extensions.apcu ];
+
       buildInputs = [
-        php.extensions.apcu
         pcre'
       ];
+
+      postInstall = ''
+        mv $out/lib/php/extensions/apc.so $out/lib/php/extensions/apcu_bc.so
+      '';
 
       meta.maintainers = lib.teams.php.members;
     };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -346,13 +346,6 @@ in
       version = "2.6.1";
       pname = "couchbase";
 
-      buildInputs = [
-        pkgs.libcouchbase
-        pkgs.zlib
-        php.extensions.igbinary
-        php.extensions.pcs
-      ];
-
       src = pkgs.fetchFromGitHub {
         owner = "couchbase";
         repo = "php-couchbase";
@@ -361,7 +354,14 @@ in
       };
 
       configureFlags = [ "--with-couchbase" ];
+
+      buildInputs = [
+        pkgs.libcouchbase
+        pkgs.zlib
+      ];
       internalDeps = [ php.extensions.json ];
+      peclDeps = [ php.extensions.igbinary ];
+
       patches = [
         (pkgs.writeText "php-couchbase.patch" ''
           --- a/config.m4
@@ -388,7 +388,6 @@ in
       ];
 
       meta.maintainers = lib.teams.php.members;
-      meta.broken = isPhp74; # Build error
     };
 
     event = buildPecl {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -562,8 +562,10 @@ in
 
       sha256 = "0d4p1gpl8gkzdiv860qzxfz250ryf0wmjgyc8qcaaqgkdyh5jy5p";
 
+      internalDeps = [ php.extensions.tokenizer ];
+
       meta.maintainers = lib.teams.php.members;
-      meta.broken = isPhp74; # Build error
+      meta.broken = isPhp73; # Runtime failure on 7.3, build error on 7.4
     };
 
     pdo_oci = buildPecl rec {


### PR DESCRIPTION

###### Motivation for this change
- Some PECLs depend on other PECLs and, like internal PHP extension dependencies, need to be loaded in the correct order. This makes this possible by adding the argument `peclDeps` to `buildPecl`, which adds the extension to `buildInputs` and is treated the same way as
`internalDeps` when the extension config is generated.

- Fix an issue brought up in #86463, where the `apcu_bc` extension isn't loaded correctly since it produces a `.so` with a different name than the extension name. Also, the `apcu` extension has to be loaded and loaded prior to loading this extension.

- The `couchbase` extension depends on the `igbinary` PECL which needs to be loaded and loaded prior to it. It also seems like the `pcs` extension isn't actually needed - it at least builds and loads without it. Since the `pcs` extension dependency was the reason `couchbase` didn't build on
PHP 7.4 it now does. I don't have any couchbase testing setup, though, so I can't verify that the extension _really_ works - if anyone does, help with testing would be greatly appreciated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
