### PR TITLE
vimPlugins.vim-go: set g:go_bin_path to work with pure nix-shell

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -589,14 +589,15 @@ self: super: {
       asmfmt
       delve
       errcheck
+      go
       go-motion
       go-tools
       gocode
       gocode-gomod
       godef
       gogetdoc
-      golint
       golangci-lint
+      golint
       gomodifytags
       gopls
       gotags
@@ -606,6 +607,7 @@ self: super: {
       reftools
     ];
     in {
+    patches = (old.patches or []) ++ [./patches/vim-go/pure.patch];
     postPatch = ''
       ${gnused}/bin/sed \
         -Ee 's@"go_bin_path", ""@"go_bin_path", "${binPath}"@g' \

--- a/pkgs/misc/vim-plugins/patches/vim-go/pure.patch
+++ b/pkgs/misc/vim-plugins/patches/vim-go/pure.patch
@@ -1,0 +1,114 @@
+From 8d6d023dadf55f2d340ce85c51834bff218920ae Mon Sep 17 00:00:00 2001
+From: "Wael M. Nasreddine" <wael.nasreddine@gmail.com>
+Date: Sat, 2 May 2020 21:09:48 -0700
+Subject: [PATCH 1/2] util/system: respect g:go_bin_path when calling system
+ commands
+
+Respect g:go_bin_path when calling commands through system()
+---
+ autoload/go/util.vim | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/autoload/go/util.vim b/autoload/go/util.vim
+index 05e0e1b..ef869d6 100644
+--- a/autoload/go/util.vim
++++ b/autoload/go/util.vim
+@@ -169,10 +169,25 @@ function! s:system(cmd, ...) abort
+     endif
+   endif
+ 
++  let l:old_path = $PATH
++
++  let l:go_bin_path = go#path#BinPath()
++  if !empty(l:go_bin_path)
++    " append our GOBIN and GOPATH paths and be sure they can be found there...
++    " let us search in our GOBIN and GOPATH paths
++    " respect the ordering specified by go_search_bin_path_first
++    if go#config#SearchBinPathFirst()
++      let $PATH = l:go_bin_path . go#util#PathListSep() . $PATH
++    else
++      let $PATH = $PATH . go#util#PathListSep() . l:go_bin_path
++    endif
++  endif
++
+   try
+     return call('system', [a:cmd] + a:000)
+   finally
+     " Restore original values
++    let $PATH = l:old_path
+     let &shell = l:shell
+     let &shellredir = l:shellredir
+     let &shellcmdflag = l:shellcmdflag
+-- 
+2.25.0
+
+
+From 1e3b7bb7e8b7e3d1c5271989ae8769f1826763aa Mon Sep 17 00:00:00 2001
+From: "Wael M. Nasreddine" <wael.nasreddine@gmail.com>
+Date: Sat, 2 May 2020 21:15:35 -0700
+Subject: [PATCH 2/2] job: respect g:go_bin_path when starting a job
+
+When starting a job, such as gopls, respect the g:go_bin_path setting.
+---
+ autoload/go/job.vim | 20 ++++++++++++++++----
+ 1 file changed, 16 insertions(+), 4 deletions(-)
+
+diff --git a/autoload/go/job.vim b/autoload/go/job.vim
+index f0ee305..847b9ab 100644
+--- a/autoload/go/job.vim
++++ b/autoload/go/job.vim
+@@ -289,8 +289,19 @@ endfunction
+ " transformed to their Neovim equivalents.
+ function! go#job#Start(cmd, options)
+   let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd' : 'cd'
++  let l:cmd = copy(a:cmd)
+   let l:options = copy(a:options)
+ 
++  let l:go_bin_path = go#path#BinPath()
++  if !empty(l:go_bin_path)
++    if go#config#SearchBinPathFirst()
++      let l:path = l:go_bin_path . go#util#PathListSep() . $PATH
++    else
++      let l:path = $PATH . go#util#PathListSep() . l:go_bin_path
++    endif
++    let l:cmd = extend(['env', 'PATH=' . l:path], l:cmd)
++  endif
++
+   if has('nvim')
+     let l:options = s:neooptions(l:options)
+   endif
+@@ -326,8 +337,9 @@ function! go#job#Start(cmd, options)
+     call remove(l:options, 'noblock')
+   endif
+ 
++
+   if go#util#HasDebug('shell-commands')
+-    call go#util#EchoInfo('job command: ' . string(a:cmd))
++    call go#util#EchoInfo('job command: ' . string(l:cmd))
+   endif
+ 
+   if has('nvim')
+@@ -336,7 +348,7 @@ function! go#job#Start(cmd, options)
+       let l:input = readfile(a:options.in_name, "b")
+     endif
+ 
+-    let job = jobstart(a:cmd, l:options)
++    let job = jobstart(l:cmd, l:options)
+ 
+     if len(l:input) > 0
+       call chansend(job, l:input)
+@@ -344,9 +356,9 @@ function! go#job#Start(cmd, options)
+       call chanclose(job, 'stdin')
+     endif
+   else
+-    let l:cmd = a:cmd
++    let l:cmd = l:cmd
+     if go#util#IsWin()
+-      let l:cmd = join(map(copy(a:cmd), function('s:winjobarg')), " ")
++      let l:cmd = join(map(copy(l:cmd), function('s:winjobarg')), " ")
+     endif
+ 
+     let job = job_start(l:cmd, l:options)
+-- 
+2.25.0
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- It requires gopls, but it's missing because it's no longer provided by gotools.
- It was relying on PATH to find the Go compiler. I've made an update to the plugin so it relies on g:go_bin_path when calling system() or when starting a job. I've filed a pull request upstream to fix this: https://github.com/fatih/vim-go/pull/2876

**Note** My patch upstream works for Linux but will definitely break Windows support. I'm not sure we have any Windows use case for this.


<details>
<summary>Test NeoVim</summary>

```
nix-shell -I nixpkgs=. \
	--pure \
	-p which \
	-p 'with import <nixpkgs> {}; neovim.override { configure = { vam.pluginDictionaries = [ "vim-go" ]; }; }' \
		--run 'cd /path/to/project; export GOPATH=/path/to/gopath; vim main.go'
```
</details>

<details>
<summary>Test Vim</summary>

```
nix-shell -I nixpkgs=. \
	--pure \
	-p which \
	-p 'with import <nixpkgs> {}; vim_configurable.customize { name = "vim"; vimrcConfig.packages.myVimPackage = with pkgs.vimPlugins; { start = [ vim-go ]; }; }' \
		--run 'cd /path/to/project; export GOPATH=/path/to/gopath; vim main.go'
```
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
