### PR TITLE
Aarch32: disable libpfm

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm.nix
+++ b/pkgs/development/compilers/llvm/10/llvm.nix
@@ -16,6 +16,7 @@
 , enableSharedLibraries ? true
 , enablePFM ? !(stdenv.isDarwin
   || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
+  || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? true
 }:

--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -17,6 +17,7 @@
 , enableSharedLibraries ? true
 , enablePFM ? !(stdenv.isDarwin
   || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
+  || stdenv.isAarch32 # broken for the armv7l builder
   )
 , enablePolly ? false
 }:

--- a/pkgs/development/compilers/llvm/8/llvm.nix
+++ b/pkgs/development/compilers/llvm/8/llvm.nix
@@ -16,6 +16,7 @@
 , enableSharedLibraries ? true
 , enablePFM ? !(stdenv.isDarwin
   || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
+  || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false
 }:

--- a/pkgs/development/compilers/llvm/9/llvm.nix
+++ b/pkgs/development/compilers/llvm/9/llvm.nix
@@ -16,6 +16,7 @@
 , enableSharedLibraries ? true
 , enablePFM ? !(stdenv.isDarwin
   || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
+  || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false
 }:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The armv7l builder has has the same issue some of the aarch64 ones have (#56245)

See:
https://hydra.nixos.org/eval/1583749?filter=llvm_&compare=1583176&full=#tabs-still-fail
https://nix-cache.s3.amazonaws.com/log/3ppqyssyqj5d6sh257zfb5rb6km4m6sa-llvm-7.1.0.drv
https://nix-cache.s3.amazonaws.com/log/rmacd5xwkw3lyb6zknc3sgdcb3cvk6k1-llvm-8.0.1.drv
https://nix-cache.s3.amazonaws.com/log/6s8pasqwkrzzv5lgw1l22zy7mrpzx2p3-llvm-9.0.1.drv

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
