### PR TITLE
nixos/prosody: add MUC extraConfig + fixes

### DIFF
--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -382,6 +382,11 @@ let
         default = "en";
         description = "Default room language.";
       };
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Additional MUC specific configuration";
+      };
     };
   };
 
@@ -792,6 +797,8 @@ in
 
       https_ports = ${toLua cfg.httpsPorts}
 
+      ${ cfg.extraConfig }
+
       ${lib.concatMapStrings (muc: ''
         Component ${toLua muc.domain} "muc"
             modules_enabled = { "muc_mam"; ${optionalString muc.vcard_muc ''"vcard_muc";'' } }
@@ -809,8 +816,8 @@ in
             muc_room_default_change_subject = ${toLua muc.roomDefaultChangeSubject}
             muc_room_default_history_length = ${toLua muc.roomDefaultHistoryLength}
             muc_room_default_language = ${toLua muc.roomDefaultLanguage}
-
-          '') cfg.muc}
+            ${ muc.extraConfig }
+        '') cfg.muc}
 
       ${ lib.optionalString (cfg.uploadHttp != null) ''
         Component ${toLua cfg.uploadHttp.domain} "http_upload"
@@ -819,8 +826,6 @@ in
             ${lib.optionalString (cfg.uploadHttp.userQuota != null) "http_upload_quota = ${toLua cfg.uploadHttp.userQuota}"}
             http_upload_path = ${toLua cfg.uploadHttp.httpUploadPath}
       ''}
-
-      ${ cfg.extraConfig }
 
       ${ lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: ''
         VirtualHost "${v.domain}"

--- a/nixos/tests/xmpp/prosody-mysql.nix
+++ b/nixos/tests/xmpp/prosody-mysql.nix
@@ -6,6 +6,11 @@ import ../make-test-python.nix {
       environment.systemPackages = [
         (pkgs.callPackage ./xmpp-sendmessage.nix { connectTo = nodes.server.config.networking.primaryIPAddress; })
       ];
+      networking.extraHosts = ''
+        ${nodes.server.config.networking.primaryIPAddress} example.com
+        ${nodes.server.config.networking.primaryIPAddress} conference.example.com
+        ${nodes.server.config.networking.primaryIPAddress} uploads.example.com
+      '';
     };
     server = { config, pkgs, ... }: {
       nixpkgs.overlays = [
@@ -18,6 +23,8 @@ import ../make-test-python.nix {
       ];
       networking.extraHosts = ''
         ${config.networking.primaryIPAddress} example.com
+        ${config.networking.primaryIPAddress} conference.example.com
+        ${config.networking.primaryIPAddress} uploads.example.com
       '';
       networking.firewall.enable = false;
       services.prosody = {
@@ -38,6 +45,14 @@ import ../make-test-python.nix {
         virtualHosts.test = {
           domain = "example.com";
           enabled = true;
+        };
+        muc = [
+          {
+            domain = "conference.example.com";
+          }
+        ];
+        uploadHttp = {
+          domain = "uploads.example.com";
         };
       };
     };


### PR DESCRIPTION
Thanks for the work in #86067 @NinjaTrappeur, even though it probably wasn't the goal it makes the Jitsi Meet module compose better with user-defined Prosody configuration! I'd like to propose for a few modifications in this PR:

* move the main `extraConfig` before the component definitions in the config file, so that it actually [applies globally](https://prosody.im/doc/configure#overview) instead of to the http_upload component
* add `extraConfig` option to the MUC submodule so that it's possible to provide additional options (like `storage` or `admins`)
* fix `nixos/tests/xmpp/prosod-mysql.nix`

cc @flokli 

###### Motivation for this change

Mostly #82920.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
