### PR TITLE
python.pkgs.binwalk: remove p7zip from propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -7,7 +7,6 @@
 , gzip
 , bzip2
 , gnutar
-, p7zip
 , cabextract
 , lzma
 , nose
@@ -29,7 +28,7 @@ buildPythonPackage {
     sha256 = "1bxgj569fzwv6jhcbl864nmlsi9x1k1r20aywjxc8b9b1zgqrlvc";
   };
 
-  propagatedBuildInputs = [ zlib xz ncompress gzip bzip2 gnutar p7zip cabextract lzma pycrypto ]
+  propagatedBuildInputs = [ zlib xz ncompress gzip bzip2 gnutar cabextract lzma pycrypto ]
   ++ stdenv.lib.optional visualizationSupport pyqtgraph;
 
   # setup.py only installs version.py during install, not test


### PR DESCRIPTION
p7zip is abandoned and may not receive important security fixes.

It was marked as insecure in aa80b4780d849a00d86c28d6b3c78a777dd02e9a

`binwalk` might loose the possibility to extract some binary formats,
but it's better than running it on untrusted imput.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
