### PR TITLE
unar: 1.10.1 -> 1.10.7

### DIFF
--- a/pkgs/tools/archivers/unar/default.nix
+++ b/pkgs/tools/archivers/unar/default.nix
@@ -1,52 +1,54 @@
-{ stdenv, fetchurl, gnustep, unzip, bzip2, zlib, icu, openssl }:
+{ stdenv, fetchFromGitHub, installShellFiles, gnustep, bzip2, zlib, icu, openssl, wavpack }:
 
-let
+stdenv.mkDerivation rec {
   pname = "unar";
+  version = "1.10.7";
 
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
-  version = "1.10.1";
-
-  src = fetchurl {
-    url = "http://unarchiver.c3.cx/downloads/${pname}${version}_src.zip";
-    sha256 = "0aq9zlar5vzr5qxphws8dm7ax60bsfsw77f4ciwa5dq5lla715j0";
+  src = fetchFromGitHub {
+    owner = "MacPaw";
+    # the unar repo contains a shallow clone of both XADMaster and universal-detector
+    repo = "unar";
+    rev = "v${version}";
+    sha256 = "0p846q1l66k3rnd512sncp26zpv411b8ahi145sghfcsz9w8abc4";
   };
-
-  buildInputs = [ gnustep.base bzip2 icu openssl zlib ];
-
-  nativeBuildInputs = [ gnustep.make unzip ];
-
-  enableParallelBuilding = true;
 
   postPatch = ''
     for f in Makefile.linux ../UniversalDetector/Makefile.linux ; do
       substituteInPlace $f \
-        --replace "CC = gcc"     "CC=cc" \
-        --replace "CXX = g++"    "CXX=c++" \
-        --replace "OBJCC = gcc"  "OBJCC=cc" \
-        --replace "OBJCXX = g++" "OBJCXX=c++"
+        --replace "= gcc" "=cc" \
+        --replace "= g++" "=c++"
     done
+
+    # we need to build inside this directory as well, so we have to make it writeable
+    chmod +w ../UniversalDetector -R
   '';
+
+  buildInputs = [ gnustep.base bzip2 icu openssl wavpack zlib ];
+
+  nativeBuildInputs = [ gnustep.make installShellFiles ];
+
+  enableParallelBuilding = true;
+
+  dontConfigure = true;
 
   makefile = "Makefile.linux";
 
-  sourceRoot = "./The Unarchiver/XADMaster";
+  sourceRoot = "./source/XADMaster";
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 -t $out/bin lsar unar
-    install -Dm644 -t $out/share/man/man1 ../Extra/{lsar,unar}.1
-
-    mkdir -p $out/etc/bash_completion.d
-    cp ../Extra/lsar.bash_completion $out/etc/bash_completion.d/lsar
-    cp ../Extra/unar.bash_completion $out/etc/bash_completion.d/unar
+    install -Dm555 -t $out/bin lsar unar
+    for f in lsar unar; do
+      installManPage ./Extra/$f.?
+      installShellCompletion --bash --name $f ./Extra/$f.bash_completion
+    done
 
     runHook postInstall
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://unarchiver.c3.cx/unarchiver";
+    homepage = "https://theunarchiver.com";
     description = "An archive unpacker program";
     longDescription = ''
       The Unarchiver is an archive unpacker program with support for the popular \
@@ -55,7 +57,8 @@ in stdenv.mkDerivation rec {
       Compact Pro, Packit, cpio, compress (.Z), ARJ, ARC, PAK, ACE, ZOO, LZH, \
       ADF, DMS, LZX, PowerPacker, LBR, Squeeze, Crunch, and other old formats.
     '';
-    license = with licenses; [ lgpl21Plus ];
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ peterhoeg ];
     platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Quite a lot of fixes upstream and build from the public repo as opposed
to a zip file that was out of date anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).