### PR TITLE
[20.03] salt: 2019.2.0 -> 2019.2.4

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -1,21 +1,40 @@
 {
-  stdenv, pythonPackages, openssl,
+  stdenv, python2, openssl,
 
   # Many Salt modules require various Python modules to be installed,
   # passing them in this array enables Salt to find them.
   extraInputs ? []
 }:
 
-pythonPackages.buildPythonApplication rec {
-  pname = "salt";
-  version = "2019.2.0";
+let
 
-  src = pythonPackages.fetchPypi {
-    inherit pname version;
-    sha256 = "1kgn3lway0zwwysyzpphv05j4xgxk92dk4rv1vybr2527wmvp5an";
+  py = python2.override {
+    packageOverrides = self: super: {
+      pyyaml = super.pyyaml.overridePythonAttrs (
+        oldAttrs: rec {
+          version = "3.13";
+          src = oldAttrs.src.override {
+            inherit version;
+            sha256 = "1gx603g484z46cb74j9rzr6sjlh2vndxayicvlyhxdz98lhhkwry";
+          };
+          postPatch = "rm ext/_yaml.c";
+          doCheck = false;
+        }
+      );
+    };
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+in
+py.pkgs.buildPythonApplication rec {
+  pname = "salt";
+  version = "2019.2.4";
+
+  src = py.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "0ir8gmir4jl21v252vxwgjaskj15wlkhp715jn7h1jb1vfairsxg";
+  };
+
+  propagatedBuildInputs = with py.pkgs; [
     jinja2
     markupsafe
     msgpack
@@ -24,8 +43,6 @@ pythonPackages.buildPythonApplication rec {
     pyzmq
     requests
     tornado_4
-  ] ++ stdenv.lib.optionals (!pythonPackages.isPy3k) [
-    futures
   ] ++ extraInputs;
 
   patches = [ ./fix-libcrypto-loading.patch ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes CVE-2020-11651 and CVE-2020-11652, see also #85561.

###### Things done
nixpkgs-review failed, I guess `release-20.03` is currently broken. The same patch worked for 19.09 in #86651.
```sh
$ nix-env -f /home/sebi/.cache/nixpkgs-review/rev-b5a4c50e31b27a041f992acb3c87aae510fa736d/nixpkgs -qaP --xml --out-path --show-trace --meta
error: while querying the derivation named 'lambdabot-5.2':
while evaluating the attribute 'buildInputs' of the derivation 'lambdabot-5.2' at /home/sebi/.cache/nixpkgs-review/rev-b5a4c50e31b27a041f992acb3c87aae510fa736d/nixpkgs/pkgs/development/haskell-modules/generic-builder.nix:291:3:
while evaluating the attribute 'propagatedBuildInputs' of the derivation 'lambdabot-core-5.2' at /home/sebi/.cache/nixpkgs-review/rev-b5a4c50e31b27a041f992acb3c87aae510fa736d/nixpkgs/pkgs/development/haskell-modules/generic-builder.nix:291:3:
while evaluating 'getOutput' at /home/sebi/.cache/nixpkgs-review/rev-b5a4c50e31b27a041f992acb3c87aae510fa736d/nixpkgs/lib/attrsets.nix:464:23, called from undefined position:
while evaluating anonymous function at /home/sebi/.cache/nixpkgs-review/rev-b5a4c50e31b27a041f992acb3c87aae510fa736d/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:156:17, called from undefined position:
attribute 'hslogger_1_3_0_0' missing, at /home/sebi/.cache/nixpkgs-review/rev-b5a4c50e31b27a041f992acb3c87aae510fa736d/nixpkgs/pkgs/development/haskell-modules/configuration-common.nix:1215:114
Nothing changed
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
