### PR TITLE
zsh: added option to enable compatibility with bash's completion system

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -135,6 +135,13 @@ in
         type = types.bool;
       };
 
+      enableBashCompletion = mkOption {
+        default = false;
+        description = ''
+          Enable compatibility with bash's programmable completion system.
+        '';
+        type = types.bool;
+      };
 
       enableGlobalCompInit = mkOption {
         default = cfg.enableCompletion;
@@ -237,6 +244,11 @@ in
         ${optionalString cfg.enableGlobalCompInit ''
           # Enable autocompletion.
           autoload -U compinit && compinit
+        ''}
+
+        ${optionalString cfg.enableBashCompletion ''
+          # Enable compatibility with bash's completion system.
+          autoload -U bashcompinit && bashcompinit
         ''}
 
         # Setup custom interactive shell init stuff.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Added ability to add `bashcompinit` to system wide zshrc configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 asbachb@nixos  ~/dev/src/nix/nixpkgs   zsh-bash-autocomplete  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (0.08 MiB download, 0.40 MiB unpacked):
  /nix/store/0rbnlnd1pvlpii8p72ybvvg672j2wc2f-bash-interactive-4.4-p23-dev
  /nix/store/c0j7hbxbffh08la9bp90dxqx8s1xm1xp-nixpkgs-review-2.3.0
copying path '/nix/store/0rbnlnd1pvlpii8p72ybvvg672j2wc2f-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/c0j7hbxbffh08la9bp90dxqx8s1xm1xp-nixpkgs-review-2.3.0' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   05f0934825c..776f12b39ec  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-400baf9946ae1ba7e73a5b931c64f91415be5eed-dirty/nixpkgs 776f12b39ec436ea31c57ecf755464b175d765d9
Preparing worktree (detached HEAD 776f12b39ec)
Updating files: 100% (21628/21628), done.
HEAD is now at 776f12b39ec Merge pull request #86401 from etu/php-add-doc-to-index
$ nix-env -f /home/asbachb/.cache/nixpkgs-review/rev-400baf9946ae1ba7e73a5b931c64f91415be5eed-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
