### PR TITLE
[20.03] steam: update generated runtime dependencies

### DIFF
--- a/pkgs/games/steam/runtime-generated.nix
+++ b/pkgs/games/steam/runtime-generated.nix
@@ -130,6 +130,15 @@
       };
     }
     rec {
+      name = "libatomic1_5.4.0-7.really.6+steamrt1.2+srt2_amd64";
+      sha256 = "8dd843d4497f66c1af07551d8cc636e63ffff692187b51d0a01191c96bc0049a";
+      url = "mirror://steamrt/pool/main/g/gcc-5/libatomic1_5.4.0-7.really.6+steamrt1.2+srt2_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libatomic1.deb";
+      };
+    }
+    rec {
       name = "libattr1_2.4.46-5ubuntu1+steamrt1.1+srt2_amd64";
       sha256 = "d33b00c3e19337f3abbb070f646adda7420f171f5487dca5e253b68b63a4d8fc";
       url = "mirror://steamrt/pool/main/a/attr/libattr1_2.4.46-5ubuntu1+steamrt1.1+srt2_amd64.deb";
@@ -244,6 +253,15 @@
       source = fetchurl {
         inherit url sha256;
         name = "libcap2.deb";
+      };
+    }
+    rec {
+      name = "libcapsule-tools-relocatable_0.20190926.0-0co1+srt1_amd64";
+      sha256 = "9ddaac17a0f812eec785e34eefccb8ea24a4abf0fa6ad008d03b26d5493ea010";
+      url = "mirror://steamrt/pool/main/libc/libcapsule/libcapsule-tools-relocatable_0.20190926.0-0co1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libcapsule-tools-relocatable.deb";
       };
     }
     rec {
@@ -661,6 +679,15 @@
       };
     }
     rec {
+      name = "libitm1_5.4.0-7.really.6+steamrt1.2+srt2_amd64";
+      sha256 = "3c01841997e77fe1616b16936394c86383dc76e875f70e6d96ed016e4b945050";
+      url = "mirror://steamrt/pool/main/g/gcc-5/libitm1_5.4.0-7.really.6+steamrt1.2+srt2_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libitm1.deb";
+      };
+    }
+    rec {
       name = "libjack-jackd2-0_1.9.8~dfsg.1-1ubuntu2+srt5_amd64";
       sha256 = "9a419baf1b88386cf643ca64965de607321e5d27f13c5bd68be0eb1a803fd7a9";
       url = "mirror://steamrt/pool/main/j/jackd2/libjack-jackd2-0_1.9.8~dfsg.1-1ubuntu2+srt5_amd64.deb";
@@ -976,6 +1003,15 @@
       };
     }
     rec {
+      name = "libquadmath0_5.4.0-7.really.6+steamrt1.2+srt2_amd64";
+      sha256 = "12523138b2f21cd6d824b5c778ee49789ef0129ba6207cf03d3cf6b4138b1a1b";
+      url = "mirror://steamrt/pool/main/g/gcc-5/libquadmath0_5.4.0-7.really.6+steamrt1.2+srt2_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libquadmath0.deb";
+      };
+    }
+    rec {
       name = "libroken18-heimdal_1.6~git20120311.dfsg.1-2+srt6_amd64";
       sha256 = "e55b129066b92ab99f518d2f857b54e8754c3c873b5fb603270e3c4c36564a7b";
       url = "mirror://steamrt/pool/main/h/heimdal/libroken18-heimdal_1.6~git20120311.dfsg.1-2+srt6_amd64.deb";
@@ -1174,6 +1210,33 @@
       };
     }
     rec {
+      name = "libsteam-runtime-tools-0-0_0.20200415.0+srt1_amd64";
+      sha256 = "0db05ccf5ca6705a6001d2c43ae5163cc289ef60126381bf886014e2344b4190";
+      url = "mirror://steamrt/pool/main/s/steam-runtime-tools/libsteam-runtime-tools-0-0_0.20200415.0+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libsteam-runtime-tools-0-0.deb";
+      };
+    }
+    rec {
+      name = "libsteam-runtime-tools-0-helpers_0.20200415.0+srt1_amd64";
+      sha256 = "c568548d3c73df1c61efe06574e4ab17c2250059e9659690dec6c43db8695ce8";
+      url = "mirror://steamrt/pool/main/s/steam-runtime-tools/libsteam-runtime-tools-0-helpers_0.20200415.0+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libsteam-runtime-tools-0-helpers.deb";
+      };
+    }
+    rec {
+      name = "libsteam-runtime-tools-0-relocatable-libs_0.20200415.0+srt1_amd64";
+      sha256 = "450c03778f4901e8b54f5dc879b071a84d18f4fc65e6308b91eebf40c77ef093";
+      url = "mirror://steamrt/pool/main/s/steam-runtime-tools/libsteam-runtime-tools-0-relocatable-libs_0.20200415.0+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libsteam-runtime-tools-0-relocatable-libs.deb";
+      };
+    }
+    rec {
       name = "libswscale2_0.8.13-0ubuntu0.12.04.1+steamrt1+srt3_amd64";
       sha256 = "dda1950d7e1f50547ce57246bc7e19c3c1ab1166ee81ca637ff86d373e20253c";
       url = "mirror://steamrt/pool/main/liba/libav/libswscale2_0.8.13-0ubuntu0.12.04.1+steamrt1+srt3_amd64.deb";
@@ -1354,12 +1417,21 @@
       };
     }
     rec {
-      name = "libvulkan1_1.1.73+dfsg-1+steamosc2+srt2_amd64";
-      sha256 = "a3820a7cdceef1cf070b762d81437ec87a4d3a2b41566dadaa1cdcb1f08dad3e";
-      url = "mirror://steamrt/pool/main/v/vulkan/libvulkan1_1.1.73+dfsg-1+steamosc2+srt2_amd64.deb";
+      name = "libvulkan1_1.2.135.0-1~steamrt1.1+srt1_amd64";
+      sha256 = "fa3dfb44b47c35e8a16de3c8240accdca131b70dd59a84f6e38cc6824219fa28";
+      url = "mirror://steamrt/pool/main/v/vulkan-loader/libvulkan1_1.2.135.0-1~steamrt1.1+srt1_amd64.deb";
       source = fetchurl {
         inherit url sha256;
         name = "libvulkan1.deb";
+      };
+    }
+    rec {
+      name = "libwaffle-1-0_1.6.1-0+steamrt1.1+srt1_amd64";
+      sha256 = "a2a73515ddef193da5de918190df27fce75cf27c3081662c2f6fc5d227c96cc4";
+      url = "mirror://steamrt/pool/main/w/waffle/libwaffle-1-0_1.6.1-0+steamrt1.1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libwaffle-1-0.deb";
       };
     }
     rec {
@@ -1813,36 +1885,117 @@
       };
     }
     rec {
-      name = "steamrt-legacy_1.20190624.0+srt1_amd64";
-      sha256 = "0a0e96fc8dbe806b2d0b4ac26f217ca5ff49188f295a9a4b0d39cbe0a4da52b0";
-      url = "mirror://steamrt/pool/main/s/steamrt/steamrt-legacy_1.20190624.0+srt1_amd64.deb";
+      name = "steam-runtime-tools-bin_0.20200415.0+srt1_amd64";
+      sha256 = "e21848eb4cf02402600a952f5ca8bafbd95db9f5b3bb8d5af746721c5ac4ebc3";
+      url = "mirror://steamrt/pool/main/s/steam-runtime-tools/steam-runtime-tools-bin_0.20200415.0+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "steam-runtime-tools-bin.deb";
+      };
+    }
+    rec {
+      name = "steamrt-legacy_1.20200421.0+srt1_amd64";
+      sha256 = "9ee2744dbefc6c8055d3f496ad8e7ab8df01049a5571b9558c23b15001218fa6";
+      url = "mirror://steamrt/pool/main/s/steamrt/steamrt-legacy_1.20200421.0+srt1_amd64.deb";
       source = fetchurl {
         inherit url sha256;
         name = "steamrt-legacy.deb";
       };
     }
     rec {
-      name = "steamrt-libs_1.20190624.0+srt1_amd64";
-      sha256 = "ed7124e8d11d9dd435ec7b7516a0d0e2c766f677b2c5a1d0b257790c03f307a2";
-      url = "mirror://steamrt/pool/main/s/steamrt/steamrt-libs_1.20190624.0+srt1_amd64.deb";
+      name = "steamrt-libs_1.20200421.0+srt1_amd64";
+      sha256 = "52ffad4cdca3f7f1c8091474a1a978941512c993e52d15fadab49165e248603b";
+      url = "mirror://steamrt/pool/main/s/steamrt/steamrt-libs_1.20200421.0+srt1_amd64.deb";
       source = fetchurl {
         inherit url sha256;
         name = "steamrt-libs.deb";
       };
     }
     rec {
-      name = "zenity_3.4.0-0ubuntu4+steamrt2+srt6_amd64";
-      sha256 = "5eb59aa8d2211153c780aab2304e8694d7eb0204f284193ff2a037dc9e1274db";
-      url = "mirror://steamrt/pool/main/z/zenity/zenity_3.4.0-0ubuntu4+steamrt2+srt6_amd64.deb";
+      name = "vainfo_2.1.0+ds1-1~steamrt1.1+srt1_amd64";
+      sha256 = "20758135cdf3ada791e1c6b57cdf8db1505b3dd3f429f3f12a6e92d589f568d9";
+      url = "mirror://steamrt/pool/main/libv/libva-utils/vainfo_2.1.0+ds1-1~steamrt1.1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vainfo.deb";
+      };
+    }
+    rec {
+      name = "vainfo-1_1.7.0-1+steamrt1.1+srt1_amd64";
+      sha256 = "f6f80b18d853edcac5ee09a522d01e83f9d02d3ccc7e7fda09b567c37d9f516e";
+      url = "mirror://steamrt/pool/main/libv/libva1/vainfo-1_1.7.0-1+steamrt1.1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vainfo-1.deb";
+      };
+    }
+    rec {
+      name = "vainfo-1-multiarch_1.7.0-1+steamrt1.1+srt1_amd64";
+      sha256 = "6b4369f80a1d24c3c9fdd73f5c8f00ab67c136ad9ef60dfe70f4b662e5040306";
+      url = "mirror://steamrt/pool/main/libv/libva1/vainfo-1-multiarch_1.7.0-1+steamrt1.1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vainfo-1-multiarch.deb";
+      };
+    }
+    rec {
+      name = "vainfo-multiarch_2.1.0+ds1-1~steamrt1.1+srt1_amd64";
+      sha256 = "3ac30bc566b2c949da526d5d26a957cb9bcce1ea7d109ee4b79e2109ae1ee995";
+      url = "mirror://steamrt/pool/main/libv/libva-utils/vainfo-multiarch_2.1.0+ds1-1~steamrt1.1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vainfo-multiarch.deb";
+      };
+    }
+    rec {
+      name = "vulkan-tools_1.2.135.0+dfsg1-1~steamrt1.1+srt1_amd64";
+      sha256 = "bb70e1a31fe204319ea24292fe0ee7a9073f1b8f79e66ffb1ab192e500f8452b";
+      url = "mirror://steamrt/pool/main/v/vulkan-tools/vulkan-tools_1.2.135.0+dfsg1-1~steamrt1.1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vulkan-tools.deb";
+      };
+    }
+    rec {
+      name = "vulkan-tools-multiarch_1.2.135.0+dfsg1-1~steamrt1.1+srt1_amd64";
+      sha256 = "8e8aa0bf8fe147dd52e442a88e57a16f86b3a807201175585d47c64531865822";
+      url = "mirror://steamrt/pool/main/v/vulkan-tools/vulkan-tools-multiarch_1.2.135.0+dfsg1-1~steamrt1.1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vulkan-tools-multiarch.deb";
+      };
+    }
+    rec {
+      name = "waffle-utils_1.6.1-0+steamrt1.1+srt1_amd64";
+      sha256 = "ad14f1e2dcc6b9ed7b036989cf5f18efb683879927a4b474692bbe1d7ddbe94c";
+      url = "mirror://steamrt/pool/main/w/waffle/waffle-utils_1.6.1-0+steamrt1.1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "waffle-utils.deb";
+      };
+    }
+    rec {
+      name = "waffle-utils-multiarch_1.6.1-0+steamrt1.1+srt1_amd64";
+      sha256 = "cf66bcb711bee45fb722d4125d37d8001fe7f3691f81ac224b62f849af0b4fba";
+      url = "mirror://steamrt/pool/main/w/waffle/waffle-utils-multiarch_1.6.1-0+steamrt1.1+srt1_amd64.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "waffle-utils-multiarch.deb";
+      };
+    }
+    rec {
+      name = "zenity_3.4.0-0ubuntu4+steamrt3+srt1_amd64";
+      sha256 = "c31a99f8d47cba157db251ea97cd14074d99c622969dd4d4173f76494feb7723";
+      url = "mirror://steamrt/pool/main/z/zenity/zenity_3.4.0-0ubuntu4+steamrt3+srt1_amd64.deb";
       source = fetchurl {
         inherit url sha256;
         name = "zenity.deb";
       };
     }
     rec {
-      name = "zenity-common_3.4.0-0ubuntu4+steamrt2+srt6_all";
-      sha256 = "bc8f0b80672833be72c6dd87d406b5fc0ef92e51f91e3a461678fc97844649bc";
-      url = "mirror://steamrt/pool/main/z/zenity/zenity-common_3.4.0-0ubuntu4+steamrt2+srt6_all.deb";
+      name = "zenity-common_3.4.0-0ubuntu4+steamrt3+srt1_all";
+      sha256 = "7ec603c8b00c5573e88e1df9785af4baef93b54e377e697515eb939b7c119cdc";
+      url = "mirror://steamrt/pool/main/z/zenity/zenity-common_3.4.0-0ubuntu4+steamrt3+srt1_all.deb";
       source = fetchurl {
         inherit url sha256;
         name = "zenity-common.deb";
@@ -1986,6 +2139,15 @@
       };
     }
     rec {
+      name = "libatomic1_5.4.0-7.really.6+steamrt1.2+srt2_i386";
+      sha256 = "aafd5b3b573f22562e3f93bfa449ca374e2788fb14d555193c5c57e996def8fb";
+      url = "mirror://steamrt/pool/main/g/gcc-5/libatomic1_5.4.0-7.really.6+steamrt1.2+srt2_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libatomic1.deb";
+      };
+    }
+    rec {
       name = "libattr1_2.4.46-5ubuntu1+steamrt1.1+srt2_i386";
       sha256 = "bcea5d6f2743c617dac44c4d836b6937a64816f3c288a56b656ee4adbf63714a";
       url = "mirror://steamrt/pool/main/a/attr/libattr1_2.4.46-5ubuntu1+steamrt1.1+srt2_i386.deb";
@@ -2100,6 +2262,15 @@
       source = fetchurl {
         inherit url sha256;
         name = "libcap2.deb";
+      };
+    }
+    rec {
+      name = "libcapsule-tools-relocatable_0.20190926.0-0co1+srt1_i386";
+      sha256 = "5ce9e11e0204db54cecb59b59b1c6fc6bd5e4aefe73a327dbb85283b08591428";
+      url = "mirror://steamrt/pool/main/libc/libcapsule/libcapsule-tools-relocatable_0.20190926.0-0co1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libcapsule-tools-relocatable.deb";
       };
     }
     rec {
@@ -2517,6 +2688,15 @@
       };
     }
     rec {
+      name = "libitm1_5.4.0-7.really.6+steamrt1.2+srt2_i386";
+      sha256 = "188591aec152ece7b33b765079593a110a005046977d15794d5cc3be5b3381c7";
+      url = "mirror://steamrt/pool/main/g/gcc-5/libitm1_5.4.0-7.really.6+steamrt1.2+srt2_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libitm1.deb";
+      };
+    }
+    rec {
       name = "libjack-jackd2-0_1.9.8~dfsg.1-1ubuntu2+srt5_i386";
       sha256 = "a59a4de570335899d10f36b4b9552ee894fc0bb21c4ee4e06ed689f3fa55c2e6";
       url = "mirror://steamrt/pool/main/j/jackd2/libjack-jackd2-0_1.9.8~dfsg.1-1ubuntu2+srt5_i386.deb";
@@ -2832,6 +3012,15 @@
       };
     }
     rec {
+      name = "libquadmath0_5.4.0-7.really.6+steamrt1.2+srt2_i386";
+      sha256 = "58f646279972a537cf838fc935f9f37285e5255604d7b5c1e034644e77d3e25b";
+      url = "mirror://steamrt/pool/main/g/gcc-5/libquadmath0_5.4.0-7.really.6+steamrt1.2+srt2_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libquadmath0.deb";
+      };
+    }
+    rec {
       name = "libroken18-heimdal_1.6~git20120311.dfsg.1-2+srt6_i386";
       sha256 = "8827d782d8fedf7fe0285bbab14914e61d2ac5fe5e7ea297fbff916c7fd73939";
       url = "mirror://steamrt/pool/main/h/heimdal/libroken18-heimdal_1.6~git20120311.dfsg.1-2+srt6_i386.deb";
@@ -3030,6 +3219,33 @@
       };
     }
     rec {
+      name = "libsteam-runtime-tools-0-0_0.20200415.0+srt1_i386";
+      sha256 = "7da98a9a206829dbf5cc95570049502d1cf8dd2a2234a981787f14cc098c1739";
+      url = "mirror://steamrt/pool/main/s/steam-runtime-tools/libsteam-runtime-tools-0-0_0.20200415.0+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libsteam-runtime-tools-0-0.deb";
+      };
+    }
+    rec {
+      name = "libsteam-runtime-tools-0-helpers_0.20200415.0+srt1_i386";
+      sha256 = "bf06ad0ef0d5c80ddff53c58e4397c87fd655e1913ecf48a29560d27719b4d71";
+      url = "mirror://steamrt/pool/main/s/steam-runtime-tools/libsteam-runtime-tools-0-helpers_0.20200415.0+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libsteam-runtime-tools-0-helpers.deb";
+      };
+    }
+    rec {
+      name = "libsteam-runtime-tools-0-relocatable-libs_0.20200415.0+srt1_i386";
+      sha256 = "79e3b5b5a2904daccb17f5f54e3a87842dd9408fe04a8fee8d4ee83c3a3c0bcf";
+      url = "mirror://steamrt/pool/main/s/steam-runtime-tools/libsteam-runtime-tools-0-relocatable-libs_0.20200415.0+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libsteam-runtime-tools-0-relocatable-libs.deb";
+      };
+    }
+    rec {
       name = "libswscale2_0.8.13-0ubuntu0.12.04.1+steamrt1+srt3_i386";
       sha256 = "938ac8ecc9f75f070b65b5d8bddea58d89ba8e1673d004d1b20ca0e1f677ba14";
       url = "mirror://steamrt/pool/main/liba/libav/libswscale2_0.8.13-0ubuntu0.12.04.1+steamrt1+srt3_i386.deb";
@@ -3210,12 +3426,21 @@
       };
     }
     rec {
-      name = "libvulkan1_1.1.73+dfsg-1+steamosc2+srt2_i386";
-      sha256 = "cac788c3fd6cea1ff7235f9b14f82eb8121e209743f08d15529e54732e692e05";
-      url = "mirror://steamrt/pool/main/v/vulkan/libvulkan1_1.1.73+dfsg-1+steamosc2+srt2_i386.deb";
+      name = "libvulkan1_1.2.135.0-1~steamrt1.1+srt1_i386";
+      sha256 = "dd6167b259a8ec4c927f3fa710d01456321b3ff40f6daa3383ec353866615aaa";
+      url = "mirror://steamrt/pool/main/v/vulkan-loader/libvulkan1_1.2.135.0-1~steamrt1.1+srt1_i386.deb";
       source = fetchurl {
         inherit url sha256;
         name = "libvulkan1.deb";
+      };
+    }
+    rec {
+      name = "libwaffle-1-0_1.6.1-0+steamrt1.1+srt1_i386";
+      sha256 = "06f22a35ca49969e44f1bdaca82a1d085e69211bf3b39915d77d80f414ea8668";
+      url = "mirror://steamrt/pool/main/w/waffle/libwaffle-1-0_1.6.1-0+steamrt1.1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "libwaffle-1-0.deb";
       };
     }
     rec {
@@ -3669,36 +3894,117 @@
       };
     }
     rec {
-      name = "steamrt-legacy_1.20190624.0+srt1_i386";
-      sha256 = "22bb83259ee421abdb7cb9877365460619011c859eaf4119615e55726defa56b";
-      url = "mirror://steamrt/pool/main/s/steamrt/steamrt-legacy_1.20190624.0+srt1_i386.deb";
+      name = "steam-runtime-tools-bin_0.20200415.0+srt1_i386";
+      sha256 = "3ea27a32f19f6e5133385fe4072f3d9a027c4f83604355baa34cf3ae5e346db5";
+      url = "mirror://steamrt/pool/main/s/steam-runtime-tools/steam-runtime-tools-bin_0.20200415.0+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "steam-runtime-tools-bin.deb";
+      };
+    }
+    rec {
+      name = "steamrt-legacy_1.20200421.0+srt1_i386";
+      sha256 = "08371f2a03aacd50f578b7aca4e6934fc60b9db1927e9eb3c8f1a5f6421e79e5";
+      url = "mirror://steamrt/pool/main/s/steamrt/steamrt-legacy_1.20200421.0+srt1_i386.deb";
       source = fetchurl {
         inherit url sha256;
         name = "steamrt-legacy.deb";
       };
     }
     rec {
-      name = "steamrt-libs_1.20190624.0+srt1_i386";
-      sha256 = "f9a38284deb9c08fbe6f3b8d1617bec74bb803d639a0a77d77736f19a1de765a";
-      url = "mirror://steamrt/pool/main/s/steamrt/steamrt-libs_1.20190624.0+srt1_i386.deb";
+      name = "steamrt-libs_1.20200421.0+srt1_i386";
+      sha256 = "0f84ef7ebea603df58d4549a8368a51ceb3989d136174870bfd4c2ed50a13195";
+      url = "mirror://steamrt/pool/main/s/steamrt/steamrt-libs_1.20200421.0+srt1_i386.deb";
       source = fetchurl {
         inherit url sha256;
         name = "steamrt-libs.deb";
       };
     }
     rec {
-      name = "zenity_3.4.0-0ubuntu4+steamrt2+srt6_i386";
-      sha256 = "1c772d4f96424d204ab4913efcafbe43518257ca5032ca7b23d6c6ab76439117";
-      url = "mirror://steamrt/pool/main/z/zenity/zenity_3.4.0-0ubuntu4+steamrt2+srt6_i386.deb";
+      name = "vainfo_2.1.0+ds1-1~steamrt1.1+srt1_i386";
+      sha256 = "785128cd89e53ce63317eb958c59546b5526e66183b3819a3d351eb04c599e38";
+      url = "mirror://steamrt/pool/main/libv/libva-utils/vainfo_2.1.0+ds1-1~steamrt1.1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vainfo.deb";
+      };
+    }
+    rec {
+      name = "vainfo-1_1.7.0-1+steamrt1.1+srt1_i386";
+      sha256 = "8d1c25ccfa3f62ccd680673a0b2460ab4090c66bc539c7f1991e60cd50e1ce1b";
+      url = "mirror://steamrt/pool/main/libv/libva1/vainfo-1_1.7.0-1+steamrt1.1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vainfo-1.deb";
+      };
+    }
+    rec {
+      name = "vainfo-1-multiarch_1.7.0-1+steamrt1.1+srt1_i386";
+      sha256 = "f50869e6dc73354ab1aa3472ca9092c07d7868f3949b0ca1e2cd2fc817967f42";
+      url = "mirror://steamrt/pool/main/libv/libva1/vainfo-1-multiarch_1.7.0-1+steamrt1.1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vainfo-1-multiarch.deb";
+      };
+    }
+    rec {
+      name = "vainfo-multiarch_2.1.0+ds1-1~steamrt1.1+srt1_i386";
+      sha256 = "066f979526321c2d74223426fbc40fd7b210ce6c0396ffc58220313358ae155c";
+      url = "mirror://steamrt/pool/main/libv/libva-utils/vainfo-multiarch_2.1.0+ds1-1~steamrt1.1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vainfo-multiarch.deb";
+      };
+    }
+    rec {
+      name = "vulkan-tools_1.2.135.0+dfsg1-1~steamrt1.1+srt1_i386";
+      sha256 = "1a252f79e90034726d80e49ab892ddfd504fa32dfef93887ed2c6e6e83e77248";
+      url = "mirror://steamrt/pool/main/v/vulkan-tools/vulkan-tools_1.2.135.0+dfsg1-1~steamrt1.1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vulkan-tools.deb";
+      };
+    }
+    rec {
+      name = "vulkan-tools-multiarch_1.2.135.0+dfsg1-1~steamrt1.1+srt1_i386";
+      sha256 = "f7f68aefcb4f45f855949ad84463c68071595568db27480d3df3ed9be5683b5f";
+      url = "mirror://steamrt/pool/main/v/vulkan-tools/vulkan-tools-multiarch_1.2.135.0+dfsg1-1~steamrt1.1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "vulkan-tools-multiarch.deb";
+      };
+    }
+    rec {
+      name = "waffle-utils_1.6.1-0+steamrt1.1+srt1_i386";
+      sha256 = "c88c88a12f5a9486a20275624c45ab7ac2170e846ea1368d1180e7b39c9d586f";
+      url = "mirror://steamrt/pool/main/w/waffle/waffle-utils_1.6.1-0+steamrt1.1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "waffle-utils.deb";
+      };
+    }
+    rec {
+      name = "waffle-utils-multiarch_1.6.1-0+steamrt1.1+srt1_i386";
+      sha256 = "9aa2ee8c466c343dda5c8db9465238eb5f4cb55b5cfcfca8a3c109ba1d6c6d65";
+      url = "mirror://steamrt/pool/main/w/waffle/waffle-utils-multiarch_1.6.1-0+steamrt1.1+srt1_i386.deb";
+      source = fetchurl {
+        inherit url sha256;
+        name = "waffle-utils-multiarch.deb";
+      };
+    }
+    rec {
+      name = "zenity_3.4.0-0ubuntu4+steamrt3+srt1_i386";
+      sha256 = "b8b0d0781ed2e59ac22af8006e61323a5f1f5be44d47e0fea0ca32e8c575528d";
+      url = "mirror://steamrt/pool/main/z/zenity/zenity_3.4.0-0ubuntu4+steamrt3+srt1_i386.deb";
       source = fetchurl {
         inherit url sha256;
         name = "zenity.deb";
       };
     }
     rec {
-      name = "zenity-common_3.4.0-0ubuntu4+steamrt2+srt6_all";
-      sha256 = "bc8f0b80672833be72c6dd87d406b5fc0ef92e51f91e3a461678fc97844649bc";
-      url = "mirror://steamrt/pool/main/z/zenity/zenity-common_3.4.0-0ubuntu4+steamrt2+srt6_all.deb";
+      name = "zenity-common_3.4.0-0ubuntu4+steamrt3+srt1_all";
+      sha256 = "7ec603c8b00c5573e88e1df9785af4baef93b54e377e697515eb939b7c119cdc";
+      url = "mirror://steamrt/pool/main/z/zenity/zenity-common_3.4.0-0ubuntu4+steamrt3+srt1_all.deb";
       source = fetchurl {
         inherit url sha256;
         name = "zenity-common.deb";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/86358 to stable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
