### PR TITLE
[20.03] haskellPackages.ghcide: Fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1440,6 +1440,21 @@ self: super: {
     HsYAML = self.HsYAML_0_2_1_0;
   };
 
+  # Needed for ghcide
+  haskell-lsp_0_19_0_0 = super.haskell-lsp_0_19_0_0.override {
+    haskell-lsp-types = self.haskell-lsp-types_0_19_0_0;
+  };
+
+  # this will probably need to get updated with every ghcide update,
+  # we need an override because ghcide is tracking haskell-lsp closely.
+  ghcide = dontCheck (super.ghcide.override rec {
+    haskell-lsp-types = self.haskell-lsp-types_0_19_0_0;
+    haskell-lsp = self.haskell-lsp_0_19_0_0;
+    regex-tdfa = self.regex-tdfa_1_3_1_0;
+    haddock-library = self.haddock-library_1_8_0;
+  });
+
+
   # 20.03 broken packages
 
   envy-extensible = markBroken super.envy-extensible;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2523,6 +2523,8 @@ extra-packages:
   - happy <1.19.6                       # newer versions break Agda
   - happy == 1.19.9                     # for purescript
   - haskell-gi-overloading == 0.0       # gi-* packages use this dependency to disable overloading support
+  - haskell-lsp == 0.19.*               # required for ghcide
+  - haskell-lsp-types == 0.19.*         # required for ghcide
   - haskell-src-exts == 1.19.*          # required by hindent and structured-haskell-mode
   - hinotify == 0.3.9                   # for xmonad-0.26: https://github.com/kolmodin/hinotify/issues/29
   - hoogle == 5.0.14                    # required by hie-hoogle
@@ -5056,7 +5058,6 @@ broken-packages:
   - ghci-lib
   - ghci-ng
   - ghci-pretty
-  - ghcide
   - ghcjs-base-stub
   - ghcjs-dom-jsffi
   - ghcjs-fetch
@@ -5806,7 +5807,6 @@ broken-packages:
   - hiccup
   - hichi
   - hid-examples
-  - hie-bios
   - hie-core
   - hieraclus
   - hierarchical-clustering

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -688,4 +688,6 @@ self: super: builtins.intersectAttrs super {
   # checks SQL statements at compile time, and so requires a running PostgreSQL
   # database to run it's test suite
   postgresql-typed = dontCheck super.postgresql-typed;
+
+  hie-bios = dontCheck super.hie-bios;
 }


### PR DESCRIPTION
###### Motivation for this change

`ghcide` is marked as broken and is not building. With these changes it builds.

Please let me know if I should structure the overrides in a different way.
When this PR is approved I will port it to the haskell-updates branch. But first I wanna know if I did this right.
I am especially confused by the recursive library overrides. It‘s not pretty this way. e.g. the override for regex-tdfa_1_3_1_0 which needs a pinned regex-base version is now twice in the file.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
