### PR TITLE
lxd: added patch for fixing path `/usr/share/misc/usb.ids`

### DIFF
--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgconfig, lxc, buildGoPackage, fetchurl
+{ stdenv, hwdata, pkgconfig, lxc, buildGoPackage, fetchurl
 , makeWrapper, acl, rsync, gnutar, xz, btrfs-progs, gzip, dnsmasq
 , squashfsTools, iproute, iptables, ebtables, libcap, libco-canonical, dqlite
 , raft-canonical, sqlite-replication, udev
@@ -18,6 +18,11 @@ buildGoPackage rec {
     url = "https://github.com/lxc/lxd/releases/download/${pname}-${version}/${pname}-${version}.tar.gz";
     sha256 = "0sxkyjayn7yyiy9kvbdlpkl58lwsl2rhlxnncg628f2kad2zgkdx";
   };
+
+  postPatch = ''
+    substituteInPlace shared/usbid/load.go \
+      --replace "/usr/share/misc/usb.ids" "${hwdata}/share/hwdata/usb.ids"
+  '';
 
   preBuild = ''
     # unpack vendor


### PR DESCRIPTION
closes #86650

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 ✘ asbachb@nixos  ~/dev/src/nix/nixpkgs   lxd-usb.ids  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (0.03 MiB download, 0.13 MiB unpacked):
  /nix/store/c0j7hbxbffh08la9bp90dxqx8s1xm1xp-nixpkgs-review-2.3.0
copying path '/nix/store/c0j7hbxbffh08la9bp90dxqx8s1xm1xp-nixpkgs-review-2.3.0' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 246, done.
remote: Counting objects: 100% (246/246), done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 395 (delta 238), reused 234 (delta 234), pack-reused 149
Receiving objects: 100% (395/395), 342.44 KiB | 1.25 MiB/s, done.
Resolving deltas: 100% (289/289), completed with 129 local objects.
From https://github.com/NixOS/nixpkgs
   776f12b39ec..65d4935c0d0  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-5857a17f403105246cc5ac13b206a059215e8703-dirty/nixpkgs 65d4935c0d0cc67e2c22911150bfda8fb597c12d
Preparing worktree (detached HEAD 65d4935c0d0)
Updating files: 100% (21630/21630), done.
HEAD is now at 65d4935c0d0 jsoncpp: fix build on 32-bit arm
$ nix-env -f /home/asbachb/.cache/nixpkgs-review/rev-5857a17f403105246cc5ac13b206a059215e8703-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
```
asbachb@nixos  ~/dev/src/nix/nixpkgs   lxd-usb.ids  nix-shell -I nixpkgs=/home/asbachb/dev/src/nix/nixpkgs -p lxd     

[nix-shell:~/dev/src/nix/nixpkgs]$ lxc --version
4.0.1

[nix-shell:~/dev/src/nix/nixpkgs]$ lxd --version
4.0.1
```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
