### PR TITLE
libgpiod: add patch fixing cross-compilation

### DIFF
--- a/pkgs/development/libraries/libgpiod/0001-Drop-AC_FUNC_MALLOC-and-_REALLOC-and-check-for-them-.patch
+++ b/pkgs/development/libraries/libgpiod/0001-Drop-AC_FUNC_MALLOC-and-_REALLOC-and-check-for-them-.patch
@@ -1,0 +1,31 @@
+From 2cc80dc06ea42087788cf27b31821ffa99a22f89 Mon Sep 17 00:00:00 2001
+From: Johannes Lode <johannes.lode@dynainstruments.com>
+Date: Thu, 14 Nov 2019 10:44:00 +0100
+Subject: [PATCH] Drop AC_FUNC_MALLOC and _REALLOC and check for them as
+ regular functions.
+
+While cross-compiling there occurred "undefined reference to
+`rpl_malloc'", the suggested change fixes the problem.
+
+Tested for native X86_64 and armv7a-unknown-linux-gnueabihf.
+---
+ configure.ac | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 008499d..b492dc4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -81,7 +81,8 @@ AC_DEFUN([HEADER_NOT_FOUND_CXX],
+ 
+ # This is always checked (library needs this)
+ AC_HEADER_STDC
+-AC_FUNC_MALLOC
++# AC_FUNC_MALLOC -- does not work while cross-compiling
++AC_CHECK_FUNC([malloc realloc])
+ AC_CHECK_FUNC([ioctl], [], [FUNC_NOT_FOUND_LIB([ioctl])])
+ AC_CHECK_FUNC([asprintf], [], [FUNC_NOT_FOUND_LIB([asprintf])])
+ AC_CHECK_FUNC([scandir], [], [FUNC_NOT_FOUND_LIB([scandir])])
+-- 
+2.25.1
+

--- a/pkgs/development/libraries/libgpiod/default.nix
+++ b/pkgs/development/libraries/libgpiod/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "14iv8iwyvfznyifhkqz1bjh24dvb03gmpjn8v3fs6h734l93vvw5";
   };
 
+  patches = [
+    # cross compiling fix
+    # https://github.com/brgl/libgpiod/pull/45
+    ./0001-Drop-AC_FUNC_MALLOC-and-_REALLOC-and-check-for-them-.patch
+  ];
+
   buildInputs = [ kmod ] ++ lib.optionals enablePython [ python3 ncurses ];
   nativeBuildInputs = [
     autoconf-archive


### PR DESCRIPTION
Fixes "undefined reference to `rpl_malloc'".

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes build for `armv7l` and probably `aarch64` as well. https://github.com/brgl/libgpiod/pull/45

Tested on `x86_64` as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
