### PR TITLE
gnupg: disable ldap support on darwin

### DIFF
--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper, apr, expat, gnused
 , sslSupport ? true, openssl
 , bdbSupport ? true, db
-, ldapSupport ? !stdenv.isCygwin, openldap
+, ldapSupport ? !stdenv.isLinux, openldap
 , libiconv
 , cyrus_sasl, autoreconfHook
 }:

--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -4,12 +4,14 @@
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
 , pinentry ? null, guiSupport ? false
-, openldap ? null, bzip2 ? null, libusb-compat-0_1 ? null, curl ? null
+, openldapSupport ? stdenv.isLinux, openldap ? null
+, bzip2 ? null, libusb-compat-0_1 ? null, curl ? null
 }:
 
 with stdenv.lib;
 
 assert guiSupport -> pinentry != null;
+assert openldapSupport -> openldap != null;
 
 stdenv.mkDerivation rec {
   pname = "gnupg";
@@ -22,7 +24,8 @@ stdenv.mkDerivation rec {
 
   buildInputs
     = [ readline zlib libgpgerror libgcrypt libassuan libksba pth
-        openldap bzip2 libusb-compat-0_1 curl libiconv ];
+        bzip2 libusb-compat-0_1 curl libiconv ]
+    ++ optional openldapSupport openldap;
 
   patches = [ ./gpgkey2ssh-20.patch ];
 

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -4,7 +4,8 @@
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
 , guiSupport ? true, enableMinimal ? false
-, adns ? null , bzip2 ? null , gnutls ? null , libusb1 ? null , openldap ? null
+, openldapSupport ? stdenv.isLinux, openldap ? null
+, adns ? null , bzip2 ? null , gnutls ? null , libusb1 ? null
 , pcsclite ? null , pinentry ? null , readline ? null , sqlite ? null , zlib ?
 null
 }:
@@ -12,6 +13,7 @@ null
 with stdenv.lib;
 
 assert guiSupport -> pinentry != null && enableMinimal == false;
+assert openldapSupport -> openldap != null;
 
 stdenv.mkDerivation rec {
   pname = "gnupg";
@@ -27,8 +29,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig texinfo ];
   buildInputs = [
     libgcrypt libassuan libksba libiconv npth gettext
-    readline libusb1 gnutls adns openldap zlib bzip2 sqlite
-  ];
+    readline libusb1 gnutls adns zlib bzip2 sqlite
+  ] ++ optional openldapSupport openldap;
 
   patches = [
     ./fix-libusb-include-path.patch


### PR DESCRIPTION
#### Motivation for this change

I personally don't think this should be enabled by default, but on other platforms like darwin ldap support isn't really relevant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
