### PR TITLE
kismet: 2016-07-R1 -> 2020-04-R2

### DIFF
--- a/pkgs/applications/networking/sniffers/kismet/default.nix
+++ b/pkgs/applications/networking/sniffers/kismet/default.nix
@@ -1,16 +1,37 @@
-{ stdenv, fetchurl, pkgconfig, libpcap, ncurses, expat, pcre, libnl }:
+{ stdenv, fetchurl, pkgconfig, libpcap, pcre, libnl, zlib, libmicrohttpd
+, sqlite, protobuf, protobufc, libusb1, libcap, binutils, elfutils
+, withNetworkManager ? false, glib, networkmanager
+, withPython ? false, python3
+, withSensors ? false, lm_sensors}:
+
+# couldn't get python modules to build correctly,
+# waiting for some other volunteer to fix it
+assert !withPython;
 
 stdenv.mkDerivation rec {
   pname = "kismet";
-  version = "2016-07-R1";
+  version = "2020-04-R2";
 
   src = fetchurl {
     url = "https://www.kismetwireless.net/code/${pname}-${version}.tar.xz";
-    sha256 = "0dz28y4ay4lskhl0lawqy2dkcrhgfkbg06v22qxzzw8i6caizcmx";
+    sha256 = "0hxmaln0y6bk9m1rshr4swmg0sqy3ic693vfk8haj7f5gnph96cm";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libpcap ncurses expat pcre libnl ];
+
+  buildInputs = [
+    libpcap pcre libmicrohttpd libnl zlib sqlite protobuf protobufc
+    libusb1 libcap binutils elfutils
+  ] ++ stdenv.lib.optionals withNetworkManager [ networkmanager glib ]
+    ++ stdenv.lib.optional withSensors lm_sensors
+    ++ stdenv.lib.optional withPython (python3.withPackages(ps: [ ps.setuptools ps.protobuf
+                                                                  ps.numpy ps.pyserial ]));
+
+  configureFlags = []
+    ++ stdenv.lib.optional (!withNetworkManager) "--disable-libnm"
+    ++ stdenv.lib.optional (!withPython) "--disable-python-tools"
+    ++ stdenv.lib.optional (!withSensors) "--disable-lmsensors";
+
   postConfigure = ''
     sed -e 's/-o $(INSTUSR)//' \
         -e 's/-g $(INSTGRP)//' \
@@ -18,6 +39,8 @@ stdenv.mkDerivation rec {
         -e 's/-g $(SUIDGROUP)//' \
         -i Makefile
   '';
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Wireless network sniffer";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

package upgrade

unfortunately I wasn't able to get Python modules working (had same problem as you @jonringer and ran out of ideas how to overcome it), but I am inclined to argue that this package could do with an upgrade even if these modules aren't working...

I did verify that Linux WiFi and Bluetooth capture works correctly when ran as `root`. adding setuid capabilities would require writing a module which does set up the proper wrappers I guess..?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
