### PR TITLE
fuseiso: allow building from checkout

### DIFF
--- a/pkgs/tools/filesystems/fuseiso/default.nix
+++ b/pkgs/tools/filesystems/fuseiso/default.nix
@@ -1,40 +1,55 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, fuse, zlib, glib }:
+{ stdenv, fetchurl, fetchpatch, autoreconfHook, pkgconfig, fuse, glib, zlib }:
 
-stdenv.mkDerivation {
-  name = "fuseiso-20070708";
+stdenv.mkDerivation rec {
+  pname = "fuseiso";
+  version = "20070708";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/fuseiso/fuseiso/20070708/fuseiso-20070708.tar.bz2";
+    url = "mirror://sourceforge/project/fuseiso/fuseiso/${version}/fuseiso-${version}.tar.bz2";
     sha256 = "127xql52dcdhmh7s5m9xc6q39jdlj3zhbjar1j821kb6gl3jw94b";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ fuse zlib glib ];
-
-  patches = let fetchPatchFromDebian = { patch, sha256 }:
+  patches = map (p:
     fetchpatch {
-      inherit sha256;
-      url = "https://sources.debian.net/data/main/f/fuseiso/20070708-3.2/debian/patches/${patch}";
-    };
-  in [
-    (fetchPatchFromDebian {
-      patch = "00-support_large_iso.patch";
+      inherit (p) name sha256;
+      url = "https://sources.debian.net/data/main/f/fuseiso/${version}-3.2/debian/patches/${p.name}";
+    }) [
+    {
+      name = "00-support_large_iso.patch";
       sha256 = "1lmclb1qwzz5f4wlq693g83bblwnjjl73qhgfxbsaac5hnn2shjw";
-    })
-    (fetchPatchFromDebian { # CVE-2015-8837
-      patch = "02-prevent-buffer-overflow.patch";
+    }
+    {
+      name = "01-fix_typo.patch";
+      sha256 = "14rpxp0yylzsgqv0r19l4wx1h5hvqp617gpv1yg0w48amr9drasa";
+    }
+    { # CVE-2015-8837
+      name = "02-prevent-buffer-overflow.patch";
       sha256 = "1ls2pp3mh91pdb51qz1fsd8pwhbky6988bpd156bn7wgfxqzh8ig";
-    })
-    (fetchPatchFromDebian { # CVE-2015-8836
-      patch = "03-prevent-integer-overflow.patch";
+    }
+    { # CVE-2015-8836
+      name = "03-prevent-integer-overflow.patch";
       sha256 = "100cw07fk4sa3hl7a1gk2hgz4qsxdw99y20r7wpidwwwzy463zcv";
-    })
+    }
   ];
 
-  meta = {
-    homepage = "https://sourceforge.net/projects/fuseiso";
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ fuse glib zlib ];
+
+  # after autoreconfHook, glib and zlib are not found, so force link against
+  # them
+  NIX_LDFLAGS = "-lglib-2.0 -lz";
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    install -Dm444 -t $out/share/doc/${pname} NEWS README
+  '';
+
+  meta = with stdenv.lib; {
     description = "FUSE module to mount ISO filesystem images";
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.gpl2;
+    homepage = "https://sourceforge.net/projects/fuseiso";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Also: cleanups and add basic docs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).